### PR TITLE
fix crash when updating style sheet(from upstream)

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -212,7 +212,7 @@ public:
     }
 
     /// remove all rules from stylesheet
-    void clear() { _selectors.clear(); }
+    void clear() { _selectors.clear(); _stack.clear();}
     /// set document to retrieve ID values from
     void setDocument( lxmlDocBase * doc ) { _doc = doc; }
     /// constructor


### PR DESCRIPTION
tested on a few books used to crash koreader when switch embedded style on and off