### PR TITLE
Fix parsing of long decimal values in css

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -323,8 +323,12 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
         str++;
         while (*str>='0' && *str<='9')
         {
-            frac = frac*10 + (*str - '0');
-            frac_div *= 10;
+            // don't process more than 6 digits after decimal point
+            // to avoid overflow in case of very long values
+            if (frac_div < 1000000) {
+                frac = frac*10 + (*str - '0');
+                frac_div *= 10;
+            }
             str++;
         }
     }


### PR DESCRIPTION
I've seen some books with styles like:
```
h1.Heading-1 {font-size:1.81818181818181em;font-style:normal;font-variant:normal;font-weight:bold;margin-bottom:1.84251968503938em;margin-left:0em;margin-right:0em;margin-top:2.97779527559056em;page-break-after:auto;page-break-before:auto;text-align:center;text-indent:0em;text-transform:none}
p.Endnote {font-size:0.909090909090909em;font-weight:normal;margin-bottom:0em;margin-left:1.69511811023622em;margn-right:0em;margin-top:0em;text-align:justify;text-indent:-1.69511811023622em}
```
The parsing of these very long `font-size:0.909090909090909em` was giving a size of 0 (which crengine would rendered with a very small size, but not a null size), because the `int frac` and `int frac_size` were overflowed.
I could have changed them to type `long`, but `font-size:0.909090909090909909090909090909909090909090909909090909090909em` would probably have overflowed them too :)
So, I think it's safer to count the decimal numbers and stop at the 6th, so the above value would be processed just as `font-size:0.909090em` would.
