### PR TITLE
table borders and image zoom

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -79,7 +79,7 @@ span { display: inline }
 .epigraph { margin-left: 15%; margin-right: 1em; margin-top: 15px; margin-bottom: 25px; text-align: left; text-indent: 1em; font-style: italic }
 .citation { font-style: italic; margin-left: 5%; margin-right: 5%; margin-top: 20px; margin-bottom: 20px; text-align: justify; }
 
-table { font-size: 80% }
+table { font-size: 80% ; margin:3px;}
 td, th { text-indent: 0px; padding: 3px }
 th {  font-weight: bold; text-align: center; background-color: #DDD  }
 table caption { text-indent: 0px; padding: 4px; background-color: #EEE }

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -217,6 +217,14 @@ enum css_background_position_value_t {
     css_background_p_inherit,
     css_background_p_none
 };
+
+enum css_border_collapse_value_t{
+    css_border_seperate,
+    css_border_collapse,
+    css_border_c_initial,
+    css_border_c_inherit,
+    css_border_c_none
+};
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -64,6 +64,8 @@ typedef struct css_style_rec_tag {
     css_background_repeat_value_t background_repeat;
     css_background_attachment_value_t background_attachment;
     css_background_position_value_t background_position;
+    css_border_collapse_value_t border_collapse;
+    css_length_t border_spacing[2];//first horizontal and the second vertical spacing
     css_style_rec_tag()
     : refCount(0)
     , hash(0)
@@ -97,6 +99,7 @@ typedef struct css_style_rec_tag {
     , background_repeat(css_background_r_none)
     , background_attachment(css_background_a_none)
     , background_position(css_background_p_none)
+    , border_collapse(css_border_seperate)
     {
     }
     void AddRef() { refCount++; }

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -82,8 +82,8 @@ typedef struct
             lUInt16         offset;   /**< \brief offset from node start to beginning of line */
         } t;
         struct {
-            lUInt16         width;    /**< \brief handle of font to draw string */
-            lUInt16         height;   /**< \brief pointer to unicode text string */
+            lInt16         width;    /**< \brief handle of font to draw string */
+            lInt16         height;   /**< \brief pointer to unicode text string */
         } o;
     };
 } src_text_fragment_t;
@@ -228,8 +228,8 @@ void lvtextAddSourceLine(
 */
 void lvtextAddSourceObject( 
    formatted_text_fragment_t * pbuffer,
-   lUInt16         width,
-   lUInt16         height,
+   lInt16         width,
+   lInt16         height,
    lUInt32         flags,    /* flags */
    lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
    lUInt16         margin,   /* first line margin */

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -87,6 +87,8 @@ enum css_decl_code {
     cssd_background_repeat,
     cssd_background_attachment,
     cssd_background_position,
+    cssd_border_collapse,
+    cssd_border_spacing,
     cssd_stop
 };
 
@@ -156,6 +158,8 @@ static const char * css_decl_name[] = {
     "background-repeat",
     "background-attachment",
     "background-position",
+    "border-collapse",
+    "border-spacing",
     NULL
 };
 
@@ -793,6 +797,16 @@ static const char * css_bg_position_names[]={
         "inherit",
         NULL
 };
+
+//border-collpase names
+static const char * css_bc_names[]={
+        "seperate",
+        "collapse",
+        "initial",
+        "inherit",
+        NULL
+};
+
 bool LVCssDeclaration::parse( const char * &decl )
 {
     #define MAX_DECL_SIZE 512
@@ -1559,6 +1573,29 @@ bool LVCssDeclaration::parse( const char * &decl )
 
             }
                break;
+            case cssd_border_spacing:
+            {
+                css_length_t len[2];
+                int i;
+                for (i = 0; i < 2; ++i)
+                    if (!parse_number_value( decl, len[i]))
+                        break;
+                if (i)
+                {
+                    if (i==1) len[1] = len[0];
+
+                    buf[ buf_pos++ ] = prop_code;
+                    for (i = 0; i < 2; ++i)
+                    {
+                        buf[ buf_pos++ ] = len[i].type;
+                        buf[ buf_pos++ ] = len[i].value;
+                    }
+                }
+            }
+                break;
+            case cssd_border_collapse:
+                n=parse_name(decl,css_bc_names,-1);
+                break;
             case cssd_stop:
             case cssd_unknown:
             default:
@@ -1815,6 +1852,13 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_background_position:
             style->background_position=(css_background_position_value_t) *p++;
+            break;
+        case cssd_border_spacing:
+            style->border_spacing[0]=read_length(p);
+            style->border_spacing[1]=read_length(p);
+            break;
+        case cssd_border_collapse:
+            style->border_collapse=(css_border_collapse_value_t) *p++;
             break;
         case cssd_stop:
             return;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -40,7 +40,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((lUInt32)rec.display * 31
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((lUInt32)rec.display * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
          + (lUInt32)rec.text_align_last) * 31
@@ -85,6 +85,9 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.background_attachment)*31
          + (lUInt32)rec.background_position)*31
          + (lUInt32)rec.font_family) * 31
+         + (lUInt32)rec.border_collapse)*31
+         + (lUInt32)rec.border_spacing[0].pack())*31
+         + (lUInt32)rec.border_spacing[1].pack())*31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash());
     return rec.hash;
@@ -138,6 +141,9 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.background_repeat==r2.background_repeat&&
            r1.background_attachment==r2.background_attachment&&
            r1.background_position==r2.background_position;
+           r1.border_collapse==r2.border_collapse;
+           r1.border_spacing[0]==r2.border_spacing[0];
+           r1.border_spacing[1]==r2.border_spacing[1];
 }
 
 
@@ -310,6 +316,9 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(background_repeat);
     ST_PUT_ENUM(background_attachment);
     ST_PUT_ENUM(background_position);
+    ST_PUT_ENUM(border_collapse);
+    ST_PUT_LEN(border_spacing[0]);
+    ST_PUT_LEN(border_spacing[1]);
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -356,6 +365,9 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_background_repeat_value_t ,background_repeat);
     ST_GET_ENUM(css_background_attachment_value_t ,background_attachment);
     ST_GET_ENUM(css_background_position_value_t ,background_position);
+    ST_GET_ENUM(css_border_collapse_value_t ,border_collapse);
+    ST_GET_LEN(border_spacing[0]);
+    ST_GET_LEN(border_spacing[1]);
     lUInt32 hash = 0;
     buf >> hash;
     lUInt32 newhash = calcHash(*this);


### PR DESCRIPTION
1. support table borders , border-collapse(simple) and border-spacing.
2. support image's height and width properties, in px or %. Disabled
zoomin of low resolution images. Now it only zoom out large images to
fit the screen.