### PR TITLE
bug of fixed font size

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2660,12 +2660,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             pstyle->fld.value = parent_style->fld.value * pstyle->fld.value / 100; \
             break; \
         case css_val_px: \
-            pstyle->fld.type = css_val_px; \
-            pstyle->fld.value = pstyle->fld.value * baseFontSize / (256 * 18); \
             break; \
         case css_val_pt: \
-            pstyle->fld.type = css_val_px; \
-            pstyle->fld.value = pstyle->fld.value * baseFontSize / (256 * 12); \
             break; \
         case css_val_em: \
             pstyle->fld.type = css_val_px; \

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2660,8 +2660,11 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             pstyle->fld.value = parent_style->fld.value * pstyle->fld.value / 100; \
             break; \
         case css_val_px: \
+            /*no need to change*/\
             break; \
         case css_val_pt: \
+            /*treat as px*/\
+            pstyle->fld.type = css_val_px; \
             break; \
         case css_val_em: \
             pstyle->fld.type = css_val_px; \


### PR DESCRIPTION
This bug only affects fixed font-size style which is not recommended in
ebooks. it is obvious as fontsize*basefontsize/(256*18) usually returns
0 and cre's minimum font size is 8, so it always shows these text in 8px
font.