### PR TITLE
support CSS Border Properties

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -173,6 +173,18 @@ enum css_value_type_t {
     css_val_color
 };
 
+/// css border style values
+enum css_border_style_type_t {
+    css_border_solid,
+    css_border_dotted,
+    css_border_dashed,
+    css_border_double,
+    css_border_groove,
+    css_border_ridge,
+    css_border_inset,
+    css_border_outset,
+    css_border_none
+};
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -184,6 +184,8 @@ public:
     virtual void DrawFragment(LVDrawBuf * src, int srcx, int srcy, int srcdx, int srcdy, int x, int y, int dx, int dy, int options) {
         CR_UNUSED10(src, srcx, srcy, srcdx, srcdy, x, y, dx, dy, options);
     }
+    /// draw lines
+    virtual void DrawLine(int x0,int y0,int x1,int y1,lUInt32 color0 ,int length1,int length2,int direction)=0;
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(QT_GL)
     /// draws buffer content to another buffer doing color conversion if necessary
     virtual void DrawTo( HDC dc, int x, int y, int options, lUInt32 * palette ) = 0;
@@ -248,6 +250,7 @@ public:
     virtual int  GetHeight();
     /// get row size (bytes)
     virtual int  GetRowSize() { return _rowsize; }
+    virtual void DrawLine(int x0, int y0, int x1, int y1, lUInt32 color0,int length1,int length2,int direction)=0;
     /// draws text string
     /*
     virtual void DrawTextString( int x, int y, LVFont * pfont,
@@ -369,6 +372,7 @@ public:
     virtual ~LVGrayDrawBuf();
     /// convert to 1-bit bitmap
     void ConvertToBitmap(bool flgDither);
+    virtual void DrawLine(int x0, int y0, int x1, int y1, lUInt32 color0,int length1,int length2,int direction=0);
 };
 
 inline lUInt32 RevRGB( lUInt32 cl )
@@ -440,6 +444,8 @@ public:
     virtual ~LVColorDrawBuf();
     /// convert to 1-bit bitmap
     void ConvertToBitmap(bool flgDither);
+    /// draw line
+    virtual void DrawLine(int x0,int y0,int x1,int y1,lUInt32 color0 ,int length1=1,int length2=0,int direction=0);
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(QT_GL)
     /// returns device context for bitmap buffer
     HDC GetDC() { return _drawdc; }

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -50,3 +50,4 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 int LVRendGetFontEmbolden();
 
 #endif
+int measureBorder(ldomNode *enode,int border);

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -54,6 +54,12 @@ typedef struct css_style_rec_tag {
     css_hyphenate_t        hyphenate;
     css_list_style_type_t list_style_type;
     css_list_style_position_t list_style_position;
+    css_border_style_type_t border_style_top;
+    css_border_style_type_t border_style_bottom;
+    css_border_style_type_t border_style_right;
+    css_border_style_type_t border_style_left;
+    css_length_t border_width[4];
+    css_length_t border_color[4];
     css_style_rec_tag()
     : refCount(0)
     , hash(0)
@@ -80,6 +86,10 @@ typedef struct css_style_rec_tag {
     , hyphenate(css_hyph_inherit)
     , list_style_type(css_lst_inherit)
     , list_style_position(css_lsp_inherit)
+    , border_style_top(css_border_none)
+    , border_style_bottom(css_border_none)
+    , border_style_right(css_border_none)
+    , border_style_left(css_border_none)
     {
     }
     void AddRef() { refCount++; }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1002,7 +1002,49 @@ LVGrayDrawBuf::~LVGrayDrawBuf()
     	free( _data );
     }
 }
+void LVGrayDrawBuf::DrawLine(int x0, int y0, int x1, int y1, lUInt32 color0,int length1,int length2,int direction)
+{
+    if (x0<_clip.left)
+        x0 = _clip.left;
+    if (y0<_clip.top)
+        y0 = _clip.top;
+    if (x1>_clip.right)
+        x1 = _clip.right;
+    if (y1>_clip.bottom)
+        y1 = _clip.bottom;
+    if (x0>=x1 || y0>=y1)
+        return;
+    lUInt8 color = rgbToGrayMask( color0, _bpp );
+#if (GRAY_INVERSE==1)
+    color ^= 0xFF;
+#endif
 
+    for (int y=y0; y<y1; y++)
+    {
+        if (_bpp==1) {
+            for (int x=x0; x<x1; x++)
+            {
+                lUInt8 * line = GetScanLine(y);
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = color;
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = color;
+            }
+        } else if (_bpp==2) {
+            for (int x=x0; x<x1; x++)
+            {
+                lUInt8 * line = GetScanLine(y);
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = color;
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = color;
+            }
+        } else { // 3, 4, 8
+            for (int x=x0; x<x1; x++)
+            {
+                lUInt8 * line = GetScanLine(y);
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = color;
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = color;
+            }
+        }
+    }
+}
 void LVGrayDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int height, lUInt32 * )
 {
     //int buf_width = _dx; /* 2bpp */
@@ -1460,6 +1502,41 @@ void LVColorDrawBuf::FillRect( int x0, int y0, int x1, int y1, lUInt32 color )
     }
 }
 
+void LVColorDrawBuf::DrawLine(int x0,int y0,int x1,int y1,lUInt32 color0 ,int length1,int length2,int direction)
+{
+    if (x0<_clip.left)
+        x0 = _clip.left;
+    if (y0<_clip.top)
+        y0 = _clip.top;
+    if (x1>_clip.right)
+        x1 = _clip.right;
+    if (y1>_clip.bottom)
+        y1 = _clip.bottom;
+    if (x0>=x1 || y0>=y1)
+        return;
+    if ( _bpp==16 ) {
+        lUInt16 cl16_0 = rgb888to565(color0);
+        for (int y=y0; y<y1; y++)
+        {
+            lUInt16 * line = (lUInt16 *)GetScanLine(y);
+            for (int x=x0; x<x1; x++)
+            {
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = color0;
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = color0;
+            }
+        }
+    } else {
+        for (int y=y0; y<y1; y++)
+        {
+            lUInt32 * line = (lUInt32 *)GetScanLine(y);
+            for (int x=x0; x<x1; x++)
+            {
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = color0;
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = color0;
+            }
+        }
+    }
+}
 /// fills rectangle with specified color
 void LVColorDrawBuf::FillRectPattern( int x0, int y0, int x1, int y1, lUInt32 color0, lUInt32 color1, lUInt8 * pattern )
 {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1947,19 +1947,19 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
             switch (enode->getStyle()->border_style_bottom){
                 case css_border_dotted:
                     dot=interval=bottomBorderwidth;
-                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    for(int i=0;i<leftpoint1.y-leftpoint3.y;i++)
                     {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
                                       rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
                     break;
                 case css_border_dashed:
                     dot=3*bottomBorderwidth;
                     interval=3*bottomBorderwidth;
-                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    for(int i=0;i<leftpoint1.y-leftpoint3.y;i++)
                     {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
                                       rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
                     break;
                 case css_border_solid:
-                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    for(int i=0;i<leftpoint1.y-leftpoint3.y;i++)
                     {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
                                       rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
                     break;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -13,6 +13,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <lvtextfm.h>
 #include "../include/lvtinydom.h"
 #include "../include/fb2def.h"
 #include "../include/lvrend.h"
@@ -70,7 +71,7 @@ simpleLogFile logfile;
 
 #endif
 
-
+int measureBorder(ldomNode *enode,int border);
 // prototypes
 int lengthToPx( css_length_t val, int base_px, int base_em );
 
@@ -1418,6 +1419,41 @@ void getPageBreakStyle( ldomNode * el, css_page_break_t &before, css_page_break_
     }
 }
 
+//measure border width, 0 for top,1 for right,2 for bottom,3 for left
+int measureBorder(ldomNode *enode,int border) {
+        int em = enode->getFont()->getSize();
+        int width = 0;
+        if (border==0){
+                bool hastopBorder = (enode->getStyle()->border_style_top >= css_border_solid &&
+                                     enode->getStyle()->border_style_top <= css_border_outset);
+                int topBorderwidth = lengthToPx(enode->getStyle()->border_width[0], width, em);
+                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : 2;
+                topBorderwidth = hastopBorder?topBorderwidth:0;
+                return topBorderwidth;}
+            else if (border==1){
+                bool hasrightBorder = (enode->getStyle()->border_style_right >= css_border_solid &&
+                                       enode->getStyle()->border_style_right <= css_border_outset);
+                int rightBorderwidth = lengthToPx(enode->getStyle()->border_width[1], width, em);
+                rightBorderwidth = hasrightBorder?rightBorderwidth:0;
+                rightBorderwidth = rightBorderwidth != 0 ? rightBorderwidth : 2;
+                return rightBorderwidth;}
+            else if (border ==2){
+                bool hasbottomBorder = (enode->getStyle()->border_style_bottom >= css_border_solid &&
+                                        enode->getStyle()->border_style_bottom <= css_border_outset);
+                int bottomBorderwidth = lengthToPx(enode->getStyle()->border_width[2], width, em);
+                bottomBorderwidth = bottomBorderwidth != 0 ? bottomBorderwidth : 2;
+                bottomBorderwidth = hasbottomBorder?bottomBorderwidth:0;
+                return bottomBorderwidth;}
+            else if (border==3){
+                bool hasleftBorder = (enode->getStyle()->border_style_left >= css_border_solid &&
+                                      enode->getStyle()->border_style_left <= css_border_outset);
+                int leftBorderwidth = lengthToPx(enode->getStyle()->border_width[3], width, em);
+                leftBorderwidth = leftBorderwidth != 0 ? leftBorderwidth : 2;
+                leftBorderwidth = hasleftBorder?leftBorderwidth:0;
+                return leftBorderwidth;}
+           else return 0;
+        }
+
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width )
 {
     if ( enode->isElement() )
@@ -1444,10 +1480,10 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         int margin_right = lengthToPx( enode->getStyle()->margin[1], width, em ) + DEBUG_TREE_DRAW;
         int margin_top = lengthToPx( enode->getStyle()->margin[2], width, em ) + DEBUG_TREE_DRAW;
         int margin_bottom = lengthToPx( enode->getStyle()->margin[3], width, em ) + DEBUG_TREE_DRAW;
-        int padding_left = lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW;
-        int padding_right = lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW;
-        int padding_top = lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW;
-        int padding_bottom = lengthToPx( enode->getStyle()->padding[3], width, em ) + DEBUG_TREE_DRAW;
+        int padding_left = lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,3);
+        int padding_right = lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,1);
+        int padding_top = lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,0);
+        int padding_bottom = lengthToPx( enode->getStyle()->padding[3], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,2);
 
         //margin_left += 50;
         //margin_right += 50;
@@ -1505,6 +1541,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     // recurse all sub-blocks for blocks
                     int y = padding_top;
                     int cnt = enode->getChildCount();
+                    context.AddLine(0,y,RN_SPLIT_BEFORE);//add line for top border
                     for (int i=0; i<cnt; i++)
                     {
                         ldomNode * child = enode->getChildNode( i );
@@ -1517,6 +1554,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     if ( y < st_y )
                         y = st_y;
                     fmt.setHeight( y + padding_bottom ); //+ margin_top + margin_bottom ); //???
+                    context.AddLine(y,y+padding_bottom,RN_SPLIT_AFTER);//add line for bottom border
                     if ( isFootNoteBody )
                         context.leaveFootNote();
                     return y + margin_top + margin_bottom + padding_bottom; // return block height
@@ -1592,9 +1630,11 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                         line_flags |= break_after << RN_SPLIT_AFTER;
                     else
                         line_flags |= break_inside << RN_SPLIT_AFTER;
-
+                    if (measureBorder(enode,0)>0&&i==0) {line_flags=break_inside<<RN_SPLIT_BEFORE<<RN_SPLIT_AFTER;
+                    context.AddLine(rect.top,rect.top+padding_top,break_before<<RN_SPLIT_BEFORE);}
+                    if (measureBorder(enode,2)>0&&i==count-1) line_flags=break_inside<<RN_SPLIT_BEFORE<<RN_SPLIT_AFTER;
                     context.AddLine(rect.top+line->y+padding_top, rect.top+line->y+line->height+padding_top, line_flags);
-
+                    if (measureBorder(enode,2)>0&&i==count-1) context.AddLine(rect.bottom-padding_bottom,rect.bottom,break_after<<RN_SPLIT_AFTER);
                     // footnote links analysis
                     if ( !isFootNoteBody && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) { // disable footnotes for footnotes
                         for ( int w=0; w<line->word_count; w++ ) {
@@ -1631,6 +1671,445 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
     return 0;
 }
 
+//draw border lines,support color,width,all styles, not support border-collapse
+void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int doc_y,RenderRectAccessor fmt)
+{
+    bool hastopBorder = (enode->getStyle()->border_style_top >=css_border_solid&&enode->getStyle()->border_style_top<=css_border_outset);
+    bool hasrightBorder = (enode->getStyle()->border_style_right >=css_border_solid&&enode->getStyle()->border_style_right<=css_border_outset);
+    bool hasbottomBorder = (enode->getStyle()->border_style_bottom >=css_border_solid&&enode->getStyle()->border_style_bottom<=css_border_outset);
+    bool hasleftBorder = (enode->getStyle()->border_style_left >=css_border_solid&&enode->getStyle()->border_style_left<=css_border_outset);
+
+    if (hasbottomBorder or hasleftBorder or hasrightBorder or hastopBorder) {
+        lUInt32 shadecolor=0x555555;
+        lUInt32 lightcolor=0xAAAAAA;
+        int em = enode->getFont()->getSize();
+        int width = fmt.getWidth();
+        int topBorderwidth = lengthToPx(enode->getStyle()->border_width[0],width,em);
+        topBorderwidth=topBorderwidth!=0?topBorderwidth:2;
+        int rightBorderwidth = lengthToPx(enode->getStyle()->border_width[1],width,em);
+        rightBorderwidth=rightBorderwidth!=0?rightBorderwidth:2;
+        int bottomBorderwidth = lengthToPx(enode->getStyle()->border_width[2],width,em);
+        bottomBorderwidth=bottomBorderwidth!=0?bottomBorderwidth:2;
+        int leftBorderwidth = lengthToPx(enode->getStyle()->border_width[3],width,em);
+        leftBorderwidth=leftBorderwidth!=0?leftBorderwidth:2;
+        int tbw=topBorderwidth,rbw=rightBorderwidth,bbw=bottomBorderwidth,lbw=leftBorderwidth;
+        if (hastopBorder) {
+            int dot=1,interval=0;//default style
+            lUInt32 topBordercolor = enode->getStyle()->border_color[0].value;
+            topBorderwidth=tbw;
+            rightBorderwidth=rbw;
+            bottomBorderwidth=bbw;
+            leftBorderwidth=lbw;
+            if (enode->getStyle()->border_color[0].type==css_val_color)
+            {
+                lUInt32 r,g,b;
+                r=g=b=topBordercolor;
+                r=r>>16;
+                g=g>>8&0xff;
+                b=b&0xff;
+                shadecolor=(r*160/255)<<16|(b*160/255)<<8|b*160/255;
+                lightcolor=topBordercolor;
+            }
+            int left=1,right=1;
+            left=(hasleftBorder)?0:1;
+            right=(hasrightBorder)?0:1;
+            left=(enode->getStyle()->border_style_left==css_border_dotted||enode->getStyle()->border_style_left==css_border_dashed)?0:left;
+            right=(enode->getStyle()->border_style_right==css_border_dotted||enode->getStyle()->border_style_right==css_border_dashed)?0:right;
+            lvPoint leftpoint1=lvPoint(x0+doc_x,y0+doc_y),
+                    leftpoint2=lvPoint(x0+doc_x,y0+doc_y+0.5*topBorderwidth),
+                    leftpoint3=lvPoint(x0+doc_x,doc_y+y0-topBorderwidth),
+                    rightpoint1=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0),
+                    rightpoint2=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+0.5*topBorderwidth),
+                    rightpoint3=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+topBorderwidth);
+            double leftrate=1,rightrate=1;
+            if (left==0) {
+                leftpoint1.x=x0+doc_x;
+                leftpoint1.y=doc_y+y0;
+                leftpoint2.x=x0+doc_x+0.5*leftBorderwidth;
+                leftpoint2.y=doc_y+y0+0.5*topBorderwidth;
+                leftpoint3.x=x0+doc_x+leftBorderwidth;
+                leftpoint3.y=doc_y+y0+topBorderwidth;
+            }else leftBorderwidth=0;
+            leftrate=(double)leftBorderwidth/(double)topBorderwidth;
+            if (right==0) {
+                rightpoint1.x=x0+doc_x+fmt.getWidth();
+                rightpoint1.y=doc_y+y0;
+                rightpoint2.x=x0+doc_x+fmt.getWidth()-0.5*rightBorderwidth;
+                rightpoint2.y=doc_y+y0+0.5*topBorderwidth;
+                rightpoint3.x=x0+doc_x+fmt.getWidth()-rightBorderwidth;
+                rightpoint3.y=doc_y+y0+topBorderwidth;
+            } else rightBorderwidth=0;
+            rightrate=(double)rightBorderwidth/(double)topBorderwidth;
+            switch (enode->getStyle()->border_style_top){
+                case css_border_dotted:
+                    dot=interval=topBorderwidth;
+                    for(int i=0;i<leftpoint3.y-leftpoint1.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, topBordercolor,dot,interval,0);}
+                    break;
+                case css_border_dashed:
+                    dot=3*topBorderwidth;
+                    interval=3*topBorderwidth;
+                    for(int i=0;i<leftpoint3.y-leftpoint1.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, topBordercolor,dot,interval,0);}
+                    break;
+                case css_border_solid:
+                    for(int i=0;i<leftpoint3.y-leftpoint1.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, topBordercolor,dot,interval,0);}
+                    break;
+                case css_border_double:
+                    for(int i=0;i<=(leftpoint2.y-leftpoint1.y)/(leftpoint2.y-leftpoint1.y>2?3:2);i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, topBordercolor);}
+                    for(int i=0;i<=(leftpoint3.y-leftpoint2.y)/(leftpoint3.y-leftpoint2.y>2?3:2);i++)
+                    {drawbuf.FillRect(leftpoint3.x-i*leftrate, leftpoint3.y-i, rightpoint3.x+i*rightrate,
+                                      rightpoint3.y-i+1, topBordercolor);}
+                    break;
+                case css_border_groove:
+                    for(int i=0;i<=leftpoint2.y-leftpoint1.y;i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, shadecolor);}
+                    for(int i=0;i<leftpoint3.y-leftpoint2.y;i++)
+                    {drawbuf.FillRect(leftpoint2.x+i*leftrate, leftpoint2.y+i, rightpoint2.x-i*rightrate,
+                                      rightpoint2.y+i+1, lightcolor);}
+                    break;
+                case css_border_inset:
+                    for(int i=0;i<leftpoint3.y-leftpoint1.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, shadecolor,dot,interval,0);}
+                    break;
+                case css_border_outset:
+                    for(int i=0;i<leftpoint3.y-leftpoint1.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y+i+1, lightcolor,dot,interval,0);}
+                    break;
+                case css_border_ridge:
+                    for(int i=0;i<=leftpoint2.y-leftpoint1.y;i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y+i, rightpoint1.x-i*rightrate,
+                                     rightpoint1.y+i+1, lightcolor);}
+                    for(int i=0;i<leftpoint3.y-leftpoint2.y;i++)
+                    {drawbuf.FillRect(leftpoint2.x+i*leftrate, leftpoint2.y+i, rightpoint2.x-i*rightrate,
+                                      rightpoint2.y+i+1, shadecolor);}
+                    break;
+                default:
+                    break;
+            }
+        }
+        //right
+        if (hasrightBorder) {
+            int dot=1,interval=0;//default style
+            lUInt32 rightBordercolor = enode->getStyle()->border_color[1].value;
+            topBorderwidth=tbw;
+            rightBorderwidth=rbw;
+            bottomBorderwidth=bbw;
+            leftBorderwidth=lbw;
+            if (enode->getStyle()->border_color[1].type==css_val_color)
+            {
+                lUInt32 r,g,b;
+                r=g=b=rightBordercolor;
+                r=r>>16;
+                g=g>>8&0xff;
+                b=b&0xff;
+                shadecolor=(r*160/255)<<16|(b*160/255)<<8|b*160/255;
+                lightcolor=rightBordercolor;
+            }
+            int up=1,down=1;
+            up=(hastopBorder)?0:1;
+            down=(hasbottomBorder)?0:1;
+            up=(enode->getStyle()->border_style_top==css_border_dotted||enode->getStyle()->border_style_top==css_border_dashed)?1:up;
+            down=(enode->getStyle()->border_style_bottom==css_border_dotted||enode->getStyle()->border_style_bottom==css_border_dashed)?1:down;
+            lvPoint toppoint1=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0),
+                    toppoint2=lvPoint(x0+doc_x+fmt.getWidth()-0.5*rightBorderwidth,doc_y+y0),
+                    toppoint3=lvPoint(x0+doc_x+fmt.getWidth()-rightBorderwidth,doc_y+y0),
+                    bottompoint1=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+fmt.getHeight()),
+                    bottompoint2=lvPoint(x0+doc_x+fmt.getWidth()-0.5*rightBorderwidth,doc_y+y0+fmt.getHeight()),
+                    bottompoint3=lvPoint(x0+doc_x+fmt.getWidth()-rightBorderwidth,doc_y+y0+fmt.getHeight());
+            double toprate=1,bottomrate=1;
+            if (up==0) {
+                toppoint3.y=doc_y+y0+topBorderwidth;
+                toppoint2.y=doc_y+y0+0.5*topBorderwidth;
+            } else topBorderwidth=0;
+            toprate=(double)topBorderwidth/(double)rightBorderwidth;
+            if (down==0) {
+                bottompoint3.y=y0+doc_y+fmt.getHeight()-bottomBorderwidth;
+                bottompoint2.y=y0+doc_y+fmt.getHeight()-0.5*bottomBorderwidth;
+            } else bottomBorderwidth=0;
+            bottomrate=(double)bottomBorderwidth/(double)rightBorderwidth;
+            switch (enode->getStyle()->border_style_right){
+                case css_border_dotted:
+                    dot=interval=rightBorderwidth;
+                    for (int i=0;i<toppoint1.x-toppoint3.x;i++){
+                        drawbuf.DrawLine(toppoint1.x-i-1,toppoint1.y+i*toprate,bottompoint1.x-i,
+                                         bottompoint1.y-i*bottomrate, rightBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_dashed:
+                    dot=3*rightBorderwidth;
+                    interval=3*rightBorderwidth;
+                    for (int i=0;i<toppoint1.x-toppoint3.x;i++){
+                        drawbuf.DrawLine(toppoint1.x-i-1,toppoint1.y+i*toprate,bottompoint1.x-i,
+                                         bottompoint1.y-i*bottomrate, rightBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_solid:
+                    for (int i=0;i<toppoint1.x-toppoint3.x;i++){
+                        drawbuf.DrawLine(toppoint1.x-i-1,toppoint1.y+i*toprate,bottompoint1.x-i,
+                                         bottompoint1.y-i*bottomrate+1, rightBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_double:
+                    for (int i=0;i<=(toppoint1.x-toppoint2.x)/(toppoint1.x-toppoint2.x>2?3:2);i++){
+                        drawbuf.FillRect(toppoint1.x-i,toppoint1.y+i*toprate,bottompoint1.x-i+1,
+                                         bottompoint1.y-i*bottomrate+1, rightBordercolor);
+                    }
+                    for (int i=0;i<=(toppoint2.x-toppoint3.x)/(toppoint2.x-toppoint3.x>2?3:2);i++){
+                        drawbuf.FillRect(toppoint3.x+i,toppoint3.y-i*toprate,bottompoint3.x+i+1,
+                                         bottompoint3.y+i*bottomrate+1, rightBordercolor);
+                    }
+                    break;
+                case css_border_groove:
+                    for (int i=0;i<toppoint1.x-toppoint2.x;i++){
+                        drawbuf.FillRect(toppoint1.x-i,toppoint1.y+i*toprate,bottompoint1.x-i+1,
+                                         bottompoint1.y-i*bottomrate+1, lightcolor);
+                    }
+                    for (int i=0;i<=toppoint2.x-toppoint3.x;i++){
+                        drawbuf.FillRect(toppoint2.x-i,toppoint2.y+i*toprate,bottompoint2.x-i+1,
+                                         bottompoint2.y-i*bottomrate+1, shadecolor);
+                    }
+                    break;
+                case css_border_inset:
+                    for (int i=0;i<toppoint1.x-toppoint3.x;i++){
+                        drawbuf.DrawLine(toppoint1.x-i-1,toppoint1.y+i*toprate,bottompoint1.x-i,
+                                         bottompoint1.y-i*bottomrate+1, lightcolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_outset:
+                    for (int i=0;i<toppoint1.x-toppoint3.x;i++){
+                        drawbuf.DrawLine(toppoint1.x-i-1,toppoint1.y+i*toprate,bottompoint1.x-i,
+                                         bottompoint1.y-i*bottomrate+1, shadecolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_ridge:
+                    for (int i=0;i<toppoint1.x-toppoint2.x;i++){
+                        drawbuf.FillRect(toppoint1.x-i,toppoint1.y+i*toprate,bottompoint1.x-i+1,
+                                         bottompoint1.y-i*bottomrate+1, shadecolor);
+                    }
+                    for (int i=0;i<=toppoint2.x-toppoint3.x;i++){
+                        drawbuf.FillRect(toppoint2.x-i,toppoint2.y+i*toprate,bottompoint2.x-i+1,
+                                         bottompoint2.y-i*bottomrate+1,lightcolor);
+                    }
+                    break;
+                default:break;
+            }
+        }
+        //bottom
+        if (hasbottomBorder) {
+            int dot=1,interval=0;//default style
+            lUInt32 bottomBordercolor = enode->getStyle()->border_color[2].value;
+            topBorderwidth=tbw;
+            rightBorderwidth=rbw;
+            bottomBorderwidth=bbw;
+            leftBorderwidth=lbw;
+            if (enode->getStyle()->border_color[2].type==css_val_color)
+            {
+                lUInt32 r,g,b;
+                r=g=b=bottomBordercolor;
+                r=r>>16;
+                g=g>>8&0xff;
+                b=b&0xff;
+                shadecolor=(r*160/255)<<16|(g*160/255)<<8|b*160/255;
+                lightcolor=bottomBordercolor;
+            }
+            int left=1,right=1;
+            left=(hasleftBorder)?0:1;
+            right=(hasrightBorder)?0:1;
+            left=(enode->getStyle()->border_style_left==css_border_dotted||enode->getStyle()->border_style_left==css_border_dashed)?1:left;
+            right=(enode->getStyle()->border_style_right==css_border_dotted||enode->getStyle()->border_style_right==css_border_dashed)?1:right;
+            lvPoint leftpoint1=lvPoint(x0+doc_x,y0+doc_y+fmt.getHeight()),
+                    leftpoint2=lvPoint(x0+doc_x,y0+doc_y-0.5*bottomBorderwidth+fmt.getHeight()),
+                    leftpoint3=lvPoint(x0+doc_x,doc_y+y0+fmt.getHeight()-bottomBorderwidth),
+                    rightpoint1=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+fmt.getHeight()),
+                    rightpoint2=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+fmt.getHeight()-0.5*bottomBorderwidth),
+                    rightpoint3=lvPoint(x0+doc_x+fmt.getWidth(),doc_y+y0+fmt.getHeight()-bottomBorderwidth);
+            double leftrate=1,rightrate=1;
+            if (left==0) {
+                leftpoint3.x=x0+doc_x+leftBorderwidth;
+                leftpoint2.x=x0+doc_x+0.5*leftBorderwidth;
+            }else leftBorderwidth=0;
+            leftrate=(double)leftBorderwidth/(double)bottomBorderwidth;
+            if (right==0) {
+                rightpoint3.x=x0+doc_x+fmt.getWidth()-rightBorderwidth;
+                rightpoint2.x=x0+doc_x+fmt.getWidth()-0.5*rightBorderwidth;
+            } else rightBorderwidth=0;
+            rightrate=(double)rightBorderwidth/(double)bottomBorderwidth;
+            switch (enode->getStyle()->border_style_bottom){
+                case css_border_dotted:
+                    dot=interval=bottomBorderwidth;
+                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
+                    break;
+                case css_border_dashed:
+                    dot=3*bottomBorderwidth;
+                    interval=3*bottomBorderwidth;
+                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
+                    break;
+                case css_border_solid:
+                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, bottomBordercolor,dot,interval,0);}
+                    break;
+                case css_border_double:
+                    for(int i=0;i<=(leftpoint1.y-leftpoint2.y)/(leftpoint1.y-leftpoint2.y>2?3:2);i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate+1,
+                                      rightpoint1.y-i+1, bottomBordercolor);}
+                    for(int i=0;i<=(leftpoint2.y-leftpoint3.y)/(leftpoint2.y-leftpoint3.y>2?3:2);i++)
+                    {drawbuf.FillRect(leftpoint3.x-i*leftrate, leftpoint3.y+i, rightpoint3.x+i*rightrate+1,
+                                      rightpoint3.y+i+1, bottomBordercolor);}
+                    break;
+                case css_border_groove:
+                    for(int i=0;i<=leftpoint1.y-leftpoint2.y;i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate+1,
+                                      rightpoint1.y-i+1, lightcolor);}
+                    for(int i=0;i<leftpoint2.y-leftpoint3.y;i++)
+                    {drawbuf.FillRect(leftpoint2.x+i*leftrate, leftpoint2.y-i, rightpoint2.x-i*rightrate+1,
+                                      rightpoint2.y-i+1, shadecolor);}
+                    break;
+                case css_border_inset:
+                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, lightcolor,dot,interval,0);}
+                    break;
+                case css_border_outset:
+                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, shadecolor,dot,interval,0);}
+                    break;
+                case css_border_ridge:
+                    for(int i=0;i<=leftpoint1.y-leftpoint2.y;i++)
+                    {drawbuf.FillRect(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate,
+                                      rightpoint1.y-i+1, shadecolor);}
+                    for(int i=0;i<leftpoint2.y-leftpoint3.y;i++)
+                    {drawbuf.FillRect(leftpoint2.x+i*leftrate, leftpoint2.y-i, rightpoint2.x-i*rightrate,
+                                      rightpoint2.y-i+1, lightcolor);}
+                    break;
+                default:break;
+            }
+        }
+        //left
+        if (hasleftBorder) {
+            int dot=1,interval=0;//default style
+            lUInt32 leftBordercolor = enode->getStyle()->border_color[3].value;
+            topBorderwidth=tbw;
+            rightBorderwidth=rbw;
+            bottomBorderwidth=bbw;
+            leftBorderwidth=lbw;
+            if (enode->getStyle()->border_color[3].type==css_val_color)
+            {
+                lUInt32 r,g,b;
+                r=g=b=leftBordercolor;
+                r=r>>16;
+                g=g>>8&0xff;
+                b=b&0xff;
+                shadecolor=(r*160/255)<<16|(b*160/255)<<8|b*160/255;
+                lightcolor=leftBordercolor;
+            }
+            int up=1,down=1;
+            up=(hastopBorder)?0:1;
+            down=(hasbottomBorder)?0:1;
+            up=(enode->getStyle()->border_style_top==css_border_dotted||enode->getStyle()->border_style_top==css_border_dashed)?1:up;
+            down=(enode->getStyle()->border_style_bottom==css_border_dotted||enode->getStyle()->border_style_bottom==css_border_dashed)?1:down;
+            lvPoint toppoint1=lvPoint(x0+doc_x,doc_y+y0),
+                    toppoint2=lvPoint(x0+doc_x+0.5*leftBorderwidth,doc_y+y0),
+                    toppoint3=lvPoint(x0+doc_x+leftBorderwidth,doc_y+y0),
+                    bottompoint1=lvPoint(x0+doc_x,doc_y+y0+fmt.getHeight()),
+                    bottompoint2=lvPoint(x0+doc_x+0.5*leftBorderwidth,doc_y+y0+fmt.getHeight()),
+                    bottompoint3=lvPoint(x0+doc_x+leftBorderwidth,doc_y+y0+fmt.getHeight());
+            double toprate=1,bottomrate=1;
+            if (up==0) {
+                toppoint3.y=doc_y+y0+topBorderwidth;
+                toppoint2.y=doc_y+y0+0.5*topBorderwidth;
+            } else topBorderwidth=0;
+            toprate=(double)topBorderwidth/(double)leftBorderwidth;
+            if (down==0) {
+                bottompoint3.y=y0+doc_y+fmt.getHeight()-bottomBorderwidth;
+                bottompoint2.y=y0+doc_y+fmt.getHeight()-0.5*bottomBorderwidth;
+            } else bottomBorderwidth=0;
+            bottomrate=(double)bottomBorderwidth/(double)leftBorderwidth;
+            switch (enode->getStyle()->border_style_left){
+                case css_border_dotted:
+                    dot=interval=leftBorderwidth;
+                    for (int i=0;i<toppoint3.x-toppoint1.x;i++){
+                        drawbuf.DrawLine(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,leftBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_dashed:
+                    dot=3*leftBorderwidth;
+                    interval=3*leftBorderwidth;
+                    for (int i=0;i<toppoint3.x-toppoint1.x;i++){
+                        drawbuf.DrawLine(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,leftBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_solid:
+                    for (int i=0;i<toppoint3.x-toppoint1.x;i++){
+                        drawbuf.DrawLine(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,leftBordercolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_double:
+                    for (int i=0;i<=(toppoint2.x-toppoint1.x)/(toppoint2.x-toppoint1.x>2?3:2);i++){
+                        drawbuf.FillRect(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,leftBordercolor);
+                    }
+                    for (int i=0;i<=(toppoint3.x-toppoint2.x)/(toppoint3.x-toppoint2.x>2?3:2);i++){
+                        drawbuf.FillRect(toppoint3.x-i,toppoint3.y-i*toprate,bottompoint3.x-i+1,
+                                         bottompoint3.y+i*bottomrate,leftBordercolor);
+                    }
+                    break;
+                case css_border_groove:
+                    for (int i=0;i<=toppoint2.x-toppoint1.x;i++){
+                        drawbuf.FillRect(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,shadecolor);
+                    }
+                    for (int i=0;i<toppoint3.x-toppoint2.x;i++){
+                        drawbuf.FillRect(toppoint2.x+i,toppoint2.y+i*toprate,bottompoint2.x+i+1,
+                                         bottompoint2.y-i*bottomrate,lightcolor);
+                    }
+                    break;
+                case css_border_inset:
+                    for (int i=0;i<toppoint3.x-toppoint1.x;i++){
+                        drawbuf.DrawLine(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,shadecolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_outset:
+                    for (int i=0;i<toppoint3.x-toppoint1.x;i++){
+                        drawbuf.DrawLine(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,lightcolor,dot,interval,1);
+                    }
+                    break;
+                case css_border_ridge:
+                    for (int i=0;i<=toppoint2.x-toppoint1.x;i++){
+                        drawbuf.FillRect(toppoint1.x+i,toppoint1.y+i*toprate,bottompoint1.x+i+1,
+                                         bottompoint1.y-i*bottomrate,lightcolor);
+                    }
+                    for (int i=0;i<toppoint3.x-toppoint2.x;i++){
+                        drawbuf.FillRect(toppoint2.x+i,toppoint2.y+i*toprate,bottompoint2.x+i+1,
+                                         bottompoint2.y-i*bottomrate,shadecolor);
+                    }
+                    break;
+                default:break;
+            }
+        }
+    }
+}
+
 void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx, int dy, int doc_x, int doc_y, int page_height, ldomMarkedRangeList * marks,
                    ldomMarkedRangeList *bookmarks)
 {
@@ -1643,9 +2122,9 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         int width = fmt.getWidth();
         int height = fmt.getHeight();
         bool draw_padding_bg = true; //( enode->getRendMethod()==erm_final );
-        int padding_left = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW;
-        int padding_right = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW;
-        int padding_top = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW;
+        int padding_left = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,3);
+        int padding_right = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,1);
+        int padding_top = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,0);
         //int padding_bottom = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[3], width, em ) + DEBUG_TREE_DRAW;
         if ( (doc_y + height <= 0 || doc_y > 0 + dy)
             && (
@@ -1693,11 +2172,11 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 drawbuf.FillRect( doc_x+x0+fmt.getWidth()-1, doc_y+y0, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
                 drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt.getHeight()-1, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
 #endif
-                lUInt32 tableBorderColor = 0xAAAAAA;
+                /*lUInt32 tableBorderColor = 0xAAAAAA;
                 lUInt32 tableBorderColorDark = 0x555555;
                 bool needBorder = enode->getRendMethod()==erm_table || enode->getStyle()->display==css_d_table_cell;
                 if ( needBorder ) {
-                    drawbuf.FillRect( doc_x+x0, doc_y+y0,
+                   drawbuf.FillRect( doc_x+x0, doc_y+y0,
                                       doc_x+x0+fmt.getWidth(), doc_y+y0+1, tableBorderColor );
                     drawbuf.FillRect( doc_x+x0, doc_y+y0,
                                       doc_x+x0+1, doc_y+y0+fmt.getHeight(), tableBorderColor );
@@ -1705,13 +2184,15 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                                       doc_x+x0+fmt.getWidth(),   doc_y+y0+fmt.getHeight(), tableBorderColorDark );
                     drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt.getHeight()-1,
                                       doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), tableBorderColorDark );
-                }
-            }
+                }*/
+                 DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
+            	}
             break;
         case erm_list_item:
         case erm_final:
         case erm_table_caption:
             {
+                DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
                 // draw whole node content as single formatted object
                 LFormattedTextRef txform;
                 enode->renderFinalBlock( txform, &fmt, fmt.getWidth() - padding_left - padding_right );
@@ -1742,7 +2223,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 drawbuf.FillRect( doc_x+x0+fmt.getWidth()-1, doc_y+y0, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
                 drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt.getHeight()-1, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
 #endif
-                lUInt32 tableBorderColor = 0x555555;
+                /*lUInt32 tableBorderColor = 0x555555;
                 lUInt32 tableBorderColorDark = 0xAAAAAA;
                 bool needBorder = enode->getStyle()->display==css_d_table_cell;
                 if ( needBorder ) {
@@ -1758,7 +2239,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     //drawbuf.FillRect( doc_x+x0, doc_y+y0, doc_x+x0+1, doc_y+y0+fmt->getHeight(), tableBorderColorDark );
                     //drawbuf.FillRect( doc_x+x0+fmt->getWidth()-1, doc_y+y0, doc_x+x0+fmt->getWidth(), doc_y+y0+fmt->getHeight(), tableBorderColor );
                     //drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt->getHeight()-1, doc_x+x0+fmt->getWidth(), doc_y+y0+fmt->getHeight(), tableBorderColor );
-                }
+                }*/
             }
             break;
         case erm_invisible:

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -33,6 +33,10 @@ enum css_decl_code {
     cssd_hyphenate3, // adobe-hyphenate
     cssd_hyphenate4, // adobe-text-layout
     cssd_color,
+    cssd_border_top_color,
+    cssd_border_right_color,
+    cssd_border_bottom_color,
+    cssd_border_left_color,
     cssd_background_color,
     cssd_vertical_align,
     cssd_font_family, // id families like serif, sans-serif
@@ -62,6 +66,22 @@ enum css_decl_code {
     cssd_list_style_type,
     cssd_list_style_position,
     cssd_list_style_image,
+    cssd_border_top_style,
+    cssd_border_top_width,
+    cssd_border_right_style,
+    cssd_border_right_width,
+    cssd_border_bottom_style,
+    cssd_border_bottom_width,
+    cssd_border_left_style,
+    cssd_border_left_width,
+    cssd_border_style,
+    cssd_border_width,
+    cssd_border_color,
+    cssd_border,
+    cssd_border_top,
+    cssd_border_right,
+    cssd_border_bottom,
+    cssd_border_left,
     cssd_stop
 };
 
@@ -77,6 +97,10 @@ static const char * css_decl_name[] = {
     "adobe-hyphenate",
     "adobe-text-layout",
     "color",
+    "border-top-color",
+    "border-right-color",
+    "border-bottom-color",
+    "border-left-color",
     "background-color",
     "vertical-align",
     "font-family",
@@ -106,6 +130,22 @@ static const char * css_decl_name[] = {
     "list-style-type",
     "list-style-position",
     "list-style-image",
+    "border-top-style",
+    "border-top-width",
+    "border-right-style",
+    "border-right-width",
+    "border-bottom-style",
+    "border-bottom-width",
+    "border-left-style",
+    "border-left-width",
+    "border-style",
+    "border-width",
+    "border-color",
+    "border",
+    "border-top",
+    "border-right",
+    "border-bottom",
+    "border-left",
     NULL
 };
 
@@ -547,6 +587,19 @@ static const char * css_lsp_names[] =
     "outside",
     NULL
 };
+///border style names
+static const char * css_bst_names[]={
+  "solid",
+  "dotted",
+  "dashed",
+  "double",
+  "groove",
+  "ridge",
+  "inset",
+  "outset",
+  "none",
+  NULL
+};
 
 
 bool LVCssDeclaration::parse( const char * &decl )
@@ -687,6 +740,10 @@ bool LVCssDeclaration::parse( const char * &decl )
             case cssd_padding_left:
             case cssd_padding_right:
             case cssd_padding_top:
+            case cssd_border_bottom_width:
+            case cssd_border_top_width:
+            case cssd_border_left_width:
+            case cssd_border_right_width:
             case cssd_padding_bottom:
                 {
                     css_length_t len;
@@ -699,6 +756,7 @@ bool LVCssDeclaration::parse( const char * &decl )
                 }
                 break;
             case cssd_margin:
+            case cssd_border_width:
             case cssd_padding:
 		{
 		    css_length_t len[4];
@@ -725,6 +783,10 @@ bool LVCssDeclaration::parse( const char * &decl )
 		break;
             case cssd_color:
             case cssd_background_color:
+            case cssd_border_top_color:
+            case cssd_border_right_color:
+            case cssd_border_bottom_color:
+            case cssd_border_left_color:
             {
                 css_length_t len;
                 if ( parse_color_value( decl, len ) )
@@ -734,7 +796,336 @@ bool LVCssDeclaration::parse( const char * &decl )
                     buf[ buf_pos++ ] = len.value;
                 }
             }
-            break;
+                break;
+            case cssd_border_color:
+            {
+                css_length_t len[4];
+                int i;
+                for (i = 0; i < 4; ++i)
+                    if (!parse_color_value( decl, len[i]))
+                        break;
+                if (i)
+                {
+                    switch (i)
+                    {
+                        case 1: len[1] = len[0]; /* fall through */
+                        case 2: len[2] = len[0]; /* fall through */
+                        case 3: len[3] = len[1];
+                    }
+                    buf[ buf_pos++ ] = prop_code;
+                    for (i = 0; i < 4; ++i)
+                    {
+                        buf[ buf_pos++ ] = len[i].type;
+                        buf[ buf_pos++ ] = len[i].value;
+                    }
+                }
+            }
+                break;
+            case cssd_border_top_style:
+            case cssd_border_right_style:
+            case cssd_border_bottom_style:
+            case cssd_border_left_style:
+            {
+                n = parse_name( decl, css_bst_names, -1 );
+                break;
+            }
+            case cssd_border_style: {
+                int n1=-1,n2=-1,n3=-1,n4=-1,sum=0;
+                n1 = parse_name(decl, css_bst_names, -1);
+                skip_spaces(decl);
+                if (n1!=-1) {
+                    sum=1;
+                    n2 = parse_name(decl, css_bst_names, -1);
+                    skip_spaces(decl);
+                    if (n2!=-1) {
+                        sum=2;
+                        n3 = parse_name(decl, css_bst_names, -1);
+                        skip_spaces(decl);
+                        if (n3!=-1) {
+                            sum=3;
+                            n4 = parse_name(decl, css_bst_names, -1);
+                            skip_spaces(decl);
+                            if (n4!=-1) sum=4;
+                        }
+                        }
+                    }
+                switch (sum) {
+                    case 1:
+                    {
+                        buf[buf_pos++] = prop_code;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n1;
+                    }
+                        break;
+                    case 2:
+                    {
+                        buf[buf_pos++] = prop_code;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n2;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n2;
+                    }
+                    break;
+                    case 3:
+                    {
+                        buf[buf_pos++] = prop_code;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n2;
+                        buf[buf_pos++] = n3;
+                        buf[buf_pos++] = n2;
+                    }
+                    break;
+                    case 4:
+                    {
+                        buf[buf_pos++] = prop_code;
+                        buf[buf_pos++] = n1;
+                        buf[buf_pos++] = n2;
+                        buf[buf_pos++] = n3;
+                        buf[buf_pos++] = n4;
+                    }
+                    break;
+                    default:break;
+                }
+            }
+                break;
+            case cssd_border:
+            {
+                css_length_t width,color;
+                int n1=-1,n2=-1,n3=-1;
+                lString8 tmp = lString8(decl);
+                lString16 tmp1=lString16(tmp.c_str());
+                tmp1.trimDoubleSpaces(false,false,true);//remove double spaces
+                tmp=UnicodeToLocal(tmp1.c_str());
+                const char *str1=tmp.c_str();
+                if(!parse_color_value(str1,color))
+                {   str1=tmp.c_str();
+                    if(!parse_number_value(str1,width)) {
+                        str1=tmp.c_str();
+                        n1 = parse_name(str1, css_bst_names, -1);
+                        skip_spaces(str1);
+                        if (n1!=-1){
+                            const char * str2=str1;
+                            const char * str3=str1;
+                            if(!parse_color_value(str2,color)){
+                                str2=str3;
+                                if(parse_number_value(str2,width)) n3=1;
+                                skip_spaces(str2);
+                                if(parse_color_value(str2,color)) n2=1;
+                            }
+                            else {
+                                n2=1;
+                                skip_spaces(str2);
+                                if(parse_number_value(str2,width)) n3=1;
+                            }
+                        }
+                    }
+                    else{
+                        n3=1;
+                        skip_spaces(str1);
+                        const char * str2=str1;
+                        if(!parse_color_value(str2,color)){
+                            str2=str1;
+                            skip_spaces(str2);
+                            n1 = parse_name(str1, css_bst_names, -1);
+                            if(parse_color_value(str2,color)) n2=1;
+                        }
+                        else{
+                            n2=1;
+                            skip_spaces(str2);
+                            n1 = parse_name(str2, css_bst_names, -1);
+                        }
+                    }
+                }
+                else
+                {
+                    n2=1;
+                    skip_spaces(str1);
+                    const char * str2=str1;
+                    if(!parse_number_value(str1,width)) {
+                        str1=str2;
+                        n1 = parse_name(str1, css_bst_names, -1);
+                        skip_spaces(str1);
+                        if(parse_number_value(str1,width)) n3=1;
+                    }
+                    else{
+                        n3=1;
+                        skip_spaces(str1);
+                        n1 = parse_name(str1, css_bst_names, -1);
+                    }
+                }
+
+                if (n1 != -1)
+                {
+                            buf[buf_pos++] = cssd_border_top_style;
+                            buf[buf_pos++] = n1;
+                            buf[buf_pos++] = cssd_border_right_style;
+                            buf[buf_pos++] = n1;
+                            buf[buf_pos++] = cssd_border_bottom_style;
+                            buf[buf_pos++] = n1;
+                            buf[buf_pos++] = cssd_border_left_style;
+                            buf[buf_pos++] = n1;
+                            if (n2 != -1) {
+                                buf[buf_pos++] = cssd_border_color;
+                                for (int i = 0; i < 4; i++) {
+                                    buf[buf_pos++] = color.type;
+                                    buf[buf_pos++] = color.value;
+                                }
+                            }
+                            if (n3 != -1) {
+                                buf[buf_pos++] = cssd_border_width;
+                                for (int i = 0; i < 4; i++) {
+                                    buf[buf_pos++] = width.type;
+                                    buf[buf_pos++] = width.value;
+                                }
+                            }
+                        }
+            }
+                break;
+                case cssd_border_top:
+                case cssd_border_right:
+                case cssd_border_bottom:
+                case cssd_border_left:
+                {
+                    css_length_t width,color;
+                    int n1=-1,n2=-1,n3=-1;
+                    lString8 tmp = lString8(decl);
+                    lString16 tmp1=lString16(tmp.c_str());
+                    tmp1.trimDoubleSpaces(false,false,true);//remove double spaces
+                    tmp=UnicodeToLocal(tmp1.c_str());
+                    const char *str1=tmp.c_str();
+                    if(!parse_color_value(str1,color))
+                    {   str1=tmp.c_str();
+                        if(!parse_number_value(str1,width)) {
+                            str1=tmp.c_str();
+                            n1 = parse_name(str1, css_bst_names, -1);
+                            skip_spaces(str1);
+                            if (n1!=-1){
+                                const char * str2=str1;
+                                const char * str3=str1;
+                                if(!parse_color_value(str2,color)){
+                                    str2=str3;
+                                    if(parse_number_value(str2,width)) n3=1;
+                                    skip_spaces(str2);
+                                    if(parse_color_value(str2,color)) n2=1;
+                                }
+                                else {
+                                    n2=1;
+                                    skip_spaces(str2);
+                                    if(parse_number_value(str2,width)) n3=1;
+                                }
+                            }
+                        }
+                        else{
+                            n3=1;
+                            skip_spaces(str1);
+                            const char * str2=str1;
+                            if(!parse_color_value(str2,color)){
+                                str2=str1;
+                                skip_spaces(str2);
+                                n1 = parse_name(str1, css_bst_names, -1);
+                                if(parse_color_value(str2,color)) n2=1;
+                            }
+                            else{
+                                n2=1;
+                                skip_spaces(str2);
+                                n1 = parse_name(str2, css_bst_names, -1);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        n2=1;
+                        skip_spaces(str1);
+                        const char * str2=str1;
+                        if(!parse_number_value(str1,width)) {
+                            str1=str2;
+                            n1 = parse_name(str1, css_bst_names, -1);
+                            skip_spaces(str1);
+                            if(parse_number_value(str1,width)) n3=1;
+                        }
+                        else{
+                            n3=1;
+                            skip_spaces(str1);
+                            n1 = parse_name(str1, css_bst_names, -1);
+                        }
+                    }
+                    if (n1 != -1) {
+                        switch (prop_code){
+                            case cssd_border_top:
+                                buf[buf_pos++] = cssd_border_top_style;
+                                buf[buf_pos++] = n1;
+                                break;
+                            case cssd_border_right:
+                                buf[buf_pos++] = cssd_border_right_style;
+                                buf[buf_pos++] = n1;
+                                break;
+                            case cssd_border_bottom:
+                                buf[buf_pos++] = cssd_border_bottom_style;
+                                buf[buf_pos++] = n1;
+                                break;
+                            case cssd_border_left:
+                                buf[buf_pos++] = cssd_border_left_style;
+                                buf[buf_pos++] = n1;
+                                break;
+                            default:break;
+                        }
+                        if (n2 != -1) {
+                            switch (prop_code){
+                                case cssd_border_top:
+                                    buf[buf_pos++] = cssd_border_top_color;
+                                    buf[buf_pos++] = color.type;
+                                    buf[buf_pos++] = color.value;
+                                    break;
+                                case cssd_border_right:
+                                    buf[buf_pos++] = cssd_border_right_color;
+                                    buf[buf_pos++] = color.type;
+                                    buf[buf_pos++] = color.value;
+                                    break;
+                                case cssd_border_bottom:
+                                    buf[buf_pos++] = cssd_border_bottom_color;
+                                    buf[buf_pos++] = color.type;
+                                    buf[buf_pos++] = color.value;
+                                    break;
+                                case cssd_border_left:
+                                    buf[buf_pos++] = cssd_border_left_color;
+                                    buf[buf_pos++] = color.type;
+                                    buf[buf_pos++] = color.value;
+                                    break;
+                                default:break;
+                            }
+                            }
+                        }
+                        if (n3 != -1) {
+                            switch (prop_code){
+                                case cssd_border_top:
+                                    buf[buf_pos++] = cssd_border_top_width;
+                                    buf[buf_pos++] = width.type;
+                                    buf[buf_pos++] = width.value;
+                                    break;
+                                case cssd_border_right:
+                                    buf[buf_pos++] = cssd_border_right_width;
+                                    buf[buf_pos++] = width.type;
+                                    buf[buf_pos++] = width.value;
+                                    break;
+                                case cssd_border_bottom:
+                                    buf[buf_pos++] = cssd_border_bottom_width;
+                                    buf[buf_pos++] = width.type;
+                                    buf[buf_pos++] = width.value;
+                                    break;
+                                case cssd_border_left:
+                                    buf[buf_pos++] = cssd_border_left_width;
+                                    buf[buf_pos++] = width.type;
+                                    buf[buf_pos++] = width.value;
+                                    break;
+                                default:break;
+                            }
+                            }
+                        }
+
+
+                    break;
             case cssd_stop:
             case cssd_unknown:
             default:
@@ -917,6 +1308,60 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             style->padding[1] = read_length( p );
             style->padding[3] = read_length( p );
             style->padding[0] = read_length( p );
+            break;
+        case cssd_border_top_color:
+            style->border_color[0]=read_length(p);
+            break;
+        case cssd_border_right_color:
+            style->border_color[1]=read_length(p);
+            break;
+        case cssd_border_bottom_color:
+            style->border_color[2]=read_length(p);
+            break;
+        case cssd_border_left_color:
+            style->border_color[3]=read_length(p);
+            break;
+        case cssd_border_top_width:
+            style->border_width[0]=read_length(p);
+            break;
+        case cssd_border_right_width:
+            style->border_width[1]=read_length(p);
+            break;
+        case cssd_border_bottom_width:
+            style->border_width[2]=read_length(p);
+            break;
+        case cssd_border_left_width:
+            style->border_width[3]=read_length(p);
+            break;
+        case cssd_border_top_style:
+            style->border_style_top=(css_border_style_type_t) *p++;
+            break;
+        case cssd_border_right_style:
+            style->border_style_right=(css_border_style_type_t) *p++;
+            break;
+        case cssd_border_bottom_style:
+            style->border_style_bottom=(css_border_style_type_t) *p++;
+            break;
+        case cssd_border_left_style:
+            style->border_style_left=(css_border_style_type_t) *p++;
+            break;
+        case cssd_border_color:
+            style->border_color[0]=read_length(p);
+            style->border_color[1]=read_length(p);
+            style->border_color[2]=read_length(p);
+            style->border_color[3]=read_length(p);
+            break;
+        case cssd_border_width:
+            style->border_width[0]=read_length(p);
+            style->border_width[1]=read_length(p);
+            style->border_width[2]=read_length(p);
+            style->border_width[3]=read_length(p);
+            break;
+        case cssd_border_style:
+            style->border_style_top=(css_border_style_type_t) *p++;
+            style->border_style_right=(css_border_style_type_t) *p++;
+            style->border_style_bottom=(css_border_style_type_t) *p++;
+            style->border_style_left=(css_border_style_type_t) *p++;
             break;
         case cssd_stop:
             return;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -70,7 +70,19 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.padding[2].pack()) * 31
          + (lUInt32)rec.padding[3].pack()) * 31
          + (lUInt32)rec.font_family) * 31
-         + (lUInt32)rec.font_name.getHash());
+         + (lUInt32)rec.font_name.getHash())
+         +(lUInt32)rec.border_style_top * 31
+         +(lUInt32)rec.border_style_right * 31
+         +(lUInt32)rec.border_style_bottom * 31
+         +(lUInt32)rec.border_style_left * 31
+         +(lUInt32)rec.border_width[0].pack() * 31
+         +(lUInt32)rec.border_width[1].pack() * 31
+         +(lUInt32)rec.border_width[2].pack() * 31
+         +(lUInt32)rec.border_width[3].pack() * 31
+         +(lUInt32)rec.border_color[0].pack() * 31
+         +(lUInt32)rec.border_color[1].pack() * 31
+         +(lUInt32)rec.border_color[2].pack() * 31
+         +(lUInt32)rec.border_color[3].pack() * 31;
     return rec.hash;
 }
 
@@ -105,7 +117,19 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_style == r2.font_style &&
            r1.font_weight == r2.font_weight &&
            r1.font_name == r2.font_name &&
-           r1.font_family == r2.font_family;
+           r1.font_family == r2.font_family&&
+           r1.border_style_top==r2.border_style_top&&
+           r1.border_style_right==r2.border_style_right&&
+           r1.border_style_bottom==r2.border_style_bottom&&
+           r1.border_style_left==r2.border_style_left&&
+           r1.border_width[0]==r2.border_width[0]&&
+           r1.border_width[1]==r2.border_width[1]&&
+           r1.border_width[2]==r2.border_width[2]&&
+           r1.border_width[3]==r2.border_width[3]&&
+           r1.border_color[0]==r2.border_color[0]&&
+           r1.border_color[1]==r2.border_color[1]&&
+           r1.border_color[2]==r2.border_color[2]&&
+           r1.border_color[3]==r2.border_color[3];
 }
 
 
@@ -268,6 +292,12 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(hyphenate);         //    css_hyphenate_t      hyphenate;
     ST_PUT_ENUM(list_style_type);   //    css_list_style_type_t list_style_type;
     ST_PUT_ENUM(list_style_position);//    css_list_style_position_t list_style_position;
+    ST_PUT_ENUM(border_style_top);
+    ST_PUT_ENUM(border_style_right);
+    ST_PUT_ENUM(border_style_bottom);
+    ST_PUT_ENUM(border_style_left);
+    ST_PUT_LEN4(border_width);
+    ST_PUT_LEN4(border_color);
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -304,6 +334,12 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_hyphenate_t, hyphenate);                //    css_hyphenate_t        hyphenate;
     ST_GET_ENUM(css_list_style_type_t, list_style_type);    //    css_list_style_type_t list_style_type;
     ST_GET_ENUM(css_list_style_position_t, list_style_position);//    css_list_style_position_t list_style_position;
+    ST_GET_ENUM(css_border_style_type_t ,border_style_top);
+    ST_GET_ENUM(css_border_style_type_t ,border_style_right);
+    ST_GET_ENUM(css_border_style_type_t ,border_style_bottom);
+    ST_GET_ENUM(css_border_style_type_t ,border_style_left);
+    ST_GET_LEN4(border_width);
+    ST_GET_LEN4(border_color);
     lUInt32 hash = 0;
     buf >> hash;
     lUInt32 newhash = calcHash(*this);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4878,8 +4878,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
     lvRect rc;
     finalNode->getAbsRect( rc );
     //CRLog::debug("ldomDocument::createXPointer point = (%d, %d), finalNode %08X rect = (%d,%d,%d,%d)", pt.x, pt.y, (lUInt32)finalNode, rc.left, rc.top, rc.right, rc.bottom );
-    pt.x -= rc.left;
-    pt.y -= rc.top;
+    pt.x -= rc.left+measureBorder(finalNode,3);//
+    pt.y -= rc.top+measureBorder(finalNode,0);//add offset for borders
     //if ( !r )
     //    return ptr;
     if ( finalNode->getRendMethod() != erm_final && finalNode->getRendMethod() !=  erm_list_item) {


### PR DESCRIPTION
support all CSS Border Properties, fully working for block and
paragraph. partially working for tables as they are rendered in different
ways. I may work on tables in the future.
border	Sets all the border properties in one declaration
border-bottom	Sets all the bottom border properties in one declaration
border-bottom-color	Sets the color of the bottom border
border-bottom-style	Sets the style of the bottom border
border-bottom-width	Sets the width of the bottom border
border-color	Sets the color of the four borders
border-left	Sets all the left border properties in one declaration
border-left-color	Sets the color of the left border
border-left-style	Sets the style of the left border
border-left-width	Sets the width of the left border
border-right	Sets all the right border properties in one declaration
border-right-color	Sets the color of the right border
border-right-style	Sets the style of the right border
border-right-width	Sets the width of the right border
border-style	Sets the style of the four borders
border-top	Sets all the top border properties in one declaration
border-top-color	Sets the color of the top border
border-top-style	Sets the style of the top border
border-top-width	Sets the width of the top border
border-width	Sets the width of the four borders
![screenshot_2015-aug-20_001135](https://cloud.githubusercontent.com/assets/8104251/9359604/1d364982-46d1-11e5-9640-546f833f13e6.png)