### PR TITLE
Add LVTextRobustParser to force using utf-8 encoding to open unknown format text file

### DIFF
--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -358,6 +358,17 @@ public:
     virtual bool Parse();
 };
 
+class LVTextRobustParser : public LVTextParser
+{
+public:
+    /// constructor
+    LVTextRobustParser( LVStreamRef stream, LVXMLParserCallback * callback, bool isPreFormatted );
+    /// destructor
+    virtual ~LVTextRobustParser();
+    /// returns true if format is recognized by parser
+    virtual bool CheckFormat();
+};
+
 /// parser of CoolReader's text format bookmarks
 class LVTextBookmarkParser : public LVTextParser
 {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4182,7 +4182,21 @@ bool LVDocView::ParseDocument() {
 		} else {
 		}
 
-		// unknown format
+		/// plain text format (robust, never fail)
+		if (parser == NULL) {
+
+			setDocFormat( doc_format_txt);
+			parser = new LVTextRobustParser(m_stream, &writer,
+							 getTextFormatOptions() == txt_format_pre);
+			if (!parser->CheckFormat()) {
+				// Never reach
+				delete parser;
+				parser = NULL;
+			}
+		} else {
+		}
+
+		// unknown format (never reach)
 		if (!parser) {
 			setDocFormat( doc_format_none);
             createDefaultDocument(cs16("ERROR: Unknown document format"),

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -448,12 +448,14 @@ public:
 class LVFontGlyphWidthCache
 {
 private:
-    lUInt8 * ptrs[360]; //support up to 0X2CFFF=360*512-1
+    static const int COUNT = 360;
+    lUInt8 * ptrs[COUNT]; //support up to 0X2CFFF=360*512-1
 public:
     lUInt8 get( lChar16 ch )
     {
         FONT_GLYPH_CACHE_GUARD
         int inx = (ch>>9) & 0x1ff;
+        if (inx >= COUNT) return 0xFF;
         lUInt8 * ptr = ptrs[inx];
         if ( !ptr )
             return 0xFF;
@@ -463,6 +465,7 @@ public:
     {
         FONT_GLYPH_CACHE_GUARD
         int inx = (ch>>9) & 0x1ff;
+        if (inx >= COUNT) return;
         lUInt8 * ptr = ptrs[inx];
         if ( !ptr ) {
             ptr = new lUInt8[512];

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -2689,6 +2689,28 @@ bool LVTextParser::Parse()
     return true;
 }
 
+//==================================================
+// Text file robust parser
+
+/// constructor
+LVTextRobustParser::LVTextRobustParser( LVStreamRef stream, LVXMLParserCallback * callback, bool isPreFormatted )
+    : LVTextParser(stream, callback, isPreFormatted)
+{
+}
+
+/// descructor
+LVTextRobustParser::~LVTextRobustParser()
+{
+}
+
+
+/// returns true if format is recognized by parser
+bool LVTextRobustParser::CheckFormat()
+{
+    m_lang_name = lString16( "en" );
+    SetCharset( lString16( "utf-8" ).c_str() );
+    return true;
+}
 
 /*******************************************************************************/
 // LVXMLTextCache


### PR DESCRIPTION
Instead of a very unfriendly 'Error: unknown format' message.
This issue has been discussed in issue #4 (https://github.com/koreader/crengine/issues/4)

This change fixes following issues,
1. Cannot open a book with only several invalid characters in top 3.2K.
2. Cannot open a book without spaces or newlines.
3. Crash if a book contains an invalid characters after 3.2K. (It should crash, but the requirement is a little bit complex, I have not tried to build a case to actually crash it.)

This change won't fix a non utf-8 file which contains several invalid characters in top 3.2K. It will only render garbage. A better solution should be calculating an invalid characters ratio, fail only when the ratio is over a certain bar. Which I believe is a common solution across different text file editors.

You can find the cases @ https://github.com/Hzj-jie/files/tree/master/koreader/b4/