### PR TITLE
support "local" in css

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -372,7 +372,7 @@ public:
     virtual void SetHintingMode(hinting_mode_t /*mode*/) { }
     /// returns current hinting mode
     virtual hinting_mode_t  GetHintingMode() { return HINTING_MODE_AUTOHINT; }
-
+    virtual bool setalias(lString8 alias,lString8 facename,int id){ return false;}
 };
 
 class LVBaseFont : public LVFont

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -481,6 +481,7 @@ class EmbeddedFontStyleParser {
     lString16 _basePath;
     int _state;
     lString8 _face;
+    lString8 islocal;
     bool _italic;
     bool _bold;
     lString16 _url;
@@ -526,6 +527,7 @@ public:
                 if (!_url.empty()) {
 //                    CRLog::trace("@font { face: %s; bold: %s; italic: %s; url: %s", _face.c_str(), _bold ? "yes" : "no",
 //                                 _italic ? "yes" : "no", LCSTR(_url));
+			  if (islocal.length()==5) _url=(_url.substr((_basePath.length()+1),(_url.length()-_basePath.length())));
                     _fontList.add(_url, _face, _bold, _italic);
                 }
             }
@@ -534,7 +536,10 @@ public:
 		case ',':
             if (_state == 2) {
                 if (!_url.empty())
+           	    {
+                      if (islocal.length() == 5) _url=(_url.substr((_basePath.length()+1),(_url.length()-_basePath.length())));
                     _fontList.add(_url, _face, _bold, _italic);
+			}
                 _state = 11;
             }
             break;
@@ -583,7 +588,15 @@ public:
             _state = 2;
         } else if (_state == 11) {
             if (t == "url")
+		{
                 _state = 12;
+		islocal=t;
+	        }
+            else if (t=="local")
+            	{
+                _state=12;
+                islocal=t;
+            	}
             else
                 _state = 2;
         }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -401,6 +401,7 @@ public:
     void gc(); // garbage collector
     void update( const LVFontDef * def, LVFontRef ref );
     void removeDocumentFonts(int documentId);
+    void removefont(const LVFontDef * def);
     int  length() { return _registered_list.length(); }
     void addInstance( const LVFontDef * def, LVFontRef ref );
     LVPtrVector< LVFontCacheItem > * getInstances() { return &_instance_list; }
@@ -2221,7 +2222,46 @@ public:
         FONT_MAN_GUARD
         _cache.getFaceList( list );
     }
-
+	bool setalias(lString8 alias,lString8 facename,int id)
+{
+    FONT_MAN_GUARD
+    lString8 fontname=lString8("\0");
+    LVFontDef def(
+            fontname,
+            10,
+            400,
+            false,
+            css_ff_inherit,
+            facename,
+            -1,
+            id
+    );
+        LVFontCacheItem * item = _cache.find( &def);
+    LVFontDef def1(
+            fontname,
+            10,
+            400,
+            false,
+            css_ff_inherit,
+            alias,
+            -1,
+            id
+    );
+        if (!item->getDef()->getName().empty()) {
+            _cache.removefont(&def1);
+            def.setTypeFace(alias);
+            def.setName(item->getDef()->getName());
+            LVFontDef newDef(*item->getDef());
+            newDef.setTypeFace(alias);
+            LVFontRef ref = item->getFont();
+            _cache.update(&newDef, ref);
+            return true;
+        }
+    else
+        {
+            return false;
+        }
+}
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId)
     {
         FONT_MAN_GUARD
@@ -3387,7 +3427,26 @@ void LVFontCache::update( const LVFontDef * def, LVFontRef ref )
         _registered_list.add( item );
     }
 }
+void LVFontCache::removefont(const LVFontDef * def)
+{
+    int i;
+        for (i=0; i<_instance_list.length(); i++)
+        {
+            if ( _instance_list[i]->_def.getTypeFace() == def->getTypeFace() )
+            {
+                _instance_list.remove(i);
+            }
 
+        }
+        for (i=0; i<_registered_list.length(); i++)
+        {
+            if ( _registered_list[i]->_def.getTypeFace() == def->getTypeFace() )
+            {
+                _registered_list.remove(i);
+            }
+        }
+
+}
 void LVFontCache::removeDocumentFonts(int documentId)
 {
     int i;


### PR DESCRIPTION
fontface must be the same as shown in koreader's font selection menu. 
I also found a bug in this version of crengine related to "font-style:Italic;", which may cause words overlap when define Italic style. The newest version of crengine have fixed this. I wonder if you can update it in koreader-base. I have tested the newest version with koreader, it works well.
the left is the newest version of crengine with my patch
the middle is the current version in koreader-base
the right one is the current version with my patch
![screen](https://cloud.githubusercontent.com/assets/8104251/8012116/e453918c-0bfd-11e5-8fc8-8bc924bc88c3.jpg)
the @font-face used of the tested book is 
```
@font-face{
src:local("STSong"),local("FZSongS-Extended"),local("华文宋体"),local("Song S"),local("Droid Sans Fallback");
font-family:'Song';
}
```
here is the newest crengine with my patch. https://github.com/frankyifei/crengine-snapshot-sourceforge/tree/patched
