### PR TITLE
fix

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1434,8 +1434,8 @@ int measureBorder(ldomNode *enode,int border) {
                 bool hasrightBorder = (enode->getStyle()->border_style_right >= css_border_solid &&
                                        enode->getStyle()->border_style_right <= css_border_outset);
                 int rightBorderwidth = lengthToPx(enode->getStyle()->border_width[1], width, em);
-                rightBorderwidth = hasrightBorder?rightBorderwidth:0;
                 rightBorderwidth = rightBorderwidth != 0 ? rightBorderwidth : 2;
+                rightBorderwidth = hasrightBorder?rightBorderwidth:0;
                 return rightBorderwidth;}
             else if (border ==2){
                 bool hasbottomBorder = (enode->getStyle()->border_style_bottom >= css_border_solid &&

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4893,7 +4893,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
     LFormattedTextRef txtform;
     {
         RenderRectAccessor r( finalNode );
-        finalNode->renderFinalBlock( txtform, &r, r.getWidth() );
+        finalNode->renderFinalBlock( txtform, &r, r.getWidth() -measureBorder(finalNode,1)-measureBorder(finalNode,3));
     }
     int lcount = txtform->GetLineCount();
     for ( int l = 0; l<lcount; l++ ) {
@@ -4998,7 +4998,7 @@ bool ldomXPointer::getRect(lvRect & rect) const
         //if ( !r )
         //    return false;
         LFormattedTextRef txtform;
-        finalNode->renderFinalBlock( txtform, &r, r.getWidth() );
+        finalNode->renderFinalBlock( txtform, &r, r.getWidth()-measureBorder(finalNode,1)-measureBorder(finalNode,3));
 
         ldomNode * node = getNode();
         int offset = getOffset();
@@ -11184,7 +11184,7 @@ bool ldomNode::refreshFinalBlock()
     fmt.getRect( oldRect );
     LFormattedTextRef txtform;
     int width = fmt.getWidth();
-    renderFinalBlock( txtform, &fmt, width );
+    renderFinalBlock( txtform, &fmt, width-measureBorder(this,1)-measureBorder(this,3));
     fmt.getRect( newRect );
     if ( oldRect == newRect )
         return false;


### PR DESCRIPTION
fix txt format changes when it was opened before. ( crengine will get
rendered height and width from cache if it was opened before )
This problem is not so obvious when the border width is small.  I set
the width to 50 px and the text had been wrongly placed when opened with
cache existed.