### PR TITLE
epub: extract description and subjects metadata

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -726,6 +726,10 @@ public:
     lString16 getLanguage() { return m_doc_props->getStringDef(DOC_PROP_LANGUAGE); }
     /// returns book author(s)
     lString16 getAuthors() { return m_doc_props->getStringDef(DOC_PROP_AUTHORS); }
+    /// returns book description
+    lString16 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
+    /// returns book keywords (separated by "; ")
+    lString16 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
     /// returns book series name and number (series name #1)
     lString16 getSeries()
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -78,6 +78,8 @@
 #define DOC_PROP_AUTHORS         "doc.authors"
 #define DOC_PROP_TITLE           "doc.title"
 #define DOC_PROP_LANGUAGE        "doc.language"
+#define DOC_PROP_DESCRIPTION     "doc.description"
+#define DOC_PROP_KEYWORDS        "doc.keywords"
 #define DOC_PROP_SERIES_NAME     "doc.series.name"
 #define DOC_PROP_SERIES_NUMBER   "doc.series.number"
 #define DOC_PROP_ARC_NAME        "doc.archive.name"

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -769,9 +769,29 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         lString16 author = doc->textFromXPath( cs16("package/metadata/creator"));
         lString16 title = doc->textFromXPath( cs16("package/metadata/title"));
         lString16 language = doc->textFromXPath( cs16("package/metadata/language"));
+        lString16 description = doc->textFromXPath( cs16("package/metadata/description"));
         m_doc_props->setString(DOC_PROP_TITLE, title);
         m_doc_props->setString(DOC_PROP_LANGUAGE, language);
         m_doc_props->setString(DOC_PROP_AUTHORS, author );
+        m_doc_props->setString(DOC_PROP_DESCRIPTION, description );
+
+        // There may be multiple <dc:subject> tags, which are usually used for keywords, categories
+        bool subjects_set = false;
+        lString16 subjects;
+        for ( int i=1; i<20; i++ ) {
+            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/subject[") << fmt::decimal(i) << "]");
+            if (!item)
+                break;
+            lString16 subject = item->getText();
+            if (subjects_set) {
+                subjects << "; " << subject;
+            }
+            else {
+                subjects << subject;
+                subjects_set = true;
+            }
+        }
+        m_doc_props->setString(DOC_PROP_KEYWORDS, subjects );
 
         for ( int i=1; i<50; i++ ) {
             ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/identifier[") << fmt::decimal(i) << "]");


### PR DESCRIPTION
Found out there was often an interesting (and often long) `<dc:description>` in epub metadata, that we may want to make available to KOReader for display in `Book Information` (and extracted and stored in CoverBrowser plugin cache database). This will be followed by a small patch to base/cre.cpp.
I also added extraction of multiple `<dc:subject>`, which are often used as keywords or categories (I named the methode `getKeywords()`, as this may be implemented for other formats (html, fb2, pdb...), where the multiplicity may have more sense for Keywords than for a possibly single Category - Keywords feels also more generic than Categories).

On the PDF side, there are 2 interesting (most often not) metadata that KOReader does not currently display https://github.com/koreader/koreader-base/blob/master/ffi/mupdf.lua#L216 : 
```
        subject = getMetadataInfo(self.doc, "info:Subject"),
        keywords = getMetadataInfo(self.doc, "info:Keywords"),
```
There's often text that has nothing to do with keywords or subject in these, but well.
I also didn't find any reference about the correct usage of these 2 metadata in PDF.
@Frenzie : if you have quality PDF books, could you check what you usually have in these.
I want to know in the end how to name these 2 properties on the KOReader Properties side.
Should keywords (crengine + pdf) be named Keywords or Categories ?
Can PDF's Subject be used as the equivalent of EPUB's Description or should we just forget it ?


