### PR TITLE
fix #2908,#2386 cre crash, and better handling of gifs

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -283,6 +283,7 @@ void LFormattedText::AddSourceObject(
             }
         } else if ( h==0 ) {
             h = w*height/width;
+            if (h == 0) h = height;
         }
     }
     width = w;
@@ -456,8 +457,8 @@ public:
         } else {
             int scale_div = 1;
             int scale_mul = 1;
-            int div_x = (width / maxw) + 1;
-            int div_y = (height / maxh) + 1;
+            int div_x = (width * 1000 / maxw);
+            int div_y = (height * 1000 / maxh);
             if ( maxScaleMult>=3 && height*3 < maxh - 20
                     && width*3 < maxw - 20 ) {
                 scale_mul = 3;
@@ -470,8 +471,8 @@ public:
                 else
                     scale_div = div_y;
             }
-            height = height * scale_mul / scale_div;
-            width = width * scale_mul / scale_div;
+            height = height * 1000 * scale_mul / scale_div;
+            width = width * 1000 * scale_mul / scale_div;
         }
     }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3815,10 +3815,10 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex )
         removeChildren(lastNonEmpty+1, endIndex);
 
         // inner inline
-        ldomNode * abox = insertChildElement( firstNonEmpty, LXML_NS_NONE, el_autoBoxing );
+        /*ldomNode * abox = insertChildElement( firstNonEmpty, LXML_NS_NONE, el_autoBoxing );
         abox->initNodeStyle();
         abox->setRendMethod( erm_final );
-        moveItemsTo( abox, firstNonEmpty+1, lastNonEmpty+1 );
+        moveItemsTo( abox, firstNonEmpty+1, lastNonEmpty+1 );*/ //cause crash problem
         // remove trailing empty
         removeChildren(startIndex, firstNonEmpty-1);
     } else {


### PR DESCRIPTION
- #2908
  - in rare circumstances, image height being 0 (integer dividing result is less
than 1) causes crash
- #2386 and maybe other weird epub crash
  - there is a function called autoboxchildren(), which is to remove
empty nodes when openning a new book. autoboxchildren() will be called
again when the embedded styles is turned off. usually it will not cause
problem.
  - if there is an empty `<br/ class="block">` tag (css: ``.block { display: block;}``) 
in the epub and the book is large enough, it will crash in unpredictable ways.
  - with above embedded style, the `<br/> `tag was stored as a block node, if
embedded style is off, it is treated as inline node. I suspect after the
cache file is saved it does not allow some node manipulation because
turning off emmbedded when the book is openning for first time will not
crash. as all this has no visual effect to the book, I believe it is
better to partially disable this funtion, ie. insert or move nodes.