### PR TITLE
Fix for links clickable out of bounds

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -706,7 +706,7 @@ public:
     void setPageSkin( CRPageSkinRef skin );
 
     /// returns xpointer for specified window point
-    ldomXPointer getNodeByPoint( lvPoint pt );
+    ldomXPointer getNodeByPoint( lvPoint pt, bool strictBounds=false );
     /// returns image source for specified window point, if point is inside image
     LVImageSourceRef getImageByPoint(lvPoint pt);
     /// draws scaled image into buffer, clear background according to current settings

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2107,7 +2107,7 @@ public:
     ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr );
 #if BUILD_LITE!=1
     /// create xpointer from doc point
-    ldomXPointer createXPointer( lvPoint pt, int direction=0 );
+    ldomXPointer createXPointer( lvPoint pt, int direction=0, bool strictBounds=false );
     /// get rendered block cache object
     CVRendBlockCache & getRendBlockCache() { return _renderedBlockCache; }
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2272,11 +2272,11 @@ bool LVDocView::docToWindowPoint(lvPoint & pt) {
 }
 
 /// returns xpointer for specified window point
-ldomXPointer LVDocView::getNodeByPoint(lvPoint pt) {
+ldomXPointer LVDocView::getNodeByPoint(lvPoint pt, bool strictBounds) {
 	LVLock lock(getMutex());
     CHECK_RENDER("getNodeByPoint()")
 	if (windowToDocPoint(pt) && m_doc) {
-		ldomXPointer ptr = m_doc->createXPointer(pt);
+		ldomXPointer ptr = m_doc->createXPointer(pt, 0, strictBounds);
 		//CRLog::debug("  ptr (%d, %d) node=%08X offset=%d", pt.x, pt.y, (lUInt32)ptr.getNode(), ptr.getOffset() );
 		return ptr;
 	}

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4868,7 +4868,7 @@ ldomNode * ldomXPointer::getFinalNode() const
 }
 
 /// create xpointer from doc point
-ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
+ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool strictBounds )
 {
     //
     ldomXPointer ptr;
@@ -4917,6 +4917,12 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
         // found line, searching for word
         int wc = (int)frmline->word_count;
         int x = pt.x - frmline->x;
+        // frmline->x is text indentation (+ possibly some margin)
+        if (strictBounds) {
+            if (x < 0 || x > frmline->width) { // pt is before or after formatted text: nothing there
+                return ptr;
+            }
+        }
         for ( int w=0; w<wc; w++ ) {
             const formatted_word_t * word = &frmline->words[w];
             if ( x < word->x + word->width || w==wc-1 ) {


### PR DESCRIPTION
Possible fix for https://github.com/koreader/koreader/issues/2412

I added an optional parameter strictBounds=false to the functions in the call chain, so that this code is not executed for existing calls to these functions: so no risk of side effects.
It would only be used in cre.cpp for links with this:
```
--- a/cre.cpp
+++ b/cre.cpp
@@ -912,7 +912,7 @@ static int getLinkFromPosition(lua_State *L) {
        int y = luaL_checkint(L, 3);

        lvPoint pt(x, y);
-       ldomXPointer p = doc->text_view->getNodeByPoint(pt);
+       ldomXPointer p = doc->text_view->getNodeByPoint(pt, true);
        lString16 href = p.getHRef();
        lua_pushstring(L, UnicodeToLocal(href).c_str());
        return 1;
```

It works perfectly on my Kobo.
But it is less perfect on the emulator... where there's some remaining area that are still clickable...
I spent hours on the emulator printf'ing pt.x, frmline->, frmline->width... and the values obtained were sometimes a bit different from what they should be as displayed on the screen... Pulled hairs, gave up, and went to see what it does on the device ... and joy.
2nd time that i get perfect and expected results for some simple code on the device, while I get strange things on the emulator. Is that a shared experience ? :|

