### PR TITLE
Allow libpng to be compiled with `-mfpu=neon`

### DIFF
--- a/thirdparty/libpng/CMakeLists.txt
+++ b/thirdparty/libpng/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
 
 project(libpng C)
 enable_testing()
+enable_language(C ASM)
 
 set(PNGLIB_MAJOR 1)
 set(PNGLIB_MINOR 6)
@@ -97,6 +98,8 @@ set(libpng_sources
   pngwrite.c
   pngwtran.c
   pngwutil.c
+  arm/arm_init.c
+  arm/filter_neon.S
 )
 set(pngtest_sources
   pngtest.c


### PR DESCRIPTION
This is needed because currently compiling KOReader with the `-mfpu=neon` flag will make it crash with unresolved symbol errors.

This change is otherwise innocuous because of the `PNG_ARM_NEON_OPT` check in both new source files. So it will still compile fine both for non-NEON ARM and for non-ARM architectures.
