### PR TITLE
add support for background-image and one fix

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -185,6 +185,38 @@ enum css_border_style_type_t {
     css_border_outset,
     css_border_none
 };
+/// css background property values
+enum css_background_repeat_value_t {
+    css_background_repeat,
+    css_background_repeat_x,
+    css_background_repeat_y,
+    css_background_no_repeat,
+    css_background_r_initial,
+    css_background_r_inherit,
+    css_background_r_none
+};
+enum css_background_attachment_value_t {
+    css_background_scroll,
+    css_background_fixed,
+    css_background_local,
+    css_background_a_initial,
+    css_background_a_inherit,
+    css_background_a_none
+};
+enum css_background_position_value_t {
+    css_background_left_top,
+    css_background_left_center,
+    css_background_left_bottom,
+    css_background_right_top,
+    css_background_right_center,
+    css_background_right_bottom,
+    css_background_center_top,
+    css_background_center_center,
+    css_background_center_bottom,
+    css_background_p_initial,
+    css_background_p_inherit,
+    css_background_p_none
+};
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -178,6 +178,8 @@ public:
     virtual void DrawRotated( LVImageSourceRef img, int x, int y, int width, int height, int rotationAngle) { Draw(img, x, y, width, height); CR_UNUSED(rotationAngle); }
     /// draws buffer content to another buffer doing color conversion if necessary
     virtual void DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 * palette ) = 0;
+    // draws buffer on top of another buffer to implement background
+    virtual void DrawOnTop( LVDrawBuf * buf, int x, int y) = 0;
     /// draws rescaled buffer content to another buffer doing color conversion if necessary
     virtual void DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, int options) = 0;
     /// draws rescaled buffer content to another buffer doing color conversion if necessary
@@ -338,6 +340,8 @@ public:
     virtual lUInt32 GetBlackColor();
     /// draws buffer content to another buffer doing color conversion if necessary
     virtual void DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 * palette );
+    // draws buffer on top of another buffer to implement background
+    virtual void DrawOnTop( LVDrawBuf * buf, int x, int y);
     /// draws rescaled buffer content to another buffer doing color conversion if necessary
     virtual void DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, int options);
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(QT_GL)
@@ -407,6 +411,8 @@ public:
     virtual lUInt32 GetBlackColor();
     /// draws buffer content to another buffer doing color conversion if necessary
     virtual void DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 * palette );
+    // draws buffer on top of another buffer to implement background
+    virtual void DrawOnTop( LVDrawBuf * buf, int x, int y);
     /// draws rescaled buffer content to another buffer doing color conversion if necessary
     virtual void DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, int options);
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(QT_GL)

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -51,3 +51,4 @@ int LVRendGetFontEmbolden();
 
 #endif
 int measureBorder(ldomNode *enode,int border);
+int lengthToPx( css_length_t val, int base_px, int base_em );

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -60,6 +60,10 @@ typedef struct css_style_rec_tag {
     css_border_style_type_t border_style_left;
     css_length_t border_width[4];
     css_length_t border_color[4];
+    lString8 background_image;
+    css_background_repeat_value_t background_repeat;
+    css_background_attachment_value_t background_attachment;
+    css_background_position_value_t background_position;
     css_style_rec_tag()
     : refCount(0)
     , hash(0)
@@ -90,6 +94,9 @@ typedef struct css_style_rec_tag {
     , border_style_bottom(css_border_none)
     , border_style_right(css_border_none)
     , border_style_left(css_border_none)
+    , background_repeat(css_background_r_none)
+    , background_attachment(css_background_a_none)
+    , background_position(css_background_p_none)
     {
     }
     void AddRef() { refCount++; }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -2054,6 +2054,236 @@ void LVGrayDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 
 }
 
 /// draws buffer content to another buffer doing color conversion if necessary
+void LVGrayDrawBuf::DrawOnTop( LVDrawBuf * buf, int x, int y )
+{
+
+    lvRect clip;
+    buf->GetClipRect(&clip);
+
+    if ( !(!clip.isEmpty() || buf->GetBitsPerPixel()!=GetBitsPerPixel() || GetWidth()!=buf->GetWidth() || GetHeight()!=buf->GetHeight()) ) {
+        // simple copy
+        memcpy( buf->GetScanLine(0), GetScanLine(0), GetHeight() * GetRowSize() );
+        return;
+    }
+    int bpp = GetBitsPerPixel();
+    if (buf->GetBitsPerPixel() == 32) {
+        // support for 32bpp to Gray drawing
+        for (int yy=0; yy<_dy; yy++)
+        {
+            if (y+yy >= clip.top && y+yy < clip.bottom)
+            {
+                lUInt8 * src = (lUInt8 *)GetScanLine(yy);
+                lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y+yy)) + x;
+                if (bpp==1)
+                {
+                    int shift = x & 7;
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt8 cl = (*src << shift) & 0x80;
+                            if(src!=0) *dst = cl ? 0xFFFFFF : 0x000000;
+                        }
+                        dst++;
+                        if (++shift >= 8) {
+                            shift = 0;
+                            src++;
+                        }
+
+                    }
+                }
+                else if (bpp==2)
+                {
+                    int shift = x & 3;
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt32 cl = (*src << (shift<<1)) & 0xC0;
+                            cl = cl | (cl >> 2) | (cl>>4) | (cl>>6);
+                            if(src!=0) *dst = cl | (cl << 8) | (cl << 16);
+                        }
+                        dst++;
+                        if (++shift >= 4) {
+                            shift = 0;
+                            src++;
+                        }
+
+                    }
+                }
+                else
+                {
+                    // byte per pixel
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt32 cl = *src;
+                            if (bpp == 3) {
+                                cl &= 0xE0;
+                                cl = cl | (cl>>3) | (cl>>6);
+                            } else if (bpp == 4) {
+                                cl &= 0xF0;
+                                cl = cl | (cl>>4);
+                            }
+                            if(src!=0) *dst = cl | (cl << 8) | (cl << 16);
+                        }
+                        dst++;
+                        src++;
+                    }
+                }
+            }
+        }
+        return;
+    }
+    if (buf->GetBitsPerPixel() == 16) {
+        // support for 32bpp to Gray drawing
+        for (int yy=0; yy<_dy; yy++)
+        {
+            if (y+yy >= clip.top && y+yy < clip.bottom)
+            {
+                lUInt8 * src = (lUInt8 *)GetScanLine(yy);
+                lUInt16 * dst = ((lUInt16 *)buf->GetScanLine(y+yy)) + x;
+                if (bpp==1)
+                {
+                    int shift = x & 7;
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt8 cl = (*src << shift) & 0x80;
+                            if(*src!=0) *dst = cl ? 0xFFFF : 0x0000;
+                        }
+                        dst++;
+                        if (++shift >= 8) {
+                            shift = 0;
+                            src++;
+                        }
+
+                    }
+                }
+                else if (bpp==2)
+                {
+                    int shift = x & 3;
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt16 cl = (*src << (shift<<1)) & 0xC0;
+                            cl = cl | (cl >> 2) | (cl>>4) | (cl>>6);
+                            if(*src!=0) *dst = rgb565(cl, cl, cl);
+                        }
+                        dst++;
+                        if (++shift >= 4) {
+                            shift = 0;
+                            src++;
+                        }
+
+                    }
+                }
+                else
+                {
+                    // byte per pixel
+                    for (int xx=0; xx<_dx; xx++)
+                    {
+                        if ( x+xx >= clip.left && x+xx < clip.right )
+                        {
+                            lUInt16 cl = *src;
+                            if (bpp == 3) {
+                                cl &= 0xE0;
+                                cl = cl | (cl>>3) | (cl>>6);
+                            } else if (bpp == 4) {
+                                cl &= 0xF0;
+                                cl = cl | (cl>>4);
+                            }
+                            if(*src!=0) *dst = rgb565(cl, cl, cl);
+                        }
+                        dst++;
+                        src++;
+                    }
+                }
+            }
+        }
+        return;
+    }
+    if (buf->GetBitsPerPixel() != bpp)
+        return; // not supported yet
+    for (int yy=0; yy<_dy; yy++)
+    {
+        if (y+yy >= clip.top && y+yy < clip.bottom)
+        {
+            lUInt8 * src = (lUInt8 *)GetScanLine(yy);
+            if (bpp==1)
+            {
+                int shift = x & 7;
+                lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>3);
+                for (int xx=0; xx<_dx; xx+=8)
+                {
+                    if ( x+xx >= clip.left && x+xx < clip.right )
+                    {
+                        //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+                        lUInt16 cl = (*src << 8)>>shift;
+                        lUInt16 mask = (0xFF00)>>shift;
+                        lUInt8 c = *dst;
+                        c &= ~(mask>>8);
+                        c |= (cl>>8);
+                        if(*src!=0) *dst = c;
+                        if (mask & 0xFF) {
+                            c = *(dst+1);
+                            c &= ~(mask&0xFF);
+                            c |= (cl&0xFF);
+                            if(*src!=0) *(dst+1) = c;
+                        }
+                    }
+                    dst++;
+                    src++;
+                }
+            }
+            else if (bpp==2)
+            {
+                int shift = (x & 3) * 2;
+                lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>2);
+                for (int xx=0; xx<_dx; xx+=4)
+                {
+                    if ( x+xx >= clip.left && x+xx < clip.right )
+                    {
+                        //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+                        lUInt16 cl = (*src << 8)>>shift;
+                        lUInt16 mask = (0xFF00)>>shift;
+                        lUInt8 c = *dst;
+                        c &= ~(mask>>8);
+                        c |= (cl>>8);
+                        if(*src!=0) *dst = c;
+                        if (mask & 0xFF) {
+                            c = *(dst+1);
+                            c &= ~(mask&0xFF);
+                            c |= (cl&0xFF);
+                            if(*src!=0) *(dst+1) = c;
+                        }
+                    }
+                    dst++;
+                    src++;
+                }
+            }
+            else
+            {
+                lUInt8 * dst = buf->GetScanLine(y+yy) + x;
+                for (int xx=0; xx<_dx; xx++)
+                {
+                    if ( x+xx >= clip.left && x+xx < clip.right )
+                    {
+                        if(*src!=0) *dst = *src;
+                    }
+                    dst++;
+                    src++;
+                }
+            }
+        }
+    }
+    CHECK_GUARD_BYTE;
+}
+
+/// draws buffer content to another buffer doing color conversion if necessary
 void LVColorDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 * palette )
 {
     CR_UNUSED(options);
@@ -2189,7 +2419,140 @@ void LVColorDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32
         }
     }
 }
-
+/// draws buffer content on top of another buffer doing color conversion if necessary
+void LVColorDrawBuf::DrawOnTop( LVDrawBuf * buf, int x, int y)
+{
+    //
+    lvRect clip;
+    buf->GetClipRect(&clip);
+    int bpp = buf->GetBitsPerPixel();
+    for (int yy=0; yy<_dy; yy++) {
+        if (y+yy >= clip.top && y+yy < clip.bottom) {
+            if ( _bpp==16 ) {
+                lUInt16 * src = (lUInt16 *)GetScanLine(yy);
+                if (bpp == 1) {
+                    int shift = x & 7;
+                    lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>3);
+                    for (int xx=0; xx<_dx; xx++) {
+                        if (x + xx >= clip.left && x + xx < clip.right) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+#if (GRAY_INVERSE==1)
+                            lUInt8 cl = (((lUInt8)(*src)&0x8000)^0x8000) >> (shift+8);
+    #else
+                            lUInt8 cl = (((lUInt8)(*src)&0x8000)) >> (shift+8);
+#endif
+                            if(cl!=0) *dst |= cl;
+                        }
+                        if (!((shift = (shift + 1) & 7)))
+                            dst++;
+                        src++;
+                    }
+                } else if (bpp == 2) {
+                    int shift = x & 3;
+                    lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>2);
+                    for (int xx=0; xx < _dx; xx++) {
+                        if ( x+xx >= clip.left && x+xx < clip.right ) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+#if (GRAY_INVERSE==1)
+                            lUInt8 cl = (((lUInt8)(*src)&0xC000)^0xC000) >> ((shift<<1) + 8);
+    #else
+                            lUInt8 cl = (((lUInt8)(*src)&0xC000)) >> ((shift<<1) + 8);
+#endif
+                            if(cl!=0) *dst |= cl;
+                        }
+                        if (!((shift = ((shift + 1) & 3))))
+                            dst++;
+                        src++;
+                    }
+                } else if (bpp<=8) {
+                    lUInt8 * dst = buf->GetScanLine(y+yy) + x;
+                    for (int xx=0; xx<_dx; xx++) {
+                        if ( x+xx >= clip.left && x+xx < clip.right ) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+                            if(src!=0) *dst = (lUInt8)(*src >> 8);
+                        }
+                        dst++;
+                        src++;
+                    }
+                } else if (bpp == 16) {
+                    lUInt16 * dst = ((lUInt16 *)buf->GetScanLine(y + yy)) + x;
+                    for (int xx=0; xx < _dx; xx++) {
+                        if (x + xx >= clip.left && x + xx < clip.right) {
+                            if(src!=0) *dst = *src;
+                        }
+                        dst++;
+                        src++;
+                    }
+                } else if (bpp == 32) {
+                    lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y + yy)) + x;
+                    for (int xx=0; xx<_dx; xx++) {
+                        if ( x+xx >= clip.left && x+xx < clip.right ) {
+                            if(src!=0) *dst = rgb565to888( *src );
+                        }
+                        dst++;
+                        src++;
+                    }
+                }
+            } else {
+                lUInt32 * src = (lUInt32 *)GetScanLine(yy);
+                if (bpp==1) {
+                    int shift = x & 7;
+                    lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>3);
+                    for (int xx=0; xx<_dx; xx++) {
+                        if ( x+xx >= clip.left && x+xx < clip.right ) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+#if (GRAY_INVERSE==1)
+                            lUInt8 cl = (((lUInt8)(*src)&0x80)^0x80) >> (shift);
+    #else
+                            lUInt8 cl = (((lUInt8)(*src)&0x80)) >> (shift);
+#endif
+                            if(*src!=0) *dst |= cl;
+                        }
+                        if (!((shift = (shift + 1) & 7)))
+                            dst++;
+                        src++;
+                    }
+                } else if (bpp==2) {
+                    int shift = x & 3;
+                    lUInt8 * dst = buf->GetScanLine(y+yy) + (x>>2);
+                    for (int xx=0; xx<_dx; xx++) {
+                        if ( x+xx >= clip.left && x+xx < clip.right ) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+#if (GRAY_INVERSE==1)
+                            lUInt8 cl = (((lUInt8)(*src)&0xC0)^0xC0) >> (shift<<1);
+    #else
+                            lUInt8 cl = (((lUInt8)(*src)&0xC0)) >> (shift<<1);
+#endif
+                            if(*src!=0) *dst |= cl;
+                        }
+                        if (!((shift = (shift + 1) & 3)))
+                            dst++;
+                        src++;
+                    }
+                } else if (bpp<=8) {
+                    lUInt8 * dst = buf->GetScanLine(y + yy) + x;
+                    for (int xx=0; xx<_dx; xx++) {
+                        if (x + xx >= clip.left && x + xx < clip.right) {
+                            //lUInt8 mask = ~((lUInt8)0xC0>>shift);
+                            if(*src!=0) *dst = (lUInt8)*src;
+                        }
+                        dst++;
+                        src++;
+                    }
+                } else if (bpp == 32) {
+                    lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y + yy)) + x;
+                    for (int xx = 0; xx < _dx; xx++) {
+                        if (x+xx >= clip.left && x + xx < clip.right) {
+                            if(*src!=0) *dst = *src;
+                        }
+                        dst++;
+                        src++;
+                    }
+                }
+            }
+        }
+    }
+}
 /// draws rescaled buffer content to another buffer doing color conversion if necessary
 void LVGrayDrawBuf::DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, int options)
 {

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -40,7 +40,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((lUInt32)rec.display * 31
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((lUInt32)rec.display * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
          + (lUInt32)rec.text_align_last) * 31
@@ -69,20 +69,24 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.padding[1].pack()) * 31
          + (lUInt32)rec.padding[2].pack()) * 31
          + (lUInt32)rec.padding[3].pack()) * 31
+         + (lUInt32)rec.border_style_top) * 31
+         + (lUInt32)rec.border_style_right) * 31
+         + (lUInt32)rec.border_style_bottom) * 31
+         + (lUInt32)rec.border_style_left) * 31
+         + (lUInt32)rec.border_width[0].pack()) * 31
+         + (lUInt32)rec.border_width[1].pack()) * 31
+         + (lUInt32)rec.border_width[2].pack()) * 31
+         + (lUInt32)rec.border_width[3].pack()) * 31
+         + (lUInt32)rec.border_color[0].pack()) * 31
+         + (lUInt32)rec.border_color[1].pack()) * 31
+         + (lUInt32)rec.border_color[2].pack()) * 31
+         + (lUInt32)rec.border_color[3].pack()) * 31
+         + (lUInt32)rec.background_repeat)*31
+         + (lUInt32)rec.background_attachment)*31
+         + (lUInt32)rec.background_position)*31
          + (lUInt32)rec.font_family) * 31
-         + (lUInt32)rec.font_name.getHash())
-         +(lUInt32)rec.border_style_top * 31
-         +(lUInt32)rec.border_style_right * 31
-         +(lUInt32)rec.border_style_bottom * 31
-         +(lUInt32)rec.border_style_left * 31
-         +(lUInt32)rec.border_width[0].pack() * 31
-         +(lUInt32)rec.border_width[1].pack() * 31
-         +(lUInt32)rec.border_width[2].pack() * 31
-         +(lUInt32)rec.border_width[3].pack() * 31
-         +(lUInt32)rec.border_color[0].pack() * 31
-         +(lUInt32)rec.border_color[1].pack() * 31
-         +(lUInt32)rec.border_color[2].pack() * 31
-         +(lUInt32)rec.border_color[3].pack() * 31;
+         + (lUInt32)rec.font_name.getHash()
+         + (lUInt32)rec.background_image.getHash());
     return rec.hash;
 }
 
@@ -129,7 +133,11 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.border_color[0]==r2.border_color[0]&&
            r1.border_color[1]==r2.border_color[1]&&
            r1.border_color[2]==r2.border_color[2]&&
-           r1.border_color[3]==r2.border_color[3];
+           r1.border_color[3]==r2.border_color[3]&&
+           r1.background_image==r2.background_image&&
+           r1.background_repeat==r2.background_repeat&&
+           r1.background_attachment==r2.background_attachment&&
+           r1.background_position==r2.background_position;
 }
 
 
@@ -298,6 +306,10 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(border_style_left);
     ST_PUT_LEN4(border_width);
     ST_PUT_LEN4(border_color);
+    buf<<background_image;
+    ST_PUT_ENUM(background_repeat);
+    ST_PUT_ENUM(background_attachment);
+    ST_PUT_ENUM(background_position);
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -340,6 +352,10 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_border_style_type_t ,border_style_left);
     ST_GET_LEN4(border_width);
     ST_GET_LEN4(border_color);
+    buf>>background_image;
+    ST_GET_ENUM(css_background_repeat_value_t ,background_repeat);
+    ST_GET_ENUM(css_background_attachment_value_t ,background_attachment);
+    ST_GET_ENUM(css_background_position_value_t ,background_position);
     lUInt32 hash = 0;
     buf >> hash;
     lUInt32 newhash = calcHash(*this);

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1127,9 +1127,9 @@ public:
                 if ( wrapPos<0 )
                     wrapPos = i-1;
                 if ( wrapPos<=upSkipPos ) {
-                    CRLog::trace("guard old wrapPos at %d", wrapPos);
+                    //CRLog::trace("guard old wrapPos at %d", wrapPos);
                     wrapPos = upSkipPos+1;
-                    CRLog::trace("guard new wrapPos at %d", wrapPos);
+                    //CRLog::trace("guard new wrapPos at %d", wrapPos);
                     upSkipPos = -1;
                 }
             }
@@ -1138,29 +1138,29 @@ public:
             int downSkipCount = 0;
             int upSkipCount = 0;
             if (endp > 1 && isCJKLeftPunctuation(*(m_text + endp))) {
-                CRLog::trace("skip skip punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
+                //CRLog::trace("skip skip punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
             } else if (endp > 1 && endp < m_length - 1 && isCJKLeftPunctuation(*(m_text + endp - 1))) {
                 upSkipPos = endp;
                 endp--; wrapPos--;
-                CRLog::trace("up skip left punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
+                //CRLog::trace("up skip left punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
             } else if (endp > 1 && isCJKPunctuation(*(m_text + endp))) {
                 for (int epos = endp; epos<m_length; epos++, downSkipCount++) {
                    if ( !isCJKPunctuation(*(m_text + epos)) ) break;
-                   CRLog::trace("down skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
+                   //CRLog::trace("down skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
                 }
                 for (int epos = endp; epos>=start; epos--, upSkipCount++) {
                    if ( !isCJKPunctuation(*(m_text + epos)) ) break;
-                   CRLog::trace("up skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
+                   //CRLog::trace("up skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
 				}
                 if (downSkipCount <= upSkipCount && downSkipCount <= 2 && visualAlignmentEnabled) {
                    endp += downSkipCount;
                    wrapPos += downSkipCount;
-                   CRLog::trace("finally down skip punctuations %d", downSkipCount);
+                   //CRLog::trace("finally down skip punctuations %d", downSkipCount);
                 } else if (upSkipCount <= 2) {
                    upSkipPos = endp;
                    endp -= upSkipCount;
                    wrapPos -= upSkipCount;
-                   CRLog::trace("finally up skip punctuations %d", upSkipCount);
+                   //CRLog::trace("finally up skip punctuations %d", upSkipCount);
                 }
             }
             int lastnonspace = endp-1;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4882,8 +4882,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
     lvRect rc;
     finalNode->getAbsRect( rc );
     //CRLog::debug("ldomDocument::createXPointer point = (%d, %d), finalNode %08X rect = (%d,%d,%d,%d)", pt.x, pt.y, (lUInt32)finalNode, rc.left, rc.top, rc.right, rc.bottom );
-    pt.x -= rc.left+measureBorder(finalNode,3);//
-    pt.y -= rc.top+measureBorder(finalNode,0);//add offset for borders
+    pt.x -= rc.left+measureBorder(finalNode,3)+lengthToPx(finalNode->getStyle()->padding[0],rc.width(),finalNode->getFont()->getSize());//
+    pt.y -= rc.top+measureBorder(finalNode,0)+lengthToPx(finalNode->getStyle()->padding[2],rc.height(),finalNode->getFont()->getSize());//add offset for borders,paddings
     //if ( !r )
     //    return ptr;
     if ( finalNode->getRendMethod() != erm_final && finalNode->getRendMethod() !=  erm_list_item) {
@@ -4897,7 +4897,9 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
     LFormattedTextRef txtform;
     {
         RenderRectAccessor r( finalNode );
-        finalNode->renderFinalBlock( txtform, &r, r.getWidth() -measureBorder(finalNode,1)-measureBorder(finalNode,3));
+        finalNode->renderFinalBlock( txtform, &r, r.getWidth() -measureBorder(finalNode,1)-measureBorder(finalNode,3)
+        -lengthToPx(finalNode->getStyle()->padding[0],rc.width(),finalNode->getFont()->getSize())
+        -lengthToPx(finalNode->getStyle()->padding[1],rc.width(),finalNode->getFont()->getSize()));
     }
     int lcount = txtform->GetLineCount();
     for ( int l = 0; l<lcount; l++ ) {
@@ -5002,7 +5004,9 @@ bool ldomXPointer::getRect(lvRect & rect) const
         //if ( !r )
         //    return false;
         LFormattedTextRef txtform;
-        finalNode->renderFinalBlock( txtform, &r, r.getWidth()-measureBorder(finalNode,1)-measureBorder(finalNode,3));
+        finalNode->renderFinalBlock( txtform, &r, r.getWidth()-measureBorder(finalNode,1) -measureBorder(finalNode,3)
+                                                  -lengthToPx(finalNode->getStyle()->padding[0],rc.width(),finalNode->getFont()->getSize())
+                                                  -lengthToPx(finalNode->getStyle()->padding[1],rc.width(),finalNode->getFont()->getSize()));
 
         ldomNode * node = getNode();
         int offset = getOffset();
@@ -11188,7 +11192,9 @@ bool ldomNode::refreshFinalBlock()
     fmt.getRect( oldRect );
     LFormattedTextRef txtform;
     int width = fmt.getWidth();
-    renderFinalBlock( txtform, &fmt, width-measureBorder(this,1)-measureBorder(this,3));
+    renderFinalBlock( txtform, &fmt, width-measureBorder(this,1)-measureBorder(this,3)
+                                                                 -lengthToPx(this->getStyle()->padding[0],fmt.getWidth(),this->getFont()->getSize())
+                                                                 -lengthToPx(this->getStyle()->padding[1],fmt.getWidth(),this->getFont()->getSize()));
     fmt.getRect( newRect );
     if ( oldRect == newRect )
         return false;


### PR DESCRIPTION
add css support:
background-image: support one image per element
background-position: do not support x% y% or xpos ypos only support keywords like "left top"
background-repeat: support repeat,repeat-x,repeat-y
background: color,image,repeat, position must be in order, use default for missing properties

Fixed one bug releated to padding on left or right. set any paragraph's left or right padding to 50px or 100px will be easier to observe this bug. The format will change when any word is selected, and there is a distance equal to padding between actual word and area to select the word.