### PR TITLE
properly include freetype2 headers

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -40,18 +40,8 @@
 
 #if (USE_FREETYPE==1)
 
-//#include <ft2build.h>
-
-#ifdef ANDROID
-#include "freetype/config/ftheader.h"
-#include "freetype/freetype.h"
-#else
-
-#include <freetype/config/ftheader.h>
-//#include <ft2build.h>
+#include <ft2build.h>
 #include FT_FREETYPE_H
-//#include <freetype/freetype.h>
-#endif
 
 #if (USE_FONTCONFIG==1)
     #include <fontconfig/fontconfig.h>


### PR DESCRIPTION
This is work that is needed for integrating the crengine build with the freetype library we build in base anyway. CREngine had its own freetype library. Needs changes in base, too.
