### PR TITLE
try to fix #2015

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1457,6 +1457,9 @@ css_page_break_t getPageBreakBefore( ldomNode * el ) {
             if(!style.isNull())
             {
                 copystyle(style,el->getStyle());
+                el->getStyle()->page_break_before=css_pb_auto;
+                el->getStyle()->page_break_inside=style->page_break_inside;
+                el->getStyle()->page_break_after=style->page_break_after;
             }
             return before;
         }
@@ -1726,9 +1729,9 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     lvRect rect;
                     enode->getAbsRect(rect);
                     if(padding_bottom>0)
-                        context.AddLine(y+rect.top+1,y+rect.top+padding_bottom,RN_SPLIT_AFTER_AUTO);
+                        context.AddLine(y+rect.top+1,y+rect.top+padding_bottom,margin_bottom>0?RN_SPLIT_AFTER_AUTO:CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
                     if(margin_bottom>0)
-                        context.AddLine(y+rect.top+padding_bottom+1,y+rect.top+padding_bottom+margin_bottom,RN_SPLIT_AFTER_AUTO);
+                        context.AddLine(y+rect.top+padding_bottom+1,y+rect.top+padding_bottom+margin_bottom,CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
                     if ( isFootNoteBody )
                         context.leaveFootNote();
                     return y + margin_top + margin_bottom + padding_bottom; // return block height
@@ -1803,15 +1806,15 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                         line_flags |= break_before << RN_SPLIT_BEFORE;
                     else
                         line_flags |= break_inside << RN_SPLIT_BEFORE;
-                    if (i==count-1)
+                    if (i==count-1&&(padding_bottom+margin_bottom==0))
                         line_flags |= break_after << RN_SPLIT_AFTER;
                     else
                         line_flags |= break_inside << RN_SPLIT_AFTER;
                     context.AddLine(rect.top+line->y+padding_top, rect.top+line->y+line->height+padding_top, line_flags);
                     if(padding_bottom>0&&i==count-1)
-                        context.AddLine(rect.bottom-padding_top,rect.bottom+padding_bottom-padding_top,RN_SPLIT_AFTER_AUTO);
+                        context.AddLine(rect.bottom-padding_top,rect.bottom+padding_bottom-padding_top,margin_bottom>0?RN_SPLIT_AFTER_AUTO:CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
                     if(margin_bottom>0&&i==count-1)
-                        context.AddLine(rect.bottom+padding_bottom-padding_top+1,rect.bottom+padding_bottom-padding_top+margin_bottom,RN_SPLIT_AFTER_AUTO);
+                        context.AddLine(rect.bottom+padding_bottom-padding_top+1,rect.bottom+padding_bottom-padding_top+margin_bottom,CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
                     // footnote links analysis
                     if ( !isFootNoteBody && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) { // disable footnotes for footnotes
                         for ( int w=0; w<line->word_count; w++ ) {
@@ -2665,6 +2668,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         case css_val_pt: \
             /*treat as px*/\
             pstyle->fld.type = css_val_px; \
+            pstyle->fld.value = pstyle->fld.value/256; \
             break; \
         case css_val_em: \
             pstyle->fld.type = css_val_px; \

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10310,6 +10310,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         return NULL;
     ldomNode * enode = this;
     RenderRectAccessor fmt( this );
+    pt.y+=lengthToPx(enode->getStyle()->margin[2],fmt.getWidth(),enode->getFont()->getSize());
     if ( enode->getRendMethod() == erm_invisible ) {
         return NULL;
     }


### PR DESCRIPTION
since the start point of a page could be inside margin, we could add back margin to offset the difference when looking for node from a given point.
Also change something about page_break_after.