### PR TITLE
Fix segfault when holding on list item text

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4861,7 +4861,7 @@ ldomNode * ldomXPointer::getFinalNode() const
     for (;;) {
         if ( !node )
             return NULL;
-        if ( node->getRendMethod()==erm_final )
+        if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item )
             return node;
         node = node->getParentNode();
     }
@@ -10537,16 +10537,16 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         return NULL;
     }
     if ( pt.y < fmt.getY() - top_margin) {
-        if ( direction>0 && enode->getRendMethod() == erm_final )
+        if ( direction>0 && (enode->getRendMethod() == erm_final || enode->getRendMethod() == erm_list_item) )
             return this;
         return NULL;
     }
     if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
-        if ( direction<0 && enode->getRendMethod() == erm_final )
+        if ( direction<0 && (enode->getRendMethod() == erm_final || enode->getRendMethod() == erm_list_item) )
             return this;
         return NULL;
     }
-    if ( enode->getRendMethod() == erm_final ) {
+    if ( enode->getRendMethod() == erm_final || enode->getRendMethod() == erm_list_item ) {
         return this;
     }
     int count = getChildCount();


### PR DESCRIPTION
Holding text in list item was triggering a segmentation fault.
Sample file for testing the segfault : [hold_on_li.html.txt](https://github.com/koreader/crengine/files/706235/hold_on_li.html.txt)

First line change is enough to fix the segfault.
And now that it do not segfault, and selected word or text is mostly fine, I noticed it was not fine when the list item text contains some italic, or some spans (some text before the holded word, back to some words from the previous paragraph or list item, was selected instead). The next 3 changed lines fix that.

I debugged that with printf()s following the function calls :| , and noticed that this `->getRendMethod()==erm_list_item` was often along the `->getRendMethod()==erm_final` at some other parts of the code, and took my chance :)

If does fix the segfault and selection, and I haven't noticed yet any side effects.
But as I don't get the full crengine picture, confirmation from those who know is welcome.
I see @frankyifei has used this combination of erm_final and erm_list_item recently in this commit: https://github.com/koreader/crengine/commit/110d810895b96bee9d9ba78b214c612c816a6b69