### PR TITLE
Fix Dutch and Spanish hyph dictionary

### DIFF
--- a/cr3gui/data/hyph/Dutch.pattern
+++ b/cr3gui/data/hyph/Dutch.pattern
@@ -103,345 +103,345 @@
 %
 -->
 <HyphenationDescription>
-<pattern>.a4</pattern>
-<pattern>.aan5</pattern>
-<pattern>.aarts5</pattern>
-<pattern>.aat5</pattern>
-<pattern>.ab5l</pattern>
-<pattern>.acht5end</pattern>
-<pattern>.ac5re</pattern>
-<pattern>.adi5</pattern>
-<pattern>.af3</pattern>
-<pattern>.af5l</pattern>
-<pattern>.af5s</pattern>
-<pattern>.aftu5re</pattern>
-<pattern>.al3ee</pattern>
-<pattern>.al3f</pattern>
-<pattern>.alk4</pattern>
-<pattern>.al5ko</pattern>
-<pattern>.alko5v</pattern>
-<pattern>.al5ma</pattern>
-<pattern>.al3om</pattern>
-<pattern>.al4st</pattern>
-<pattern>.ana3s</pattern>
-<pattern>.an3d2</pattern>
-<pattern>.an3en</pattern>
-<pattern>.an3gl</pattern>
-<pattern>.an5th</pattern>
-<pattern>.ar5d</pattern>
-<pattern>.ar5tr</pattern>
-<pattern>.as5h</pattern>
-<pattern>.as5l</pattern>
-<pattern>.as3t</pattern>
-<pattern>.as5tra</pattern>
-<pattern>.as3u</pattern>
-<pattern>.at4a</pattern>
-<pattern>.ave5n</pattern>
-<pattern>.b4</pattern>
-<pattern>.be3la</pattern>
-<pattern>.be5ra</pattern>
-<pattern>.be5ri</pattern>
-<pattern>.bos1</pattern>
-<pattern>.c4</pattern>
-<pattern>.coo5</pattern>
-<pattern>.co3ro</pattern>
-<pattern>.cus5</pattern>
-<pattern>.d4</pattern>
-<pattern>.daar5</pattern>
-<pattern>.da4gi</pattern>
-<pattern>.dag5r</pattern>
-<pattern>.da2k</pattern>
-<pattern>.dan2</pattern>
-<pattern>.debe4</pattern>
-<pattern>.de2k</pattern>
-<pattern>.dek5l</pattern>
-<pattern>.dek5s</pattern>
-<pattern>.den4k5r</pattern>
-<pattern>.de5od</pattern>
-<pattern>.de3ro</pattern>
-<pattern>.de5sta</pattern>
-<pattern>.di4a</pattern>
-<pattern>.die4p</pattern>
-<pattern>.di3o</pattern>
-<pattern>.doet3</pattern>
-<pattern>.do3v</pattern>
-<pattern>.du4w</pattern>
-<pattern>.e4</pattern>
-<pattern>.ede2</pattern>
-<pattern>.edel5a</pattern>
-<pattern>.ed3w</pattern>
-<pattern>.ee4n</pattern>
-<pattern>.eer5ste</pattern>
-<pattern>.eest3</pattern>
-<pattern>.eesto4</pattern>
-<pattern>.eet3</pattern>
-<pattern>.ei3l</pattern>
-<pattern>.ei5sc</pattern>
-<pattern>.ei3sp</pattern>
-<pattern>.ei5t</pattern>
-<pattern>.el4s5</pattern>
-<pattern>.en5s</pattern>
-<pattern>.en5th</pattern>
-<pattern>.ep4a</pattern>
-<pattern>.ere5s</pattern>
-<pattern>.er2f</pattern>
-<pattern>.erf3l</pattern>
-<pattern>.er3in</pattern>
-<pattern>.ert4</pattern>
-<pattern>.erts3</pattern>
-<pattern>.es3</pattern>
-<pattern>.es5c</pattern>
-<pattern>.es5pe</pattern>
-<pattern>.es5tr</pattern>
-<pattern>.eten4</pattern>
-<pattern>.et4h</pattern>
-<pattern>.ets5te.</pattern>
-<pattern>.eu3</pattern>
-<pattern>.eus5</pattern>
-<pattern>.é2</pattern>
-<pattern>.f4</pattern>
-<pattern>.fel4s</pattern>
-<pattern>.g4</pattern>
-<pattern>.gaat5</pattern>
-<pattern>.gang5s</pattern>
-<pattern>.gea5v</pattern>
-<pattern>.ge3l4a</pattern>
-<pattern>.ge5le</pattern>
-<pattern>.gelo5v</pattern>
-<pattern>.ge3n4a</pattern>
-<pattern>.gena5z</pattern>
-<pattern>.ge5ne</pattern>
-<pattern>.ge5no</pattern>
-<pattern>.ge3ra</pattern>
-<pattern>.ge5r4e</pattern>
-<pattern>.ge5r4o</pattern>
-<pattern>.gerst5a</pattern>
-<pattern>.ge3s</pattern>
-<pattern>.ge5sk</pattern>
-<pattern>.ge5ta</pattern>
-<pattern>.ge5tj</pattern>
-<pattern>.ge5to</pattern>
-<pattern>.gid4</pattern>
-<pattern>.go4m</pattern>
-<pattern>.goot3</pattern>
-<pattern>.h2</pattern>
-<pattern>.handels5</pattern>
-<pattern>.her5in</pattern>
-<pattern>.hits5t</pattern>
-<pattern>.ho4lo</pattern>
-<pattern>.houd5s</pattern>
-<pattern>.i4</pattern>
-<pattern>.ide5o</pattern>
-<pattern>.ij4s</pattern>
-<pattern>.ijs5l</pattern>
-<pattern>.ijs3p</pattern>
-<pattern>.ijs3t</pattern>
-<pattern>.ik3</pattern>
-<pattern>.in1</pattern>
-<pattern>.in5d4</pattern>
-<pattern>.in3g4</pattern>
-<pattern>.in5gr</pattern>
-<pattern>.ink2</pattern>
-<pattern>.in5kr</pattern>
-<pattern>.in5kw</pattern>
-<pattern>.in3s4</pattern>
-<pattern>.in5sl</pattern>
-<pattern>.in5st</pattern>
-<pattern>.in5ta</pattern>
-<pattern>.is5c</pattern>
-<pattern>.j4</pattern>
-<pattern>.jor5</pattern>
-<pattern>.k4</pattern>
-<pattern>.ka3d</pattern>
-<pattern>.ka5g</pattern>
-<pattern>.ka4taa</pattern>
-<pattern>.kerk5l</pattern>
-<pattern>.kerk5r</pattern>
-<pattern>.kerk5u</pattern>
-<pattern>.ker5sten</pattern>
-<pattern>.ke4s</pattern>
-<pattern>.koot5</pattern>
-<pattern>.ko5pe</pattern>
-<pattern>.kop5l</pattern>
-<pattern>.ko3v</pattern>
-<pattern>.kun2</pattern>
-<pattern>.l4</pattern>
-<pattern>.laat5ste</pattern>
-<pattern>.le4b5</pattern>
-<pattern>.leg3o</pattern>
-<pattern>.le4g3r</pattern>
-<pattern>.leid5st</pattern>
-<pattern>.len4s3</pattern>
-<pattern>.le5r4</pattern>
-<pattern>.le4s3</pattern>
-<pattern>.le5th</pattern>
-<pattern>.lin5d</pattern>
-<pattern>.lof5</pattern>
-<pattern>.loot3</pattern>
-<pattern>.lo4s1</pattern>
-<pattern>.lu3e</pattern>
-<pattern>.lui5t4j</pattern>
-<pattern>.lu4s</pattern>
-<pattern>.m4</pattern>
-<pattern>.ma5d</pattern>
-<pattern>.ma5ï</pattern>
-<pattern>.meel5d</pattern>
-<pattern>.me5la</pattern>
-<pattern>.me5ni</pattern>
-<pattern>.merk5l</pattern>
-<pattern>.me2s</pattern>
-<pattern>.me4st</pattern>
-<pattern>.met5ee</pattern>
-<pattern>.mij4n5i</pattern>
-<pattern>.moot3</pattern>
-<pattern>.mor5sten</pattern>
-<pattern>.mo4s</pattern>
-<pattern>.n4</pattern>
-<pattern>.naat5</pattern>
-<pattern>.na3d</pattern>
-<pattern>.na3n</pattern>
-<pattern>.na3s4</pattern>
-<pattern>.nee5s</pattern>
-<pattern>.ne2p</pattern>
-<pattern>.nep3a</pattern>
-<pattern>.ne4s</pattern>
-<pattern>.ne5te</pattern>
-<pattern>.ne4t3j</pattern>
-<pattern>.neu4t5j</pattern>
-<pattern>.nie4t5j</pattern>
-<pattern>.noot5</pattern>
-<pattern>.nos5t</pattern>
-<pattern>.no5v</pattern>
-<pattern>.o4</pattern>
-<pattern>.oe4r5</pattern>
-<pattern>.oe4s5</pattern>
-<pattern>.oeve4</pattern>
-<pattern>.ol3f</pattern>
-<pattern>.om1</pattern>
-<pattern>.omme3</pattern>
-<pattern>.on3a</pattern>
-<pattern>.on3d</pattern>
-<pattern>.onde4r</pattern>
-<pattern>.on1e</pattern>
-<pattern>.on5g</pattern>
-<pattern>.on3i</pattern>
-<pattern>.on5k</pattern>
-<pattern>.on1o</pattern>
-<pattern>.ono5v</pattern>
-<pattern>.on2t3</pattern>
-<pattern>.on4tee</pattern>
-<pattern>.on4ter</pattern>
-<pattern>.ont5s</pattern>
-<pattern>.ooi5tj</pattern>
-<pattern>.oot5jes</pattern>
-<pattern>.op5ee</pattern>
-<pattern>.opi5</pattern>
-<pattern>.op5l</pattern>
-<pattern>.op3r</pattern>
-<pattern>.op5s</pattern>
-<pattern>.org4</pattern>
-<pattern>.os5</pattern>
-<pattern>.ove4</pattern>
-<pattern>.p4</pattern>
-<pattern>.pee5tj</pattern>
-<pattern>.peri5</pattern>
-<pattern>.pers5te.</pattern>
-<pattern>.piet5j</pattern>
-<pattern>.pits5te.</pattern>
-<pattern>.poort5j</pattern>
-<pattern>.po4st</pattern>
-<pattern>.puit4</pattern>
-<pattern>.pui5tj</pattern>
-<pattern>.pu2t</pattern>
-<pattern>.r4</pattern>
-<pattern>.raads5le</pattern>
-<pattern>.ran4d</pattern>
-<pattern>.rand5a</pattern>
-<pattern>.re4men</pattern>
-<pattern>.ren4o</pattern>
-<pattern>.reno5v</pattern>
-<pattern>.re5o</pattern>
-<pattern>.rie4t3</pattern>
-<pattern>.rij5sp</pattern>
-<pattern>.ring5s4</pattern>
-<pattern>.roe5tj</pattern>
-<pattern>.ro4l</pattern>
-<pattern>.ro4st</pattern>
-<pattern>.ro4t3h</pattern>
-<pattern>.ro5v</pattern>
-<pattern>.s4</pattern>
-<pattern>.sap3</pattern>
-<pattern>.sa5v</pattern>
-<pattern>.sci3</pattern>
-<pattern>.see3</pattern>
-<pattern>.seks5te</pattern>
-<pattern>.se5re</pattern>
-<pattern>.set3</pattern>
-<pattern>.se5v</pattern>
-<pattern>.side3</pattern>
-<pattern>.ski3s4</pattern>
-<pattern>.sneu3</pattern>
-<pattern>.sno2</pattern>
-<pattern>.so2k3</pattern>
-<pattern>.song5</pattern>
-<pattern>.spoor5tj</pattern>
-<pattern>.st4</pattern>
-<pattern>.ste4m</pattern>
-<pattern>.t4</pattern>
-<pattern>.taart5j</pattern>
-<pattern>.tan4da</pattern>
-<pattern>.te4a</pattern>
-<pattern>.te4f</pattern>
-<pattern>.tek2</pattern>
-<pattern>.te3le</pattern>
-<pattern>.ten5ac</pattern>
-<pattern>.te3no</pattern>
-<pattern>.ten4t5j</pattern>
-<pattern>.te3ra</pattern>
-<pattern>.ter4p5a</pattern>
-<pattern>.ter5s</pattern>
-<pattern>.te4s</pattern>
-<pattern>.ti2n</pattern>
-<pattern>.tin3a</pattern>
-<pattern>.tin3e</pattern>
-<pattern>.toe5pr</pattern>
-<pattern>.to4lo</pattern>
-<pattern>.to4p</pattern>
-<pattern>.to5v</pattern>
-<pattern>.tri3s4</pattern>
-<pattern>.ts4</pattern>
-<pattern>.tsa3</pattern>
-<pattern>.tuit5j</pattern>
-<pattern>.ty2r</pattern>
-<pattern>.u4</pattern>
-<pattern>.ui2</pattern>
-<pattern>.ui5s</pattern>
-<pattern>.uit1</pattern>
-<pattern>.uit4je</pattern>
-<pattern>.uke5</pattern>
-<pattern>.ur4a</pattern>
-<pattern>.vaat5j</pattern>
-<pattern>.ven4t5j</pattern>
-<pattern>.ve4r3</pattern>
-<pattern>.ves5p</pattern>
-<pattern>.vet3j</pattern>
-<pattern>.vie4r</pattern>
-<pattern>.vol5s</pattern>
-<pattern>.w4</pattern>
-<pattern>.wals5te.</pattern>
-<pattern>.wee4ko</pattern>
-<pattern>.wee4t3</pattern>
-<pattern>.we4l3</pattern>
-<pattern>.wen4s5t</pattern>
-<pattern>.west5r</pattern>
-<pattern>.win4s</pattern>
-<pattern>.xe3</pattern>
-<pattern>.y2</pattern>
-<pattern>.z4</pattern>
-<pattern>.zes5</pattern>
-<pattern>.zit5</pattern>
-<pattern>.zooi5</pattern>
-<pattern>4a.</pattern>
+<pattern> a4</pattern>
+<pattern> aan5</pattern>
+<pattern> aarts5</pattern>
+<pattern> aat5</pattern>
+<pattern> ab5l</pattern>
+<pattern> acht5end</pattern>
+<pattern> ac5re</pattern>
+<pattern> adi5</pattern>
+<pattern> af3</pattern>
+<pattern> af5l</pattern>
+<pattern> af5s</pattern>
+<pattern> aftu5re</pattern>
+<pattern> al3ee</pattern>
+<pattern> al3f</pattern>
+<pattern> alk4</pattern>
+<pattern> al5ko</pattern>
+<pattern> alko5v</pattern>
+<pattern> al5ma</pattern>
+<pattern> al3om</pattern>
+<pattern> al4st</pattern>
+<pattern> ana3s</pattern>
+<pattern> an3d2</pattern>
+<pattern> an3en</pattern>
+<pattern> an3gl</pattern>
+<pattern> an5th</pattern>
+<pattern> ar5d</pattern>
+<pattern> ar5tr</pattern>
+<pattern> as5h</pattern>
+<pattern> as5l</pattern>
+<pattern> as3t</pattern>
+<pattern> as5tra</pattern>
+<pattern> as3u</pattern>
+<pattern> at4a</pattern>
+<pattern> ave5n</pattern>
+<pattern> b4</pattern>
+<pattern> be3la</pattern>
+<pattern> be5ra</pattern>
+<pattern> be5ri</pattern>
+<pattern> bos1</pattern>
+<pattern> c4</pattern>
+<pattern> coo5</pattern>
+<pattern> co3ro</pattern>
+<pattern> cus5</pattern>
+<pattern> d4</pattern>
+<pattern> daar5</pattern>
+<pattern> da4gi</pattern>
+<pattern> dag5r</pattern>
+<pattern> da2k</pattern>
+<pattern> dan2</pattern>
+<pattern> debe4</pattern>
+<pattern> de2k</pattern>
+<pattern> dek5l</pattern>
+<pattern> dek5s</pattern>
+<pattern> den4k5r</pattern>
+<pattern> de5od</pattern>
+<pattern> de3ro</pattern>
+<pattern> de5sta</pattern>
+<pattern> di4a</pattern>
+<pattern> die4p</pattern>
+<pattern> di3o</pattern>
+<pattern> doet3</pattern>
+<pattern> do3v</pattern>
+<pattern> du4w</pattern>
+<pattern> e4</pattern>
+<pattern> ede2</pattern>
+<pattern> edel5a</pattern>
+<pattern> ed3w</pattern>
+<pattern> ee4n</pattern>
+<pattern> eer5ste</pattern>
+<pattern> eest3</pattern>
+<pattern> eesto4</pattern>
+<pattern> eet3</pattern>
+<pattern> ei3l</pattern>
+<pattern> ei5sc</pattern>
+<pattern> ei3sp</pattern>
+<pattern> ei5t</pattern>
+<pattern> el4s5</pattern>
+<pattern> en5s</pattern>
+<pattern> en5th</pattern>
+<pattern> ep4a</pattern>
+<pattern> ere5s</pattern>
+<pattern> er2f</pattern>
+<pattern> erf3l</pattern>
+<pattern> er3in</pattern>
+<pattern> ert4</pattern>
+<pattern> erts3</pattern>
+<pattern> es3</pattern>
+<pattern> es5c</pattern>
+<pattern> es5pe</pattern>
+<pattern> es5tr</pattern>
+<pattern> eten4</pattern>
+<pattern> et4h</pattern>
+<pattern> ets5te </pattern>
+<pattern> eu3</pattern>
+<pattern> eus5</pattern>
+<pattern> é2</pattern>
+<pattern> f4</pattern>
+<pattern> fel4s</pattern>
+<pattern> g4</pattern>
+<pattern> gaat5</pattern>
+<pattern> gang5s</pattern>
+<pattern> gea5v</pattern>
+<pattern> ge3l4a</pattern>
+<pattern> ge5le</pattern>
+<pattern> gelo5v</pattern>
+<pattern> ge3n4a</pattern>
+<pattern> gena5z</pattern>
+<pattern> ge5ne</pattern>
+<pattern> ge5no</pattern>
+<pattern> ge3ra</pattern>
+<pattern> ge5r4e</pattern>
+<pattern> ge5r4o</pattern>
+<pattern> gerst5a</pattern>
+<pattern> ge3s</pattern>
+<pattern> ge5sk</pattern>
+<pattern> ge5ta</pattern>
+<pattern> ge5tj</pattern>
+<pattern> ge5to</pattern>
+<pattern> gid4</pattern>
+<pattern> go4m</pattern>
+<pattern> goot3</pattern>
+<pattern> h2</pattern>
+<pattern> handels5</pattern>
+<pattern> her5in</pattern>
+<pattern> hits5t</pattern>
+<pattern> ho4lo</pattern>
+<pattern> houd5s</pattern>
+<pattern> i4</pattern>
+<pattern> ide5o</pattern>
+<pattern> ij4s</pattern>
+<pattern> ijs5l</pattern>
+<pattern> ijs3p</pattern>
+<pattern> ijs3t</pattern>
+<pattern> ik3</pattern>
+<pattern> in1</pattern>
+<pattern> in5d4</pattern>
+<pattern> in3g4</pattern>
+<pattern> in5gr</pattern>
+<pattern> ink2</pattern>
+<pattern> in5kr</pattern>
+<pattern> in5kw</pattern>
+<pattern> in3s4</pattern>
+<pattern> in5sl</pattern>
+<pattern> in5st</pattern>
+<pattern> in5ta</pattern>
+<pattern> is5c</pattern>
+<pattern> j4</pattern>
+<pattern> jor5</pattern>
+<pattern> k4</pattern>
+<pattern> ka3d</pattern>
+<pattern> ka5g</pattern>
+<pattern> ka4taa</pattern>
+<pattern> kerk5l</pattern>
+<pattern> kerk5r</pattern>
+<pattern> kerk5u</pattern>
+<pattern> ker5sten</pattern>
+<pattern> ke4s</pattern>
+<pattern> koot5</pattern>
+<pattern> ko5pe</pattern>
+<pattern> kop5l</pattern>
+<pattern> ko3v</pattern>
+<pattern> kun2</pattern>
+<pattern> l4</pattern>
+<pattern> laat5ste</pattern>
+<pattern> le4b5</pattern>
+<pattern> leg3o</pattern>
+<pattern> le4g3r</pattern>
+<pattern> leid5st</pattern>
+<pattern> len4s3</pattern>
+<pattern> le5r4</pattern>
+<pattern> le4s3</pattern>
+<pattern> le5th</pattern>
+<pattern> lin5d</pattern>
+<pattern> lof5</pattern>
+<pattern> loot3</pattern>
+<pattern> lo4s1</pattern>
+<pattern> lu3e</pattern>
+<pattern> lui5t4j</pattern>
+<pattern> lu4s</pattern>
+<pattern> m4</pattern>
+<pattern> ma5d</pattern>
+<pattern> ma5ï</pattern>
+<pattern> meel5d</pattern>
+<pattern> me5la</pattern>
+<pattern> me5ni</pattern>
+<pattern> merk5l</pattern>
+<pattern> me2s</pattern>
+<pattern> me4st</pattern>
+<pattern> met5ee</pattern>
+<pattern> mij4n5i</pattern>
+<pattern> moot3</pattern>
+<pattern> mor5sten</pattern>
+<pattern> mo4s</pattern>
+<pattern> n4</pattern>
+<pattern> naat5</pattern>
+<pattern> na3d</pattern>
+<pattern> na3n</pattern>
+<pattern> na3s4</pattern>
+<pattern> nee5s</pattern>
+<pattern> ne2p</pattern>
+<pattern> nep3a</pattern>
+<pattern> ne4s</pattern>
+<pattern> ne5te</pattern>
+<pattern> ne4t3j</pattern>
+<pattern> neu4t5j</pattern>
+<pattern> nie4t5j</pattern>
+<pattern> noot5</pattern>
+<pattern> nos5t</pattern>
+<pattern> no5v</pattern>
+<pattern> o4</pattern>
+<pattern> oe4r5</pattern>
+<pattern> oe4s5</pattern>
+<pattern> oeve4</pattern>
+<pattern> ol3f</pattern>
+<pattern> om1</pattern>
+<pattern> omme3</pattern>
+<pattern> on3a</pattern>
+<pattern> on3d</pattern>
+<pattern> onde4r</pattern>
+<pattern> on1e</pattern>
+<pattern> on5g</pattern>
+<pattern> on3i</pattern>
+<pattern> on5k</pattern>
+<pattern> on1o</pattern>
+<pattern> ono5v</pattern>
+<pattern> on2t3</pattern>
+<pattern> on4tee</pattern>
+<pattern> on4ter</pattern>
+<pattern> ont5s</pattern>
+<pattern> ooi5tj</pattern>
+<pattern> oot5jes</pattern>
+<pattern> op5ee</pattern>
+<pattern> opi5</pattern>
+<pattern> op5l</pattern>
+<pattern> op3r</pattern>
+<pattern> op5s</pattern>
+<pattern> org4</pattern>
+<pattern> os5</pattern>
+<pattern> ove4</pattern>
+<pattern> p4</pattern>
+<pattern> pee5tj</pattern>
+<pattern> peri5</pattern>
+<pattern> pers5te </pattern>
+<pattern> piet5j</pattern>
+<pattern> pits5te </pattern>
+<pattern> poort5j</pattern>
+<pattern> po4st</pattern>
+<pattern> puit4</pattern>
+<pattern> pui5tj</pattern>
+<pattern> pu2t</pattern>
+<pattern> r4</pattern>
+<pattern> raads5le</pattern>
+<pattern> ran4d</pattern>
+<pattern> rand5a</pattern>
+<pattern> re4men</pattern>
+<pattern> ren4o</pattern>
+<pattern> reno5v</pattern>
+<pattern> re5o</pattern>
+<pattern> rie4t3</pattern>
+<pattern> rij5sp</pattern>
+<pattern> ring5s4</pattern>
+<pattern> roe5tj</pattern>
+<pattern> ro4l</pattern>
+<pattern> ro4st</pattern>
+<pattern> ro4t3h</pattern>
+<pattern> ro5v</pattern>
+<pattern> s4</pattern>
+<pattern> sap3</pattern>
+<pattern> sa5v</pattern>
+<pattern> sci3</pattern>
+<pattern> see3</pattern>
+<pattern> seks5te</pattern>
+<pattern> se5re</pattern>
+<pattern> set3</pattern>
+<pattern> se5v</pattern>
+<pattern> side3</pattern>
+<pattern> ski3s4</pattern>
+<pattern> sneu3</pattern>
+<pattern> sno2</pattern>
+<pattern> so2k3</pattern>
+<pattern> song5</pattern>
+<pattern> spoor5tj</pattern>
+<pattern> st4</pattern>
+<pattern> ste4m</pattern>
+<pattern> t4</pattern>
+<pattern> taart5j</pattern>
+<pattern> tan4da</pattern>
+<pattern> te4a</pattern>
+<pattern> te4f</pattern>
+<pattern> tek2</pattern>
+<pattern> te3le</pattern>
+<pattern> ten5ac</pattern>
+<pattern> te3no</pattern>
+<pattern> ten4t5j</pattern>
+<pattern> te3ra</pattern>
+<pattern> ter4p5a</pattern>
+<pattern> ter5s</pattern>
+<pattern> te4s</pattern>
+<pattern> ti2n</pattern>
+<pattern> tin3a</pattern>
+<pattern> tin3e</pattern>
+<pattern> toe5pr</pattern>
+<pattern> to4lo</pattern>
+<pattern> to4p</pattern>
+<pattern> to5v</pattern>
+<pattern> tri3s4</pattern>
+<pattern> ts4</pattern>
+<pattern> tsa3</pattern>
+<pattern> tuit5j</pattern>
+<pattern> ty2r</pattern>
+<pattern> u4</pattern>
+<pattern> ui2</pattern>
+<pattern> ui5s</pattern>
+<pattern> uit1</pattern>
+<pattern> uit4je</pattern>
+<pattern> uke5</pattern>
+<pattern> ur4a</pattern>
+<pattern> vaat5j</pattern>
+<pattern> ven4t5j</pattern>
+<pattern> ve4r3</pattern>
+<pattern> ves5p</pattern>
+<pattern> vet3j</pattern>
+<pattern> vie4r</pattern>
+<pattern> vol5s</pattern>
+<pattern> w4</pattern>
+<pattern> wals5te </pattern>
+<pattern> wee4ko</pattern>
+<pattern> wee4t3</pattern>
+<pattern> we4l3</pattern>
+<pattern> wen4s5t</pattern>
+<pattern> west5r</pattern>
+<pattern> win4s</pattern>
+<pattern> xe3</pattern>
+<pattern> y2</pattern>
+<pattern> z4</pattern>
+<pattern> zes5</pattern>
+<pattern> zit5</pattern>
+<pattern> zooi5</pattern>
+<pattern>4a </pattern>
 <pattern>a4a4</pattern>
 <pattern>4aad</pattern>
 <pattern>aad1a</pattern>
@@ -530,12 +530,12 @@
 <pattern>abot4j</pattern>
 <pattern>2abr</pattern>
 <pattern>ab3ru</pattern>
-<pattern>4ac.</pattern>
+<pattern>4ac </pattern>
 <pattern>a3cal</pattern>
 <pattern>a3car</pattern>
 <pattern>4ace</pattern>
 <pattern>ace3st</pattern>
-<pattern>4ach.</pattern>
+<pattern>4ach </pattern>
 <pattern>a3cha</pattern>
 <pattern>2a1che</pattern>
 <pattern>4a1chi</pattern>
@@ -554,15 +554,15 @@
 <pattern>ac5res</pattern>
 <pattern>4acta</pattern>
 <pattern>4acu</pattern>
-<pattern>4ad.</pattern>
-<pattern>a5da.</pattern>
+<pattern>4ad </pattern>
+<pattern>a5da </pattern>
 <pattern>ad3ac</pattern>
 <pattern>ada2d</pattern>
 <pattern>ada4l</pattern>
 <pattern>ada2r3</pattern>
 <pattern>adas5</pattern>
 <pattern>2add</pattern>
-<pattern>a5de.</pattern>
+<pattern>a5de </pattern>
 <pattern>ad3ei</pattern>
 <pattern>ade5re</pattern>
 <pattern>a5des</pattern>
@@ -576,7 +576,7 @@
 <pattern>adi4od</pattern>
 <pattern>4adk</pattern>
 <pattern>2adl</pattern>
-<pattern>4ado.</pattern>
+<pattern>4ado </pattern>
 <pattern>a3doo</pattern>
 <pattern>2adp</pattern>
 <pattern>ad3rei</pattern>
@@ -613,7 +613,7 @@
 <pattern>4afi</pattern>
 <pattern>af3l</pattern>
 <pattern>4afo</pattern>
-<pattern>a5fo.</pattern>
+<pattern>a5fo </pattern>
 <pattern>a2foe</pattern>
 <pattern>afon4d</pattern>
 <pattern>af3op</pattern>
@@ -628,15 +628,15 @@
 <pattern>af5tr</pattern>
 <pattern>af3ui</pattern>
 <pattern>2afy</pattern>
-<pattern>4ag.</pattern>
+<pattern>4ag </pattern>
 <pattern>ag1a2d</pattern>
 <pattern>ag3af</pattern>
 <pattern>ag3a2m</pattern>
 <pattern>ag3ar</pattern>
 <pattern>ag3di</pattern>
-<pattern>a5ge.</pattern>
+<pattern>a5ge </pattern>
 <pattern>agee5t</pattern>
-<pattern>4a5gen.</pattern>
+<pattern>4a5gen </pattern>
 <pattern>ager4s</pattern>
 <pattern>ag3ex</pattern>
 <pattern>a4gil</pattern>
@@ -738,7 +738,7 @@
 <pattern>al3art</pattern>
 <pattern>4ald</pattern>
 <pattern>a1le</pattern>
-<pattern>a5le.</pattern>
+<pattern>a5le </pattern>
 <pattern>al3eff</pattern>
 <pattern>2aleg</pattern>
 <pattern>a2l3el</pattern>
@@ -787,7 +787,7 @@
 <pattern>al3uit</pattern>
 <pattern>al3u4r</pattern>
 <pattern>alu2s5</pattern>
-<pattern>4am.</pattern>
+<pattern>4am </pattern>
 <pattern>a4m3ac</pattern>
 <pattern>am3adr</pattern>
 <pattern>ama4f</pattern>
@@ -808,7 +808,7 @@
 <pattern>am4sm</pattern>
 <pattern>am4s3o</pattern>
 <pattern>am4spr</pattern>
-<pattern>ams5te.</pattern>
+<pattern>ams5te </pattern>
 <pattern>a2m3ui</pattern>
 <pattern>a3nad</pattern>
 <pattern>an3alg</pattern>
@@ -832,7 +832,7 @@
 <pattern>4aner</pattern>
 <pattern>an3est</pattern>
 <pattern>ane3us</pattern>
-<pattern>4ang.</pattern>
+<pattern>4ang </pattern>
 <pattern>an4gan</pattern>
 <pattern>anga5p</pattern>
 <pattern>ange5st</pattern>
@@ -847,7 +847,7 @@
 <pattern>a4n5isl</pattern>
 <pattern>ani5t</pattern>
 <pattern>4aniv</pattern>
-<pattern>4ank.</pattern>
+<pattern>4ank </pattern>
 <pattern>an4kaa</pattern>
 <pattern>anka4n</pattern>
 <pattern>an4k3as</pattern>
@@ -874,7 +874,7 @@
 <pattern>ans3pi</pattern>
 <pattern>ans5pir</pattern>
 <pattern>an1st</pattern>
-<pattern>an4s5te.</pattern>
+<pattern>an4s5te </pattern>
 <pattern>an5stru</pattern>
 <pattern>an4tac</pattern>
 <pattern>ante4n</pattern>
@@ -897,11 +897,11 @@
 <pattern>a3os</pattern>
 <pattern>aos3p</pattern>
 <pattern>aos5t</pattern>
-<pattern>4ap.</pattern>
+<pattern>4ap </pattern>
 <pattern>a1pa</pattern>
 <pattern>a4pak</pattern>
 <pattern>a4pas</pattern>
-<pattern>ap3as.</pattern>
+<pattern>ap3as </pattern>
 <pattern>ap3ass</pattern>
 <pattern>a1pe</pattern>
 <pattern>ap5eten</pattern>
@@ -931,12 +931,12 @@
 <pattern>ap4si</pattern>
 <pattern>ap2s3l</pattern>
 <pattern>ap3sn</pattern>
-<pattern>ap4ste.</pattern>
+<pattern>ap4ste </pattern>
 <pattern>2apt</pattern>
 <pattern>ap3tj</pattern>
 <pattern>2apu</pattern>
 <pattern>a2q</pattern>
-<pattern>4ar.</pattern>
+<pattern>4ar </pattern>
 <pattern>a1ra</pattern>
 <pattern>araat5j</pattern>
 <pattern>a4r3app</pattern>
@@ -1066,7 +1066,7 @@
 <pattern>3assu</pattern>
 <pattern>a2st</pattern>
 <pattern>4as3ta</pattern>
-<pattern>a4sta.</pattern>
+<pattern>a4sta </pattern>
 <pattern>as5tag</pattern>
 <pattern>as4tas</pattern>
 <pattern>as4tat</pattern>
@@ -1081,13 +1081,13 @@
 <pattern>ast3op</pattern>
 <pattern>4astr</pattern>
 <pattern>ast5rem</pattern>
-<pattern>as5tro.</pattern>
+<pattern>as5tro </pattern>
 <pattern>as4tu</pattern>
 <pattern>a1t</pattern>
 <pattern>ataart5j</pattern>
 <pattern>at1ac</pattern>
 <pattern>at3ade</pattern>
-<pattern>at3af.</pattern>
+<pattern>at3af </pattern>
 <pattern>at3ank</pattern>
 <pattern>ata3s</pattern>
 <pattern>2atek</pattern>
@@ -1132,11 +1132,11 @@
 <pattern>at2st</pattern>
 <pattern>at4staa</pattern>
 <pattern>at4s5tak</pattern>
-<pattern>at4ste.</pattern>
+<pattern>at4ste </pattern>
 <pattern>at5sten</pattern>
 <pattern>at5stij</pattern>
 <pattern>ats5tol</pattern>
-<pattern>ats5top.</pattern>
+<pattern>ats5top </pattern>
 <pattern>ats5trek</pattern>
 <pattern>at4t3u4</pattern>
 <pattern>a2t3ui</pattern>
@@ -1158,7 +1158,7 @@
 <pattern>au4s5p</pattern>
 <pattern>au3sto</pattern>
 <pattern>au3t4</pattern>
-<pattern>4aut.</pattern>
+<pattern>4aut </pattern>
 <pattern>1auto</pattern>
 <pattern>auto3p</pattern>
 <pattern>2auts3</pattern>
@@ -1187,7 +1187,7 @@
 <pattern>ämme3</pattern>
 <pattern>ä3r</pattern>
 <pattern>1b</pattern>
-<pattern>4b.</pattern>
+<pattern>4b </pattern>
 <pattern>3ba</pattern>
 <pattern>baar5ste</pattern>
 <pattern>baar5tj</pattern>
@@ -1284,8 +1284,8 @@
 <pattern>be3so</pattern>
 <pattern>be5sp</pattern>
 <pattern>bes5s</pattern>
-<pattern>bes5te.</pattern>
-<pattern>bes5ten.</pattern>
+<pattern>bes5te </pattern>
+<pattern>bes5ten </pattern>
 <pattern>be5stie</pattern>
 <pattern>bet2</pattern>
 <pattern>be3t4h</pattern>
@@ -1372,7 +1372,7 @@
 <pattern>bon4t3j</pattern>
 <pattern>bon4t5o4</pattern>
 <pattern>boot3j</pattern>
-<pattern>boots5te.</pattern>
+<pattern>boots5te </pattern>
 <pattern>bo3p2</pattern>
 <pattern>bor4sta</pattern>
 <pattern>borst5o</pattern>
@@ -1401,7 +1401,7 @@
 <pattern>bra5str</pattern>
 <pattern>brei5s4</pattern>
 <pattern>brie4t</pattern>
-<pattern>brie5tje.</pattern>
+<pattern>brie5tje </pattern>
 <pattern>bri4l</pattern>
 <pattern>bro2n</pattern>
 <pattern>bron3o4</pattern>
@@ -1439,9 +1439,9 @@
 <pattern>2b3w</pattern>
 <pattern>by3</pattern>
 <pattern>4bz</pattern>
-<pattern>4c.</pattern>
+<pattern>4c </pattern>
 <pattern>1ca</pattern>
-<pattern>3ca.</pattern>
+<pattern>3ca </pattern>
 <pattern>ca3b</pattern>
 <pattern>ca1ch</pattern>
 <pattern>5cada</pattern>
@@ -1510,7 +1510,7 @@
 <pattern>cet3oo</pattern>
 <pattern>1cé</pattern>
 <pattern>c3g</pattern>
-<pattern>4ch.</pattern>
+<pattern>4ch </pattern>
 <pattern>3chaï</pattern>
 <pattern>5chao</pattern>
 <pattern>3chas</pattern>
@@ -1518,7 +1518,7 @@
 <pattern>5chauf</pattern>
 <pattern>2chc</pattern>
 <pattern>1chef</pattern>
-<pattern>5chef.</pattern>
+<pattern>5chef </pattern>
 <pattern>5chefs</pattern>
 <pattern>5chemi</pattern>
 <pattern>5cheq</pattern>
@@ -1649,9 +1649,9 @@
 <pattern>1cy</pattern>
 <pattern>1ç</pattern>
 <pattern>ça4o</pattern>
-<pattern>4d.</pattern>
+<pattern>4d </pattern>
 <pattern>1da</pattern>
-<pattern>3da.</pattern>
+<pattern>3da </pattern>
 <pattern>3daag</pattern>
 <pattern>d4aal</pattern>
 <pattern>d3aap</pattern>
@@ -1749,7 +1749,7 @@
 <pattern>d5do</pattern>
 <pattern>ddo3p</pattern>
 <pattern>1de</pattern>
-<pattern>3de.</pattern>
+<pattern>3de </pattern>
 <pattern>de2al</pattern>
 <pattern>de1ch</pattern>
 <pattern>d4e5den</pattern>
@@ -1762,7 +1762,7 @@
 <pattern>dee4r</pattern>
 <pattern>4d3eff</pattern>
 <pattern>de3g</pattern>
-<pattern>4d5eg.</pattern>
+<pattern>4d5eg </pattern>
 <pattern>4d5egg</pattern>
 <pattern>2d5egy</pattern>
 <pattern>2dei</pattern>
@@ -1792,7 +1792,7 @@
 <pattern>2demh</pattern>
 <pattern>5demi</pattern>
 <pattern>dem5ond</pattern>
-<pattern>d2en.</pattern>
+<pattern>d2en </pattern>
 <pattern>den4ac</pattern>
 <pattern>den5ate</pattern>
 <pattern>den3ei</pattern>
@@ -1819,7 +1819,7 @@
 <pattern>de3ran</pattern>
 <pattern>de3rap</pattern>
 <pattern>de3ras</pattern>
-<pattern>de4r5as.</pattern>
+<pattern>de4r5as </pattern>
 <pattern>de4r5ass</pattern>
 <pattern>der2e</pattern>
 <pattern>der5ede</pattern>
@@ -1865,7 +1865,7 @@
 <pattern>4d3e4tap</pattern>
 <pattern>de5tw</pattern>
 <pattern>deu4r3o4</pattern>
-<pattern>de3us.</pattern>
+<pattern>de3us </pattern>
 <pattern>deu4tj</pattern>
 <pattern>deve4</pattern>
 <pattern>2dex</pattern>
@@ -1885,7 +1885,7 @@
 <pattern>2d1h</pattern>
 <pattern>d5he</pattern>
 <pattern>dheer4</pattern>
-<pattern>3d4hi.</pattern>
+<pattern>3d4hi </pattern>
 <pattern>1di</pattern>
 <pattern>di2a</pattern>
 <pattern>di5ae</pattern>
@@ -1915,7 +1915,7 @@
 <pattern>di5n2a</pattern>
 <pattern>2d3ind</pattern>
 <pattern>2dinf</pattern>
-<pattern>3d4ing.</pattern>
+<pattern>3d4ing </pattern>
 <pattern>4d5ingel</pattern>
 <pattern>4d3inj</pattern>
 <pattern>4d3inko</pattern>
@@ -1950,7 +1950,7 @@
 <pattern>2d1j</pattern>
 <pattern>2d3k2</pattern>
 <pattern>4d3l</pattern>
-<pattern>d5le.</pattern>
+<pattern>d5le </pattern>
 <pattern>dli4n</pattern>
 <pattern>dlot4s</pattern>
 <pattern>2d1m</pattern>
@@ -1958,12 +1958,12 @@
 <pattern>d5ne</pattern>
 <pattern>dni3s</pattern>
 <pattern>1do</pattern>
-<pattern>3do.</pattern>
+<pattern>3do </pattern>
 <pattern>do3a</pattern>
 <pattern>2dobj</pattern>
 <pattern>4d3obs</pattern>
 <pattern>3d4oe</pattern>
-<pattern>5doe.</pattern>
+<pattern>5doe </pattern>
 <pattern>doe5d</pattern>
 <pattern>4doef</pattern>
 <pattern>d5oefe</pattern>
@@ -1977,7 +1977,7 @@
 <pattern>d4olin</pattern>
 <pattern>dolk5s</pattern>
 <pattern>5dol5s</pattern>
-<pattern>3d4om.</pattern>
+<pattern>3d4om </pattern>
 <pattern>5domi</pattern>
 <pattern>do4m3o4</pattern>
 <pattern>d3omr</pattern>
@@ -1985,7 +1985,7 @@
 <pattern>5domu</pattern>
 <pattern>d3omv</pattern>
 <pattern>4domz</pattern>
-<pattern>5don.</pattern>
+<pattern>5don </pattern>
 <pattern>d4ona</pattern>
 <pattern>5done</pattern>
 <pattern>do5ni</pattern>
@@ -2020,13 +2020,13 @@
 <pattern>dpren4</pattern>
 <pattern>1dr4</pattern>
 <pattern>3dra</pattern>
-<pattern>5dra.</pattern>
+<pattern>5dra </pattern>
 <pattern>d3raam</pattern>
 <pattern>d3raap</pattern>
 <pattern>d4rac</pattern>
 <pattern>d5race</pattern>
 <pattern>5drach</pattern>
-<pattern>d3rad.</pattern>
+<pattern>d3rad </pattern>
 <pattern>d3rada</pattern>
 <pattern>5draf</pattern>
 <pattern>5d4rag</pattern>
@@ -2149,7 +2149,7 @@
 <pattern>d3s4tat</pattern>
 <pattern>d5stav</pattern>
 <pattern>d3ste</pattern>
-<pattern>ds4te.</pattern>
+<pattern>ds4te </pattern>
 <pattern>d5stee</pattern>
 <pattern>d4stek</pattern>
 <pattern>ds4ter</pattern>
@@ -2184,7 +2184,7 @@
 <pattern>5duik</pattern>
 <pattern>d3uil</pattern>
 <pattern>2duit</pattern>
-<pattern>4duit.</pattern>
+<pattern>4duit </pattern>
 <pattern>d3uitd</pattern>
 <pattern>5duite</pattern>
 <pattern>4duitg</pattern>
@@ -2222,7 +2222,7 @@
 <pattern>dy4sp</pattern>
 <pattern>dy2s4t</pattern>
 <pattern>2dz</pattern>
-<pattern>4e.</pattern>
+<pattern>4e </pattern>
 <pattern>4ea</pattern>
 <pattern>e3aa</pattern>
 <pattern>e1ab</pattern>
@@ -2246,7 +2246,7 @@
 <pattern>e4als</pattern>
 <pattern>ea5mi</pattern>
 <pattern>e3an</pattern>
-<pattern>e4an.</pattern>
+<pattern>e4an </pattern>
 <pattern>eang3</pattern>
 <pattern>ean4s</pattern>
 <pattern>e5ap</pattern>
@@ -2260,12 +2260,12 @@
 <pattern>ease5t</pattern>
 <pattern>ea3so</pattern>
 <pattern>e1at</pattern>
-<pattern>e4at.</pattern>
+<pattern>e4at </pattern>
 <pattern>eat3s</pattern>
 <pattern>eau3s4t</pattern>
 <pattern>e1av</pattern>
 <pattern>e3bo</pattern>
-<pattern>ebots5te.</pattern>
+<pattern>ebots5te </pattern>
 <pattern>e5br</pattern>
 <pattern>3ecd</pattern>
 <pattern>e3ce</pattern>
@@ -2287,7 +2287,7 @@
 <pattern>e3d4an</pattern>
 <pattern>e4d4as</pattern>
 <pattern>ede3a</pattern>
-<pattern>ed3ei.</pattern>
+<pattern>ed3ei </pattern>
 <pattern>ede5le</pattern>
 <pattern>edem4</pattern>
 <pattern>ede5nac</pattern>
@@ -2357,7 +2357,7 @@
 <pattern>ee2l</pattern>
 <pattern>eel3a</pattern>
 <pattern>ee3lad</pattern>
-<pattern>eel4as.</pattern>
+<pattern>eel4as </pattern>
 <pattern>eel5d4u</pattern>
 <pattern>ee3le</pattern>
 <pattern>eel4ee</pattern>
@@ -2463,12 +2463,12 @@
 <pattern>ef3sf</pattern>
 <pattern>4e1g</pattern>
 <pattern>egas4</pattern>
-<pattern>eg3as.</pattern>
+<pattern>eg3as </pattern>
 <pattern>ega5sk</pattern>
 <pattern>eg3ebb</pattern>
 <pattern>e4ge4c</pattern>
 <pattern>eg3eig</pattern>
-<pattern>egel5ei.</pattern>
+<pattern>egel5ei </pattern>
 <pattern>ege4l5ov</pattern>
 <pattern>ege4net</pattern>
 <pattern>egen5of</pattern>
@@ -2481,7 +2481,7 @@
 <pattern>egip4</pattern>
 <pattern>egiste4</pattern>
 <pattern>e2gl</pattern>
-<pattern>e4go.</pattern>
+<pattern>e4go </pattern>
 <pattern>eg3org</pattern>
 <pattern>e2gos</pattern>
 <pattern>eg3oud</pattern>
@@ -2513,7 +2513,7 @@
 <pattern>ei3kn</pattern>
 <pattern>ei5kr</pattern>
 <pattern>eiks4</pattern>
-<pattern>4eil.</pattern>
+<pattern>4eil </pattern>
 <pattern>eil5ant</pattern>
 <pattern>4eild4</pattern>
 <pattern>eil5dr</pattern>
@@ -2542,7 +2542,7 @@
 <pattern>eit4s3</pattern>
 <pattern>eits5c</pattern>
 <pattern>eits5n</pattern>
-<pattern>eits5te.</pattern>
+<pattern>eits5te </pattern>
 <pattern>eit5sten</pattern>
 <pattern>eits5tr</pattern>
 <pattern>eive4</pattern>
@@ -2552,16 +2552,16 @@
 <pattern>ek3aan</pattern>
 <pattern>ekaart5j</pattern>
 <pattern>ekaat4</pattern>
-<pattern>ek3af.</pattern>
+<pattern>ek3af </pattern>
 <pattern>e4k3a4g</pattern>
-<pattern>ek3al.</pattern>
+<pattern>ek3al </pattern>
 <pattern>ek3alt</pattern>
 <pattern>e5kam</pattern>
 <pattern>ek3ang</pattern>
 <pattern>ek4ee</pattern>
 <pattern>ek1ei</pattern>
 <pattern>e3kem</pattern>
-<pattern>e5ker.</pattern>
+<pattern>e5ker </pattern>
 <pattern>e5kers</pattern>
 <pattern>ekes3</pattern>
 <pattern>ekes4t</pattern>
@@ -2583,7 +2583,7 @@
 <pattern>ek3oli</pattern>
 <pattern>ek3opz</pattern>
 <pattern>e5kor</pattern>
-<pattern>ek5os.</pattern>
+<pattern>ek5os </pattern>
 <pattern>ek5oss</pattern>
 <pattern>e5kran</pattern>
 <pattern>ek3roz</pattern>
@@ -2614,13 +2614,13 @@
 <pattern>e3lan</pattern>
 <pattern>el5ana</pattern>
 <pattern>e3lap</pattern>
-<pattern>e5lap.</pattern>
+<pattern>e5lap </pattern>
 <pattern>e4lapp</pattern>
 <pattern>el3arb</pattern>
 <pattern>el3arc</pattern>
 <pattern>el3arm</pattern>
 <pattern>el3art</pattern>
-<pattern>e4l3as.</pattern>
+<pattern>e4l3as </pattern>
 <pattern>el3asi</pattern>
 <pattern>e4l3asp</pattern>
 <pattern>e4l3ass</pattern>
@@ -2632,7 +2632,7 @@
 <pattern>el4dr</pattern>
 <pattern>el4du</pattern>
 <pattern>e1le</pattern>
-<pattern>e3le.</pattern>
+<pattern>e3le </pattern>
 <pattern>el3eeu</pattern>
 <pattern>el5eff</pattern>
 <pattern>e5leid</pattern>
@@ -2732,7 +2732,7 @@
 <pattern>en5af</pattern>
 <pattern>e2n1ak</pattern>
 <pattern>e2nal</pattern>
-<pattern>en3al.</pattern>
+<pattern>en3al </pattern>
 <pattern>en3als</pattern>
 <pattern>en3amb</pattern>
 <pattern>en4ame</pattern>
@@ -2749,7 +2749,7 @@
 <pattern>en1av</pattern>
 <pattern>e2n3a2z</pattern>
 <pattern>enci4</pattern>
-<pattern>3ency.</pattern>
+<pattern>3ency </pattern>
 <pattern>en3da</pattern>
 <pattern>en5daa</pattern>
 <pattern>end5ama</pattern>
@@ -2762,7 +2762,7 @@
 <pattern>e3nee</pattern>
 <pattern>en3eed</pattern>
 <pattern>enee5t</pattern>
-<pattern>en5eg.</pattern>
+<pattern>en5eg </pattern>
 <pattern>en5egg</pattern>
 <pattern>en3ela</pattern>
 <pattern>en3elf</pattern>
@@ -2801,7 +2801,7 @@
 <pattern>e4n3oor</pattern>
 <pattern>enoot5</pattern>
 <pattern>e2n1o2p</pattern>
-<pattern>e3nor.</pattern>
+<pattern>e3nor </pattern>
 <pattern>en3ord</pattern>
 <pattern>eno3s</pattern>
 <pattern>en3ou</pattern>
@@ -2885,10 +2885,10 @@
 <pattern>e3par</pattern>
 <pattern>ep3asp</pattern>
 <pattern>e1pe</pattern>
-<pattern>e5pe.</pattern>
+<pattern>e5pe </pattern>
 <pattern>ep5een</pattern>
 <pattern>e5per</pattern>
-<pattern>epers5te.</pattern>
+<pattern>epers5te </pattern>
 <pattern>e1pi</pattern>
 <pattern>3epid</pattern>
 <pattern>ep3ijs</pattern>
@@ -2907,7 +2907,7 @@
 <pattern>e4p5o4ge</pattern>
 <pattern>epoort5j</pattern>
 <pattern>epoot4j</pattern>
-<pattern>3e4pos.</pattern>
+<pattern>3e4pos </pattern>
 <pattern>e3pot</pattern>
 <pattern>epou4</pattern>
 <pattern>e1pr</pattern>
@@ -2934,20 +2934,20 @@
 <pattern>ep5tro</pattern>
 <pattern>ep3uit</pattern>
 <pattern>4equa</pattern>
-<pattern>e3ra.</pattern>
+<pattern>e3ra </pattern>
 <pattern>e1raa</pattern>
 <pattern>e5raad</pattern>
-<pattern>e4raak.</pattern>
+<pattern>e4raak </pattern>
 <pattern>er3aan</pattern>
 <pattern>er5aanp</pattern>
-<pattern>e4raap.</pattern>
+<pattern>e4raap </pattern>
 <pattern>e5raat</pattern>
 <pattern>e4r1ac</pattern>
-<pattern>e5rac.</pattern>
+<pattern>e5rac </pattern>
 <pattern>e5race</pattern>
 <pattern>e5raco</pattern>
 <pattern>e3rad</pattern>
-<pattern>e5rad.</pattern>
+<pattern>e5rad </pattern>
 <pattern>er3ado</pattern>
 <pattern>er3af</pattern>
 <pattern>e3raff</pattern>
@@ -2969,7 +2969,7 @@
 <pattern>er3d4i</pattern>
 <pattern>erd4o</pattern>
 <pattern>er3d2r</pattern>
-<pattern>erd5uit.</pattern>
+<pattern>erd5uit </pattern>
 <pattern>er3d4w</pattern>
 <pattern>e1re</pattern>
 <pattern>er5eat</pattern>
@@ -2981,7 +2981,7 @@
 <pattern>er3eet</pattern>
 <pattern>er3ef</pattern>
 <pattern>er5eff</pattern>
-<pattern>er5eg.</pattern>
+<pattern>er5eg </pattern>
 <pattern>er3egd</pattern>
 <pattern>er5egg</pattern>
 <pattern>er5egt</pattern>
@@ -2997,7 +2997,7 @@
 <pattern>e5rendel</pattern>
 <pattern>ere4ne</pattern>
 <pattern>eren5eg</pattern>
-<pattern>er5enen.</pattern>
+<pattern>er5enen </pattern>
 <pattern>e3renm</pattern>
 <pattern>e3rent</pattern>
 <pattern>er5enth</pattern>
@@ -3008,7 +3008,7 @@
 <pattern>er3epi</pattern>
 <pattern>er3e2q</pattern>
 <pattern>er3eri</pattern>
-<pattern>e3res.</pattern>
+<pattern>e3res </pattern>
 <pattern>er3esk</pattern>
 <pattern>e3ress</pattern>
 <pattern>ere4st</pattern>
@@ -3024,7 +3024,7 @@
 <pattern>erig5a</pattern>
 <pattern>er3ijl</pattern>
 <pattern>er3ijs</pattern>
-<pattern>e4rijs.</pattern>
+<pattern>e4rijs </pattern>
 <pattern>er3ijv</pattern>
 <pattern>e4r3ijz</pattern>
 <pattern>e5rik</pattern>
@@ -3040,7 +3040,7 @@
 <pattern>er3m4i</pattern>
 <pattern>er5mo</pattern>
 <pattern>er5nu</pattern>
-<pattern>e1ro.</pattern>
+<pattern>e1ro </pattern>
 <pattern>e3rob</pattern>
 <pattern>er3oc</pattern>
 <pattern>e4r3oed</pattern>
@@ -3052,12 +3052,12 @@
 <pattern>ero2g</pattern>
 <pattern>e3rok</pattern>
 <pattern>e1ro2l</pattern>
-<pattern>e5rol.</pattern>
+<pattern>e5rol </pattern>
 <pattern>er3oli</pattern>
 <pattern>e5roll</pattern>
 <pattern>er3om</pattern>
 <pattern>er1on</pattern>
-<pattern>e3ron.</pattern>
+<pattern>e3ron </pattern>
 <pattern>e3rone</pattern>
 <pattern>er3onv</pattern>
 <pattern>er3oog</pattern>
@@ -3124,7 +3124,7 @@
 <pattern>e3sie</pattern>
 <pattern>es1in</pattern>
 <pattern>e4sir</pattern>
-<pattern>es5je.</pattern>
+<pattern>es5je </pattern>
 <pattern>es5jes</pattern>
 <pattern>e3s4jo</pattern>
 <pattern>es5jon</pattern>
@@ -3132,7 +3132,7 @@
 <pattern>es5kr</pattern>
 <pattern>e3sl</pattern>
 <pattern>es4la</pattern>
-<pattern>e5sla.</pattern>
+<pattern>e5sla </pattern>
 <pattern>e5slag</pattern>
 <pattern>es3lak</pattern>
 <pattern>es5lat</pattern>
@@ -3140,13 +3140,13 @@
 <pattern>es5leg</pattern>
 <pattern>es2m</pattern>
 <pattern>es4mui</pattern>
-<pattern>e5smuil.</pattern>
+<pattern>e5smuil </pattern>
 <pattern>e1sn</pattern>
 <pattern>e3s4ne</pattern>
 <pattern>e1so</pattern>
 <pattern>e3sol</pattern>
 <pattern>es4oo</pattern>
-<pattern>es5oor.</pattern>
+<pattern>es5oor </pattern>
 <pattern>eso4p</pattern>
 <pattern>es3ore</pattern>
 <pattern>e1sp</pattern>
@@ -3162,16 +3162,16 @@
 <pattern>e3stap</pattern>
 <pattern>es4tar</pattern>
 <pattern>es5tatie</pattern>
-<pattern>e4s3te.</pattern>
+<pattern>e4s3te </pattern>
 <pattern>es4tea</pattern>
 <pattern>es4teel</pattern>
-<pattern>est5ei.</pattern>
+<pattern>est5ei </pattern>
 <pattern>e4steka</pattern>
 <pattern>es5tekam</pattern>
 <pattern>e3s4tem</pattern>
 <pattern>es5temo</pattern>
 <pattern>es3ten</pattern>
-<pattern>e4sten.</pattern>
+<pattern>e4sten </pattern>
 <pattern>es5tenb</pattern>
 <pattern>es3ter</pattern>
 <pattern>estere5o</pattern>
@@ -3181,7 +3181,7 @@
 <pattern>es4tic</pattern>
 <pattern>e4stie</pattern>
 <pattern>e3stot</pattern>
-<pattern>es5tra.</pattern>
+<pattern>es5tra </pattern>
 <pattern>es5trac</pattern>
 <pattern>es5trak</pattern>
 <pattern>e5stral</pattern>
@@ -3194,14 +3194,14 @@
 <pattern>esu4r</pattern>
 <pattern>e3sy</pattern>
 <pattern>e1ta</pattern>
-<pattern>e3ta.</pattern>
+<pattern>e3ta </pattern>
 <pattern>et3aan</pattern>
 <pattern>et3ac</pattern>
 <pattern>et3ad</pattern>
 <pattern>et3afz</pattern>
 <pattern>3e2tag</pattern>
 <pattern>e3tak</pattern>
-<pattern>e5tak.</pattern>
+<pattern>e5tak </pattern>
 <pattern>et4ana</pattern>
 <pattern>e5tand</pattern>
 <pattern>e2tap</pattern>
@@ -3214,7 +3214,7 @@
 <pattern>et3edi</pattern>
 <pattern>e5tek</pattern>
 <pattern>4etel</pattern>
-<pattern>e5tel.</pattern>
+<pattern>e5tel </pattern>
 <pattern>e4t5elf</pattern>
 <pattern>e5tels</pattern>
 <pattern>et5emb</pattern>
@@ -3284,7 +3284,7 @@
 <pattern>eu4ler</pattern>
 <pattern>eu4li</pattern>
 <pattern>e1um</pattern>
-<pattern>e3um.</pattern>
+<pattern>e3um </pattern>
 <pattern>e2umd</pattern>
 <pattern>eu2na</pattern>
 <pattern>eun3t</pattern>
@@ -3299,7 +3299,7 @@
 <pattern>euro5v</pattern>
 <pattern>eur4sta</pattern>
 <pattern>eurs5taa</pattern>
-<pattern>eurs5te.</pattern>
+<pattern>eurs5te </pattern>
 <pattern>eur4s5tr</pattern>
 <pattern>eur4su</pattern>
 <pattern>eu5sch</pattern>
@@ -3326,12 +3326,12 @@
 <pattern>e5wa</pattern>
 <pattern>e5we</pattern>
 <pattern>ewen4s</pattern>
-<pattern>ewens5te.</pattern>
+<pattern>ewens5te </pattern>
 <pattern>ewest5r</pattern>
 <pattern>ew2h</pattern>
 <pattern>e5wi</pattern>
 <pattern>ewo3v</pattern>
-<pattern>4ex.</pattern>
+<pattern>4ex </pattern>
 <pattern>2ex3aa</pattern>
 <pattern>ex3af</pattern>
 <pattern>4exco</pattern>
@@ -3373,7 +3373,7 @@
 <pattern>ê3per</pattern>
 <pattern>ê5t</pattern>
 <pattern>3ë</pattern>
-<pattern>4ë.</pattern>
+<pattern>4ë </pattern>
 <pattern>ë2b</pattern>
 <pattern>ë3c</pattern>
 <pattern>ë3d</pattern>
@@ -3405,7 +3405,7 @@
 <pattern>ëve5</pattern>
 <pattern>ëven4</pattern>
 <pattern>4ëzu</pattern>
-<pattern>4f.</pattern>
+<pattern>4f </pattern>
 <pattern>1fa</pattern>
 <pattern>f3aanb</pattern>
 <pattern>f4aat</pattern>
@@ -3532,7 +3532,7 @@
 <pattern>f4lam</pattern>
 <pattern>f3lei</pattern>
 <pattern>flen4st</pattern>
-<pattern>flens5te.</pattern>
+<pattern>flens5te </pattern>
 <pattern>f4les</pattern>
 <pattern>fle2t</pattern>
 <pattern>flet3j</pattern>
@@ -3581,10 +3581,10 @@
 <pattern>4f1ov</pattern>
 <pattern>3fö</pattern>
 <pattern>4f5p4</pattern>
-<pattern>fpers5te.</pattern>
-<pattern>fpits5te.</pattern>
+<pattern>fpers5te </pattern>
+<pattern>fpits5te </pattern>
 <pattern>fr4</pattern>
-<pattern>f4raak.</pattern>
+<pattern>f4raak </pattern>
 <pattern>fraam5</pattern>
 <pattern>5frac</pattern>
 <pattern>f3rad</pattern>
@@ -3686,20 +3686,20 @@
 <pattern>3fy1</pattern>
 <pattern>2fz</pattern>
 <pattern>fzet5</pattern>
-<pattern>4g.</pattern>
+<pattern>4g </pattern>
 <pattern>1ga</pattern>
-<pattern>3ga.</pattern>
+<pattern>3ga </pattern>
 <pattern>gaar5tj</pattern>
 <pattern>g4aat</pattern>
 <pattern>2g1ac</pattern>
 <pattern>4g3adm</pattern>
-<pattern>g4af.</pattern>
+<pattern>g4af </pattern>
 <pattern>g3afd</pattern>
 <pattern>ga3fr</pattern>
 <pattern>4g3afs</pattern>
 <pattern>4g3afw</pattern>
 <pattern>2g3a4h</pattern>
-<pattern>4gal.</pattern>
+<pattern>4gal </pattern>
 <pattern>ga3la</pattern>
 <pattern>ga4l3ap</pattern>
 <pattern>ga5ler</pattern>
@@ -3711,7 +3711,7 @@
 <pattern>5gane</pattern>
 <pattern>gan4s5t</pattern>
 <pattern>ga3pl</pattern>
-<pattern>3gar.</pattern>
+<pattern>3gar </pattern>
 <pattern>4g3arb</pattern>
 <pattern>ga3re</pattern>
 <pattern>g1arm</pattern>
@@ -3721,7 +3721,7 @@
 <pattern>ga4s</pattern>
 <pattern>gas5c</pattern>
 <pattern>gas3i</pattern>
-<pattern>ga5sla.</pattern>
+<pattern>ga5sla </pattern>
 <pattern>ga3sli</pattern>
 <pattern>ga5slo</pattern>
 <pattern>gas3o</pattern>
@@ -3745,7 +3745,7 @@
 <pattern>gd5ate</pattern>
 <pattern>g3de</pattern>
 <pattern>g4d3elf</pattern>
-<pattern>g5der.</pattern>
+<pattern>g5der </pattern>
 <pattern>gd3erv</pattern>
 <pattern>g4d3id</pattern>
 <pattern>gd3im</pattern>
@@ -3756,14 +3756,14 @@
 <pattern>gd5sp</pattern>
 <pattern>g3du</pattern>
 <pattern>1ge</pattern>
-<pattern>3ge.</pattern>
+<pattern>3ge </pattern>
 <pattern>ge3a</pattern>
 <pattern>gea3dr</pattern>
 <pattern>gea5na</pattern>
 <pattern>gea3q</pattern>
 <pattern>ge4ari</pattern>
 <pattern>ge5au</pattern>
-<pattern>4g3eb.</pattern>
+<pattern>4g3eb </pattern>
 <pattern>2gebb</pattern>
 <pattern>ge3c</pattern>
 <pattern>ge3d4</pattern>
@@ -3809,7 +3809,7 @@
 <pattern>2g3emp</pattern>
 <pattern>gems3</pattern>
 <pattern>ge3m4u</pattern>
-<pattern>g4en.</pattern>
+<pattern>g4en </pattern>
 <pattern>ge3nak</pattern>
 <pattern>gen4az</pattern>
 <pattern>3ge3ne</pattern>
@@ -3834,14 +3834,14 @@
 <pattern>ge5p4</pattern>
 <pattern>ge1ra</pattern>
 <pattern>ger5aal</pattern>
-<pattern>ger5aap.</pattern>
+<pattern>ger5aap </pattern>
 <pattern>ge4r3a4l</pattern>
 <pattern>gera4p</pattern>
 <pattern>ger5ape</pattern>
-<pattern>ger5as.</pattern>
+<pattern>ger5as </pattern>
 <pattern>ge5reg</pattern>
 <pattern>ge3rem</pattern>
-<pattern>ge5ren.</pattern>
+<pattern>ge5ren </pattern>
 <pattern>ger4i</pattern>
 <pattern>ger5ini</pattern>
 <pattern>ge1r2o</pattern>
@@ -3866,8 +3866,8 @@
 <pattern>ge5sper</pattern>
 <pattern>ge5spo</pattern>
 <pattern>ge5stan</pattern>
-<pattern>ges5te.</pattern>
-<pattern>ges5ten.</pattern>
+<pattern>ges5te </pattern>
+<pattern>ges5ten </pattern>
 <pattern>ge3str</pattern>
 <pattern>ge5sw</pattern>
 <pattern>ge3ta</pattern>
@@ -3946,7 +3946,7 @@
 <pattern>glas3e</pattern>
 <pattern>g5lat</pattern>
 <pattern>3g4laz</pattern>
-<pattern>3gle.</pattern>
+<pattern>3gle </pattern>
 <pattern>g5leer</pattern>
 <pattern>glee5t</pattern>
 <pattern>g3len</pattern>
@@ -3984,7 +3984,7 @@
 <pattern>gnie4tj</pattern>
 <pattern>4gnu</pattern>
 <pattern>1go</pattern>
-<pattern>3go.</pattern>
+<pattern>3go </pattern>
 <pattern>3go2a</pattern>
 <pattern>3gob</pattern>
 <pattern>2goc</pattern>
@@ -3999,7 +3999,7 @@
 <pattern>g4og</pattern>
 <pattern>4goh</pattern>
 <pattern>go2k</pattern>
-<pattern>5gom.</pattern>
+<pattern>5gom </pattern>
 <pattern>go2ma</pattern>
 <pattern>g3oml</pattern>
 <pattern>4gomz</pattern>
@@ -4015,7 +4015,7 @@
 <pattern>g4opr</pattern>
 <pattern>g4ora</pattern>
 <pattern>4go4re</pattern>
-<pattern>go5re.</pattern>
+<pattern>go5re </pattern>
 <pattern>5g4ori</pattern>
 <pattern>gor2s</pattern>
 <pattern>gos1</pattern>
@@ -4026,11 +4026,11 @@
 <pattern>gpes3</pattern>
 <pattern>1gr4</pattern>
 <pattern>3gra</pattern>
-<pattern>5gra.</pattern>
+<pattern>5gra </pattern>
 <pattern>graat5j</pattern>
 <pattern>g5rak</pattern>
 <pattern>gra2m</pattern>
-<pattern>g4ram.</pattern>
+<pattern>g4ram </pattern>
 <pattern>gram3a</pattern>
 <pattern>g3ramp</pattern>
 <pattern>gra4s3</pattern>
@@ -4090,7 +4090,7 @@
 <pattern>g3sie</pattern>
 <pattern>gs5is</pattern>
 <pattern>gs1j</pattern>
-<pattern>g3s4ke.</pattern>
+<pattern>g3s4ke </pattern>
 <pattern>gs3l</pattern>
 <pattern>gs4la</pattern>
 <pattern>gs5laag</pattern>
@@ -4113,7 +4113,7 @@
 <pattern>g3snij</pattern>
 <pattern>g4s1o4</pattern>
 <pattern>g5sol</pattern>
-<pattern>g5som.</pattern>
+<pattern>g5som </pattern>
 <pattern>gs5ons</pattern>
 <pattern>gs3op</pattern>
 <pattern>gs3p</pattern>
@@ -4124,7 +4124,7 @@
 <pattern>gs4pi</pattern>
 <pattern>g3spie</pattern>
 <pattern>g3spil</pattern>
-<pattern>g5spin.</pattern>
+<pattern>g5spin </pattern>
 <pattern>g5spinn</pattern>
 <pattern>gs5pir</pattern>
 <pattern>gs5pol</pattern>
@@ -4141,7 +4141,7 @@
 <pattern>g4st3ap</pattern>
 <pattern>g5stat</pattern>
 <pattern>g1ste</pattern>
-<pattern>g5s4te.</pattern>
+<pattern>g5s4te </pattern>
 <pattern>g5sted</pattern>
 <pattern>g5stee</pattern>
 <pattern>g3stei</pattern>
@@ -4149,7 +4149,7 @@
 <pattern>g5stel</pattern>
 <pattern>g3sten</pattern>
 <pattern>g3ster</pattern>
-<pattern>g5ster.</pattern>
+<pattern>g5ster </pattern>
 <pattern>gs5terr</pattern>
 <pattern>g5sters</pattern>
 <pattern>gs3th</pattern>
@@ -4188,14 +4188,14 @@
 <pattern>g3tr</pattern>
 <pattern>g1tu</pattern>
 <pattern>1gu</pattern>
-<pattern>5gu.</pattern>
+<pattern>5gu </pattern>
 <pattern>3gue</pattern>
 <pattern>gu4eu</pattern>
 <pattern>2guit</pattern>
 <pattern>gu4ni</pattern>
 <pattern>gu2s3</pattern>
 <pattern>gut4st</pattern>
-<pattern>guts5te.</pattern>
+<pattern>guts5te </pattern>
 <pattern>4gv</pattern>
 <pattern>g5vo</pattern>
 <pattern>4g1w</pattern>
@@ -4203,13 +4203,13 @@
 <pattern>1gy</pattern>
 <pattern>4gyp</pattern>
 <pattern>2gz</pattern>
-<pattern>4h.</pattern>
+<pattern>4h </pattern>
 <pattern>haams5ta</pattern>
 <pattern>haar5sl</pattern>
 <pattern>haar5sp</pattern>
 <pattern>haars5te</pattern>
 <pattern>haar5tj</pattern>
-<pattern>haats5te.</pattern>
+<pattern>haats5te </pattern>
 <pattern>h3afd</pattern>
 <pattern>haf4t3u</pattern>
 <pattern>ha3g</pattern>
@@ -4219,7 +4219,7 @@
 <pattern>hal4sto</pattern>
 <pattern>5halz</pattern>
 <pattern>2hamp</pattern>
-<pattern>4han.</pattern>
+<pattern>4han </pattern>
 <pattern>han4dr</pattern>
 <pattern>hand5sl</pattern>
 <pattern>han3ga</pattern>
@@ -4240,7 +4240,7 @@
 <pattern>ha2t3r</pattern>
 <pattern>hat3s</pattern>
 <pattern>ha3v</pattern>
-<pattern>4have.</pattern>
+<pattern>4have </pattern>
 <pattern>4hb</pattern>
 <pattern>2hd</pattern>
 <pattern>h4e</pattern>
@@ -4248,7 +4248,7 @@
 <pattern>he2ar</pattern>
 <pattern>3hech</pattern>
 <pattern>he3co</pattern>
-<pattern>4hee.</pattern>
+<pattern>4hee </pattern>
 <pattern>hee3g4</pattern>
 <pattern>hee4k</pattern>
 <pattern>heek3a</pattern>
@@ -4267,7 +4267,7 @@
 <pattern>he2k3a</pattern>
 <pattern>he2kl</pattern>
 <pattern>hek4st</pattern>
-<pattern>heks5te.</pattern>
+<pattern>heks5te </pattern>
 <pattern>hek5sten</pattern>
 <pattern>hek3w</pattern>
 <pattern>he3le</pattern>
@@ -4301,7 +4301,7 @@
 <pattern>he5se</pattern>
 <pattern>he2sp</pattern>
 <pattern>he2s5t</pattern>
-<pattern>hets5te.</pattern>
+<pattern>hets5te </pattern>
 <pattern>heu5le</pattern>
 <pattern>2h3f</pattern>
 <pattern>4h5g</pattern>
@@ -4329,7 +4329,7 @@
 <pattern>his5p</pattern>
 <pattern>hi3tr</pattern>
 <pattern>hit4st</pattern>
-<pattern>hits5te.</pattern>
+<pattern>hits5te </pattern>
 <pattern>hit5sten</pattern>
 <pattern>h3j</pattern>
 <pattern>2hl</pattern>
@@ -4344,7 +4344,7 @@
 <pattern>h1n</pattern>
 <pattern>h2na</pattern>
 <pattern>hno3</pattern>
-<pattern>2ho.</pattern>
+<pattern>2ho </pattern>
 <pattern>ho3a</pattern>
 <pattern>hoa3n</pattern>
 <pattern>hoboot4</pattern>
@@ -4378,7 +4378,7 @@
 <pattern>5horl</pattern>
 <pattern>ho3ro</pattern>
 <pattern>hor4st</pattern>
-<pattern>hors5te.</pattern>
+<pattern>hors5te </pattern>
 <pattern>hor5sten</pattern>
 <pattern>hor4t3j</pattern>
 <pattern>ho3ru</pattern>
@@ -4387,7 +4387,7 @@
 <pattern>ho3tr</pattern>
 <pattern>ho4t3re</pattern>
 <pattern>hot4st</pattern>
-<pattern>hots5te.</pattern>
+<pattern>hots5te </pattern>
 <pattern>ho3v</pattern>
 <pattern>2ho4w</pattern>
 <pattern>how3o</pattern>
@@ -4411,7 +4411,7 @@
 <pattern>h3tal</pattern>
 <pattern>ht3ala</pattern>
 <pattern>h5tans</pattern>
-<pattern>h3te.</pattern>
+<pattern>h3te </pattern>
 <pattern>h4t3ec</pattern>
 <pattern>ht4eco</pattern>
 <pattern>h2t3ee</pattern>
@@ -4462,13 +4462,13 @@
 <pattern>hul4der</pattern>
 <pattern>hur4t5</pattern>
 <pattern>hut3j</pattern>
-<pattern>huts5te.</pattern>
+<pattern>huts5te </pattern>
 <pattern>huur5s</pattern>
 <pattern>4h1w</pattern>
 <pattern>hy4la</pattern>
 <pattern>3hyp</pattern>
 <pattern>hypo1</pattern>
-<pattern>4i.</pattern>
+<pattern>4i </pattern>
 <pattern>i1a</pattern>
 <pattern>i3aa</pattern>
 <pattern>i4ab</pattern>
@@ -4476,21 +4476,21 @@
 <pattern>i4ac</pattern>
 <pattern>i3ady</pattern>
 <pattern>i3ae</pattern>
-<pattern>i5ae.</pattern>
+<pattern>i5ae </pattern>
 <pattern>i2a3f4</pattern>
 <pattern>i2a3g2</pattern>
 <pattern>i3agr</pattern>
 <pattern>i3ai</pattern>
-<pattern>i5ak.</pattern>
+<pattern>i5ak </pattern>
 <pattern>i3ake4</pattern>
 <pattern>ia4kem</pattern>
 <pattern>ia3kl</pattern>
 <pattern>ia3kr</pattern>
-<pattern>i3al.</pattern>
+<pattern>i3al </pattern>
 <pattern>i4a3la</pattern>
 <pattern>i3ali</pattern>
 <pattern>i2am</pattern>
-<pattern>i5am.</pattern>
+<pattern>i5am </pattern>
 <pattern>i3ami</pattern>
 <pattern>i3an</pattern>
 <pattern>ian4o</pattern>
@@ -4525,7 +4525,7 @@
 <pattern>i3dam</pattern>
 <pattern>idde4r5a</pattern>
 <pattern>ide3a</pattern>
-<pattern>i4dee.</pattern>
+<pattern>i4dee </pattern>
 <pattern>ider4sp</pattern>
 <pattern>ider4st</pattern>
 <pattern>ides4</pattern>
@@ -4589,7 +4589,7 @@
 <pattern>iel5do</pattern>
 <pattern>iel5d4r</pattern>
 <pattern>iel4e</pattern>
-<pattern>iel5ei.</pattern>
+<pattern>iel5ei </pattern>
 <pattern>iel5k</pattern>
 <pattern>iel3sc</pattern>
 <pattern>ie3ma</pattern>
@@ -4597,7 +4597,7 @@
 <pattern>ien4dr</pattern>
 <pattern>ien3ij</pattern>
 <pattern>i3enn</pattern>
-<pattern>i5enne.</pattern>
+<pattern>i5enne </pattern>
 <pattern>ien3s4m</pattern>
 <pattern>ien5sp</pattern>
 <pattern>ien4sta</pattern>
@@ -4622,9 +4622,9 @@
 <pattern>ie3rap</pattern>
 <pattern>ier3as</pattern>
 <pattern>ie4rat</pattern>
-<pattern>ier5el.</pattern>
+<pattern>ier5el </pattern>
 <pattern>ier5els</pattern>
-<pattern>ie5ren.</pattern>
+<pattern>ie5ren </pattern>
 <pattern>ie5ring</pattern>
 <pattern>ierk4</pattern>
 <pattern>ie3r2o</pattern>
@@ -4643,7 +4643,7 @@
 <pattern>ie2so4</pattern>
 <pattern>ie4s3pl</pattern>
 <pattern>ie3sta</pattern>
-<pattern>ies5te.</pattern>
+<pattern>ies5te </pattern>
 <pattern>ie5stel</pattern>
 <pattern>ies5tere</pattern>
 <pattern>ie3sto</pattern>
@@ -4660,7 +4660,7 @@
 <pattern>ieto5re</pattern>
 <pattern>ie4t3ov</pattern>
 <pattern>ie5troe</pattern>
-<pattern>iets5te.</pattern>
+<pattern>iets5te </pattern>
 <pattern>iet3ur</pattern>
 <pattern>iet3uu</pattern>
 <pattern>ie3twi</pattern>
@@ -4717,7 +4717,7 @@
 <pattern>ii2n</pattern>
 <pattern>i5is</pattern>
 <pattern>i2j</pattern>
-<pattern>4ij.</pattern>
+<pattern>4ij </pattern>
 <pattern>ij5a</pattern>
 <pattern>ija4d</pattern>
 <pattern>4ijd</pattern>
@@ -4772,11 +4772,11 @@
 <pattern>ik4spa</pattern>
 <pattern>ik1st</pattern>
 <pattern>ik5sta</pattern>
-<pattern>iks5te.</pattern>
+<pattern>iks5te </pattern>
 <pattern>ik1w</pattern>
 <pattern>ik5war</pattern>
 <pattern>i1la</pattern>
-<pattern>i3la.</pattern>
+<pattern>i3la </pattern>
 <pattern>il4aa</pattern>
 <pattern>il5aan</pattern>
 <pattern>il3ac</pattern>
@@ -4827,7 +4827,7 @@
 <pattern>il4sti</pattern>
 <pattern>il2th</pattern>
 <pattern>i1lu</pattern>
-<pattern>4im.</pattern>
+<pattern>4im </pattern>
 <pattern>i2mag</pattern>
 <pattern>i4mago</pattern>
 <pattern>im5au</pattern>
@@ -4868,7 +4868,7 @@
 <pattern>in2go</pattern>
 <pattern>in4gr</pattern>
 <pattern>ing4st</pattern>
-<pattern>4ini.</pattern>
+<pattern>4ini </pattern>
 <pattern>i3nie</pattern>
 <pattern>ini5on</pattern>
 <pattern>ini5sl</pattern>
@@ -4887,7 +4887,7 @@
 <pattern>ino3s4t</pattern>
 <pattern>in3ov</pattern>
 <pattern>1inri</pattern>
-<pattern>4ins.</pattern>
+<pattern>4ins </pattern>
 <pattern>in5sch</pattern>
 <pattern>in5se</pattern>
 <pattern>in3sl</pattern>
@@ -4914,7 +4914,7 @@
 <pattern>io3f</pattern>
 <pattern>io3g2</pattern>
 <pattern>i3ol</pattern>
-<pattern>i5ol.</pattern>
+<pattern>i5ol </pattern>
 <pattern>i5olen</pattern>
 <pattern>i5olus</pattern>
 <pattern>i3on</pattern>
@@ -4931,13 +4931,13 @@
 <pattern>i3ori</pattern>
 <pattern>io3ru</pattern>
 <pattern>io4s</pattern>
-<pattern>i3os.</pattern>
+<pattern>i3os </pattern>
 <pattern>ios3c</pattern>
 <pattern>i3o5se</pattern>
 <pattern>i3o5sf</pattern>
 <pattern>io5sh</pattern>
 <pattern>io5si</pattern>
-<pattern>i5osi.</pattern>
+<pattern>i5osi </pattern>
 <pattern>io5so</pattern>
 <pattern>io5sp</pattern>
 <pattern>io5s4t</pattern>
@@ -4971,7 +4971,7 @@
 <pattern>ipse4</pattern>
 <pattern>ip4si</pattern>
 <pattern>ip4sle</pattern>
-<pattern>ips5te.</pattern>
+<pattern>ips5te </pattern>
 <pattern>ip5sten</pattern>
 <pattern>i3ra</pattern>
 <pattern>ira3k</pattern>
@@ -5057,7 +5057,7 @@
 <pattern>ist5ong</pattern>
 <pattern>i3str</pattern>
 <pattern>is5tri</pattern>
-<pattern>i5stro.</pattern>
+<pattern>i5stro </pattern>
 <pattern>i3sty</pattern>
 <pattern>isu2m</pattern>
 <pattern>i5sy</pattern>
@@ -5091,7 +5091,7 @@
 <pattern>it3sop</pattern>
 <pattern>it1sp</pattern>
 <pattern>its4te</pattern>
-<pattern>it4ste.</pattern>
+<pattern>it4ste </pattern>
 <pattern>it4too</pattern>
 <pattern>i3tu</pattern>
 <pattern>it3w</pattern>
@@ -5114,12 +5114,12 @@
 <pattern>î3</pattern>
 <pattern>ît4</pattern>
 <pattern>1ï</pattern>
-<pattern>2ï.</pattern>
+<pattern>2ï </pattern>
 <pattern>ï5a</pattern>
 <pattern>ï1c</pattern>
 <pattern>ï1d</pattern>
 <pattern>ïe4n3</pattern>
-<pattern>ïe5nen.</pattern>
+<pattern>ïe5nen </pattern>
 <pattern>ï2n3a</pattern>
 <pattern>ïns5m</pattern>
 <pattern>ïn3sp</pattern>
@@ -5128,7 +5128,7 @@
 <pattern>ï3o</pattern>
 <pattern>ï3ri</pattern>
 <pattern>ï3ro</pattern>
-<pattern>4ïs.</pattern>
+<pattern>4ïs </pattern>
 <pattern>ïs3a</pattern>
 <pattern>ï4sc</pattern>
 <pattern>ï5sche</pattern>
@@ -5137,7 +5137,7 @@
 <pattern>ïs3t</pattern>
 <pattern>ï1t</pattern>
 <pattern>ï5z</pattern>
-<pattern>4j.</pattern>
+<pattern>4j </pattern>
 <pattern>1jaar</pattern>
 <pattern>jaar5tj</pattern>
 <pattern>ja3b</pattern>
@@ -5361,7 +5361,7 @@
 <pattern>jn2sp</pattern>
 <pattern>jns3pl</pattern>
 <pattern>jn1st</pattern>
-<pattern>jn4ste.</pattern>
+<pattern>jn4ste </pattern>
 <pattern>jnt4</pattern>
 <pattern>jn3tr</pattern>
 <pattern>joet3</pattern>
@@ -5449,7 +5449,7 @@
 <pattern>j1tag</pattern>
 <pattern>j3tak</pattern>
 <pattern>j3tan</pattern>
-<pattern>j3te.</pattern>
+<pattern>j3te </pattern>
 <pattern>jt1h</pattern>
 <pattern>j3toe</pattern>
 <pattern>jt3opt</pattern>
@@ -5477,13 +5477,13 @@
 <pattern>jvie5s</pattern>
 <pattern>j1w</pattern>
 <pattern>jze4r5o</pattern>
-<pattern>4k.</pattern>
+<pattern>4k </pattern>
 <pattern>1ka</pattern>
 <pattern>k3aanb</pattern>
 <pattern>k3aanl</pattern>
 <pattern>5kaart</pattern>
 <pattern>kaart5jes</pattern>
-<pattern>kaats5te.</pattern>
+<pattern>kaats5te </pattern>
 <pattern>kabe2</pattern>
 <pattern>ka3bo</pattern>
 <pattern>2k1ac</pattern>
@@ -5523,7 +5523,7 @@
 <pattern>kan4st</pattern>
 <pattern>kan4t3j</pattern>
 <pattern>kao3</pattern>
-<pattern>5kap.</pattern>
+<pattern>5kap </pattern>
 <pattern>ka3pe</pattern>
 <pattern>kap3l</pattern>
 <pattern>ka1po</pattern>
@@ -5572,7 +5572,7 @@
 <pattern>keers5to</pattern>
 <pattern>2kef</pattern>
 <pattern>4keff</pattern>
-<pattern>k4ei.</pattern>
+<pattern>k4ei </pattern>
 <pattern>k4eie</pattern>
 <pattern>k2eil</pattern>
 <pattern>kei3s4</pattern>
@@ -5592,7 +5592,7 @@
 <pattern>2kemp</pattern>
 <pattern>ke4n3an</pattern>
 <pattern>ke4nau</pattern>
-<pattern>ken4ei.</pattern>
+<pattern>ken4ei </pattern>
 <pattern>ke5nen</pattern>
 <pattern>ken5k</pattern>
 <pattern>ke2n1o</pattern>
@@ -5615,7 +5615,7 @@
 <pattern>ker5spe</pattern>
 <pattern>ker4spr</pattern>
 <pattern>ker4sta</pattern>
-<pattern>ker5ste.</pattern>
+<pattern>ker5ste </pattern>
 <pattern>ker4sti</pattern>
 <pattern>4k3erts</pattern>
 <pattern>4kerva</pattern>
@@ -5631,7 +5631,7 @@
 <pattern>ke2t3j</pattern>
 <pattern>ke3to</pattern>
 <pattern>ke2t3r</pattern>
-<pattern>kets5te.</pattern>
+<pattern>kets5te </pattern>
 <pattern>ketting5s</pattern>
 <pattern>4k3e2tu</pattern>
 <pattern>ket3w</pattern>
@@ -5663,7 +5663,7 @@
 <pattern>ki3na</pattern>
 <pattern>4kinb</pattern>
 <pattern>4k5indel</pattern>
-<pattern>kinds5te.</pattern>
+<pattern>kinds5te </pattern>
 <pattern>4kindu</pattern>
 <pattern>kin3en</pattern>
 <pattern>5king</pattern>
@@ -5696,20 +5696,20 @@
 <pattern>k3ladi</pattern>
 <pattern>kla2p1</pattern>
 <pattern>k4las</pattern>
-<pattern>5klas.</pattern>
+<pattern>5klas </pattern>
 <pattern>5klass</pattern>
 <pattern>k3last</pattern>
-<pattern>k3lat.</pattern>
+<pattern>k3lat </pattern>
 <pattern>k3latt</pattern>
 <pattern>3k4lav</pattern>
 <pattern>3k4led</pattern>
 <pattern>5kledi</pattern>
 <pattern>5kleed</pattern>
-<pattern>k5leer.</pattern>
+<pattern>k5leer </pattern>
 <pattern>4k5leg</pattern>
 <pattern>5klem</pattern>
 <pattern>4k5len</pattern>
-<pattern>k3ler.</pattern>
+<pattern>k3ler </pattern>
 <pattern>4klera</pattern>
 <pattern>k3lers</pattern>
 <pattern>k3les</pattern>
@@ -5725,14 +5725,14 @@
 <pattern>k5lob</pattern>
 <pattern>4klod</pattern>
 <pattern>3klok</pattern>
-<pattern>5klok.</pattern>
+<pattern>5klok </pattern>
 <pattern>k5loka</pattern>
 <pattern>k3loke</pattern>
 <pattern>k3lood</pattern>
 <pattern>5kloof</pattern>
 <pattern>k3lope</pattern>
 <pattern>5klos</pattern>
-<pattern>klots5te.</pattern>
+<pattern>klots5te </pattern>
 <pattern>2k5loz</pattern>
 <pattern>4kluc</pattern>
 <pattern>4kluih</pattern>
@@ -5745,7 +5745,7 @@
 <pattern>5knec</pattern>
 <pattern>k5nem</pattern>
 <pattern>kni2</pattern>
-<pattern>5knie.</pattern>
+<pattern>5knie </pattern>
 <pattern>knip1</pattern>
 <pattern>4k5niv</pattern>
 <pattern>3knol</pattern>
@@ -5761,7 +5761,7 @@
 <pattern>koers5p</pattern>
 <pattern>koes3</pattern>
 <pattern>koe3tj</pattern>
-<pattern>koets5te.</pattern>
+<pattern>koets5te </pattern>
 <pattern>koge4</pattern>
 <pattern>5ko5gr</pattern>
 <pattern>3k4ok</pattern>
@@ -5791,7 +5791,7 @@
 <pattern>4kopb</pattern>
 <pattern>4k3opd</pattern>
 <pattern>ko1pe</pattern>
-<pattern>ko5pen.</pattern>
+<pattern>ko5pen </pattern>
 <pattern>4kopg</pattern>
 <pattern>3ko5pi</pattern>
 <pattern>5kopj</pattern>
@@ -5802,19 +5802,19 @@
 <pattern>kor5do</pattern>
 <pattern>2k1org</pattern>
 <pattern>2k3ork</pattern>
-<pattern>kors5te.</pattern>
+<pattern>kors5te </pattern>
 <pattern>kor4ta</pattern>
 <pattern>kor4t3o4</pattern>
 <pattern>kor4tr</pattern>
 <pattern>ko3ru</pattern>
 <pattern>3k4o4s3</pattern>
-<pattern>4k3os.</pattern>
+<pattern>4k3os </pattern>
 <pattern>kos4j</pattern>
 <pattern>ko5sjere</pattern>
 <pattern>koso4</pattern>
 <pattern>4koss</pattern>
 <pattern>kot4st</pattern>
-<pattern>kots5te.</pattern>
+<pattern>kots5te </pattern>
 <pattern>4k1ov</pattern>
 <pattern>4k3ox</pattern>
 <pattern>2k3p</pattern>
@@ -5868,7 +5868,7 @@
 <pattern>ks2e2</pattern>
 <pattern>k5sec</pattern>
 <pattern>ks3ed</pattern>
-<pattern>ks5ei.</pattern>
+<pattern>ks5ei </pattern>
 <pattern>ks3ep</pattern>
 <pattern>k4serv</pattern>
 <pattern>ks3et</pattern>
@@ -5990,7 +5990,7 @@
 <pattern>k1wei</pattern>
 <pattern>5kwel</pattern>
 <pattern>kwen4st</pattern>
-<pattern>kwens5te.</pattern>
+<pattern>kwens5te </pattern>
 <pattern>4k1wer</pattern>
 <pattern>5k2wes1</pattern>
 <pattern>kwes5tr</pattern>
@@ -6004,7 +6004,7 @@
 <pattern>4k1wo</pattern>
 <pattern>ky3</pattern>
 <pattern>2kz</pattern>
-<pattern>4l.</pattern>
+<pattern>4l </pattern>
 <pattern>2laan</pattern>
 <pattern>4laand</pattern>
 <pattern>l3aanh</pattern>
@@ -6014,7 +6014,7 @@
 <pattern>l3abon</pattern>
 <pattern>2lac</pattern>
 <pattern>la4ca</pattern>
-<pattern>5lach.</pattern>
+<pattern>5lach </pattern>
 <pattern>la4cha</pattern>
 <pattern>5lache</pattern>
 <pattern>lach5te</pattern>
@@ -6059,10 +6059,10 @@
 <pattern>land5aa</pattern>
 <pattern>lan4d5oo</pattern>
 <pattern>lan4d3r</pattern>
-<pattern>lands5te.</pattern>
+<pattern>lands5te </pattern>
 <pattern>la4n3ec</pattern>
 <pattern>lanel5</pattern>
-<pattern>5lange.</pattern>
+<pattern>5lange </pattern>
 <pattern>lang5l</pattern>
 <pattern>lang5sp</pattern>
 <pattern>lang5sta</pattern>
@@ -6084,7 +6084,7 @@
 <pattern>la3q</pattern>
 <pattern>lar3da</pattern>
 <pattern>2larm</pattern>
-<pattern>4larm.</pattern>
+<pattern>4larm </pattern>
 <pattern>lar5st</pattern>
 <pattern>las3a4</pattern>
 <pattern>lase4</pattern>
@@ -6182,7 +6182,7 @@
 <pattern>leg3ec</pattern>
 <pattern>leg3l</pattern>
 <pattern>le4go</pattern>
-<pattern>le5go.</pattern>
+<pattern>le5go </pattern>
 <pattern>leg5s</pattern>
 <pattern>3leidi</pattern>
 <pattern>4leier</pattern>
@@ -6207,7 +6207,7 @@
 <pattern>len3sm</pattern>
 <pattern>4l3en5th</pattern>
 <pattern>le5o</pattern>
-<pattern>4lep.</pattern>
+<pattern>4lep </pattern>
 <pattern>3le1ra</pattern>
 <pattern>le4r3a4k</pattern>
 <pattern>le5rei</pattern>
@@ -6241,7 +6241,7 @@
 <pattern>le2t3r</pattern>
 <pattern>le3t4re</pattern>
 <pattern>let4st</pattern>
-<pattern>lets5te.</pattern>
+<pattern>lets5te </pattern>
 <pattern>le2t3u</pattern>
 <pattern>leu3ko</pattern>
 <pattern>leum3a</pattern>
@@ -6298,7 +6298,7 @@
 <pattern>li3am</pattern>
 <pattern>licht5st</pattern>
 <pattern>3lid</pattern>
-<pattern>5lid.</pattern>
+<pattern>5lid </pattern>
 <pattern>5lidm</pattern>
 <pattern>lid3s4</pattern>
 <pattern>lie4g3a</pattern>
@@ -6356,7 +6356,7 @@
 <pattern>lit4sa</pattern>
 <pattern>lit4sl</pattern>
 <pattern>lit4st</pattern>
-<pattern>lits5te.</pattern>
+<pattern>lits5te </pattern>
 <pattern>lit5sten</pattern>
 <pattern>2lix</pattern>
 <pattern>4l1j2</pattern>
@@ -6457,7 +6457,7 @@
 <pattern>4loeg</pattern>
 <pattern>loe4gr</pattern>
 <pattern>loen4st</pattern>
-<pattern>loens5te.</pattern>
+<pattern>loens5te </pattern>
 <pattern>4loes</pattern>
 <pattern>l3oeu</pattern>
 <pattern>5loev</pattern>
@@ -6481,7 +6481,7 @@
 <pattern>l3omt</pattern>
 <pattern>l3omv</pattern>
 <pattern>4lomz</pattern>
-<pattern>3lon.</pattern>
+<pattern>3lon </pattern>
 <pattern>4lond</pattern>
 <pattern>5long</pattern>
 <pattern>lon4gaa</pattern>
@@ -6507,7 +6507,7 @@
 <pattern>4l3opv</pattern>
 <pattern>4l3opw</pattern>
 <pattern>2lor</pattern>
-<pattern>3l4or.</pattern>
+<pattern>3l4or </pattern>
 <pattern>lo3re</pattern>
 <pattern>4l1org</pattern>
 <pattern>lo3ri</pattern>
@@ -6629,7 +6629,7 @@
 <pattern>l3sta</pattern>
 <pattern>l4staf</pattern>
 <pattern>l4stak</pattern>
-<pattern>ls5tak.</pattern>
+<pattern>ls5tak </pattern>
 <pattern>l3ste</pattern>
 <pattern>l4stek</pattern>
 <pattern>l4stev</pattern>
@@ -6662,17 +6662,17 @@
 <pattern>lt3rug</pattern>
 <pattern>lt3sl</pattern>
 <pattern>lt3sp</pattern>
-<pattern>lts5te.</pattern>
+<pattern>lts5te </pattern>
 <pattern>l3tu</pattern>
 <pattern>lu4b1</pattern>
 <pattern>lub5e</pattern>
 <pattern>lub5l</pattern>
 <pattern>lu1en</pattern>
-<pattern>3lui.</pattern>
+<pattern>3lui </pattern>
 <pattern>5luia</pattern>
 <pattern>5luid</pattern>
 <pattern>luids3</pattern>
-<pattern>5luie.</pattern>
+<pattern>5luie </pattern>
 <pattern>2luit</pattern>
 <pattern>luk2s</pattern>
 <pattern>luks3t</pattern>
@@ -6683,7 +6683,7 @@
 <pattern>lu3ta</pattern>
 <pattern>lut3j</pattern>
 <pattern>lut4st</pattern>
-<pattern>luts5te.</pattern>
+<pattern>luts5te </pattern>
 <pattern>lu3wi</pattern>
 <pattern>lven5s</pattern>
 <pattern>lvera4</pattern>
@@ -6693,7 +6693,7 @@
 <pattern>ly3st</pattern>
 <pattern>4lz</pattern>
 <pattern>lzooi5</pattern>
-<pattern>4m.</pattern>
+<pattern>4m </pattern>
 <pattern>1ma</pattern>
 <pattern>maas3</pattern>
 <pattern>maat5st</pattern>
@@ -6717,7 +6717,7 @@
 <pattern>ma5lac</pattern>
 <pattern>ma4l5ent</pattern>
 <pattern>mal5st</pattern>
-<pattern>5m4an.</pattern>
+<pattern>5m4an </pattern>
 <pattern>man3ac</pattern>
 <pattern>m3anal</pattern>
 <pattern>man5da</pattern>
@@ -6754,7 +6754,7 @@
 <pattern>ma4tom</pattern>
 <pattern>ma3tr</pattern>
 <pattern>mat4st</pattern>
-<pattern>mats5te.</pattern>
+<pattern>mats5te </pattern>
 <pattern>ma3v</pattern>
 <pattern>4mb</pattern>
 <pattern>m5bl</pattern>
@@ -6785,7 +6785,7 @@
 <pattern>meest5al</pattern>
 <pattern>mee5stov</pattern>
 <pattern>mee5str</pattern>
-<pattern>m5eg.</pattern>
+<pattern>m5eg </pattern>
 <pattern>me3g2a</pattern>
 <pattern>mega5s</pattern>
 <pattern>m5egd</pattern>
@@ -6796,7 +6796,7 @@
 <pattern>mei5tj</pattern>
 <pattern>m2el</pattern>
 <pattern>me4l4as</pattern>
-<pattern>mel5as.</pattern>
+<pattern>mel5as </pattern>
 <pattern>mel5dr</pattern>
 <pattern>mel4ko</pattern>
 <pattern>mel4kr</pattern>
@@ -6804,7 +6804,7 @@
 <pattern>mel3s4m</pattern>
 <pattern>me4mi</pattern>
 <pattern>3men</pattern>
-<pattern>m4en.</pattern>
+<pattern>m4en </pattern>
 <pattern>me3na</pattern>
 <pattern>men4as</pattern>
 <pattern>meng5ra</pattern>
@@ -6859,7 +6859,7 @@
 <pattern>me3t4h</pattern>
 <pattern>3meti</pattern>
 <pattern>me5tr</pattern>
-<pattern>mets5te.</pattern>
+<pattern>mets5te </pattern>
 <pattern>meve4</pattern>
 <pattern>m3e4ven</pattern>
 <pattern>2mex</pattern>
@@ -6877,7 +6877,7 @@
 <pattern>2m1h</pattern>
 <pattern>1mi</pattern>
 <pattern>3mid</pattern>
-<pattern>4mid.</pattern>
+<pattern>4mid </pattern>
 <pattern>5midd</pattern>
 <pattern>mie5kl</pattern>
 <pattern>mie3st</pattern>
@@ -6906,7 +6906,7 @@
 <pattern>mi3t4a</pattern>
 <pattern>mi1tr</pattern>
 <pattern>mit4st</pattern>
-<pattern>mits5te.</pattern>
+<pattern>mits5te </pattern>
 <pattern>mit5sten</pattern>
 <pattern>2m1j</pattern>
 <pattern>2m3k2</pattern>
@@ -6916,7 +6916,7 @@
 <pattern>2m1n</pattern>
 <pattern>m5na</pattern>
 <pattern>1mo</pattern>
-<pattern>5mo.</pattern>
+<pattern>5mo </pattern>
 <pattern>mo3a</pattern>
 <pattern>5moda</pattern>
 <pattern>5mode</pattern>
@@ -6955,7 +6955,7 @@
 <pattern>mo3ro</pattern>
 <pattern>mor4sp</pattern>
 <pattern>mor4st</pattern>
-<pattern>mors5te.</pattern>
+<pattern>mors5te </pattern>
 <pattern>5mos</pattern>
 <pattern>mo5sc</pattern>
 <pattern>mo4s5l</pattern>
@@ -6964,7 +6964,7 @@
 <pattern>mot3j</pattern>
 <pattern>mot3ol</pattern>
 <pattern>mot4st</pattern>
-<pattern>mots5te.</pattern>
+<pattern>mots5te </pattern>
 <pattern>2m3oud</pattern>
 <pattern>5mouw</pattern>
 <pattern>mou4wi</pattern>
@@ -7047,7 +7047,7 @@
 <pattern>1mu</pattern>
 <pattern>mu5da</pattern>
 <pattern>mue4</pattern>
-<pattern>5muilde.</pattern>
+<pattern>5muilde </pattern>
 <pattern>2muit</pattern>
 <pattern>2muk</pattern>
 <pattern>mul3p</pattern>
@@ -7073,14 +7073,14 @@
 <pattern>2mz</pattern>
 <pattern>mze4</pattern>
 <pattern>mzet5</pattern>
-<pattern>4n.</pattern>
+<pattern>4n </pattern>
 <pattern>1na</pattern>
-<pattern>3na.</pattern>
+<pattern>3na </pattern>
 <pattern>3naal</pattern>
 <pattern>5n4aam</pattern>
 <pattern>4n1aan</pattern>
 <pattern>2naap</pattern>
-<pattern>n4aar.</pattern>
+<pattern>n4aar </pattern>
 <pattern>4n3aard</pattern>
 <pattern>5naars</pattern>
 <pattern>naars5tr</pattern>
@@ -7097,7 +7097,7 @@
 <pattern>4n3act</pattern>
 <pattern>na5d4a</pattern>
 <pattern>nad4e</pattern>
-<pattern>3nade.</pattern>
+<pattern>3nade </pattern>
 <pattern>5n4a5den</pattern>
 <pattern>3nades</pattern>
 <pattern>3nadi</pattern>
@@ -7130,7 +7130,7 @@
 <pattern>n3a2na</pattern>
 <pattern>n3ank</pattern>
 <pattern>3nant</pattern>
-<pattern>5nant.</pattern>
+<pattern>5nant </pattern>
 <pattern>5nante</pattern>
 <pattern>n5antenn</pattern>
 <pattern>nan4t3j</pattern>
@@ -7148,7 +7148,7 @@
 <pattern>3naro</pattern>
 <pattern>4nars</pattern>
 <pattern>nar4st</pattern>
-<pattern>nars5te.</pattern>
+<pattern>nars5te </pattern>
 <pattern>nar5sten</pattern>
 <pattern>4n1art</pattern>
 <pattern>nas2</pattern>
@@ -7157,14 +7157,14 @@
 <pattern>na1sp</pattern>
 <pattern>na3sta</pattern>
 <pattern>na3stu</pattern>
-<pattern>n4at.</pattern>
+<pattern>n4at </pattern>
 <pattern>3n4ati</pattern>
 <pattern>nat5j</pattern>
 <pattern>4n3atl</pattern>
 <pattern>na3to</pattern>
 <pattern>nats4</pattern>
 <pattern>nat3sp</pattern>
-<pattern>5nau.</pattern>
+<pattern>5nau </pattern>
 <pattern>5naus</pattern>
 <pattern>2na3v</pattern>
 <pattern>5naven</pattern>
@@ -7174,7 +7174,7 @@
 <pattern>2nb</pattern>
 <pattern>nbe5st</pattern>
 <pattern>nbe5t</pattern>
-<pattern>nbots5te.</pattern>
+<pattern>nbots5te </pattern>
 <pattern>2n1c</pattern>
 <pattern>n3ce</pattern>
 <pattern>nces4t</pattern>
@@ -7184,7 +7184,7 @@
 <pattern>nch3u</pattern>
 <pattern>n5co</pattern>
 <pattern>4nd</pattern>
-<pattern>n5da.</pattern>
+<pattern>n5da </pattern>
 <pattern>nd3aan</pattern>
 <pattern>nd5aas</pattern>
 <pattern>nd3abo</pattern>
@@ -7208,23 +7208,23 @@
 <pattern>n4d1ei</pattern>
 <pattern>nde5laa</pattern>
 <pattern>n4d3emm</pattern>
-<pattern>n5den.</pattern>
+<pattern>n5den </pattern>
 <pattern>ndera4</pattern>
 <pattern>nder5aal</pattern>
 <pattern>nder5al</pattern>
 <pattern>nde4r5an</pattern>
 <pattern>n4d5e4rec</pattern>
-<pattern>nder5in.</pattern>
+<pattern>nder5in </pattern>
 <pattern>nder5og</pattern>
 <pattern>nde4ten</pattern>
 <pattern>ndi3a</pattern>
 <pattern>ndie4tj</pattern>
 <pattern>n4dijs</pattern>
-<pattern>nd5ijs.</pattern>
+<pattern>nd5ijs </pattern>
 <pattern>n4d3ink</pattern>
 <pattern>ndi3o</pattern>
 <pattern>n3d2ji</pattern>
-<pattern>n5do.</pattern>
+<pattern>n5do </pattern>
 <pattern>n5doc</pattern>
 <pattern>n4d5of</pattern>
 <pattern>nd3oli</pattern>
@@ -7263,7 +7263,7 @@
 <pattern>nd1w</pattern>
 <pattern>n3dy</pattern>
 <pattern>1ne</pattern>
-<pattern>3ne.</pattern>
+<pattern>3ne </pattern>
 <pattern>ne5ac</pattern>
 <pattern>ne3am</pattern>
 <pattern>nebe4s</pattern>
@@ -7308,9 +7308,9 @@
 <pattern>4n3emm</pattern>
 <pattern>4n3emp</pattern>
 <pattern>ne2n</pattern>
-<pattern>3n4en.</pattern>
+<pattern>3n4en </pattern>
 <pattern>5nenb</pattern>
-<pattern>5n4end.</pattern>
+<pattern>5n4end </pattern>
 <pattern>nen5do</pattern>
 <pattern>ne4n5enk</pattern>
 <pattern>ne4ni</pattern>
@@ -7369,7 +7369,7 @@
 <pattern>n3gav</pattern>
 <pattern>nge4ad</pattern>
 <pattern>n4g3een</pattern>
-<pattern>ngels5te.</pattern>
+<pattern>ngels5te </pattern>
 <pattern>ng3emb</pattern>
 <pattern>n5gen</pattern>
 <pattern>nge4rap</pattern>
@@ -7415,7 +7415,7 @@
 <pattern>ngs5lop</pattern>
 <pattern>ngs5lu</pattern>
 <pattern>ng4s5ne</pattern>
-<pattern>ngs5tak.</pattern>
+<pattern>ngs5tak </pattern>
 <pattern>ngs5take</pattern>
 <pattern>ngs5trek</pattern>
 <pattern>ng5stri</pattern>
@@ -7438,10 +7438,10 @@
 <pattern>nik4s</pattern>
 <pattern>niks3p</pattern>
 <pattern>3nil</pattern>
-<pattern>3nim.</pattern>
+<pattern>3nim </pattern>
 <pattern>5nimf</pattern>
 <pattern>n3imp</pattern>
-<pattern>2n3in.</pattern>
+<pattern>2n3in </pattern>
 <pattern>n3inb</pattern>
 <pattern>2n1ind</pattern>
 <pattern>2ninf</pattern>
@@ -7453,7 +7453,7 @@
 <pattern>2n1int</pattern>
 <pattern>2n3inv</pattern>
 <pattern>ni3o</pattern>
-<pattern>ni4on.</pattern>
+<pattern>ni4on </pattern>
 <pattern>ni4one</pattern>
 <pattern>ni5or</pattern>
 <pattern>ni5o5s4</pattern>
@@ -7533,7 +7533,7 @@
 <pattern>nning5r</pattern>
 <pattern>nnoot5</pattern>
 <pattern>nno5v</pattern>
-<pattern>3no.</pattern>
+<pattern>3no </pattern>
 <pattern>1noc</pattern>
 <pattern>1no3d</pattern>
 <pattern>2noef</pattern>
@@ -7550,14 +7550,14 @@
 <pattern>no2li</pattern>
 <pattern>1nolo</pattern>
 <pattern>1nom</pattern>
-<pattern>4n3om.</pattern>
+<pattern>4n3om </pattern>
 <pattern>n2oma</pattern>
 <pattern>n3oml</pattern>
 <pattern>n1oms</pattern>
 <pattern>n3omv</pattern>
 <pattern>2n3omw</pattern>
 <pattern>2nomz</pattern>
-<pattern>3n2on.</pattern>
+<pattern>3n2on </pattern>
 <pattern>3n4onb</pattern>
 <pattern>3nonc</pattern>
 <pattern>4n5ond</pattern>
@@ -7596,14 +7596,14 @@
 <pattern>5noti</pattern>
 <pattern>not3j</pattern>
 <pattern>not3r</pattern>
-<pattern>3nou.</pattern>
+<pattern>3nou </pattern>
 <pattern>no3v</pattern>
 <pattern>3nova</pattern>
 <pattern>no4ve</pattern>
 <pattern>3nox</pattern>
 <pattern>3noz</pattern>
 <pattern>2n1p</pattern>
-<pattern>npers5te.</pattern>
+<pattern>npers5te </pattern>
 <pattern>npi4s5</pattern>
 <pattern>npoor4</pattern>
 <pattern>npoort5j</pattern>
@@ -7640,11 +7640,11 @@
 <pattern>ns3int</pattern>
 <pattern>n1sjo</pattern>
 <pattern>n1sl</pattern>
-<pattern>n5sla.</pattern>
+<pattern>n5sla </pattern>
 <pattern>n3s4laa</pattern>
 <pattern>ns5laag</pattern>
 <pattern>n5slag</pattern>
-<pattern>ns5lap.</pattern>
+<pattern>ns5lap </pattern>
 <pattern>ns5lapp</pattern>
 <pattern>n4sle</pattern>
 <pattern>n5slep</pattern>
@@ -7655,7 +7655,7 @@
 <pattern>n5s4liep</pattern>
 <pattern>n5slim</pattern>
 <pattern>n5slip</pattern>
-<pattern>ns5lot.</pattern>
+<pattern>ns5lot </pattern>
 <pattern>ns3m</pattern>
 <pattern>ns5mac</pattern>
 <pattern>n3s4me</pattern>
@@ -7704,9 +7704,9 @@
 <pattern>n4st3ei</pattern>
 <pattern>n4s5teko</pattern>
 <pattern>ns5teks</pattern>
-<pattern>n5sten.</pattern>
+<pattern>n5sten </pattern>
 <pattern>ns5tent</pattern>
-<pattern>n5ster.</pattern>
+<pattern>n5ster </pattern>
 <pattern>ns5tes</pattern>
 <pattern>ns3the</pattern>
 <pattern>n1sti</pattern>
@@ -7791,7 +7791,7 @@
 <pattern>ntu4n</pattern>
 <pattern>n5twijf</pattern>
 <pattern>n5t4wis</pattern>
-<pattern>3nu.</pattern>
+<pattern>3nu </pattern>
 <pattern>3nuc</pattern>
 <pattern>3nue</pattern>
 <pattern>nu3en</pattern>
@@ -7829,7 +7829,7 @@
 <pattern>2nz</pattern>
 <pattern>nzet5s</pattern>
 <pattern>3ñ</pattern>
-<pattern>4o.</pattern>
+<pattern>4o </pattern>
 <pattern>4oa</pattern>
 <pattern>o3aa</pattern>
 <pattern>o2ad</pattern>
@@ -7845,7 +7845,7 @@
 <pattern>o3av</pattern>
 <pattern>o3ax</pattern>
 <pattern>2o3b</pattern>
-<pattern>4ob.</pattern>
+<pattern>4ob </pattern>
 <pattern>obal4</pattern>
 <pattern>obalt3</pattern>
 <pattern>3obj</pattern>
@@ -7888,7 +7888,7 @@
 <pattern>ods4t</pattern>
 <pattern>od5sta</pattern>
 <pattern>od4ste</pattern>
-<pattern>ods5te.</pattern>
+<pattern>ods5te </pattern>
 <pattern>od5stek</pattern>
 <pattern>od5sten</pattern>
 <pattern>od3w</pattern>
@@ -7965,7 +7965,7 @@
 <pattern>oer5aal</pattern>
 <pattern>oe4r3a4l</pattern>
 <pattern>oer4e</pattern>
-<pattern>oer5ei.</pattern>
+<pattern>oer5ei </pattern>
 <pattern>oer5eie</pattern>
 <pattern>oero2</pattern>
 <pattern>oe3roe</pattern>
@@ -7975,8 +7975,8 @@
 <pattern>oer4sp</pattern>
 <pattern>oer4sta</pattern>
 <pattern>oers5tak</pattern>
-<pattern>oers5te.</pattern>
-<pattern>4oes.</pattern>
+<pattern>oers5te </pattern>
+<pattern>4oes </pattern>
 <pattern>oe3sfe</pattern>
 <pattern>oe3si</pattern>
 <pattern>oe4sli</pattern>
@@ -8031,7 +8031,7 @@
 <pattern>of3ui</pattern>
 <pattern>og5ac</pattern>
 <pattern>oga4l</pattern>
-<pattern>og3al.</pattern>
+<pattern>og3al </pattern>
 <pattern>og5de</pattern>
 <pattern>og3di</pattern>
 <pattern>oge4d</pattern>
@@ -8073,7 +8073,7 @@
 <pattern>o3ï</pattern>
 <pattern>2o1j</pattern>
 <pattern>2ok</pattern>
-<pattern>o3ka.</pattern>
+<pattern>o3ka </pattern>
 <pattern>o3kaa</pattern>
 <pattern>o4k3aas</pattern>
 <pattern>ok3ab</pattern>
@@ -8088,7 +8088,7 @@
 <pattern>ok5lu</pattern>
 <pattern>o2k3n</pattern>
 <pattern>ok3o2l</pattern>
-<pattern>ok3op.</pattern>
+<pattern>ok3op </pattern>
 <pattern>ok3o4pe</pattern>
 <pattern>okos5</pattern>
 <pattern>o2k3ou</pattern>
@@ -8099,7 +8099,7 @@
 <pattern>ok3sn</pattern>
 <pattern>ok5spri</pattern>
 <pattern>ok1st4</pattern>
-<pattern>oks5te.</pattern>
+<pattern>oks5te </pattern>
 <pattern>ok5sten</pattern>
 <pattern>ok4s5tr</pattern>
 <pattern>ok5te</pattern>
@@ -8120,7 +8120,7 @@
 <pattern>ol3d4o</pattern>
 <pattern>ol3d2w</pattern>
 <pattern>o1le</pattern>
-<pattern>o3le.</pattern>
+<pattern>o3le </pattern>
 <pattern>ole5g</pattern>
 <pattern>ol1ei</pattern>
 <pattern>ol3eks</pattern>
@@ -8159,7 +8159,7 @@
 <pattern>olo3k</pattern>
 <pattern>ol4om</pattern>
 <pattern>o4lop</pattern>
-<pattern>ol3op.</pattern>
+<pattern>ol3op </pattern>
 <pattern>ol3opp</pattern>
 <pattern>olo3s4t</pattern>
 <pattern>olo4ve</pattern>
@@ -8186,7 +8186,7 @@
 <pattern>o4m3ef</pattern>
 <pattern>om3ela</pattern>
 <pattern>omen4s</pattern>
-<pattern>omen5ste.</pattern>
+<pattern>omen5ste </pattern>
 <pattern>ome5ren</pattern>
 <pattern>omer5kl</pattern>
 <pattern>ome5sp</pattern>
@@ -8200,7 +8200,7 @@
 <pattern>om4p5ei</pattern>
 <pattern>5omro</pattern>
 <pattern>om3sl</pattern>
-<pattern>om4ste.</pattern>
+<pattern>om4ste </pattern>
 <pattern>om3ui</pattern>
 <pattern>3omz</pattern>
 <pattern>on1ac</pattern>
@@ -8216,7 +8216,7 @@
 <pattern>ond5ete</pattern>
 <pattern>on4d3id</pattern>
 <pattern>ond5ijs</pattern>
-<pattern>ond5om.</pattern>
+<pattern>ond5om </pattern>
 <pattern>on2dr</pattern>
 <pattern>ond3re</pattern>
 <pattern>ond3ro</pattern>
@@ -8224,14 +8224,14 @@
 <pattern>ond5slo</pattern>
 <pattern>on3d4u</pattern>
 <pattern>on4dur</pattern>
-<pattern>o5ne.</pattern>
+<pattern>o5ne </pattern>
 <pattern>o3neb</pattern>
 <pattern>o2n1e2c</pattern>
 <pattern>on3ei</pattern>
 <pattern>on3erf</pattern>
 <pattern>on3erv</pattern>
 <pattern>one3st</pattern>
-<pattern>4onet.</pattern>
+<pattern>4onet </pattern>
 <pattern>on1e3v</pattern>
 <pattern>ong5aan</pattern>
 <pattern>ong5aap</pattern>
@@ -8271,7 +8271,7 @@
 <pattern>on1st</pattern>
 <pattern>on5sten</pattern>
 <pattern>on5str</pattern>
-<pattern>4ont.</pattern>
+<pattern>4ont </pattern>
 <pattern>on4taa</pattern>
 <pattern>3ont1h</pattern>
 <pattern>on4tid</pattern>
@@ -8282,12 +8282,12 @@
 <pattern>on1ui</pattern>
 <pattern>on3ur</pattern>
 <pattern>o4o2</pattern>
-<pattern>4oo.</pattern>
+<pattern>4oo </pattern>
 <pattern>oo3c</pattern>
 <pattern>4oo4d</pattern>
 <pattern>ood1a</pattern>
 <pattern>ood1e4</pattern>
-<pattern>oo5de.</pattern>
+<pattern>oo5de </pattern>
 <pattern>ood1o</pattern>
 <pattern>ood1r</pattern>
 <pattern>ood3sl</pattern>
@@ -8323,7 +8323,7 @@
 <pattern>oo3me</pattern>
 <pattern>oom3i</pattern>
 <pattern>oom1o4</pattern>
-<pattern>ooms5te.</pattern>
+<pattern>ooms5te </pattern>
 <pattern>4oon</pattern>
 <pattern>oon5a</pattern>
 <pattern>oon5du</pattern>
@@ -8371,18 +8371,18 @@
 <pattern>op3am</pattern>
 <pattern>o3pan</pattern>
 <pattern>op3and</pattern>
-<pattern>op3at.</pattern>
+<pattern>op3at </pattern>
 <pattern>op3att</pattern>
 <pattern>3opbre</pattern>
 <pattern>3opdr</pattern>
-<pattern>o3pe.</pattern>
+<pattern>o3pe </pattern>
 <pattern>op3ee</pattern>
 <pattern>op5eet</pattern>
 <pattern>op3ei</pattern>
 <pattern>o1pel</pattern>
-<pattern>o3pen.</pattern>
+<pattern>o3pen </pattern>
 <pattern>3o4peni</pattern>
-<pattern>o5per.</pattern>
+<pattern>o5per </pattern>
 <pattern>o4pera</pattern>
 <pattern>op3e4te</pattern>
 <pattern>op3e4v</pattern>
@@ -8392,7 +8392,7 @@
 <pattern>op3i2d</pattern>
 <pattern>opie5t</pattern>
 <pattern>op3ijz</pattern>
-<pattern>op3in.</pattern>
+<pattern>op3in </pattern>
 <pattern>o5pina</pattern>
 <pattern>o5pis</pattern>
 <pattern>4op1j</pattern>
@@ -8427,7 +8427,7 @@
 <pattern>op3sta</pattern>
 <pattern>op3su</pattern>
 <pattern>2opt</pattern>
-<pattern>4opt.</pattern>
+<pattern>4opt </pattern>
 <pattern>op5tr</pattern>
 <pattern>op3ui</pattern>
 <pattern>o2p3u2n</pattern>
@@ -8459,7 +8459,7 @@
 <pattern>o1ri</pattern>
 <pattern>o5ria</pattern>
 <pattern>3orië</pattern>
-<pattern>o5rig.</pattern>
+<pattern>o5rig </pattern>
 <pattern>o5rigere</pattern>
 <pattern>o4r3ink</pattern>
 <pattern>or3ins</pattern>
@@ -8527,7 +8527,7 @@
 <pattern>os2ho</pattern>
 <pattern>o3si</pattern>
 <pattern>o4sj</pattern>
-<pattern>os5jer.</pattern>
+<pattern>os5jer </pattern>
 <pattern>o4sk</pattern>
 <pattern>os5ko</pattern>
 <pattern>os3l</pattern>
@@ -8552,7 +8552,7 @@
 <pattern>os5tar</pattern>
 <pattern>o3stas</pattern>
 <pattern>o3stat</pattern>
-<pattern>os5te.</pattern>
+<pattern>os5te </pattern>
 <pattern>os4tem</pattern>
 <pattern>o5steroï</pattern>
 <pattern>os4th</pattern>
@@ -8560,7 +8560,7 @@
 <pattern>os5toli</pattern>
 <pattern>os5tou</pattern>
 <pattern>ost3o4v</pattern>
-<pattern>os5tra.</pattern>
+<pattern>os5tra </pattern>
 <pattern>os5traa</pattern>
 <pattern>ost3re</pattern>
 <pattern>ost3ri</pattern>
@@ -8582,7 +8582,7 @@
 <pattern>o5tat</pattern>
 <pattern>o3te</pattern>
 <pattern>ot3e2d</pattern>
-<pattern>o5tee.</pattern>
+<pattern>o5tee </pattern>
 <pattern>o5tees</pattern>
 <pattern>o5teg</pattern>
 <pattern>ot3ei</pattern>
@@ -8620,7 +8620,7 @@
 <pattern>ot3sn</pattern>
 <pattern>ot3sp</pattern>
 <pattern>ot4s3pa</pattern>
-<pattern>ot4ste.</pattern>
+<pattern>ot4ste </pattern>
 <pattern>ots5tek</pattern>
 <pattern>ot5sten</pattern>
 <pattern>ot4stu</pattern>
@@ -8628,7 +8628,7 @@
 <pattern>ot3ui</pattern>
 <pattern>o3tul</pattern>
 <pattern>ot5w</pattern>
-<pattern>4ou.</pattern>
+<pattern>4ou </pattern>
 <pattern>ou5a</pattern>
 <pattern>ou1c</pattern>
 <pattern>ou4d1a</pattern>
@@ -8638,7 +8638,7 @@
 <pattern>oue2t3</pattern>
 <pattern>ou3k4</pattern>
 <pattern>ou4ren</pattern>
-<pattern>ou5ren.</pattern>
+<pattern>ou5ren </pattern>
 <pattern>ou5renn</pattern>
 <pattern>ou2r3o2</pattern>
 <pattern>4ous</pattern>
@@ -8657,7 +8657,7 @@
 <pattern>ouw5ins</pattern>
 <pattern>o2v</pattern>
 <pattern>2o3va</pattern>
-<pattern>o5ve.</pattern>
+<pattern>o5ve </pattern>
 <pattern>2o5vee</pattern>
 <pattern>3o4verg</pattern>
 <pattern>over5sp</pattern>
@@ -8688,7 +8688,7 @@
 <pattern>ös4</pattern>
 <pattern>ös5t</pattern>
 <pattern>ö5su</pattern>
-<pattern>4p.</pattern>
+<pattern>4p </pattern>
 <pattern>4paan</pattern>
 <pattern>paar5du</pattern>
 <pattern>paar5tj</pattern>
@@ -8699,7 +8699,7 @@
 <pattern>pacht5s</pattern>
 <pattern>p4aci</pattern>
 <pattern>5pacu</pattern>
-<pattern>3pad.</pattern>
+<pattern>3pad </pattern>
 <pattern>pa4da</pattern>
 <pattern>4padv</pattern>
 <pattern>pa3e</pattern>
@@ -8736,7 +8736,7 @@
 <pattern>pap3l</pattern>
 <pattern>pa3po</pattern>
 <pattern>pa3pr</pattern>
-<pattern>4par.</pattern>
+<pattern>4par </pattern>
 <pattern>3pa3ra</pattern>
 <pattern>p3arb</pattern>
 <pattern>pard4</pattern>
@@ -8766,7 +8766,7 @@
 <pattern>1path</pattern>
 <pattern>p3atl</pattern>
 <pattern>3pa3tr</pattern>
-<pattern>pats5te.</pattern>
+<pattern>pats5te </pattern>
 <pattern>2paut</pattern>
 <pattern>5pauz</pattern>
 <pattern>pa4vl</pattern>
@@ -8782,7 +8782,7 @@
 <pattern>pe3de</pattern>
 <pattern>pe3do</pattern>
 <pattern>p4ee4</pattern>
-<pattern>3pee.</pattern>
+<pattern>3pee </pattern>
 <pattern>3peeë</pattern>
 <pattern>pee5li</pattern>
 <pattern>4peen</pattern>
@@ -8827,7 +8827,7 @@
 <pattern>2p3epi</pattern>
 <pattern>pep3o</pattern>
 <pattern>pep5s</pattern>
-<pattern>p4er.</pattern>
+<pattern>p4er </pattern>
 <pattern>pe1ra</pattern>
 <pattern>pera3s4</pattern>
 <pattern>per4at</pattern>
@@ -8846,7 +8846,7 @@
 <pattern>p2ert</pattern>
 <pattern>3pes</pattern>
 <pattern>pe3sa</pattern>
-<pattern>3pet.</pattern>
+<pattern>3pet </pattern>
 <pattern>pe5ta</pattern>
 <pattern>5pe5ter</pattern>
 <pattern>3peti</pattern>
@@ -8876,7 +8876,7 @@
 <pattern>pie4tj</pattern>
 <pattern>pi2g5a</pattern>
 <pattern>pi3gl</pattern>
-<pattern>3pij.</pattern>
+<pattern>3pij </pattern>
 <pattern>pij3k</pattern>
 <pattern>pij5ke</pattern>
 <pattern>pij4li</pattern>
@@ -8890,7 +8890,7 @@
 <pattern>2pind</pattern>
 <pattern>3pinda</pattern>
 <pattern>3p4ing</pattern>
-<pattern>5ping.</pattern>
+<pattern>5ping </pattern>
 <pattern>pin4ga</pattern>
 <pattern>pin5gri</pattern>
 <pattern>4p3inj</pattern>
@@ -8913,7 +8913,7 @@
 <pattern>2p1k</pattern>
 <pattern>pkaart5j</pattern>
 <pattern>p2l2</pattern>
-<pattern>p3la.</pattern>
+<pattern>p3la </pattern>
 <pattern>plaat5j</pattern>
 <pattern>2p3lad</pattern>
 <pattern>pla3di</pattern>
@@ -8945,12 +8945,12 @@
 <pattern>2p1n</pattern>
 <pattern>p3na</pattern>
 <pattern>3pneum</pattern>
-<pattern>3po.</pattern>
+<pattern>3po </pattern>
 <pattern>poda5</pattern>
 <pattern>3poei</pattern>
 <pattern>poe2s3</pattern>
 <pattern>poes5t</pattern>
-<pattern>poets5te.</pattern>
+<pattern>poets5te </pattern>
 <pattern>3poez</pattern>
 <pattern>3poë</pattern>
 <pattern>p2ofa</pattern>
@@ -8962,21 +8962,21 @@
 <pattern>po5l4o</pattern>
 <pattern>polo3p</pattern>
 <pattern>pol4s</pattern>
-<pattern>pols5te.</pattern>
+<pattern>pols5te </pattern>
 <pattern>1pom</pattern>
 <pattern>2p3oml</pattern>
 <pattern>3ponds</pattern>
 <pattern>pon4sm</pattern>
 <pattern>pon4st</pattern>
-<pattern>pons5te.</pattern>
+<pattern>pons5te </pattern>
 <pattern>pon5ta</pattern>
 <pattern>5pony</pattern>
 <pattern>poo3d</pattern>
 <pattern>poo5de</pattern>
-<pattern>4poog.</pattern>
+<pattern>4poog </pattern>
 <pattern>3pool</pattern>
 <pattern>poo5len</pattern>
-<pattern>4poor.</pattern>
+<pattern>4poor </pattern>
 <pattern>poor4tj</pattern>
 <pattern>poot3</pattern>
 <pattern>po4p3a</pattern>
@@ -9013,7 +9013,7 @@
 <pattern>p4ps</pattern>
 <pattern>pr4</pattern>
 <pattern>p2ra</pattern>
-<pattern>3pra.</pattern>
+<pattern>3pra </pattern>
 <pattern>p5raad</pattern>
 <pattern>praat5j</pattern>
 <pattern>p5rad</pattern>
@@ -9127,15 +9127,15 @@
 <pattern>puil3o</pattern>
 <pattern>pul4st</pattern>
 <pattern>3pun</pattern>
-<pattern>4pun.</pattern>
+<pattern>4pun </pattern>
 <pattern>punt3j</pattern>
-<pattern>3put.</pattern>
+<pattern>3put </pattern>
 <pattern>puter5in</pattern>
 <pattern>put1j</pattern>
 <pattern>pu2t3o</pattern>
 <pattern>put3r</pattern>
 <pattern>put4st</pattern>
-<pattern>puts5te.</pattern>
+<pattern>puts5te </pattern>
 <pattern>2pv</pattern>
 <pattern>pvan4</pattern>
 <pattern>pvari5</pattern>
@@ -9147,12 +9147,12 @@
 <pattern>qu4</pattern>
 <pattern>que4s</pattern>
 <pattern>5quo</pattern>
-<pattern>4r.</pattern>
+<pattern>4r </pattern>
 <pattern>r2aa</pattern>
 <pattern>2raan</pattern>
 <pattern>4raand</pattern>
 <pattern>3raar</pattern>
-<pattern>5raar.</pattern>
+<pattern>5raar </pattern>
 <pattern>4r3aard</pattern>
 <pattern>5raars</pattern>
 <pattern>raar5tj</pattern>
@@ -9196,7 +9196,7 @@
 <pattern>ran4dr</pattern>
 <pattern>ran4g3o</pattern>
 <pattern>ran4gr</pattern>
-<pattern>r5angst.</pattern>
+<pattern>r5angst </pattern>
 <pattern>ra4nim</pattern>
 <pattern>4ranj</pattern>
 <pattern>ran4kl</pattern>
@@ -9206,7 +9206,7 @@
 <pattern>ran4t3j</pattern>
 <pattern>r3antw</pattern>
 <pattern>ra3o</pattern>
-<pattern>4rap.</pattern>
+<pattern>4rap </pattern>
 <pattern>ra3po</pattern>
 <pattern>4rappa</pattern>
 <pattern>rap5roe</pattern>
@@ -9231,7 +9231,7 @@
 <pattern>ra5tri</pattern>
 <pattern>rat3sp</pattern>
 <pattern>rat4st</pattern>
-<pattern>rats5te.</pattern>
+<pattern>rats5te </pattern>
 <pattern>ra3t4u</pattern>
 <pattern>2rau</pattern>
 <pattern>3raus</pattern>
@@ -9283,7 +9283,7 @@
 <pattern>r3du</pattern>
 <pattern>rd2wi</pattern>
 <pattern>rd5wo</pattern>
-<pattern>3re.</pattern>
+<pattern>3re </pattern>
 <pattern>1reac</pattern>
 <pattern>re4ade</pattern>
 <pattern>4reak</pattern>
@@ -9316,7 +9316,7 @@
 <pattern>3refl</pattern>
 <pattern>re3fu</pattern>
 <pattern>1reg</pattern>
-<pattern>4reg.</pattern>
+<pattern>4reg </pattern>
 <pattern>4regd</pattern>
 <pattern>rege5ne</pattern>
 <pattern>rege4s</pattern>
@@ -9344,12 +9344,12 @@
 <pattern>re4l3ei</pattern>
 <pattern>rel5k</pattern>
 <pattern>re4lu4r</pattern>
-<pattern>3rem.</pattern>
+<pattern>3rem </pattern>
 <pattern>re4mai</pattern>
 <pattern>remie5tj</pattern>
 <pattern>re5mo5v</pattern>
 <pattern>2remp</pattern>
-<pattern>3r4en.</pattern>
+<pattern>3r4en </pattern>
 <pattern>re2na</pattern>
 <pattern>re4naa</pattern>
 <pattern>ren5aar</pattern>
@@ -9360,12 +9360,12 @@
 <pattern>r4end</pattern>
 <pattern>5rendee</pattern>
 <pattern>r5endert</pattern>
-<pattern>re5ne.</pattern>
+<pattern>re5ne </pattern>
 <pattern>re4nel</pattern>
-<pattern>re5nen.</pattern>
+<pattern>re5nen </pattern>
 <pattern>ren5enk</pattern>
 <pattern>ren3e4p</pattern>
-<pattern>re5ner.</pattern>
+<pattern>re5ner </pattern>
 <pattern>ren5erf</pattern>
 <pattern>ren5erv</pattern>
 <pattern>5renf</pattern>
@@ -9411,7 +9411,7 @@
 <pattern>2retn</pattern>
 <pattern>re4t3o4g</pattern>
 <pattern>re4t3oo</pattern>
-<pattern>rets5te.</pattern>
+<pattern>rets5te </pattern>
 <pattern>re2u</pattern>
 <pattern>reur5es</pattern>
 <pattern>reus4t</pattern>
@@ -9447,7 +9447,7 @@
 <pattern>rg3ei</pattern>
 <pattern>rg4eis</pattern>
 <pattern>rgel5dr</pattern>
-<pattern>r5gen.</pattern>
+<pattern>r5gen </pattern>
 <pattern>rge4ra</pattern>
 <pattern>rge5rap</pattern>
 <pattern>r4g3ins</pattern>
@@ -9494,7 +9494,7 @@
 <pattern>ri3gl</pattern>
 <pattern>5rigste</pattern>
 <pattern>r4ijl</pattern>
-<pattern>4r5ijl.</pattern>
+<pattern>4r5ijl </pattern>
 <pattern>r5ijld</pattern>
 <pattern>r5ijlt</pattern>
 <pattern>rij5o</pattern>
@@ -9539,12 +9539,12 @@
 <pattern>rit3j</pattern>
 <pattern>rit3ov</pattern>
 <pattern>rit4st</pattern>
-<pattern>rits5te.</pattern>
+<pattern>rits5te </pattern>
 <pattern>rit5sten</pattern>
 <pattern>3ritt</pattern>
 <pattern>r5j4</pattern>
 <pattern>rjaars5</pattern>
-<pattern>r5ka.</pattern>
+<pattern>r5ka </pattern>
 <pattern>rkaart5j</pattern>
 <pattern>rk3adr</pattern>
 <pattern>rk3af</pattern>
@@ -9578,7 +9578,7 @@
 <pattern>rkoot5</pattern>
 <pattern>rk3opg</pattern>
 <pattern>rk3ord</pattern>
-<pattern>rk5os.</pattern>
+<pattern>rk5os </pattern>
 <pattern>rk5oss</pattern>
 <pattern>rk2r</pattern>
 <pattern>r5k4ran</pattern>
@@ -9662,7 +9662,7 @@
 <pattern>r4oc</pattern>
 <pattern>ro1ch</pattern>
 <pattern>ro3d4o</pattern>
-<pattern>3roe.</pattern>
+<pattern>3roe </pattern>
 <pattern>4roef</pattern>
 <pattern>4roeg</pattern>
 <pattern>roe4g3r</pattern>
@@ -9682,7 +9682,7 @@
 <pattern>ro3kl</pattern>
 <pattern>3rokm</pattern>
 <pattern>rok3sp</pattern>
-<pattern>r4ol.</pattern>
+<pattern>r4ol </pattern>
 <pattern>ro2l3a</pattern>
 <pattern>role5st</pattern>
 <pattern>rol3g2</pattern>
@@ -9691,7 +9691,7 @@
 <pattern>ro5ma</pattern>
 <pattern>ro3mo</pattern>
 <pattern>4romz</pattern>
-<pattern>r2on.</pattern>
+<pattern>r2on </pattern>
 <pattern>ron3a4d</pattern>
 <pattern>5r4onal</pattern>
 <pattern>ron4da</pattern>
@@ -9706,7 +9706,7 @@
 <pattern>r2o1no</pattern>
 <pattern>r2ons</pattern>
 <pattern>ron4ste</pattern>
-<pattern>rons5te.</pattern>
+<pattern>rons5te </pattern>
 <pattern>4ron2t</pattern>
 <pattern>ront3j</pattern>
 <pattern>ront3r</pattern>
@@ -9748,7 +9748,7 @@
 <pattern>ro5ton</pattern>
 <pattern>ro3tr</pattern>
 <pattern>rot4ste</pattern>
-<pattern>rots5te.</pattern>
+<pattern>rots5te </pattern>
 <pattern>r1oud</pattern>
 <pattern>3rou5t4</pattern>
 <pattern>ro3v</pattern>
@@ -9783,7 +9783,7 @@
 <pattern>rren5s4</pattern>
 <pattern>rre5o</pattern>
 <pattern>rreu2</pattern>
-<pattern>rri5er.</pattern>
+<pattern>rri5er </pattern>
 <pattern>rrie4t</pattern>
 <pattern>rron5k</pattern>
 <pattern>rrot4j</pattern>
@@ -9877,8 +9877,8 @@
 <pattern>rs5tas</pattern>
 <pattern>r5stat</pattern>
 <pattern>r3ste</pattern>
-<pattern>r4s3te.</pattern>
-<pattern>r5ster.</pattern>
+<pattern>r4s3te </pattern>
+<pattern>r5ster </pattern>
 <pattern>r5sterk</pattern>
 <pattern>rs5term</pattern>
 <pattern>r5sters</pattern>
@@ -9904,13 +9904,13 @@
 <pattern>r3sy</pattern>
 <pattern>4rt</pattern>
 <pattern>r1ta</pattern>
-<pattern>r5ta.</pattern>
+<pattern>r5ta </pattern>
 <pattern>r4t3aan</pattern>
 <pattern>rt5aand</pattern>
 <pattern>rt5aanv</pattern>
 <pattern>r4t1ac</pattern>
 <pattern>rt1ad</pattern>
-<pattern>rt3af.</pattern>
+<pattern>rt3af </pattern>
 <pattern>rt3aff</pattern>
 <pattern>rt3am</pattern>
 <pattern>r5tans</pattern>
@@ -9924,7 +9924,7 @@
 <pattern>rt3eil</pattern>
 <pattern>rte4lei</pattern>
 <pattern>rt5emb</pattern>
-<pattern>r5ten.</pattern>
+<pattern>r5ten </pattern>
 <pattern>rte5nach</pattern>
 <pattern>rte3no</pattern>
 <pattern>rte3ro</pattern>
@@ -9948,7 +9948,7 @@
 <pattern>rt3off</pattern>
 <pattern>r5tofo</pattern>
 <pattern>r5tok</pattern>
-<pattern>rt3om.</pattern>
+<pattern>rt3om </pattern>
 <pattern>rt3ond</pattern>
 <pattern>r4t3op</pattern>
 <pattern>r5tori</pattern>
@@ -9957,7 +9957,7 @@
 <pattern>rt4rap</pattern>
 <pattern>r4t3ras</pattern>
 <pattern>rt3rec</pattern>
-<pattern>r5treden.</pattern>
+<pattern>r5treden </pattern>
 <pattern>r3t4rek</pattern>
 <pattern>r4t3res</pattern>
 <pattern>rt3ri</pattern>
@@ -9999,14 +9999,14 @@
 <pattern>rul5s</pattern>
 <pattern>r2um</pattern>
 <pattern>ru2mi</pattern>
-<pattern>3run.</pattern>
+<pattern>3run </pattern>
 <pattern>r2und</pattern>
 <pattern>runet3</pattern>
 <pattern>4r5u2ni</pattern>
 <pattern>ru3niv</pattern>
 <pattern>ru4r</pattern>
 <pattern>ru5ra</pattern>
-<pattern>ru5re.</pattern>
+<pattern>ru5re </pattern>
 <pattern>ru5res</pattern>
 <pattern>r2u4s</pattern>
 <pattern>rus3e</pattern>
@@ -10014,27 +10014,27 @@
 <pattern>4rut</pattern>
 <pattern>rut3j</pattern>
 <pattern>rut4st</pattern>
-<pattern>ruts5te.</pattern>
+<pattern>ruts5te </pattern>
 <pattern>4ruu</pattern>
 <pattern>ru3wa</pattern>
 <pattern>rvaat5</pattern>
 <pattern>rval4st</pattern>
-<pattern>rvals5te.</pattern>
-<pattern>rvers5te.</pattern>
+<pattern>rvals5te </pattern>
+<pattern>rvers5te </pattern>
 <pattern>rves4</pattern>
 <pattern>rve3sp</pattern>
 <pattern>rvloot5</pattern>
 <pattern>r1w</pattern>
 <pattern>rwen4st</pattern>
-<pattern>rwens5te.</pattern>
+<pattern>rwens5te </pattern>
 <pattern>r4wh</pattern>
 <pattern>rw2t3j</pattern>
 <pattern>r3x</pattern>
 <pattern>r3yu</pattern>
 <pattern>4rz</pattern>
 <pattern>rzet5st</pattern>
-<pattern>4s.</pattern>
-<pattern>5sa.</pattern>
+<pattern>4s </pattern>
+<pattern>5sa </pattern>
 <pattern>s1aa</pattern>
 <pattern>1saag</pattern>
 <pattern>5s2aai</pattern>
@@ -10062,7 +10062,7 @@
 <pattern>3saks</pattern>
 <pattern>s1akt</pattern>
 <pattern>s2al</pattern>
-<pattern>5sal.</pattern>
+<pattern>5sal </pattern>
 <pattern>3sa3la</pattern>
 <pattern>3sald</pattern>
 <pattern>5salh</pattern>
@@ -10081,7 +10081,7 @@
 <pattern>s4ant</pattern>
 <pattern>san4t3j</pattern>
 <pattern>sa2p</pattern>
-<pattern>3sap.</pattern>
+<pattern>3sap </pattern>
 <pattern>sa3pa</pattern>
 <pattern>2s3ape</pattern>
 <pattern>sa4pr</pattern>
@@ -10096,7 +10096,7 @@
 <pattern>s4ars</pattern>
 <pattern>4s1art</pattern>
 <pattern>sart5se</pattern>
-<pattern>4sas.</pattern>
+<pattern>4sas </pattern>
 <pattern>3sasa</pattern>
 <pattern>sa3sc</pattern>
 <pattern>3s4ast</pattern>
@@ -10121,12 +10121,12 @@
 <pattern>5scena</pattern>
 <pattern>5scè</pattern>
 <pattern>3s4ch2</pattern>
-<pattern>4sch.</pattern>
+<pattern>4sch </pattern>
 <pattern>sch4a</pattern>
 <pattern>5schak</pattern>
 <pattern>5schap</pattern>
 <pattern>4schau</pattern>
-<pattern>5sche.</pattern>
+<pattern>5sche </pattern>
 <pattern>s5chec</pattern>
 <pattern>4schef</pattern>
 <pattern>5schen</pattern>
@@ -10162,7 +10162,7 @@
 <pattern>s5dr</pattern>
 <pattern>s3dw</pattern>
 <pattern>3se</pattern>
-<pattern>5se.</pattern>
+<pattern>5se </pattern>
 <pattern>se2a</pattern>
 <pattern>se3ak</pattern>
 <pattern>se3al</pattern>
@@ -10185,10 +10185,10 @@
 <pattern>se3ge</pattern>
 <pattern>2s5e2go</pattern>
 <pattern>seg2r</pattern>
-<pattern>4s3ei.</pattern>
+<pattern>4s3ei </pattern>
 <pattern>4s3eig</pattern>
 <pattern>s4ein</pattern>
-<pattern>5sein.</pattern>
+<pattern>5sein </pattern>
 <pattern>5seine</pattern>
 <pattern>2seis</pattern>
 <pattern>seis4t</pattern>
@@ -10198,7 +10198,7 @@
 <pattern>seks5ten</pattern>
 <pattern>se1kw</pattern>
 <pattern>s2el</pattern>
-<pattern>5s4el.</pattern>
+<pattern>5s4el </pattern>
 <pattern>sel3ad</pattern>
 <pattern>se4l3a4g</pattern>
 <pattern>se4lak</pattern>
@@ -10223,7 +10223,7 @@
 <pattern>s5emm</pattern>
 <pattern>sem3oo</pattern>
 <pattern>s4en</pattern>
-<pattern>5sen.</pattern>
+<pattern>5sen </pattern>
 <pattern>se4n3a4g</pattern>
 <pattern>se5nan</pattern>
 <pattern>se4net</pattern>
@@ -10233,7 +10233,7 @@
 <pattern>se4n3o</pattern>
 <pattern>4s5enq</pattern>
 <pattern>sen5tw</pattern>
-<pattern>5s4er.</pattern>
+<pattern>5s4er </pattern>
 <pattern>se1r4a</pattern>
 <pattern>ser5au</pattern>
 <pattern>5se3r4e</pattern>
@@ -10285,9 +10285,9 @@
 <pattern>4s5g</pattern>
 <pattern>sgue4</pattern>
 <pattern>s1h</pattern>
-<pattern>s4ha.</pattern>
+<pattern>s4ha </pattern>
 <pattern>sha4g</pattern>
-<pattern>s5hal.</pattern>
+<pattern>s5hal </pattern>
 <pattern>3shamp</pattern>
 <pattern>4she</pattern>
 <pattern>sheid4</pattern>
@@ -10304,7 +10304,7 @@
 <pattern>3show</pattern>
 <pattern>s5hul</pattern>
 <pattern>1si</pattern>
-<pattern>5si.</pattern>
+<pattern>5si </pattern>
 <pattern>5s4ia</pattern>
 <pattern>si5ac</pattern>
 <pattern>si3am</pattern>
@@ -10312,7 +10312,7 @@
 <pattern>5sic</pattern>
 <pattern>sici4</pattern>
 <pattern>si3co</pattern>
-<pattern>3sie.</pattern>
+<pattern>3sie </pattern>
 <pattern>3sieë</pattern>
 <pattern>sie5fr</pattern>
 <pattern>sie5kl</pattern>
@@ -10338,7 +10338,7 @@
 <pattern>4s1ind</pattern>
 <pattern>2sinf</pattern>
 <pattern>sing4</pattern>
-<pattern>3sing.</pattern>
+<pattern>3sing </pattern>
 <pattern>s3inga</pattern>
 <pattern>s5ingeni</pattern>
 <pattern>sin3gl</pattern>
@@ -10371,12 +10371,12 @@
 <pattern>3siu</pattern>
 <pattern>3siz</pattern>
 <pattern>sj2</pattern>
-<pattern>4sj.</pattern>
-<pattern>3s4ja.</pattern>
+<pattern>4sj </pattern>
+<pattern>3s4ja </pattern>
 <pattern>5sjab</pattern>
 <pattern>4sj3d</pattern>
 <pattern>s1je</pattern>
-<pattern>2s3je.</pattern>
+<pattern>2s3je </pattern>
 <pattern>s5jeb</pattern>
 <pattern>3sjee</pattern>
 <pattern>3s2jei</pattern>
@@ -10398,7 +10398,7 @@
 <pattern>s5ken</pattern>
 <pattern>3s2kes</pattern>
 <pattern>sk4i</pattern>
-<pattern>3s2ki.</pattern>
+<pattern>3s2ki </pattern>
 <pattern>3skied</pattern>
 <pattern>skie3s</pattern>
 <pattern>3skië</pattern>
@@ -10411,7 +10411,7 @@
 <pattern>4sku</pattern>
 <pattern>s3k4w</pattern>
 <pattern>s2l4</pattern>
-<pattern>3s4la.</pattern>
+<pattern>3s4la </pattern>
 <pattern>5s4laan</pattern>
 <pattern>5slaap</pattern>
 <pattern>4s5laar</pattern>
@@ -10421,7 +10421,7 @@
 <pattern>3s4lag</pattern>
 <pattern>5slagm</pattern>
 <pattern>sla4me</pattern>
-<pattern>s5lamp.</pattern>
+<pattern>s5lamp </pattern>
 <pattern>s5lampe</pattern>
 <pattern>4s5land</pattern>
 <pattern>3slang</pattern>
@@ -10434,7 +10434,7 @@
 <pattern>4slaw</pattern>
 <pattern>3s4laz</pattern>
 <pattern>s3led</pattern>
-<pattern>3s4lee.</pattern>
+<pattern>3s4lee </pattern>
 <pattern>5sleep</pattern>
 <pattern>4s5leer</pattern>
 <pattern>s4leet</pattern>
@@ -10444,7 +10444,7 @@
 <pattern>s5leng</pattern>
 <pattern>s3leni</pattern>
 <pattern>slen4st</pattern>
-<pattern>slens5te.</pattern>
+<pattern>slens5te </pattern>
 <pattern>3slent</pattern>
 <pattern>s4lep</pattern>
 <pattern>4s5ler</pattern>
@@ -10455,7 +10455,7 @@
 <pattern>s5leus</pattern>
 <pattern>5sleut</pattern>
 <pattern>2s5lev</pattern>
-<pattern>s3li.</pattern>
+<pattern>s3li </pattern>
 <pattern>4s3lic</pattern>
 <pattern>4slid</pattern>
 <pattern>2slie</pattern>
@@ -10491,9 +10491,9 @@
 <pattern>4s5loz</pattern>
 <pattern>4s5luc</pattern>
 <pattern>1s4lui</pattern>
-<pattern>4s5lui.</pattern>
+<pattern>4s5lui </pattern>
 <pattern>4sluid</pattern>
-<pattern>5sluis.</pattern>
+<pattern>5sluis </pattern>
 <pattern>sluis4t</pattern>
 <pattern>slui5ste</pattern>
 <pattern>5sluit</pattern>
@@ -10504,7 +10504,7 @@
 <pattern>s1m</pattern>
 <pattern>4s5maat</pattern>
 <pattern>3smad</pattern>
-<pattern>3smak.</pattern>
+<pattern>3smak </pattern>
 <pattern>3smal</pattern>
 <pattern>2s5man</pattern>
 <pattern>s5map</pattern>
@@ -10518,7 +10518,7 @@
 <pattern>4smelo</pattern>
 <pattern>4s5men</pattern>
 <pattern>4s5mes3</pattern>
-<pattern>5smid.</pattern>
+<pattern>5smid </pattern>
 <pattern>smie2</pattern>
 <pattern>smies5</pattern>
 <pattern>s4mij</pattern>
@@ -10553,13 +10553,13 @@
 <pattern>3s4noe</pattern>
 <pattern>s3nog</pattern>
 <pattern>2snoo</pattern>
-<pattern>s4nor.</pattern>
+<pattern>s4nor </pattern>
 <pattern>s3norm</pattern>
 <pattern>sno5v</pattern>
 <pattern>3snuf</pattern>
 <pattern>s4nui</pattern>
 <pattern>2snum</pattern>
-<pattern>3so.</pattern>
+<pattern>3so </pattern>
 <pattern>so4bl</pattern>
 <pattern>so1c</pattern>
 <pattern>s3oce</pattern>
@@ -10579,7 +10579,7 @@
 <pattern>3soï</pattern>
 <pattern>3sok</pattern>
 <pattern>s2ol</pattern>
-<pattern>5sol.</pattern>
+<pattern>5sol </pattern>
 <pattern>so3la</pattern>
 <pattern>so3le</pattern>
 <pattern>so3lis</pattern>
@@ -10587,12 +10587,12 @@
 <pattern>solo5v</pattern>
 <pattern>5sols</pattern>
 <pattern>s2om</pattern>
-<pattern>3s4om.</pattern>
+<pattern>3s4om </pattern>
 <pattern>5somm</pattern>
 <pattern>2s3oms</pattern>
 <pattern>s3omv</pattern>
 <pattern>2somz</pattern>
-<pattern>5s4on.</pattern>
+<pattern>5s4on </pattern>
 <pattern>3sona</pattern>
 <pattern>so5nar</pattern>
 <pattern>s3onb</pattern>
@@ -10607,12 +10607,12 @@
 <pattern>3soo</pattern>
 <pattern>4s5oog</pattern>
 <pattern>4s3ook</pattern>
-<pattern>4s3oor.</pattern>
+<pattern>4s3oor </pattern>
 <pattern>s3oord</pattern>
 <pattern>4s3oorl</pattern>
 <pattern>5soort</pattern>
 <pattern>2s1op</pattern>
-<pattern>3s4op.</pattern>
+<pattern>3s4op </pattern>
 <pattern>4s5ope</pattern>
 <pattern>so3phi</pattern>
 <pattern>s2o5po</pattern>
@@ -10636,7 +10636,7 @@
 <pattern>2sov</pattern>
 <pattern>s1ove</pattern>
 <pattern>3so5z</pattern>
-<pattern>4sp.</pattern>
+<pattern>4sp </pattern>
 <pattern>sp4a</pattern>
 <pattern>5spaak</pattern>
 <pattern>s3paal</pattern>
@@ -10648,7 +10648,7 @@
 <pattern>s4pan</pattern>
 <pattern>3spann</pattern>
 <pattern>4s5pap</pattern>
-<pattern>5spar.</pattern>
+<pattern>5spar </pattern>
 <pattern>s4pari</pattern>
 <pattern>5sparr</pattern>
 <pattern>2spas5</pattern>
@@ -10662,11 +10662,11 @@
 <pattern>s4pek</pattern>
 <pattern>5spell</pattern>
 <pattern>4s3pen</pattern>
-<pattern>s5pen.</pattern>
+<pattern>s5pen </pattern>
 <pattern>spe4na</pattern>
 <pattern>s5pep</pattern>
 <pattern>4sper</pattern>
-<pattern>s4per.</pattern>
+<pattern>s4per </pattern>
 <pattern>s5peri</pattern>
 <pattern>s4perm</pattern>
 <pattern>5s4perr</pattern>
@@ -10696,7 +10696,7 @@
 <pattern>4spog</pattern>
 <pattern>4spol</pattern>
 <pattern>2s3pom</pattern>
-<pattern>s4pon.</pattern>
+<pattern>s4pon </pattern>
 <pattern>s4ponn</pattern>
 <pattern>s2poo</pattern>
 <pattern>s3pop</pattern>
@@ -10751,9 +10751,9 @@
 <pattern>s5su</pattern>
 <pattern>s5sy</pattern>
 <pattern>s2t</pattern>
-<pattern>4st.</pattern>
+<pattern>4st </pattern>
 <pattern>5staaf</pattern>
-<pattern>5staan.</pattern>
+<pattern>5staan </pattern>
 <pattern>4staang</pattern>
 <pattern>4staanw</pattern>
 <pattern>staart5j</pattern>
@@ -10764,7 +10764,7 @@
 <pattern>3stad</pattern>
 <pattern>5stads</pattern>
 <pattern>2staf</pattern>
-<pattern>5staf.</pattern>
+<pattern>5staf </pattern>
 <pattern>sta4fo</pattern>
 <pattern>s4tag</pattern>
 <pattern>s4tak</pattern>
@@ -10772,7 +10772,7 @@
 <pattern>4stakk</pattern>
 <pattern>st3akt</pattern>
 <pattern>4s3tali</pattern>
-<pattern>5stam.</pattern>
+<pattern>5stam </pattern>
 <pattern>5stamm</pattern>
 <pattern>3stamp</pattern>
 <pattern>3s4tand</pattern>
@@ -10812,7 +10812,7 @@
 <pattern>ste4lee</pattern>
 <pattern>st5elem</pattern>
 <pattern>3stell</pattern>
-<pattern>5stem.</pattern>
+<pattern>5stem </pattern>
 <pattern>5stemd</pattern>
 <pattern>5stemm</pattern>
 <pattern>4stemo</pattern>
@@ -10868,7 +10868,7 @@
 <pattern>2stoc</pattern>
 <pattern>4stoef</pattern>
 <pattern>3stoel</pattern>
-<pattern>5stoel.</pattern>
+<pattern>5stoel </pattern>
 <pattern>5stoele</pattern>
 <pattern>4stoen</pattern>
 <pattern>4stoer</pattern>
@@ -10896,11 +10896,11 @@
 <pattern>s4tov</pattern>
 <pattern>2stp</pattern>
 <pattern>1s4tr</pattern>
-<pattern>4stra.</pattern>
+<pattern>4stra </pattern>
 <pattern>straat5j</pattern>
 <pattern>4st4rad</pattern>
 <pattern>3stra4f</pattern>
-<pattern>5straf.</pattern>
+<pattern>5straf </pattern>
 <pattern>s5trag</pattern>
 <pattern>4strai</pattern>
 <pattern>4st3rec</pattern>
@@ -10918,11 +10918,11 @@
 <pattern>5strook</pattern>
 <pattern>5stroom</pattern>
 <pattern>4stroos</pattern>
-<pattern>st5roos.</pattern>
+<pattern>st5roos </pattern>
 <pattern>4s5trou</pattern>
 <pattern>4stroz</pattern>
 <pattern>3stru</pattern>
-<pattern>4strui.</pattern>
+<pattern>4strui </pattern>
 <pattern>5struik</pattern>
 <pattern>4st1s4</pattern>
 <pattern>st3sc</pattern>
@@ -10953,7 +10953,7 @@
 <pattern>s5typ</pattern>
 <pattern>2stz</pattern>
 <pattern>1su</pattern>
-<pattern>5su.</pattern>
+<pattern>5su </pattern>
 <pattern>5sua</pattern>
 <pattern>5su4b1</pattern>
 <pattern>suba4</pattern>
@@ -10965,9 +10965,9 @@
 <pattern>2sui</pattern>
 <pattern>5suik</pattern>
 <pattern>4s1uit</pattern>
-<pattern>5suit.</pattern>
+<pattern>5suit </pattern>
 <pattern>s5uitl</pattern>
-<pattern>5suits.</pattern>
+<pattern>5suits </pattern>
 <pattern>5suk</pattern>
 <pattern>3sul</pattern>
 <pattern>5sum</pattern>
@@ -10985,14 +10985,14 @@
 <pattern>4s1w</pattern>
 <pattern>s5wo</pattern>
 <pattern>s4y</pattern>
-<pattern>3sy.</pattern>
+<pattern>3sy </pattern>
 <pattern>4syc</pattern>
 <pattern>3syn</pattern>
 <pattern>sy4n3e</pattern>
 <pattern>1sys5</pattern>
 <pattern>4s5z</pattern>
-<pattern>4t.</pattern>
-<pattern>3taak.</pattern>
+<pattern>4t </pattern>
+<pattern>3taak </pattern>
 <pattern>t4aal</pattern>
 <pattern>t5aando</pattern>
 <pattern>t3aank</pattern>
@@ -11015,7 +11015,7 @@
 <pattern>t3adr</pattern>
 <pattern>tad4s3</pattern>
 <pattern>t3adve</pattern>
-<pattern>2taf.</pattern>
+<pattern>2taf </pattern>
 <pattern>2t3afd</pattern>
 <pattern>5ta3fe</pattern>
 <pattern>4taff</pattern>
@@ -11041,7 +11041,7 @@
 <pattern>ta3laa</pattern>
 <pattern>ta5lact</pattern>
 <pattern>4talb</pattern>
-<pattern>5tale.</pattern>
+<pattern>5tale </pattern>
 <pattern>5talent</pattern>
 <pattern>ta3li</pattern>
 <pattern>5talig</pattern>
@@ -11055,7 +11055,7 @@
 <pattern>tament5j</pattern>
 <pattern>4tamp</pattern>
 <pattern>t3ampu</pattern>
-<pattern>5tan.</pattern>
+<pattern>5tan </pattern>
 <pattern>4t3a2na</pattern>
 <pattern>ta3nag</pattern>
 <pattern>ta3nat</pattern>
@@ -11115,7 +11115,7 @@
 <pattern>te4dit</pattern>
 <pattern>t3edu</pattern>
 <pattern>tee2</pattern>
-<pattern>teeds5te.</pattern>
+<pattern>teeds5te </pattern>
 <pattern>tee4g</pattern>
 <pattern>4teek</pattern>
 <pattern>tee4k3l</pattern>
@@ -11157,7 +11157,7 @@
 <pattern>tel5een</pattern>
 <pattern>5telef</pattern>
 <pattern>5teleg</pattern>
-<pattern>tel5ei.</pattern>
+<pattern>tel5ei </pattern>
 <pattern>tel5eie</pattern>
 <pattern>tel5eit</pattern>
 <pattern>te5lel</pattern>
@@ -11203,7 +11203,7 @@
 <pattern>tens5uu</pattern>
 <pattern>3tent</pattern>
 <pattern>5tenta</pattern>
-<pattern>5tenten.</pattern>
+<pattern>5tenten </pattern>
 <pattern>ten5to</pattern>
 <pattern>t3entw</pattern>
 <pattern>5tenu</pattern>
@@ -11225,20 +11225,20 @@
 <pattern>ter5eik</pattern>
 <pattern>te4rel</pattern>
 <pattern>te4rem</pattern>
-<pattern>te5ren.</pattern>
+<pattern>te5ren </pattern>
 <pattern>te4r5enk</pattern>
 <pattern>te4r5env</pattern>
-<pattern>4t4erf.</pattern>
+<pattern>4t4erf </pattern>
 <pattern>4terfd</pattern>
 <pattern>ter3fr</pattern>
 <pattern>4t4erft</pattern>
-<pattern>te4r5in.</pattern>
+<pattern>te4r5in </pattern>
 <pattern>3terj</pattern>
-<pattern>4terk.</pattern>
+<pattern>4terk </pattern>
 <pattern>4terkt</pattern>
 <pattern>ter3k4w</pattern>
 <pattern>3term</pattern>
-<pattern>5term.</pattern>
+<pattern>5term </pattern>
 <pattern>5termi</pattern>
 <pattern>ter5oc</pattern>
 <pattern>te3rod</pattern>
@@ -11253,7 +11253,7 @@
 <pattern>5terreu</pattern>
 <pattern>5terror</pattern>
 <pattern>ter4spr</pattern>
-<pattern>ter5ste.</pattern>
+<pattern>ter5ste </pattern>
 <pattern>ter5ston</pattern>
 <pattern>3tes</pattern>
 <pattern>te3s4ap</pattern>
@@ -11274,7 +11274,7 @@
 <pattern>5tevl</pattern>
 <pattern>3tevr</pattern>
 <pattern>2tex</pattern>
-<pattern>3tex.</pattern>
+<pattern>3tex </pattern>
 <pattern>4t3exe</pattern>
 <pattern>4texp</pattern>
 <pattern>1té</pattern>
@@ -11285,7 +11285,7 @@
 <pattern>t5ge</pattern>
 <pattern>tge3la</pattern>
 <pattern>tger4</pattern>
-<pattern>4th.</pattern>
+<pattern>4th </pattern>
 <pattern>2t1ha</pattern>
 <pattern>t3haa</pattern>
 <pattern>t4haan</pattern>
@@ -11297,7 +11297,7 @@
 <pattern>t3hav</pattern>
 <pattern>5thea</pattern>
 <pattern>t3heb</pattern>
-<pattern>5thee.</pattern>
+<pattern>5thee </pattern>
 <pattern>4t3hei</pattern>
 <pattern>4t3hel</pattern>
 <pattern>3t2hen</pattern>
@@ -11324,7 +11324,7 @@
 <pattern>4thum</pattern>
 <pattern>t4hur</pattern>
 <pattern>3ti</pattern>
-<pattern>5ti.</pattern>
+<pattern>5ti </pattern>
 <pattern>5tia</pattern>
 <pattern>ti5ab</pattern>
 <pattern>ti5ae</pattern>
@@ -11335,7 +11335,7 @@
 <pattern>5tici</pattern>
 <pattern>5ticu</pattern>
 <pattern>ti3d4</pattern>
-<pattern>5tie.</pattern>
+<pattern>5tie </pattern>
 <pattern>tie5d4</pattern>
 <pattern>5tiefs</pattern>
 <pattern>tie3kn</pattern>
@@ -11363,7 +11363,7 @@
 <pattern>tij4kl</pattern>
 <pattern>5tijn</pattern>
 <pattern>tij5p</pattern>
-<pattern>t3ijs.</pattern>
+<pattern>t3ijs </pattern>
 <pattern>tij3st</pattern>
 <pattern>tij3t2</pattern>
 <pattern>tij5tr</pattern>
@@ -11422,7 +11422,7 @@
 <pattern>4t3k2</pattern>
 <pattern>tkars3</pattern>
 <pattern>4t3l</pattern>
-<pattern>t5le.</pattern>
+<pattern>t5le </pattern>
 <pattern>5tleb</pattern>
 <pattern>t5les</pattern>
 <pattern>tli4n</pattern>
@@ -11434,7 +11434,7 @@
 <pattern>tna4m3o</pattern>
 <pattern>tne4r</pattern>
 <pattern>tnes4</pattern>
-<pattern>5to.</pattern>
+<pattern>5to </pattern>
 <pattern>toa2</pattern>
 <pattern>to3ac</pattern>
 <pattern>to3ar</pattern>
@@ -11461,9 +11461,9 @@
 <pattern>toe5st</pattern>
 <pattern>toe3tj</pattern>
 <pattern>3toets</pattern>
-<pattern>5toets.</pattern>
+<pattern>5toets </pattern>
 <pattern>5toetse</pattern>
-<pattern>toets5te.</pattern>
+<pattern>toets5te </pattern>
 <pattern>3toev</pattern>
 <pattern>5toez</pattern>
 <pattern>to2f</pattern>
@@ -11489,21 +11489,21 @@
 <pattern>5tolo</pattern>
 <pattern>tolp3r</pattern>
 <pattern>t3oly</pattern>
-<pattern>4tom.</pattern>
+<pattern>4tom </pattern>
 <pattern>5tomaa</pattern>
 <pattern>tomaat5</pattern>
 <pattern>t3oml</pattern>
 <pattern>to3mo</pattern>
 <pattern>tom4p3j</pattern>
 <pattern>4t3om5s</pattern>
-<pattern>5ton.</pattern>
+<pattern>5ton </pattern>
 <pattern>4tond</pattern>
 <pattern>3t2one</pattern>
 <pattern>5tonee</pattern>
 <pattern>5to5nen</pattern>
 <pattern>to5ner</pattern>
 <pattern>3t4ong</pattern>
-<pattern>5tong.</pattern>
+<pattern>5tong </pattern>
 <pattern>3t4oni</pattern>
 <pattern>5t4onn</pattern>
 <pattern>to3no</pattern>
@@ -11512,7 +11512,7 @@
 <pattern>too4m</pattern>
 <pattern>toom3e</pattern>
 <pattern>5toon</pattern>
-<pattern>t4op.</pattern>
+<pattern>t4op </pattern>
 <pattern>top5art</pattern>
 <pattern>top3as</pattern>
 <pattern>to3pen</pattern>
@@ -11525,7 +11525,7 @@
 <pattern>to4pu</pattern>
 <pattern>to5pus</pattern>
 <pattern>t3opva</pattern>
-<pattern>5tor.</pattern>
+<pattern>5tor </pattern>
 <pattern>to3ra</pattern>
 <pattern>to4r3ag</pattern>
 <pattern>t3ord</pattern>
@@ -11543,7 +11543,7 @@
 <pattern>to3rom</pattern>
 <pattern>5torr</pattern>
 <pattern>3tors</pattern>
-<pattern>tors5te.</pattern>
+<pattern>tors5te </pattern>
 <pattern>to3r2u</pattern>
 <pattern>3tos4</pattern>
 <pattern>to3sa</pattern>
@@ -11564,10 +11564,10 @@
 <pattern>tpe4t3</pattern>
 <pattern>tpi3s</pattern>
 <pattern>tr4</pattern>
-<pattern>3tra.</pattern>
+<pattern>3tra </pattern>
 <pattern>4t3raad</pattern>
 <pattern>5tracé</pattern>
-<pattern>5trafo.</pattern>
+<pattern>5trafo </pattern>
 <pattern>3trag</pattern>
 <pattern>4tragez</pattern>
 <pattern>3t4rai</pattern>
@@ -11577,13 +11577,13 @@
 <pattern>3trakt</pattern>
 <pattern>3trans</pattern>
 <pattern>5transa</pattern>
-<pattern>5trap.</pattern>
+<pattern>5trap </pattern>
 <pattern>5trau</pattern>
 <pattern>4t3raz</pattern>
-<pattern>3t4re.</pattern>
+<pattern>3t4re </pattern>
 <pattern>4trea</pattern>
 <pattern>2trec</pattern>
-<pattern>5tred.</pattern>
+<pattern>5tred </pattern>
 <pattern>4treda</pattern>
 <pattern>t5redes</pattern>
 <pattern>4tredu</pattern>
@@ -11596,7 +11596,7 @@
 <pattern>t3resu</pattern>
 <pattern>tre2t3</pattern>
 <pattern>t4reu</pattern>
-<pattern>t3rib.</pattern>
+<pattern>t3rib </pattern>
 <pattern>5tribu</pattern>
 <pattern>5trico</pattern>
 <pattern>trie5ta</pattern>
@@ -11606,7 +11606,7 @@
 <pattern>tri5ni</pattern>
 <pattern>5t4rio4</pattern>
 <pattern>t3risi</pattern>
-<pattern>t3rit.</pattern>
+<pattern>t3rit </pattern>
 <pattern>5t4riti</pattern>
 <pattern>5trody</pattern>
 <pattern>t3roed</pattern>
@@ -11615,11 +11615,11 @@
 <pattern>3trog</pattern>
 <pattern>t4roï</pattern>
 <pattern>5troj</pattern>
-<pattern>4trol.</pattern>
+<pattern>4trol </pattern>
 <pattern>5trola</pattern>
 <pattern>5trolo</pattern>
 <pattern>5tromm</pattern>
-<pattern>5tron.</pattern>
+<pattern>5tron </pattern>
 <pattern>5trona</pattern>
 <pattern>t5rond</pattern>
 <pattern>3trone</pattern>
@@ -11636,10 +11636,10 @@
 <pattern>3trou</pattern>
 <pattern>4t5rout</pattern>
 <pattern>tro5v</pattern>
-<pattern>5truc.</pattern>
+<pattern>5truc </pattern>
 <pattern>5truf</pattern>
 <pattern>4trug</pattern>
-<pattern>5trui.</pattern>
+<pattern>5trui </pattern>
 <pattern>5truie</pattern>
 <pattern>t3ruim</pattern>
 <pattern>trui5t4</pattern>
@@ -11670,7 +11670,7 @@
 <pattern>t1sl</pattern>
 <pattern>ts4laa</pattern>
 <pattern>t3slac</pattern>
-<pattern>t5slag.</pattern>
+<pattern>t5slag </pattern>
 <pattern>ts3lam</pattern>
 <pattern>t2s3le</pattern>
 <pattern>t5slib</pattern>
@@ -11718,10 +11718,10 @@
 <pattern>t5stell</pattern>
 <pattern>t5stels</pattern>
 <pattern>t5stem</pattern>
-<pattern>t5ster.</pattern>
+<pattern>t5ster </pattern>
 <pattern>t4sterr</pattern>
 <pattern>t5sters</pattern>
-<pattern>t5s4tes.</pattern>
+<pattern>t5s4tes </pattern>
 <pattern>t5steu</pattern>
 <pattern>ts3th</pattern>
 <pattern>t1s4ti</pattern>
@@ -11800,7 +11800,7 @@
 <pattern>u3an</pattern>
 <pattern>ua5ne</pattern>
 <pattern>ua3p</pattern>
-<pattern>u5ar.</pattern>
+<pattern>u5ar </pattern>
 <pattern>uar5t</pattern>
 <pattern>ua3sa</pattern>
 <pattern>uat4</pattern>
@@ -11820,7 +11820,7 @@
 <pattern>uc4tin</pattern>
 <pattern>u1d</pattern>
 <pattern>uda2</pattern>
-<pattern>u5da.</pattern>
+<pattern>u5da </pattern>
 <pattern>ud5am</pattern>
 <pattern>ud3ei</pattern>
 <pattern>ud3ess</pattern>
@@ -11887,7 +11887,7 @@
 <pattern>uid4s</pattern>
 <pattern>uid3sp</pattern>
 <pattern>uid5spre</pattern>
-<pattern>uid5ste.</pattern>
+<pattern>uid5ste </pattern>
 <pattern>uid3u</pattern>
 <pattern>ui3e</pattern>
 <pattern>uien4t</pattern>
@@ -11945,7 +11945,7 @@
 <pattern>uit3sl</pattern>
 <pattern>uit3sn</pattern>
 <pattern>uit5sp</pattern>
-<pattern>uits5te.</pattern>
+<pattern>uits5te </pattern>
 <pattern>3uitw</pattern>
 <pattern>3uitz</pattern>
 <pattern>ui3v</pattern>
@@ -11980,7 +11980,7 @@
 <pattern>ul3fl</pattern>
 <pattern>ul5fo</pattern>
 <pattern>ul3fr</pattern>
-<pattern>ul3in.</pattern>
+<pattern>ul3in </pattern>
 <pattern>u5ling</pattern>
 <pattern>ul3inn</pattern>
 <pattern>ul3k2a</pattern>
@@ -11998,7 +11998,7 @@
 <pattern>ul3sa</pattern>
 <pattern>ul3so</pattern>
 <pattern>ul2s3p</pattern>
-<pattern>uls5te.</pattern>
+<pattern>uls5te </pattern>
 <pattern>uls5tel</pattern>
 <pattern>u3lu</pattern>
 <pattern>um3af</pattern>
@@ -12028,7 +12028,7 @@
 <pattern>uno3g</pattern>
 <pattern>un5o2p</pattern>
 <pattern>unst3a</pattern>
-<pattern>un4ste.</pattern>
+<pattern>un4ste </pattern>
 <pattern>unst3o</pattern>
 <pattern>un4st5r</pattern>
 <pattern>unst5ui</pattern>
@@ -12149,8 +12149,8 @@
 <pattern>us4t3ei</pattern>
 <pattern>u4sti</pattern>
 <pattern>ust3oo</pattern>
-<pattern>us5tra.</pattern>
-<pattern>us5tre.</pattern>
+<pattern>us5tra </pattern>
+<pattern>us5tre </pattern>
 <pattern>us5tro</pattern>
 <pattern>us5tru</pattern>
 <pattern>ustu4</pattern>
@@ -12192,7 +12192,7 @@
 <pattern>ut4spo</pattern>
 <pattern>ut2st</pattern>
 <pattern>uts5tak</pattern>
-<pattern>ut4ste.</pattern>
+<pattern>ut4ste </pattern>
 <pattern>ut5sten</pattern>
 <pattern>ut3str</pattern>
 <pattern>ut5su</pattern>
@@ -12247,7 +12247,7 @@
 <pattern>ü3ri</pattern>
 <pattern>üs3l</pattern>
 <pattern>1v2</pattern>
-<pattern>2v.</pattern>
+<pattern>2v </pattern>
 <pattern>vaar4ta</pattern>
 <pattern>vaart5r</pattern>
 <pattern>va3de</pattern>
@@ -12283,7 +12283,7 @@
 <pattern>v4b</pattern>
 <pattern>4v3c</pattern>
 <pattern>v4e</pattern>
-<pattern>3ve.</pattern>
+<pattern>3ve </pattern>
 <pattern>5veb</pattern>
 <pattern>vee4l</pattern>
 <pattern>veel5e</pattern>
@@ -12327,7 +12327,7 @@
 <pattern>ve3reg</pattern>
 <pattern>ve3rei</pattern>
 <pattern>ver5eis</pattern>
-<pattern>ve5ren.</pattern>
+<pattern>ve5ren </pattern>
 <pattern>ve5rend</pattern>
 <pattern>ver3e4t</pattern>
 <pattern>ver5ijd</pattern>
@@ -12387,7 +12387,7 @@
 <pattern>vlie4s5</pattern>
 <pattern>vlot5s</pattern>
 <pattern>v3lov</pattern>
-<pattern>5vo.</pattern>
+<pattern>5vo </pattern>
 <pattern>3voe</pattern>
 <pattern>voe4t3a</pattern>
 <pattern>voe4t3r</pattern>
@@ -12410,7 +12410,7 @@
 <pattern>voor5na</pattern>
 <pattern>vo3ra</pattern>
 <pattern>vorm3a</pattern>
-<pattern>vors5te.</pattern>
+<pattern>vors5te </pattern>
 <pattern>vor5sten</pattern>
 <pattern>vos3</pattern>
 <pattern>3vot</pattern>
@@ -12429,7 +12429,7 @@
 <pattern>vul5p</pattern>
 <pattern>vuur5s</pattern>
 <pattern>vy3</pattern>
-<pattern>2w.</pattern>
+<pattern>2w </pattern>
 <pattern>waad3</pattern>
 <pattern>w2aar</pattern>
 <pattern>waar5e</pattern>
@@ -12502,7 +12502,7 @@
 <pattern>wen3ad</pattern>
 <pattern>we3ne4</pattern>
 <pattern>we4nem</pattern>
-<pattern>we5nen.</pattern>
+<pattern>we5nen </pattern>
 <pattern>wen5enk</pattern>
 <pattern>we3ni</pattern>
 <pattern>wen4k3a</pattern>
@@ -12526,7 +12526,7 @@
 <pattern>we2s3</pattern>
 <pattern>we3spo</pattern>
 <pattern>wes4t5o</pattern>
-<pattern>3wet.</pattern>
+<pattern>3wet </pattern>
 <pattern>we2th</pattern>
 <pattern>we2t3j</pattern>
 <pattern>wet4st</pattern>
@@ -12579,7 +12579,7 @@
 <pattern>wor4g3e</pattern>
 <pattern>w1p</pattern>
 <pattern>wren4st</pattern>
-<pattern>wrens5te.</pattern>
+<pattern>wrens5te </pattern>
 <pattern>2ws</pattern>
 <pattern>ws3a2</pattern>
 <pattern>w3sc</pattern>
@@ -12708,7 +12708,7 @@
 <pattern>yvari5</pattern>
 <pattern>y1w4</pattern>
 <pattern>1z</pattern>
-<pattern>4z.</pattern>
+<pattern>4z </pattern>
 <pattern>zaar5t</pattern>
 <pattern>za3f2</pattern>
 <pattern>zags4t</pattern>
@@ -12821,7 +12821,7 @@
 <pattern>zus3</pattern>
 <pattern>2zv</pattern>
 <pattern>z4w</pattern>
-<pattern>zwets5te.</pattern>
+<pattern>zwets5te </pattern>
 <pattern>5zy</pattern>
 <pattern>2z3z</pattern>
 <pattern>zz3in</pattern>

--- a/cr3gui/data/hyph/Dutch.pattern
+++ b/cr3gui/data/hyph/Dutch.pattern
@@ -1,68 +1,13 @@
 <?xml version="1.0" encoding="utf8"?>
 <!--
+       hyphenations description for FBReader/CoolReader
+       from the original file:
 
-	hyphenations description for FBReader/CoolReader
-	from the original file:
-
-% This file is an adaptation of the original after the formatting of the pattern-files.
-% The original file is part of hyph-utf8 package and resulted from
-% semi-manual conversions of hyphenation patterns into UTF-8 in June 2008.
+% This file has been converted for the hyph-utf8 project from nehyph96.tex,
+% whose author has been identified as Piet Tutelaers.  The licence terms are
+% unchanged.
 %
-% Source: nehyph96.tex (yyyy-mm-dd)
-% Author: Piet Tutelaers
-%
-% The above mentioned file should become obsolete,
-% and the author of the original file should preferably modify this file instead.
-%
-% Modifications were needed in order to support native UTF-8 engines,
-% but functionality (hopefully) didn't change in any way, at least not intentionally.
-% This file is no longer stand-alone; at least for 8-bit engines
-% you probably want to use loadhyph-foo.tex (which will load this file) instead.
-%
-% Modifications were done by Jonathan Kew, Mojca Miklavec & Arthur Reutenauer
-% with help & support from:
-% - Karl Berry, who gave us free hands and all resources
-% - Taco Hoekwater, with useful macros
-% - Hans Hagen, who did the unicodification of patterns already long before
-%               and helped with testing, suggestions and bug reports
-% - Norbert Preining, who tested & integrated patterns into TeX Live
-%
-% However, the "copyright/copyleft" owner of patterns remains the original author.
-%
-% The copyright statement of this file is thus:
-%
-%    Do with this file whatever needs to be done in future for the sake of
-%    "a better world" as long as you respect the copyright of original file.
-%    If you're the original author of patterns or taking over a new revolution,
-%    plese remove all of the TUG comments & credits that we added here -
-%    you are the Queen / the King, we are only the servants.
-%
-% If you want to change this file, rather than uploading directly to CTAN,
-% we would be grateful if you could send it to us (http://tug.org/tex-hyphen)
-% or ask for credentials for SVN repository and commit it yourself;
-% we will then upload the whole "package" to CTAN.
-%
-% Before a new "pattern-revolution" starts,
-% please try to follow some guidelines if possible:
-%
-% - \lccode is *forbidden*, and I really mean it
-% - all the patterns should be in UTF-8
-% - the only "allowed" TeX commands in this file are: \patterns, \hyphenation,
-%   and if you really cannot do without, also \input and \message
-% - in particular, please no \catcode or \lccode changes,
-%   they belong to loadhyph-foo.tex,
-%   and no \lefthyphenmin and \righthyphenmin,
-%   they have no influence here and belong elsewhere
-% - \begingroup and/or \endinput is not needed
-% - feel free to do whatever you want inside comments
-%
-% We know that TeX is extremely powerful, but give a stupid parser
-% at least a chance to read your patterns.
-%
-% For more unformation see
-%
-%    http://tug.org/tex-hyphen
-%
+% See http://www.hyphenation.org for details on the project.
 %------------------------------------------------------------------------------
 %
 % PURPOSE: 8-bit hyphenation patterns for TeX based upon the new Dutch
@@ -103,12728 +48,12728 @@
 %
 -->
 <HyphenationDescription>
-<pattern> a4</pattern>
-<pattern> aan5</pattern>
-<pattern> aarts5</pattern>
-<pattern> aat5</pattern>
-<pattern> ab5l</pattern>
-<pattern> acht5end</pattern>
-<pattern> ac5re</pattern>
-<pattern> adi5</pattern>
-<pattern> af3</pattern>
-<pattern> af5l</pattern>
-<pattern> af5s</pattern>
-<pattern> aftu5re</pattern>
-<pattern> al3ee</pattern>
-<pattern> al3f</pattern>
-<pattern> alk4</pattern>
-<pattern> al5ko</pattern>
-<pattern> alko5v</pattern>
-<pattern> al5ma</pattern>
-<pattern> al3om</pattern>
-<pattern> al4st</pattern>
-<pattern> ana3s</pattern>
-<pattern> an3d2</pattern>
-<pattern> an3en</pattern>
-<pattern> an3gl</pattern>
-<pattern> an5th</pattern>
-<pattern> ar5d</pattern>
-<pattern> ar5tr</pattern>
-<pattern> as5h</pattern>
-<pattern> as5l</pattern>
-<pattern> as3t</pattern>
-<pattern> as5tra</pattern>
-<pattern> as3u</pattern>
-<pattern> at4a</pattern>
-<pattern> ave5n</pattern>
-<pattern> b4</pattern>
-<pattern> be3la</pattern>
-<pattern> be5ra</pattern>
-<pattern> be5ri</pattern>
-<pattern> bos1</pattern>
-<pattern> c4</pattern>
-<pattern> coo5</pattern>
-<pattern> co3ro</pattern>
-<pattern> cus5</pattern>
-<pattern> d4</pattern>
-<pattern> daar5</pattern>
-<pattern> da4gi</pattern>
-<pattern> dag5r</pattern>
-<pattern> da2k</pattern>
-<pattern> dan2</pattern>
-<pattern> debe4</pattern>
-<pattern> de2k</pattern>
-<pattern> dek5l</pattern>
-<pattern> dek5s</pattern>
-<pattern> den4k5r</pattern>
-<pattern> de5od</pattern>
-<pattern> de3ro</pattern>
-<pattern> de5sta</pattern>
-<pattern> di4a</pattern>
-<pattern> die4p</pattern>
-<pattern> di3o</pattern>
-<pattern> doet3</pattern>
-<pattern> do3v</pattern>
-<pattern> du4w</pattern>
-<pattern> e4</pattern>
-<pattern> ede2</pattern>
-<pattern> edel5a</pattern>
-<pattern> ed3w</pattern>
-<pattern> ee4n</pattern>
-<pattern> eer5ste</pattern>
-<pattern> eest3</pattern>
-<pattern> eesto4</pattern>
-<pattern> eet3</pattern>
-<pattern> ei3l</pattern>
-<pattern> ei5sc</pattern>
-<pattern> ei3sp</pattern>
-<pattern> ei5t</pattern>
-<pattern> el4s5</pattern>
-<pattern> en5s</pattern>
-<pattern> en5th</pattern>
-<pattern> ep4a</pattern>
-<pattern> ere5s</pattern>
-<pattern> er2f</pattern>
-<pattern> erf3l</pattern>
-<pattern> er3in</pattern>
-<pattern> ert4</pattern>
-<pattern> erts3</pattern>
-<pattern> es3</pattern>
-<pattern> es5c</pattern>
-<pattern> es5pe</pattern>
-<pattern> es5tr</pattern>
-<pattern> eten4</pattern>
-<pattern> et4h</pattern>
-<pattern> ets5te </pattern>
-<pattern> eu3</pattern>
-<pattern> eus5</pattern>
-<pattern> é2</pattern>
-<pattern> f4</pattern>
-<pattern> fel4s</pattern>
-<pattern> g4</pattern>
-<pattern> gaat5</pattern>
-<pattern> gang5s</pattern>
-<pattern> gea5v</pattern>
-<pattern> ge3l4a</pattern>
-<pattern> ge5le</pattern>
-<pattern> gelo5v</pattern>
-<pattern> ge3n4a</pattern>
-<pattern> gena5z</pattern>
-<pattern> ge5ne</pattern>
-<pattern> ge5no</pattern>
-<pattern> ge3ra</pattern>
-<pattern> ge5r4e</pattern>
-<pattern> ge5r4o</pattern>
-<pattern> gerst5a</pattern>
-<pattern> ge3s</pattern>
-<pattern> ge5sk</pattern>
-<pattern> ge5ta</pattern>
-<pattern> ge5tj</pattern>
-<pattern> ge5to</pattern>
-<pattern> gid4</pattern>
-<pattern> go4m</pattern>
-<pattern> goot3</pattern>
-<pattern> h2</pattern>
-<pattern> handels5</pattern>
-<pattern> her5in</pattern>
-<pattern> hits5t</pattern>
-<pattern> ho4lo</pattern>
-<pattern> houd5s</pattern>
-<pattern> i4</pattern>
-<pattern> ide5o</pattern>
-<pattern> ij4s</pattern>
-<pattern> ijs5l</pattern>
-<pattern> ijs3p</pattern>
-<pattern> ijs3t</pattern>
-<pattern> ik3</pattern>
-<pattern> in1</pattern>
-<pattern> in5d4</pattern>
-<pattern> in3g4</pattern>
-<pattern> in5gr</pattern>
-<pattern> ink2</pattern>
-<pattern> in5kr</pattern>
-<pattern> in5kw</pattern>
-<pattern> in3s4</pattern>
-<pattern> in5sl</pattern>
-<pattern> in5st</pattern>
-<pattern> in5ta</pattern>
-<pattern> is5c</pattern>
-<pattern> j4</pattern>
-<pattern> jor5</pattern>
-<pattern> k4</pattern>
-<pattern> ka3d</pattern>
-<pattern> ka5g</pattern>
-<pattern> ka4taa</pattern>
-<pattern> kerk5l</pattern>
-<pattern> kerk5r</pattern>
-<pattern> kerk5u</pattern>
-<pattern> ker5sten</pattern>
-<pattern> ke4s</pattern>
-<pattern> koot5</pattern>
-<pattern> ko5pe</pattern>
-<pattern> kop5l</pattern>
-<pattern> ko3v</pattern>
-<pattern> kun2</pattern>
-<pattern> l4</pattern>
-<pattern> laat5ste</pattern>
-<pattern> le4b5</pattern>
-<pattern> leg3o</pattern>
-<pattern> le4g3r</pattern>
-<pattern> leid5st</pattern>
-<pattern> len4s3</pattern>
-<pattern> le5r4</pattern>
-<pattern> le4s3</pattern>
-<pattern> le5th</pattern>
-<pattern> lin5d</pattern>
-<pattern> lof5</pattern>
-<pattern> loot3</pattern>
-<pattern> lo4s1</pattern>
-<pattern> lu3e</pattern>
-<pattern> lui5t4j</pattern>
-<pattern> lu4s</pattern>
-<pattern> m4</pattern>
-<pattern> ma5d</pattern>
-<pattern> ma5ï</pattern>
-<pattern> meel5d</pattern>
-<pattern> me5la</pattern>
-<pattern> me5ni</pattern>
-<pattern> merk5l</pattern>
-<pattern> me2s</pattern>
-<pattern> me4st</pattern>
-<pattern> met5ee</pattern>
-<pattern> mij4n5i</pattern>
-<pattern> moot3</pattern>
-<pattern> mor5sten</pattern>
-<pattern> mo4s</pattern>
-<pattern> n4</pattern>
-<pattern> naat5</pattern>
-<pattern> na3d</pattern>
-<pattern> na3n</pattern>
-<pattern> na3s4</pattern>
-<pattern> nee5s</pattern>
-<pattern> ne2p</pattern>
-<pattern> nep3a</pattern>
-<pattern> ne4s</pattern>
-<pattern> ne5te</pattern>
-<pattern> ne4t3j</pattern>
-<pattern> neu4t5j</pattern>
-<pattern> nie4t5j</pattern>
-<pattern> noot5</pattern>
-<pattern> nos5t</pattern>
-<pattern> no5v</pattern>
-<pattern> o4</pattern>
-<pattern> oe4r5</pattern>
-<pattern> oe4s5</pattern>
-<pattern> oeve4</pattern>
-<pattern> ol3f</pattern>
-<pattern> om1</pattern>
-<pattern> omme3</pattern>
-<pattern> on3a</pattern>
-<pattern> on3d</pattern>
-<pattern> onde4r</pattern>
-<pattern> on1e</pattern>
-<pattern> on5g</pattern>
-<pattern> on3i</pattern>
-<pattern> on5k</pattern>
-<pattern> on1o</pattern>
-<pattern> ono5v</pattern>
-<pattern> on2t3</pattern>
-<pattern> on4tee</pattern>
-<pattern> on4ter</pattern>
-<pattern> ont5s</pattern>
-<pattern> ooi5tj</pattern>
-<pattern> oot5jes</pattern>
-<pattern> op5ee</pattern>
-<pattern> opi5</pattern>
-<pattern> op5l</pattern>
-<pattern> op3r</pattern>
-<pattern> op5s</pattern>
-<pattern> org4</pattern>
-<pattern> os5</pattern>
-<pattern> ove4</pattern>
-<pattern> p4</pattern>
-<pattern> pee5tj</pattern>
-<pattern> peri5</pattern>
-<pattern> pers5te </pattern>
-<pattern> piet5j</pattern>
-<pattern> pits5te </pattern>
-<pattern> poort5j</pattern>
-<pattern> po4st</pattern>
-<pattern> puit4</pattern>
-<pattern> pui5tj</pattern>
-<pattern> pu2t</pattern>
-<pattern> r4</pattern>
-<pattern> raads5le</pattern>
-<pattern> ran4d</pattern>
-<pattern> rand5a</pattern>
-<pattern> re4men</pattern>
-<pattern> ren4o</pattern>
-<pattern> reno5v</pattern>
-<pattern> re5o</pattern>
-<pattern> rie4t3</pattern>
-<pattern> rij5sp</pattern>
-<pattern> ring5s4</pattern>
-<pattern> roe5tj</pattern>
-<pattern> ro4l</pattern>
-<pattern> ro4st</pattern>
-<pattern> ro4t3h</pattern>
-<pattern> ro5v</pattern>
-<pattern> s4</pattern>
-<pattern> sap3</pattern>
-<pattern> sa5v</pattern>
-<pattern> sci3</pattern>
-<pattern> see3</pattern>
-<pattern> seks5te</pattern>
-<pattern> se5re</pattern>
-<pattern> set3</pattern>
-<pattern> se5v</pattern>
-<pattern> side3</pattern>
-<pattern> ski3s4</pattern>
-<pattern> sneu3</pattern>
-<pattern> sno2</pattern>
-<pattern> so2k3</pattern>
-<pattern> song5</pattern>
-<pattern> spoor5tj</pattern>
-<pattern> st4</pattern>
-<pattern> ste4m</pattern>
-<pattern> t4</pattern>
-<pattern> taart5j</pattern>
-<pattern> tan4da</pattern>
-<pattern> te4a</pattern>
-<pattern> te4f</pattern>
-<pattern> tek2</pattern>
-<pattern> te3le</pattern>
-<pattern> ten5ac</pattern>
-<pattern> te3no</pattern>
-<pattern> ten4t5j</pattern>
-<pattern> te3ra</pattern>
-<pattern> ter4p5a</pattern>
-<pattern> ter5s</pattern>
-<pattern> te4s</pattern>
-<pattern> ti2n</pattern>
-<pattern> tin3a</pattern>
-<pattern> tin3e</pattern>
-<pattern> toe5pr</pattern>
-<pattern> to4lo</pattern>
-<pattern> to4p</pattern>
-<pattern> to5v</pattern>
-<pattern> tri3s4</pattern>
-<pattern> ts4</pattern>
-<pattern> tsa3</pattern>
-<pattern> tuit5j</pattern>
-<pattern> ty2r</pattern>
-<pattern> u4</pattern>
-<pattern> ui2</pattern>
-<pattern> ui5s</pattern>
-<pattern> uit1</pattern>
-<pattern> uit4je</pattern>
-<pattern> uke5</pattern>
-<pattern> ur4a</pattern>
-<pattern> vaat5j</pattern>
-<pattern> ven4t5j</pattern>
-<pattern> ve4r3</pattern>
-<pattern> ves5p</pattern>
-<pattern> vet3j</pattern>
-<pattern> vie4r</pattern>
-<pattern> vol5s</pattern>
-<pattern> w4</pattern>
-<pattern> wals5te </pattern>
-<pattern> wee4ko</pattern>
-<pattern> wee4t3</pattern>
-<pattern> we4l3</pattern>
-<pattern> wen4s5t</pattern>
-<pattern> west5r</pattern>
-<pattern> win4s</pattern>
-<pattern> xe3</pattern>
-<pattern> y2</pattern>
-<pattern> z4</pattern>
-<pattern> zes5</pattern>
-<pattern> zit5</pattern>
-<pattern> zooi5</pattern>
-<pattern>4a </pattern>
-<pattern>a4a4</pattern>
-<pattern>4aad</pattern>
-<pattern>aad1a</pattern>
-<pattern>aad1o</pattern>
-<pattern>aad1r</pattern>
-<pattern>aad5sap</pattern>
-<pattern>aaf5a</pattern>
-<pattern>4aag</pattern>
-<pattern>aag1a</pattern>
-<pattern>aag3e</pattern>
-<pattern>aag3o</pattern>
-<pattern>aag5r</pattern>
-<pattern>aags4</pattern>
-<pattern>aag3sa</pattern>
-<pattern>aag5so</pattern>
-<pattern>aag3sp</pattern>
-<pattern>aai3l</pattern>
-<pattern>aak1a</pattern>
-<pattern>aak3e2</pattern>
-<pattern>aak1o</pattern>
-<pattern>aak5r</pattern>
-<pattern>aak3sp</pattern>
-<pattern>aal5a2</pattern>
-<pattern>aal1e</pattern>
-<pattern>aal5f4o</pattern>
-<pattern>aalfo5l</pattern>
-<pattern>aal1i</pattern>
-<pattern>aal5k</pattern>
-<pattern>aal5m</pattern>
-<pattern>aal1o2</pattern>
-<pattern>aal3sl</pattern>
-<pattern>aal5so</pattern>
-<pattern>aal5spe</pattern>
-<pattern>aal5ste</pattern>
-<pattern>aal1u</pattern>
-<pattern>aam1a</pattern>
-<pattern>aam3o</pattern>
-<pattern>aam4sta</pattern>
-<pattern>aam4ste</pattern>
-<pattern>aan1a</pattern>
-<pattern>5aandee</pattern>
-<pattern>aand4r</pattern>
-<pattern>aan1e2</pattern>
-<pattern>aan5g</pattern>
-<pattern>aan5i</pattern>
-<pattern>3aanj</pattern>
-<pattern>aan5k4</pattern>
-<pattern>3aann</pattern>
-<pattern>aan3o</pattern>
-<pattern>aan3sp</pattern>
-<pattern>aans4po</pattern>
-<pattern>aant4</pattern>
-<pattern>3aanta</pattern>
-<pattern>3aanv</pattern>
-<pattern>aap1a</pattern>
-<pattern>aap3i</pattern>
-<pattern>aap3o2</pattern>
-<pattern>aap3r</pattern>
-<pattern>aar3a</pattern>
-<pattern>aar4d5as</pattern>
-<pattern>aar3e4</pattern>
-<pattern>aar1i</pattern>
-<pattern>4aarn</pattern>
-<pattern>aar1o2</pattern>
-<pattern>aar5spel</pattern>
-<pattern>aar4t5on</pattern>
-<pattern>aarts5l</pattern>
-<pattern>aar3u</pattern>
-<pattern>aas3e</pattern>
-<pattern>aas3i</pattern>
-<pattern>4aast</pattern>
-<pattern>aas5tr</pattern>
-<pattern>aat3a</pattern>
-<pattern>aat5e</pattern>
-<pattern>aat3h</pattern>
-<pattern>aat3i</pattern>
-<pattern>aat1o</pattern>
-<pattern>aat5r</pattern>
-<pattern>abak4s5</pattern>
-<pattern>aba4l</pattern>
-<pattern>abat4s</pattern>
-<pattern>ab5eun</pattern>
-<pattern>ab3ijz</pattern>
-<pattern>a2bon</pattern>
-<pattern>aboot4j</pattern>
-<pattern>abot4j</pattern>
-<pattern>2abr</pattern>
-<pattern>ab3ru</pattern>
-<pattern>4ac </pattern>
-<pattern>a3cal</pattern>
-<pattern>a3car</pattern>
-<pattern>4ace</pattern>
-<pattern>ace3st</pattern>
-<pattern>4ach </pattern>
-<pattern>a3cha</pattern>
-<pattern>2a1che</pattern>
-<pattern>4a1chi</pattern>
-<pattern>ach3l</pattern>
-<pattern>a1cho</pattern>
-<pattern>a3chr</pattern>
-<pattern>4achs</pattern>
-<pattern>ach5tec</pattern>
-<pattern>a1chu</pattern>
-<pattern>achuut5</pattern>
-<pattern>4ack</pattern>
-<pattern>ac3kl</pattern>
-<pattern>2acl</pattern>
-<pattern>2a3co</pattern>
-<pattern>2acr</pattern>
-<pattern>ac5res</pattern>
-<pattern>4acta</pattern>
-<pattern>4acu</pattern>
-<pattern>4ad </pattern>
-<pattern>a5da </pattern>
-<pattern>ad3ac</pattern>
-<pattern>ada2d</pattern>
-<pattern>ada4l</pattern>
-<pattern>ada2r3</pattern>
-<pattern>adas5</pattern>
-<pattern>2add</pattern>
-<pattern>a5de </pattern>
-<pattern>ad3ei</pattern>
-<pattern>ade5re</pattern>
-<pattern>a5des</pattern>
-<pattern>a3det</pattern>
-<pattern>a5deta</pattern>
-<pattern>ad3e4te</pattern>
-<pattern>2adh</pattern>
-<pattern>4ad4i</pattern>
-<pattern>adi3al</pattern>
-<pattern>adi4oc</pattern>
-<pattern>adi4od</pattern>
-<pattern>4adk</pattern>
-<pattern>2adl</pattern>
-<pattern>4ado </pattern>
-<pattern>a3doo</pattern>
-<pattern>2adp</pattern>
-<pattern>ad3rei</pattern>
-<pattern>a3d4ri</pattern>
-<pattern>ad3rol</pattern>
-<pattern>2ads</pattern>
-<pattern>ad5se</pattern>
-<pattern>ad3so</pattern>
-<pattern>ad1s4t</pattern>
-<pattern>ad5sta</pattern>
-<pattern>ad3ui</pattern>
-<pattern>ad3w</pattern>
-<pattern>2ady</pattern>
-<pattern>4ae</pattern>
-<pattern>aege4</pattern>
-<pattern>ae5k4</pattern>
-<pattern>a3e2p</pattern>
-<pattern>ae3r</pattern>
-<pattern>ae2s3</pattern>
-<pattern>ae4s5t</pattern>
-<pattern>a3eu</pattern>
-<pattern>a2ë</pattern>
-<pattern>a4ër</pattern>
-<pattern>4afa</pattern>
-<pattern>af3aa</pattern>
-<pattern>a2f3ac</pattern>
-<pattern>af4as</pattern>
-<pattern>af4at</pattern>
-<pattern>afd4i</pattern>
-<pattern>afd2r</pattern>
-<pattern>af5d4w</pattern>
-<pattern>4afe</pattern>
-<pattern>afee4</pattern>
-<pattern>4afi</pattern>
-<pattern>af3l</pattern>
-<pattern>4afo</pattern>
-<pattern>a5fo </pattern>
-<pattern>a2foe</pattern>
-<pattern>afon4d</pattern>
-<pattern>af3op</pattern>
-<pattern>af5org</pattern>
-<pattern>af1r</pattern>
-<pattern>af3s4</pattern>
-<pattern>afs2c</pattern>
-<pattern>af5se</pattern>
-<pattern>3afsl</pattern>
-<pattern>3afsp</pattern>
-<pattern>aft4a</pattern>
-<pattern>af5tr</pattern>
-<pattern>af3ui</pattern>
-<pattern>2afy</pattern>
-<pattern>4ag </pattern>
-<pattern>ag1a2d</pattern>
-<pattern>ag3af</pattern>
-<pattern>ag3a2m</pattern>
-<pattern>ag3ar</pattern>
-<pattern>ag3di</pattern>
-<pattern>a5ge </pattern>
-<pattern>agee5t</pattern>
-<pattern>4a5gen </pattern>
-<pattern>ager4s</pattern>
-<pattern>ag3ex</pattern>
-<pattern>a4gil</pattern>
-<pattern>ag3ind</pattern>
-<pattern>a4g3ins</pattern>
-<pattern>agi5ot</pattern>
-<pattern>4ag1l</pattern>
-<pattern>ag3of</pattern>
-<pattern>a4g3or</pattern>
-<pattern>ag4o3v</pattern>
-<pattern>a2gr</pattern>
-<pattern>ag4ra</pattern>
-<pattern>ag5rap</pattern>
-<pattern>ag3ru</pattern>
-<pattern>ag3sl</pattern>
-<pattern>ag4sle</pattern>
-<pattern>ag5slu</pattern>
-<pattern>ags2p</pattern>
-<pattern>ag3spe</pattern>
-<pattern>ag3spi</pattern>
-<pattern>ag1st</pattern>
-<pattern>ag3sta</pattern>
-<pattern>ag5str</pattern>
-<pattern>2agt</pattern>
-<pattern>agu5a</pattern>
-<pattern>a2g3ui</pattern>
-<pattern>ag3u4r</pattern>
-<pattern>a2g3uu</pattern>
-<pattern>2ah</pattern>
-<pattern>4a1ha</pattern>
-<pattern>4a5he</pattern>
-<pattern>ahe5ri</pattern>
-<pattern>a1hi</pattern>
-<pattern>ah3l</pattern>
-<pattern>a3ho</pattern>
-<pattern>ah5r</pattern>
-<pattern>ah5t2</pattern>
-<pattern>a3hu</pattern>
-<pattern>a3hy</pattern>
-<pattern>ai5a2</pattern>
-<pattern>ai4dr</pattern>
-<pattern>ai1e</pattern>
-<pattern>a1ij</pattern>
-<pattern>ai5k</pattern>
-<pattern>ail3m</pattern>
-<pattern>ai2lo</pattern>
-<pattern>a2in</pattern>
-<pattern>aio4</pattern>
-<pattern>ai3ov</pattern>
-<pattern>ai3s4</pattern>
-<pattern>ai5sc</pattern>
-<pattern>ai4s5l</pattern>
-<pattern>ai5sn</pattern>
-<pattern>ai1so</pattern>
-<pattern>ai1st</pattern>
-<pattern>ai5tj</pattern>
-<pattern>ai3tr</pattern>
-<pattern>aiu4</pattern>
-<pattern>aïn4</pattern>
-<pattern>aïns5</pattern>
-<pattern>aïs3o4</pattern>
-<pattern>2a1j</pattern>
-<pattern>ajaars5</pattern>
-<pattern>aka2</pattern>
-<pattern>ak3af</pattern>
-<pattern>ak3ag</pattern>
-<pattern>a4k3ar</pattern>
-<pattern>a4k3ed</pattern>
-<pattern>ak3emi</pattern>
-<pattern>ake2t</pattern>
-<pattern>ak3id</pattern>
-<pattern>ak3ink</pattern>
-<pattern>ak5is</pattern>
-<pattern>1akko</pattern>
-<pattern>4a2k3l</pattern>
-<pattern>a2k3n</pattern>
-<pattern>ak5ne</pattern>
-<pattern>ak4ni</pattern>
-<pattern>a3kof</pattern>
-<pattern>ak3on</pattern>
-<pattern>ak3o2p</pattern>
-<pattern>a2kr</pattern>
-<pattern>ak5ru</pattern>
-<pattern>2aks</pattern>
-<pattern>ak4so</pattern>
-<pattern>ak5spe</pattern>
-<pattern>ak1st</pattern>
-<pattern>ak5to</pattern>
-<pattern>ak5t4w</pattern>
-<pattern>a2k3u4</pattern>
-<pattern>ak1w</pattern>
-<pattern>ak3wi</pattern>
-<pattern>a1la</pattern>
-<pattern>a4l3ach</pattern>
-<pattern>al3adr</pattern>
-<pattern>a3l4ag</pattern>
-<pattern>a3lal</pattern>
-<pattern>a5lapr</pattern>
-<pattern>al3art</pattern>
-<pattern>4ald</pattern>
-<pattern>a1le</pattern>
-<pattern>a5le </pattern>
-<pattern>al3eff</pattern>
-<pattern>2aleg</pattern>
-<pattern>a2l3el</pattern>
-<pattern>ale5ro</pattern>
-<pattern>ale5ste</pattern>
-<pattern>ale4tj</pattern>
-<pattern>a3lè</pattern>
-<pattern>al4fen</pattern>
-<pattern>alf3l</pattern>
-<pattern>al5fon</pattern>
-<pattern>alfu4</pattern>
-<pattern>al2gl</pattern>
-<pattern>a3lie</pattern>
-<pattern>al3int</pattern>
-<pattern>alk5ei</pattern>
-<pattern>al5kle</pattern>
-<pattern>alk3s</pattern>
-<pattern>al4kui</pattern>
-<pattern>al5le</pattern>
-<pattern>al4mac</pattern>
-<pattern>al5me</pattern>
-<pattern>a1lo</pattern>
-<pattern>a4l3ol</pattern>
-<pattern>alo2n</pattern>
-<pattern>al3ou</pattern>
-<pattern>a4l3o4v</pattern>
-<pattern>2alp</pattern>
-<pattern>al3s4ag</pattern>
-<pattern>al3san</pattern>
-<pattern>al3scr</pattern>
-<pattern>als5j</pattern>
-<pattern>al2sl</pattern>
-<pattern>als5li</pattern>
-<pattern>als5m</pattern>
-<pattern>al4sn</pattern>
-<pattern>al4s3oo</pattern>
-<pattern>al4stem</pattern>
-<pattern>al5sten</pattern>
-<pattern>als5tou</pattern>
-<pattern>altaar5</pattern>
-<pattern>al3tha</pattern>
-<pattern>al4t3ro</pattern>
-<pattern>alt4st</pattern>
-<pattern>a1lu</pattern>
-<pattern>a2lui</pattern>
-<pattern>al3uit</pattern>
-<pattern>al3u4r</pattern>
-<pattern>alu2s5</pattern>
-<pattern>4am </pattern>
-<pattern>a4m3ac</pattern>
-<pattern>am3adr</pattern>
-<pattern>ama4f</pattern>
-<pattern>4amag</pattern>
-<pattern>am3art</pattern>
-<pattern>5ambt</pattern>
-<pattern>ament4j</pattern>
-<pattern>ame4ran</pattern>
-<pattern>ame5tj</pattern>
-<pattern>a2meu</pattern>
-<pattern>am4i</pattern>
-<pattern>4amm</pattern>
-<pattern>am3oli</pattern>
-<pattern>a2m3o4v</pattern>
-<pattern>3ampè</pattern>
-<pattern>am2pl</pattern>
-<pattern>am4ple</pattern>
-<pattern>am4sm</pattern>
-<pattern>am4s3o</pattern>
-<pattern>am4spr</pattern>
-<pattern>ams5te </pattern>
-<pattern>a2m3ui</pattern>
-<pattern>a3nad</pattern>
-<pattern>an3alg</pattern>
-<pattern>an4a3n</pattern>
-<pattern>an3arc</pattern>
-<pattern>2anc</pattern>
-<pattern>4anda</pattern>
-<pattern>anda4d</pattern>
-<pattern>and5ank</pattern>
-<pattern>an4d3e4d</pattern>
-<pattern>an4dex</pattern>
-<pattern>2andj</pattern>
-<pattern>an4dom</pattern>
-<pattern>an5d4ri</pattern>
-<pattern>and5roo</pattern>
-<pattern>ands5lo</pattern>
-<pattern>an4d3ul</pattern>
-<pattern>a4nem</pattern>
-<pattern>a3nen</pattern>
-<pattern>anen3i</pattern>
-<pattern>4aner</pattern>
-<pattern>an3est</pattern>
-<pattern>ane3us</pattern>
-<pattern>4ang </pattern>
-<pattern>an4gan</pattern>
-<pattern>anga5p</pattern>
-<pattern>ange5st</pattern>
-<pattern>ang5le</pattern>
-<pattern>an2gr</pattern>
-<pattern>ang5sna</pattern>
-<pattern>angs4te</pattern>
-<pattern>aniet3</pattern>
-<pattern>anij4</pattern>
-<pattern>3anima</pattern>
-<pattern>an5ion</pattern>
-<pattern>a4n5isl</pattern>
-<pattern>ani5t</pattern>
-<pattern>4aniv</pattern>
-<pattern>4ank </pattern>
-<pattern>an4kaa</pattern>
-<pattern>anka4n</pattern>
-<pattern>an4k3as</pattern>
-<pattern>an2k3j</pattern>
-<pattern>an4klu</pattern>
-<pattern>ank3of</pattern>
-<pattern>an2k3r</pattern>
-<pattern>a1no</pattern>
-<pattern>an3och</pattern>
-<pattern>a4n3oor</pattern>
-<pattern>an3ork</pattern>
-<pattern>ano3s</pattern>
-<pattern>ano3t4</pattern>
-<pattern>a4n3ou</pattern>
-<pattern>ano5v</pattern>
-<pattern>4ans</pattern>
-<pattern>an3san</pattern>
-<pattern>ans3cr</pattern>
-<pattern>an4seg</pattern>
-<pattern>an4serv</pattern>
-<pattern>an4sid</pattern>
-<pattern>an2so4</pattern>
-<pattern>ans5or</pattern>
-<pattern>ans3pi</pattern>
-<pattern>ans5pir</pattern>
-<pattern>an1st</pattern>
-<pattern>an4s5te </pattern>
-<pattern>an5stru</pattern>
-<pattern>an4tac</pattern>
-<pattern>ante4n</pattern>
-<pattern>an3th</pattern>
-<pattern>2anti</pattern>
-<pattern>ant5sl</pattern>
-<pattern>ant3w</pattern>
-<pattern>4a1nu</pattern>
-<pattern>a5nuf</pattern>
-<pattern>an3ui</pattern>
-<pattern>an3ur</pattern>
-<pattern>an3uu</pattern>
-<pattern>anze5s</pattern>
-<pattern>2a1o</pattern>
-<pattern>ao4g</pattern>
-<pattern>ao2l</pattern>
-<pattern>a4om</pattern>
-<pattern>a2op2</pattern>
-<pattern>aor5t</pattern>
-<pattern>a3os</pattern>
-<pattern>aos3p</pattern>
-<pattern>aos5t</pattern>
-<pattern>4ap </pattern>
-<pattern>a1pa</pattern>
-<pattern>a4pak</pattern>
-<pattern>a4pas</pattern>
-<pattern>ap3as </pattern>
-<pattern>ap3ass</pattern>
-<pattern>a1pe</pattern>
-<pattern>ap5eten</pattern>
-<pattern>4a1pi</pattern>
-<pattern>apij4t5j</pattern>
-<pattern>ap3ijz</pattern>
-<pattern>ap1j</pattern>
-<pattern>2apl</pattern>
-<pattern>ap3le</pattern>
-<pattern>ap3li</pattern>
-<pattern>ap3lo</pattern>
-<pattern>a1plu</pattern>
-<pattern>apon5</pattern>
-<pattern>ap3oo</pattern>
-<pattern>apo3p</pattern>
-<pattern>apo5sta</pattern>
-<pattern>ap3o4v</pattern>
-<pattern>1appa</pattern>
-<pattern>4appen</pattern>
-<pattern>4apr</pattern>
-<pattern>ap3ra</pattern>
-<pattern>a3pre</pattern>
-<pattern>a4prem</pattern>
-<pattern>a5p4ris</pattern>
-<pattern>ap3ru</pattern>
-<pattern>ap2sa</pattern>
-<pattern>ap4si</pattern>
-<pattern>ap2s3l</pattern>
-<pattern>ap3sn</pattern>
-<pattern>ap4ste </pattern>
-<pattern>2apt</pattern>
-<pattern>ap3tj</pattern>
-<pattern>2apu</pattern>
-<pattern>a2q</pattern>
-<pattern>4ar </pattern>
-<pattern>a1ra</pattern>
-<pattern>araat5j</pattern>
-<pattern>a4r3app</pattern>
-<pattern>ara3s4</pattern>
-<pattern>ar2da</pattern>
-<pattern>ard3ac</pattern>
-<pattern>ard3ak</pattern>
-<pattern>ardo4</pattern>
-<pattern>ar4d3om</pattern>
-<pattern>ar4d3op</pattern>
-<pattern>ar4d3ov</pattern>
-<pattern>ar2d1r</pattern>
-<pattern>ar4dra</pattern>
-<pattern>ard3re</pattern>
-<pattern>ar4du</pattern>
-<pattern>ard3w</pattern>
-<pattern>a1re</pattern>
-<pattern>5a2rea</pattern>
-<pattern>a3reg</pattern>
-<pattern>a3rem</pattern>
-<pattern>ar4en</pattern>
-<pattern>are4no</pattern>
-<pattern>are3sp</pattern>
-<pattern>a3rev</pattern>
-<pattern>ar3gh</pattern>
-<pattern>ar2gl</pattern>
-<pattern>a1ri</pattern>
-<pattern>arie4tj</pattern>
-<pattern>arij3s</pattern>
-<pattern>ar3ins</pattern>
-<pattern>ark2</pattern>
-<pattern>ark3ac</pattern>
-<pattern>ar3k4l</pattern>
-<pattern>ar4map</pattern>
-<pattern>arm3u</pattern>
-<pattern>a1ro</pattern>
-<pattern>a2r3ob</pattern>
-<pattern>ar3oge</pattern>
-<pattern>a3rok</pattern>
-<pattern>aro4ko</pattern>
-<pattern>ar3oog</pattern>
-<pattern>a2r1o2p</pattern>
-<pattern>a3rot</pattern>
-<pattern>arpi4</pattern>
-<pattern>ar2s</pattern>
-<pattern>ar5sch</pattern>
-<pattern>ar3scr</pattern>
-<pattern>ars2e</pattern>
-<pattern>ar5see</pattern>
-<pattern>ar3si</pattern>
-<pattern>ars3l</pattern>
-<pattern>ar4sla</pattern>
-<pattern>ars5m</pattern>
-<pattern>ar3sni</pattern>
-<pattern>ar4so</pattern>
-<pattern>ar4sp</pattern>
-<pattern>ar5spo</pattern>
-<pattern>ars3ta</pattern>
-<pattern>ars5tal</pattern>
-<pattern>ar4s5tek</pattern>
-<pattern>ar4str</pattern>
-<pattern>ar4su</pattern>
-<pattern>art4aa</pattern>
-<pattern>ar4t3ak</pattern>
-<pattern>ar4tan</pattern>
-<pattern>art5ank</pattern>
-<pattern>ar4tap</pattern>
-<pattern>ar3tar</pattern>
-<pattern>4arte</pattern>
-<pattern>ar4tei</pattern>
-<pattern>ar2th</pattern>
-<pattern>ar5tij</pattern>
-<pattern>4ar4tj</pattern>
-<pattern>art5jesv</pattern>
-<pattern>4arto</pattern>
-<pattern>ar5tof</pattern>
-<pattern>art5o4ge</pattern>
-<pattern>art5oog</pattern>
-<pattern>ar4t3o4v</pattern>
-<pattern>ar2t3r</pattern>
-<pattern>ar4tro</pattern>
-<pattern>art5ru</pattern>
-<pattern>art4sl</pattern>
-<pattern>art5ste</pattern>
-<pattern>a3ru</pattern>
-<pattern>ar3ui</pattern>
-<pattern>4arw</pattern>
-<pattern>arwe3s</pattern>
-<pattern>a1ry</pattern>
-<pattern>4asa</pattern>
-<pattern>as3ad</pattern>
-<pattern>as4ag</pattern>
-<pattern>as3ak</pattern>
-<pattern>as1ap</pattern>
-<pattern>a2sc</pattern>
-<pattern>as5ce</pattern>
-<pattern>2ase</pattern>
-<pattern>a4sec</pattern>
-<pattern>a4s3eg</pattern>
-<pattern>aser5a</pattern>
-<pattern>ase5tj</pattern>
-<pattern>aseve4</pattern>
-<pattern>as5ha</pattern>
-<pattern>asis1</pattern>
-<pattern>a4sj</pattern>
-<pattern>as5ja</pattern>
-<pattern>as3ji</pattern>
-<pattern>as3k</pattern>
-<pattern>as5ka</pattern>
-<pattern>as5ki</pattern>
-<pattern>as3l</pattern>
-<pattern>as4lu</pattern>
-<pattern>as3m</pattern>
-<pattern>as5mi</pattern>
-<pattern>as3n</pattern>
-<pattern>as4ne</pattern>
-<pattern>as4ni</pattern>
-<pattern>4aso</pattern>
-<pattern>as3ob</pattern>
-<pattern>aso2l</pattern>
-<pattern>aso4r</pattern>
-<pattern>as1p</pattern>
-<pattern>as3pl</pattern>
-<pattern>a4s5q</pattern>
-<pattern>as5sa</pattern>
-<pattern>4assm</pattern>
-<pattern>3assu</pattern>
-<pattern>a2st</pattern>
-<pattern>4as3ta</pattern>
-<pattern>a4sta </pattern>
-<pattern>as5tag</pattern>
-<pattern>as4tas</pattern>
-<pattern>as4tat</pattern>
-<pattern>as3te</pattern>
-<pattern>a3stek</pattern>
-<pattern>a3stem</pattern>
-<pattern>as5ten</pattern>
-<pattern>as3tè</pattern>
-<pattern>asting5sp</pattern>
-<pattern>as1to</pattern>
-<pattern>as3tob</pattern>
-<pattern>ast3op</pattern>
-<pattern>4astr</pattern>
-<pattern>ast5rem</pattern>
-<pattern>as5tro </pattern>
-<pattern>as4tu</pattern>
-<pattern>a1t</pattern>
-<pattern>ataart5j</pattern>
-<pattern>at1ac</pattern>
-<pattern>at3ade</pattern>
-<pattern>at3af </pattern>
-<pattern>at3ank</pattern>
-<pattern>ata3s</pattern>
-<pattern>2atek</pattern>
-<pattern>a5tell</pattern>
-<pattern>ate2n</pattern>
-<pattern>ate3no</pattern>
-<pattern>aten4t5r</pattern>
-<pattern>ater5ad</pattern>
-<pattern>ater5sl</pattern>
-<pattern>at4eu</pattern>
-<pattern>2atg</pattern>
-<pattern>at3hu</pattern>
-<pattern>ati5ni</pattern>
-<pattern>a2t3j</pattern>
-<pattern>at4je</pattern>
-<pattern>atjes5</pattern>
-<pattern>at5jesb</pattern>
-<pattern>at5jesh</pattern>
-<pattern>at5jesm</pattern>
-<pattern>at5jesp</pattern>
-<pattern>2atm</pattern>
-<pattern>2atn</pattern>
-<pattern>a2too</pattern>
-<pattern>at3oog</pattern>
-<pattern>atos5f</pattern>
-<pattern>ato3st</pattern>
-<pattern>at3rac</pattern>
-<pattern>at3rei</pattern>
-<pattern>at3rib</pattern>
-<pattern>at4roe</pattern>
-<pattern>at5ru</pattern>
-<pattern>at4s3a2</pattern>
-<pattern>at4s3ec</pattern>
-<pattern>atsi4</pattern>
-<pattern>at4s3id</pattern>
-<pattern>at2s3l</pattern>
-<pattern>at4slo</pattern>
-<pattern>ats5m</pattern>
-<pattern>ats3n</pattern>
-<pattern>at4sne</pattern>
-<pattern>ats3pr</pattern>
-<pattern>at2st</pattern>
-<pattern>at4staa</pattern>
-<pattern>at4s5tak</pattern>
-<pattern>at4ste </pattern>
-<pattern>at5sten</pattern>
-<pattern>at5stij</pattern>
-<pattern>ats5tol</pattern>
-<pattern>ats5top </pattern>
-<pattern>ats5trek</pattern>
-<pattern>at4t3u4</pattern>
-<pattern>a2t3ui</pattern>
-<pattern>at3w</pattern>
-<pattern>aua4</pattern>
-<pattern>au3ch</pattern>
-<pattern>au3co</pattern>
-<pattern>au5de</pattern>
-<pattern>aud4j</pattern>
-<pattern>1aug</pattern>
-<pattern>au3na</pattern>
-<pattern>aun3t</pattern>
-<pattern>aup2</pattern>
-<pattern>aur4</pattern>
-<pattern>au5re</pattern>
-<pattern>aure3u</pattern>
-<pattern>4aus</pattern>
-<pattern>au3so</pattern>
-<pattern>au4s5p</pattern>
-<pattern>au3sto</pattern>
-<pattern>au3t4</pattern>
-<pattern>4aut </pattern>
-<pattern>1auto</pattern>
-<pattern>auto3p</pattern>
-<pattern>2auts3</pattern>
-<pattern>auw3a</pattern>
-<pattern>4auz</pattern>
-<pattern>a4ü</pattern>
-<pattern>avast4</pattern>
-<pattern>ave3c</pattern>
-<pattern>avee4</pattern>
-<pattern>ave4n3i</pattern>
-<pattern>aven5sp</pattern>
-<pattern>aver3a</pattern>
-<pattern>ave3re</pattern>
-<pattern>ave3r4u</pattern>
-<pattern>4avi</pattern>
-<pattern>a2vo</pattern>
-<pattern>1a4von</pattern>
-<pattern>a5voo</pattern>
-<pattern>a5vor</pattern>
-<pattern>4avy</pattern>
-<pattern>2a1w</pattern>
-<pattern>axis4</pattern>
-<pattern>ay2a</pattern>
-<pattern>4azif</pattern>
-<pattern>ä3h</pattern>
-<pattern>ämme3</pattern>
-<pattern>ä3r</pattern>
-<pattern>1b</pattern>
-<pattern>4b </pattern>
-<pattern>3ba</pattern>
-<pattern>baar5ste</pattern>
-<pattern>baar5tj</pattern>
-<pattern>ba4da</pattern>
-<pattern>bad3ar</pattern>
-<pattern>ba4d3r</pattern>
-<pattern>bad3s</pattern>
-<pattern>ba3g4h</pattern>
-<pattern>ba3gl</pattern>
-<pattern>5b2ak</pattern>
-<pattern>ba4k3o4</pattern>
-<pattern>bak4sp</pattern>
-<pattern>ba3lan</pattern>
-<pattern>ba4lar</pattern>
-<pattern>bal3dw</pattern>
-<pattern>bale4</pattern>
-<pattern>bal3ev</pattern>
-<pattern>ba3lië</pattern>
-<pattern>bal4kl</pattern>
-<pattern>ba3lo</pattern>
-<pattern>bals4</pattern>
-<pattern>bal3sf</pattern>
-<pattern>ba4me</pattern>
-<pattern>ba5n2a</pattern>
-<pattern>ban4k3a</pattern>
-<pattern>ban4kl</pattern>
-<pattern>ban4k3o</pattern>
-<pattern>ban4kr</pattern>
-<pattern>bank3w</pattern>
-<pattern>ba3sa</pattern>
-<pattern>ba4st</pattern>
-<pattern>ba2tr</pattern>
-<pattern>ba3tro</pattern>
-<pattern>4bb</pattern>
-<pattern>bbe4l5ag</pattern>
-<pattern>bbe4l5ee</pattern>
-<pattern>bbe2n</pattern>
-<pattern>bben3a</pattern>
-<pattern>4b1c</pattern>
-<pattern>4b1d4</pattern>
-<pattern>b5de</pattern>
-<pattern>bdi5a</pattern>
-<pattern>3b4e</pattern>
-<pattern>be1a</pattern>
-<pattern>be3as</pattern>
-<pattern>be2au</pattern>
-<pattern>be3ch</pattern>
-<pattern>be5dwe</pattern>
-<pattern>be5dwi</pattern>
-<pattern>be5dwo</pattern>
-<pattern>bee4</pattern>
-<pattern>beet1</pattern>
-<pattern>be5g</pattern>
-<pattern>beie4</pattern>
-<pattern>bei3s</pattern>
-<pattern>bei5tj</pattern>
-<pattern>be5ki</pattern>
-<pattern>be3k4l</pattern>
-<pattern>be1kw</pattern>
-<pattern>be3lar</pattern>
-<pattern>be5l4as</pattern>
-<pattern>bel5dr</pattern>
-<pattern>be3le</pattern>
-<pattern>be4l3ec</pattern>
-<pattern>be4lex</pattern>
-<pattern>bel5f</pattern>
-<pattern>be3li</pattern>
-<pattern>be4l5int</pattern>
-<pattern>bel3k</pattern>
-<pattern>bel4o</pattern>
-<pattern>be3lo5v</pattern>
-<pattern>bel3sc</pattern>
-<pattern>bel3sp</pattern>
-<pattern>belt4</pattern>
-<pattern>bemen4s</pattern>
-<pattern>be3nep</pattern>
-<pattern>be5n4o</pattern>
-<pattern>be5ot</pattern>
-<pattern>be1ra</pattern>
-<pattern>bere5s4</pattern>
-<pattern>ber4g5af</pattern>
-<pattern>ber4g5et</pattern>
-<pattern>ber4gl</pattern>
-<pattern>ber4gr</pattern>
-<pattern>ber4i</pattern>
-<pattern>be1r4o</pattern>
-<pattern>bero5v</pattern>
-<pattern>be3ru</pattern>
-<pattern>be3ry</pattern>
-<pattern>be1s4</pattern>
-<pattern>bes5ac</pattern>
-<pattern>be4sh</pattern>
-<pattern>be4sje</pattern>
-<pattern>be3so</pattern>
-<pattern>be5sp</pattern>
-<pattern>bes5s</pattern>
-<pattern>bes5te </pattern>
-<pattern>bes5ten </pattern>
-<pattern>be5stie</pattern>
-<pattern>bet2</pattern>
-<pattern>be3t4h</pattern>
-<pattern>be5ton</pattern>
-<pattern>bet5ren</pattern>
-<pattern>be3tw</pattern>
-<pattern>be5twi</pattern>
-<pattern>be3und</pattern>
-<pattern>beur4s</pattern>
-<pattern>4b3f</pattern>
-<pattern>2b1g</pattern>
-<pattern>4b3h</pattern>
-<pattern>3b2i</pattern>
-<pattern>bid3s</pattern>
-<pattern>bi2du</pattern>
-<pattern>bie4li</pattern>
-<pattern>bi4en</pattern>
-<pattern>bie4t3j</pattern>
-<pattern>bij5d</pattern>
-<pattern>bij3f</pattern>
-<pattern>bij3g4</pattern>
-<pattern>bij5k4</pattern>
-<pattern>bij1p</pattern>
-<pattern>bij1s2</pattern>
-<pattern>bik4a</pattern>
-<pattern>5bil</pattern>
-<pattern>bi3lo</pattern>
-<pattern>bil3s2</pattern>
-<pattern>bin4dr</pattern>
-<pattern>bin4st</pattern>
-<pattern>bin4t3j</pattern>
-<pattern>bi5ob</pattern>
-<pattern>bi3ok</pattern>
-<pattern>bi5om</pattern>
-<pattern>bi3oso</pattern>
-<pattern>bi5ow</pattern>
-<pattern>bir3</pattern>
-<pattern>bi4st</pattern>
-<pattern>bis5troo</pattern>
-<pattern>bi1tr</pattern>
-<pattern>bit4se</pattern>
-<pattern>bit4s3p</pattern>
-<pattern>4b1j</pattern>
-<pattern>4b1k</pattern>
-<pattern>3b4l</pattern>
-<pattern>blad5ij</pattern>
-<pattern>2b5lap</pattern>
-<pattern>b5led</pattern>
-<pattern>bles3</pattern>
-<pattern>ble5spe</pattern>
-<pattern>ble2t3</pattern>
-<pattern>b5lid</pattern>
-<pattern>blijs4</pattern>
-<pattern>blij5ste</pattern>
-<pattern>bli2k</pattern>
-<pattern>4b5loi</pattern>
-<pattern>blok5l</pattern>
-<pattern>bloot5j</pattern>
-<pattern>blu2s</pattern>
-<pattern>2b1m</pattern>
-<pattern>4b1n</pattern>
-<pattern>b4o</pattern>
-<pattern>bo4d3ec</pattern>
-<pattern>body3</pattern>
-<pattern>boe4g3a</pattern>
-<pattern>boe4kn</pattern>
-<pattern>boe4ko</pattern>
-<pattern>boes4</pattern>
-<pattern>boe3st</pattern>
-<pattern>boet5st</pattern>
-<pattern>bo3f4l</pattern>
-<pattern>bo2k</pattern>
-<pattern>bok3an</pattern>
-<pattern>bokje5</pattern>
-<pattern>bok4st</pattern>
-<pattern>bolk4</pattern>
-<pattern>bo2m3a4</pattern>
-<pattern>bo2m3o</pattern>
-<pattern>bo5na</pattern>
-<pattern>bond2</pattern>
-<pattern>bond4s5</pattern>
-<pattern>3bone</pattern>
-<pattern>bo3no</pattern>
-<pattern>bon4t3j</pattern>
-<pattern>bon4t5o4</pattern>
-<pattern>boot3j</pattern>
-<pattern>boots5te </pattern>
-<pattern>bo3p2</pattern>
-<pattern>bor4sta</pattern>
-<pattern>borst5o</pattern>
-<pattern>bor4st5r</pattern>
-<pattern>bo4s</pattern>
-<pattern>bos3a</pattern>
-<pattern>bo5sco</pattern>
-<pattern>bo5si</pattern>
-<pattern>bo5so</pattern>
-<pattern>bos5p</pattern>
-<pattern>bos5to</pattern>
-<pattern>bot3j</pattern>
-<pattern>bo4to</pattern>
-<pattern>bot3r</pattern>
-<pattern>bot4sp</pattern>
-<pattern>bot4st</pattern>
-<pattern>bo2tu</pattern>
-<pattern>bou5ta</pattern>
-<pattern>bouw5s</pattern>
-<pattern>bo3v</pattern>
-<pattern>bove4</pattern>
-<pattern>4b1p</pattern>
-<pattern>3br4</pattern>
-<pattern>braad5s</pattern>
-<pattern>bran4da</pattern>
-<pattern>bra5str</pattern>
-<pattern>brei5s4</pattern>
-<pattern>brie4t</pattern>
-<pattern>brie5tje </pattern>
-<pattern>bri4l</pattern>
-<pattern>bro2n</pattern>
-<pattern>bron3o4</pattern>
-<pattern>bru2l</pattern>
-<pattern>4b1s4</pattern>
-<pattern>b2s5a</pattern>
-<pattern>b5sc</pattern>
-<pattern>b3si</pattern>
-<pattern>bsi3d</pattern>
-<pattern>bs5je</pattern>
-<pattern>b2s5la</pattern>
-<pattern>b2s5m</pattern>
-<pattern>bs5s</pattern>
-<pattern>b4stij</pattern>
-<pattern>4bt4</pattern>
-<pattern>b3ta</pattern>
-<pattern>b1tr</pattern>
-<pattern>bts5</pattern>
-<pattern>3b4u</pattern>
-<pattern>buit4j</pattern>
-<pattern>bul4k</pattern>
-<pattern>bu4lu</pattern>
-<pattern>bune5t</pattern>
-<pattern>b5urb</pattern>
-<pattern>bu5ri</pattern>
-<pattern>bus5c</pattern>
-<pattern>bus3o</pattern>
-<pattern>but4a</pattern>
-<pattern>but3j</pattern>
-<pattern>bu2to</pattern>
-<pattern>but4s</pattern>
-<pattern>buts5te</pattern>
-<pattern>buur4tj</pattern>
-<pattern>4bv</pattern>
-<pattern>2b3w</pattern>
-<pattern>by3</pattern>
-<pattern>4bz</pattern>
-<pattern>4c </pattern>
-<pattern>1ca</pattern>
-<pattern>3ca </pattern>
-<pattern>ca3b</pattern>
-<pattern>ca1ch</pattern>
-<pattern>5cada</pattern>
-<pattern>ca3do</pattern>
-<pattern>ca3dr</pattern>
-<pattern>cae3</pattern>
-<pattern>ca3g2</pattern>
-<pattern>cal4l3</pattern>
-<pattern>ca3lo</pattern>
-<pattern>came5r</pattern>
-<pattern>ca3na</pattern>
-<pattern>cant4</pattern>
-<pattern>ca2of</pattern>
-<pattern>ca1pr</pattern>
-<pattern>ca4pra</pattern>
-<pattern>ca5pri</pattern>
-<pattern>ca3ra</pattern>
-<pattern>car4u</pattern>
-<pattern>ca5se</pattern>
-<pattern>ca3s2p</pattern>
-<pattern>cas3t</pattern>
-<pattern>cas5tr</pattern>
-<pattern>ca3ta</pattern>
-<pattern>cate4n</pattern>
-<pattern>ca3t4h</pattern>
-<pattern>cau3</pattern>
-<pattern>cau4st</pattern>
-<pattern>ca3v</pattern>
-<pattern>2cb</pattern>
-<pattern>4c1c</pattern>
-<pattern>cca3</pattern>
-<pattern>cces5</pattern>
-<pattern>c4d</pattern>
-<pattern>c5do</pattern>
-<pattern>1ce</pattern>
-<pattern>3ced</pattern>
-<pattern>cee4</pattern>
-<pattern>3ceel</pattern>
-<pattern>3cel</pattern>
-<pattern>cel3d</pattern>
-<pattern>celes5</pattern>
-<pattern>ce5li</pattern>
-<pattern>cel5k</pattern>
-<pattern>ce4l3o</pattern>
-<pattern>2ce3n4a</pattern>
-<pattern>2cene</pattern>
-<pattern>ce3no</pattern>
-<pattern>5cent</pattern>
-<pattern>cen4t3j</pattern>
-<pattern>ceo4</pattern>
-<pattern>ce3ra</pattern>
-<pattern>cer2n</pattern>
-<pattern>ce5ro</pattern>
-<pattern>cer4t3r</pattern>
-<pattern>ce2s</pattern>
-<pattern>ce3s2a</pattern>
-<pattern>ce5sc</pattern>
-<pattern>ce3s2h</pattern>
-<pattern>ce3sta</pattern>
-<pattern>ce3s4ti</pattern>
-<pattern>cesu5r</pattern>
-<pattern>ce3ta</pattern>
-<pattern>ce4t3j</pattern>
-<pattern>ceto4</pattern>
-<pattern>cet3og</pattern>
-<pattern>cet3oo</pattern>
-<pattern>1cé</pattern>
-<pattern>c3g</pattern>
-<pattern>4ch </pattern>
-<pattern>3chaï</pattern>
-<pattern>5chao</pattern>
-<pattern>3chas</pattern>
-<pattern>1chau</pattern>
-<pattern>5chauf</pattern>
-<pattern>2chc</pattern>
-<pattern>1chef</pattern>
-<pattern>5chef </pattern>
-<pattern>5chefs</pattern>
-<pattern>5chemi</pattern>
-<pattern>5cheq</pattern>
-<pattern>che5ri</pattern>
-<pattern>che3ru</pattern>
-<pattern>5ches</pattern>
-<pattern>che3us</pattern>
-<pattern>1ché</pattern>
-<pattern>5chir</pattern>
-<pattern>4chn</pattern>
-<pattern>2chp</pattern>
-<pattern>5chromo</pattern>
-<pattern>4cht</pattern>
-<pattern>4chw</pattern>
-<pattern>1chy</pattern>
-<pattern>3ci</pattern>
-<pattern>ci5ab</pattern>
-<pattern>ci3am</pattern>
-<pattern>cie3k</pattern>
-<pattern>cier4s5</pattern>
-<pattern>ci1eu</pattern>
-<pattern>5cij</pattern>
-<pattern>5cil</pattern>
-<pattern>ci5le</pattern>
-<pattern>cil3m</pattern>
-<pattern>4cind</pattern>
-<pattern>ci3o</pattern>
-<pattern>ci5om</pattern>
-<pattern>5cir</pattern>
-<pattern>ci3t2</pattern>
-<pattern>ci5ta</pattern>
-<pattern>c3j</pattern>
-<pattern>c2k3a</pattern>
-<pattern>c4k3ed</pattern>
-<pattern>ck3ef</pattern>
-<pattern>cke5re</pattern>
-<pattern>c5k4et</pattern>
-<pattern>ck3id</pattern>
-<pattern>c2k3l</pattern>
-<pattern>ck4le</pattern>
-<pattern>c2k3n</pattern>
-<pattern>c2k3o4</pattern>
-<pattern>c4k3r</pattern>
-<pattern>ck5se</pattern>
-<pattern>ck3so</pattern>
-<pattern>ck5st</pattern>
-<pattern>c3ky</pattern>
-<pattern>1c4l</pattern>
-<pattern>cla2n</pattern>
-<pattern>cle3u</pattern>
-<pattern>5clu</pattern>
-<pattern>2c1n</pattern>
-<pattern>1co</pattern>
-<pattern>co3ad</pattern>
-<pattern>co3d</pattern>
-<pattern>co4i</pattern>
-<pattern>coin5</pattern>
-<pattern>co3k4</pattern>
-<pattern>co3la</pattern>
-<pattern>5com</pattern>
-<pattern>5cond</pattern>
-<pattern>con1g</pattern>
-<pattern>2co1no</pattern>
-<pattern>5cons</pattern>
-<pattern>3con5t4</pattern>
-<pattern>2coo</pattern>
-<pattern>2co1p2</pattern>
-<pattern>3copa</pattern>
-<pattern>4copi</pattern>
-<pattern>cor4dr</pattern>
-<pattern>co4rel</pattern>
-<pattern>co5ri</pattern>
-<pattern>cor2o</pattern>
-<pattern>5corr</pattern>
-<pattern>cors4</pattern>
-<pattern>co3ru</pattern>
-<pattern>co5sc</pattern>
-<pattern>co5se</pattern>
-<pattern>co5sp</pattern>
-<pattern>co3th</pattern>
-<pattern>co3tr</pattern>
-<pattern>5coun</pattern>
-<pattern>2cout</pattern>
-<pattern>co5v</pattern>
-<pattern>c3p4</pattern>
-<pattern>1c4r2</pattern>
-<pattern>3cras</pattern>
-<pattern>cre5d</pattern>
-<pattern>2crip</pattern>
-<pattern>3cris</pattern>
-<pattern>cro5f</pattern>
-<pattern>cro5k</pattern>
-<pattern>croo3</pattern>
-<pattern>cro5v</pattern>
-<pattern>crus5</pattern>
-<pattern>c3so</pattern>
-<pattern>c3sp</pattern>
-<pattern>c3ste</pattern>
-<pattern>2c1t</pattern>
-<pattern>ct3act</pattern>
-<pattern>ct3ad</pattern>
-<pattern>ct5c</pattern>
-<pattern>ctee5t</pattern>
-<pattern>cte2n3</pattern>
-<pattern>c2t1h</pattern>
-<pattern>c2t3j</pattern>
-<pattern>c4t3of</pattern>
-<pattern>c3tol</pattern>
-<pattern>c2t1on</pattern>
-<pattern>ct4or</pattern>
-<pattern>ct3rap</pattern>
-<pattern>c4t3re</pattern>
-<pattern>ct3sl</pattern>
-<pattern>ct3sp</pattern>
-<pattern>1c2u</pattern>
-<pattern>cu5d4</pattern>
-<pattern>cu3en</pattern>
-<pattern>cu3és</pattern>
-<pattern>cui5s</pattern>
-<pattern>cui2t</pattern>
-<pattern>cuit5e</pattern>
-<pattern>cu3k4</pattern>
-<pattern>cula5p</pattern>
-<pattern>cu3ra</pattern>
-<pattern>5cur3s</pattern>
-<pattern>cus3o</pattern>
-<pattern>c3w</pattern>
-<pattern>1cy</pattern>
-<pattern>1ç</pattern>
-<pattern>ça4o</pattern>
-<pattern>4d </pattern>
-<pattern>1da</pattern>
-<pattern>3da </pattern>
-<pattern>3daag</pattern>
-<pattern>d4aal</pattern>
-<pattern>d3aap</pattern>
-<pattern>daar5e</pattern>
-<pattern>5daat</pattern>
-<pattern>4dabo</pattern>
-<pattern>2d3acc</pattern>
-<pattern>da4ce</pattern>
-<pattern>da5den</pattern>
-<pattern>4dadr</pattern>
-<pattern>3dae</pattern>
-<pattern>2d1af</pattern>
-<pattern>3dag</pattern>
-<pattern>da2g3a4</pattern>
-<pattern>da3ge</pattern>
-<pattern>da4g3ed</pattern>
-<pattern>da4g3e4t</pattern>
-<pattern>da4g3on</pattern>
-<pattern>da4g3r</pattern>
-<pattern>dag4s3t</pattern>
-<pattern>da2gu</pattern>
-<pattern>3dai</pattern>
-<pattern>da3ï</pattern>
-<pattern>da3ke</pattern>
-<pattern>da4ker</pattern>
-<pattern>2dakk</pattern>
-<pattern>da4k1r</pattern>
-<pattern>4dala</pattern>
-<pattern>d3alar</pattern>
-<pattern>d3alc</pattern>
-<pattern>da3le</pattern>
-<pattern>4dalf</pattern>
-<pattern>da3li</pattern>
-<pattern>2dalm</pattern>
-<pattern>da2l3u</pattern>
-<pattern>d4am</pattern>
-<pattern>dam4a</pattern>
-<pattern>da5mac</pattern>
-<pattern>d3a4mat</pattern>
-<pattern>d2a5me4</pattern>
-<pattern>dames3</pattern>
-<pattern>dam4pl</pattern>
-<pattern>2da2na</pattern>
-<pattern>dan3as</pattern>
-<pattern>dank3l</pattern>
-<pattern>danoot5</pattern>
-<pattern>dan4si</pattern>
-<pattern>dan4sm</pattern>
-<pattern>dan4s3p</pattern>
-<pattern>dan4st</pattern>
-<pattern>dans5ta</pattern>
-<pattern>4d3antw</pattern>
-<pattern>2d1ap</pattern>
-<pattern>4d3a2pe</pattern>
-<pattern>5dapu</pattern>
-<pattern>da2r3a</pattern>
-<pattern>d3arb</pattern>
-<pattern>3dare</pattern>
-<pattern>3dari</pattern>
-<pattern>dar4mo</pattern>
-<pattern>darm5on</pattern>
-<pattern>3daro</pattern>
-<pattern>dar3s</pattern>
-<pattern>dar5st</pattern>
-<pattern>3das3</pattern>
-<pattern>5dasa</pattern>
-<pattern>da3stu</pattern>
-<pattern>3d4at</pattern>
-<pattern>da3ta</pattern>
-<pattern>dat5j</pattern>
-<pattern>4d5atl</pattern>
-<pattern>4d5atm</pattern>
-<pattern>da2t3r</pattern>
-<pattern>5daue</pattern>
-<pattern>4d1aut</pattern>
-<pattern>3dauw</pattern>
-<pattern>2db</pattern>
-<pattern>dbei5</pattern>
-<pattern>dbou4w5i</pattern>
-<pattern>2d5c</pattern>
-<pattern>4d3d4</pattern>
-<pattern>ddags4</pattern>
-<pattern>ddag5sp</pattern>
-<pattern>ddel5ev</pattern>
-<pattern>dde2n</pattern>
-<pattern>dden5a</pattern>
-<pattern>ddera4</pattern>
-<pattern>dder5al</pattern>
-<pattern>ddere4</pattern>
-<pattern>dder5ee</pattern>
-<pattern>dder5ep</pattern>
-<pattern>dder3o</pattern>
-<pattern>ddi3a</pattern>
-<pattern>d5dles</pattern>
-<pattern>d5do</pattern>
-<pattern>ddo3p</pattern>
-<pattern>1de</pattern>
-<pattern>3de </pattern>
-<pattern>de2al</pattern>
-<pattern>de1ch</pattern>
-<pattern>d4e5den</pattern>
-<pattern>5dedir</pattern>
-<pattern>de4dit</pattern>
-<pattern>dee4g3</pattern>
-<pattern>dee4l</pattern>
-<pattern>deel3i</pattern>
-<pattern>4d3een</pattern>
-<pattern>dee4r</pattern>
-<pattern>4d3eff</pattern>
-<pattern>de3g</pattern>
-<pattern>4d5eg </pattern>
-<pattern>4d5egg</pattern>
-<pattern>2d5egy</pattern>
-<pattern>2dei</pattern>
-<pattern>d3eie</pattern>
-<pattern>d3eig</pattern>
-<pattern>d3eil</pattern>
-<pattern>d1eis</pattern>
-<pattern>d3eiw</pattern>
-<pattern>5dek</pattern>
-<pattern>de3ke</pattern>
-<pattern>dek3lu</pattern>
-<pattern>dek3w</pattern>
-<pattern>del4aa</pattern>
-<pattern>del5da</pattern>
-<pattern>del5dr</pattern>
-<pattern>del5eek</pattern>
-<pattern>4d3e4lek</pattern>
-<pattern>4delem</pattern>
-<pattern>de4lev</pattern>
-<pattern>4d3e4lit</pattern>
-<pattern>del3k</pattern>
-<pattern>del2s</pattern>
-<pattern>del4s3e</pattern>
-<pattern>dels3i</pattern>
-<pattern>del4so</pattern>
-<pattern>4d3e4mai</pattern>
-<pattern>2demh</pattern>
-<pattern>5demi</pattern>
-<pattern>dem5ond</pattern>
-<pattern>d2en </pattern>
-<pattern>den4ac</pattern>
-<pattern>den5ate</pattern>
-<pattern>den3ei</pattern>
-<pattern>den3e4p</pattern>
-<pattern>den3ev</pattern>
-<pattern>4d3engt</pattern>
-<pattern>den4k5of</pattern>
-<pattern>de4noc</pattern>
-<pattern>den3o4r</pattern>
-<pattern>den3sh</pattern>
-<pattern>den5str</pattern>
-<pattern>de3nu</pattern>
-<pattern>5denvl</pattern>
-<pattern>de4o</pattern>
-<pattern>de5ofo</pattern>
-<pattern>de5ol</pattern>
-<pattern>deo4li</pattern>
-<pattern>deo3v</pattern>
-<pattern>de3rab</pattern>
-<pattern>de4r3ad</pattern>
-<pattern>der3a4g</pattern>
-<pattern>de3rak</pattern>
-<pattern>de3ram</pattern>
-<pattern>de3ran</pattern>
-<pattern>de3rap</pattern>
-<pattern>de3ras</pattern>
-<pattern>de4r5as </pattern>
-<pattern>de4r5ass</pattern>
-<pattern>der2e</pattern>
-<pattern>der5ede</pattern>
-<pattern>der5egd</pattern>
-<pattern>de4r3ei</pattern>
-<pattern>de4r3em</pattern>
-<pattern>de5re4n</pattern>
-<pattern>de4rep</pattern>
-<pattern>de4ret</pattern>
-<pattern>de5rij</pattern>
-<pattern>de4r3im</pattern>
-<pattern>der3k4</pattern>
-<pattern>der3on</pattern>
-<pattern>dero4r</pattern>
-<pattern>4d3eros</pattern>
-<pattern>der4s3a</pattern>
-<pattern>der4s5om</pattern>
-<pattern>der5ste</pattern>
-<pattern>der5sto</pattern>
-<pattern>der5stra</pattern>
-<pattern>der5th</pattern>
-<pattern>4d3erts</pattern>
-<pattern>der5tw</pattern>
-<pattern>de2r3u</pattern>
-<pattern>de3rup</pattern>
-<pattern>de2s</pattern>
-<pattern>de3sav</pattern>
-<pattern>des3m</pattern>
-<pattern>des3n</pattern>
-<pattern>des3p</pattern>
-<pattern>de3spe</pattern>
-<pattern>de5spel</pattern>
-<pattern>de4spl</pattern>
-<pattern>des5sm</pattern>
-<pattern>de3st</pattern>
-<pattern>des5tak</pattern>
-<pattern>de5stal</pattern>
-<pattern>de4s3te</pattern>
-<pattern>de4sti</pattern>
-<pattern>de5stic</pattern>
-<pattern>des5top</pattern>
-<pattern>de3t4</pattern>
-<pattern>4d3e4tap</pattern>
-<pattern>de5tw</pattern>
-<pattern>deu4r3o4</pattern>
-<pattern>de3us </pattern>
-<pattern>deu4tj</pattern>
-<pattern>deve4</pattern>
-<pattern>2dex</pattern>
-<pattern>4d1exa</pattern>
-<pattern>4dexp</pattern>
-<pattern>3dè</pattern>
-<pattern>2d1f</pattern>
-<pattern>2d3g</pattern>
-<pattern>d4gaf</pattern>
-<pattern>dge3la</pattern>
-<pattern>dge2t</pattern>
-<pattern>dgeto4</pattern>
-<pattern>dget5on</pattern>
-<pattern>dget5ov</pattern>
-<pattern>dge4tr</pattern>
-<pattern>dg4l</pattern>
-<pattern>2d1h</pattern>
-<pattern>d5he</pattern>
-<pattern>dheer4</pattern>
-<pattern>3d4hi </pattern>
-<pattern>1di</pattern>
-<pattern>di2a</pattern>
-<pattern>di5ae</pattern>
-<pattern>di4ak</pattern>
-<pattern>di4ano</pattern>
-<pattern>dia3s4</pattern>
-<pattern>di4atr</pattern>
-<pattern>5dich</pattern>
-<pattern>di4do</pattern>
-<pattern>die2f</pattern>
-<pattern>die4r3o</pattern>
-<pattern>di3esr</pattern>
-<pattern>die3st</pattern>
-<pattern>die2t</pattern>
-<pattern>diet3r</pattern>
-<pattern>di1eu</pattern>
-<pattern>3dig</pattern>
-<pattern>di2ga</pattern>
-<pattern>dig5aa</pattern>
-<pattern>diges5</pattern>
-<pattern>dijk3r</pattern>
-<pattern>di3jo</pattern>
-<pattern>2d3ijz</pattern>
-<pattern>di2k3o4</pattern>
-<pattern>5dil</pattern>
-<pattern>2d3imp</pattern>
-<pattern>di5n2a</pattern>
-<pattern>2d3ind</pattern>
-<pattern>2dinf</pattern>
-<pattern>3d4ing </pattern>
-<pattern>4d5ingel</pattern>
-<pattern>4d3inj</pattern>
-<pattern>4d3inko</pattern>
-<pattern>2d5inr</pattern>
-<pattern>2d3ins</pattern>
-<pattern>4d3int</pattern>
-<pattern>dintel5</pattern>
-<pattern>2d3inv</pattern>
-<pattern>2d3inw</pattern>
-<pattern>2d3inz</pattern>
-<pattern>di2o</pattern>
-<pattern>di5ofon</pattern>
-<pattern>di4ol</pattern>
-<pattern>di4one</pattern>
-<pattern>di4oni</pattern>
-<pattern>dio1s</pattern>
-<pattern>dio5sc</pattern>
-<pattern>2d3i2ro</pattern>
-<pattern>2d3irr</pattern>
-<pattern>3di4s</pattern>
-<pattern>dis5ag</pattern>
-<pattern>di5se</pattern>
-<pattern>di5si</pattern>
-<pattern>dis4kr</pattern>
-<pattern>dis5p</pattern>
-<pattern>dis1t</pattern>
-<pattern>dis5tr</pattern>
-<pattern>di3th</pattern>
-<pattern>dit3j</pattern>
-<pattern>dit3r</pattern>
-<pattern>5div</pattern>
-<pattern>2d1j</pattern>
-<pattern>2d3k2</pattern>
-<pattern>4d3l</pattern>
-<pattern>d5le </pattern>
-<pattern>dli4n</pattern>
-<pattern>dlot4s</pattern>
-<pattern>2d1m</pattern>
-<pattern>2d3n2</pattern>
-<pattern>d5ne</pattern>
-<pattern>dni3s</pattern>
-<pattern>1do</pattern>
-<pattern>3do </pattern>
-<pattern>do3a</pattern>
-<pattern>2dobj</pattern>
-<pattern>4d3obs</pattern>
-<pattern>3d4oe</pattern>
-<pattern>5doe </pattern>
-<pattern>doe5d</pattern>
-<pattern>4doef</pattern>
-<pattern>d5oefe</pattern>
-<pattern>5doek</pattern>
-<pattern>5doen</pattern>
-<pattern>5doet</pattern>
-<pattern>4d5oev</pattern>
-<pattern>3doi</pattern>
-<pattern>d4ole</pattern>
-<pattern>2do2li</pattern>
-<pattern>d4olin</pattern>
-<pattern>dolk5s</pattern>
-<pattern>5dol5s</pattern>
-<pattern>3d4om </pattern>
-<pattern>5domi</pattern>
-<pattern>do4m3o4</pattern>
-<pattern>d3omr</pattern>
-<pattern>dom4sn</pattern>
-<pattern>5domu</pattern>
-<pattern>d3omv</pattern>
-<pattern>4domz</pattern>
-<pattern>5don </pattern>
-<pattern>d4ona</pattern>
-<pattern>5done</pattern>
-<pattern>do5ni</pattern>
-<pattern>5d4onn</pattern>
-<pattern>5do3n4o</pattern>
-<pattern>do3nu</pattern>
-<pattern>do5ny</pattern>
-<pattern>5donz</pattern>
-<pattern>2dop</pattern>
-<pattern>do3pa</pattern>
-<pattern>d3opb</pattern>
-<pattern>d3opd</pattern>
-<pattern>do3pee</pattern>
-<pattern>5dopj</pattern>
-<pattern>4d1opl</pattern>
-<pattern>3dopo</pattern>
-<pattern>d3ops</pattern>
-<pattern>d3opz</pattern>
-<pattern>4d5org</pattern>
-<pattern>do4rië</pattern>
-<pattern>d3ork</pattern>
-<pattern>dors5m</pattern>
-<pattern>do3sp</pattern>
-<pattern>do3sta</pattern>
-<pattern>dot3j</pattern>
-<pattern>5dou</pattern>
-<pattern>2dov</pattern>
-<pattern>dover5s</pattern>
-<pattern>3dovl</pattern>
-<pattern>3dovo</pattern>
-<pattern>2d3p</pattern>
-<pattern>dpren4</pattern>
-<pattern>1dr4</pattern>
-<pattern>3dra</pattern>
-<pattern>5dra </pattern>
-<pattern>d3raam</pattern>
-<pattern>d3raap</pattern>
-<pattern>d4rac</pattern>
-<pattern>d5race</pattern>
-<pattern>5drach</pattern>
-<pattern>d3rad </pattern>
-<pattern>d3rada</pattern>
-<pattern>5draf</pattern>
-<pattern>5d4rag</pattern>
-<pattern>d4rama</pattern>
-<pattern>d3rame</pattern>
-<pattern>4d3rand</pattern>
-<pattern>4drap</pattern>
-<pattern>4dras</pattern>
-<pattern>4d3raz</pattern>
-<pattern>2dre</pattern>
-<pattern>4d1rec</pattern>
-<pattern>d5reco</pattern>
-<pattern>d1red</pattern>
-<pattern>d2ree</pattern>
-<pattern>4d3reek</pattern>
-<pattern>4drend</pattern>
-<pattern>d4ress</pattern>
-<pattern>4dret</pattern>
-<pattern>3d2rev</pattern>
-<pattern>5dreve</pattern>
-<pattern>d3ric</pattern>
-<pattern>dries4</pattern>
-<pattern>5d2rif</pattern>
-<pattern>dri5ga</pattern>
-<pattern>d3rijd</pattern>
-<pattern>d3rijk</pattern>
-<pattern>d3rijm</pattern>
-<pattern>d3rijs</pattern>
-<pattern>5d4rin</pattern>
-<pattern>3dris</pattern>
-<pattern>4d3rit</pattern>
-<pattern>4d3roei</pattern>
-<pattern>d3roer</pattern>
-<pattern>5d2rog</pattern>
-<pattern>4d3rok</pattern>
-<pattern>d3roma</pattern>
-<pattern>d3rond</pattern>
-<pattern>3droog</pattern>
-<pattern>4droos</pattern>
-<pattern>5drop</pattern>
-<pattern>2drou</pattern>
-<pattern>2d3ro5v</pattern>
-<pattern>2droz</pattern>
-<pattern>drug4s</pattern>
-<pattern>d3ruim</pattern>
-<pattern>d3ruit</pattern>
-<pattern>5d4ru4k</pattern>
-<pattern>4d3rus</pattern>
-<pattern>2ds</pattern>
-<pattern>d2s1a2</pattern>
-<pattern>d4saa</pattern>
-<pattern>dsa4b</pattern>
-<pattern>d3sal</pattern>
-<pattern>ds4ate</pattern>
-<pattern>ds2ch</pattern>
-<pattern>d5schi</pattern>
-<pattern>dse2</pattern>
-<pattern>ds3eco</pattern>
-<pattern>d4s3ed</pattern>
-<pattern>d4s5ee</pattern>
-<pattern>d4sef</pattern>
-<pattern>d4sei</pattern>
-<pattern>ds3eis</pattern>
-<pattern>ds3elf</pattern>
-<pattern>dse4li</pattern>
-<pattern>d5sen</pattern>
-<pattern>d4s3es</pattern>
-<pattern>d4set</pattern>
-<pattern>d2sh</pattern>
-<pattern>ds3ho</pattern>
-<pattern>d2s1i2</pattern>
-<pattern>d4s5id</pattern>
-<pattern>dsig5a</pattern>
-<pattern>ds2im</pattern>
-<pattern>ds4ing</pattern>
-<pattern>ds5is</pattern>
-<pattern>d4s3j</pattern>
-<pattern>ds4jo</pattern>
-<pattern>ds5jon</pattern>
-<pattern>ds4l</pattern>
-<pattern>d1sla</pattern>
-<pattern>ds5las</pattern>
-<pattern>ds5lic</pattern>
-<pattern>d4s5lie</pattern>
-<pattern>ds5lim</pattern>
-<pattern>d3slin</pattern>
-<pattern>d2sm</pattern>
-<pattern>ds4mak</pattern>
-<pattern>d3smij</pattern>
-<pattern>ds5mo</pattern>
-<pattern>ds3n</pattern>
-<pattern>ds4ne</pattern>
-<pattern>ds5neu</pattern>
-<pattern>d3snu</pattern>
-<pattern>ds1o4</pattern>
-<pattern>ds3ob</pattern>
-<pattern>ds3om</pattern>
-<pattern>d4son</pattern>
-<pattern>ds2oo</pattern>
-<pattern>ds3op</pattern>
-<pattern>d4spa</pattern>
-<pattern>d5span</pattern>
-<pattern>ds5pati</pattern>
-<pattern>d5spec</pattern>
-<pattern>d5s4pel</pattern>
-<pattern>d4s3pet</pattern>
-<pattern>d1spi</pattern>
-<pattern>d4s3pl</pattern>
-<pattern>d5spoe</pattern>
-<pattern>d5spok</pattern>
-<pattern>d5spor</pattern>
-<pattern>ds5s</pattern>
-<pattern>dst4</pattern>
-<pattern>d1sta</pattern>
-<pattern>d5staat</pattern>
-<pattern>d4stab</pattern>
-<pattern>ds3tak</pattern>
-<pattern>d4s3tal</pattern>
-<pattern>ds4tan</pattern>
-<pattern>d3s4tat</pattern>
-<pattern>d5stav</pattern>
-<pattern>d3ste</pattern>
-<pattern>ds4te </pattern>
-<pattern>d5stee</pattern>
-<pattern>d4stek</pattern>
-<pattern>ds4ter</pattern>
-<pattern>d4sterr</pattern>
-<pattern>d4stev</pattern>
-<pattern>ds3th</pattern>
-<pattern>d3s4ti</pattern>
-<pattern>d4stit</pattern>
-<pattern>d1sto</pattern>
-<pattern>ds5tram</pattern>
-<pattern>ds5trekk</pattern>
-<pattern>ds5ty</pattern>
-<pattern>d2su4</pattern>
-<pattern>ds3ure</pattern>
-<pattern>ds3uu</pattern>
-<pattern>d1sy</pattern>
-<pattern>2dt</pattern>
-<pattern>d1ta</pattern>
-<pattern>dtaart5j</pattern>
-<pattern>d1th</pattern>
-<pattern>d2tj</pattern>
-<pattern>d1to</pattern>
-<pattern>d1tr</pattern>
-<pattern>d1tu</pattern>
-<pattern>1du</pattern>
-<pattern>2duca</pattern>
-<pattern>5due</pattern>
-<pattern>du3en</pattern>
-<pattern>du3et</pattern>
-<pattern>5duid</pattern>
-<pattern>5duif</pattern>
-<pattern>5duik</pattern>
-<pattern>d3uil</pattern>
-<pattern>2duit</pattern>
-<pattern>4duit </pattern>
-<pattern>d3uitd</pattern>
-<pattern>5duite</pattern>
-<pattern>4duitg</pattern>
-<pattern>d3uitv</pattern>
-<pattern>5duiv</pattern>
-<pattern>du4n</pattern>
-<pattern>dun5i</pattern>
-<pattern>du2o</pattern>
-<pattern>du4ol</pattern>
-<pattern>3durf</pattern>
-<pattern>3durv</pattern>
-<pattern>5du1s</pattern>
-<pattern>dut3j</pattern>
-<pattern>du5wen</pattern>
-<pattern>2dv</pattern>
-<pattern>dvaat5</pattern>
-<pattern>dvee3</pattern>
-<pattern>dve5na</pattern>
-<pattern>dvies5</pattern>
-<pattern>2dw</pattern>
-<pattern>d3wac</pattern>
-<pattern>d3was</pattern>
-<pattern>d3wat</pattern>
-<pattern>d1we</pattern>
-<pattern>3d2wei</pattern>
-<pattern>d3wek</pattern>
-<pattern>d3wet</pattern>
-<pattern>d3wez</pattern>
-<pattern>d1wi</pattern>
-<pattern>4d1wo</pattern>
-<pattern>d3wor</pattern>
-<pattern>d3wr</pattern>
-<pattern>1dy</pattern>
-<pattern>4d3yo</pattern>
-<pattern>dy4sp</pattern>
-<pattern>dy2s4t</pattern>
-<pattern>2dz</pattern>
-<pattern>4e </pattern>
-<pattern>4ea</pattern>
-<pattern>e3aa</pattern>
-<pattern>e1ab</pattern>
-<pattern>ea3bo</pattern>
-<pattern>e3ac</pattern>
-<pattern>ea4ca</pattern>
-<pattern>eac5t</pattern>
-<pattern>e1ad</pattern>
-<pattern>ea3da</pattern>
-<pattern>e5adem</pattern>
-<pattern>ea3do</pattern>
-<pattern>ead3s2</pattern>
-<pattern>ead5sh</pattern>
-<pattern>e1af</pattern>
-<pattern>e1ag</pattern>
-<pattern>e3ai</pattern>
-<pattern>ea4k3o4</pattern>
-<pattern>e1al</pattern>
-<pattern>ea3la</pattern>
-<pattern>e3ali</pattern>
-<pattern>e4als</pattern>
-<pattern>ea5mi</pattern>
-<pattern>e3an</pattern>
-<pattern>e4an </pattern>
-<pattern>eang3</pattern>
-<pattern>ean4s</pattern>
-<pattern>e5ap</pattern>
-<pattern>ea3pr</pattern>
-<pattern>e3aq</pattern>
-<pattern>e1ar</pattern>
-<pattern>ear2c</pattern>
-<pattern>e1as</pattern>
-<pattern>e2asc</pattern>
-<pattern>ea5s4e</pattern>
-<pattern>ease5t</pattern>
-<pattern>ea3so</pattern>
-<pattern>e1at</pattern>
-<pattern>e4at </pattern>
-<pattern>eat3s</pattern>
-<pattern>eau3s4t</pattern>
-<pattern>e1av</pattern>
-<pattern>e3bo</pattern>
-<pattern>ebots5te </pattern>
-<pattern>e5br</pattern>
-<pattern>3ecd</pattern>
-<pattern>e3ce</pattern>
-<pattern>e1che</pattern>
-<pattern>e1chi</pattern>
-<pattern>echt5ec</pattern>
-<pattern>echts5o</pattern>
-<pattern>e3chu</pattern>
-<pattern>4eck</pattern>
-<pattern>ec5le</pattern>
-<pattern>4ecor</pattern>
-<pattern>4ect</pattern>
-<pattern>ec3ta</pattern>
-<pattern>ec4taa</pattern>
-<pattern>3ecz</pattern>
-<pattern>e1d</pattern>
-<pattern>ed4ag</pattern>
-<pattern>e3dam</pattern>
-<pattern>e3d4an</pattern>
-<pattern>e4d4as</pattern>
-<pattern>ede3a</pattern>
-<pattern>ed3ei </pattern>
-<pattern>ede5le</pattern>
-<pattern>edem4</pattern>
-<pattern>ede5nac</pattern>
-<pattern>ede5o</pattern>
-<pattern>ed4er</pattern>
-<pattern>e4d5erns</pattern>
-<pattern>ede5rog</pattern>
-<pattern>edi3al</pattern>
-<pattern>edi3am</pattern>
-<pattern>e5die</pattern>
-<pattern>4edir</pattern>
-<pattern>edoe5tj</pattern>
-<pattern>e3d4oo</pattern>
-<pattern>ed3opv</pattern>
-<pattern>edors5te</pattern>
-<pattern>ed3ov</pattern>
-<pattern>e3d2r</pattern>
-<pattern>ed3rod</pattern>
-<pattern>ed3rol</pattern>
-<pattern>ed1s</pattern>
-<pattern>ed5se</pattern>
-<pattern>ed2sl</pattern>
-<pattern>ed4so</pattern>
-<pattern>ed5sp</pattern>
-<pattern>ed3su</pattern>
-<pattern>ed3uit</pattern>
-<pattern>e4d2w</pattern>
-<pattern>e5dwan</pattern>
-<pattern>e4e</pattern>
-<pattern>eea4</pattern>
-<pattern>ee5b</pattern>
-<pattern>ee5ca</pattern>
-<pattern>ee5che</pattern>
-<pattern>ee2d3a</pattern>
-<pattern>eed4ac</pattern>
-<pattern>eed5as</pattern>
-<pattern>ee5de</pattern>
-<pattern>ee5do</pattern>
-<pattern>eed3ru</pattern>
-<pattern>eed3si</pattern>
-<pattern>eed3w</pattern>
-<pattern>ee2f</pattern>
-<pattern>ee3fa</pattern>
-<pattern>eef3ac</pattern>
-<pattern>ee3fi</pattern>
-<pattern>eef3l</pattern>
-<pattern>eef3r</pattern>
-<pattern>ee4gap</pattern>
-<pattern>eeg3l</pattern>
-<pattern>ee3i</pattern>
-<pattern>ee2k</pattern>
-<pattern>ee3ka</pattern>
-<pattern>ee5kaa</pattern>
-<pattern>eek3ak</pattern>
-<pattern>eek5all</pattern>
-<pattern>eek1e</pattern>
-<pattern>ee5ket</pattern>
-<pattern>ee3ki</pattern>
-<pattern>ee3kl</pattern>
-<pattern>ee4k3lo</pattern>
-<pattern>eek3n</pattern>
-<pattern>eek3re</pattern>
-<pattern>ee3kri</pattern>
-<pattern>eek3ro</pattern>
-<pattern>eek5st</pattern>
-<pattern>eek3w</pattern>
-<pattern>ee2l</pattern>
-<pattern>eel3a</pattern>
-<pattern>ee3lad</pattern>
-<pattern>eel4as </pattern>
-<pattern>eel5d4u</pattern>
-<pattern>ee3le</pattern>
-<pattern>eel4ee</pattern>
-<pattern>ee3li</pattern>
-<pattern>ee5lij</pattern>
-<pattern>eel5k4</pattern>
-<pattern>ee3lob</pattern>
-<pattern>eel3og</pattern>
-<pattern>eelo4ge</pattern>
-<pattern>ee3lu4</pattern>
-<pattern>eel3ur</pattern>
-<pattern>eel3uu</pattern>
-<pattern>4eem</pattern>
-<pattern>eema4</pattern>
-<pattern>ee2n</pattern>
-<pattern>een3a</pattern>
-<pattern>eena4r</pattern>
-<pattern>een3e2</pattern>
-<pattern>een5g</pattern>
-<pattern>ee3ni</pattern>
-<pattern>een5ie</pattern>
-<pattern>een5k</pattern>
-<pattern>ee5o2</pattern>
-<pattern>ee2pa</pattern>
-<pattern>eep3an</pattern>
-<pattern>ee3pl</pattern>
-<pattern>eepo4</pattern>
-<pattern>ee4p3re</pattern>
-<pattern>eep3ru</pattern>
-<pattern>ee2r</pattern>
-<pattern>eer1a</pattern>
-<pattern>eer3aa</pattern>
-<pattern>ee4rad</pattern>
-<pattern>eera4l</pattern>
-<pattern>ee3ram</pattern>
-<pattern>ee3ran</pattern>
-<pattern>ee3re</pattern>
-<pattern>ee4ree</pattern>
-<pattern>ee5rei</pattern>
-<pattern>ee4r3i</pattern>
-<pattern>ee5ric</pattern>
-<pattern>eer5k</pattern>
-<pattern>eer3og</pattern>
-<pattern>eer5oom</pattern>
-<pattern>ee3rot</pattern>
-<pattern>eer5ston</pattern>
-<pattern>eer5str</pattern>
-<pattern>ee2s3</pattern>
-<pattern>ee5sch</pattern>
-<pattern>ee4s5em</pattern>
-<pattern>ees5et</pattern>
-<pattern>ee3sj</pattern>
-<pattern>ees5lo</pattern>
-<pattern>ee3sn</pattern>
-<pattern>ee3s4p</pattern>
-<pattern>ees5pl</pattern>
-<pattern>ees5pot</pattern>
-<pattern>ees5ten</pattern>
-<pattern>ee3stu</pattern>
-<pattern>ee2t</pattern>
-<pattern>eet5aa</pattern>
-<pattern>ee3tal</pattern>
-<pattern>ee3tan</pattern>
-<pattern>ee5te</pattern>
-<pattern>eet5h</pattern>
-<pattern>ee3tj</pattern>
-<pattern>eetna4</pattern>
-<pattern>ee3to</pattern>
-<pattern>eet3og</pattern>
-<pattern>eeto4ge</pattern>
-<pattern>eet3oo</pattern>
-<pattern>eeto4r</pattern>
-<pattern>ee3tr</pattern>
-<pattern>ee4tro</pattern>
-<pattern>eet5rok</pattern>
-<pattern>eet3sp</pattern>
-<pattern>eet5ste</pattern>
-<pattern>ee5v</pattern>
-<pattern>ee5z</pattern>
-<pattern>eën3</pattern>
-<pattern>e5ër</pattern>
-<pattern>ef3ad</pattern>
-<pattern>efa4z</pattern>
-<pattern>efde5l</pattern>
-<pattern>ef3do</pattern>
-<pattern>ef3ei</pattern>
-<pattern>e5fer</pattern>
-<pattern>4efi</pattern>
-<pattern>efie4t</pattern>
-<pattern>efiet5j</pattern>
-<pattern>ef3ins</pattern>
-<pattern>e3fis5</pattern>
-<pattern>e1fl</pattern>
-<pattern>ef3li</pattern>
-<pattern>ef3loo</pattern>
-<pattern>e3flu</pattern>
-<pattern>ef3om</pattern>
-<pattern>e3foo</pattern>
-<pattern>ef3op</pattern>
-<pattern>e1fr</pattern>
-<pattern>ef3rij</pattern>
-<pattern>e5fron</pattern>
-<pattern>ef3sf</pattern>
-<pattern>4e1g</pattern>
-<pattern>egas4</pattern>
-<pattern>eg3as </pattern>
-<pattern>ega5sk</pattern>
-<pattern>eg3ebb</pattern>
-<pattern>e4ge4c</pattern>
-<pattern>eg3eig</pattern>
-<pattern>egel5ei </pattern>
-<pattern>ege4l5ov</pattern>
-<pattern>ege4net</pattern>
-<pattern>egen5of</pattern>
-<pattern>ege4ra</pattern>
-<pattern>eger5eng</pattern>
-<pattern>ege4ro</pattern>
-<pattern>eger5on</pattern>
-<pattern>e3g4i</pattern>
-<pattern>eg3ijz</pattern>
-<pattern>egip4</pattern>
-<pattern>egiste4</pattern>
-<pattern>e2gl</pattern>
-<pattern>e4go </pattern>
-<pattern>eg3org</pattern>
-<pattern>e2gos</pattern>
-<pattern>eg3oud</pattern>
-<pattern>e5graf</pattern>
-<pattern>eg3s4</pattern>
-<pattern>eg5sle</pattern>
-<pattern>eg5so</pattern>
-<pattern>e2g3u4r</pattern>
-<pattern>egut4</pattern>
-<pattern>e4g3uu</pattern>
-<pattern>e1h4</pattern>
-<pattern>e5ha</pattern>
-<pattern>eheis5</pattern>
-<pattern>ehit4</pattern>
-<pattern>e2i</pattern>
-<pattern>ei5a</pattern>
-<pattern>4eid</pattern>
-<pattern>ei3do</pattern>
-<pattern>eid4sc</pattern>
-<pattern>ei1e</pattern>
-<pattern>4eien</pattern>
-<pattern>eien5s</pattern>
-<pattern>eie5re</pattern>
-<pattern>ei3f4</pattern>
-<pattern>ei3gl</pattern>
-<pattern>4eign</pattern>
-<pattern>e3ij</pattern>
-<pattern>eik4l</pattern>
-<pattern>ei3kn</pattern>
-<pattern>ei5kr</pattern>
-<pattern>eiks4</pattern>
-<pattern>4eil </pattern>
-<pattern>eil5ant</pattern>
-<pattern>4eild4</pattern>
-<pattern>eil5dr</pattern>
-<pattern>4eile</pattern>
-<pattern>ei4lev</pattern>
-<pattern>eil5m</pattern>
-<pattern>ei2l3o</pattern>
-<pattern>ei4n3ab</pattern>
-<pattern>ei3n4ac</pattern>
-<pattern>ein4do</pattern>
-<pattern>eind5oo</pattern>
-<pattern>ein4d3r</pattern>
-<pattern>ein5gr</pattern>
-<pattern>ein5k</pattern>
-<pattern>ei2no</pattern>
-<pattern>ein5sl</pattern>
-<pattern>ei3o</pattern>
-<pattern>ei2sa</pattern>
-<pattern>ei5sha</pattern>
-<pattern>ei3s4la</pattern>
-<pattern>ei3slo</pattern>
-<pattern>eis4p</pattern>
-<pattern>ei3s4ta</pattern>
-<pattern>4eit2</pattern>
-<pattern>ei4too</pattern>
-<pattern>eit4s3</pattern>
-<pattern>eits5c</pattern>
-<pattern>eits5n</pattern>
-<pattern>eits5te </pattern>
-<pattern>eit5sten</pattern>
-<pattern>eits5tr</pattern>
-<pattern>eive4</pattern>
-<pattern>4eiz</pattern>
-<pattern>e1j2</pattern>
-<pattern>e3je</pattern>
-<pattern>ek3aan</pattern>
-<pattern>ekaart5j</pattern>
-<pattern>ekaat4</pattern>
-<pattern>ek3af </pattern>
-<pattern>e4k3a4g</pattern>
-<pattern>ek3al </pattern>
-<pattern>ek3alt</pattern>
-<pattern>e5kam</pattern>
-<pattern>ek3ang</pattern>
-<pattern>ek4ee</pattern>
-<pattern>ek1ei</pattern>
-<pattern>e3kem</pattern>
-<pattern>e5ker </pattern>
-<pattern>e5kers</pattern>
-<pattern>ekes3</pattern>
-<pattern>ekes4t</pattern>
-<pattern>ekes5tr</pattern>
-<pattern>e3ket</pattern>
-<pattern>ek5eter</pattern>
-<pattern>e5kic</pattern>
-<pattern>e4kil</pattern>
-<pattern>e5kis</pattern>
-<pattern>ekla4m</pattern>
-<pattern>eklam5a</pattern>
-<pattern>ek3lev</pattern>
-<pattern>e5klim</pattern>
-<pattern>ek5loos</pattern>
-<pattern>ek4ni</pattern>
-<pattern>e3ko</pattern>
-<pattern>e4k3ob</pattern>
-<pattern>e5kof</pattern>
-<pattern>ek3oli</pattern>
-<pattern>ek3opz</pattern>
-<pattern>e5kor</pattern>
-<pattern>ek5os </pattern>
-<pattern>ek5oss</pattern>
-<pattern>e5kran</pattern>
-<pattern>ek3roz</pattern>
-<pattern>eks4e</pattern>
-<pattern>eks5erv</pattern>
-<pattern>ek5set</pattern>
-<pattern>ek4str</pattern>
-<pattern>eks5tra</pattern>
-<pattern>ek5t4e</pattern>
-<pattern>ek3to</pattern>
-<pattern>eku4</pattern>
-<pattern>ek3uit</pattern>
-<pattern>ek3ur</pattern>
-<pattern>ek1uu</pattern>
-<pattern>ekwet5ste</pattern>
-<pattern>ek3win</pattern>
-<pattern>e1la</pattern>
-<pattern>el3aan</pattern>
-<pattern>el5aand</pattern>
-<pattern>el1ac</pattern>
-<pattern>el4ade</pattern>
-<pattern>el3adj</pattern>
-<pattern>el3adm</pattern>
-<pattern>el3adr</pattern>
-<pattern>el3adv</pattern>
-<pattern>el1a4f</pattern>
-<pattern>el1al</pattern>
-<pattern>e3lan</pattern>
-<pattern>el5ana</pattern>
-<pattern>e3lap</pattern>
-<pattern>e5lap </pattern>
-<pattern>e4lapp</pattern>
-<pattern>el3arb</pattern>
-<pattern>el3arc</pattern>
-<pattern>el3arm</pattern>
-<pattern>el3art</pattern>
-<pattern>e4l3as </pattern>
-<pattern>el3asi</pattern>
-<pattern>e4l3asp</pattern>
-<pattern>e4l3ass</pattern>
-<pattern>el1au</pattern>
-<pattern>e4laut</pattern>
-<pattern>e3laz</pattern>
-<pattern>el5azi</pattern>
-<pattern>el4dec</pattern>
-<pattern>el4dr</pattern>
-<pattern>el4du</pattern>
-<pattern>e1le</pattern>
-<pattern>e3le </pattern>
-<pattern>el3eeu</pattern>
-<pattern>el5eff</pattern>
-<pattern>e5leid</pattern>
-<pattern>el5eier</pattern>
-<pattern>el3eig</pattern>
-<pattern>el3ei5s</pattern>
-<pattern>e4lel</pattern>
-<pattern>3e2lem</pattern>
-<pattern>el3emp</pattern>
-<pattern>e5l4en</pattern>
-<pattern>e3ler</pattern>
-<pattern>ele5r4a</pattern>
-<pattern>eler4s</pattern>
-<pattern>el3erv</pattern>
-<pattern>e3les</pattern>
-<pattern>eles4t</pattern>
-<pattern>e4l3eta</pattern>
-<pattern>ele4tr</pattern>
-<pattern>e4l3etu</pattern>
-<pattern>el3exc</pattern>
-<pattern>e3lé</pattern>
-<pattern>elfi4d</pattern>
-<pattern>el1fl</pattern>
-<pattern>elf3s4</pattern>
-<pattern>el3gu</pattern>
-<pattern>2eli</pattern>
-<pattern>e5lie</pattern>
-<pattern>e5lig</pattern>
-<pattern>eli5kw</pattern>
-<pattern>el3imp</pattern>
-<pattern>e4l3ind</pattern>
-<pattern>e3ling</pattern>
-<pattern>e4l5inkt</pattern>
-<pattern>el5inz</pattern>
-<pattern>3elix</pattern>
-<pattern>el4kee</pattern>
-<pattern>elk3s</pattern>
-<pattern>el4k3u4r</pattern>
-<pattern>el4kw</pattern>
-<pattern>4e1lo</pattern>
-<pattern>e5loep</pattern>
-<pattern>el3oes</pattern>
-<pattern>e3lok</pattern>
-<pattern>el3ol</pattern>
-<pattern>el3oms</pattern>
-<pattern>el5ond</pattern>
-<pattern>el5ont</pattern>
-<pattern>e3loo</pattern>
-<pattern>e5lood</pattern>
-<pattern>e5loos</pattern>
-<pattern>el3ops</pattern>
-<pattern>el5opt</pattern>
-<pattern>el5opv</pattern>
-<pattern>el3o2r</pattern>
-<pattern>el5org</pattern>
-<pattern>elot4j</pattern>
-<pattern>e5lou</pattern>
-<pattern>el3o4ve</pattern>
-<pattern>e5loz</pattern>
-<pattern>elp4o</pattern>
-<pattern>el4ps</pattern>
-<pattern>el4s5em</pattern>
-<pattern>el4s3k</pattern>
-<pattern>el5smed</pattern>
-<pattern>el5twe</pattern>
-<pattern>4e1lu</pattern>
-<pattern>el3uit</pattern>
-<pattern>eluks5</pattern>
-<pattern>2ema</pattern>
-<pattern>e4mana</pattern>
-<pattern>ema3sc</pattern>
-<pattern>ema5to</pattern>
-<pattern>emees5</pattern>
-<pattern>emens5te</pattern>
-<pattern>emer4s</pattern>
-<pattern>emes3</pattern>
-<pattern>emie4tj</pattern>
-<pattern>e5mok</pattern>
-<pattern>em3oli</pattern>
-<pattern>em3op</pattern>
-<pattern>em3org</pattern>
-<pattern>emor5sten</pattern>
-<pattern>e4mo4v</pattern>
-<pattern>em3sa</pattern>
-<pattern>em5sc</pattern>
-<pattern>em4sli</pattern>
-<pattern>em4sm</pattern>
-<pattern>em1st</pattern>
-<pattern>em3su</pattern>
-<pattern>em3uit</pattern>
-<pattern>emut4</pattern>
-<pattern>en3aap</pattern>
-<pattern>e3naar</pattern>
-<pattern>e4n3aas</pattern>
-<pattern>en1ac</pattern>
-<pattern>e5n4acc</pattern>
-<pattern>en5af</pattern>
-<pattern>e2n1ak</pattern>
-<pattern>e2nal</pattern>
-<pattern>en3al </pattern>
-<pattern>en3als</pattern>
-<pattern>en3amb</pattern>
-<pattern>en4ame</pattern>
-<pattern>e2nan</pattern>
-<pattern>e4n3ang</pattern>
-<pattern>en1a2p</pattern>
-<pattern>e5nari</pattern>
-<pattern>en3ars</pattern>
-<pattern>e2n3a2s</pattern>
-<pattern>enas3p</pattern>
-<pattern>e3nat</pattern>
-<pattern>ena4tel</pattern>
-<pattern>e4n3att</pattern>
-<pattern>en1av</pattern>
-<pattern>e2n3a2z</pattern>
-<pattern>enci4</pattern>
-<pattern>3ency </pattern>
-<pattern>en3da</pattern>
-<pattern>en5daa</pattern>
-<pattern>end5ama</pattern>
-<pattern>5enderti</pattern>
-<pattern>en3d4o</pattern>
-<pattern>en3dr</pattern>
-<pattern>en5drek</pattern>
-<pattern>e2n3e2c</pattern>
-<pattern>enede4</pattern>
-<pattern>e3nee</pattern>
-<pattern>en3eed</pattern>
-<pattern>enee5t</pattern>
-<pattern>en5eg </pattern>
-<pattern>en5egg</pattern>
-<pattern>en3ela</pattern>
-<pattern>en3elf</pattern>
-<pattern>en3ema</pattern>
-<pattern>e4n3en5t</pattern>
-<pattern>e2ne2p</pattern>
-<pattern>en3epo</pattern>
-<pattern>e5nere</pattern>
-<pattern>5energ</pattern>
-<pattern>e4nerv</pattern>
-<pattern>en3eta</pattern>
-<pattern>en3ete</pattern>
-<pattern>ene4ten</pattern>
-<pattern>e3neu</pattern>
-<pattern>4enf</pattern>
-<pattern>en5ga</pattern>
-<pattern>en3gl</pattern>
-<pattern>en4g5le</pattern>
-<pattern>eng4r</pattern>
-<pattern>en5gri</pattern>
-<pattern>engs4</pattern>
-<pattern>eng5se</pattern>
-<pattern>eng3sm</pattern>
-<pattern>e3nie</pattern>
-<pattern>e5nijd</pattern>
-<pattern>e2n3im</pattern>
-<pattern>e4ninga</pattern>
-<pattern>e4n3ink</pattern>
-<pattern>e3niv</pattern>
-<pattern>e4n3i4vo</pattern>
-<pattern>en3k2a</pattern>
-<pattern>e4n3och</pattern>
-<pattern>en3off</pattern>
-<pattern>e4n3oli</pattern>
-<pattern>e2n1on</pattern>
-<pattern>e4n3oor</pattern>
-<pattern>enoot5</pattern>
-<pattern>e2n1o2p</pattern>
-<pattern>e3nor </pattern>
-<pattern>en3ord</pattern>
-<pattern>eno3s</pattern>
-<pattern>en3ou</pattern>
-<pattern>e2n1ov</pattern>
-<pattern>3enq</pattern>
-<pattern>en5sce</pattern>
-<pattern>en4sei</pattern>
-<pattern>ens5ein</pattern>
-<pattern>ensek5</pattern>
-<pattern>3ensem</pattern>
-<pattern>ens4fe</pattern>
-<pattern>en4sin</pattern>
-<pattern>en5slak</pattern>
-<pattern>en4s3on</pattern>
-<pattern>en1s2p</pattern>
-<pattern>ens5pot</pattern>
-<pattern>en5stan</pattern>
-<pattern>en5sten</pattern>
-<pattern>enst5ijv</pattern>
-<pattern>en4stin</pattern>
-<pattern>en4stu4r</pattern>
-<pattern>en3su</pattern>
-<pattern>en4tac</pattern>
-<pattern>en5tee</pattern>
-<pattern>en5tei</pattern>
-<pattern>ente5re</pattern>
-<pattern>en4terv</pattern>
-<pattern>3entè</pattern>
-<pattern>en1t2h</pattern>
-<pattern>en5tom</pattern>
-<pattern>ent4r</pattern>
-<pattern>en3tre</pattern>
-<pattern>ent5rol</pattern>
-<pattern>ent4sl</pattern>
-<pattern>ents3m</pattern>
-<pattern>ent4s3p</pattern>
-<pattern>en3tw</pattern>
-<pattern>e1nu</pattern>
-<pattern>e4n1ui</pattern>
-<pattern>e2nun</pattern>
-<pattern>en3ur</pattern>
-<pattern>en3uu</pattern>
-<pattern>5envelo</pattern>
-<pattern>eny4</pattern>
-<pattern>e3o</pattern>
-<pattern>eo3d</pattern>
-<pattern>eodo3</pattern>
-<pattern>e5oe</pattern>
-<pattern>eoes3</pattern>
-<pattern>e5off</pattern>
-<pattern>eo3fr</pattern>
-<pattern>e4o3k4</pattern>
-<pattern>e5on</pattern>
-<pattern>eo5ni</pattern>
-<pattern>e5oo</pattern>
-<pattern>eo3pa</pattern>
-<pattern>eo3pe</pattern>
-<pattern>eo3pl</pattern>
-<pattern>eop4la</pattern>
-<pattern>eo3p2r</pattern>
-<pattern>e5ops</pattern>
-<pattern>eor5d</pattern>
-<pattern>e5org</pattern>
-<pattern>e5ori</pattern>
-<pattern>eo3ro</pattern>
-<pattern>eo3s4</pattern>
-<pattern>eo5st</pattern>
-<pattern>e4ot</pattern>
-<pattern>eo5te</pattern>
-<pattern>e5o3t4h</pattern>
-<pattern>e1pa</pattern>
-<pattern>e3paa</pattern>
-<pattern>ep3aak</pattern>
-<pattern>ep3ac</pattern>
-<pattern>e4paf</pattern>
-<pattern>epa4k</pattern>
-<pattern>ep5ake</pattern>
-<pattern>e3pal</pattern>
-<pattern>e3pap</pattern>
-<pattern>e4p3app</pattern>
-<pattern>e3par</pattern>
-<pattern>ep3asp</pattern>
-<pattern>e1pe</pattern>
-<pattern>e5pe </pattern>
-<pattern>ep5een</pattern>
-<pattern>e5per</pattern>
-<pattern>epers5te </pattern>
-<pattern>e1pi</pattern>
-<pattern>3epid</pattern>
-<pattern>ep3ijs</pattern>
-<pattern>ep3ijz</pattern>
-<pattern>ep5ingr</pattern>
-<pattern>ep3ins</pattern>
-<pattern>epit4s</pattern>
-<pattern>epits5te</pattern>
-<pattern>ep1j</pattern>
-<pattern>e1pl</pattern>
-<pattern>ep3led</pattern>
-<pattern>e4p3lod</pattern>
-<pattern>e5ploe</pattern>
-<pattern>ep3lus</pattern>
-<pattern>e1po</pattern>
-<pattern>e4p5o4ge</pattern>
-<pattern>epoort5j</pattern>
-<pattern>epoot4j</pattern>
-<pattern>3e4pos </pattern>
-<pattern>e3pot</pattern>
-<pattern>epou4</pattern>
-<pattern>e1pr</pattern>
-<pattern>ep4ra</pattern>
-<pattern>e3pri</pattern>
-<pattern>ep5rode</pattern>
-<pattern>eprot4</pattern>
-<pattern>ep2s</pattern>
-<pattern>ep4s5ee</pattern>
-<pattern>ep4ser</pattern>
-<pattern>eps3l</pattern>
-<pattern>eps5n</pattern>
-<pattern>eps3p</pattern>
-<pattern>eps3ta</pattern>
-<pattern>eps5taa</pattern>
-<pattern>eps5tal</pattern>
-<pattern>eps5to</pattern>
-<pattern>eps3tr</pattern>
-<pattern>eps5tro</pattern>
-<pattern>ep4tak</pattern>
-<pattern>ep2tj</pattern>
-<pattern>ep4tr</pattern>
-<pattern>ept3ra</pattern>
-<pattern>ep5tro</pattern>
-<pattern>ep3uit</pattern>
-<pattern>4equa</pattern>
-<pattern>e3ra </pattern>
-<pattern>e1raa</pattern>
-<pattern>e5raad</pattern>
-<pattern>e4raak </pattern>
-<pattern>er3aan</pattern>
-<pattern>er5aanp</pattern>
-<pattern>e4raap </pattern>
-<pattern>e5raat</pattern>
-<pattern>e4r1ac</pattern>
-<pattern>e5rac </pattern>
-<pattern>e5race</pattern>
-<pattern>e5raco</pattern>
-<pattern>e3rad</pattern>
-<pattern>e5rad </pattern>
-<pattern>er3ado</pattern>
-<pattern>er3af</pattern>
-<pattern>e3raff</pattern>
-<pattern>era4gen</pattern>
-<pattern>e1rai</pattern>
-<pattern>e4r3all</pattern>
-<pattern>er3ama</pattern>
-<pattern>er3ana</pattern>
-<pattern>e5randa</pattern>
-<pattern>e5rane</pattern>
-<pattern>e5ra3pl</pattern>
-<pattern>er3arc</pattern>
-<pattern>e3rare</pattern>
-<pattern>e3rari</pattern>
-<pattern>e1rat4</pattern>
-<pattern>er3a4tr</pattern>
-<pattern>er3azi</pattern>
-<pattern>er3d2a</pattern>
-<pattern>er3d4i</pattern>
-<pattern>erd4o</pattern>
-<pattern>er3d2r</pattern>
-<pattern>erd5uit </pattern>
-<pattern>er3d4w</pattern>
-<pattern>e1re</pattern>
-<pattern>er5eat</pattern>
-<pattern>4erec</pattern>
-<pattern>er5editi</pattern>
-<pattern>er3een</pattern>
-<pattern>e5reep</pattern>
-<pattern>er5eers</pattern>
-<pattern>er3eet</pattern>
-<pattern>er3ef</pattern>
-<pattern>er5eff</pattern>
-<pattern>er5eg </pattern>
-<pattern>er3egd</pattern>
-<pattern>er5egg</pattern>
-<pattern>er5egt</pattern>
-<pattern>er3eie</pattern>
-<pattern>er3eig</pattern>
-<pattern>er3eil</pattern>
-<pattern>er5eind</pattern>
-<pattern>ere3kl</pattern>
-<pattern>er3elk</pattern>
-<pattern>e4r3emm</pattern>
-<pattern>er3emp</pattern>
-<pattern>e3rend</pattern>
-<pattern>e5rendel</pattern>
-<pattern>ere4ne</pattern>
-<pattern>eren5eg</pattern>
-<pattern>er5enen </pattern>
-<pattern>e3renm</pattern>
-<pattern>e3rent</pattern>
-<pattern>er5enth</pattern>
-<pattern>e5rento</pattern>
-<pattern>eren5tw</pattern>
-<pattern>ere2o</pattern>
-<pattern>ere4og</pattern>
-<pattern>er3epi</pattern>
-<pattern>er3e2q</pattern>
-<pattern>er3eri</pattern>
-<pattern>e3res </pattern>
-<pattern>er3esk</pattern>
-<pattern>e3ress</pattern>
-<pattern>ere4st</pattern>
-<pattern>ere4t3j</pattern>
-<pattern>er3etn</pattern>
-<pattern>e4r3ets</pattern>
-<pattern>e4r5ex</pattern>
-<pattern>erg2l</pattern>
-<pattern>e3ri</pattern>
-<pattern>eri5ab</pattern>
-<pattern>e5rif</pattern>
-<pattern>e5rig</pattern>
-<pattern>erig5a</pattern>
-<pattern>er3ijl</pattern>
-<pattern>er3ijs</pattern>
-<pattern>e4rijs </pattern>
-<pattern>er3ijv</pattern>
-<pattern>e4r3ijz</pattern>
-<pattern>e5rik</pattern>
-<pattern>er5ind</pattern>
-<pattern>e4r3ini</pattern>
-<pattern>er5inkt</pattern>
-<pattern>er3ins</pattern>
-<pattern>er3int</pattern>
-<pattern>e5rio</pattern>
-<pattern>e5ris</pattern>
-<pattern>erkeers5</pattern>
-<pattern>er2kn</pattern>
-<pattern>er3m4i</pattern>
-<pattern>er5mo</pattern>
-<pattern>er5nu</pattern>
-<pattern>e1ro </pattern>
-<pattern>e3rob</pattern>
-<pattern>er3oc</pattern>
-<pattern>e4r3oed</pattern>
-<pattern>er3oef</pattern>
-<pattern>e5roep</pattern>
-<pattern>eroe5tj</pattern>
-<pattern>er3oev</pattern>
-<pattern>er3of</pattern>
-<pattern>ero2g</pattern>
-<pattern>e3rok</pattern>
-<pattern>e1ro2l</pattern>
-<pattern>e5rol </pattern>
-<pattern>er3oli</pattern>
-<pattern>e5roll</pattern>
-<pattern>er3om</pattern>
-<pattern>er1on</pattern>
-<pattern>e3ron </pattern>
-<pattern>e3rone</pattern>
-<pattern>er3onv</pattern>
-<pattern>er3oog</pattern>
-<pattern>er3oor</pattern>
-<pattern>e5roos</pattern>
-<pattern>e4r3op</pattern>
-<pattern>erop3a</pattern>
-<pattern>ero5pen</pattern>
-<pattern>e2r3or</pattern>
-<pattern>er1ov</pattern>
-<pattern>er3oxi</pattern>
-<pattern>e3roz</pattern>
-<pattern>e3rö</pattern>
-<pattern>er4plu</pattern>
-<pattern>errie5tj</pattern>
-<pattern>er3scr</pattern>
-<pattern>er3sj</pattern>
-<pattern>er5slag</pattern>
-<pattern>er5span</pattern>
-<pattern>ers4pot</pattern>
-<pattern>er5stem</pattern>
-<pattern>er5te</pattern>
-<pattern>er3t2h</pattern>
-<pattern>er5t4i</pattern>
-<pattern>er5t4o</pattern>
-<pattern>er3tr</pattern>
-<pattern>ert5se</pattern>
-<pattern>erts5l</pattern>
-<pattern>er3t4u</pattern>
-<pattern>er3t4w</pattern>
-<pattern>e1ru</pattern>
-<pattern>e3rub</pattern>
-<pattern>e3rug5</pattern>
-<pattern>e2rui</pattern>
-<pattern>er3uit</pattern>
-<pattern>erui5t4j</pattern>
-<pattern>e2run</pattern>
-<pattern>e3runs</pattern>
-<pattern>e4r3ur</pattern>
-<pattern>e3rus</pattern>
-<pattern>er5uu</pattern>
-<pattern>3ervar</pattern>
-<pattern>3erwt</pattern>
-<pattern>e4saf</pattern>
-<pattern>e4s3a2g</pattern>
-<pattern>e3sam</pattern>
-<pattern>e5san</pattern>
-<pattern>es3ap</pattern>
-<pattern>es3arr</pattern>
-<pattern>e3sa3s</pattern>
-<pattern>e3scop</pattern>
-<pattern>e3s2cr</pattern>
-<pattern>es4e</pattern>
-<pattern>e5sec</pattern>
-<pattern>es5een</pattern>
-<pattern>e5sel</pattern>
-<pattern>es5ene</pattern>
-<pattern>e4s5eng</pattern>
-<pattern>es5ex</pattern>
-<pattern>es2fe</pattern>
-<pattern>es5he</pattern>
-<pattern>e4shi</pattern>
-<pattern>e3sid</pattern>
-<pattern>e3sie</pattern>
-<pattern>es1in</pattern>
-<pattern>e4sir</pattern>
-<pattern>es5je </pattern>
-<pattern>es5jes</pattern>
-<pattern>e3s4jo</pattern>
-<pattern>es5jon</pattern>
-<pattern>e4s3ka</pattern>
-<pattern>es5kr</pattern>
-<pattern>e3sl</pattern>
-<pattern>es4la</pattern>
-<pattern>e5sla </pattern>
-<pattern>e5slag</pattern>
-<pattern>es3lak</pattern>
-<pattern>es5lat</pattern>
-<pattern>es4le</pattern>
-<pattern>es5leg</pattern>
-<pattern>es2m</pattern>
-<pattern>es4mui</pattern>
-<pattern>e5smuil </pattern>
-<pattern>e1sn</pattern>
-<pattern>e3s4ne</pattern>
-<pattern>e1so</pattern>
-<pattern>e3sol</pattern>
-<pattern>es4oo</pattern>
-<pattern>es5oor </pattern>
-<pattern>eso4p</pattern>
-<pattern>es3ore</pattern>
-<pattern>e1sp</pattern>
-<pattern>es5pas</pattern>
-<pattern>es4pel</pattern>
-<pattern>espit5ste</pattern>
-<pattern>e3spl</pattern>
-<pattern>e4sprie</pattern>
-<pattern>esp5riem</pattern>
-<pattern>es4sm</pattern>
-<pattern>e3stak</pattern>
-<pattern>e3s4tal</pattern>
-<pattern>e3stap</pattern>
-<pattern>es4tar</pattern>
-<pattern>es5tatie</pattern>
-<pattern>e4s3te </pattern>
-<pattern>es4tea</pattern>
-<pattern>es4teel</pattern>
-<pattern>est5ei </pattern>
-<pattern>e4steka</pattern>
-<pattern>es5tekam</pattern>
-<pattern>e3s4tem</pattern>
-<pattern>es5temo</pattern>
-<pattern>es3ten</pattern>
-<pattern>e4sten </pattern>
-<pattern>es5tenb</pattern>
-<pattern>es3ter</pattern>
-<pattern>estere5o</pattern>
-<pattern>es5tes</pattern>
-<pattern>es4tet</pattern>
-<pattern>e3steu</pattern>
-<pattern>es4tic</pattern>
-<pattern>e4stie</pattern>
-<pattern>e3stot</pattern>
-<pattern>es5tra </pattern>
-<pattern>es5trac</pattern>
-<pattern>es5trak</pattern>
-<pattern>e5stral</pattern>
-<pattern>est5rap</pattern>
-<pattern>es5trei</pattern>
-<pattern>est4sc</pattern>
-<pattern>es4tur</pattern>
-<pattern>e3sty</pattern>
-<pattern>e3su</pattern>
-<pattern>esu4r</pattern>
-<pattern>e3sy</pattern>
-<pattern>e1ta</pattern>
-<pattern>e3ta </pattern>
-<pattern>et3aan</pattern>
-<pattern>et3ac</pattern>
-<pattern>et3ad</pattern>
-<pattern>et3afz</pattern>
-<pattern>3e2tag</pattern>
-<pattern>e3tak</pattern>
-<pattern>e5tak </pattern>
-<pattern>et4ana</pattern>
-<pattern>e5tand</pattern>
-<pattern>e2tap</pattern>
-<pattern>e4tapp</pattern>
-<pattern>e5tat</pattern>
-<pattern>e4tau</pattern>
-<pattern>e2tav</pattern>
-<pattern>e3te</pattern>
-<pattern>e5tea</pattern>
-<pattern>et3edi</pattern>
-<pattern>e5tek</pattern>
-<pattern>4etel</pattern>
-<pattern>e5tel </pattern>
-<pattern>e4t5elf</pattern>
-<pattern>e5tels</pattern>
-<pattern>et5emb</pattern>
-<pattern>et5emm</pattern>
-<pattern>etens5u</pattern>
-<pattern>eten5tj</pattern>
-<pattern>ete5r4a</pattern>
-<pattern>ete3ro</pattern>
-<pattern>eters5la</pattern>
-<pattern>eter5sm</pattern>
-<pattern>e5tes</pattern>
-<pattern>e1th</pattern>
-<pattern>et3ha</pattern>
-<pattern>et3hor</pattern>
-<pattern>et5hu</pattern>
-<pattern>e4t5i4d</pattern>
-<pattern>e5tie</pattern>
-<pattern>e4t3inc</pattern>
-<pattern>e4tiq</pattern>
-<pattern>e5tis</pattern>
-<pattern>e4tja</pattern>
-<pattern>e1to</pattern>
-<pattern>e5toc</pattern>
-<pattern>e3toe</pattern>
-<pattern>e5toev</pattern>
-<pattern>e3tol</pattern>
-<pattern>eto4p</pattern>
-<pattern>et3ope</pattern>
-<pattern>et3opl</pattern>
-<pattern>e4t3ork</pattern>
-<pattern>eto3sf</pattern>
-<pattern>e1tr</pattern>
-<pattern>et3rec</pattern>
-<pattern>e4t5res</pattern>
-<pattern>e3troe</pattern>
-<pattern>e5tron</pattern>
-<pattern>e5troo</pattern>
-<pattern>etros4</pattern>
-<pattern>e4t3ru</pattern>
-<pattern>et4sl</pattern>
-<pattern>ets5lap</pattern>
-<pattern>et5slu</pattern>
-<pattern>ets3n</pattern>
-<pattern>et4s3oo</pattern>
-<pattern>et3spe</pattern>
-<pattern>ets3pr</pattern>
-<pattern>et3spu</pattern>
-<pattern>et4ste</pattern>
-<pattern>ets5tek</pattern>
-<pattern>et5sten</pattern>
-<pattern>et5sti</pattern>
-<pattern>ets4u</pattern>
-<pattern>et5su5r</pattern>
-<pattern>et5suu</pattern>
-<pattern>e1tu</pattern>
-<pattern>etui5tj</pattern>
-<pattern>etu4r</pattern>
-<pattern>et3we</pattern>
-<pattern>et2wi</pattern>
-<pattern>1eua4</pattern>
-<pattern>1euc</pattern>
-<pattern>eudi5o</pattern>
-<pattern>eu5dr</pattern>
-<pattern>eu3e</pattern>
-<pattern>eugd3r</pattern>
-<pattern>eu3g2r</pattern>
-<pattern>eu4ler</pattern>
-<pattern>eu4li</pattern>
-<pattern>e1um</pattern>
-<pattern>e3um </pattern>
-<pattern>e2umd</pattern>
-<pattern>eu2na</pattern>
-<pattern>eun3t</pattern>
-<pattern>1eu1o</pattern>
-<pattern>eu2po</pattern>
-<pattern>eu4rad</pattern>
-<pattern>eu4rec</pattern>
-<pattern>eu3ren</pattern>
-<pattern>eu4res</pattern>
-<pattern>eu4rij</pattern>
-<pattern>eur5k</pattern>
-<pattern>euro5v</pattern>
-<pattern>eur4sta</pattern>
-<pattern>eurs5taa</pattern>
-<pattern>eurs5te </pattern>
-<pattern>eur4s5tr</pattern>
-<pattern>eur4su</pattern>
-<pattern>eu5sch</pattern>
-<pattern>eus4p</pattern>
-<pattern>eu3spa</pattern>
-<pattern>eu4st</pattern>
-<pattern>eu5str</pattern>
-<pattern>eu3tj</pattern>
-<pattern>eu1tr</pattern>
-<pattern>e3uu</pattern>
-<pattern>2euw</pattern>
-<pattern>eu4wa</pattern>
-<pattern>eu5win</pattern>
-<pattern>euw4str</pattern>
-<pattern>evaar5tj</pattern>
-<pattern>eval4s</pattern>
-<pattern>evari5</pattern>
-<pattern>eve4lo</pattern>
-<pattern>evel5op</pattern>
-<pattern>eve5n4aa</pattern>
-<pattern>4ever</pattern>
-<pattern>eve3ra</pattern>
-<pattern>4e1w</pattern>
-<pattern>e5wa</pattern>
-<pattern>e5we</pattern>
-<pattern>ewen4s</pattern>
-<pattern>ewens5te </pattern>
-<pattern>ewest5r</pattern>
-<pattern>ew2h</pattern>
-<pattern>e5wi</pattern>
-<pattern>ewo3v</pattern>
-<pattern>4ex </pattern>
-<pattern>2ex3aa</pattern>
-<pattern>ex3af</pattern>
-<pattern>4exco</pattern>
-<pattern>3exeg</pattern>
-<pattern>3exem</pattern>
-<pattern>4exi</pattern>
-<pattern>ex3in</pattern>
-<pattern>ex5op</pattern>
-<pattern>1exp</pattern>
-<pattern>e3y4o</pattern>
-<pattern>eys4</pattern>
-<pattern>ey3st</pattern>
-<pattern>e5za</pattern>
-<pattern>e3zee</pattern>
-<pattern>4e3zen</pattern>
-<pattern>ezers5</pattern>
-<pattern>e3zo</pattern>
-<pattern>ezz4</pattern>
-<pattern>é3a</pattern>
-<pattern>é1d</pattern>
-<pattern>édee4</pattern>
-<pattern>édi3</pattern>
-<pattern>é1g</pattern>
-<pattern>égee5</pattern>
-<pattern>é3h</pattern>
-<pattern>é3j</pattern>
-<pattern>é3n</pattern>
-<pattern>é3p</pattern>
-<pattern>é3r</pattern>
-<pattern>é1t</pattern>
-<pattern>è1</pattern>
-<pattern>4èc</pattern>
-<pattern>è2l</pattern>
-<pattern>è2s</pattern>
-<pattern>è5t</pattern>
-<pattern>èta5</pattern>
-<pattern>ê1</pattern>
-<pattern>ê2p</pattern>
-<pattern>ê3per</pattern>
-<pattern>ê5t</pattern>
-<pattern>3ë</pattern>
-<pattern>4ë </pattern>
-<pattern>ë2b</pattern>
-<pattern>ë3c</pattern>
-<pattern>ë3d</pattern>
-<pattern>ëe2</pattern>
-<pattern>ëen3</pattern>
-<pattern>ë3j</pattern>
-<pattern>ë1l</pattern>
-<pattern>5ën</pattern>
-<pattern>ënce3</pattern>
-<pattern>ën4e</pattern>
-<pattern>ëns2</pattern>
-<pattern>ën5sc</pattern>
-<pattern>ënt2</pattern>
-<pattern>ën5th</pattern>
-<pattern>ën5tw</pattern>
-<pattern>ë3p</pattern>
-<pattern>ë1ra</pattern>
-<pattern>ë1re</pattern>
-<pattern>ë1ri</pattern>
-<pattern>ë1ro</pattern>
-<pattern>ëro1g2</pattern>
-<pattern>ëro3s</pattern>
-<pattern>ë2s</pattern>
-<pattern>ë3si</pattern>
-<pattern>ës3t</pattern>
-<pattern>ë1t</pattern>
-<pattern>ët4s</pattern>
-<pattern>ëts3te</pattern>
-<pattern>ëve5</pattern>
-<pattern>ëven4</pattern>
-<pattern>4ëzu</pattern>
-<pattern>4f </pattern>
-<pattern>1fa</pattern>
-<pattern>f3aanb</pattern>
-<pattern>f4aat</pattern>
-<pattern>3fab</pattern>
-<pattern>fa2bo</pattern>
-<pattern>f3acc</pattern>
-<pattern>face4</pattern>
-<pattern>f1ach</pattern>
-<pattern>2fad</pattern>
-<pattern>2f1af</pattern>
-<pattern>fa3g</pattern>
-<pattern>fal3s</pattern>
-<pattern>fa3m</pattern>
-<pattern>f3ang</pattern>
-<pattern>fant2</pattern>
-<pattern>fan4t3j</pattern>
-<pattern>fant4s5</pattern>
-<pattern>2f3a2p</pattern>
-<pattern>f4arm</pattern>
-<pattern>3fa5se</pattern>
-<pattern>fa2to</pattern>
-<pattern>fa3v</pattern>
-<pattern>4fb</pattern>
-<pattern>fbe5dw</pattern>
-<pattern>f1c</pattern>
-<pattern>4fd</pattern>
-<pattern>f3da</pattern>
-<pattern>fda4g</pattern>
-<pattern>f5dan</pattern>
-<pattern>fd1ar</pattern>
-<pattern>fde4k</pattern>
-<pattern>fdek3l</pattern>
-<pattern>fde4s3</pattern>
-<pattern>fdes5e</pattern>
-<pattern>fdes5l</pattern>
-<pattern>fde5sm</pattern>
-<pattern>fdes5t</pattern>
-<pattern>f2d3in</pattern>
-<pattern>fd3of</pattern>
-<pattern>fdors5te</pattern>
-<pattern>fd4ra</pattern>
-<pattern>f3d4ru</pattern>
-<pattern>fd5se</pattern>
-<pattern>fd3si</pattern>
-<pattern>fd3so</pattern>
-<pattern>fd3sp</pattern>
-<pattern>f4d2w</pattern>
-<pattern>fd3wo</pattern>
-<pattern>1fe</pattern>
-<pattern>fe2a</pattern>
-<pattern>fec4tr</pattern>
-<pattern>fede3</pattern>
-<pattern>fe4del</pattern>
-<pattern>f3een</pattern>
-<pattern>5fees</pattern>
-<pattern>feest5r</pattern>
-<pattern>fel5dr</pattern>
-<pattern>fe4l3ee</pattern>
-<pattern>3feli</pattern>
-<pattern>fe4lom</pattern>
-<pattern>fe4l3op</pattern>
-<pattern>fel3sp</pattern>
-<pattern>fe3no</pattern>
-<pattern>f4er</pattern>
-<pattern>fe3rab</pattern>
-<pattern>fe3ran</pattern>
-<pattern>fe4r3et</pattern>
-<pattern>fe3rom</pattern>
-<pattern>fe3ron</pattern>
-<pattern>3fes3</pattern>
-<pattern>fe4t3j</pattern>
-<pattern>fetu5r</pattern>
-<pattern>2f3ex</pattern>
-<pattern>1fé</pattern>
-<pattern>3fè</pattern>
-<pattern>3fê</pattern>
-<pattern>4f1f</pattern>
-<pattern>f5fe</pattern>
-<pattern>f5fi</pattern>
-<pattern>ffs2</pattern>
-<pattern>ff3sh</pattern>
-<pattern>ff3si</pattern>
-<pattern>f3fu</pattern>
-<pattern>f3g2</pattern>
-<pattern>fge3</pattern>
-<pattern>fge5r4</pattern>
-<pattern>fge5t</pattern>
-<pattern>4f5h</pattern>
-<pattern>1fi</pattern>
-<pattern>fi5ac</pattern>
-<pattern>fi4al</pattern>
-<pattern>fi3am</pattern>
-<pattern>fi3apa</pattern>
-<pattern>fi3apo</pattern>
-<pattern>fia4s</pattern>
-<pattern>3fib</pattern>
-<pattern>fi1ch</pattern>
-<pattern>5fie</pattern>
-<pattern>5fig</pattern>
-<pattern>f3ijs</pattern>
-<pattern>2f1ijz</pattern>
-<pattern>fik4st</pattern>
-<pattern>3f2il</pattern>
-<pattern>fil4m3a</pattern>
-<pattern>film5on</pattern>
-<pattern>fi3lo</pattern>
-<pattern>4find</pattern>
-<pattern>3fini</pattern>
-<pattern>f3inj</pattern>
-<pattern>4fink</pattern>
-<pattern>2finr</pattern>
-<pattern>fi3o</pattern>
-<pattern>fi4r</pattern>
-<pattern>fi4s</pattern>
-<pattern>fi5se</pattern>
-<pattern>f5iso</pattern>
-<pattern>f1j</pattern>
-<pattern>fjes5</pattern>
-<pattern>4f1k4</pattern>
-<pattern>f3ke</pattern>
-<pattern>f2l2</pattern>
-<pattern>4f3laa</pattern>
-<pattern>f1laf</pattern>
-<pattern>f4lam</pattern>
-<pattern>f3lei</pattern>
-<pattern>flen4st</pattern>
-<pattern>flens5te </pattern>
-<pattern>f4les</pattern>
-<pattern>fle2t</pattern>
-<pattern>flet3j</pattern>
-<pattern>4flev</pattern>
-<pattern>f4lex</pattern>
-<pattern>f3lez</pattern>
-<pattern>2flie</pattern>
-<pattern>2flij</pattern>
-<pattern>f4lik</pattern>
-<pattern>f4lip</pattern>
-<pattern>f4lit</pattern>
-<pattern>f3lok</pattern>
-<pattern>3f4lor</pattern>
-<pattern>flu4t3</pattern>
-<pattern>4f1m</pattern>
-<pattern>f1n</pattern>
-<pattern>1fo</pattern>
-<pattern>3fob</pattern>
-<pattern>5foc</pattern>
-<pattern>foe5d</pattern>
-<pattern>foe5ta</pattern>
-<pattern>2f3of</pattern>
-<pattern>5fok</pattern>
-<pattern>2foms</pattern>
-<pattern>fo5na</pattern>
-<pattern>fond5en</pattern>
-<pattern>fonds5l</pattern>
-<pattern>fon5eng</pattern>
-<pattern>fo1no</pattern>
-<pattern>4font</pattern>
-<pattern>fon5te</pattern>
-<pattern>foo4</pattern>
-<pattern>fooi5</pattern>
-<pattern>f3oom</pattern>
-<pattern>5foon</pattern>
-<pattern>2fo4p</pattern>
-<pattern>fop5s4</pattern>
-<pattern>f4or</pattern>
-<pattern>3fo5re</pattern>
-<pattern>fo5ri</pattern>
-<pattern>5form</pattern>
-<pattern>for4t3j</pattern>
-<pattern>fo1ru</pattern>
-<pattern>fo3t</pattern>
-<pattern>2f3oud</pattern>
-<pattern>4f1ov</pattern>
-<pattern>3fö</pattern>
-<pattern>4f5p4</pattern>
-<pattern>fpers5te </pattern>
-<pattern>fpits5te </pattern>
-<pattern>fr4</pattern>
-<pattern>f4raak </pattern>
-<pattern>fraam5</pattern>
-<pattern>5frac</pattern>
-<pattern>f3rad</pattern>
-<pattern>f2ras</pattern>
-<pattern>5frau</pattern>
-<pattern>f1rec</pattern>
-<pattern>f3rek</pattern>
-<pattern>5freq</pattern>
-<pattern>frie4s</pattern>
-<pattern>frie4t</pattern>
-<pattern>friet5j</pattern>
-<pattern>f4rik</pattern>
-<pattern>f4rod</pattern>
-<pattern>4f3rol</pattern>
-<pattern>f4rolo</pattern>
-<pattern>f3roma</pattern>
-<pattern>frus3</pattern>
-<pattern>4f1s</pattern>
-<pattern>f2sa4</pattern>
-<pattern>fs3ad</pattern>
-<pattern>fs3an</pattern>
-<pattern>fs3ar</pattern>
-<pattern>f3sc</pattern>
-<pattern>f5sch</pattern>
-<pattern>f4scr</pattern>
-<pattern>fse2</pattern>
-<pattern>f4s3ec</pattern>
-<pattern>f4s5ee</pattern>
-<pattern>f4sei</pattern>
-<pattern>f4s3eth</pattern>
-<pattern>fs4fe</pattern>
-<pattern>f2sh</pattern>
-<pattern>fs5he</pattern>
-<pattern>f2si</pattern>
-<pattern>f3sie</pattern>
-<pattern>fs3im</pattern>
-<pattern>fs1in</pattern>
-<pattern>f5slaa</pattern>
-<pattern>f5slac</pattern>
-<pattern>f5slag</pattern>
-<pattern>fs3lap</pattern>
-<pattern>fs2m</pattern>
-<pattern>fs3ma</pattern>
-<pattern>fs4mi</pattern>
-<pattern>fs3mo</pattern>
-<pattern>fs3mu</pattern>
-<pattern>f2s1o4</pattern>
-<pattern>fs3ob</pattern>
-<pattern>fs3om</pattern>
-<pattern>fs4oo</pattern>
-<pattern>fs2p</pattern>
-<pattern>fs4pre</pattern>
-<pattern>fs4t</pattern>
-<pattern>fst3as</pattern>
-<pattern>f3ste</pattern>
-<pattern>fs5tec</pattern>
-<pattern>f5stell</pattern>
-<pattern>fste4m3</pattern>
-<pattern>f4sterr</pattern>
-<pattern>f3sti</pattern>
-<pattern>f5stif</pattern>
-<pattern>f3sto</pattern>
-<pattern>f4st3oc</pattern>
-<pattern>f4ston</pattern>
-<pattern>f3str</pattern>
-<pattern>f3stu</pattern>
-<pattern>f3sy</pattern>
-<pattern>4ft</pattern>
-<pattern>f1ta</pattern>
-<pattern>ft1ac</pattern>
-<pattern>fta4kl</pattern>
-<pattern>fta4p</pattern>
-<pattern>ft3art</pattern>
-<pattern>fter5sh</pattern>
-<pattern>ft3h</pattern>
-<pattern>f1to</pattern>
-<pattern>f5tond</pattern>
-<pattern>f4tont</pattern>
-<pattern>f1tr</pattern>
-<pattern>ft2s3l</pattern>
-<pattern>ft4sm</pattern>
-<pattern>fts3n</pattern>
-<pattern>ft4so</pattern>
-<pattern>fts3p</pattern>
-<pattern>f1tu</pattern>
-<pattern>ftu4r</pattern>
-<pattern>1fu</pattern>
-<pattern>2fuit</pattern>
-<pattern>fu4ma</pattern>
-<pattern>fum3ac</pattern>
-<pattern>3f2un</pattern>
-<pattern>fur4o</pattern>
-<pattern>3fus</pattern>
-<pattern>2fuu</pattern>
-<pattern>4fv</pattern>
-<pattern>fva2</pattern>
-<pattern>fval3</pattern>
-<pattern>4f1w4</pattern>
-<pattern>3fy1</pattern>
-<pattern>2fz</pattern>
-<pattern>fzet5</pattern>
-<pattern>4g </pattern>
-<pattern>1ga</pattern>
-<pattern>3ga </pattern>
-<pattern>gaar5tj</pattern>
-<pattern>g4aat</pattern>
-<pattern>2g1ac</pattern>
-<pattern>4g3adm</pattern>
-<pattern>g4af </pattern>
-<pattern>g3afd</pattern>
-<pattern>ga3fr</pattern>
-<pattern>4g3afs</pattern>
-<pattern>4g3afw</pattern>
-<pattern>2g3a4h</pattern>
-<pattern>4gal </pattern>
-<pattern>ga3la</pattern>
-<pattern>ga4l3ap</pattern>
-<pattern>ga5ler</pattern>
-<pattern>gal3s</pattern>
-<pattern>4gamb</pattern>
-<pattern>g4a3mi</pattern>
-<pattern>3gan</pattern>
-<pattern>gan5d</pattern>
-<pattern>5gane</pattern>
-<pattern>gan4s5t</pattern>
-<pattern>ga3pl</pattern>
-<pattern>3gar </pattern>
-<pattern>4g3arb</pattern>
-<pattern>ga3re</pattern>
-<pattern>g1arm</pattern>
-<pattern>3gars</pattern>
-<pattern>2g3art</pattern>
-<pattern>gar5tj</pattern>
-<pattern>ga4s</pattern>
-<pattern>gas5c</pattern>
-<pattern>gas3i</pattern>
-<pattern>ga5sla </pattern>
-<pattern>ga3sli</pattern>
-<pattern>ga5slo</pattern>
-<pattern>gas3o</pattern>
-<pattern>gas3p</pattern>
-<pattern>gas3tr</pattern>
-<pattern>gas5tra</pattern>
-<pattern>gast5rol</pattern>
-<pattern>3gat</pattern>
-<pattern>gat5j</pattern>
-<pattern>gat3s</pattern>
-<pattern>4gaut</pattern>
-<pattern>ga5ve</pattern>
-<pattern>g1avo</pattern>
-<pattern>2g5b</pattern>
-<pattern>2g1c</pattern>
-<pattern>4gd</pattern>
-<pattern>g5dac</pattern>
-<pattern>g5dag</pattern>
-<pattern>gd3art</pattern>
-<pattern>gd3at</pattern>
-<pattern>gd5ate</pattern>
-<pattern>g3de</pattern>
-<pattern>g4d3elf</pattern>
-<pattern>g5der </pattern>
-<pattern>gd3erv</pattern>
-<pattern>g4d3id</pattern>
-<pattern>gd3im</pattern>
-<pattern>g2din</pattern>
-<pattern>g3dr</pattern>
-<pattern>g5dru</pattern>
-<pattern>gd3sa</pattern>
-<pattern>gd5sp</pattern>
-<pattern>g3du</pattern>
-<pattern>1ge</pattern>
-<pattern>3ge </pattern>
-<pattern>ge3a</pattern>
-<pattern>gea3dr</pattern>
-<pattern>gea5na</pattern>
-<pattern>gea3q</pattern>
-<pattern>ge4ari</pattern>
-<pattern>ge5au</pattern>
-<pattern>4g3eb </pattern>
-<pattern>2gebb</pattern>
-<pattern>ge3c</pattern>
-<pattern>ge3d4</pattern>
-<pattern>gedi3a</pattern>
-<pattern>ge4dit</pattern>
-<pattern>ge5dr</pattern>
-<pattern>ge5dw</pattern>
-<pattern>3gee4</pattern>
-<pattern>geest5r</pattern>
-<pattern>geet3a</pattern>
-<pattern>ge3f4</pattern>
-<pattern>2g3eff</pattern>
-<pattern>ge5g4</pattern>
-<pattern>gege4s</pattern>
-<pattern>4geig</pattern>
-<pattern>2g3eik</pattern>
-<pattern>gei4l5a</pattern>
-<pattern>5geit</pattern>
-<pattern>geit3j</pattern>
-<pattern>ge3k4a</pattern>
-<pattern>ge3ke</pattern>
-<pattern>ge5ki</pattern>
-<pattern>ge5k4l</pattern>
-<pattern>ge3kr</pattern>
-<pattern>gek4st</pattern>
-<pattern>gek4u</pattern>
-<pattern>ge3k4w</pattern>
-<pattern>ge3lau</pattern>
-<pattern>gel4d3a4</pattern>
-<pattern>ge3l4e</pattern>
-<pattern>4ge4lem</pattern>
-<pattern>gel5f</pattern>
-<pattern>gel5k</pattern>
-<pattern>5ge3l4o</pattern>
-<pattern>gel5si</pattern>
-<pattern>gel3sl</pattern>
-<pattern>gel3sp</pattern>
-<pattern>gel5ste</pattern>
-<pattern>ge5ma</pattern>
-<pattern>4gemb</pattern>
-<pattern>4g3emf</pattern>
-<pattern>ge5mo</pattern>
-<pattern>2g3emp</pattern>
-<pattern>gems3</pattern>
-<pattern>ge3m4u</pattern>
-<pattern>g4en </pattern>
-<pattern>ge3nak</pattern>
-<pattern>gen4az</pattern>
-<pattern>3ge3ne</pattern>
-<pattern>ge4n3ed</pattern>
-<pattern>ge4nend</pattern>
-<pattern>4g3engt</pattern>
-<pattern>3geni</pattern>
-<pattern>gen5k</pattern>
-<pattern>ge1no</pattern>
-<pattern>ge4n4of</pattern>
-<pattern>ge4nog</pattern>
-<pattern>gen5sfe</pattern>
-<pattern>gen5ston</pattern>
-<pattern>gen5stu</pattern>
-<pattern>genstu5r</pattern>
-<pattern>5genw</pattern>
-<pattern>ge5om</pattern>
-<pattern>geo5pe</pattern>
-<pattern>georke5</pattern>
-<pattern>ge5os</pattern>
-<pattern>ge5ot</pattern>
-<pattern>ge5p4</pattern>
-<pattern>ge1ra</pattern>
-<pattern>ger5aal</pattern>
-<pattern>ger5aap </pattern>
-<pattern>ge4r3a4l</pattern>
-<pattern>gera4p</pattern>
-<pattern>ger5ape</pattern>
-<pattern>ger5as </pattern>
-<pattern>ge5reg</pattern>
-<pattern>ge3rem</pattern>
-<pattern>ge5ren </pattern>
-<pattern>ger4i</pattern>
-<pattern>ger5ini</pattern>
-<pattern>ge1r2o</pattern>
-<pattern>ger4of</pattern>
-<pattern>ge5rol</pattern>
-<pattern>ger5slan</pattern>
-<pattern>ger4sli</pattern>
-<pattern>gers5lij</pattern>
-<pattern>ger4sp</pattern>
-<pattern>4g3erts</pattern>
-<pattern>ge3r4u</pattern>
-<pattern>3ge1s4</pattern>
-<pattern>ge3sa</pattern>
-<pattern>ge3sc</pattern>
-<pattern>ge5se</pattern>
-<pattern>ge3si</pattern>
-<pattern>4ge3sk</pattern>
-<pattern>ge5sl</pattern>
-<pattern>ge3sn</pattern>
-<pattern>ge3so</pattern>
-<pattern>ge5spend</pattern>
-<pattern>ge5sper</pattern>
-<pattern>ge5spo</pattern>
-<pattern>ge5stan</pattern>
-<pattern>ges5te </pattern>
-<pattern>ges5ten </pattern>
-<pattern>ge3str</pattern>
-<pattern>ge5sw</pattern>
-<pattern>ge3ta</pattern>
-<pattern>get4aa</pattern>
-<pattern>ge5tam</pattern>
-<pattern>ge2th</pattern>
-<pattern>ge5t4i</pattern>
-<pattern>ge3t4j</pattern>
-<pattern>get4o</pattern>
-<pattern>ge3tr</pattern>
-<pattern>ge5tra</pattern>
-<pattern>ge5tro</pattern>
-<pattern>ge5tru</pattern>
-<pattern>ge5tsj</pattern>
-<pattern>ge5tu</pattern>
-<pattern>ge5t4w</pattern>
-<pattern>ge3ui</pattern>
-<pattern>5g4ev</pattern>
-<pattern>4gex</pattern>
-<pattern>5g4ez</pattern>
-<pattern>1gé</pattern>
-<pattern>gédi4</pattern>
-<pattern>3gè</pattern>
-<pattern>4g1f</pattern>
-<pattern>gfijn5ste</pattern>
-<pattern>4g3g4</pattern>
-<pattern>g5ge</pattern>
-<pattern>gge3la</pattern>
-<pattern>gge4r5on</pattern>
-<pattern>gges5ti</pattern>
-<pattern>g4g5h</pattern>
-<pattern>g5gi</pattern>
-<pattern>ggings5</pattern>
-<pattern>g5gl</pattern>
-<pattern>2g1h</pattern>
-<pattern>g2het</pattern>
-<pattern>ght4</pattern>
-<pattern>gh5te</pattern>
-<pattern>g2hum</pattern>
-<pattern>1gi</pattern>
-<pattern>gids5te</pattern>
-<pattern>gie5ra</pattern>
-<pattern>gier4s</pattern>
-<pattern>gi1eu</pattern>
-<pattern>gi2f</pattern>
-<pattern>gif5r</pattern>
-<pattern>gi3ga</pattern>
-<pattern>5gigere</pattern>
-<pattern>5gigste</pattern>
-<pattern>2gij</pattern>
-<pattern>g3ijs</pattern>
-<pattern>4gijz</pattern>
-<pattern>gi2m</pattern>
-<pattern>gi3na</pattern>
-<pattern>4g3inb</pattern>
-<pattern>4g3inf</pattern>
-<pattern>g5infe</pattern>
-<pattern>g5infr</pattern>
-<pattern>5ging</pattern>
-<pattern>2g3inh</pattern>
-<pattern>gin3o</pattern>
-<pattern>2ginr</pattern>
-<pattern>gi4oc</pattern>
-<pattern>gi2od</pattern>
-<pattern>gi4onet</pattern>
-<pattern>gi2or</pattern>
-<pattern>gip4st</pattern>
-<pattern>5gir</pattern>
-<pattern>3gis</pattern>
-<pattern>4g1j</pattern>
-<pattern>4g1k</pattern>
-<pattern>gl4</pattern>
-<pattern>g5lab</pattern>
-<pattern>3glai</pattern>
-<pattern>1gla4s</pattern>
-<pattern>glas3e</pattern>
-<pattern>g5lat</pattern>
-<pattern>3g4laz</pattern>
-<pattern>3gle </pattern>
-<pattern>g5leer</pattern>
-<pattern>glee5t</pattern>
-<pattern>g3len</pattern>
-<pattern>2g5lep</pattern>
-<pattern>4g5ler</pattern>
-<pattern>g3les</pattern>
-<pattern>3gle4t</pattern>
-<pattern>glet3j</pattern>
-<pattern>g5lev</pattern>
-<pattern>g5lice</pattern>
-<pattern>g5lich</pattern>
-<pattern>3glië</pattern>
-<pattern>g2lif</pattern>
-<pattern>g5lijs</pattern>
-<pattern>g2lim</pattern>
-<pattern>3g4lio</pattern>
-<pattern>g2lob</pattern>
-<pattern>3glof</pattern>
-<pattern>g5log</pattern>
-<pattern>3glom</pattern>
-<pattern>4g3lon</pattern>
-<pattern>g3loon</pattern>
-<pattern>g3lop</pattern>
-<pattern>3g2los</pattern>
-<pattern>g5loz</pattern>
-<pattern>3g2ly</pattern>
-<pattern>4g1m</pattern>
-<pattern>gmaat5j</pattern>
-<pattern>2g1n</pattern>
-<pattern>g3na</pattern>
-<pattern>gn4e</pattern>
-<pattern>gne5g</pattern>
-<pattern>gne5m</pattern>
-<pattern>gne4t3j</pattern>
-<pattern>gnie4tj</pattern>
-<pattern>4gnu</pattern>
-<pattern>1go</pattern>
-<pattern>3go </pattern>
-<pattern>3go2a</pattern>
-<pattern>3gob</pattern>
-<pattern>2goc</pattern>
-<pattern>g1och</pattern>
-<pattern>go4d3a</pattern>
-<pattern>god4s3</pattern>
-<pattern>gods5t</pattern>
-<pattern>4goef</pattern>
-<pattern>goe1r</pattern>
-<pattern>2gof</pattern>
-<pattern>go3f2r</pattern>
-<pattern>g4og</pattern>
-<pattern>4goh</pattern>
-<pattern>go2k</pattern>
-<pattern>5gom </pattern>
-<pattern>go2ma</pattern>
-<pattern>g3oml</pattern>
-<pattern>4gomz</pattern>
-<pattern>go4n3az</pattern>
-<pattern>2g3ong</pattern>
-<pattern>go5no</pattern>
-<pattern>2g1ont</pattern>
-<pattern>g2oo</pattern>
-<pattern>2g3oor</pattern>
-<pattern>3goot</pattern>
-<pattern>2g1op</pattern>
-<pattern>go3pa</pattern>
-<pattern>g4opr</pattern>
-<pattern>g4ora</pattern>
-<pattern>4go4re</pattern>
-<pattern>go5re </pattern>
-<pattern>5g4ori</pattern>
-<pattern>gor2s</pattern>
-<pattern>gos1</pattern>
-<pattern>go3tr</pattern>
-<pattern>gou4d5ee</pattern>
-<pattern>2g3ov</pattern>
-<pattern>2g5p</pattern>
-<pattern>gpes3</pattern>
-<pattern>1gr4</pattern>
-<pattern>3gra</pattern>
-<pattern>5gra </pattern>
-<pattern>graat5j</pattern>
-<pattern>g5rak</pattern>
-<pattern>gra2m</pattern>
-<pattern>g4ram </pattern>
-<pattern>gram3a</pattern>
-<pattern>g3ramp</pattern>
-<pattern>gra4s3</pattern>
-<pattern>5grav</pattern>
-<pattern>2g3rec</pattern>
-<pattern>2g3red</pattern>
-<pattern>5gredi</pattern>
-<pattern>g5redu</pattern>
-<pattern>g3reek</pattern>
-<pattern>g3reel</pattern>
-<pattern>g4reep</pattern>
-<pattern>g3reis</pattern>
-<pattern>4g3rek</pattern>
-<pattern>2g3rem</pattern>
-<pattern>gren4s</pattern>
-<pattern>gre4s</pattern>
-<pattern>g4reu</pattern>
-<pattern>g3rev</pattern>
-<pattern>5gria</pattern>
-<pattern>grie4t5j</pattern>
-<pattern>g5rijd</pattern>
-<pattern>g5rijk</pattern>
-<pattern>g5rijm</pattern>
-<pattern>g5ring</pattern>
-<pattern>5g4ris</pattern>
-<pattern>grit5s</pattern>
-<pattern>2g3riv</pattern>
-<pattern>groet5j</pattern>
-<pattern>grof5</pattern>
-<pattern>g3rok</pattern>
-<pattern>g3rook</pattern>
-<pattern>g3room</pattern>
-<pattern>groot5j</pattern>
-<pattern>2grou</pattern>
-<pattern>gro5v</pattern>
-<pattern>2g3rug</pattern>
-<pattern>g3ruim</pattern>
-<pattern>g3rup</pattern>
-<pattern>4gs</pattern>
-<pattern>gs1a2</pattern>
-<pattern>gsa4g</pattern>
-<pattern>gs5alar</pattern>
-<pattern>gs3alt</pattern>
-<pattern>g2sc</pattern>
-<pattern>gse4</pattern>
-<pattern>gs3eco</pattern>
-<pattern>g4s3ed</pattern>
-<pattern>gs5een</pattern>
-<pattern>gs3ei</pattern>
-<pattern>gs3en</pattern>
-<pattern>gs5ene</pattern>
-<pattern>gs3erv</pattern>
-<pattern>gs3et</pattern>
-<pattern>gs3ev</pattern>
-<pattern>gs5he</pattern>
-<pattern>g2s1i2</pattern>
-<pattern>g3sie</pattern>
-<pattern>gs5is</pattern>
-<pattern>gs1j</pattern>
-<pattern>g3s4ke </pattern>
-<pattern>gs3l</pattern>
-<pattern>gs4la</pattern>
-<pattern>gs5laag</pattern>
-<pattern>gs5lam</pattern>
-<pattern>gs5las</pattern>
-<pattern>gs1le</pattern>
-<pattern>g3slep</pattern>
-<pattern>g4sleu</pattern>
-<pattern>gs5lie</pattern>
-<pattern>gs4lin</pattern>
-<pattern>g5sling</pattern>
-<pattern>gs4lo</pattern>
-<pattern>gs5log</pattern>
-<pattern>gs5lok</pattern>
-<pattern>gs5lon</pattern>
-<pattern>gs4lu</pattern>
-<pattern>g4s5ma</pattern>
-<pattern>gs3n</pattern>
-<pattern>g4sna</pattern>
-<pattern>g3snij</pattern>
-<pattern>g4s1o4</pattern>
-<pattern>g5sol</pattern>
-<pattern>g5som </pattern>
-<pattern>gs5ons</pattern>
-<pattern>gs3op</pattern>
-<pattern>gs3p</pattern>
-<pattern>gs5pand</pattern>
-<pattern>g3spec</pattern>
-<pattern>g3s4pel</pattern>
-<pattern>g3s4pet</pattern>
-<pattern>gs4pi</pattern>
-<pattern>g3spie</pattern>
-<pattern>g3spil</pattern>
-<pattern>g5spin </pattern>
-<pattern>g5spinn</pattern>
-<pattern>gs5pir</pattern>
-<pattern>gs5pol</pattern>
-<pattern>g3s4pon</pattern>
-<pattern>gs5ps</pattern>
-<pattern>gs5q</pattern>
-<pattern>gs5sc</pattern>
-<pattern>gst2a</pattern>
-<pattern>gs5taal</pattern>
-<pattern>gst5aang</pattern>
-<pattern>gs5tac</pattern>
-<pattern>g5stad</pattern>
-<pattern>g5s4tan</pattern>
-<pattern>g4st3ap</pattern>
-<pattern>g5stat</pattern>
-<pattern>g1ste</pattern>
-<pattern>g5s4te </pattern>
-<pattern>g5sted</pattern>
-<pattern>g5stee</pattern>
-<pattern>g3stei</pattern>
-<pattern>gs3tek</pattern>
-<pattern>g5stel</pattern>
-<pattern>g3sten</pattern>
-<pattern>g3ster</pattern>
-<pattern>g5ster </pattern>
-<pattern>gs5terr</pattern>
-<pattern>g5sters</pattern>
-<pattern>gs3th</pattern>
-<pattern>g5s4tic</pattern>
-<pattern>g3s4tig</pattern>
-<pattern>gs5tijg</pattern>
-<pattern>g5stof</pattern>
-<pattern>g5stop</pattern>
-<pattern>g5stor</pattern>
-<pattern>gst3o4v</pattern>
-<pattern>g4s3tra</pattern>
-<pattern>gs5trad</pattern>
-<pattern>gs5trak</pattern>
-<pattern>gst5ram</pattern>
-<pattern>gs5trap</pattern>
-<pattern>g5strat</pattern>
-<pattern>gst5res</pattern>
-<pattern>gs5troe</pattern>
-<pattern>gs5tron</pattern>
-<pattern>g4stru</pattern>
-<pattern>g5struc</pattern>
-<pattern>g3stu</pattern>
-<pattern>gs5ty</pattern>
-<pattern>g2s1u4</pattern>
-<pattern>gsver3</pattern>
-<pattern>gs5w</pattern>
-<pattern>g5sy</pattern>
-<pattern>4gt</pattern>
-<pattern>g1ta</pattern>
-<pattern>g2t3ap</pattern>
-<pattern>g3te</pattern>
-<pattern>gte3ro</pattern>
-<pattern>gtes4</pattern>
-<pattern>gte3st</pattern>
-<pattern>g1to</pattern>
-<pattern>g3tr</pattern>
-<pattern>g1tu</pattern>
-<pattern>1gu</pattern>
-<pattern>5gu </pattern>
-<pattern>3gue</pattern>
-<pattern>gu4eu</pattern>
-<pattern>2guit</pattern>
-<pattern>gu4ni</pattern>
-<pattern>gu2s3</pattern>
-<pattern>gut4st</pattern>
-<pattern>guts5te </pattern>
-<pattern>4gv</pattern>
-<pattern>g5vo</pattern>
-<pattern>4g1w</pattern>
-<pattern>g5wa</pattern>
-<pattern>1gy</pattern>
-<pattern>4gyp</pattern>
-<pattern>2gz</pattern>
-<pattern>4h </pattern>
-<pattern>haams5ta</pattern>
-<pattern>haar5sl</pattern>
-<pattern>haar5sp</pattern>
-<pattern>haars5te</pattern>
-<pattern>haar5tj</pattern>
-<pattern>haats5te </pattern>
-<pattern>h3afd</pattern>
-<pattern>haf4t3u</pattern>
-<pattern>ha3g</pattern>
-<pattern>ha5ge</pattern>
-<pattern>hal2f1</pattern>
-<pattern>5hals</pattern>
-<pattern>hal4sto</pattern>
-<pattern>5halz</pattern>
-<pattern>2hamp</pattern>
-<pattern>4han </pattern>
-<pattern>han4dr</pattern>
-<pattern>hand5sl</pattern>
-<pattern>han3ga</pattern>
-<pattern>hang5l</pattern>
-<pattern>hang5s</pattern>
-<pattern>han4s3l</pattern>
-<pattern>han3so</pattern>
-<pattern>han4st</pattern>
-<pattern>hap2s</pattern>
-<pattern>hap4se</pattern>
-<pattern>har4ta</pattern>
-<pattern>harte5l</pattern>
-<pattern>hart3j</pattern>
-<pattern>har4t3o4</pattern>
-<pattern>har5tre</pattern>
-<pattern>hart5sl</pattern>
-<pattern>hat5j</pattern>
-<pattern>ha2t3r</pattern>
-<pattern>hat3s</pattern>
-<pattern>ha3v</pattern>
-<pattern>4have </pattern>
-<pattern>4hb</pattern>
-<pattern>2hd</pattern>
-<pattern>h4e</pattern>
-<pattern>2hea</pattern>
-<pattern>he2ar</pattern>
-<pattern>3hech</pattern>
-<pattern>he3co</pattern>
-<pattern>4hee </pattern>
-<pattern>hee3g4</pattern>
-<pattern>hee4k</pattern>
-<pattern>heek3a</pattern>
-<pattern>heek5l</pattern>
-<pattern>hee4l3o</pattern>
-<pattern>heep4s</pattern>
-<pattern>heeps5c</pattern>
-<pattern>heers5tak</pattern>
-<pattern>hee5sto</pattern>
-<pattern>hee5tjes</pattern>
-<pattern>he2f</pattern>
-<pattern>he4i</pattern>
-<pattern>heids5p</pattern>
-<pattern>heis4</pattern>
-<pattern>hei5tj</pattern>
-<pattern>he2k3a</pattern>
-<pattern>he2kl</pattern>
-<pattern>hek4st</pattern>
-<pattern>heks5te </pattern>
-<pattern>hek5sten</pattern>
-<pattern>hek3w</pattern>
-<pattern>he3le</pattern>
-<pattern>he4l3ee</pattern>
-<pattern>he3li</pattern>
-<pattern>hel4m3a</pattern>
-<pattern>helo4</pattern>
-<pattern>hel4p3a</pattern>
-<pattern>hel3sm</pattern>
-<pattern>he5mo</pattern>
-<pattern>he5ne</pattern>
-<pattern>hen4kr</pattern>
-<pattern>he3n4o</pattern>
-<pattern>4he5o</pattern>
-<pattern>he4pij</pattern>
-<pattern>he2p3l</pattern>
-<pattern>he2pr</pattern>
-<pattern>he1ra</pattern>
-<pattern>her4aa</pattern>
-<pattern>he4r3ad</pattern>
-<pattern>he3r4au</pattern>
-<pattern>he4r3i</pattern>
-<pattern>herm5eng</pattern>
-<pattern>he3ros</pattern>
-<pattern>hero5v</pattern>
-<pattern>her4p5aa</pattern>
-<pattern>3herst</pattern>
-<pattern>hert4</pattern>
-<pattern>herts5te</pattern>
-<pattern>he2ru</pattern>
-<pattern>he5se</pattern>
-<pattern>he2sp</pattern>
-<pattern>he2s5t</pattern>
-<pattern>hets5te </pattern>
-<pattern>heu5le</pattern>
-<pattern>2h3f</pattern>
-<pattern>4h5g</pattern>
-<pattern>h3h</pattern>
-<pattern>hi5d</pattern>
-<pattern>hie4f3</pattern>
-<pattern>hielsges5</pattern>
-<pattern>hie4r3</pattern>
-<pattern>hie5ren</pattern>
-<pattern>hier5u</pattern>
-<pattern>hie4t5o</pattern>
-<pattern>hie4tr</pattern>
-<pattern>hiet5s</pattern>
-<pattern>hij4sl</pattern>
-<pattern>hik4s5</pattern>
-<pattern>hi3kw</pattern>
-<pattern>hil3m</pattern>
-<pattern>him4pl</pattern>
-<pattern>him4pr</pattern>
-<pattern>hin5d</pattern>
-<pattern>h3ins</pattern>
-<pattern>hin4t3j</pattern>
-<pattern>hi2p5l</pattern>
-<pattern>2hir2</pattern>
-<pattern>his5p</pattern>
-<pattern>hi3tr</pattern>
-<pattern>hit4st</pattern>
-<pattern>hits5te </pattern>
-<pattern>hit5sten</pattern>
-<pattern>h3j</pattern>
-<pattern>2hl</pattern>
-<pattern>h3la</pattern>
-<pattern>h4lag</pattern>
-<pattern>h3lep</pattern>
-<pattern>h3loc</pattern>
-<pattern>2h2m</pattern>
-<pattern>h3ma</pattern>
-<pattern>h3me</pattern>
-<pattern>h4mer</pattern>
-<pattern>h1n</pattern>
-<pattern>h2na</pattern>
-<pattern>hno3</pattern>
-<pattern>2ho </pattern>
-<pattern>ho3a</pattern>
-<pattern>hoa3n</pattern>
-<pattern>hoboot4</pattern>
-<pattern>ho3ch</pattern>
-<pattern>hoe4ker</pattern>
-<pattern>hoe4s</pattern>
-<pattern>hoes5l</pattern>
-<pattern>hoe3t</pattern>
-<pattern>ho2f</pattern>
-<pattern>hof5d</pattern>
-<pattern>hof3e</pattern>
-<pattern>ho3g2</pattern>
-<pattern>ho2ka</pattern>
-<pattern>ho5mo</pattern>
-<pattern>hon3dr</pattern>
-<pattern>hond4s</pattern>
-<pattern>hon3g</pattern>
-<pattern>honi4</pattern>
-<pattern>ho1no</pattern>
-<pattern>hool3e</pattern>
-<pattern>4hoom</pattern>
-<pattern>hoort4</pattern>
-<pattern>hoor5tr</pattern>
-<pattern>2hoot</pattern>
-<pattern>ho3pa</pattern>
-<pattern>ho1pe</pattern>
-<pattern>ho2p3o</pattern>
-<pattern>hop3r</pattern>
-<pattern>hop4str</pattern>
-<pattern>hor5de</pattern>
-<pattern>5horl</pattern>
-<pattern>ho3ro</pattern>
-<pattern>hor4st</pattern>
-<pattern>hors5te </pattern>
-<pattern>hor5sten</pattern>
-<pattern>hor4t3j</pattern>
-<pattern>ho3ru</pattern>
-<pattern>ho3sa</pattern>
-<pattern>hot3j</pattern>
-<pattern>ho3tr</pattern>
-<pattern>ho4t3re</pattern>
-<pattern>hot4st</pattern>
-<pattern>hots5te </pattern>
-<pattern>ho3v</pattern>
-<pattern>2ho4w</pattern>
-<pattern>how3o</pattern>
-<pattern>2h1p</pattern>
-<pattern>hpi4</pattern>
-<pattern>2hr</pattern>
-<pattern>hra4b</pattern>
-<pattern>h4re</pattern>
-<pattern>h5rea</pattern>
-<pattern>hri4</pattern>
-<pattern>hro2k</pattern>
-<pattern>hrok3o</pattern>
-<pattern>hroot3</pattern>
-<pattern>4hs</pattern>
-<pattern>h3sa</pattern>
-<pattern>h3sp</pattern>
-<pattern>h3st</pattern>
-<pattern>2ht</pattern>
-<pattern>h4t1a2</pattern>
-<pattern>ht3ac</pattern>
-<pattern>h3tal</pattern>
-<pattern>ht3ala</pattern>
-<pattern>h5tans</pattern>
-<pattern>h3te </pattern>
-<pattern>h4t3ec</pattern>
-<pattern>ht4eco</pattern>
-<pattern>h2t3ee</pattern>
-<pattern>h2t3ef</pattern>
-<pattern>h2t3ei</pattern>
-<pattern>ht5em</pattern>
-<pattern>h3ten</pattern>
-<pattern>h4ten5t</pattern>
-<pattern>ht5entw</pattern>
-<pattern>hter3a</pattern>
-<pattern>hte4r5o</pattern>
-<pattern>h4t3esk</pattern>
-<pattern>h4tev</pattern>
-<pattern>ht5eve</pattern>
-<pattern>h5tevo</pattern>
-<pattern>ht3ex</pattern>
-<pattern>h2t5h</pattern>
-<pattern>h4t3int</pattern>
-<pattern>h2t1j</pattern>
-<pattern>ht1o4</pattern>
-<pattern>ht5oef</pattern>
-<pattern>ht5op</pattern>
-<pattern>h4t1r</pattern>
-<pattern>ht5roo</pattern>
-<pattern>ht4sap</pattern>
-<pattern>htse4</pattern>
-<pattern>ht4ser</pattern>
-<pattern>ht2si</pattern>
-<pattern>ht4sl</pattern>
-<pattern>ht5sla</pattern>
-<pattern>ht5slot</pattern>
-<pattern>ht3sme</pattern>
-<pattern>ht5smij</pattern>
-<pattern>ht4s3o</pattern>
-<pattern>ht3spe</pattern>
-<pattern>hts3pl</pattern>
-<pattern>ht3spr</pattern>
-<pattern>hts5taal</pattern>
-<pattern>ht4s5tak</pattern>
-<pattern>ht4s5tek</pattern>
-<pattern>ht4sti</pattern>
-<pattern>hts5tore</pattern>
-<pattern>hts5trekk</pattern>
-<pattern>ht1u2</pattern>
-<pattern>ht3w</pattern>
-<pattern>hu4ba</pattern>
-<pattern>3huiz</pattern>
-<pattern>hul4der</pattern>
-<pattern>hur4t5</pattern>
-<pattern>hut3j</pattern>
-<pattern>huts5te </pattern>
-<pattern>huur5s</pattern>
-<pattern>4h1w</pattern>
-<pattern>hy4la</pattern>
-<pattern>3hyp</pattern>
-<pattern>hypo1</pattern>
-<pattern>4i </pattern>
-<pattern>i1a</pattern>
-<pattern>i3aa</pattern>
-<pattern>i4ab</pattern>
-<pattern>i5abi</pattern>
-<pattern>i4ac</pattern>
-<pattern>i3ady</pattern>
-<pattern>i3ae</pattern>
-<pattern>i5ae </pattern>
-<pattern>i2a3f4</pattern>
-<pattern>i2a3g2</pattern>
-<pattern>i3agr</pattern>
-<pattern>i3ai</pattern>
-<pattern>i5ak </pattern>
-<pattern>i3ake4</pattern>
-<pattern>ia4kem</pattern>
-<pattern>ia3kl</pattern>
-<pattern>ia3kr</pattern>
-<pattern>i3al </pattern>
-<pattern>i4a3la</pattern>
-<pattern>i3ali</pattern>
-<pattern>i2am</pattern>
-<pattern>i5am </pattern>
-<pattern>i3ami</pattern>
-<pattern>i3an</pattern>
-<pattern>ian4o</pattern>
-<pattern>ia3o</pattern>
-<pattern>i2a1p4</pattern>
-<pattern>ia5pa</pattern>
-<pattern>i5api</pattern>
-<pattern>ia3sc</pattern>
-<pattern>ia5se</pattern>
-<pattern>ia3so</pattern>
-<pattern>ia4s5po</pattern>
-<pattern>ia3sta</pattern>
-<pattern>i3at</pattern>
-<pattern>ia3t2h</pattern>
-<pattern>i5atri</pattern>
-<pattern>iave4</pattern>
-<pattern>i5ble</pattern>
-<pattern>iboot4</pattern>
-<pattern>4ic</pattern>
-<pattern>i3ce</pattern>
-<pattern>5i4cepa</pattern>
-<pattern>i1cha</pattern>
-<pattern>i1che</pattern>
-<pattern>ichee4t</pattern>
-<pattern>i1chi</pattern>
-<pattern>i1cho</pattern>
-<pattern>i3chr</pattern>
-<pattern>ick5l</pattern>
-<pattern>icos4</pattern>
-<pattern>ic4t3op</pattern>
-<pattern>ict4s5c</pattern>
-<pattern>i3dam</pattern>
-<pattern>idde4r5a</pattern>
-<pattern>ide3a</pattern>
-<pattern>i4dee </pattern>
-<pattern>ider4sp</pattern>
-<pattern>ider4st</pattern>
-<pattern>ides4</pattern>
-<pattern>idi3a</pattern>
-<pattern>idi5ab</pattern>
-<pattern>i2di5o</pattern>
-<pattern>id4mak</pattern>
-<pattern>i3dok</pattern>
-<pattern>i2dr</pattern>
-<pattern>id3ran</pattern>
-<pattern>id3ru</pattern>
-<pattern>id2s1</pattern>
-<pattern>id4s3a</pattern>
-<pattern>id4ser</pattern>
-<pattern>ids5i</pattern>
-<pattern>ids5j</pattern>
-<pattern>ids5l</pattern>
-<pattern>id4sm</pattern>
-<pattern>ids5ma</pattern>
-<pattern>id5s4mee</pattern>
-<pattern>id4s3o</pattern>
-<pattern>ids3ta</pattern>
-<pattern>ids5tak</pattern>
-<pattern>ids5tek</pattern>
-<pattern>id4stem</pattern>
-<pattern>id4sti</pattern>
-<pattern>ids5tr</pattern>
-<pattern>id3u4r</pattern>
-<pattern>id3uu</pattern>
-<pattern>idu3w</pattern>
-<pattern>id3w</pattern>
-<pattern>4ie</pattern>
-<pattern>ie1a2</pattern>
-<pattern>ie4d3ac</pattern>
-<pattern>ie3de</pattern>
-<pattern>ie4dro</pattern>
-<pattern>ied3w</pattern>
-<pattern>i1ee4</pattern>
-<pattern>ieë2</pattern>
-<pattern>ie3fi</pattern>
-<pattern>ie2fl</pattern>
-<pattern>ie3fle</pattern>
-<pattern>ie3fon</pattern>
-<pattern>ie4fr</pattern>
-<pattern>ie4gas</pattern>
-<pattern>ie3ge</pattern>
-<pattern>ie4g5ins</pattern>
-<pattern>i2ek</pattern>
-<pattern>iek3e4v</pattern>
-<pattern>ie4kl</pattern>
-<pattern>iek3li</pattern>
-<pattern>ie5klu</pattern>
-<pattern>ie2kn</pattern>
-<pattern>iek5ond</pattern>
-<pattern>iek4s5n</pattern>
-<pattern>iek4sp</pattern>
-<pattern>ie2ku</pattern>
-<pattern>ie3kwa</pattern>
-<pattern>ie5lan</pattern>
-<pattern>ie5lap</pattern>
-<pattern>iel5do</pattern>
-<pattern>iel5d4r</pattern>
-<pattern>iel4e</pattern>
-<pattern>iel5ei </pattern>
-<pattern>iel5k</pattern>
-<pattern>iel3sc</pattern>
-<pattern>ie3ma</pattern>
-<pattern>iem3ov</pattern>
-<pattern>ien4dr</pattern>
-<pattern>ien3ij</pattern>
-<pattern>i3enn</pattern>
-<pattern>i5enne </pattern>
-<pattern>ien3s4m</pattern>
-<pattern>ien5sp</pattern>
-<pattern>ien4sta</pattern>
-<pattern>ien4st5o</pattern>
-<pattern>ien4str</pattern>
-<pattern>ienst5ur</pattern>
-<pattern>ieo4</pattern>
-<pattern>i4ep</pattern>
-<pattern>ie5pen</pattern>
-<pattern>iepiet5</pattern>
-<pattern>iep5oog</pattern>
-<pattern>iepou5</pattern>
-<pattern>iep5rel</pattern>
-<pattern>iepro4s</pattern>
-<pattern>iep3s4</pattern>
-<pattern>iep5st</pattern>
-<pattern>iep5tr</pattern>
-<pattern>ie4pui</pattern>
-<pattern>ie5r4ad</pattern>
-<pattern>ier3a4l</pattern>
-<pattern>ie3ram</pattern>
-<pattern>ie3rap</pattern>
-<pattern>ier3as</pattern>
-<pattern>ie4rat</pattern>
-<pattern>ier5el </pattern>
-<pattern>ier5els</pattern>
-<pattern>ie5ren </pattern>
-<pattern>ie5ring</pattern>
-<pattern>ierk4</pattern>
-<pattern>ie3r2o</pattern>
-<pattern>ie4rof</pattern>
-<pattern>ier4sl</pattern>
-<pattern>ier5slu</pattern>
-<pattern>ie3ru</pattern>
-<pattern>ier4ui</pattern>
-<pattern>ie3sf</pattern>
-<pattern>ie2si</pattern>
-<pattern>ie4sl</pattern>
-<pattern>ie5sle</pattern>
-<pattern>ies3li</pattern>
-<pattern>ies3m</pattern>
-<pattern>ie2s3n</pattern>
-<pattern>ie2so4</pattern>
-<pattern>ie4s3pl</pattern>
-<pattern>ie3sta</pattern>
-<pattern>ies5te </pattern>
-<pattern>ie5stel</pattern>
-<pattern>ies5tere</pattern>
-<pattern>ie3sto</pattern>
-<pattern>ie4taa</pattern>
-<pattern>ie5tal</pattern>
-<pattern>iet5ant</pattern>
-<pattern>ie5ten</pattern>
-<pattern>ie3tj</pattern>
-<pattern>ie3to4</pattern>
-<pattern>ie4t3og</pattern>
-<pattern>ie4too</pattern>
-<pattern>ie4top</pattern>
-<pattern>ie4tor</pattern>
-<pattern>ieto5re</pattern>
-<pattern>ie4t3ov</pattern>
-<pattern>ie5troe</pattern>
-<pattern>iets5te </pattern>
-<pattern>iet3ur</pattern>
-<pattern>iet3uu</pattern>
-<pattern>ie3twi</pattern>
-<pattern>i3ety</pattern>
-<pattern>ie2u</pattern>
-<pattern>ieu3k</pattern>
-<pattern>i1eur</pattern>
-<pattern>ieu5r4e</pattern>
-<pattern>i1eus</pattern>
-<pattern>ieu3sp</pattern>
-<pattern>i1euz</pattern>
-<pattern>ie3v</pattern>
-<pattern>ie3z</pattern>
-<pattern>iezel5a</pattern>
-<pattern>i3és</pattern>
-<pattern>i1ét</pattern>
-<pattern>i1è</pattern>
-<pattern>i4ëg</pattern>
-<pattern>i4ëva</pattern>
-<pattern>4if</pattern>
-<pattern>if3aa</pattern>
-<pattern>if3ad</pattern>
-<pattern>if3l</pattern>
-<pattern>if3r</pattern>
-<pattern>if4ra</pattern>
-<pattern>if4taa</pattern>
-<pattern>if4tar</pattern>
-<pattern>if4tre</pattern>
-<pattern>iftu5r</pattern>
-<pattern>if3ui</pattern>
-<pattern>ig4a</pattern>
-<pattern>ig3aa</pattern>
-<pattern>ig5ac</pattern>
-<pattern>i5gal</pattern>
-<pattern>i4g5av</pattern>
-<pattern>i3ge</pattern>
-<pattern>ige2s</pattern>
-<pattern>ig3esk</pattern>
-<pattern>ig3ij</pattern>
-<pattern>i4gind</pattern>
-<pattern>igi3o</pattern>
-<pattern>ig5no</pattern>
-<pattern>i3g4om</pattern>
-<pattern>ig4op</pattern>
-<pattern>igs4</pattern>
-<pattern>ig3sk</pattern>
-<pattern>ig3sl</pattern>
-<pattern>ig3sp</pattern>
-<pattern>ig3sto</pattern>
-<pattern>ig3un</pattern>
-<pattern>i1h</pattern>
-<pattern>i3i</pattern>
-<pattern>i5ie</pattern>
-<pattern>ii2n</pattern>
-<pattern>i5is</pattern>
-<pattern>i2j</pattern>
-<pattern>4ij </pattern>
-<pattern>ij5a</pattern>
-<pattern>ija4d</pattern>
-<pattern>4ijd</pattern>
-<pattern>4ije</pattern>
-<pattern>ij3ef</pattern>
-<pattern>ij3ei</pattern>
-<pattern>ij3el</pattern>
-<pattern>ij5e4n3</pattern>
-<pattern>ij1er</pattern>
-<pattern>ij3i</pattern>
-<pattern>4ijn</pattern>
-<pattern>ij3o4</pattern>
-<pattern>i3jou</pattern>
-<pattern>4ijso</pattern>
-<pattern>4ijsp</pattern>
-<pattern>4ijst</pattern>
-<pattern>ij5te</pattern>
-<pattern>ij4tr</pattern>
-<pattern>ij5u</pattern>
-<pattern>4ijvo</pattern>
-<pattern>4ijzo</pattern>
-<pattern>4ik</pattern>
-<pattern>ik3aar</pattern>
-<pattern>i4kam</pattern>
-<pattern>i3ke</pattern>
-<pattern>ik3ef</pattern>
-<pattern>ike4ra</pattern>
-<pattern>iket3</pattern>
-<pattern>i2kij</pattern>
-<pattern>i3kl</pattern>
-<pattern>ik3la</pattern>
-<pattern>i4k3lo</pattern>
-<pattern>i4k3lu</pattern>
-<pattern>i2k4n</pattern>
-<pattern>i4k5na</pattern>
-<pattern>ik5o2g</pattern>
-<pattern>i3kom</pattern>
-<pattern>i2koo</pattern>
-<pattern>iko2p</pattern>
-<pattern>ik3ope</pattern>
-<pattern>ik3ord</pattern>
-<pattern>i4kr</pattern>
-<pattern>ik3re</pattern>
-<pattern>ik3ri</pattern>
-<pattern>ik3ro</pattern>
-<pattern>ik5se</pattern>
-<pattern>ik5si</pattern>
-<pattern>ik3s4l</pattern>
-<pattern>iks3n</pattern>
-<pattern>ik3sno</pattern>
-<pattern>ik3sp</pattern>
-<pattern>ik4spa</pattern>
-<pattern>ik1st</pattern>
-<pattern>ik5sta</pattern>
-<pattern>iks5te </pattern>
-<pattern>ik1w</pattern>
-<pattern>ik5war</pattern>
-<pattern>i1la</pattern>
-<pattern>i3la </pattern>
-<pattern>il4aa</pattern>
-<pattern>il5aan</pattern>
-<pattern>il3ac</pattern>
-<pattern>il4act</pattern>
-<pattern>il3ad</pattern>
-<pattern>il3af</pattern>
-<pattern>i3lak</pattern>
-<pattern>il3al</pattern>
-<pattern>i5land</pattern>
-<pattern>il2da</pattern>
-<pattern>il4d3r</pattern>
-<pattern>ilds4</pattern>
-<pattern>4i3le</pattern>
-<pattern>il3een</pattern>
-<pattern>ile3l</pattern>
-<pattern>i4l3erv</pattern>
-<pattern>ile4t</pattern>
-<pattern>ilet5r</pattern>
-<pattern>ile3u</pattern>
-<pattern>il3e4ve</pattern>
-<pattern>ilevin4</pattern>
-<pattern>i4l3e2z</pattern>
-<pattern>i3lé</pattern>
-<pattern>il5f</pattern>
-<pattern>i3li</pattern>
-<pattern>ilie5g</pattern>
-<pattern>ilie5t</pattern>
-<pattern>il3ink</pattern>
-<pattern>ilk4l</pattern>
-<pattern>ilk3s2</pattern>
-<pattern>illa3s</pattern>
-<pattern>1illu</pattern>
-<pattern>il2m</pattern>
-<pattern>ilme2</pattern>
-<pattern>il4min</pattern>
-<pattern>il4mo</pattern>
-<pattern>i1lo</pattern>
-<pattern>ilo4ge</pattern>
-<pattern>il3ond</pattern>
-<pattern>i3loo</pattern>
-<pattern>i5loon</pattern>
-<pattern>il3oor</pattern>
-<pattern>il1or</pattern>
-<pattern>ilo4re</pattern>
-<pattern>ilo4ve</pattern>
-<pattern>il3s2h</pattern>
-<pattern>ils5j</pattern>
-<pattern>il4sti</pattern>
-<pattern>il2th</pattern>
-<pattern>i1lu</pattern>
-<pattern>4im </pattern>
-<pattern>i2mag</pattern>
-<pattern>i4mago</pattern>
-<pattern>im5au</pattern>
-<pattern>imee4</pattern>
-<pattern>im3een</pattern>
-<pattern>i4m3em</pattern>
-<pattern>im3enc</pattern>
-<pattern>im3ex</pattern>
-<pattern>4imf</pattern>
-<pattern>i2m3of</pattern>
-<pattern>im3op</pattern>
-<pattern>im3org</pattern>
-<pattern>im5pa</pattern>
-<pattern>im4s3oo</pattern>
-<pattern>im1st</pattern>
-<pattern>i3mu</pattern>
-<pattern>in1ac</pattern>
-<pattern>i2nau</pattern>
-<pattern>ind4aa</pattern>
-<pattern>in4dene</pattern>
-<pattern>ind3sc</pattern>
-<pattern>ind5ste</pattern>
-<pattern>1indu</pattern>
-<pattern>in3e4de</pattern>
-<pattern>in3edi</pattern>
-<pattern>in3eed</pattern>
-<pattern>inek4</pattern>
-<pattern>ineo2</pattern>
-<pattern>inet4s</pattern>
-<pattern>i5neu</pattern>
-<pattern>1inf</pattern>
-<pattern>in2ga4</pattern>
-<pattern>ing3aa</pattern>
-<pattern>ing3ag</pattern>
-<pattern>ing3al</pattern>
-<pattern>3ingan</pattern>
-<pattern>ing5lo</pattern>
-<pattern>in2go</pattern>
-<pattern>in4gr</pattern>
-<pattern>ing4st</pattern>
-<pattern>4ini </pattern>
-<pattern>i3nie</pattern>
-<pattern>ini5on</pattern>
-<pattern>ini5sl</pattern>
-<pattern>ini5sta</pattern>
-<pattern>4inkj</pattern>
-<pattern>in2kn</pattern>
-<pattern>3inkom</pattern>
-<pattern>in4kri</pattern>
-<pattern>3inno</pattern>
-<pattern>i1no</pattern>
-<pattern>i3noc</pattern>
-<pattern>i3nod</pattern>
-<pattern>in4o2g</pattern>
-<pattern>in1on</pattern>
-<pattern>ino5pe</pattern>
-<pattern>ino3s4t</pattern>
-<pattern>in3ov</pattern>
-<pattern>1inri</pattern>
-<pattern>4ins </pattern>
-<pattern>in5sch</pattern>
-<pattern>in5se</pattern>
-<pattern>in3sl</pattern>
-<pattern>in3smi</pattern>
-<pattern>in3so</pattern>
-<pattern>in1sp</pattern>
-<pattern>in5spo</pattern>
-<pattern>in5sten</pattern>
-<pattern>in5swi</pattern>
-<pattern>in4t3ap</pattern>
-<pattern>in5te</pattern>
-<pattern>intes5</pattern>
-<pattern>in3th</pattern>
-<pattern>1int4r</pattern>
-<pattern>i1nu</pattern>
-<pattern>inuut3</pattern>
-<pattern>4i1o</pattern>
-<pattern>io5a</pattern>
-<pattern>ioas5</pattern>
-<pattern>io5b</pattern>
-<pattern>i3o1c</pattern>
-<pattern>i3ode</pattern>
-<pattern>ioes3</pattern>
-<pattern>io3f</pattern>
-<pattern>io3g2</pattern>
-<pattern>i3ol</pattern>
-<pattern>i5ol </pattern>
-<pattern>i5olen</pattern>
-<pattern>i5olus</pattern>
-<pattern>i3on</pattern>
-<pattern>ioneel4</pattern>
-<pattern>i5ong</pattern>
-<pattern>ion4s3</pattern>
-<pattern>ions5c</pattern>
-<pattern>i5oo</pattern>
-<pattern>i2op4</pattern>
-<pattern>io3pa</pattern>
-<pattern>io3pr</pattern>
-<pattern>i3opt</pattern>
-<pattern>io3ra</pattern>
-<pattern>i3ori</pattern>
-<pattern>io3ru</pattern>
-<pattern>io4s</pattern>
-<pattern>i3os </pattern>
-<pattern>ios3c</pattern>
-<pattern>i3o5se</pattern>
-<pattern>i3o5sf</pattern>
-<pattern>io5sh</pattern>
-<pattern>io5si</pattern>
-<pattern>i5osi </pattern>
-<pattern>io5so</pattern>
-<pattern>io5sp</pattern>
-<pattern>io5s4t</pattern>
-<pattern>i5o5su</pattern>
-<pattern>i3osy</pattern>
-<pattern>i5othek</pattern>
-<pattern>i3oti</pattern>
-<pattern>iot3j</pattern>
-<pattern>i5otorens</pattern>
-<pattern>io3tr</pattern>
-<pattern>i2o3v</pattern>
-<pattern>i3ox</pattern>
-<pattern>i2oz</pattern>
-<pattern>i1pa</pattern>
-<pattern>i2p1ac</pattern>
-<pattern>ip3af</pattern>
-<pattern>i3pap</pattern>
-<pattern>i1pe</pattern>
-<pattern>i4perw</pattern>
-<pattern>ipe4t3j</pattern>
-<pattern>i1pi</pattern>
-<pattern>ip1j</pattern>
-<pattern>i1pl</pattern>
-<pattern>ip3lu</pattern>
-<pattern>i1po</pattern>
-<pattern>ipo4g</pattern>
-<pattern>i1pr</pattern>
-<pattern>i2pri</pattern>
-<pattern>ip3ru</pattern>
-<pattern>i4ps</pattern>
-<pattern>ipse4</pattern>
-<pattern>ip4si</pattern>
-<pattern>ip4sle</pattern>
-<pattern>ips5te </pattern>
-<pattern>ip5sten</pattern>
-<pattern>i3ra</pattern>
-<pattern>ira3k</pattern>
-<pattern>i1r2e</pattern>
-<pattern>ires4</pattern>
-<pattern>ire3st</pattern>
-<pattern>i3ré</pattern>
-<pattern>i1ri</pattern>
-<pattern>irk4s</pattern>
-<pattern>i1ro</pattern>
-<pattern>iro3p</pattern>
-<pattern>iro5v</pattern>
-<pattern>ir2s</pattern>
-<pattern>ir4sc</pattern>
-<pattern>ir3sp</pattern>
-<pattern>ir5ste</pattern>
-<pattern>irt3r</pattern>
-<pattern>i1ru</pattern>
-<pattern>4is</pattern>
-<pattern>i1sa</pattern>
-<pattern>i2saa</pattern>
-<pattern>i4s3ad</pattern>
-<pattern>is3a2g</pattern>
-<pattern>is3ap</pattern>
-<pattern>i2s1ar</pattern>
-<pattern>i2s3as</pattern>
-<pattern>i4sc</pattern>
-<pattern>i5scha</pattern>
-<pattern>i5schr</pattern>
-<pattern>is5col</pattern>
-<pattern>i5scoo</pattern>
-<pattern>i5scope</pattern>
-<pattern>ise2d</pattern>
-<pattern>i4s3ei</pattern>
-<pattern>is3ell</pattern>
-<pattern>is5eng</pattern>
-<pattern>i4s3erv</pattern>
-<pattern>ise3st</pattern>
-<pattern>iset3j</pattern>
-<pattern>is4fee</pattern>
-<pattern>is4fer</pattern>
-<pattern>i4sh</pattern>
-<pattern>is5ho</pattern>
-<pattern>isi2d</pattern>
-<pattern>i2sij</pattern>
-<pattern>i2s3im</pattern>
-<pattern>is3ja</pattern>
-<pattern>i4sk</pattern>
-<pattern>is3ka</pattern>
-<pattern>is3ke</pattern>
-<pattern>is3l</pattern>
-<pattern>is5lag</pattern>
-<pattern>is5las</pattern>
-<pattern>is5le</pattern>
-<pattern>i4s5m</pattern>
-<pattern>i4s3n</pattern>
-<pattern>is5ned</pattern>
-<pattern>is5nij</pattern>
-<pattern>is5no</pattern>
-<pattern>5isol</pattern>
-<pattern>i4soo</pattern>
-<pattern>is4oor</pattern>
-<pattern>iso3s</pattern>
-<pattern>i2sot</pattern>
-<pattern>is3ott</pattern>
-<pattern>is3p</pattern>
-<pattern>is5pas</pattern>
-<pattern>is2pi</pattern>
-<pattern>is5pl</pattern>
-<pattern>is5q</pattern>
-<pattern>is5sa</pattern>
-<pattern>is5so</pattern>
-<pattern>i2s3t</pattern>
-<pattern>is1ta</pattern>
-<pattern>i3stak</pattern>
-<pattern>ist3ap</pattern>
-<pattern>i4s5tas</pattern>
-<pattern>is4tat</pattern>
-<pattern>is5terd</pattern>
-<pattern>is5tere</pattern>
-<pattern>is4th</pattern>
-<pattern>is1to</pattern>
-<pattern>ist5ong</pattern>
-<pattern>i3str</pattern>
-<pattern>is5tri</pattern>
-<pattern>i5stro </pattern>
-<pattern>i3sty</pattern>
-<pattern>isu2m</pattern>
-<pattern>i5sy</pattern>
-<pattern>4it</pattern>
-<pattern>i1ta</pattern>
-<pattern>it3ac</pattern>
-<pattern>ita5d</pattern>
-<pattern>it3een</pattern>
-<pattern>i3ten</pattern>
-<pattern>i3ter</pattern>
-<pattern>ite5rei</pattern>
-<pattern>ites4</pattern>
-<pattern>ite3st</pattern>
-<pattern>ite4t</pattern>
-<pattern>it3hie</pattern>
-<pattern>it1ho</pattern>
-<pattern>it1hu</pattern>
-<pattern>it2i</pattern>
-<pattern>itie5st</pattern>
-<pattern>i4tj</pattern>
-<pattern>i1to</pattern>
-<pattern>it5oef</pattern>
-<pattern>it3oog</pattern>
-<pattern>i3t2ou</pattern>
-<pattern>i4to4v</pattern>
-<pattern>itper5st</pattern>
-<pattern>it3red</pattern>
-<pattern>it1ru</pattern>
-<pattern>it3sje</pattern>
-<pattern>it3sli</pattern>
-<pattern>it3sop</pattern>
-<pattern>it1sp</pattern>
-<pattern>its4te</pattern>
-<pattern>it4ste </pattern>
-<pattern>it4too</pattern>
-<pattern>i3tu</pattern>
-<pattern>it3w</pattern>
-<pattern>4i3u2</pattern>
-<pattern>iu4m</pattern>
-<pattern>ium3a4</pattern>
-<pattern>ium3e</pattern>
-<pattern>ium3o</pattern>
-<pattern>iu3r</pattern>
-<pattern>i3ve</pattern>
-<pattern>iven5s</pattern>
-<pattern>ive3re</pattern>
-<pattern>i5w</pattern>
-<pattern>iwi2</pattern>
-<pattern>iwie2</pattern>
-<pattern>iwit3</pattern>
-<pattern>4iz</pattern>
-<pattern>i3ze</pattern>
-<pattern>ize3t</pattern>
-<pattern>î3</pattern>
-<pattern>ît4</pattern>
-<pattern>1ï</pattern>
-<pattern>2ï </pattern>
-<pattern>ï5a</pattern>
-<pattern>ï1c</pattern>
-<pattern>ï1d</pattern>
-<pattern>ïe4n3</pattern>
-<pattern>ïe5nen </pattern>
-<pattern>ï2n3a</pattern>
-<pattern>ïns5m</pattern>
-<pattern>ïn3sp</pattern>
-<pattern>ïn3u</pattern>
-<pattern>ï3n4ur</pattern>
-<pattern>ï3o</pattern>
-<pattern>ï3ri</pattern>
-<pattern>ï3ro</pattern>
-<pattern>4ïs </pattern>
-<pattern>ïs3a</pattern>
-<pattern>ï4sc</pattern>
-<pattern>ï5sche</pattern>
-<pattern>ïs3l</pattern>
-<pattern>ï3so</pattern>
-<pattern>ïs3t</pattern>
-<pattern>ï1t</pattern>
-<pattern>ï5z</pattern>
-<pattern>4j </pattern>
-<pattern>1jaar</pattern>
-<pattern>jaar5tj</pattern>
-<pattern>ja3b</pattern>
-<pattern>2jaf</pattern>
-<pattern>1jag</pattern>
-<pattern>jagers5</pattern>
-<pattern>ja3kn</pattern>
-<pattern>ja3mi</pattern>
-<pattern>jan4s3l</pattern>
-<pattern>jan4st</pattern>
-<pattern>ja3pl</pattern>
-<pattern>ja1po</pattern>
-<pattern>1jar</pattern>
-<pattern>jare4</pattern>
-<pattern>1jas3</pattern>
-<pattern>jas5p</pattern>
-<pattern>3jaw</pattern>
-<pattern>jaz4</pattern>
-<pattern>j3b</pattern>
-<pattern>jba4l</pattern>
-<pattern>jbe4l3i</pattern>
-<pattern>j1c</pattern>
-<pattern>jda2</pattern>
-<pattern>j2d3aa</pattern>
-<pattern>jd3an</pattern>
-<pattern>j4d3ar</pattern>
-<pattern>j2d3ee</pattern>
-<pattern>jde4n3e</pattern>
-<pattern>jden4s</pattern>
-<pattern>jdens5p</pattern>
-<pattern>j4d3erv</pattern>
-<pattern>jdes4</pattern>
-<pattern>jde3sp</pattern>
-<pattern>jde5st</pattern>
-<pattern>jdi3a</pattern>
-<pattern>j2do4</pattern>
-<pattern>j3dom</pattern>
-<pattern>jd5on</pattern>
-<pattern>jd3op</pattern>
-<pattern>j3dr</pattern>
-<pattern>j4d3re</pattern>
-<pattern>j4d1ri</pattern>
-<pattern>j4d3ro</pattern>
-<pattern>j4d3ru</pattern>
-<pattern>jd5sei</pattern>
-<pattern>jd3spo</pattern>
-<pattern>jd1st</pattern>
-<pattern>j2d3u</pattern>
-<pattern>jd3w</pattern>
-<pattern>j3d4wan</pattern>
-<pattern>jea4</pattern>
-<pattern>3jeba</pattern>
-<pattern>je3ch</pattern>
-<pattern>jec4ta</pattern>
-<pattern>2j1ee</pattern>
-<pattern>jel4</pattern>
-<pattern>je3la</pattern>
-<pattern>j1en</pattern>
-<pattern>je2na2</pattern>
-<pattern>je3n4o</pattern>
-<pattern>5jep</pattern>
-<pattern>jepiet5</pattern>
-<pattern>je3ro</pattern>
-<pattern>jers4</pattern>
-<pattern>jer3sp</pattern>
-<pattern>je4s3</pattern>
-<pattern>3jesa</pattern>
-<pattern>5jesal</pattern>
-<pattern>je5sch</pattern>
-<pattern>3jeskn</pattern>
-<pattern>jes5l</pattern>
-<pattern>jes5m</pattern>
-<pattern>jeso2</pattern>
-<pattern>jes5pa</pattern>
-<pattern>jes4pr</pattern>
-<pattern>3jesr</pattern>
-<pattern>jes5tr</pattern>
-<pattern>5jesvo</pattern>
-<pattern>3jeswa</pattern>
-<pattern>3jeswi</pattern>
-<pattern>je2t</pattern>
-<pattern>jet3er</pattern>
-<pattern>jeto4v</pattern>
-<pattern>jet5st</pattern>
-<pattern>5jeu</pattern>
-<pattern>3jevr</pattern>
-<pattern>2jew</pattern>
-<pattern>j3ex</pattern>
-<pattern>j2f1a</pattern>
-<pattern>j2f3ei</pattern>
-<pattern>j2f1en5</pattern>
-<pattern>j4f3ij</pattern>
-<pattern>jf3ink</pattern>
-<pattern>jf3l</pattern>
-<pattern>j3f4lat</pattern>
-<pattern>jf5le</pattern>
-<pattern>j2f3o4</pattern>
-<pattern>jf3r</pattern>
-<pattern>j3f4ra</pattern>
-<pattern>j3f4ro</pattern>
-<pattern>jf2s</pattern>
-<pattern>jfs3a</pattern>
-<pattern>jf4sc</pattern>
-<pattern>jf4s3er</pattern>
-<pattern>jfs5f</pattern>
-<pattern>jfs3l</pattern>
-<pattern>jfs5m</pattern>
-<pattern>jfs3n</pattern>
-<pattern>jfs3p</pattern>
-<pattern>jfs5pa</pattern>
-<pattern>jf3st</pattern>
-<pattern>jf4sta</pattern>
-<pattern>jfs5tak</pattern>
-<pattern>jf5stan</pattern>
-<pattern>jf4stel</pattern>
-<pattern>jf4sti</pattern>
-<pattern>jf4s5to</pattern>
-<pattern>jft2</pattern>
-<pattern>jf5ti</pattern>
-<pattern>jf5tw</pattern>
-<pattern>j1g</pattern>
-<pattern>j3ge</pattern>
-<pattern>jger5sl</pattern>
-<pattern>j2g3l</pattern>
-<pattern>jg4s5e</pattern>
-<pattern>jg3sn</pattern>
-<pattern>jg2st</pattern>
-<pattern>jg3s4te</pattern>
-<pattern>j3h</pattern>
-<pattern>jif3</pattern>
-<pattern>j3ig</pattern>
-<pattern>jin3g</pattern>
-<pattern>ji5t2j</pattern>
-<pattern>j3j</pattern>
-<pattern>2jk</pattern>
-<pattern>j3ka</pattern>
-<pattern>j4kaa</pattern>
-<pattern>jk5aard</pattern>
-<pattern>j4kar</pattern>
-<pattern>jk3arb</pattern>
-<pattern>j4kau</pattern>
-<pattern>j4kav</pattern>
-<pattern>j2kij</pattern>
-<pattern>j2k4l</pattern>
-<pattern>j3klaa</pattern>
-<pattern>jk5lak</pattern>
-<pattern>jk5lap</pattern>
-<pattern>jk5las</pattern>
-<pattern>j4kle</pattern>
-<pattern>j5kled</pattern>
-<pattern>jk5les</pattern>
-<pattern>jk5li</pattern>
-<pattern>j3klon</pattern>
-<pattern>jk5lop</pattern>
-<pattern>jk5luc</pattern>
-<pattern>j2kna</pattern>
-<pattern>j2k3of</pattern>
-<pattern>j4k3o4l</pattern>
-<pattern>j2k3on</pattern>
-<pattern>j2ko4p</pattern>
-<pattern>jk3opb</pattern>
-<pattern>jk3ope</pattern>
-<pattern>jk3opl</pattern>
-<pattern>j3kops</pattern>
-<pattern>j2kr</pattern>
-<pattern>j4kra</pattern>
-<pattern>jk3raa</pattern>
-<pattern>j5kran</pattern>
-<pattern>jk3re</pattern>
-<pattern>jk3ro</pattern>
-<pattern>j4k5ru</pattern>
-<pattern>jk3slo</pattern>
-<pattern>jks3pl</pattern>
-<pattern>jk4sta</pattern>
-<pattern>jks5taak</pattern>
-<pattern>jks5taal</pattern>
-<pattern>jks5tak</pattern>
-<pattern>jk5stan</pattern>
-<pattern>j2k3ui</pattern>
-<pattern>jk3w</pattern>
-<pattern>j3k4was</pattern>
-<pattern>j1la</pattern>
-<pattern>j3laa</pattern>
-<pattern>jl5ana</pattern>
-<pattern>j1le</pattern>
-<pattern>j2l3ef</pattern>
-<pattern>j2l3el</pattern>
-<pattern>jl5f</pattern>
-<pattern>jl3ink</pattern>
-<pattern>j1lo</pattern>
-<pattern>j2loe</pattern>
-<pattern>j3lu</pattern>
-<pattern>j2m3af</pattern>
-<pattern>j5m4ar</pattern>
-<pattern>j3mi</pattern>
-<pattern>jm3op</pattern>
-<pattern>jm3s</pattern>
-<pattern>j2n1a4</pattern>
-<pattern>j4naa</pattern>
-<pattern>jn5ac</pattern>
-<pattern>j3na5g</pattern>
-<pattern>jn3ak</pattern>
-<pattern>jn2am</pattern>
-<pattern>jna5me</pattern>
-<pattern>j3n4an</pattern>
-<pattern>jn5d2r</pattern>
-<pattern>j2nef</pattern>
-<pattern>jne4n</pattern>
-<pattern>j4n3erk</pattern>
-<pattern>j4n3erv</pattern>
-<pattern>jn3gl</pattern>
-<pattern>j4n3im</pattern>
-<pattern>j4n3ink</pattern>
-<pattern>jn3k4</pattern>
-<pattern>j2n1o4</pattern>
-<pattern>jn4si</pattern>
-<pattern>jn2s3l</pattern>
-<pattern>jns5lac</pattern>
-<pattern>jn3slu</pattern>
-<pattern>jns5or</pattern>
-<pattern>jn2sp</pattern>
-<pattern>jns3pl</pattern>
-<pattern>jn1st</pattern>
-<pattern>jn4ste </pattern>
-<pattern>jnt4</pattern>
-<pattern>jn3tr</pattern>
-<pattern>joet3</pattern>
-<pattern>4joi</pattern>
-<pattern>jol4e</pattern>
-<pattern>jo5lij</pattern>
-<pattern>j3om</pattern>
-<pattern>1j4on</pattern>
-<pattern>jone2</pattern>
-<pattern>j3op</pattern>
-<pattern>jo3pe</pattern>
-<pattern>jo3ra</pattern>
-<pattern>jo3ru</pattern>
-<pattern>j4ou</pattern>
-<pattern>1jour</pattern>
-<pattern>jou5re</pattern>
-<pattern>joy3</pattern>
-<pattern>j3pa</pattern>
-<pattern>j4p3ac</pattern>
-<pattern>jp3arm</pattern>
-<pattern>j1pe</pattern>
-<pattern>j2p3em</pattern>
-<pattern>jp3ij</pattern>
-<pattern>j1pin</pattern>
-<pattern>j3pio</pattern>
-<pattern>jp1j</pattern>
-<pattern>j1pla</pattern>
-<pattern>jp3li</pattern>
-<pattern>j1po</pattern>
-<pattern>j2p3or</pattern>
-<pattern>j4pre</pattern>
-<pattern>jp3ri</pattern>
-<pattern>jp3rok</pattern>
-<pattern>jps4</pattern>
-<pattern>j3r</pattern>
-<pattern>jraads5</pattern>
-<pattern>2js</pattern>
-<pattern>js1a</pattern>
-<pattern>j4sef</pattern>
-<pattern>j4s3ela</pattern>
-<pattern>j5seli</pattern>
-<pattern>j4s5em</pattern>
-<pattern>j4s3e4r</pattern>
-<pattern>j2s1i</pattern>
-<pattern>js5in</pattern>
-<pattern>js4ir</pattern>
-<pattern>js4le</pattern>
-<pattern>js3lee</pattern>
-<pattern>js3li</pattern>
-<pattern>js5lie</pattern>
-<pattern>js4me</pattern>
-<pattern>js5mel</pattern>
-<pattern>js5met</pattern>
-<pattern>js3n</pattern>
-<pattern>j4s1o4</pattern>
-<pattern>j5soe</pattern>
-<pattern>js3ol</pattern>
-<pattern>js3pac</pattern>
-<pattern>js3par</pattern>
-<pattern>j3spe</pattern>
-<pattern>js3pl</pattern>
-<pattern>j4spo</pattern>
-<pattern>js3poo</pattern>
-<pattern>jspoort5j</pattern>
-<pattern>j5spor</pattern>
-<pattern>j1sta</pattern>
-<pattern>j4star</pattern>
-<pattern>j2s3te</pattern>
-<pattern>j3stee</pattern>
-<pattern>j3s4tek</pattern>
-<pattern>j3s4tel</pattern>
-<pattern>j5s4teng</pattern>
-<pattern>js3th</pattern>
-<pattern>js4tij</pattern>
-<pattern>j5stond</pattern>
-<pattern>j4stoo</pattern>
-<pattern>js3tou</pattern>
-<pattern>jst5ran</pattern>
-<pattern>j5strok</pattern>
-<pattern>j2su</pattern>
-<pattern>j3sy</pattern>
-<pattern>j3taal</pattern>
-<pattern>jt3aar</pattern>
-<pattern>jt1ac</pattern>
-<pattern>j1tag</pattern>
-<pattern>j3tak</pattern>
-<pattern>j3tan</pattern>
-<pattern>j3te </pattern>
-<pattern>jt1h</pattern>
-<pattern>j3toe</pattern>
-<pattern>jt3opt</pattern>
-<pattern>j3tr</pattern>
-<pattern>jt3ra</pattern>
-<pattern>j5tred</pattern>
-<pattern>j5tree</pattern>
-<pattern>jt3rei</pattern>
-<pattern>j5trek</pattern>
-<pattern>jt3ri</pattern>
-<pattern>j5trok</pattern>
-<pattern>jt3rot</pattern>
-<pattern>jt1s</pattern>
-<pattern>j1tu</pattern>
-<pattern>1j4u</pattern>
-<pattern>ju3d</pattern>
-<pattern>4jum</pattern>
-<pattern>jus3</pattern>
-<pattern>juve5</pattern>
-<pattern>j3v</pattern>
-<pattern>jve2n</pattern>
-<pattern>jver4s</pattern>
-<pattern>jvers5p</pattern>
-<pattern>jve3t</pattern>
-<pattern>jvie5s</pattern>
-<pattern>j1w</pattern>
-<pattern>jze4r5o</pattern>
-<pattern>4k </pattern>
-<pattern>1ka</pattern>
-<pattern>k3aanb</pattern>
-<pattern>k3aanl</pattern>
-<pattern>5kaart</pattern>
-<pattern>kaart5jes</pattern>
-<pattern>kaats5te </pattern>
-<pattern>kabe2</pattern>
-<pattern>ka3bo</pattern>
-<pattern>2k1ac</pattern>
-<pattern>kade4t5</pattern>
-<pattern>4k3adm</pattern>
-<pattern>ka3do</pattern>
-<pattern>k3adv</pattern>
-<pattern>2kaf</pattern>
-<pattern>k3afd</pattern>
-<pattern>k4aff</pattern>
-<pattern>ka3fl</pattern>
-<pattern>3k4aft</pattern>
-<pattern>ka4ga</pattern>
-<pattern>k3a4gen</pattern>
-<pattern>k3ah</pattern>
-<pattern>ka3i</pattern>
-<pattern>2k3alb</pattern>
-<pattern>ka3le</pattern>
-<pattern>5kalf</pattern>
-<pattern>kalf4s5</pattern>
-<pattern>ka3l4i</pattern>
-<pattern>kal2k</pattern>
-<pattern>kalk3a</pattern>
-<pattern>4kalt</pattern>
-<pattern>5kalv</pattern>
-<pattern>3kam</pattern>
-<pattern>4kamb</pattern>
-<pattern>kamen4</pattern>
-<pattern>kame4re</pattern>
-<pattern>kam4pa</pattern>
-<pattern>kam4pl</pattern>
-<pattern>kam4pr</pattern>
-<pattern>ka5naa</pattern>
-<pattern>kan5d</pattern>
-<pattern>4kang</pattern>
-<pattern>kan4sl</pattern>
-<pattern>kan4st</pattern>
-<pattern>kan4t3j</pattern>
-<pattern>kao3</pattern>
-<pattern>5kap </pattern>
-<pattern>ka3pe</pattern>
-<pattern>kap3l</pattern>
-<pattern>ka1po</pattern>
-<pattern>4kappa</pattern>
-<pattern>ka3pr</pattern>
-<pattern>kap3s</pattern>
-<pattern>k3arc</pattern>
-<pattern>k4a3ro</pattern>
-<pattern>kart4</pattern>
-<pattern>4k3arti</pattern>
-<pattern>kar3tr</pattern>
-<pattern>ka4s</pattern>
-<pattern>kas5c</pattern>
-<pattern>4k3asi</pattern>
-<pattern>kast3o4</pattern>
-<pattern>ka3str</pattern>
-<pattern>kast5ra</pattern>
-<pattern>ka5stro</pattern>
-<pattern>kas3u4r</pattern>
-<pattern>kat5aal</pattern>
-<pattern>ka4t5a4le</pattern>
-<pattern>ka4tan</pattern>
-<pattern>kati4</pattern>
-<pattern>ka4t5io</pattern>
-<pattern>kat5j</pattern>
-<pattern>k3atl</pattern>
-<pattern>kato4</pattern>
-<pattern>ka4t3og</pattern>
-<pattern>ka5tr</pattern>
-<pattern>kat3s</pattern>
-<pattern>2k1aut</pattern>
-<pattern>2kavo</pattern>
-<pattern>2k3b</pattern>
-<pattern>2k1c</pattern>
-<pattern>k3ca</pattern>
-<pattern>2k5d</pattern>
-<pattern>kdi3a</pattern>
-<pattern>1ke</pattern>
-<pattern>k4eb</pattern>
-<pattern>2k3ec</pattern>
-<pattern>ke4di</pattern>
-<pattern>2k3een</pattern>
-<pattern>kee4p5l</pattern>
-<pattern>kee4r</pattern>
-<pattern>keer4s</pattern>
-<pattern>keers5to</pattern>
-<pattern>2kef</pattern>
-<pattern>4keff</pattern>
-<pattern>k4ei </pattern>
-<pattern>k4eie</pattern>
-<pattern>k2eil</pattern>
-<pattern>kei3s4</pattern>
-<pattern>kei5t</pattern>
-<pattern>ke4lap</pattern>
-<pattern>kel5da</pattern>
-<pattern>kel5dr</pattern>
-<pattern>ke5lel</pattern>
-<pattern>4kelem</pattern>
-<pattern>kel5f</pattern>
-<pattern>ke4l5int</pattern>
-<pattern>ke4lom</pattern>
-<pattern>ke4l3op</pattern>
-<pattern>kel3sp</pattern>
-<pattern>5k4ema</pattern>
-<pattern>2kemm</pattern>
-<pattern>2kemp</pattern>
-<pattern>ke4n3an</pattern>
-<pattern>ke4nau</pattern>
-<pattern>ken4ei </pattern>
-<pattern>ke5nen</pattern>
-<pattern>ken5k</pattern>
-<pattern>ke2n1o</pattern>
-<pattern>kens5po</pattern>
-<pattern>kepie5t</pattern>
-<pattern>4k3e4q</pattern>
-<pattern>ke3ram</pattern>
-<pattern>ke4r5enk</pattern>
-<pattern>ker3kl</pattern>
-<pattern>ker4kle</pattern>
-<pattern>ker4kn</pattern>
-<pattern>ker4k3r</pattern>
-<pattern>ker4ku</pattern>
-<pattern>ker4kw</pattern>
-<pattern>ker4n3a</pattern>
-<pattern>ker4no</pattern>
-<pattern>ker3o4</pattern>
-<pattern>ke3ros</pattern>
-<pattern>ker4sm</pattern>
-<pattern>ker5spe</pattern>
-<pattern>ker4spr</pattern>
-<pattern>ker4sta</pattern>
-<pattern>ker5ste </pattern>
-<pattern>ker4sti</pattern>
-<pattern>4k3erts</pattern>
-<pattern>4kerva</pattern>
-<pattern>4kerwt</pattern>
-<pattern>ke2s</pattern>
-<pattern>ke3s4p</pattern>
-<pattern>ke3sta</pattern>
-<pattern>kes5ten</pattern>
-<pattern>ke3sto</pattern>
-<pattern>ke5straa</pattern>
-<pattern>k2et</pattern>
-<pattern>5ketel</pattern>
-<pattern>ke2t3j</pattern>
-<pattern>ke3to</pattern>
-<pattern>ke2t3r</pattern>
-<pattern>kets5te </pattern>
-<pattern>ketting5s</pattern>
-<pattern>4k3e2tu</pattern>
-<pattern>ket3w</pattern>
-<pattern>3k2eu</pattern>
-<pattern>keviet5</pattern>
-<pattern>ke4vl</pattern>
-<pattern>4k1ex</pattern>
-<pattern>2k3e2z</pattern>
-<pattern>2k1f</pattern>
-<pattern>2k3g</pattern>
-<pattern>2k1h4</pattern>
-<pattern>k3ho</pattern>
-<pattern>khoud5s</pattern>
-<pattern>1ki</pattern>
-<pattern>2ki2d</pattern>
-<pattern>4kied</pattern>
-<pattern>kie4sp</pattern>
-<pattern>kie4s4t</pattern>
-<pattern>kie5ste</pattern>
-<pattern>kie4tj</pattern>
-<pattern>kieze4</pattern>
-<pattern>2kië</pattern>
-<pattern>kijk5l</pattern>
-<pattern>k3ijs</pattern>
-<pattern>4kijv</pattern>
-<pattern>4k1ijz</pattern>
-<pattern>ki3lo</pattern>
-<pattern>kilo5v</pattern>
-<pattern>ki3na</pattern>
-<pattern>4kinb</pattern>
-<pattern>4k5indel</pattern>
-<pattern>kinds5te </pattern>
-<pattern>4kindu</pattern>
-<pattern>kin3en</pattern>
-<pattern>5king</pattern>
-<pattern>kings5l</pattern>
-<pattern>2k3inh</pattern>
-<pattern>kinie4</pattern>
-<pattern>k3inko</pattern>
-<pattern>4k1inr</pattern>
-<pattern>2k1ins</pattern>
-<pattern>2k3int</pattern>
-<pattern>4k3inv</pattern>
-<pattern>ki3o</pattern>
-<pattern>ki2p3l</pattern>
-<pattern>ki5se</pattern>
-<pattern>ki3s4p</pattern>
-<pattern>kit4s</pattern>
-<pattern>kits5te</pattern>
-<pattern>k1j</pattern>
-<pattern>2k3ja</pattern>
-<pattern>k3jew</pattern>
-<pattern>k3jo</pattern>
-<pattern>2k3ju</pattern>
-<pattern>4k5k4</pattern>
-<pattern>kke5nei</pattern>
-<pattern>kker4s</pattern>
-<pattern>kkers5ten</pattern>
-<pattern>kke3st</pattern>
-<pattern>1k2l4</pattern>
-<pattern>5klac</pattern>
-<pattern>k3ladi</pattern>
-<pattern>kla2p1</pattern>
-<pattern>k4las</pattern>
-<pattern>5klas </pattern>
-<pattern>5klass</pattern>
-<pattern>k3last</pattern>
-<pattern>k3lat </pattern>
-<pattern>k3latt</pattern>
-<pattern>3k4lav</pattern>
-<pattern>3k4led</pattern>
-<pattern>5kledi</pattern>
-<pattern>5kleed</pattern>
-<pattern>k5leer </pattern>
-<pattern>4k5leg</pattern>
-<pattern>5klem</pattern>
-<pattern>4k5len</pattern>
-<pattern>k3ler </pattern>
-<pattern>4klera</pattern>
-<pattern>k3lers</pattern>
-<pattern>k3les</pattern>
-<pattern>5k4le4u</pattern>
-<pattern>k5lic</pattern>
-<pattern>4klid</pattern>
-<pattern>k3lig</pattern>
-<pattern>2k3lij</pattern>
-<pattern>4klijs</pattern>
-<pattern>k4lim</pattern>
-<pattern>kli4me</pattern>
-<pattern>3k4lin</pattern>
-<pattern>k5lob</pattern>
-<pattern>4klod</pattern>
-<pattern>3klok</pattern>
-<pattern>5klok </pattern>
-<pattern>k5loka</pattern>
-<pattern>k3loke</pattern>
-<pattern>k3lood</pattern>
-<pattern>5kloof</pattern>
-<pattern>k3lope</pattern>
-<pattern>5klos</pattern>
-<pattern>klots5te </pattern>
-<pattern>2k5loz</pattern>
-<pattern>4kluc</pattern>
-<pattern>4kluih</pattern>
-<pattern>2k1m</pattern>
-<pattern>k3ma</pattern>
-<pattern>1k2n4</pattern>
-<pattern>4knam</pattern>
-<pattern>k4nap</pattern>
-<pattern>3k4nar</pattern>
-<pattern>5knec</pattern>
-<pattern>k5nem</pattern>
-<pattern>kni2</pattern>
-<pattern>5knie </pattern>
-<pattern>knip1</pattern>
-<pattern>4k5niv</pattern>
-<pattern>3knol</pattern>
-<pattern>k3note</pattern>
-<pattern>2knum</pattern>
-<pattern>1ko</pattern>
-<pattern>ko4bl</pattern>
-<pattern>k4oc</pattern>
-<pattern>2k5oct</pattern>
-<pattern>4k1oef</pattern>
-<pattern>5koek</pattern>
-<pattern>koe4ket</pattern>
-<pattern>koers5p</pattern>
-<pattern>koes3</pattern>
-<pattern>koe3tj</pattern>
-<pattern>koets5te </pattern>
-<pattern>koge4</pattern>
-<pattern>5ko5gr</pattern>
-<pattern>3k4ok</pattern>
-<pattern>ko5ko</pattern>
-<pattern>kol2e2</pattern>
-<pattern>kolen3</pattern>
-<pattern>2kolm</pattern>
-<pattern>5kolo</pattern>
-<pattern>ko4ly</pattern>
-<pattern>ko2m3a</pattern>
-<pattern>4komg</pattern>
-<pattern>kom5p</pattern>
-<pattern>k3omsl</pattern>
-<pattern>kom4str</pattern>
-<pattern>4komz</pattern>
-<pattern>konge4</pattern>
-<pattern>k4oni</pattern>
-<pattern>k3ontb</pattern>
-<pattern>kon4t3j</pattern>
-<pattern>kon4t3r</pattern>
-<pattern>koo4</pattern>
-<pattern>2k1oog</pattern>
-<pattern>kooi5tj</pattern>
-<pattern>koot3</pattern>
-<pattern>koot4j</pattern>
-<pattern>ko3pa</pattern>
-<pattern>4kopb</pattern>
-<pattern>4k3opd</pattern>
-<pattern>ko1pe</pattern>
-<pattern>ko5pen </pattern>
-<pattern>4kopg</pattern>
-<pattern>3ko5pi</pattern>
-<pattern>5kopj</pattern>
-<pattern>ko2pl</pattern>
-<pattern>2kops</pattern>
-<pattern>4kopz</pattern>
-<pattern>2kord</pattern>
-<pattern>kor5do</pattern>
-<pattern>2k1org</pattern>
-<pattern>2k3ork</pattern>
-<pattern>kors5te </pattern>
-<pattern>kor4ta</pattern>
-<pattern>kor4t3o4</pattern>
-<pattern>kor4tr</pattern>
-<pattern>ko3ru</pattern>
-<pattern>3k4o4s3</pattern>
-<pattern>4k3os </pattern>
-<pattern>kos4j</pattern>
-<pattern>ko5sjere</pattern>
-<pattern>koso4</pattern>
-<pattern>4koss</pattern>
-<pattern>kot4st</pattern>
-<pattern>kots5te </pattern>
-<pattern>4k1ov</pattern>
-<pattern>4k3ox</pattern>
-<pattern>2k3p</pattern>
-<pattern>kpi3s</pattern>
-<pattern>k4plam</pattern>
-<pattern>kpren4</pattern>
-<pattern>1kr4</pattern>
-<pattern>3kra</pattern>
-<pattern>k5raad</pattern>
-<pattern>kraads5</pattern>
-<pattern>kra4b</pattern>
-<pattern>4k5rad</pattern>
-<pattern>k5rand</pattern>
-<pattern>2k1rea</pattern>
-<pattern>2k3rec</pattern>
-<pattern>4k3rede</pattern>
-<pattern>k4ree4</pattern>
-<pattern>k5reep</pattern>
-<pattern>kreet3</pattern>
-<pattern>k3ref</pattern>
-<pattern>k2reg</pattern>
-<pattern>2k3rel</pattern>
-<pattern>2k1ric</pattern>
-<pattern>k3rijk</pattern>
-<pattern>k3rijp</pattern>
-<pattern>krij4t</pattern>
-<pattern>krijt5j</pattern>
-<pattern>k4rit</pattern>
-<pattern>k5ritm</pattern>
-<pattern>kroet5j</pattern>
-<pattern>2krol</pattern>
-<pattern>k4ron</pattern>
-<pattern>kron3t</pattern>
-<pattern>5kroon</pattern>
-<pattern>krop3a</pattern>
-<pattern>kro4to</pattern>
-<pattern>2krou</pattern>
-<pattern>k3ro5v</pattern>
-<pattern>3k4ru</pattern>
-<pattern>k5rub</pattern>
-<pattern>5kruis</pattern>
-<pattern>kru4l</pattern>
-<pattern>krul5a</pattern>
-<pattern>2ks</pattern>
-<pattern>k3sal</pattern>
-<pattern>ks3alm</pattern>
-<pattern>ks3an</pattern>
-<pattern>ks3ap</pattern>
-<pattern>ks1ar</pattern>
-<pattern>ks3as</pattern>
-<pattern>ks2e2</pattern>
-<pattern>k5sec</pattern>
-<pattern>ks3ed</pattern>
-<pattern>ks5ei </pattern>
-<pattern>ks3ep</pattern>
-<pattern>k4serv</pattern>
-<pattern>ks3et</pattern>
-<pattern>kse3v</pattern>
-<pattern>ksges5t</pattern>
-<pattern>k4si</pattern>
-<pattern>k5sil</pattern>
-<pattern>ks1in</pattern>
-<pattern>k5sis</pattern>
-<pattern>k5sit</pattern>
-<pattern>ks1j</pattern>
-<pattern>k1sla</pattern>
-<pattern>ks3lab</pattern>
-<pattern>k4slan</pattern>
-<pattern>ks3le</pattern>
-<pattern>ks3li</pattern>
-<pattern>k4smo</pattern>
-<pattern>ks3na</pattern>
-<pattern>ks3no</pattern>
-<pattern>ks3nu</pattern>
-<pattern>kso4</pattern>
-<pattern>ks3om</pattern>
-<pattern>k5song</pattern>
-<pattern>k2s3pa</pattern>
-<pattern>ks5pand</pattern>
-<pattern>k4spar</pattern>
-<pattern>k1spe</pattern>
-<pattern>k3spi</pattern>
-<pattern>ks3poo</pattern>
-<pattern>k5spor</pattern>
-<pattern>ks3pot</pattern>
-<pattern>ks3pru</pattern>
-<pattern>k3spu</pattern>
-<pattern>ks5s</pattern>
-<pattern>ks4t</pattern>
-<pattern>k1sta</pattern>
-<pattern>k5staan</pattern>
-<pattern>k5staat</pattern>
-<pattern>k1ste</pattern>
-<pattern>ks5tec</pattern>
-<pattern>k4st3ed</pattern>
-<pattern>k3sten</pattern>
-<pattern>ks5tent</pattern>
-<pattern>kste4r</pattern>
-<pattern>kster5a</pattern>
-<pattern>k4sterr</pattern>
-<pattern>ks3th</pattern>
-<pattern>k3sti</pattern>
-<pattern>k3sto</pattern>
-<pattern>ks5ton</pattern>
-<pattern>k5stoo</pattern>
-<pattern>k4stop</pattern>
-<pattern>k5stot</pattern>
-<pattern>ks5trek</pattern>
-<pattern>ks3tri</pattern>
-<pattern>k3stue</pattern>
-<pattern>kst5uit</pattern>
-<pattern>k1sy</pattern>
-<pattern>4kt</pattern>
-<pattern>k1ta</pattern>
-<pattern>kt3aan</pattern>
-<pattern>k3taar</pattern>
-<pattern>ktaat5</pattern>
-<pattern>kt3ac</pattern>
-<pattern>kt3art</pattern>
-<pattern>k3te</pattern>
-<pattern>kte2c</pattern>
-<pattern>kt3eco</pattern>
-<pattern>k4tex</pattern>
-<pattern>kt1h</pattern>
-<pattern>k5tij</pattern>
-<pattern>kt3im</pattern>
-<pattern>kt3in</pattern>
-<pattern>k5tit</pattern>
-<pattern>kt3j</pattern>
-<pattern>k1to</pattern>
-<pattern>kt3om</pattern>
-<pattern>kto4p</pattern>
-<pattern>kt4or</pattern>
-<pattern>kt5ord</pattern>
-<pattern>kt5org</pattern>
-<pattern>kt5ori</pattern>
-<pattern>kt3o4v</pattern>
-<pattern>k1tr</pattern>
-<pattern>kt3res</pattern>
-<pattern>k5troll</pattern>
-<pattern>ktro3s</pattern>
-<pattern>k3tu</pattern>
-<pattern>1ku</pattern>
-<pattern>ku5be</pattern>
-<pattern>kui2f</pattern>
-<pattern>2kuit</pattern>
-<pattern>ku5k</pattern>
-<pattern>ku5me</pattern>
-<pattern>3k4u2n</pattern>
-<pattern>4k5uni</pattern>
-<pattern>5kuns</pattern>
-<pattern>ku2r</pattern>
-<pattern>ku3ra</pattern>
-<pattern>ku3re</pattern>
-<pattern>kur3s</pattern>
-<pattern>3ku2s</pattern>
-<pattern>kut3</pattern>
-<pattern>2kû</pattern>
-<pattern>2kv</pattern>
-<pattern>k3ve</pattern>
-<pattern>kven4t3</pattern>
-<pattern>5k4waal</pattern>
-<pattern>2k3wac</pattern>
-<pattern>k2wad</pattern>
-<pattern>k1wag</pattern>
-<pattern>5k2wal</pattern>
-<pattern>5k2wam</pattern>
-<pattern>3k4war</pattern>
-<pattern>k5ware</pattern>
-<pattern>4kwat</pattern>
-<pattern>k3weer</pattern>
-<pattern>2kweg</pattern>
-<pattern>k1wei</pattern>
-<pattern>5kwel</pattern>
-<pattern>kwen4st</pattern>
-<pattern>kwens5te </pattern>
-<pattern>4k1wer</pattern>
-<pattern>5k2wes1</pattern>
-<pattern>kwes5tr</pattern>
-<pattern>5kwets</pattern>
-<pattern>k2wie</pattern>
-<pattern>k3wijz</pattern>
-<pattern>k4wik</pattern>
-<pattern>2kwil</pattern>
-<pattern>2kwin</pattern>
-<pattern>k3wind</pattern>
-<pattern>4k1wo</pattern>
-<pattern>ky3</pattern>
-<pattern>2kz</pattern>
-<pattern>4l </pattern>
-<pattern>2laan</pattern>
-<pattern>4laand</pattern>
-<pattern>l3aanh</pattern>
-<pattern>laa5re</pattern>
-<pattern>laar5tj</pattern>
-<pattern>laat5sta</pattern>
-<pattern>l3abon</pattern>
-<pattern>2lac</pattern>
-<pattern>la4ca</pattern>
-<pattern>5lach </pattern>
-<pattern>la4cha</pattern>
-<pattern>5lache</pattern>
-<pattern>lach5te</pattern>
-<pattern>lacht4s</pattern>
-<pattern>l4aci</pattern>
-<pattern>la2d5a</pattern>
-<pattern>la4det</pattern>
-<pattern>2ladj</pattern>
-<pattern>4ladm</pattern>
-<pattern>la2d3o</pattern>
-<pattern>4la2dr</pattern>
-<pattern>lad5s</pattern>
-<pattern>la2du</pattern>
-<pattern>4ladv</pattern>
-<pattern>3lae3</pattern>
-<pattern>2laf</pattern>
-<pattern>la2fa</pattern>
-<pattern>la3fl</pattern>
-<pattern>lafo2</pattern>
-<pattern>4l3afs</pattern>
-<pattern>la2g3a</pattern>
-<pattern>la4gent</pattern>
-<pattern>la2go</pattern>
-<pattern>lag3r</pattern>
-<pattern>lags4</pattern>
-<pattern>lag5sa</pattern>
-<pattern>la2k3a</pattern>
-<pattern>la4ki</pattern>
-<pattern>la3kr</pattern>
-<pattern>2lal</pattern>
-<pattern>3lald</pattern>
-<pattern>lal4o</pattern>
-<pattern>lam4p3j</pattern>
-<pattern>lam4p5l</pattern>
-<pattern>lam4po4</pattern>
-<pattern>lam4s3p</pattern>
-<pattern>l4an</pattern>
-<pattern>4la2na</pattern>
-<pattern>lan3ac</pattern>
-<pattern>3land</pattern>
-<pattern>lan4da</pattern>
-<pattern>land5aa</pattern>
-<pattern>lan4d5oo</pattern>
-<pattern>lan4d3r</pattern>
-<pattern>lands5te </pattern>
-<pattern>la4n3ec</pattern>
-<pattern>lanel5</pattern>
-<pattern>5lange </pattern>
-<pattern>lang5l</pattern>
-<pattern>lang5sp</pattern>
-<pattern>lang5sta</pattern>
-<pattern>lan4k3a</pattern>
-<pattern>lan4k3l</pattern>
-<pattern>lank3w</pattern>
-<pattern>4lann</pattern>
-<pattern>la4nor</pattern>
-<pattern>lan2s</pattern>
-<pattern>lans3l</pattern>
-<pattern>lan4st</pattern>
-<pattern>lan4t3j</pattern>
-<pattern>lap3ac</pattern>
-<pattern>la3pi</pattern>
-<pattern>lap3l</pattern>
-<pattern>lap3o4</pattern>
-<pattern>la5pre</pattern>
-<pattern>la2p3u</pattern>
-<pattern>la3q</pattern>
-<pattern>lar3da</pattern>
-<pattern>2larm</pattern>
-<pattern>4larm </pattern>
-<pattern>lar5st</pattern>
-<pattern>las3a4</pattern>
-<pattern>lase4</pattern>
-<pattern>la2si</pattern>
-<pattern>las3to</pattern>
-<pattern>5lastt</pattern>
-<pattern>la3te</pattern>
-<pattern>la4t3he</pattern>
-<pattern>lat5j</pattern>
-<pattern>la4t3ro</pattern>
-<pattern>4lats4</pattern>
-<pattern>lat3sl</pattern>
-<pattern>2lau</pattern>
-<pattern>5lauf</pattern>
-<pattern>lau4st</pattern>
-<pattern>l2auw</pattern>
-<pattern>la3v</pattern>
-<pattern>lava3</pattern>
-<pattern>la4vo</pattern>
-<pattern>5law</pattern>
-<pattern>l4az</pattern>
-<pattern>4lazi</pattern>
-<pattern>la4zij</pattern>
-<pattern>2lb4</pattern>
-<pattern>lber4t</pattern>
-<pattern>lbert5j</pattern>
-<pattern>lboot4</pattern>
-<pattern>2l1c</pattern>
-<pattern>lce4l5</pattern>
-<pattern>4ld</pattern>
-<pattern>ldaat5</pattern>
-<pattern>l2d3ac</pattern>
-<pattern>ldak4</pattern>
-<pattern>ld3alf</pattern>
-<pattern>l4da4r</pattern>
-<pattern>ld3arc</pattern>
-<pattern>ld3ari</pattern>
-<pattern>ld3art</pattern>
-<pattern>l2dau</pattern>
-<pattern>ld3eco</pattern>
-<pattern>ldeks5</pattern>
-<pattern>l4d3e4z</pattern>
-<pattern>ldi3a</pattern>
-<pattern>ld5oef</pattern>
-<pattern>ld3oli</pattern>
-<pattern>l2d3om</pattern>
-<pattern>l2d3on</pattern>
-<pattern>ld3oog</pattern>
-<pattern>l4do4p</pattern>
-<pattern>ld3opi</pattern>
-<pattern>ld3ord</pattern>
-<pattern>ld1ov</pattern>
-<pattern>l3dr</pattern>
-<pattern>l5drade</pattern>
-<pattern>ld3ram</pattern>
-<pattern>ld5rang</pattern>
-<pattern>ld3rat</pattern>
-<pattern>ld1re</pattern>
-<pattern>l5dree</pattern>
-<pattern>ld3rij</pattern>
-<pattern>ld3roe</pattern>
-<pattern>ld3rol</pattern>
-<pattern>ld3rom</pattern>
-<pattern>ld3rui</pattern>
-<pattern>ld3sa</pattern>
-<pattern>ld3sl</pattern>
-<pattern>ld3sma</pattern>
-<pattern>ld5sp</pattern>
-<pattern>ld5ste</pattern>
-<pattern>l3du</pattern>
-<pattern>ld3uit</pattern>
-<pattern>ld3uu</pattern>
-<pattern>ld1w</pattern>
-<pattern>le2a</pattern>
-<pattern>le4ane</pattern>
-<pattern>le3at</pattern>
-<pattern>leba4l</pattern>
-<pattern>lecht5st</pattern>
-<pattern>lee4</pattern>
-<pattern>leeg3</pattern>
-<pattern>leege4</pattern>
-<pattern>leeg5i</pattern>
-<pattern>4leekh</pattern>
-<pattern>lee5l</pattern>
-<pattern>leem3</pattern>
-<pattern>3leen</pattern>
-<pattern>4leep</pattern>
-<pattern>leep3o</pattern>
-<pattern>lees5e</pattern>
-<pattern>lees5l</pattern>
-<pattern>lees5po</pattern>
-<pattern>2leeu</pattern>
-<pattern>2leff</pattern>
-<pattern>lega5s</pattern>
-<pattern>leg3ec</pattern>
-<pattern>leg3l</pattern>
-<pattern>le4go</pattern>
-<pattern>le5go </pattern>
-<pattern>leg5s</pattern>
-<pattern>3leidi</pattern>
-<pattern>4leier</pattern>
-<pattern>4leig</pattern>
-<pattern>lei5tj</pattern>
-<pattern>leit5s</pattern>
-<pattern>le4ko4</pattern>
-<pattern>4leks</pattern>
-<pattern>lek5str</pattern>
-<pattern>5leld</pattern>
-<pattern>le2le</pattern>
-<pattern>5leli</pattern>
-<pattern>l3elp</pattern>
-<pattern>le4n3a4d</pattern>
-<pattern>len3a4k</pattern>
-<pattern>3lene</pattern>
-<pattern>le4n3e4m</pattern>
-<pattern>len5kw</pattern>
-<pattern>le2no</pattern>
-<pattern>len3op</pattern>
-<pattern>len3sf</pattern>
-<pattern>len3sm</pattern>
-<pattern>4l3en5th</pattern>
-<pattern>le5o</pattern>
-<pattern>4lep </pattern>
-<pattern>3le1ra</pattern>
-<pattern>le4r3a4k</pattern>
-<pattern>le5rei</pattern>
-<pattern>le4r3e4v</pattern>
-<pattern>ler5g4</pattern>
-<pattern>le3r4o</pattern>
-<pattern>le4ron</pattern>
-<pattern>ler4sl</pattern>
-<pattern>ler5spo</pattern>
-<pattern>4l3erts</pattern>
-<pattern>le2s</pattern>
-<pattern>le4sa</pattern>
-<pattern>le3sc</pattern>
-<pattern>les5et</pattern>
-<pattern>le3s4h</pattern>
-<pattern>les3m</pattern>
-<pattern>le4sp</pattern>
-<pattern>le3spe</pattern>
-<pattern>4l3essa</pattern>
-<pattern>les3t</pattern>
-<pattern>les4ta</pattern>
-<pattern>les5taa</pattern>
-<pattern>le5s4tel</pattern>
-<pattern>le3str</pattern>
-<pattern>le4s3u</pattern>
-<pattern>le4t4h</pattern>
-<pattern>le3tha</pattern>
-<pattern>let4i</pattern>
-<pattern>le5tin</pattern>
-<pattern>le4top</pattern>
-<pattern>le2t3r</pattern>
-<pattern>le3t4re</pattern>
-<pattern>let4st</pattern>
-<pattern>lets5te </pattern>
-<pattern>le2t3u</pattern>
-<pattern>leu3ko</pattern>
-<pattern>leum3a</pattern>
-<pattern>leur4o</pattern>
-<pattern>leus4</pattern>
-<pattern>leu5ste</pattern>
-<pattern>5leuz</pattern>
-<pattern>leven4s</pattern>
-<pattern>levink5j</pattern>
-<pattern>4lexc</pattern>
-<pattern>4lexp</pattern>
-<pattern>l2fac</pattern>
-<pattern>l3f4ag</pattern>
-<pattern>lfa3s</pattern>
-<pattern>l2fau</pattern>
-<pattern>lfe4n</pattern>
-<pattern>l4f3end</pattern>
-<pattern>lf3ene</pattern>
-<pattern>l2fe2z</pattern>
-<pattern>lf3li</pattern>
-<pattern>l3f4lo</pattern>
-<pattern>lf3lu</pattern>
-<pattern>l4fo</pattern>
-<pattern>l5foe</pattern>
-<pattern>lf3o4l</pattern>
-<pattern>lf1op</pattern>
-<pattern>lf5ord</pattern>
-<pattern>lf5org</pattern>
-<pattern>l5fou</pattern>
-<pattern>l1fra</pattern>
-<pattern>l3fru</pattern>
-<pattern>lfs5ei</pattern>
-<pattern>lf4sl</pattern>
-<pattern>lfs3le</pattern>
-<pattern>lf2s3m</pattern>
-<pattern>lf4so</pattern>
-<pattern>lft4</pattern>
-<pattern>lf5ta</pattern>
-<pattern>lf5tw</pattern>
-<pattern>lf3uu</pattern>
-<pattern>2l1g</pattern>
-<pattern>l5gaar</pattern>
-<pattern>l4gap</pattern>
-<pattern>lge4n5a</pattern>
-<pattern>l3gla</pattern>
-<pattern>l3g4oe</pattern>
-<pattern>l3gog</pattern>
-<pattern>l3goo</pattern>
-<pattern>lg3s4</pattern>
-<pattern>lgse5</pattern>
-<pattern>4l1h</pattern>
-<pattern>1li</pattern>
-<pattern>li3ag</pattern>
-<pattern>li3am</pattern>
-<pattern>licht5st</pattern>
-<pattern>3lid</pattern>
-<pattern>5lid </pattern>
-<pattern>5lidm</pattern>
-<pattern>lid3s4</pattern>
-<pattern>lie4g3a</pattern>
-<pattern>lie4gr</pattern>
-<pattern>lie3ka</pattern>
-<pattern>lie4sp</pattern>
-<pattern>lie3s4t</pattern>
-<pattern>lie4to</pattern>
-<pattern>li3eu</pattern>
-<pattern>3liè</pattern>
-<pattern>3lift</pattern>
-<pattern>l4ig</pattern>
-<pattern>li3go</pattern>
-<pattern>lijk3a</pattern>
-<pattern>lij4m3a</pattern>
-<pattern>4lijmv</pattern>
-<pattern>5lijn</pattern>
-<pattern>4lijp</pattern>
-<pattern>3lij2s</pattern>
-<pattern>lijst5a</pattern>
-<pattern>4lijt</pattern>
-<pattern>4l3ijz</pattern>
-<pattern>li5kr</pattern>
-<pattern>lik5sp</pattern>
-<pattern>li4kw</pattern>
-<pattern>li3kwi</pattern>
-<pattern>lim4a</pattern>
-<pattern>li3mi</pattern>
-<pattern>2limp</pattern>
-<pattern>lim4p3j</pattern>
-<pattern>lin4da</pattern>
-<pattern>4linf</pattern>
-<pattern>4l3inh</pattern>
-<pattern>li5ni</pattern>
-<pattern>lin4k3a</pattern>
-<pattern>3linn</pattern>
-<pattern>l3inna</pattern>
-<pattern>2linr</pattern>
-<pattern>2l3ins</pattern>
-<pattern>lin4t3j</pattern>
-<pattern>l3inv</pattern>
-<pattern>4linz</pattern>
-<pattern>li3ob</pattern>
-<pattern>li5om</pattern>
-<pattern>li5o5s4</pattern>
-<pattern>li3ot</pattern>
-<pattern>li2pa</pattern>
-<pattern>li3pi</pattern>
-<pattern>li2p3l</pattern>
-<pattern>li5see</pattern>
-<pattern>2liso</pattern>
-<pattern>l5isw</pattern>
-<pattern>li1t2h</pattern>
-<pattern>lit3r</pattern>
-<pattern>lit4sa</pattern>
-<pattern>lit4sl</pattern>
-<pattern>lit4st</pattern>
-<pattern>lits5te </pattern>
-<pattern>lit5sten</pattern>
-<pattern>2lix</pattern>
-<pattern>4l1j2</pattern>
-<pattern>lk3af</pattern>
-<pattern>l4k3ank</pattern>
-<pattern>lk3arm</pattern>
-<pattern>lk3art</pattern>
-<pattern>l3ke</pattern>
-<pattern>l4k3ei</pattern>
-<pattern>l4k3em</pattern>
-<pattern>lken5e</pattern>
-<pattern>lken4s</pattern>
-<pattern>l4k3ep</pattern>
-<pattern>l3ki</pattern>
-<pattern>lking4</pattern>
-<pattern>lk3laa</pattern>
-<pattern>lk3lag</pattern>
-<pattern>l5klas</pattern>
-<pattern>l4k3lev</pattern>
-<pattern>l5klim</pattern>
-<pattern>l3ko</pattern>
-<pattern>l5koe</pattern>
-<pattern>lk3ont</pattern>
-<pattern>lkooi5</pattern>
-<pattern>lk3opb</pattern>
-<pattern>l5kor</pattern>
-<pattern>l5kou</pattern>
-<pattern>l5kra</pattern>
-<pattern>l2kre</pattern>
-<pattern>lk3rep</pattern>
-<pattern>lk3res</pattern>
-<pattern>lk3rij</pattern>
-<pattern>l2k3ro</pattern>
-<pattern>lk2s</pattern>
-<pattern>lk4se</pattern>
-<pattern>lk4so</pattern>
-<pattern>lk3son</pattern>
-<pattern>lks3oo</pattern>
-<pattern>lks5taa</pattern>
-<pattern>lk3ste</pattern>
-<pattern>lks5tel</pattern>
-<pattern>lks5tr</pattern>
-<pattern>l4k3uu</pattern>
-<pattern>l3kw</pattern>
-<pattern>lk3wi</pattern>
-<pattern>l3ky</pattern>
-<pattern>2l1l</pattern>
-<pattern>l5la</pattern>
-<pattern>lla3d</pattern>
-<pattern>lla3g4</pattern>
-<pattern>lla5tr</pattern>
-<pattern>ll3eig</pattern>
-<pattern>lle3k</pattern>
-<pattern>ll4el</pattern>
-<pattern>lleo4</pattern>
-<pattern>ller5on</pattern>
-<pattern>lle3s4m</pattern>
-<pattern>lle5th</pattern>
-<pattern>llevie5</pattern>
-<pattern>l3l4i</pattern>
-<pattern>l3lo</pattern>
-<pattern>llo5f</pattern>
-<pattern>l5lon</pattern>
-<pattern>ll3sh</pattern>
-<pattern>2lm</pattern>
-<pattern>l3maa</pattern>
-<pattern>lmaat5</pattern>
-<pattern>lm3a4ca</pattern>
-<pattern>lm3af</pattern>
-<pattern>lma5ï</pattern>
-<pattern>l3mak</pattern>
-<pattern>lm3arc</pattern>
-<pattern>lm3art</pattern>
-<pattern>lma3s2</pattern>
-<pattern>lm3au</pattern>
-<pattern>l3me</pattern>
-<pattern>l4med</pattern>
-<pattern>lm3edi</pattern>
-<pattern>l4m3ep</pattern>
-<pattern>lme2s</pattern>
-<pattern>lme5te</pattern>
-<pattern>l3mi</pattern>
-<pattern>l3mo</pattern>
-<pattern>l5mog</pattern>
-<pattern>lm3oli</pattern>
-<pattern>lm3or</pattern>
-<pattern>lmro4z</pattern>
-<pattern>lm5sc</pattern>
-<pattern>lm3sh</pattern>
-<pattern>lm3su</pattern>
-<pattern>2l3n</pattern>
-<pattern>lni4s</pattern>
-<pattern>lo3a</pattern>
-<pattern>2lobj</pattern>
-<pattern>lo4boo</pattern>
-<pattern>loe4d5a</pattern>
-<pattern>loed3r</pattern>
-<pattern>4loeg</pattern>
-<pattern>loe4gr</pattern>
-<pattern>loen4st</pattern>
-<pattern>loens5te </pattern>
-<pattern>4loes</pattern>
-<pattern>l3oeu</pattern>
-<pattern>5loev</pattern>
-<pattern>lo4faa</pattern>
-<pattern>lof5d2</pattern>
-<pattern>lof4s4</pattern>
-<pattern>log4</pattern>
-<pattern>log5l</pattern>
-<pattern>lo3go</pattern>
-<pattern>5logr</pattern>
-<pattern>log2s3</pattern>
-<pattern>lo4k3ar</pattern>
-<pattern>lo2k3o2</pattern>
-<pattern>lo4kr</pattern>
-<pattern>lo2ku</pattern>
-<pattern>2lo2l</pattern>
-<pattern>lo3la</pattern>
-<pattern>l3oml</pattern>
-<pattern>lom4p3j</pattern>
-<pattern>lom4p3l</pattern>
-<pattern>l3omt</pattern>
-<pattern>l3omv</pattern>
-<pattern>4lomz</pattern>
-<pattern>3lon </pattern>
-<pattern>4lond</pattern>
-<pattern>5long</pattern>
-<pattern>lon4gaa</pattern>
-<pattern>lon4g3o</pattern>
-<pattern>lon4gr</pattern>
-<pattern>lon3o</pattern>
-<pattern>2lont</pattern>
-<pattern>lon4t3j</pattern>
-<pattern>3look</pattern>
-<pattern>loo5pi</pattern>
-<pattern>3loosh</pattern>
-<pattern>loot3e</pattern>
-<pattern>lo3pa</pattern>
-<pattern>4lopb</pattern>
-<pattern>l3opd</pattern>
-<pattern>lo1pe</pattern>
-<pattern>2l3oph</pattern>
-<pattern>2l3opl</pattern>
-<pattern>lop4la</pattern>
-<pattern>2lopn</pattern>
-<pattern>lo3p2r</pattern>
-<pattern>4lopt</pattern>
-<pattern>4l3opv</pattern>
-<pattern>4l3opw</pattern>
-<pattern>2lor</pattern>
-<pattern>3l4or </pattern>
-<pattern>lo3re</pattern>
-<pattern>4l1org</pattern>
-<pattern>lo3ri</pattern>
-<pattern>l4o1r2o3</pattern>
-<pattern>3l4ors</pattern>
-<pattern>lo3ru</pattern>
-<pattern>lo3spe</pattern>
-<pattern>lost4</pattern>
-<pattern>los5to</pattern>
-<pattern>lo4s5tr</pattern>
-<pattern>lo5s2u</pattern>
-<pattern>lo2ta</pattern>
-<pattern>lot3a4l</pattern>
-<pattern>lo4tet</pattern>
-<pattern>lo2t3h</pattern>
-<pattern>lot3j</pattern>
-<pattern>lo4tof</pattern>
-<pattern>lot3r</pattern>
-<pattern>lou3s</pattern>
-<pattern>lo3v</pattern>
-<pattern>2love</pattern>
-<pattern>3lo5z</pattern>
-<pattern>4lp</pattern>
-<pattern>l1pa</pattern>
-<pattern>l3paa</pattern>
-<pattern>lp3aan</pattern>
-<pattern>lp3a4g</pattern>
-<pattern>lp3am</pattern>
-<pattern>l3par</pattern>
-<pattern>l3pas</pattern>
-<pattern>l1pe</pattern>
-<pattern>lpe2n</pattern>
-<pattern>l2pex</pattern>
-<pattern>l3pi</pattern>
-<pattern>l5ping</pattern>
-<pattern>lp3ins</pattern>
-<pattern>lp3j</pattern>
-<pattern>l1pl</pattern>
-<pattern>l3p4la</pattern>
-<pattern>l4plam</pattern>
-<pattern>l1po</pattern>
-<pattern>lp3of</pattern>
-<pattern>l3pom</pattern>
-<pattern>lp3on</pattern>
-<pattern>lp3ope</pattern>
-<pattern>l3pos</pattern>
-<pattern>l3pot</pattern>
-<pattern>l1pr</pattern>
-<pattern>lp3ram</pattern>
-<pattern>4l3r</pattern>
-<pattern>lraads5</pattern>
-<pattern>lrus5</pattern>
-<pattern>4ls</pattern>
-<pattern>l4saa</pattern>
-<pattern>ls1a2d</pattern>
-<pattern>ls3a2g</pattern>
-<pattern>l1sam</pattern>
-<pattern>ls3an</pattern>
-<pattern>l3sap</pattern>
-<pattern>ls3as</pattern>
-<pattern>l2sat</pattern>
-<pattern>ls4cor</pattern>
-<pattern>ls4cu</pattern>
-<pattern>ls3eco</pattern>
-<pattern>l4s3e2d</pattern>
-<pattern>l4sef</pattern>
-<pattern>l5sen</pattern>
-<pattern>l4s3e2p</pattern>
-<pattern>lsge4st</pattern>
-<pattern>l3s2hi</pattern>
-<pattern>l3si</pattern>
-<pattern>l4s3im</pattern>
-<pattern>l4sin</pattern>
-<pattern>ls3inj</pattern>
-<pattern>ls3ink</pattern>
-<pattern>ls3int</pattern>
-<pattern>ls4j</pattern>
-<pattern>ls5ja</pattern>
-<pattern>l3s4kel</pattern>
-<pattern>l3s2ki</pattern>
-<pattern>l1sl</pattern>
-<pattern>l3sla</pattern>
-<pattern>l2s4le</pattern>
-<pattern>ls5led</pattern>
-<pattern>ls5lee</pattern>
-<pattern>ls5leg</pattern>
-<pattern>ls5len</pattern>
-<pattern>l2s3li</pattern>
-<pattern>ls4lin</pattern>
-<pattern>l3slo</pattern>
-<pattern>ls4maak</pattern>
-<pattern>ls4med</pattern>
-<pattern>ls4mee</pattern>
-<pattern>l3smid</pattern>
-<pattern>ls3na</pattern>
-<pattern>l3sne</pattern>
-<pattern>l3sno</pattern>
-<pattern>ls3nor</pattern>
-<pattern>l3soc</pattern>
-<pattern>ls3of</pattern>
-<pattern>l3sol</pattern>
-<pattern>ls3op</pattern>
-<pattern>ls3o4r</pattern>
-<pattern>ls1ov</pattern>
-<pattern>l1sp</pattern>
-<pattern>l2spa</pattern>
-<pattern>ls3pac</pattern>
-<pattern>l3span</pattern>
-<pattern>ls3par</pattern>
-<pattern>ls4pe</pattern>
-<pattern>l3spi</pattern>
-<pattern>ls3pli</pattern>
-<pattern>l3spoo</pattern>
-<pattern>l4s5poot</pattern>
-<pattern>l3spor</pattern>
-<pattern>l2spr</pattern>
-<pattern>ls3pra</pattern>
-<pattern>l1st</pattern>
-<pattern>l3sta</pattern>
-<pattern>l4staf</pattern>
-<pattern>l4stak</pattern>
-<pattern>ls5tak </pattern>
-<pattern>l3ste</pattern>
-<pattern>l4stek</pattern>
-<pattern>l4stev</pattern>
-<pattern>ls4ti</pattern>
-<pattern>l3sto</pattern>
-<pattern>l5straa</pattern>
-<pattern>ls5trak</pattern>
-<pattern>l5strat</pattern>
-<pattern>l3stu</pattern>
-<pattern>ls5ty</pattern>
-<pattern>l2su</pattern>
-<pattern>l3sur</pattern>
-<pattern>ls3us</pattern>
-<pattern>l3sy</pattern>
-<pattern>4l1t</pattern>
-<pattern>lt4aa</pattern>
-<pattern>lt1ac</pattern>
-<pattern>l4tam</pattern>
-<pattern>l5tame</pattern>
-<pattern>l5t4an</pattern>
-<pattern>lt4han</pattern>
-<pattern>l4t3hi</pattern>
-<pattern>l2t3ho</pattern>
-<pattern>l3thu</pattern>
-<pattern>lto4l</pattern>
-<pattern>lt3oli</pattern>
-<pattern>l2t3o4v</pattern>
-<pattern>l3tr</pattern>
-<pattern>ltra3s</pattern>
-<pattern>lt3rug</pattern>
-<pattern>lt3sl</pattern>
-<pattern>lt3sp</pattern>
-<pattern>lts5te </pattern>
-<pattern>l3tu</pattern>
-<pattern>lu4b1</pattern>
-<pattern>lub5e</pattern>
-<pattern>lub5l</pattern>
-<pattern>lu1en</pattern>
-<pattern>3lui </pattern>
-<pattern>5luia</pattern>
-<pattern>5luid</pattern>
-<pattern>luids3</pattern>
-<pattern>5luie </pattern>
-<pattern>2luit</pattern>
-<pattern>luk2s</pattern>
-<pattern>luks3t</pattern>
-<pattern>lu3na</pattern>
-<pattern>3lunc</pattern>
-<pattern>2l3u2ni</pattern>
-<pattern>lu3sta</pattern>
-<pattern>lu3ta</pattern>
-<pattern>lut3j</pattern>
-<pattern>lut4st</pattern>
-<pattern>luts5te </pattern>
-<pattern>lu3wi</pattern>
-<pattern>lven5s</pattern>
-<pattern>lvera4</pattern>
-<pattern>l1w</pattern>
-<pattern>1ly</pattern>
-<pattern>ly5i</pattern>
-<pattern>ly3st</pattern>
-<pattern>4lz</pattern>
-<pattern>lzooi5</pattern>
-<pattern>4m </pattern>
-<pattern>1ma</pattern>
-<pattern>maas3</pattern>
-<pattern>maat5st</pattern>
-<pattern>m3act</pattern>
-<pattern>2m3adv</pattern>
-<pattern>ma5esto</pattern>
-<pattern>m3afl</pattern>
-<pattern>ma3fr</pattern>
-<pattern>2m3afs</pattern>
-<pattern>4m3afw</pattern>
-<pattern>m4ag</pattern>
-<pattern>ma3gl</pattern>
-<pattern>ma5go</pattern>
-<pattern>ma3gr</pattern>
-<pattern>maï4</pattern>
-<pattern>ma5ka</pattern>
-<pattern>ma5ke</pattern>
-<pattern>5ma3k4r</pattern>
-<pattern>ma3kw</pattern>
-<pattern>ma3l4a</pattern>
-<pattern>ma5lac</pattern>
-<pattern>ma4l5ent</pattern>
-<pattern>mal5st</pattern>
-<pattern>5m4an </pattern>
-<pattern>man3ac</pattern>
-<pattern>m3anal</pattern>
-<pattern>man5da</pattern>
-<pattern>man5do</pattern>
-<pattern>mand4s</pattern>
-<pattern>5m4ann</pattern>
-<pattern>ma5no</pattern>
-<pattern>5man2s</pattern>
-<pattern>man4se</pattern>
-<pattern>mans5ee</pattern>
-<pattern>man4so</pattern>
-<pattern>mans3p</pattern>
-<pattern>man4s3t</pattern>
-<pattern>mans5ta</pattern>
-<pattern>man4th</pattern>
-<pattern>mant4r</pattern>
-<pattern>ma5pa</pattern>
-<pattern>ma3pr</pattern>
-<pattern>ma3q</pattern>
-<pattern>m4a5ri</pattern>
-<pattern>mariet5</pattern>
-<pattern>5m4ark</pattern>
-<pattern>mar3sh</pattern>
-<pattern>mar4s5t</pattern>
-<pattern>mar5ti</pattern>
-<pattern>ma1so</pattern>
-<pattern>ma3s4po</pattern>
-<pattern>5mass</pattern>
-<pattern>ma4ste</pattern>
-<pattern>ma3str</pattern>
-<pattern>ma5ta</pattern>
-<pattern>5mater</pattern>
-<pattern>mat5j</pattern>
-<pattern>ma4tom</pattern>
-<pattern>ma3tr</pattern>
-<pattern>mat4st</pattern>
-<pattern>mats5te </pattern>
-<pattern>ma3v</pattern>
-<pattern>4mb</pattern>
-<pattern>m5bl</pattern>
-<pattern>mboot4j</pattern>
-<pattern>mbo5st</pattern>
-<pattern>mb4r</pattern>
-<pattern>2m1c</pattern>
-<pattern>2m1d</pattern>
-<pattern>m5da</pattern>
-<pattern>mdi3a</pattern>
-<pattern>mdis5</pattern>
-<pattern>m3do</pattern>
-<pattern>mdo3p</pattern>
-<pattern>m3dr</pattern>
-<pattern>m3dw</pattern>
-<pattern>1me</pattern>
-<pattern>me1c</pattern>
-<pattern>me5de</pattern>
-<pattern>5media</pattern>
-<pattern>5mediu</pattern>
-<pattern>mee5g</pattern>
-<pattern>mee3k4r</pattern>
-<pattern>mee5las</pattern>
-<pattern>mee3lo</pattern>
-<pattern>mee5re</pattern>
-<pattern>mee5ri</pattern>
-<pattern>5mees</pattern>
-<pattern>meest5al</pattern>
-<pattern>mee5stov</pattern>
-<pattern>mee5str</pattern>
-<pattern>m5eg </pattern>
-<pattern>me3g2a</pattern>
-<pattern>mega5s</pattern>
-<pattern>m5egd</pattern>
-<pattern>m5egg</pattern>
-<pattern>m5egt</pattern>
-<pattern>me4i</pattern>
-<pattern>mei2n</pattern>
-<pattern>mei5tj</pattern>
-<pattern>m2el</pattern>
-<pattern>me4l4as</pattern>
-<pattern>mel5as </pattern>
-<pattern>mel5dr</pattern>
-<pattern>mel4ko</pattern>
-<pattern>mel4kr</pattern>
-<pattern>5melo</pattern>
-<pattern>mel3s4m</pattern>
-<pattern>me4mi</pattern>
-<pattern>3men</pattern>
-<pattern>m4en </pattern>
-<pattern>me3na</pattern>
-<pattern>men4as</pattern>
-<pattern>meng5ra</pattern>
-<pattern>men5k</pattern>
-<pattern>me5nor</pattern>
-<pattern>4menq</pattern>
-<pattern>men4s5uu</pattern>
-<pattern>men4t3j</pattern>
-<pattern>ment3w</pattern>
-<pattern>me5nu</pattern>
-<pattern>me3p2j</pattern>
-<pattern>2m3e2q</pattern>
-<pattern>me1ra</pattern>
-<pattern>me4r5aak</pattern>
-<pattern>me4r3a4k</pattern>
-<pattern>me4r4am</pattern>
-<pattern>mer5ante</pattern>
-<pattern>me4rap</pattern>
-<pattern>me3rau</pattern>
-<pattern>me4rav</pattern>
-<pattern>mer3ei</pattern>
-<pattern>5merk</pattern>
-<pattern>mer4kl</pattern>
-<pattern>mer4kn</pattern>
-<pattern>mer4kw</pattern>
-<pattern>mer5oc</pattern>
-<pattern>me5rong</pattern>
-<pattern>me3roo</pattern>
-<pattern>4m3eros</pattern>
-<pattern>me3rot</pattern>
-<pattern>mer4si</pattern>
-<pattern>mer4sl</pattern>
-<pattern>mers5m</pattern>
-<pattern>mers5ta</pattern>
-<pattern>me2ru4</pattern>
-<pattern>m4es</pattern>
-<pattern>me3s4h</pattern>
-<pattern>me4s4l</pattern>
-<pattern>mes5li</pattern>
-<pattern>me5slo</pattern>
-<pattern>mes3m</pattern>
-<pattern>me3so</pattern>
-<pattern>me4sp</pattern>
-<pattern>mes3pa</pattern>
-<pattern>me5spe</pattern>
-<pattern>me5spot</pattern>
-<pattern>me5stel</pattern>
-<pattern>mesto4</pattern>
-<pattern>mest5ov</pattern>
-<pattern>me3stu</pattern>
-<pattern>me5ta5n</pattern>
-<pattern>me3t4h</pattern>
-<pattern>3meti</pattern>
-<pattern>me5tr</pattern>
-<pattern>mets5te </pattern>
-<pattern>meve4</pattern>
-<pattern>m3e4ven</pattern>
-<pattern>2mex</pattern>
-<pattern>3mé</pattern>
-<pattern>3mè</pattern>
-<pattern>3mê</pattern>
-<pattern>2m1f</pattern>
-<pattern>mfa3t</pattern>
-<pattern>mf4l</pattern>
-<pattern>mf3li</pattern>
-<pattern>mf5lie</pattern>
-<pattern>m5fo</pattern>
-<pattern>2m5g</pattern>
-<pattern>mger4</pattern>
-<pattern>2m1h</pattern>
-<pattern>1mi</pattern>
-<pattern>3mid</pattern>
-<pattern>4mid </pattern>
-<pattern>5midd</pattern>
-<pattern>mie5kl</pattern>
-<pattern>mie3st</pattern>
-<pattern>4m3ijs</pattern>
-<pattern>4m3ijz</pattern>
-<pattern>mi3kn</pattern>
-<pattern>5mili</pattern>
-<pattern>mi3lo</pattern>
-<pattern>mimie4</pattern>
-<pattern>m3imp</pattern>
-<pattern>mi5nar</pattern>
-<pattern>2minf</pattern>
-<pattern>5ming</pattern>
-<pattern>4minh</pattern>
-<pattern>2m5inr</pattern>
-<pattern>2m3ins</pattern>
-<pattern>mi5nu</pattern>
-<pattern>4m3inw</pattern>
-<pattern>m2is</pattern>
-<pattern>mis5f</pattern>
-<pattern>mi2s3i</pattern>
-<pattern>mi3s4la</pattern>
-<pattern>mi4st</pattern>
-<pattern>mi5stra</pattern>
-<pattern>mis5tro</pattern>
-<pattern>mi3t4a</pattern>
-<pattern>mi1tr</pattern>
-<pattern>mit4st</pattern>
-<pattern>mits5te </pattern>
-<pattern>mit5sten</pattern>
-<pattern>2m1j</pattern>
-<pattern>2m3k2</pattern>
-<pattern>mkaart5j</pattern>
-<pattern>2m3l</pattern>
-<pattern>2m1m</pattern>
-<pattern>2m1n</pattern>
-<pattern>m5na</pattern>
-<pattern>1mo</pattern>
-<pattern>5mo </pattern>
-<pattern>mo3a</pattern>
-<pattern>5moda</pattern>
-<pattern>5mode</pattern>
-<pattern>moed4s</pattern>
-<pattern>2moef</pattern>
-<pattern>5moei</pattern>
-<pattern>moers5t</pattern>
-<pattern>moe2s</pattern>
-<pattern>moes3p</pattern>
-<pattern>moes4te</pattern>
-<pattern>mog2</pattern>
-<pattern>5moge</pattern>
-<pattern>mogen4s</pattern>
-<pattern>mo3gl</pattern>
-<pattern>4mok</pattern>
-<pattern>5mole</pattern>
-<pattern>2moli</pattern>
-<pattern>mo4lie</pattern>
-<pattern>mol4m3a</pattern>
-<pattern>4molt</pattern>
-<pattern>3mom</pattern>
-<pattern>4m3omv</pattern>
-<pattern>mond3r</pattern>
-<pattern>mo5no</pattern>
-<pattern>5mons</pattern>
-<pattern>mon4so</pattern>
-<pattern>mon5ta</pattern>
-<pattern>3mooi</pattern>
-<pattern>2mop</pattern>
-<pattern>mo3pa</pattern>
-<pattern>m1ope</pattern>
-<pattern>m4opp</pattern>
-<pattern>mop4s</pattern>
-<pattern>mo3ra</pattern>
-<pattern>mo3r4e</pattern>
-<pattern>mo3ro</pattern>
-<pattern>mor4sp</pattern>
-<pattern>mor4st</pattern>
-<pattern>mors5te </pattern>
-<pattern>5mos</pattern>
-<pattern>mo5sc</pattern>
-<pattern>mo4s5l</pattern>
-<pattern>mo3sta</pattern>
-<pattern>mo3t2h</pattern>
-<pattern>mot3j</pattern>
-<pattern>mot3ol</pattern>
-<pattern>mot4st</pattern>
-<pattern>mots5te </pattern>
-<pattern>2m3oud</pattern>
-<pattern>5mouw</pattern>
-<pattern>mou4wi</pattern>
-<pattern>mo3v</pattern>
-<pattern>m3ox</pattern>
-<pattern>2m1p</pattern>
-<pattern>mp3ach</pattern>
-<pattern>m4p3af</pattern>
-<pattern>m5pan</pattern>
-<pattern>mp3arm</pattern>
-<pattern>mp5arts</pattern>
-<pattern>m4p3ec</pattern>
-<pattern>m5pen</pattern>
-<pattern>m4p3erv</pattern>
-<pattern>mp3ins</pattern>
-<pattern>m3pl</pattern>
-<pattern>mp3lam</pattern>
-<pattern>m5plan</pattern>
-<pattern>mp3leg</pattern>
-<pattern>mp3lei</pattern>
-<pattern>mp3lev</pattern>
-<pattern>mp3lie</pattern>
-<pattern>m4plu</pattern>
-<pattern>mp5olie</pattern>
-<pattern>m5pon</pattern>
-<pattern>mpon4g</pattern>
-<pattern>mp3ope</pattern>
-<pattern>mp2r</pattern>
-<pattern>mp3rec</pattern>
-<pattern>mp3red</pattern>
-<pattern>m5pres</pattern>
-<pattern>m4ps2</pattern>
-<pattern>mp5sc</pattern>
-<pattern>m5p4se</pattern>
-<pattern>mp3sh</pattern>
-<pattern>mp5su</pattern>
-<pattern>2m1r</pattern>
-<pattern>2ms</pattern>
-<pattern>m3sam</pattern>
-<pattern>ms3ana</pattern>
-<pattern>ms3ap</pattern>
-<pattern>ms2c</pattern>
-<pattern>ms3co</pattern>
-<pattern>ms3cu</pattern>
-<pattern>ms2j</pattern>
-<pattern>m3sje</pattern>
-<pattern>m1sl</pattern>
-<pattern>m2sle</pattern>
-<pattern>ms3len</pattern>
-<pattern>ms3lie</pattern>
-<pattern>m3s2m</pattern>
-<pattern>ms3ma</pattern>
-<pattern>m1sn</pattern>
-<pattern>ms3nee</pattern>
-<pattern>mso4</pattern>
-<pattern>m3sol</pattern>
-<pattern>ms3or</pattern>
-<pattern>m3s2p</pattern>
-<pattern>ms4t</pattern>
-<pattern>m3sta</pattern>
-<pattern>m1ste</pattern>
-<pattern>ms5tec</pattern>
-<pattern>m5stel</pattern>
-<pattern>m5sten</pattern>
-<pattern>m1sti</pattern>
-<pattern>m1sto</pattern>
-<pattern>ms5toc</pattern>
-<pattern>m4s5ton</pattern>
-<pattern>mst5s</pattern>
-<pattern>m3sy</pattern>
-<pattern>2mt</pattern>
-<pattern>m1ta</pattern>
-<pattern>mte5re</pattern>
-<pattern>mtes4</pattern>
-<pattern>mte5sta</pattern>
-<pattern>m1th</pattern>
-<pattern>m1to</pattern>
-<pattern>m3tr</pattern>
-<pattern>m1tu</pattern>
-<pattern>1mu</pattern>
-<pattern>mu5da</pattern>
-<pattern>mue4</pattern>
-<pattern>5muilde </pattern>
-<pattern>2muit</pattern>
-<pattern>2muk</pattern>
-<pattern>mul3p</pattern>
-<pattern>mu2m3</pattern>
-<pattern>mu3no</pattern>
-<pattern>munt3j</pattern>
-<pattern>mu3sa</pattern>
-<pattern>mus5ta</pattern>
-<pattern>5mut</pattern>
-<pattern>mut3j</pattern>
-<pattern>muts2</pattern>
-<pattern>muts5te</pattern>
-<pattern>3muu</pattern>
-<pattern>5muz</pattern>
-<pattern>2mv</pattern>
-<pattern>mvari5</pattern>
-<pattern>mve4</pattern>
-<pattern>mvee3</pattern>
-<pattern>mver3e</pattern>
-<pattern>2m1w</pattern>
-<pattern>1my</pattern>
-<pattern>my3e</pattern>
-<pattern>2mz</pattern>
-<pattern>mze4</pattern>
-<pattern>mzet5</pattern>
-<pattern>4n </pattern>
-<pattern>1na</pattern>
-<pattern>3na </pattern>
-<pattern>3naal</pattern>
-<pattern>5n4aam</pattern>
-<pattern>4n1aan</pattern>
-<pattern>2naap</pattern>
-<pattern>n4aar </pattern>
-<pattern>4n3aard</pattern>
-<pattern>5naars</pattern>
-<pattern>naars5tr</pattern>
-<pattern>naar5tj</pattern>
-<pattern>5naast</pattern>
-<pattern>5naat</pattern>
-<pattern>n3abd</pattern>
-<pattern>5nabe</pattern>
-<pattern>2nac</pattern>
-<pattern>na2ca</pattern>
-<pattern>nacee5t</pattern>
-<pattern>n2aci</pattern>
-<pattern>3naco</pattern>
-<pattern>4n3act</pattern>
-<pattern>na5d4a</pattern>
-<pattern>nad4e</pattern>
-<pattern>3nade </pattern>
-<pattern>5n4a5den</pattern>
-<pattern>3nades</pattern>
-<pattern>3nadi</pattern>
-<pattern>4n3adm</pattern>
-<pattern>na5dra</pattern>
-<pattern>2n1adv</pattern>
-<pattern>5nae</pattern>
-<pattern>n3aë</pattern>
-<pattern>4n1af</pattern>
-<pattern>na3f4lu</pattern>
-<pattern>n2a3g4</pattern>
-<pattern>na1h</pattern>
-<pattern>3nai</pattern>
-<pattern>3naï</pattern>
-<pattern>n2ake</pattern>
-<pattern>na3k4l</pattern>
-<pattern>na3kr</pattern>
-<pattern>n3alb</pattern>
-<pattern>3n4ale</pattern>
-<pattern>5nalen</pattern>
-<pattern>4n3alf</pattern>
-<pattern>n3alm</pattern>
-<pattern>2naly</pattern>
-<pattern>4nalys</pattern>
-<pattern>3nam</pattern>
-<pattern>4namb</pattern>
-<pattern>name5st</pattern>
-<pattern>n4ami</pattern>
-<pattern>n3amp</pattern>
-<pattern>n3a2na</pattern>
-<pattern>n3ank</pattern>
-<pattern>3nant</pattern>
-<pattern>5nant </pattern>
-<pattern>5nante</pattern>
-<pattern>n5antenn</pattern>
-<pattern>nan4t3j</pattern>
-<pattern>2nap</pattern>
-<pattern>nap3ac</pattern>
-<pattern>3na3p4l</pattern>
-<pattern>na3p4r</pattern>
-<pattern>nap3s</pattern>
-<pattern>nap5st</pattern>
-<pattern>2n1arb</pattern>
-<pattern>5nares</pattern>
-<pattern>2n3arg</pattern>
-<pattern>narie5t</pattern>
-<pattern>2n1arm</pattern>
-<pattern>3naro</pattern>
-<pattern>4nars</pattern>
-<pattern>nar4st</pattern>
-<pattern>nars5te </pattern>
-<pattern>nar5sten</pattern>
-<pattern>4n1art</pattern>
-<pattern>nas2</pattern>
-<pattern>3na3sa</pattern>
-<pattern>na1s4l</pattern>
-<pattern>na1sp</pattern>
-<pattern>na3sta</pattern>
-<pattern>na3stu</pattern>
-<pattern>n4at </pattern>
-<pattern>3n4ati</pattern>
-<pattern>nat5j</pattern>
-<pattern>4n3atl</pattern>
-<pattern>na3to</pattern>
-<pattern>nats4</pattern>
-<pattern>nat3sp</pattern>
-<pattern>5nau </pattern>
-<pattern>5naus</pattern>
-<pattern>2na3v</pattern>
-<pattern>5naven</pattern>
-<pattern>3navi</pattern>
-<pattern>3nazif</pattern>
-<pattern>na4zij</pattern>
-<pattern>2nb</pattern>
-<pattern>nbe5st</pattern>
-<pattern>nbe5t</pattern>
-<pattern>nbots5te </pattern>
-<pattern>2n1c</pattern>
-<pattern>n3ce</pattern>
-<pattern>nces4t</pattern>
-<pattern>n3che</pattern>
-<pattern>ncht2</pattern>
-<pattern>nch5tr</pattern>
-<pattern>nch3u</pattern>
-<pattern>n5co</pattern>
-<pattern>4nd</pattern>
-<pattern>n5da </pattern>
-<pattern>nd3aan</pattern>
-<pattern>nd5aas</pattern>
-<pattern>nd3abo</pattern>
-<pattern>nd3act</pattern>
-<pattern>nd5adel</pattern>
-<pattern>nd3adr</pattern>
-<pattern>ndags5p</pattern>
-<pattern>nd3alf</pattern>
-<pattern>nd3alm</pattern>
-<pattern>n4d3ana</pattern>
-<pattern>n4dap</pattern>
-<pattern>n2dar</pattern>
-<pattern>nd3art</pattern>
-<pattern>n4das</pattern>
-<pattern>nd3ass</pattern>
-<pattern>nda3st</pattern>
-<pattern>n4dav</pattern>
-<pattern>n4d3a4z</pattern>
-<pattern>n3de</pattern>
-<pattern>n4d3edi</pattern>
-<pattern>n4d1ei</pattern>
-<pattern>nde5laa</pattern>
-<pattern>n4d3emm</pattern>
-<pattern>n5den </pattern>
-<pattern>ndera4</pattern>
-<pattern>nder5aal</pattern>
-<pattern>nder5al</pattern>
-<pattern>nde4r5an</pattern>
-<pattern>n4d5e4rec</pattern>
-<pattern>nder5in </pattern>
-<pattern>nder5og</pattern>
-<pattern>nde4ten</pattern>
-<pattern>ndi3a</pattern>
-<pattern>ndie4tj</pattern>
-<pattern>n4dijs</pattern>
-<pattern>nd5ijs </pattern>
-<pattern>n4d3ink</pattern>
-<pattern>ndi3o</pattern>
-<pattern>n3d2ji</pattern>
-<pattern>n5do </pattern>
-<pattern>n5doc</pattern>
-<pattern>n4d5of</pattern>
-<pattern>nd3oli</pattern>
-<pattern>nd3omd</pattern>
-<pattern>n4don</pattern>
-<pattern>n5dona</pattern>
-<pattern>nd5ond</pattern>
-<pattern>n5dons</pattern>
-<pattern>nd3ont</pattern>
-<pattern>nd3oog</pattern>
-<pattern>nd3ope</pattern>
-<pattern>nd3opp</pattern>
-<pattern>nd3ov</pattern>
-<pattern>nd5rap</pattern>
-<pattern>nd3rat</pattern>
-<pattern>nd1re</pattern>
-<pattern>nd4rek</pattern>
-<pattern>n4dres</pattern>
-<pattern>nd3rot</pattern>
-<pattern>nd3rug</pattern>
-<pattern>nd3s4cu</pattern>
-<pattern>nd4sec</pattern>
-<pattern>nd5set</pattern>
-<pattern>nd3s4i</pattern>
-<pattern>nd3sjo</pattern>
-<pattern>nd4sm</pattern>
-<pattern>nd3sp</pattern>
-<pattern>nd4spo</pattern>
-<pattern>nd4spra</pattern>
-<pattern>nds5taal</pattern>
-<pattern>nd3su</pattern>
-<pattern>nd3uit</pattern>
-<pattern>n2d3u4r</pattern>
-<pattern>nd5ure</pattern>
-<pattern>n4d3uu</pattern>
-<pattern>nd1w</pattern>
-<pattern>n3dy</pattern>
-<pattern>1ne</pattern>
-<pattern>3ne </pattern>
-<pattern>ne5ac</pattern>
-<pattern>ne3am</pattern>
-<pattern>nebe4s</pattern>
-<pattern>3neck</pattern>
-<pattern>ne2cl</pattern>
-<pattern>ne4dit</pattern>
-<pattern>ne3do</pattern>
-<pattern>n3edu</pattern>
-<pattern>ne5dw</pattern>
-<pattern>nee4</pattern>
-<pattern>4need</pattern>
-<pattern>nee5k</pattern>
-<pattern>neel5d</pattern>
-<pattern>neel3o</pattern>
-<pattern>3neem</pattern>
-<pattern>4n1een</pattern>
-<pattern>nee5ri</pattern>
-<pattern>nee5se</pattern>
-<pattern>neet3a</pattern>
-<pattern>neet5o</pattern>
-<pattern>neet3r</pattern>
-<pattern>neet5s</pattern>
-<pattern>4n1eff</pattern>
-<pattern>ne3g2</pattern>
-<pattern>ne4gel</pattern>
-<pattern>negen5en</pattern>
-<pattern>nege4re</pattern>
-<pattern>4n1ei</pattern>
-<pattern>5neien</pattern>
-<pattern>n5eier</pattern>
-<pattern>n2eig</pattern>
-<pattern>5neigd</pattern>
-<pattern>5nei5t</pattern>
-<pattern>ne4k3r</pattern>
-<pattern>ne2la</pattern>
-<pattern>4nelem</pattern>
-<pattern>4nelf</pattern>
-<pattern>3nem</pattern>
-<pattern>4n3emb</pattern>
-<pattern>5n4eme</pattern>
-<pattern>4n3e4mig</pattern>
-<pattern>4n3emm</pattern>
-<pattern>4n3emp</pattern>
-<pattern>ne2n</pattern>
-<pattern>3n4en </pattern>
-<pattern>5nenb</pattern>
-<pattern>5n4end </pattern>
-<pattern>nen5do</pattern>
-<pattern>ne4n5enk</pattern>
-<pattern>ne4ni</pattern>
-<pattern>ne5nig</pattern>
-<pattern>nen5k4</pattern>
-<pattern>nen1o4</pattern>
-<pattern>5nenp</pattern>
-<pattern>nen5t4a</pattern>
-<pattern>ne5oc</pattern>
-<pattern>ne5ok</pattern>
-<pattern>ne5om</pattern>
-<pattern>neo5p</pattern>
-<pattern>ne5os</pattern>
-<pattern>ne5ot</pattern>
-<pattern>nep3ag</pattern>
-<pattern>ne3pe</pattern>
-<pattern>nepi3s</pattern>
-<pattern>ne1ra</pattern>
-<pattern>nera4d</pattern>
-<pattern>3n2e5re</pattern>
-<pattern>n3erfe</pattern>
-<pattern>2nerg</pattern>
-<pattern>ne4r3id</pattern>
-<pattern>ne3ros</pattern>
-<pattern>ner4sl</pattern>
-<pattern>ner4sp</pattern>
-<pattern>ner4st</pattern>
-<pattern>ners5te</pattern>
-<pattern>ner3u</pattern>
-<pattern>ne3ry</pattern>
-<pattern>3nes</pattern>
-<pattern>ness5a</pattern>
-<pattern>ness5t</pattern>
-<pattern>ne3sta</pattern>
-<pattern>nes3te</pattern>
-<pattern>nes4tei</pattern>
-<pattern>ne5s4tek</pattern>
-<pattern>ne4ter</pattern>
-<pattern>net3on</pattern>
-<pattern>net4si</pattern>
-<pattern>ne2u</pattern>
-<pattern>4neum</pattern>
-<pattern>ne3ums</pattern>
-<pattern>neu5ste</pattern>
-<pattern>2nex</pattern>
-<pattern>3né</pattern>
-<pattern>2n3f</pattern>
-<pattern>2ng</pattern>
-<pattern>ngaat5j</pattern>
-<pattern>n2g1a2d</pattern>
-<pattern>ng3af</pattern>
-<pattern>ng3ana</pattern>
-<pattern>n4ga4p</pattern>
-<pattern>n2gar</pattern>
-<pattern>nga5sl</pattern>
-<pattern>n3gav</pattern>
-<pattern>nge4ad</pattern>
-<pattern>n4g3een</pattern>
-<pattern>ngels5te </pattern>
-<pattern>ng3emb</pattern>
-<pattern>n5gen</pattern>
-<pattern>nge4rap</pattern>
-<pattern>nge4ras</pattern>
-<pattern>n4giger</pattern>
-<pattern>n4gigs</pattern>
-<pattern>ng3ij</pattern>
-<pattern>n4gind</pattern>
-<pattern>ng3ink</pattern>
-<pattern>n4g3ins</pattern>
-<pattern>ng4l</pattern>
-<pattern>ng5lad</pattern>
-<pattern>ng5lam</pattern>
-<pattern>ng5lan</pattern>
-<pattern>ng5led</pattern>
-<pattern>ng5leu</pattern>
-<pattern>ng2li</pattern>
-<pattern>ng5lin</pattern>
-<pattern>ng5lop</pattern>
-<pattern>n3goe</pattern>
-<pattern>ng3of</pattern>
-<pattern>n3goï</pattern>
-<pattern>n2g1on</pattern>
-<pattern>ng5oor</pattern>
-<pattern>ng5op</pattern>
-<pattern>ng3ore</pattern>
-<pattern>ng3org</pattern>
-<pattern>n3got</pattern>
-<pattern>n3gr</pattern>
-<pattern>ng3rac</pattern>
-<pattern>ng3rad</pattern>
-<pattern>ng3rai</pattern>
-<pattern>n4gras</pattern>
-<pattern>ng5rass</pattern>
-<pattern>ng4red</pattern>
-<pattern>n4g4ri</pattern>
-<pattern>ng5rie</pattern>
-<pattern>ng3rij</pattern>
-<pattern>n5gron</pattern>
-<pattern>ng3rui</pattern>
-<pattern>ng2s</pattern>
-<pattern>ng4se</pattern>
-<pattern>ngs5lop</pattern>
-<pattern>ngs5lu</pattern>
-<pattern>ng4s5ne</pattern>
-<pattern>ngs5tak </pattern>
-<pattern>ngs5take</pattern>
-<pattern>ngs5trek</pattern>
-<pattern>ng5stri</pattern>
-<pattern>ng3uit</pattern>
-<pattern>4n3h</pattern>
-<pattern>nhek5</pattern>
-<pattern>1ni</pattern>
-<pattern>n4i2d</pattern>
-<pattern>nie5kle</pattern>
-<pattern>ni3eri</pattern>
-<pattern>nie4s3p</pattern>
-<pattern>nie4tr</pattern>
-<pattern>3nieu</pattern>
-<pattern>ni4g3ee</pattern>
-<pattern>nig3ra</pattern>
-<pattern>nij3f</pattern>
-<pattern>nij3k</pattern>
-<pattern>2n3ijz</pattern>
-<pattern>ni5kr</pattern>
-<pattern>nik4s</pattern>
-<pattern>niks3p</pattern>
-<pattern>3nil</pattern>
-<pattern>3nim </pattern>
-<pattern>5nimf</pattern>
-<pattern>n3imp</pattern>
-<pattern>2n3in </pattern>
-<pattern>n3inb</pattern>
-<pattern>2n1ind</pattern>
-<pattern>2ninf</pattern>
-<pattern>ning3r</pattern>
-<pattern>2n3inh</pattern>
-<pattern>n3inj</pattern>
-<pattern>2ninr</pattern>
-<pattern>2n1ins</pattern>
-<pattern>2n1int</pattern>
-<pattern>2n3inv</pattern>
-<pattern>ni3o</pattern>
-<pattern>ni4on </pattern>
-<pattern>ni4one</pattern>
-<pattern>ni5or</pattern>
-<pattern>ni5o5s4</pattern>
-<pattern>nip3l</pattern>
-<pattern>3nis</pattern>
-<pattern>ni4sau</pattern>
-<pattern>ni4sel</pattern>
-<pattern>ni4s3ev</pattern>
-<pattern>ni3sfe</pattern>
-<pattern>ni2s3i</pattern>
-<pattern>ni4sl</pattern>
-<pattern>nis5n</pattern>
-<pattern>ni3sot</pattern>
-<pattern>ni5stel</pattern>
-<pattern>nis5to</pattern>
-<pattern>ni3t2h</pattern>
-<pattern>ni1tr</pattern>
-<pattern>nits4</pattern>
-<pattern>n1j4</pattern>
-<pattern>n3je</pattern>
-<pattern>njes4</pattern>
-<pattern>nje5sp</pattern>
-<pattern>nje5st</pattern>
-<pattern>nje3t</pattern>
-<pattern>4n1k</pattern>
-<pattern>nk3aan</pattern>
-<pattern>nk5aard</pattern>
-<pattern>nkaart5j</pattern>
-<pattern>nk3af</pattern>
-<pattern>n5k4am</pattern>
-<pattern>n4k3arb</pattern>
-<pattern>nkar5s</pattern>
-<pattern>n4k3asp</pattern>
-<pattern>n3kef</pattern>
-<pattern>nk3eff</pattern>
-<pattern>nk3emp</pattern>
-<pattern>n3ken</pattern>
-<pattern>nken4e</pattern>
-<pattern>nker5ku</pattern>
-<pattern>nk3id</pattern>
-<pattern>nk2j</pattern>
-<pattern>nk3lad</pattern>
-<pattern>nk3lod</pattern>
-<pattern>nk3luc</pattern>
-<pattern>nk3lus</pattern>
-<pattern>n2k3na</pattern>
-<pattern>n3kne</pattern>
-<pattern>n4ko4g</pattern>
-<pattern>nk3oge</pattern>
-<pattern>nkoot5</pattern>
-<pattern>nk4ra</pattern>
-<pattern>n4krim</pattern>
-<pattern>nk3rol</pattern>
-<pattern>nk5se</pattern>
-<pattern>nk5si</pattern>
-<pattern>nk3sl</pattern>
-<pattern>nk3s4m</pattern>
-<pattern>nk3sn</pattern>
-<pattern>nk4s5o</pattern>
-<pattern>nk1sp</pattern>
-<pattern>nk1st</pattern>
-<pattern>n4kw</pattern>
-<pattern>nk3waa</pattern>
-<pattern>nk3wez</pattern>
-<pattern>nk3wi</pattern>
-<pattern>2n3l</pattern>
-<pattern>2n3m4</pattern>
-<pattern>n3n</pattern>
-<pattern>n5n2e</pattern>
-<pattern>nnee5t</pattern>
-<pattern>nne3ne</pattern>
-<pattern>nnepo4</pattern>
-<pattern>nne4p5ol</pattern>
-<pattern>nne5te</pattern>
-<pattern>nnet4j</pattern>
-<pattern>nn4i</pattern>
-<pattern>nning5r</pattern>
-<pattern>nnoot5</pattern>
-<pattern>nno5v</pattern>
-<pattern>3no </pattern>
-<pattern>1noc</pattern>
-<pattern>1no3d</pattern>
-<pattern>2noef</pattern>
-<pattern>noen5s</pattern>
-<pattern>noes3</pattern>
-<pattern>noet5s</pattern>
-<pattern>n5offi</pattern>
-<pattern>n3o2ge</pattern>
-<pattern>n5ogi</pattern>
-<pattern>1nogr</pattern>
-<pattern>3noï</pattern>
-<pattern>no3kl</pattern>
-<pattern>no3k2w</pattern>
-<pattern>no2li</pattern>
-<pattern>1nolo</pattern>
-<pattern>1nom</pattern>
-<pattern>4n3om </pattern>
-<pattern>n2oma</pattern>
-<pattern>n3oml</pattern>
-<pattern>n1oms</pattern>
-<pattern>n3omv</pattern>
-<pattern>2n3omw</pattern>
-<pattern>2nomz</pattern>
-<pattern>3n2on </pattern>
-<pattern>3n4onb</pattern>
-<pattern>3nonc</pattern>
-<pattern>4n5ond</pattern>
-<pattern>n4o5ni</pattern>
-<pattern>4nont</pattern>
-<pattern>3nood</pattern>
-<pattern>4n5oof</pattern>
-<pattern>4n1oog</pattern>
-<pattern>nooi5tj</pattern>
-<pattern>3noot3</pattern>
-<pattern>noot4j</pattern>
-<pattern>3no3pa</pattern>
-<pattern>no4p3as</pattern>
-<pattern>4n3opb</pattern>
-<pattern>no1pe</pattern>
-<pattern>n1opg</pattern>
-<pattern>n5opleidi</pattern>
-<pattern>no4poo</pattern>
-<pattern>no4por</pattern>
-<pattern>2nops</pattern>
-<pattern>2n3opz</pattern>
-<pattern>2nord</pattern>
-<pattern>no3re</pattern>
-<pattern>2n1org</pattern>
-<pattern>1norm</pattern>
-<pattern>4norr</pattern>
-<pattern>3nors</pattern>
-<pattern>3norz</pattern>
-<pattern>1nos</pattern>
-<pattern>no3sf</pattern>
-<pattern>no3sn</pattern>
-<pattern>no3sp</pattern>
-<pattern>1not</pattern>
-<pattern>3nota</pattern>
-<pattern>not5a4p</pattern>
-<pattern>5noti</pattern>
-<pattern>not3j</pattern>
-<pattern>not3r</pattern>
-<pattern>3nou </pattern>
-<pattern>no3v</pattern>
-<pattern>3nova</pattern>
-<pattern>no4ve</pattern>
-<pattern>3nox</pattern>
-<pattern>3noz</pattern>
-<pattern>2n1p</pattern>
-<pattern>npers5te </pattern>
-<pattern>npi4s5</pattern>
-<pattern>npoor4</pattern>
-<pattern>npoort5j</pattern>
-<pattern>n3ps</pattern>
-<pattern>2n3r</pattern>
-<pattern>nraads5l</pattern>
-<pattern>n5re</pattern>
-<pattern>n5ri</pattern>
-<pattern>2ns</pattern>
-<pattern>ns3a4d</pattern>
-<pattern>n3sag</pattern>
-<pattern>n1sal</pattern>
-<pattern>ns3alp</pattern>
-<pattern>n1sam</pattern>
-<pattern>ns3an</pattern>
-<pattern>n3sanc</pattern>
-<pattern>n1sap</pattern>
-<pattern>n3s4cal</pattern>
-<pattern>n5scho</pattern>
-<pattern>ns4ci</pattern>
-<pattern>n4sco</pattern>
-<pattern>nsee5t</pattern>
-<pattern>n4sef</pattern>
-<pattern>nse4g</pattern>
-<pattern>ns5ege</pattern>
-<pattern>ns3eis</pattern>
-<pattern>ns5emp</pattern>
-<pattern>n3si</pattern>
-<pattern>ns3idi</pattern>
-<pattern>n2sin</pattern>
-<pattern>n5sing</pattern>
-<pattern>ns3inj</pattern>
-<pattern>ns3ink</pattern>
-<pattern>ns3int</pattern>
-<pattern>n1sjo</pattern>
-<pattern>n1sl</pattern>
-<pattern>n5sla </pattern>
-<pattern>n3s4laa</pattern>
-<pattern>ns5laag</pattern>
-<pattern>n5slag</pattern>
-<pattern>ns5lap </pattern>
-<pattern>ns5lapp</pattern>
-<pattern>n4sle</pattern>
-<pattern>n5slep</pattern>
-<pattern>ns4let</pattern>
-<pattern>n5sleu</pattern>
-<pattern>n5slib</pattern>
-<pattern>ns3lie</pattern>
-<pattern>n5s4liep</pattern>
-<pattern>n5slim</pattern>
-<pattern>n5slip</pattern>
-<pattern>ns5lot </pattern>
-<pattern>ns3m</pattern>
-<pattern>ns5mac</pattern>
-<pattern>n3s4me</pattern>
-<pattern>n3smij</pattern>
-<pattern>n3smol</pattern>
-<pattern>n4smu</pattern>
-<pattern>n1sn</pattern>
-<pattern>n2sna</pattern>
-<pattern>n5sne</pattern>
-<pattern>ns3nod</pattern>
-<pattern>n4snoo</pattern>
-<pattern>n4snot</pattern>
-<pattern>n1so</pattern>
-<pattern>n2s3ob</pattern>
-<pattern>n2sof</pattern>
-<pattern>n3sol</pattern>
-<pattern>n2son</pattern>
-<pattern>ns3ong</pattern>
-<pattern>ns3onz</pattern>
-<pattern>ns4opp</pattern>
-<pattern>ns4or</pattern>
-<pattern>n2s3ou</pattern>
-<pattern>ns1ov</pattern>
-<pattern>n4s3paa</pattern>
-<pattern>ns3pad</pattern>
-<pattern>n1spe</pattern>
-<pattern>n5spee</pattern>
-<pattern>n5spel</pattern>
-<pattern>ns3per</pattern>
-<pattern>n4spet</pattern>
-<pattern>ns4pi</pattern>
-<pattern>ns1po</pattern>
-<pattern>ns3pol</pattern>
-<pattern>n4spot</pattern>
-<pattern>n1spr</pattern>
-<pattern>ns5q</pattern>
-<pattern>ns5s</pattern>
-<pattern>ns4t</pattern>
-<pattern>n1sta</pattern>
-<pattern>nst5aang</pattern>
-<pattern>nst5aans</pattern>
-<pattern>nst3a4g</pattern>
-<pattern>n3stal</pattern>
-<pattern>n3ste</pattern>
-<pattern>ns5tec</pattern>
-<pattern>n4st3ei</pattern>
-<pattern>n4s5teko</pattern>
-<pattern>ns5teks</pattern>
-<pattern>n5sten </pattern>
-<pattern>ns5tent</pattern>
-<pattern>n5ster </pattern>
-<pattern>ns5tes</pattern>
-<pattern>ns3the</pattern>
-<pattern>n1sti</pattern>
-<pattern>n3stig</pattern>
-<pattern>n4stijv</pattern>
-<pattern>n1sto</pattern>
-<pattern>nst5oef</pattern>
-<pattern>n4ston</pattern>
-<pattern>n3stor</pattern>
-<pattern>nst5rade</pattern>
-<pattern>n5stree</pattern>
-<pattern>ns5trekk</pattern>
-<pattern>ns5troe</pattern>
-<pattern>ns5trog</pattern>
-<pattern>nst5roos</pattern>
-<pattern>ns5ty</pattern>
-<pattern>ns3uil</pattern>
-<pattern>n3sy</pattern>
-<pattern>2nt</pattern>
-<pattern>n3ta</pattern>
-<pattern>n5taal</pattern>
-<pattern>n4t5aard</pattern>
-<pattern>ntaar5tj</pattern>
-<pattern>n5tab</pattern>
-<pattern>nt3ach</pattern>
-<pattern>nt4act</pattern>
-<pattern>nt1ad</pattern>
-<pattern>nt3aga</pattern>
-<pattern>n4t3art</pattern>
-<pattern>nt4as</pattern>
-<pattern>n5t4at</pattern>
-<pattern>n3te</pattern>
-<pattern>n5tec</pattern>
-<pattern>n4t3ei</pattern>
-<pattern>nte4lo</pattern>
-<pattern>n5tem</pattern>
-<pattern>n5te2n</pattern>
-<pattern>nte5nach</pattern>
-<pattern>ntene5ten</pattern>
-<pattern>nte5rad</pattern>
-<pattern>nte4rof</pattern>
-<pattern>n3tè</pattern>
-<pattern>nt3ha</pattern>
-<pattern>n4tho</pattern>
-<pattern>n5thol</pattern>
-<pattern>n5tig</pattern>
-<pattern>nt3inw</pattern>
-<pattern>nt4jo</pattern>
-<pattern>n3to</pattern>
-<pattern>nt4og</pattern>
-<pattern>nt4ol</pattern>
-<pattern>n4t5oli</pattern>
-<pattern>n5ton</pattern>
-<pattern>nt4oo</pattern>
-<pattern>nt5oog</pattern>
-<pattern>n4top</pattern>
-<pattern>nt3opl</pattern>
-<pattern>nt3opm</pattern>
-<pattern>nt3opt</pattern>
-<pattern>n1tr</pattern>
-<pattern>nt3rec</pattern>
-<pattern>nt3rei</pattern>
-<pattern>nt3rel</pattern>
-<pattern>ntre4s</pattern>
-<pattern>nt5ribb</pattern>
-<pattern>nt5rij</pattern>
-<pattern>n5troos</pattern>
-<pattern>nt4rou</pattern>
-<pattern>nt3rus</pattern>
-<pattern>n5try</pattern>
-<pattern>nts3a</pattern>
-<pattern>nt5slu</pattern>
-<pattern>nt1sn</pattern>
-<pattern>nt4sno</pattern>
-<pattern>nt1sp</pattern>
-<pattern>nt4spr</pattern>
-<pattern>nts5pre</pattern>
-<pattern>nt1st</pattern>
-<pattern>nt5ste</pattern>
-<pattern>n3tu</pattern>
-<pattern>n4t3uit</pattern>
-<pattern>ntu4n</pattern>
-<pattern>n5twijf</pattern>
-<pattern>n5t4wis</pattern>
-<pattern>3nu </pattern>
-<pattern>3nuc</pattern>
-<pattern>3nue</pattern>
-<pattern>nu3en</pattern>
-<pattern>nu3et</pattern>
-<pattern>4nuf</pattern>
-<pattern>2nui</pattern>
-<pattern>4n3uil</pattern>
-<pattern>nu2lo</pattern>
-<pattern>3num</pattern>
-<pattern>nu2m3a</pattern>
-<pattern>5numm</pattern>
-<pattern>nu2n</pattern>
-<pattern>3nunc</pattern>
-<pattern>n3uni</pattern>
-<pattern>2nu4r</pattern>
-<pattern>3n4u5ri</pattern>
-<pattern>nu5ro</pattern>
-<pattern>1nus</pattern>
-<pattern>nu4s3o</pattern>
-<pattern>nu3tr</pattern>
-<pattern>nut4st</pattern>
-<pattern>4nuu</pattern>
-<pattern>5nuut</pattern>
-<pattern>nuw5a</pattern>
-<pattern>nu2w3i</pattern>
-<pattern>2nv</pattern>
-<pattern>nve5na</pattern>
-<pattern>2n1w</pattern>
-<pattern>nx3</pattern>
-<pattern>n3xe</pattern>
-<pattern>nxo4</pattern>
-<pattern>1ny</pattern>
-<pattern>4n3yi</pattern>
-<pattern>4n3yo</pattern>
-<pattern>2nz</pattern>
-<pattern>nzet5s</pattern>
-<pattern>3ñ</pattern>
-<pattern>4o </pattern>
-<pattern>4oa</pattern>
-<pattern>o3aa</pattern>
-<pattern>o2ad</pattern>
-<pattern>o3af</pattern>
-<pattern>o1ag</pattern>
-<pattern>o3ah</pattern>
-<pattern>o3ai</pattern>
-<pattern>o1al</pattern>
-<pattern>oa2m</pattern>
-<pattern>o1a2n</pattern>
-<pattern>oa4tiev</pattern>
-<pattern>o3au</pattern>
-<pattern>o3av</pattern>
-<pattern>o3ax</pattern>
-<pattern>2o3b</pattern>
-<pattern>4ob </pattern>
-<pattern>obal4</pattern>
-<pattern>obalt3</pattern>
-<pattern>3obj</pattern>
-<pattern>1o4bli</pattern>
-<pattern>ob5oor</pattern>
-<pattern>o4b5o4r</pattern>
-<pattern>4obr</pattern>
-<pattern>4oca</pattern>
-<pattern>ocaat5</pattern>
-<pattern>5o2cea</pattern>
-<pattern>o3cha</pattern>
-<pattern>o1che</pattern>
-<pattern>o3chi</pattern>
-<pattern>o3cho</pattern>
-<pattern>o3chr</pattern>
-<pattern>ocke4</pattern>
-<pattern>4o3co</pattern>
-<pattern>oco3a</pattern>
-<pattern>oco3s4</pattern>
-<pattern>oc3t4</pattern>
-<pattern>od5ac</pattern>
-<pattern>oda3g</pattern>
-<pattern>ode4m5ar</pattern>
-<pattern>ode4mo</pattern>
-<pattern>ode5re</pattern>
-<pattern>odes4</pattern>
-<pattern>odi3a</pattern>
-<pattern>o5dru</pattern>
-<pattern>od5sc</pattern>
-<pattern>od5sei</pattern>
-<pattern>od3s4i</pattern>
-<pattern>od2sl</pattern>
-<pattern>ods5lam</pattern>
-<pattern>od5slan</pattern>
-<pattern>od3sli</pattern>
-<pattern>od5smak</pattern>
-<pattern>od4s3o</pattern>
-<pattern>od3spo</pattern>
-<pattern>od4spr</pattern>
-<pattern>ods4t</pattern>
-<pattern>od5sta</pattern>
-<pattern>od4ste</pattern>
-<pattern>ods5te </pattern>
-<pattern>od5stek</pattern>
-<pattern>od5sten</pattern>
-<pattern>od3w</pattern>
-<pattern>o4e</pattern>
-<pattern>oe5an</pattern>
-<pattern>oe3as</pattern>
-<pattern>oe2d3a</pattern>
-<pattern>oeda4d</pattern>
-<pattern>oede4n</pattern>
-<pattern>oe2d3o2</pattern>
-<pattern>oe4dr</pattern>
-<pattern>oed3re</pattern>
-<pattern>oed3ri</pattern>
-<pattern>oed3ro</pattern>
-<pattern>oe2d3u</pattern>
-<pattern>oed3w</pattern>
-<pattern>oe3e</pattern>
-<pattern>oe5er</pattern>
-<pattern>oe4f1a</pattern>
-<pattern>1oefe</pattern>
-<pattern>oe2fi</pattern>
-<pattern>oe2fl</pattern>
-<pattern>oef3la</pattern>
-<pattern>oef5le</pattern>
-<pattern>oef3lo</pattern>
-<pattern>oe4f5o4</pattern>
-<pattern>oe2f3r</pattern>
-<pattern>oege3l</pattern>
-<pattern>oeg5ij</pattern>
-<pattern>oeg1l</pattern>
-<pattern>oe4gou</pattern>
-<pattern>oeii4</pattern>
-<pattern>oei3n</pattern>
-<pattern>oei5s4</pattern>
-<pattern>oei5tj</pattern>
-<pattern>oei3tr</pattern>
-<pattern>oe4kaa</pattern>
-<pattern>oek5erk</pattern>
-<pattern>oeke4t</pattern>
-<pattern>oe2k3l</pattern>
-<pattern>oe4k3op</pattern>
-<pattern>oe4k3r</pattern>
-<pattern>oe2ku</pattern>
-<pattern>oek1w</pattern>
-<pattern>oe4lap</pattern>
-<pattern>oe4lar</pattern>
-<pattern>oel5dr</pattern>
-<pattern>oe4l3ei</pattern>
-<pattern>oe3lem</pattern>
-<pattern>oel5f</pattern>
-<pattern>oelo4</pattern>
-<pattern>oe5loe</pattern>
-<pattern>oelo5p</pattern>
-<pattern>oel3sp</pattern>
-<pattern>oe4m3ac</pattern>
-<pattern>oem3o4</pattern>
-<pattern>oen3al</pattern>
-<pattern>oe5n4e</pattern>
-<pattern>oen5gr</pattern>
-<pattern>oen3o</pattern>
-<pattern>oen4sn</pattern>
-<pattern>2oep</pattern>
-<pattern>oep5ind</pattern>
-<pattern>oe4pl</pattern>
-<pattern>oe5plo</pattern>
-<pattern>oe4p3r</pattern>
-<pattern>oe3pra</pattern>
-<pattern>oe4ps</pattern>
-<pattern>oeps3e</pattern>
-<pattern>oe2p3u</pattern>
-<pattern>4oer</pattern>
-<pattern>oe1ra</pattern>
-<pattern>oe4raa</pattern>
-<pattern>oer5aal</pattern>
-<pattern>oe4r3a4l</pattern>
-<pattern>oer4e</pattern>
-<pattern>oer5ei </pattern>
-<pattern>oer5eie</pattern>
-<pattern>oero2</pattern>
-<pattern>oe3roe</pattern>
-<pattern>oer3og</pattern>
-<pattern>oer5om</pattern>
-<pattern>oer4sl</pattern>
-<pattern>oer4sp</pattern>
-<pattern>oer4sta</pattern>
-<pattern>oers5tak</pattern>
-<pattern>oers5te </pattern>
-<pattern>4oes </pattern>
-<pattern>oe3sfe</pattern>
-<pattern>oe3si</pattern>
-<pattern>oe4sli</pattern>
-<pattern>oe4s3o4</pattern>
-<pattern>oes4ta</pattern>
-<pattern>oes4th</pattern>
-<pattern>oe3sto</pattern>
-<pattern>oe4taa</pattern>
-<pattern>oe2t3h</pattern>
-<pattern>oe5t4i</pattern>
-<pattern>oe2tj</pattern>
-<pattern>oe4t3o4</pattern>
-<pattern>oe5toe</pattern>
-<pattern>oe4t3ra</pattern>
-<pattern>oet4s3p</pattern>
-<pattern>oet3w</pattern>
-<pattern>2oë</pattern>
-<pattern>of3ar</pattern>
-<pattern>of3at</pattern>
-<pattern>o4fav</pattern>
-<pattern>of4d1a4</pattern>
-<pattern>ofd3ei</pattern>
-<pattern>of2d3o</pattern>
-<pattern>of2d3r</pattern>
-<pattern>ofd3w</pattern>
-<pattern>of3l</pattern>
-<pattern>o4fli</pattern>
-<pattern>o4flo</pattern>
-<pattern>4ofo</pattern>
-<pattern>of3om</pattern>
-<pattern>o3foo</pattern>
-<pattern>of3op</pattern>
-<pattern>o3for</pattern>
-<pattern>of3ox</pattern>
-<pattern>of1r</pattern>
-<pattern>o3f2ra</pattern>
-<pattern>of5se</pattern>
-<pattern>of4sl</pattern>
-<pattern>of5sla</pattern>
-<pattern>ofs3le</pattern>
-<pattern>of2sp</pattern>
-<pattern>of3spe</pattern>
-<pattern>ofs3pl</pattern>
-<pattern>of3spo</pattern>
-<pattern>ofs3pr</pattern>
-<pattern>ofs3tr</pattern>
-<pattern>ofs5tra</pattern>
-<pattern>4oft</pattern>
-<pattern>of4tu</pattern>
-<pattern>oft3ur</pattern>
-<pattern>oft3uu</pattern>
-<pattern>of3ui</pattern>
-<pattern>og5ac</pattern>
-<pattern>oga4l</pattern>
-<pattern>og3al </pattern>
-<pattern>og5de</pattern>
-<pattern>og3di</pattern>
-<pattern>oge4d</pattern>
-<pattern>oge5laa</pattern>
-<pattern>ogel5ei</pattern>
-<pattern>2ogem</pattern>
-<pattern>o3ger</pattern>
-<pattern>oge4ro</pattern>
-<pattern>oger5on</pattern>
-<pattern>oge4s3t</pattern>
-<pattern>2og5h</pattern>
-<pattern>1ogig</pattern>
-<pattern>og1l</pattern>
-<pattern>og5ne</pattern>
-<pattern>og3op</pattern>
-<pattern>og3sp</pattern>
-<pattern>og3sta</pattern>
-<pattern>og4st5ei</pattern>
-<pattern>og3sto</pattern>
-<pattern>og4ston</pattern>
-<pattern>og4str</pattern>
-<pattern>ogs5tro</pattern>
-<pattern>og3ui</pattern>
-<pattern>o3gy</pattern>
-<pattern>2o1h</pattern>
-<pattern>3ohm</pattern>
-<pattern>4oi</pattern>
-<pattern>oi3do</pattern>
-<pattern>oi1e</pattern>
-<pattern>oi3j</pattern>
-<pattern>oi5k</pattern>
-<pattern>o3ing</pattern>
-<pattern>oi3o4</pattern>
-<pattern>oi3s4</pattern>
-<pattern>oi5sc</pattern>
-<pattern>ois2p</pattern>
-<pattern>oist2</pattern>
-<pattern>ois5tj</pattern>
-<pattern>o3ï</pattern>
-<pattern>2o1j</pattern>
-<pattern>2ok</pattern>
-<pattern>o3ka </pattern>
-<pattern>o3kaa</pattern>
-<pattern>o4k3aas</pattern>
-<pattern>ok3ab</pattern>
-<pattern>ok3ag</pattern>
-<pattern>o3kal</pattern>
-<pattern>ok3ank</pattern>
-<pattern>o4k3a4z</pattern>
-<pattern>ok3ef</pattern>
-<pattern>o2k4l</pattern>
-<pattern>ok5let</pattern>
-<pattern>o4kli</pattern>
-<pattern>ok5lu</pattern>
-<pattern>o2k3n</pattern>
-<pattern>ok3o2l</pattern>
-<pattern>ok3op </pattern>
-<pattern>ok3o4pe</pattern>
-<pattern>okos5</pattern>
-<pattern>o2k3ou</pattern>
-<pattern>o2k3r</pattern>
-<pattern>ok4ra</pattern>
-<pattern>ok1sa</pattern>
-<pattern>ok3s4l</pattern>
-<pattern>ok3sn</pattern>
-<pattern>ok5spri</pattern>
-<pattern>ok1st4</pattern>
-<pattern>oks5te </pattern>
-<pattern>ok5sten</pattern>
-<pattern>ok4s5tr</pattern>
-<pattern>ok5te</pattern>
-<pattern>okter4s</pattern>
-<pattern>oku4</pattern>
-<pattern>ok3ur</pattern>
-<pattern>ok3uu</pattern>
-<pattern>ok1w</pattern>
-<pattern>ok2wi</pattern>
-<pattern>o1la</pattern>
-<pattern>o3l4ab</pattern>
-<pattern>ol3ac</pattern>
-<pattern>o3lal</pattern>
-<pattern>ol3a2p</pattern>
-<pattern>ol3arm</pattern>
-<pattern>ola3s4m</pattern>
-<pattern>4old</pattern>
-<pattern>ol3d4o</pattern>
-<pattern>ol3d2w</pattern>
-<pattern>o1le</pattern>
-<pattern>o3le </pattern>
-<pattern>ole5g</pattern>
-<pattern>ol1ei</pattern>
-<pattern>ol3eks</pattern>
-<pattern>ol3emm</pattern>
-<pattern>o3len</pattern>
-<pattern>o5ler</pattern>
-<pattern>oleu2</pattern>
-<pattern>ole3um</pattern>
-<pattern>ol3exa</pattern>
-<pattern>ol2fa</pattern>
-<pattern>olf3l</pattern>
-<pattern>ol3fr</pattern>
-<pattern>olf5sl</pattern>
-<pattern>ol2gl</pattern>
-<pattern>ol2g1o</pattern>
-<pattern>olg5rap</pattern>
-<pattern>ol4gre</pattern>
-<pattern>ol4g3ri</pattern>
-<pattern>ol2g3u</pattern>
-<pattern>o3lia</pattern>
-<pattern>o3lic</pattern>
-<pattern>o5lid</pattern>
-<pattern>o3lik</pattern>
-<pattern>o3lin</pattern>
-<pattern>o5ling</pattern>
-<pattern>ol3int</pattern>
-<pattern>o3lit</pattern>
-<pattern>ol3kaf</pattern>
-<pattern>ol5ke</pattern>
-<pattern>ol2kr</pattern>
-<pattern>olk4s</pattern>
-<pattern>olk2v</pattern>
-<pattern>ollie4</pattern>
-<pattern>o3lo</pattern>
-<pattern>o5loc</pattern>
-<pattern>olo3k</pattern>
-<pattern>ol4om</pattern>
-<pattern>o4lop</pattern>
-<pattern>ol3op </pattern>
-<pattern>ol3opp</pattern>
-<pattern>olo3s4t</pattern>
-<pattern>olo4ve</pattern>
-<pattern>ol4pra</pattern>
-<pattern>4ols</pattern>
-<pattern>ol5se</pattern>
-<pattern>ol4s5h</pattern>
-<pattern>ol5si</pattern>
-<pattern>ol1sj</pattern>
-<pattern>ol3s4l</pattern>
-<pattern>ol3s4n</pattern>
-<pattern>ol3so</pattern>
-<pattern>ol3sp</pattern>
-<pattern>ol5ster</pattern>
-<pattern>4o1lu</pattern>
-<pattern>ol3uit</pattern>
-<pattern>olu4r</pattern>
-<pattern>4oma</pattern>
-<pattern>om2aa</pattern>
-<pattern>om1ac</pattern>
-<pattern>om1af</pattern>
-<pattern>o3man</pattern>
-<pattern>4ome</pattern>
-<pattern>o4m3ef</pattern>
-<pattern>om3ela</pattern>
-<pattern>omen4s</pattern>
-<pattern>omen5ste </pattern>
-<pattern>ome5ren</pattern>
-<pattern>omer5kl</pattern>
-<pattern>ome5sp</pattern>
-<pattern>ome5t</pattern>
-<pattern>om2i</pattern>
-<pattern>o4m3int</pattern>
-<pattern>4omm</pattern>
-<pattern>4omo</pattern>
-<pattern>omo5l</pattern>
-<pattern>omo3s</pattern>
-<pattern>om4p5ei</pattern>
-<pattern>5omro</pattern>
-<pattern>om3sl</pattern>
-<pattern>om4ste </pattern>
-<pattern>om3ui</pattern>
-<pattern>3omz</pattern>
-<pattern>on1ac</pattern>
-<pattern>on4ag</pattern>
-<pattern>o4n3am</pattern>
-<pattern>on4an</pattern>
-<pattern>on3ap</pattern>
-<pattern>ona3th</pattern>
-<pattern>2onc</pattern>
-<pattern>on4d3ac</pattern>
-<pattern>on5d4as</pattern>
-<pattern>on5der</pattern>
-<pattern>ond5ete</pattern>
-<pattern>on4d3id</pattern>
-<pattern>ond5ijs</pattern>
-<pattern>ond5om </pattern>
-<pattern>on2dr</pattern>
-<pattern>ond3re</pattern>
-<pattern>ond3ro</pattern>
-<pattern>ond5sj</pattern>
-<pattern>ond5slo</pattern>
-<pattern>on3d4u</pattern>
-<pattern>on4dur</pattern>
-<pattern>o5ne </pattern>
-<pattern>o3neb</pattern>
-<pattern>o2n1e2c</pattern>
-<pattern>on3ei</pattern>
-<pattern>on3erf</pattern>
-<pattern>on3erv</pattern>
-<pattern>one3st</pattern>
-<pattern>4onet </pattern>
-<pattern>on1e3v</pattern>
-<pattern>ong5aan</pattern>
-<pattern>ong5aap</pattern>
-<pattern>ong3ap</pattern>
-<pattern>4ongen</pattern>
-<pattern>ong5le</pattern>
-<pattern>ong2r</pattern>
-<pattern>ongs4</pattern>
-<pattern>ong5se</pattern>
-<pattern>ong3sp</pattern>
-<pattern>ong3st</pattern>
-<pattern>on5id</pattern>
-<pattern>o5nig</pattern>
-<pattern>on4k3ap</pattern>
-<pattern>onke5lap</pattern>
-<pattern>on3k2i</pattern>
-<pattern>on4k3lo</pattern>
-<pattern>on3kn</pattern>
-<pattern>on5kw</pattern>
-<pattern>onnes4</pattern>
-<pattern>onne5st</pattern>
-<pattern>o4n3of</pattern>
-<pattern>ono3l</pattern>
-<pattern>on1on</pattern>
-<pattern>o2n1ov</pattern>
-<pattern>on3sc</pattern>
-<pattern>ons4e</pattern>
-<pattern>on5sei</pattern>
-<pattern>ons2f</pattern>
-<pattern>on3s4m</pattern>
-<pattern>on2s3n</pattern>
-<pattern>ons5op</pattern>
-<pattern>on3sor</pattern>
-<pattern>on1s2p</pattern>
-<pattern>ons4pe</pattern>
-<pattern>on3spl</pattern>
-<pattern>on1st</pattern>
-<pattern>on5sten</pattern>
-<pattern>on5str</pattern>
-<pattern>4ont </pattern>
-<pattern>on4taa</pattern>
-<pattern>3ont1h</pattern>
-<pattern>on4tid</pattern>
-<pattern>3ont1s4</pattern>
-<pattern>ont5sp</pattern>
-<pattern>3ontv</pattern>
-<pattern>1ont3w</pattern>
-<pattern>on1ui</pattern>
-<pattern>on3ur</pattern>
-<pattern>o4o2</pattern>
-<pattern>4oo </pattern>
-<pattern>oo3c</pattern>
-<pattern>4oo4d</pattern>
-<pattern>ood1a</pattern>
-<pattern>ood1e4</pattern>
-<pattern>oo5de </pattern>
-<pattern>ood1o</pattern>
-<pattern>ood1r</pattern>
-<pattern>ood3sl</pattern>
-<pattern>ood3sp</pattern>
-<pattern>4oof</pattern>
-<pattern>oo3fi</pattern>
-<pattern>oo4g</pattern>
-<pattern>oog1a</pattern>
-<pattern>oog3e</pattern>
-<pattern>oo5gi</pattern>
-<pattern>oog1r</pattern>
-<pattern>oogs4</pattern>
-<pattern>oog3sh</pattern>
-<pattern>oog3sl</pattern>
-<pattern>ook3a</pattern>
-<pattern>oo3ke</pattern>
-<pattern>ook5l</pattern>
-<pattern>ook3s4</pattern>
-<pattern>ook5st</pattern>
-<pattern>oo4k5w</pattern>
-<pattern>oo4l</pattern>
-<pattern>ool5a2</pattern>
-<pattern>oole2</pattern>
-<pattern>ool3ed</pattern>
-<pattern>ool5f</pattern>
-<pattern>ool5g</pattern>
-<pattern>oo5lig</pattern>
-<pattern>ool3ij</pattern>
-<pattern>ool3k</pattern>
-<pattern>ool1o4</pattern>
-<pattern>ool1u</pattern>
-<pattern>oom5a4</pattern>
-<pattern>oo3me</pattern>
-<pattern>oom3i</pattern>
-<pattern>oom1o4</pattern>
-<pattern>ooms5te </pattern>
-<pattern>4oon</pattern>
-<pattern>oon5a</pattern>
-<pattern>oon5du</pattern>
-<pattern>oon3in5</pattern>
-<pattern>oon5k4</pattern>
-<pattern>oon1o</pattern>
-<pattern>oon5ta</pattern>
-<pattern>oo4p1</pattern>
-<pattern>oopa2</pattern>
-<pattern>oop5ee</pattern>
-<pattern>oop3o4</pattern>
-<pattern>oop3r</pattern>
-<pattern>oop4sp</pattern>
-<pattern>oor3a</pattern>
-<pattern>oord5aa</pattern>
-<pattern>oor5dop</pattern>
-<pattern>oor1e4</pattern>
-<pattern>oor3g4</pattern>
-<pattern>oor5i</pattern>
-<pattern>oor5k</pattern>
-<pattern>oor5m</pattern>
-<pattern>oor1o</pattern>
-<pattern>oor3sm</pattern>
-<pattern>oor5ste</pattern>
-<pattern>oor5sto</pattern>
-<pattern>4oort</pattern>
-<pattern>oor4th</pattern>
-<pattern>oo4s</pattern>
-<pattern>oos3a</pattern>
-<pattern>oo5se</pattern>
-<pattern>oos5n</pattern>
-<pattern>oo4t</pattern>
-<pattern>oot1a</pattern>
-<pattern>oot3es</pattern>
-<pattern>oot3h</pattern>
-<pattern>oot5o</pattern>
-<pattern>oot3r</pattern>
-<pattern>oot4sl</pattern>
-<pattern>o1ö</pattern>
-<pattern>2opa</pattern>
-<pattern>o4p3ac</pattern>
-<pattern>op3ad</pattern>
-<pattern>o4p3af</pattern>
-<pattern>o4p3ak</pattern>
-<pattern>op3am</pattern>
-<pattern>o3pan</pattern>
-<pattern>op3and</pattern>
-<pattern>op3at </pattern>
-<pattern>op3att</pattern>
-<pattern>3opbre</pattern>
-<pattern>3opdr</pattern>
-<pattern>o3pe </pattern>
-<pattern>op3ee</pattern>
-<pattern>op5eet</pattern>
-<pattern>op3ei</pattern>
-<pattern>o1pel</pattern>
-<pattern>o3pen </pattern>
-<pattern>3o4peni</pattern>
-<pattern>o5per </pattern>
-<pattern>o4pera</pattern>
-<pattern>op3e4te</pattern>
-<pattern>op3e4v</pattern>
-<pattern>4opf</pattern>
-<pattern>o1pi</pattern>
-<pattern>o5pic</pattern>
-<pattern>op3i2d</pattern>
-<pattern>opie5t</pattern>
-<pattern>op3ijz</pattern>
-<pattern>op3in </pattern>
-<pattern>o5pina</pattern>
-<pattern>o5pis</pattern>
-<pattern>4op1j</pattern>
-<pattern>op3l</pattern>
-<pattern>op5los</pattern>
-<pattern>1opn</pattern>
-<pattern>o1po</pattern>
-<pattern>opoe3</pattern>
-<pattern>op1of</pattern>
-<pattern>o5pog</pattern>
-<pattern>o5poi</pattern>
-<pattern>o5pol</pattern>
-<pattern>op3ond</pattern>
-<pattern>o5poni</pattern>
-<pattern>op3ont</pattern>
-<pattern>op3ord</pattern>
-<pattern>op3o4re</pattern>
-<pattern>op3o4v</pattern>
-<pattern>op1r</pattern>
-<pattern>op3ric</pattern>
-<pattern>o4pru</pattern>
-<pattern>o4ps</pattern>
-<pattern>op5s2c</pattern>
-<pattern>op5se</pattern>
-<pattern>op5si</pattern>
-<pattern>3ops4l</pattern>
-<pattern>ops4m</pattern>
-<pattern>op3sma</pattern>
-<pattern>op3sn</pattern>
-<pattern>op3so</pattern>
-<pattern>op3sp</pattern>
-<pattern>op3sta</pattern>
-<pattern>op3su</pattern>
-<pattern>2opt</pattern>
-<pattern>4opt </pattern>
-<pattern>op5tr</pattern>
-<pattern>op3ui</pattern>
-<pattern>o2p3u2n</pattern>
-<pattern>o1ra</pattern>
-<pattern>or3ach</pattern>
-<pattern>or3act</pattern>
-<pattern>or3adm</pattern>
-<pattern>or1af</pattern>
-<pattern>ora4g</pattern>
-<pattern>o4r3alg</pattern>
-<pattern>or3ana</pattern>
-<pattern>o5rate</pattern>
-<pattern>or4daa</pattern>
-<pattern>or4d3as</pattern>
-<pattern>or4denv</pattern>
-<pattern>or4do</pattern>
-<pattern>ord5ond</pattern>
-<pattern>ord3or</pattern>
-<pattern>ord3o4v</pattern>
-<pattern>or3dr</pattern>
-<pattern>or4drad</pattern>
-<pattern>ord3w</pattern>
-<pattern>o1re</pattern>
-<pattern>ore5ad</pattern>
-<pattern>4orec</pattern>
-<pattern>oree4</pattern>
-<pattern>ore4no</pattern>
-<pattern>or2gl</pattern>
-<pattern>o1ri</pattern>
-<pattern>o5ria</pattern>
-<pattern>3orië</pattern>
-<pattern>o5rig </pattern>
-<pattern>o5rigere</pattern>
-<pattern>o4r3ink</pattern>
-<pattern>or3ins</pattern>
-<pattern>ork2a</pattern>
-<pattern>or5k4e</pattern>
-<pattern>or3kl</pattern>
-<pattern>or5kn</pattern>
-<pattern>or3kw</pattern>
-<pattern>or4m3ac</pattern>
-<pattern>or4mas</pattern>
-<pattern>or4m3ei</pattern>
-<pattern>or4n3ac</pattern>
-<pattern>or3ni</pattern>
-<pattern>orno3s4</pattern>
-<pattern>or3oe</pattern>
-<pattern>o3rol</pattern>
-<pattern>or1on</pattern>
-<pattern>or3ont</pattern>
-<pattern>or1oo</pattern>
-<pattern>or1o2p</pattern>
-<pattern>or3or</pattern>
-<pattern>o3ros</pattern>
-<pattern>or5ov</pattern>
-<pattern>4orp</pattern>
-<pattern>or4p3ac</pattern>
-<pattern>orp4s5c</pattern>
-<pattern>or3sag</pattern>
-<pattern>or5sc</pattern>
-<pattern>or5se</pattern>
-<pattern>or3sli</pattern>
-<pattern>or3smi</pattern>
-<pattern>or3so</pattern>
-<pattern>or4son</pattern>
-<pattern>or3sp</pattern>
-<pattern>or5s4pa</pattern>
-<pattern>or5spu</pattern>
-<pattern>or4t3ak</pattern>
-<pattern>ort5een</pattern>
-<pattern>or4t5ijl</pattern>
-<pattern>or2to</pattern>
-<pattern>or4tof</pattern>
-<pattern>or4t3oo</pattern>
-<pattern>or4tred</pattern>
-<pattern>ort5sp</pattern>
-<pattern>ort5ste</pattern>
-<pattern>or1u</pattern>
-<pattern>o3ry</pattern>
-<pattern>orzet5</pattern>
-<pattern>2os</pattern>
-<pattern>o4sac</pattern>
-<pattern>o5sas</pattern>
-<pattern>o3sau</pattern>
-<pattern>4o3s2c</pattern>
-<pattern>osca4</pattern>
-<pattern>o4sci</pattern>
-<pattern>o5s4cl</pattern>
-<pattern>os3cu</pattern>
-<pattern>o5sed</pattern>
-<pattern>os4el</pattern>
-<pattern>o5ser</pattern>
-<pattern>os3f</pattern>
-<pattern>os4fe</pattern>
-<pattern>o4sha</pattern>
-<pattern>o3shi</pattern>
-<pattern>os2ho</pattern>
-<pattern>o3si</pattern>
-<pattern>o4sj</pattern>
-<pattern>os5jer </pattern>
-<pattern>o4sk</pattern>
-<pattern>os5ko</pattern>
-<pattern>os3l</pattern>
-<pattern>os5li4</pattern>
-<pattern>o4s3m</pattern>
-<pattern>os4n</pattern>
-<pattern>os5no</pattern>
-<pattern>o3s2o</pattern>
-<pattern>os3pa</pattern>
-<pattern>os3per</pattern>
-<pattern>os1pi</pattern>
-<pattern>os4pir</pattern>
-<pattern>o4spr</pattern>
-<pattern>os4s5m</pattern>
-<pattern>o2s3t</pattern>
-<pattern>os4ta</pattern>
-<pattern>os5taal</pattern>
-<pattern>os5taar</pattern>
-<pattern>osta3c</pattern>
-<pattern>ost3a4g</pattern>
-<pattern>os5tan</pattern>
-<pattern>os5tar</pattern>
-<pattern>o3stas</pattern>
-<pattern>o3stat</pattern>
-<pattern>os5te </pattern>
-<pattern>os4tem</pattern>
-<pattern>o5steroï</pattern>
-<pattern>os4th</pattern>
-<pattern>os4to</pattern>
-<pattern>os5toli</pattern>
-<pattern>os5tou</pattern>
-<pattern>ost3o4v</pattern>
-<pattern>os5tra </pattern>
-<pattern>os5traa</pattern>
-<pattern>ost3re</pattern>
-<pattern>ost3ri</pattern>
-<pattern>o3stro</pattern>
-<pattern>os5trum</pattern>
-<pattern>os1tu</pattern>
-<pattern>o3sty</pattern>
-<pattern>o3su</pattern>
-<pattern>o5sy</pattern>
-<pattern>4o1ta</pattern>
-<pattern>ot3aar</pattern>
-<pattern>ot1ac</pattern>
-<pattern>ot3af</pattern>
-<pattern>o3tag</pattern>
-<pattern>ot3akt</pattern>
-<pattern>ot3app</pattern>
-<pattern>ot3art</pattern>
-<pattern>otas4</pattern>
-<pattern>o5tat</pattern>
-<pattern>o3te</pattern>
-<pattern>ot3e2d</pattern>
-<pattern>o5tee </pattern>
-<pattern>o5tees</pattern>
-<pattern>o5teg</pattern>
-<pattern>ot3ei</pattern>
-<pattern>ote4lan</pattern>
-<pattern>o5ten</pattern>
-<pattern>o5ter</pattern>
-<pattern>oter5sp</pattern>
-<pattern>ote4st</pattern>
-<pattern>ote4t</pattern>
-<pattern>ot3eta</pattern>
-<pattern>o1th</pattern>
-<pattern>o2t1ho</pattern>
-<pattern>ot3hu</pattern>
-<pattern>o4tj</pattern>
-<pattern>otje5sp</pattern>
-<pattern>otli2</pattern>
-<pattern>o1to</pattern>
-<pattern>ot3off</pattern>
-<pattern>ot3olv</pattern>
-<pattern>o5tom</pattern>
-<pattern>ot3ont</pattern>
-<pattern>ot3opm</pattern>
-<pattern>oto5po</pattern>
-<pattern>ot3opr</pattern>
-<pattern>o5t4or</pattern>
-<pattern>oto3s</pattern>
-<pattern>2otr</pattern>
-<pattern>o1t4ro</pattern>
-<pattern>ot3ru</pattern>
-<pattern>ot5s4i</pattern>
-<pattern>ot2sl</pattern>
-<pattern>ot3sla</pattern>
-<pattern>ots3li</pattern>
-<pattern>ot3smo</pattern>
-<pattern>ot3sn</pattern>
-<pattern>ot3sp</pattern>
-<pattern>ot4s3pa</pattern>
-<pattern>ot4ste </pattern>
-<pattern>ots5tek</pattern>
-<pattern>ot5sten</pattern>
-<pattern>ot4stu</pattern>
-<pattern>o1tu</pattern>
-<pattern>ot3ui</pattern>
-<pattern>o3tul</pattern>
-<pattern>ot5w</pattern>
-<pattern>4ou </pattern>
-<pattern>ou5a</pattern>
-<pattern>ou1c</pattern>
-<pattern>ou4d1a</pattern>
-<pattern>ou4des</pattern>
-<pattern>ou2do</pattern>
-<pattern>ou1e</pattern>
-<pattern>oue2t3</pattern>
-<pattern>ou3k4</pattern>
-<pattern>ou4ren</pattern>
-<pattern>ou5ren </pattern>
-<pattern>ou5renn</pattern>
-<pattern>ou2r3o2</pattern>
-<pattern>4ous</pattern>
-<pattern>ou3sa</pattern>
-<pattern>ous5c</pattern>
-<pattern>oust4</pattern>
-<pattern>ou2ta</pattern>
-<pattern>out3h</pattern>
-<pattern>out1j</pattern>
-<pattern>ou2t3o</pattern>
-<pattern>out1r</pattern>
-<pattern>out5sp</pattern>
-<pattern>out5ste</pattern>
-<pattern>ouw3a</pattern>
-<pattern>ouw5do</pattern>
-<pattern>ouw5ins</pattern>
-<pattern>o2v</pattern>
-<pattern>2o3va</pattern>
-<pattern>o5ve </pattern>
-<pattern>2o5vee</pattern>
-<pattern>3o4verg</pattern>
-<pattern>over5sp</pattern>
-<pattern>over5ste</pattern>
-<pattern>o5ves</pattern>
-<pattern>2ovi</pattern>
-<pattern>ovi5so</pattern>
-<pattern>4ovl</pattern>
-<pattern>4o3vo</pattern>
-<pattern>4ovr</pattern>
-<pattern>ovu3</pattern>
-<pattern>4ow</pattern>
-<pattern>o1wa</pattern>
-<pattern>o1we</pattern>
-<pattern>o5wen</pattern>
-<pattern>ow3h</pattern>
-<pattern>o1wi</pattern>
-<pattern>ow2n</pattern>
-<pattern>o3wo</pattern>
-<pattern>ow3r</pattern>
-<pattern>o4x</pattern>
-<pattern>oys4</pattern>
-<pattern>ozet5</pattern>
-<pattern>ö3l</pattern>
-<pattern>ö1p</pattern>
-<pattern>öpe1</pattern>
-<pattern>ö4r</pattern>
-<pattern>ös4</pattern>
-<pattern>ös5t</pattern>
-<pattern>ö5su</pattern>
-<pattern>4p </pattern>
-<pattern>4paan</pattern>
-<pattern>paar5du</pattern>
-<pattern>paar5tj</pattern>
-<pattern>5paas</pattern>
-<pattern>3pab</pattern>
-<pattern>p3acc</pattern>
-<pattern>2pach</pattern>
-<pattern>pacht5s</pattern>
-<pattern>p4aci</pattern>
-<pattern>5pacu</pattern>
-<pattern>3pad </pattern>
-<pattern>pa4da</pattern>
-<pattern>4padv</pattern>
-<pattern>pa3e</pattern>
-<pattern>4p3afd</pattern>
-<pattern>1pag</pattern>
-<pattern>pag2a</pattern>
-<pattern>pa4gen</pattern>
-<pattern>pa3gh</pattern>
-<pattern>p4a5gi</pattern>
-<pattern>3pak</pattern>
-<pattern>pa2k3a</pattern>
-<pattern>4p4ake</pattern>
-<pattern>pa4ki</pattern>
-<pattern>pa4k5l</pattern>
-<pattern>2p3alb</pattern>
-<pattern>3pale</pattern>
-<pattern>pal3f</pattern>
-<pattern>pa3li</pattern>
-<pattern>paling5s</pattern>
-<pattern>palle4</pattern>
-<pattern>palm5ac</pattern>
-<pattern>pal4mo</pattern>
-<pattern>pa4m</pattern>
-<pattern>pa3na</pattern>
-<pattern>pa4n3a4d</pattern>
-<pattern>5panee</pattern>
-<pattern>5panel</pattern>
-<pattern>4pank</pattern>
-<pattern>pan5sp</pattern>
-<pattern>pan4tr</pattern>
-<pattern>1pap</pattern>
-<pattern>pa4pe4t</pattern>
-<pattern>5papi</pattern>
-<pattern>pap3l</pattern>
-<pattern>pa3po</pattern>
-<pattern>pa3pr</pattern>
-<pattern>4par </pattern>
-<pattern>3pa3ra</pattern>
-<pattern>p3arb</pattern>
-<pattern>pard4</pattern>
-<pattern>par3da</pattern>
-<pattern>3park</pattern>
-<pattern>par4ka</pattern>
-<pattern>par4k5l</pattern>
-<pattern>3parl</pattern>
-<pattern>4parm</pattern>
-<pattern>pa5ro</pattern>
-<pattern>4parr</pattern>
-<pattern>par5ta</pattern>
-<pattern>3parti</pattern>
-<pattern>part3j</pattern>
-<pattern>3partn</pattern>
-<pattern>pa5ru</pattern>
-<pattern>paru5r</pattern>
-<pattern>1pa4s3</pattern>
-<pattern>pa5sa</pattern>
-<pattern>pas5c</pattern>
-<pattern>pa5se</pattern>
-<pattern>pa5so</pattern>
-<pattern>pas4th</pattern>
-<pattern>pas5to</pattern>
-<pattern>pas5tr</pattern>
-<pattern>pa5te</pattern>
-<pattern>1path</pattern>
-<pattern>p3atl</pattern>
-<pattern>3pa3tr</pattern>
-<pattern>pats5te </pattern>
-<pattern>2paut</pattern>
-<pattern>5pauz</pattern>
-<pattern>pa4vl</pattern>
-<pattern>5paz</pattern>
-<pattern>2pb4</pattern>
-<pattern>2p1c</pattern>
-<pattern>2p3d2</pattern>
-<pattern>pe4al</pattern>
-<pattern>4peci</pattern>
-<pattern>p3e2co</pattern>
-<pattern>3pectu</pattern>
-<pattern>1ped</pattern>
-<pattern>pe3de</pattern>
-<pattern>pe3do</pattern>
-<pattern>p4ee4</pattern>
-<pattern>3pee </pattern>
-<pattern>3peeë</pattern>
-<pattern>pee5li</pattern>
-<pattern>4peen</pattern>
-<pattern>5pees</pattern>
-<pattern>3peg</pattern>
-<pattern>1p4eil</pattern>
-<pattern>pei4l3a</pattern>
-<pattern>4peis</pattern>
-<pattern>pek5ee</pattern>
-<pattern>pe2k3l</pattern>
-<pattern>pe2k3n</pattern>
-<pattern>pek5s</pattern>
-<pattern>p4el</pattern>
-<pattern>pe3l4aa</pattern>
-<pattern>pe4l3ak</pattern>
-<pattern>pel5dr</pattern>
-<pattern>pe3le</pattern>
-<pattern>pe4l3ee</pattern>
-<pattern>pe4l3e4t</pattern>
-<pattern>pe3l4i</pattern>
-<pattern>pe3l4or</pattern>
-<pattern>pel5si</pattern>
-<pattern>pel3so</pattern>
-<pattern>pel3sp</pattern>
-<pattern>2p3emm</pattern>
-<pattern>pe3na</pattern>
-<pattern>pe4nak</pattern>
-<pattern>pe4nap</pattern>
-<pattern>pe4nau</pattern>
-<pattern>pe4naz</pattern>
-<pattern>p3ency</pattern>
-<pattern>pen5d4r</pattern>
-<pattern>penge5</pattern>
-<pattern>pen5k</pattern>
-<pattern>5penn</pattern>
-<pattern>pen3sa</pattern>
-<pattern>pen5sl</pattern>
-<pattern>pen3sm</pattern>
-<pattern>pen5sp</pattern>
-<pattern>pent4</pattern>
-<pattern>pen5to</pattern>
-<pattern>2p3epi</pattern>
-<pattern>pep3o</pattern>
-<pattern>pep5s</pattern>
-<pattern>p4er </pattern>
-<pattern>pe1ra</pattern>
-<pattern>pera3s4</pattern>
-<pattern>per4at</pattern>
-<pattern>3perc</pattern>
-<pattern>pe4r5eg</pattern>
-<pattern>pe5req</pattern>
-<pattern>1peri</pattern>
-<pattern>peri3s</pattern>
-<pattern>per1o</pattern>
-<pattern>pe3ron</pattern>
-<pattern>pe5ros</pattern>
-<pattern>3pers</pattern>
-<pattern>per4sm</pattern>
-<pattern>per5sti</pattern>
-<pattern>per4str</pattern>
-<pattern>p2ert</pattern>
-<pattern>3pes</pattern>
-<pattern>pe3sa</pattern>
-<pattern>3pet </pattern>
-<pattern>pe5ta</pattern>
-<pattern>5pe5ter</pattern>
-<pattern>3peti</pattern>
-<pattern>pe4t3ra</pattern>
-<pattern>pets5te</pattern>
-<pattern>petu5</pattern>
-<pattern>3peuk</pattern>
-<pattern>5peut</pattern>
-<pattern>1pé</pattern>
-<pattern>3pê</pattern>
-<pattern>2p1f</pattern>
-<pattern>2p1g</pattern>
-<pattern>pge5s</pattern>
-<pattern>2p1h4</pattern>
-<pattern>4p3ha</pattern>
-<pattern>3p4hec</pattern>
-<pattern>p4his</pattern>
-<pattern>4pho</pattern>
-<pattern>pi3am</pattern>
-<pattern>pi5an</pattern>
-<pattern>pi4at</pattern>
-<pattern>2pid</pattern>
-<pattern>piek5la</pattern>
-<pattern>5piep</pattern>
-<pattern>pie4r3o</pattern>
-<pattern>pie4s3p</pattern>
-<pattern>pie4tj</pattern>
-<pattern>pi2g5a</pattern>
-<pattern>pi3gl</pattern>
-<pattern>3pij </pattern>
-<pattern>pij3k</pattern>
-<pattern>pij5ke</pattern>
-<pattern>pij4li</pattern>
-<pattern>3pijn</pattern>
-<pattern>5pijp</pattern>
-<pattern>pij4p3a</pattern>
-<pattern>2pijz</pattern>
-<pattern>pi4k3l</pattern>
-<pattern>pilo5g</pattern>
-<pattern>pi5nam</pattern>
-<pattern>2pind</pattern>
-<pattern>3pinda</pattern>
-<pattern>3p4ing</pattern>
-<pattern>5ping </pattern>
-<pattern>pin4ga</pattern>
-<pattern>pin5gri</pattern>
-<pattern>4p3inj</pattern>
-<pattern>pink3r</pattern>
-<pattern>pink5s</pattern>
-<pattern>4pinr</pattern>
-<pattern>2pins</pattern>
-<pattern>pin4ta</pattern>
-<pattern>pi5o</pattern>
-<pattern>pis5n</pattern>
-<pattern>pis5ta</pattern>
-<pattern>pi3th</pattern>
-<pattern>pit3j</pattern>
-<pattern>pit3r</pattern>
-<pattern>pit4sp</pattern>
-<pattern>2p1ja</pattern>
-<pattern>pjes5</pattern>
-<pattern>p3ji</pattern>
-<pattern>p1jo</pattern>
-<pattern>2p1k</pattern>
-<pattern>pkaart5j</pattern>
-<pattern>p2l2</pattern>
-<pattern>p3la </pattern>
-<pattern>plaat5j</pattern>
-<pattern>2p3lad</pattern>
-<pattern>pla3di</pattern>
-<pattern>4p3lamp</pattern>
-<pattern>4p3lang</pattern>
-<pattern>p4lant</pattern>
-<pattern>p3lap</pattern>
-<pattern>1p4las</pattern>
-<pattern>3p4lat</pattern>
-<pattern>pla4t3r</pattern>
-<pattern>5p4lay</pattern>
-<pattern>p4lec</pattern>
-<pattern>plee5tj</pattern>
-<pattern>p3leid</pattern>
-<pattern>3p4len</pattern>
-<pattern>p3lep</pattern>
-<pattern>pleu5ro</pattern>
-<pattern>p4lex</pattern>
-<pattern>2p3lig</pattern>
-<pattern>4plij</pattern>
-<pattern>p4lom</pattern>
-<pattern>p3lone</pattern>
-<pattern>p5lood</pattern>
-<pattern>plooi5tj</pattern>
-<pattern>p3loon</pattern>
-<pattern>p3luie</pattern>
-<pattern>2p1m</pattern>
-<pattern>pmans5t</pattern>
-<pattern>2p1n</pattern>
-<pattern>p3na</pattern>
-<pattern>3pneum</pattern>
-<pattern>3po </pattern>
-<pattern>poda5</pattern>
-<pattern>3poei</pattern>
-<pattern>poe2s3</pattern>
-<pattern>poes5t</pattern>
-<pattern>poets5te </pattern>
-<pattern>3poez</pattern>
-<pattern>3poë</pattern>
-<pattern>p2ofa</pattern>
-<pattern>3pogi</pattern>
-<pattern>po5gr</pattern>
-<pattern>po2k3i2</pattern>
-<pattern>po4kol</pattern>
-<pattern>1pol</pattern>
-<pattern>po5l4o</pattern>
-<pattern>polo3p</pattern>
-<pattern>pol4s</pattern>
-<pattern>pols5te </pattern>
-<pattern>1pom</pattern>
-<pattern>2p3oml</pattern>
-<pattern>3ponds</pattern>
-<pattern>pon4sm</pattern>
-<pattern>pon4st</pattern>
-<pattern>pons5te </pattern>
-<pattern>pon5ta</pattern>
-<pattern>5pony</pattern>
-<pattern>poo3d</pattern>
-<pattern>poo5de</pattern>
-<pattern>4poog </pattern>
-<pattern>3pool</pattern>
-<pattern>poo5len</pattern>
-<pattern>4poor </pattern>
-<pattern>poor4tj</pattern>
-<pattern>poot3</pattern>
-<pattern>po4p3a</pattern>
-<pattern>4popd</pattern>
-<pattern>2pope</pattern>
-<pattern>pop5h</pattern>
-<pattern>2p3org</pattern>
-<pattern>2p3ork</pattern>
-<pattern>po3ro</pattern>
-<pattern>p4ort</pattern>
-<pattern>5portef</pattern>
-<pattern>por4to</pattern>
-<pattern>por4t5ra</pattern>
-<pattern>po3ru</pattern>
-<pattern>1pos</pattern>
-<pattern>po1sa</pattern>
-<pattern>po3sf</pattern>
-<pattern>po4taa</pattern>
-<pattern>po4t3as</pattern>
-<pattern>po5te</pattern>
-<pattern>potes5t</pattern>
-<pattern>pot1j</pattern>
-<pattern>pot3r</pattern>
-<pattern>3poul</pattern>
-<pattern>po3v</pattern>
-<pattern>4p3p</pattern>
-<pattern>p5pa</pattern>
-<pattern>p5pe</pattern>
-<pattern>ppe4l3o</pattern>
-<pattern>ppe5ni</pattern>
-<pattern>pper5ste</pattern>
-<pattern>ppie5k</pattern>
-<pattern>ppij5p</pattern>
-<pattern>p4ps</pattern>
-<pattern>pr4</pattern>
-<pattern>p2ra</pattern>
-<pattern>3pra </pattern>
-<pattern>p5raad</pattern>
-<pattern>praat5j</pattern>
-<pattern>p5rad</pattern>
-<pattern>3prakt</pattern>
-<pattern>4pram</pattern>
-<pattern>p5rand</pattern>
-<pattern>3prao</pattern>
-<pattern>4p3rap</pattern>
-<pattern>p4rat</pattern>
-<pattern>p4rax</pattern>
-<pattern>4preeku</pattern>
-<pattern>1prem</pattern>
-<pattern>p3remm</pattern>
-<pattern>3prent</pattern>
-<pattern>pren4t5j</pattern>
-<pattern>3pres</pattern>
-<pattern>p3reso</pattern>
-<pattern>3pret</pattern>
-<pattern>pre4t3j</pattern>
-<pattern>pret3r</pattern>
-<pattern>4pric</pattern>
-<pattern>4p3riek</pattern>
-<pattern>4priet</pattern>
-<pattern>prie4t5j</pattern>
-<pattern>1prij</pattern>
-<pattern>3prik</pattern>
-<pattern>3princ</pattern>
-<pattern>pring5s4</pattern>
-<pattern>5prins</pattern>
-<pattern>3p4rio</pattern>
-<pattern>3p4riu</pattern>
-<pattern>5priv</pattern>
-<pattern>5p4rob</pattern>
-<pattern>3p2roc</pattern>
-<pattern>1p2rod</pattern>
-<pattern>p3roed</pattern>
-<pattern>3proef</pattern>
-<pattern>proet5j</pattern>
-<pattern>3proev</pattern>
-<pattern>5p4rof</pattern>
-<pattern>5p2rog</pattern>
-<pattern>1proj</pattern>
-<pattern>pro3la</pattern>
-<pattern>3prom</pattern>
-<pattern>p3rood</pattern>
-<pattern>prooi5</pattern>
-<pattern>pro5pa</pattern>
-<pattern>p4roq</pattern>
-<pattern>3pros</pattern>
-<pattern>pro5sc</pattern>
-<pattern>pro4s5t</pattern>
-<pattern>pro3t4a</pattern>
-<pattern>3proto</pattern>
-<pattern>3pro5v</pattern>
-<pattern>4proy</pattern>
-<pattern>pru2t</pattern>
-<pattern>prut3o4</pattern>
-<pattern>2ps</pattern>
-<pattern>p3sab</pattern>
-<pattern>ps3a2g</pattern>
-<pattern>p3sak</pattern>
-<pattern>ps3ar</pattern>
-<pattern>ps3ass</pattern>
-<pattern>4pse</pattern>
-<pattern>ps3erk</pattern>
-<pattern>p4s3et</pattern>
-<pattern>p3si</pattern>
-<pattern>p4s3i2d</pattern>
-<pattern>p4sin</pattern>
-<pattern>p5sis</pattern>
-<pattern>p1sl</pattern>
-<pattern>ps3le</pattern>
-<pattern>ps2me</pattern>
-<pattern>ps5mi</pattern>
-<pattern>p4s3na</pattern>
-<pattern>ps3neu</pattern>
-<pattern>p4sof</pattern>
-<pattern>p3sol</pattern>
-<pattern>ps3opt</pattern>
-<pattern>pso4r</pattern>
-<pattern>p1sp</pattern>
-<pattern>ps2pl</pattern>
-<pattern>ps3ple</pattern>
-<pattern>p1s4t</pattern>
-<pattern>p3stat</pattern>
-<pattern>p3ste</pattern>
-<pattern>ps5tent</pattern>
-<pattern>ps5tes</pattern>
-<pattern>ps5th</pattern>
-<pattern>ps3tor</pattern>
-<pattern>ps5tron</pattern>
-<pattern>p3stu</pattern>
-<pattern>ps5ty</pattern>
-<pattern>3psy</pattern>
-<pattern>5psyc</pattern>
-<pattern>p3sys</pattern>
-<pattern>4p1t</pattern>
-<pattern>pt3ad</pattern>
-<pattern>pt3alb</pattern>
-<pattern>p3te</pattern>
-<pattern>p2t1h</pattern>
-<pattern>p5ti</pattern>
-<pattern>pt3j</pattern>
-<pattern>p4t3o4v</pattern>
-<pattern>p3tr</pattern>
-<pattern>pt3ric</pattern>
-<pattern>1p2u</pattern>
-<pattern>3pub</pattern>
-<pattern>pu3ch</pattern>
-<pattern>pu3e</pattern>
-<pattern>puil3o</pattern>
-<pattern>pul4st</pattern>
-<pattern>3pun</pattern>
-<pattern>4pun </pattern>
-<pattern>punt3j</pattern>
-<pattern>3put </pattern>
-<pattern>puter5in</pattern>
-<pattern>put1j</pattern>
-<pattern>pu2t3o</pattern>
-<pattern>put3r</pattern>
-<pattern>put4st</pattern>
-<pattern>puts5te </pattern>
-<pattern>2pv</pattern>
-<pattern>pvan4</pattern>
-<pattern>pvari5</pattern>
-<pattern>2p1w</pattern>
-<pattern>1py1</pattern>
-<pattern>2p5z</pattern>
-<pattern>1q</pattern>
-<pattern>5qe</pattern>
-<pattern>qu4</pattern>
-<pattern>que4s</pattern>
-<pattern>5quo</pattern>
-<pattern>4r </pattern>
-<pattern>r2aa</pattern>
-<pattern>2raan</pattern>
-<pattern>4raand</pattern>
-<pattern>3raar</pattern>
-<pattern>5raar </pattern>
-<pattern>4r3aard</pattern>
-<pattern>5raars</pattern>
-<pattern>raar5tj</pattern>
-<pattern>2rac</pattern>
-<pattern>ra4ca</pattern>
-<pattern>ra3ce</pattern>
-<pattern>5racl</pattern>
-<pattern>rad4a</pattern>
-<pattern>3radb</pattern>
-<pattern>ra5den</pattern>
-<pattern>ra3di</pattern>
-<pattern>5radia</pattern>
-<pattern>3radio</pattern>
-<pattern>4radm</pattern>
-<pattern>4r3adr</pattern>
-<pattern>3rad3s</pattern>
-<pattern>4radv</pattern>
-<pattern>2rafd</pattern>
-<pattern>r4aff</pattern>
-<pattern>raf5ond</pattern>
-<pattern>ra3fra</pattern>
-<pattern>3ragez</pattern>
-<pattern>ra5gi</pattern>
-<pattern>ra3g2n</pattern>
-<pattern>ra5go</pattern>
-<pattern>rag4s</pattern>
-<pattern>3rais</pattern>
-<pattern>raket3</pattern>
-<pattern>ra3k4l</pattern>
-<pattern>rak5r</pattern>
-<pattern>4r3a2la</pattern>
-<pattern>ra4l3ee</pattern>
-<pattern>4r3alf</pattern>
-<pattern>r3a4lim</pattern>
-<pattern>r3alt</pattern>
-<pattern>ra4man</pattern>
-<pattern>r5ameu</pattern>
-<pattern>ra3mi</pattern>
-<pattern>r2amp</pattern>
-<pattern>4rana</pattern>
-<pattern>ran4dr</pattern>
-<pattern>ran4g3o</pattern>
-<pattern>ran4gr</pattern>
-<pattern>r5angst </pattern>
-<pattern>ra4nim</pattern>
-<pattern>4ranj</pattern>
-<pattern>ran4kl</pattern>
-<pattern>rank3w</pattern>
-<pattern>ran4sa</pattern>
-<pattern>ran4st</pattern>
-<pattern>ran4t3j</pattern>
-<pattern>r3antw</pattern>
-<pattern>ra3o</pattern>
-<pattern>4rap </pattern>
-<pattern>ra3po</pattern>
-<pattern>4rappa</pattern>
-<pattern>rap5roe</pattern>
-<pattern>ra3q</pattern>
-<pattern>2r3arb</pattern>
-<pattern>r4a5re</pattern>
-<pattern>4rarit</pattern>
-<pattern>2r1arm</pattern>
-<pattern>4r3arr</pattern>
-<pattern>2r1art</pattern>
-<pattern>ra5sei</pattern>
-<pattern>ra4sk</pattern>
-<pattern>ra4sl</pattern>
-<pattern>ra1so</pattern>
-<pattern>ra2sp</pattern>
-<pattern>ras3po</pattern>
-<pattern>rast5ri</pattern>
-<pattern>r4ati</pattern>
-<pattern>rat5j</pattern>
-<pattern>ra4tom</pattern>
-<pattern>ra4tra</pattern>
-<pattern>ra5tri</pattern>
-<pattern>rat3sp</pattern>
-<pattern>rat4st</pattern>
-<pattern>rats5te </pattern>
-<pattern>ra3t4u</pattern>
-<pattern>2rau</pattern>
-<pattern>3raus</pattern>
-<pattern>r1aut</pattern>
-<pattern>5ravr</pattern>
-<pattern>ra4zij</pattern>
-<pattern>rbe4ti</pattern>
-<pattern>r1c</pattern>
-<pattern>r3ce</pattern>
-<pattern>rces3</pattern>
-<pattern>r3chi</pattern>
-<pattern>r3co</pattern>
-<pattern>2r1d</pattern>
-<pattern>r4d3act</pattern>
-<pattern>rd3alk</pattern>
-<pattern>rda2m</pattern>
-<pattern>rd5ama</pattern>
-<pattern>r3dan</pattern>
-<pattern>r2d3ar</pattern>
-<pattern>rd3ei</pattern>
-<pattern>r4d5e4las</pattern>
-<pattern>rden5dr</pattern>
-<pattern>rde5o4</pattern>
-<pattern>r4derva</pattern>
-<pattern>rde5s4t</pattern>
-<pattern>rdi3a</pattern>
-<pattern>rdi5o</pattern>
-<pattern>rd5l</pattern>
-<pattern>r3do</pattern>
-<pattern>r5doc</pattern>
-<pattern>r4d3ol</pattern>
-<pattern>rd5olie</pattern>
-<pattern>rd3ont</pattern>
-<pattern>rd3oos</pattern>
-<pattern>rdo3pe</pattern>
-<pattern>rdo3v</pattern>
-<pattern>rd3ras</pattern>
-<pattern>rd3res</pattern>
-<pattern>rd5roos</pattern>
-<pattern>rd2ru</pattern>
-<pattern>rd3sa</pattern>
-<pattern>rd3s4c</pattern>
-<pattern>rd3so</pattern>
-<pattern>rd1sp</pattern>
-<pattern>rds4t</pattern>
-<pattern>rd5sta</pattern>
-<pattern>rd5ste</pattern>
-<pattern>rd3su</pattern>
-<pattern>r3du</pattern>
-<pattern>rd2wi</pattern>
-<pattern>rd5wo</pattern>
-<pattern>3re </pattern>
-<pattern>1reac</pattern>
-<pattern>re4ade</pattern>
-<pattern>4reak</pattern>
-<pattern>re3amb</pattern>
-<pattern>4re5at</pattern>
-<pattern>re3co</pattern>
-<pattern>3recr</pattern>
-<pattern>rec5ta</pattern>
-<pattern>3reda</pattern>
-<pattern>3redd</pattern>
-<pattern>rede4s3</pattern>
-<pattern>4re4diti</pattern>
-<pattern>3redu</pattern>
-<pattern>re5dw</pattern>
-<pattern>ree4k</pattern>
-<pattern>2r1een</pattern>
-<pattern>ree3n4e</pattern>
-<pattern>r5eenh</pattern>
-<pattern>ree2p</pattern>
-<pattern>reeps5</pattern>
-<pattern>ree5r4ad</pattern>
-<pattern>4reers</pattern>
-<pattern>reer5ste</pattern>
-<pattern>r3eerw</pattern>
-<pattern>ree4s</pattern>
-<pattern>ree5sh</pattern>
-<pattern>r4ef</pattern>
-<pattern>4refb</pattern>
-<pattern>2reff</pattern>
-<pattern>3refl</pattern>
-<pattern>re3fu</pattern>
-<pattern>1reg</pattern>
-<pattern>4reg </pattern>
-<pattern>4regd</pattern>
-<pattern>rege5ne</pattern>
-<pattern>rege4s</pattern>
-<pattern>4regg</pattern>
-<pattern>3regi</pattern>
-<pattern>re3gl</pattern>
-<pattern>4regt</pattern>
-<pattern>4reie</pattern>
-<pattern>4reil</pattern>
-<pattern>4reind</pattern>
-<pattern>rei5tj</pattern>
-<pattern>5reiz</pattern>
-<pattern>re4kap</pattern>
-<pattern>5rekeni</pattern>
-<pattern>re2k3l</pattern>
-<pattern>re2k5n</pattern>
-<pattern>re4ko</pattern>
-<pattern>re4k3re</pattern>
-<pattern>rek3sp</pattern>
-<pattern>re4ku</pattern>
-<pattern>re1kw</pattern>
-<pattern>rel4di</pattern>
-<pattern>rel4d3o</pattern>
-<pattern>reld3r</pattern>
-<pattern>re4l3ei</pattern>
-<pattern>rel5k</pattern>
-<pattern>re4lu4r</pattern>
-<pattern>3rem </pattern>
-<pattern>re4mai</pattern>
-<pattern>remie5tj</pattern>
-<pattern>re5mo5v</pattern>
-<pattern>2remp</pattern>
-<pattern>3r4en </pattern>
-<pattern>re2na</pattern>
-<pattern>re4naa</pattern>
-<pattern>ren5aar</pattern>
-<pattern>re5nade</pattern>
-<pattern>re3nal</pattern>
-<pattern>re4n3an</pattern>
-<pattern>ren3a4r</pattern>
-<pattern>r4end</pattern>
-<pattern>5rendee</pattern>
-<pattern>r5endert</pattern>
-<pattern>re5ne </pattern>
-<pattern>re4nel</pattern>
-<pattern>re5nen </pattern>
-<pattern>ren5enk</pattern>
-<pattern>ren3e4p</pattern>
-<pattern>re5ner </pattern>
-<pattern>ren5erf</pattern>
-<pattern>ren5erv</pattern>
-<pattern>5renf</pattern>
-<pattern>2r1eni</pattern>
-<pattern>5r4enkl</pattern>
-<pattern>r4enn</pattern>
-<pattern>re4noc</pattern>
-<pattern>ren4og</pattern>
-<pattern>ren4opl</pattern>
-<pattern>re3nov</pattern>
-<pattern>5r4enp</pattern>
-<pattern>4renq</pattern>
-<pattern>ren4sl</pattern>
-<pattern>r4ento</pattern>
-<pattern>r3entw</pattern>
-<pattern>r5enveer</pattern>
-<pattern>re4of</pattern>
-<pattern>re4op4</pattern>
-<pattern>re5pa</pattern>
-<pattern>3repet</pattern>
-<pattern>re4pie</pattern>
-<pattern>4req</pattern>
-<pattern>re3qua</pattern>
-<pattern>4r1erf</pattern>
-<pattern>2r1erg</pattern>
-<pattern>re3r2o</pattern>
-<pattern>rer4s</pattern>
-<pattern>2r3ert</pattern>
-<pattern>4r5erv</pattern>
-<pattern>2rerw</pattern>
-<pattern>re3sa</pattern>
-<pattern>re5se</pattern>
-<pattern>re4sl</pattern>
-<pattern>res5le</pattern>
-<pattern>res3m</pattern>
-<pattern>re2s1p</pattern>
-<pattern>res3t</pattern>
-<pattern>re4tem</pattern>
-<pattern>re3t4h</pattern>
-<pattern>ret4i</pattern>
-<pattern>re4tik</pattern>
-<pattern>re5tin</pattern>
-<pattern>2retn</pattern>
-<pattern>re4t3o4g</pattern>
-<pattern>re4t3oo</pattern>
-<pattern>rets5te </pattern>
-<pattern>re2u</pattern>
-<pattern>reur5es</pattern>
-<pattern>reus4t</pattern>
-<pattern>reu5ste</pattern>
-<pattern>3revis</pattern>
-<pattern>3revo</pattern>
-<pattern>2r3ex</pattern>
-<pattern>r4f3aa</pattern>
-<pattern>rf3act</pattern>
-<pattern>r2f3a4g</pattern>
-<pattern>rf3al</pattern>
-<pattern>r3fas</pattern>
-<pattern>r3fe</pattern>
-<pattern>r4f3eng</pattern>
-<pattern>r1fl</pattern>
-<pattern>r4f3lag</pattern>
-<pattern>rf3lev</pattern>
-<pattern>r2f3li</pattern>
-<pattern>rf3lus</pattern>
-<pattern>r4f3op</pattern>
-<pattern>r1fr</pattern>
-<pattern>r4f3re</pattern>
-<pattern>r5frea</pattern>
-<pattern>rf2s2</pattern>
-<pattern>rf3sm</pattern>
-<pattern>rf3sp</pattern>
-<pattern>r4f3u4r</pattern>
-<pattern>rf3uu</pattern>
-<pattern>r1g</pattern>
-<pattern>r4g3ab</pattern>
-<pattern>rg3amb</pattern>
-<pattern>r4g3een</pattern>
-<pattern>rg3ei</pattern>
-<pattern>rg4eis</pattern>
-<pattern>rgel5dr</pattern>
-<pattern>r5gen </pattern>
-<pattern>rge4ra</pattern>
-<pattern>rge5rap</pattern>
-<pattern>r4g3ins</pattern>
-<pattern>r5glas</pattern>
-<pattern>r3glo</pattern>
-<pattern>r4g3lu</pattern>
-<pattern>rg4o3v</pattern>
-<pattern>r5grij</pattern>
-<pattern>rg3rit</pattern>
-<pattern>r3g4ro</pattern>
-<pattern>rg1s4</pattern>
-<pattern>rg2sm</pattern>
-<pattern>rg5so</pattern>
-<pattern>rg4s5pr</pattern>
-<pattern>r3h</pattern>
-<pattern>ri5abel</pattern>
-<pattern>ri4ag</pattern>
-<pattern>ri2ak</pattern>
-<pattern>ri5an</pattern>
-<pattern>rias4</pattern>
-<pattern>ri4av</pattern>
-<pattern>ri4bl</pattern>
-<pattern>4rice</pattern>
-<pattern>ri3co</pattern>
-<pattern>ridde4</pattern>
-<pattern>ri3di</pattern>
-<pattern>ri4dol</pattern>
-<pattern>ri4doo</pattern>
-<pattern>rie5dr</pattern>
-<pattern>rie4k5ap</pattern>
-<pattern>rie5kl</pattern>
-<pattern>rie3kw</pattern>
-<pattern>rie4la</pattern>
-<pattern>riel5aa</pattern>
-<pattern>rie4lei</pattern>
-<pattern>rie4ro</pattern>
-<pattern>rie4ta</pattern>
-<pattern>riet3o</pattern>
-<pattern>ri1eu</pattern>
-<pattern>ri3fl</pattern>
-<pattern>ri3fr</pattern>
-<pattern>r4ig</pattern>
-<pattern>ri4gaa</pattern>
-<pattern>ri3gl</pattern>
-<pattern>5rigste</pattern>
-<pattern>r4ijl</pattern>
-<pattern>4r5ijl </pattern>
-<pattern>r5ijld</pattern>
-<pattern>r5ijlt</pattern>
-<pattern>rij5o</pattern>
-<pattern>rij3pl</pattern>
-<pattern>rij3pr</pattern>
-<pattern>rij3sp</pattern>
-<pattern>rij5ster</pattern>
-<pattern>rij4str</pattern>
-<pattern>4rijv</pattern>
-<pattern>ri4k5l</pattern>
-<pattern>rik5n</pattern>
-<pattern>ri3k4o</pattern>
-<pattern>ril5m</pattern>
-<pattern>ri3ma</pattern>
-<pattern>rim4pr</pattern>
-<pattern>4r3inb</pattern>
-<pattern>4rind</pattern>
-<pattern>ri5ne</pattern>
-<pattern>4r5inf</pattern>
-<pattern>r4ing</pattern>
-<pattern>4r5ingan</pattern>
-<pattern>r5ingeni</pattern>
-<pattern>ring5l</pattern>
-<pattern>4r3inh</pattern>
-<pattern>ri4nit</pattern>
-<pattern>rin4k3l</pattern>
-<pattern>r3inko</pattern>
-<pattern>4rinkt</pattern>
-<pattern>r3inl</pattern>
-<pattern>4r3inna</pattern>
-<pattern>4r1inr</pattern>
-<pattern>4rins</pattern>
-<pattern>r3inst</pattern>
-<pattern>4rint</pattern>
-<pattern>4r1inv</pattern>
-<pattern>ri5on</pattern>
-<pattern>ri3o5s</pattern>
-<pattern>ri4sam</pattern>
-<pattern>ri3sc</pattern>
-<pattern>ri3sot</pattern>
-<pattern>ris5to</pattern>
-<pattern>rit3j</pattern>
-<pattern>rit3ov</pattern>
-<pattern>rit4st</pattern>
-<pattern>rits5te </pattern>
-<pattern>rit5sten</pattern>
-<pattern>3ritt</pattern>
-<pattern>r5j4</pattern>
-<pattern>rjaars5</pattern>
-<pattern>r5ka </pattern>
-<pattern>rkaart5j</pattern>
-<pattern>rk3adr</pattern>
-<pattern>rk3af</pattern>
-<pattern>r2kah</pattern>
-<pattern>rk3ang</pattern>
-<pattern>r4k3art</pattern>
-<pattern>r2k3ei</pattern>
-<pattern>rke4n</pattern>
-<pattern>rken4s</pattern>
-<pattern>rker4sl</pattern>
-<pattern>r4k3erv</pattern>
-<pattern>rke4s</pattern>
-<pattern>rke5stree</pattern>
-<pattern>rke5strer</pattern>
-<pattern>rk5iep</pattern>
-<pattern>rk3ijv</pattern>
-<pattern>rk3inb</pattern>
-<pattern>r4k3ink</pattern>
-<pattern>rkjes5</pattern>
-<pattern>rk3lag</pattern>
-<pattern>r4k3lat</pattern>
-<pattern>rk5leid</pattern>
-<pattern>r2klo</pattern>
-<pattern>rk3loo</pattern>
-<pattern>rk3lus</pattern>
-<pattern>r3kn</pattern>
-<pattern>r4kne</pattern>
-<pattern>r2kob</pattern>
-<pattern>rk3olm</pattern>
-<pattern>rk3omg</pattern>
-<pattern>rkoot5</pattern>
-<pattern>rk3opg</pattern>
-<pattern>rk3ord</pattern>
-<pattern>rk5os </pattern>
-<pattern>rk5oss</pattern>
-<pattern>rk2r</pattern>
-<pattern>r5k4ran</pattern>
-<pattern>rk4ri</pattern>
-<pattern>r5kris</pattern>
-<pattern>r5kron</pattern>
-<pattern>rk1s</pattern>
-<pattern>rk3s4f</pattern>
-<pattern>rk5si</pattern>
-<pattern>rks4p</pattern>
-<pattern>rk4t5e4v</pattern>
-<pattern>rkt3h</pattern>
-<pattern>rk4ti</pattern>
-<pattern>rkt3o</pattern>
-<pattern>rkt1r</pattern>
-<pattern>rk3uit</pattern>
-<pattern>r1kwa</pattern>
-<pattern>rk3waa</pattern>
-<pattern>rk5wat</pattern>
-<pattern>rk3wee</pattern>
-<pattern>r1kwi</pattern>
-<pattern>rk3win</pattern>
-<pattern>r3l</pattern>
-<pattern>rlaat5ste</pattern>
-<pattern>rle4g3r</pattern>
-<pattern>rlink4s</pattern>
-<pattern>rlinks5te</pattern>
-<pattern>rlofs5</pattern>
-<pattern>rlui5t4</pattern>
-<pattern>r1m</pattern>
-<pattern>rmaf4r</pattern>
-<pattern>r4m3art</pattern>
-<pattern>r2m3eb</pattern>
-<pattern>r2m5eg</pattern>
-<pattern>rme4r3a4</pattern>
-<pattern>rmes3</pattern>
-<pattern>rme4t3j</pattern>
-<pattern>rmet5st</pattern>
-<pattern>rm3inh</pattern>
-<pattern>rmi2s</pattern>
-<pattern>r3mo</pattern>
-<pattern>r5moe</pattern>
-<pattern>r4mop</pattern>
-<pattern>rm3opm</pattern>
-<pattern>rmors5te</pattern>
-<pattern>rmos5f</pattern>
-<pattern>rm3s4a</pattern>
-<pattern>rm1st</pattern>
-<pattern>rm3uit</pattern>
-<pattern>rmun4</pattern>
-<pattern>2r1n</pattern>
-<pattern>r3na</pattern>
-<pattern>r5n4am</pattern>
-<pattern>r4n3ap</pattern>
-<pattern>rn3ars</pattern>
-<pattern>rnee5t</pattern>
-<pattern>r4n3ene</pattern>
-<pattern>rnes3</pattern>
-<pattern>rne5te</pattern>
-<pattern>rne4t3j</pattern>
-<pattern>r2n5id</pattern>
-<pattern>r2nin</pattern>
-<pattern>r2n1on</pattern>
-<pattern>rn3oor</pattern>
-<pattern>r5noot</pattern>
-<pattern>rn3ops</pattern>
-<pattern>r5not</pattern>
-<pattern>rn3ove</pattern>
-<pattern>rns4</pattern>
-<pattern>rn3sm</pattern>
-<pattern>rn3sp</pattern>
-<pattern>rn1st</pattern>
-<pattern>rn3sta</pattern>
-<pattern>rn3th</pattern>
-<pattern>rn5tj</pattern>
-<pattern>rn5to</pattern>
-<pattern>r3nu</pattern>
-<pattern>rnu5r</pattern>
-<pattern>ro1a</pattern>
-<pattern>ro5ac</pattern>
-<pattern>r4oc</pattern>
-<pattern>ro1ch</pattern>
-<pattern>ro3d4o</pattern>
-<pattern>3roe </pattern>
-<pattern>4roef</pattern>
-<pattern>4roeg</pattern>
-<pattern>roe4g3r</pattern>
-<pattern>3roem</pattern>
-<pattern>roens4</pattern>
-<pattern>roen5sm</pattern>
-<pattern>roep3l</pattern>
-<pattern>roe4rei</pattern>
-<pattern>roet4j</pattern>
-<pattern>4roev</pattern>
-<pattern>3roë</pattern>
-<pattern>r5offi</pattern>
-<pattern>r4ofi</pattern>
-<pattern>ro3fl</pattern>
-<pattern>roges5</pattern>
-<pattern>1roï</pattern>
-<pattern>ro3kl</pattern>
-<pattern>3rokm</pattern>
-<pattern>rok3sp</pattern>
-<pattern>r4ol </pattern>
-<pattern>ro2l3a</pattern>
-<pattern>role5st</pattern>
-<pattern>rol3g2</pattern>
-<pattern>2roli</pattern>
-<pattern>rol3ov</pattern>
-<pattern>ro5ma</pattern>
-<pattern>ro3mo</pattern>
-<pattern>4romz</pattern>
-<pattern>r2on </pattern>
-<pattern>ron3a4d</pattern>
-<pattern>5r4onal</pattern>
-<pattern>ron4da</pattern>
-<pattern>ron4d3o</pattern>
-<pattern>ron4d3r</pattern>
-<pattern>ron4d5u</pattern>
-<pattern>r2one</pattern>
-<pattern>r2oni</pattern>
-<pattern>r2onk</pattern>
-<pattern>ron4ka</pattern>
-<pattern>r2onn</pattern>
-<pattern>r2o1no</pattern>
-<pattern>r2ons</pattern>
-<pattern>ron4ste</pattern>
-<pattern>rons5te </pattern>
-<pattern>4ron2t</pattern>
-<pattern>ront3j</pattern>
-<pattern>ront3r</pattern>
-<pattern>ro3nu</pattern>
-<pattern>4ronv</pattern>
-<pattern>3roof</pattern>
-<pattern>2roog</pattern>
-<pattern>4roon</pattern>
-<pattern>2r1oor</pattern>
-<pattern>root5ste</pattern>
-<pattern>ro3pa</pattern>
-<pattern>ro4paa</pattern>
-<pattern>ro4pan</pattern>
-<pattern>4ropb</pattern>
-<pattern>ro1pe</pattern>
-<pattern>ro5pee</pattern>
-<pattern>ro4pin</pattern>
-<pattern>ro3p4la</pattern>
-<pattern>4ropn</pattern>
-<pattern>r4opo</pattern>
-<pattern>rop5rak</pattern>
-<pattern>rop3sh</pattern>
-<pattern>r4opte</pattern>
-<pattern>ro4pu</pattern>
-<pattern>ror5d</pattern>
-<pattern>ro3ro</pattern>
-<pattern>ro3sa</pattern>
-<pattern>ro5se</pattern>
-<pattern>ro3sf</pattern>
-<pattern>ro3sh</pattern>
-<pattern>r4o5si</pattern>
-<pattern>ro3sp</pattern>
-<pattern>ros4s5t</pattern>
-<pattern>ro5stel</pattern>
-<pattern>ros5tra</pattern>
-<pattern>ro5te</pattern>
-<pattern>ro3t2h</pattern>
-<pattern>rot3j</pattern>
-<pattern>ro5ton</pattern>
-<pattern>ro3tr</pattern>
-<pattern>rot4ste</pattern>
-<pattern>rots5te </pattern>
-<pattern>r1oud</pattern>
-<pattern>3rou5t4</pattern>
-<pattern>ro3v</pattern>
-<pattern>ro4ve</pattern>
-<pattern>ro5veri</pattern>
-<pattern>4roxi</pattern>
-<pattern>3roy</pattern>
-<pattern>r1p</pattern>
-<pattern>r3pa</pattern>
-<pattern>rp3aan</pattern>
-<pattern>rp3adv</pattern>
-<pattern>rp3ank</pattern>
-<pattern>r5pee</pattern>
-<pattern>rp3eis</pattern>
-<pattern>rpi3s</pattern>
-<pattern>r2p3j</pattern>
-<pattern>rp4lo</pattern>
-<pattern>rp5lod</pattern>
-<pattern>rpoort5j</pattern>
-<pattern>r4p3o4v</pattern>
-<pattern>r4p3rec</pattern>
-<pattern>rp3ric</pattern>
-<pattern>rp4ro</pattern>
-<pattern>r3psa</pattern>
-<pattern>rp4si</pattern>
-<pattern>rp2sl</pattern>
-<pattern>rp3sli</pattern>
-<pattern>rp5spe</pattern>
-<pattern>rp4s5to</pattern>
-<pattern>2r5r</pattern>
-<pattern>rre4l3u</pattern>
-<pattern>rren5s4</pattern>
-<pattern>rre5o</pattern>
-<pattern>rreu2</pattern>
-<pattern>rri5er </pattern>
-<pattern>rrie4t</pattern>
-<pattern>rron5k</pattern>
-<pattern>rrot4j</pattern>
-<pattern>4rs</pattern>
-<pattern>rs3a2d</pattern>
-<pattern>rs3a2g</pattern>
-<pattern>r3sal</pattern>
-<pattern>rs3alm</pattern>
-<pattern>rs3amb</pattern>
-<pattern>r3san</pattern>
-<pattern>rs3ana</pattern>
-<pattern>rs3ap</pattern>
-<pattern>rs3ar</pattern>
-<pattern>rs3as</pattern>
-<pattern>rs4asse</pattern>
-<pattern>rsa4te</pattern>
-<pattern>r5schi</pattern>
-<pattern>rs2cr</pattern>
-<pattern>r4s3eis</pattern>
-<pattern>rsek5ste</pattern>
-<pattern>rs4et</pattern>
-<pattern>rseve3</pattern>
-<pattern>r2s3ez</pattern>
-<pattern>rs4fer</pattern>
-<pattern>rs4hal</pattern>
-<pattern>r3s2hi</pattern>
-<pattern>r3s4hoc</pattern>
-<pattern>rs3hot</pattern>
-<pattern>rs3ini</pattern>
-<pattern>rs3int</pattern>
-<pattern>r4sj4</pattern>
-<pattern>r5sjac</pattern>
-<pattern>r5sjou</pattern>
-<pattern>r5sjt</pattern>
-<pattern>r3s4kat</pattern>
-<pattern>r1sl</pattern>
-<pattern>r4slan</pattern>
-<pattern>r5slec</pattern>
-<pattern>r5slep</pattern>
-<pattern>r5sleu</pattern>
-<pattern>r5slib</pattern>
-<pattern>rs4lie</pattern>
-<pattern>r5sling</pattern>
-<pattern>rs3lob</pattern>
-<pattern>rs5loep</pattern>
-<pattern>r4s3loo</pattern>
-<pattern>r5sluis</pattern>
-<pattern>rs4m</pattern>
-<pattern>r5smaak</pattern>
-<pattern>rs5maal</pattern>
-<pattern>rs5mak</pattern>
-<pattern>r3sme</pattern>
-<pattern>r3smij</pattern>
-<pattern>rs5mis</pattern>
-<pattern>r5smit</pattern>
-<pattern>rs5mu</pattern>
-<pattern>r1sn</pattern>
-<pattern>r2s3na</pattern>
-<pattern>rs3neu</pattern>
-<pattern>r2s3no</pattern>
-<pattern>r1so</pattern>
-<pattern>r5sol</pattern>
-<pattern>rs3ong</pattern>
-<pattern>r2sor</pattern>
-<pattern>rsorkes5</pattern>
-<pattern>rs1ov</pattern>
-<pattern>r1sp</pattern>
-<pattern>r3spaa</pattern>
-<pattern>rs3pad</pattern>
-<pattern>r4s3par</pattern>
-<pattern>rs4pare</pattern>
-<pattern>r3spe</pattern>
-<pattern>r5spec</pattern>
-<pattern>r5spee</pattern>
-<pattern>r5spek</pattern>
-<pattern>rs4pene</pattern>
-<pattern>r4s3pet</pattern>
-<pattern>r5spit</pattern>
-<pattern>r5spoe</pattern>
-<pattern>r5spog</pattern>
-<pattern>r5spon</pattern>
-<pattern>r5spoo</pattern>
-<pattern>rs3pot</pattern>
-<pattern>r5spraa</pattern>
-<pattern>r4spu</pattern>
-<pattern>r5spul</pattern>
-<pattern>rs3put</pattern>
-<pattern>r1s4t</pattern>
-<pattern>r4s5taak</pattern>
-<pattern>rst5aang</pattern>
-<pattern>rs5tas</pattern>
-<pattern>r5stat</pattern>
-<pattern>r3ste</pattern>
-<pattern>r4s3te </pattern>
-<pattern>r5ster </pattern>
-<pattern>r5sterk</pattern>
-<pattern>rs5term</pattern>
-<pattern>r5sters</pattern>
-<pattern>r5stes</pattern>
-<pattern>rste5st</pattern>
-<pattern>r4steva</pattern>
-<pattern>r3sti</pattern>
-<pattern>r4stit</pattern>
-<pattern>r3sto</pattern>
-<pattern>rs5toma</pattern>
-<pattern>r4ston</pattern>
-<pattern>rst5ora</pattern>
-<pattern>r3str</pattern>
-<pattern>rs5trap</pattern>
-<pattern>r4st5red</pattern>
-<pattern>rs5trei</pattern>
-<pattern>r5stren</pattern>
-<pattern>rs5trog</pattern>
-<pattern>rst5roz</pattern>
-<pattern>r3sty</pattern>
-<pattern>r3su</pattern>
-<pattern>rs3usa</pattern>
-<pattern>r3sy</pattern>
-<pattern>4rt</pattern>
-<pattern>r1ta</pattern>
-<pattern>r5ta </pattern>
-<pattern>r4t3aan</pattern>
-<pattern>rt5aand</pattern>
-<pattern>rt5aanv</pattern>
-<pattern>r4t1ac</pattern>
-<pattern>rt1ad</pattern>
-<pattern>rt3af </pattern>
-<pattern>rt3aff</pattern>
-<pattern>rt3am</pattern>
-<pattern>r5tans</pattern>
-<pattern>r2tar</pattern>
-<pattern>rt3art</pattern>
-<pattern>r4tau</pattern>
-<pattern>r2tav</pattern>
-<pattern>rt5c</pattern>
-<pattern>r5teco</pattern>
-<pattern>rt3eig</pattern>
-<pattern>rt3eil</pattern>
-<pattern>rte4lei</pattern>
-<pattern>rt5emb</pattern>
-<pattern>r5ten </pattern>
-<pattern>rte5nach</pattern>
-<pattern>rte3no</pattern>
-<pattern>rte3ro</pattern>
-<pattern>rtes4</pattern>
-<pattern>rte5sta</pattern>
-<pattern>r2t5e2v</pattern>
-<pattern>r4tha</pattern>
-<pattern>rt1he</pattern>
-<pattern>r3ther</pattern>
-<pattern>rt3hi</pattern>
-<pattern>r1tho</pattern>
-<pattern>rt3hol</pattern>
-<pattern>rt3hu</pattern>
-<pattern>rt3hy</pattern>
-<pattern>rt4ij</pattern>
-<pattern>rtij3k</pattern>
-<pattern>r4t3ini</pattern>
-<pattern>r4t3ink</pattern>
-<pattern>rt5jesc</pattern>
-<pattern>r3to</pattern>
-<pattern>rt3off</pattern>
-<pattern>r5tofo</pattern>
-<pattern>r5tok</pattern>
-<pattern>rt3om </pattern>
-<pattern>rt3ond</pattern>
-<pattern>r4t3op</pattern>
-<pattern>r5tori</pattern>
-<pattern>r1tr</pattern>
-<pattern>r3tra</pattern>
-<pattern>rt4rap</pattern>
-<pattern>r4t3ras</pattern>
-<pattern>rt3rec</pattern>
-<pattern>r5treden </pattern>
-<pattern>r3t4rek</pattern>
-<pattern>r4t3res</pattern>
-<pattern>rt3ri</pattern>
-<pattern>r4t3rol</pattern>
-<pattern>r2t4ru</pattern>
-<pattern>rt5ruk</pattern>
-<pattern>rt5rus</pattern>
-<pattern>rt4s5eco</pattern>
-<pattern>rt5sei</pattern>
-<pattern>rt2s3l</pattern>
-<pattern>rt3sle</pattern>
-<pattern>rts5li</pattern>
-<pattern>rt4slu</pattern>
-<pattern>rts5m</pattern>
-<pattern>rts5no</pattern>
-<pattern>rt4soo</pattern>
-<pattern>rt1sp</pattern>
-<pattern>rt4s3pr</pattern>
-<pattern>rts5ten</pattern>
-<pattern>r1tu</pattern>
-<pattern>rt3ui4t</pattern>
-<pattern>rt3w</pattern>
-<pattern>rt2wi</pattern>
-<pattern>5rubr</pattern>
-<pattern>rude3r</pattern>
-<pattern>ru1e</pattern>
-<pattern>4ruf</pattern>
-<pattern>ru2g</pattern>
-<pattern>ru4gr</pattern>
-<pattern>r5uitr</pattern>
-<pattern>ru2k</pattern>
-<pattern>4ru3ke</pattern>
-<pattern>ruk3i</pattern>
-<pattern>rul3aa</pattern>
-<pattern>rul3ap</pattern>
-<pattern>ru2li</pattern>
-<pattern>ru4l3ij</pattern>
-<pattern>ru3lin</pattern>
-<pattern>rul5s</pattern>
-<pattern>r2um</pattern>
-<pattern>ru2mi</pattern>
-<pattern>3run </pattern>
-<pattern>r2und</pattern>
-<pattern>runet3</pattern>
-<pattern>4r5u2ni</pattern>
-<pattern>ru3niv</pattern>
-<pattern>ru4r</pattern>
-<pattern>ru5ra</pattern>
-<pattern>ru5re </pattern>
-<pattern>ru5res</pattern>
-<pattern>r2u4s</pattern>
-<pattern>rus3e</pattern>
-<pattern>rus5tr</pattern>
-<pattern>4rut</pattern>
-<pattern>rut3j</pattern>
-<pattern>rut4st</pattern>
-<pattern>ruts5te </pattern>
-<pattern>4ruu</pattern>
-<pattern>ru3wa</pattern>
-<pattern>rvaat5</pattern>
-<pattern>rval4st</pattern>
-<pattern>rvals5te </pattern>
-<pattern>rvers5te </pattern>
-<pattern>rves4</pattern>
-<pattern>rve3sp</pattern>
-<pattern>rvloot5</pattern>
-<pattern>r1w</pattern>
-<pattern>rwen4st</pattern>
-<pattern>rwens5te </pattern>
-<pattern>r4wh</pattern>
-<pattern>rw2t3j</pattern>
-<pattern>r3x</pattern>
-<pattern>r3yu</pattern>
-<pattern>4rz</pattern>
-<pattern>rzet5st</pattern>
-<pattern>4s </pattern>
-<pattern>5sa </pattern>
-<pattern>s1aa</pattern>
-<pattern>1saag</pattern>
-<pattern>5s2aai</pattern>
-<pattern>saai4s</pattern>
-<pattern>3s2aal</pattern>
-<pattern>3s4aat</pattern>
-<pattern>1sab</pattern>
-<pattern>sa3bo</pattern>
-<pattern>2s1ac</pattern>
-<pattern>sa2ca</pattern>
-<pattern>3sacr</pattern>
-<pattern>s1adv</pattern>
-<pattern>2s1af</pattern>
-<pattern>3safe</pattern>
-<pattern>3safo</pattern>
-<pattern>sa3fr</pattern>
-<pattern>s5agg</pattern>
-<pattern>s4a3gi</pattern>
-<pattern>3sagn</pattern>
-<pattern>sa3go</pattern>
-<pattern>3sah</pattern>
-<pattern>3sai</pattern>
-<pattern>3saj</pattern>
-<pattern>2sak</pattern>
-<pattern>3saks</pattern>
-<pattern>s1akt</pattern>
-<pattern>s2al</pattern>
-<pattern>5sal </pattern>
-<pattern>3sa3la</pattern>
-<pattern>3sald</pattern>
-<pattern>5salh</pattern>
-<pattern>s3all</pattern>
-<pattern>4salm</pattern>
-<pattern>sal5ma</pattern>
-<pattern>s3aln</pattern>
-<pattern>3s4a3lo</pattern>
-<pattern>3s2ame</pattern>
-<pattern>5samm</pattern>
-<pattern>sam5p</pattern>
-<pattern>4sa2na</pattern>
-<pattern>sa3nat</pattern>
-<pattern>s4anc</pattern>
-<pattern>s2a3ne</pattern>
-<pattern>s4ant</pattern>
-<pattern>san4t3j</pattern>
-<pattern>sa2p</pattern>
-<pattern>3sap </pattern>
-<pattern>sa3pa</pattern>
-<pattern>2s3ape</pattern>
-<pattern>sa4pr</pattern>
-<pattern>sa5pro</pattern>
-<pattern>sa3ra</pattern>
-<pattern>s1arb</pattern>
-<pattern>3sard</pattern>
-<pattern>sa2re</pattern>
-<pattern>s1arm</pattern>
-<pattern>saro4</pattern>
-<pattern>sar3ol</pattern>
-<pattern>s4ars</pattern>
-<pattern>4s1art</pattern>
-<pattern>sart5se</pattern>
-<pattern>4sas </pattern>
-<pattern>3sasa</pattern>
-<pattern>sa3sc</pattern>
-<pattern>3s4ast</pattern>
-<pattern>1sat</pattern>
-<pattern>3sa3te</pattern>
-<pattern>5sati</pattern>
-<pattern>2s3atl</pattern>
-<pattern>2s1att</pattern>
-<pattern>s3aud</pattern>
-<pattern>1saur</pattern>
-<pattern>3s2aus</pattern>
-<pattern>s1aut</pattern>
-<pattern>3sauz</pattern>
-<pattern>1sax</pattern>
-<pattern>4s3b</pattern>
-<pattern>s5ba</pattern>
-<pattern>s5be</pattern>
-<pattern>s5bo</pattern>
-<pattern>1sc</pattern>
-<pattern>2sca</pattern>
-<pattern>4sce</pattern>
-<pattern>5scena</pattern>
-<pattern>5scè</pattern>
-<pattern>3s4ch2</pattern>
-<pattern>4sch </pattern>
-<pattern>sch4a</pattern>
-<pattern>5schak</pattern>
-<pattern>5schap</pattern>
-<pattern>4schau</pattern>
-<pattern>5sche </pattern>
-<pattern>s5chec</pattern>
-<pattern>4schef</pattern>
-<pattern>5schen</pattern>
-<pattern>4scheq</pattern>
-<pattern>5scher</pattern>
-<pattern>5schev</pattern>
-<pattern>5schew</pattern>
-<pattern>s2chi</pattern>
-<pattern>4schir</pattern>
-<pattern>5schol</pattern>
-<pattern>5schoo</pattern>
-<pattern>5schot</pattern>
-<pattern>sch5ta</pattern>
-<pattern>2sci</pattern>
-<pattern>4scl</pattern>
-<pattern>2sco</pattern>
-<pattern>3s4cola</pattern>
-<pattern>3scoo</pattern>
-<pattern>3scope</pattern>
-<pattern>5scopi</pattern>
-<pattern>3s4co5re</pattern>
-<pattern>3scout</pattern>
-<pattern>2scr</pattern>
-<pattern>4scris</pattern>
-<pattern>2scu</pattern>
-<pattern>2scy</pattern>
-<pattern>4s1d</pattern>
-<pattern>s5de</pattern>
-<pattern>s4dh</pattern>
-<pattern>sdi5a</pattern>
-<pattern>sdis5</pattern>
-<pattern>s3do</pattern>
-<pattern>s5dr</pattern>
-<pattern>s3dw</pattern>
-<pattern>3se</pattern>
-<pattern>5se </pattern>
-<pattern>se2a</pattern>
-<pattern>se3ak</pattern>
-<pattern>se3al</pattern>
-<pattern>sear4</pattern>
-<pattern>se3au</pattern>
-<pattern>s4eb</pattern>
-<pattern>4s3ech</pattern>
-<pattern>se3cr</pattern>
-<pattern>5sect</pattern>
-<pattern>4secz</pattern>
-<pattern>s4ee</pattern>
-<pattern>4s5eed</pattern>
-<pattern>5seei</pattern>
-<pattern>4s1een</pattern>
-<pattern>s5eenh</pattern>
-<pattern>see4t</pattern>
-<pattern>see5ts</pattern>
-<pattern>4seev</pattern>
-<pattern>s1eff</pattern>
-<pattern>se3ge</pattern>
-<pattern>2s5e2go</pattern>
-<pattern>seg2r</pattern>
-<pattern>4s3ei </pattern>
-<pattern>4s3eig</pattern>
-<pattern>s4ein</pattern>
-<pattern>5sein </pattern>
-<pattern>5seine</pattern>
-<pattern>2seis</pattern>
-<pattern>seis4t</pattern>
-<pattern>sei5tj</pattern>
-<pattern>5seiz</pattern>
-<pattern>sek4st</pattern>
-<pattern>seks5ten</pattern>
-<pattern>se1kw</pattern>
-<pattern>s2el</pattern>
-<pattern>5s4el </pattern>
-<pattern>sel3ad</pattern>
-<pattern>se4l3a4g</pattern>
-<pattern>se4lak</pattern>
-<pattern>se4las</pattern>
-<pattern>se3le</pattern>
-<pattern>4s3e4lek</pattern>
-<pattern>sel3el</pattern>
-<pattern>4se4lem</pattern>
-<pattern>4self</pattern>
-<pattern>se5ling</pattern>
-<pattern>4s3elit</pattern>
-<pattern>sel5k</pattern>
-<pattern>5selm</pattern>
-<pattern>selo4</pattern>
-<pattern>5selp</pattern>
-<pattern>5s4els</pattern>
-<pattern>sel3sp</pattern>
-<pattern>5selt</pattern>
-<pattern>se2l3u</pattern>
-<pattern>s4em</pattern>
-<pattern>se4m3ac</pattern>
-<pattern>s5emm</pattern>
-<pattern>sem3oo</pattern>
-<pattern>s4en</pattern>
-<pattern>5sen </pattern>
-<pattern>se4n3a4g</pattern>
-<pattern>se5nan</pattern>
-<pattern>se4net</pattern>
-<pattern>5sengr</pattern>
-<pattern>5senh</pattern>
-<pattern>sen5k</pattern>
-<pattern>se4n3o</pattern>
-<pattern>4s5enq</pattern>
-<pattern>sen5tw</pattern>
-<pattern>5s4er </pattern>
-<pattern>se1r4a</pattern>
-<pattern>ser5au</pattern>
-<pattern>5se3r4e</pattern>
-<pattern>se4ree</pattern>
-<pattern>se5ren</pattern>
-<pattern>s4erg</pattern>
-<pattern>5sergl</pattern>
-<pattern>s5ergo</pattern>
-<pattern>5sergr</pattern>
-<pattern>ser4i</pattern>
-<pattern>se5rij</pattern>
-<pattern>4s3ern</pattern>
-<pattern>se3ro</pattern>
-<pattern>se5rop</pattern>
-<pattern>ser2s</pattern>
-<pattern>sers3p</pattern>
-<pattern>ser3st</pattern>
-<pattern>sert5w</pattern>
-<pattern>se3ru</pattern>
-<pattern>s4es</pattern>
-<pattern>se5sc</pattern>
-<pattern>se3sf</pattern>
-<pattern>2s5esk</pattern>
-<pattern>5sess</pattern>
-<pattern>se4t</pattern>
-<pattern>se5ta</pattern>
-<pattern>4s3ete</pattern>
-<pattern>se5ti</pattern>
-<pattern>se3tj</pattern>
-<pattern>set3r</pattern>
-<pattern>se5t4ra</pattern>
-<pattern>set5st</pattern>
-<pattern>4s5etu</pattern>
-<pattern>set3w</pattern>
-<pattern>se3um</pattern>
-<pattern>se4ven</pattern>
-<pattern>4s1ex</pattern>
-<pattern>4sez</pattern>
-<pattern>se2ze</pattern>
-<pattern>3sé</pattern>
-<pattern>3sè</pattern>
-<pattern>2s1f</pattern>
-<pattern>4sfed</pattern>
-<pattern>s5fei</pattern>
-<pattern>4sfi</pattern>
-<pattern>4s5fr</pattern>
-<pattern>4sfu</pattern>
-<pattern>sfu5m</pattern>
-<pattern>4s5g</pattern>
-<pattern>sgue4</pattern>
-<pattern>s1h</pattern>
-<pattern>s4ha </pattern>
-<pattern>sha4g</pattern>
-<pattern>s5hal </pattern>
-<pattern>3shamp</pattern>
-<pattern>4she</pattern>
-<pattern>sheid4</pattern>
-<pattern>sheids5</pattern>
-<pattern>s5hie</pattern>
-<pattern>5s4hir</pattern>
-<pattern>sh3l</pattern>
-<pattern>4shm</pattern>
-<pattern>s3hoe</pattern>
-<pattern>s3hoo</pattern>
-<pattern>3s4hop</pattern>
-<pattern>s2hot</pattern>
-<pattern>s3hote</pattern>
-<pattern>3show</pattern>
-<pattern>s5hul</pattern>
-<pattern>1si</pattern>
-<pattern>5si </pattern>
-<pattern>5s4ia</pattern>
-<pattern>si5ac</pattern>
-<pattern>si3am</pattern>
-<pattern>si5an</pattern>
-<pattern>5sic</pattern>
-<pattern>sici4</pattern>
-<pattern>si3co</pattern>
-<pattern>3sie </pattern>
-<pattern>3sieë</pattern>
-<pattern>sie5fr</pattern>
-<pattern>sie5kl</pattern>
-<pattern>siep4</pattern>
-<pattern>sies4</pattern>
-<pattern>sie5sl</pattern>
-<pattern>sie3so</pattern>
-<pattern>sie3st</pattern>
-<pattern>sie5ta</pattern>
-<pattern>sie5to</pattern>
-<pattern>si5è</pattern>
-<pattern>si1f4</pattern>
-<pattern>5s2ig</pattern>
-<pattern>si5go5</pattern>
-<pattern>s3ijv</pattern>
-<pattern>4s1ijz</pattern>
-<pattern>5sile</pattern>
-<pattern>4s5imper</pattern>
-<pattern>3simu</pattern>
-<pattern>5sina</pattern>
-<pattern>s3inb</pattern>
-<pattern>4s3inc</pattern>
-<pattern>4s1ind</pattern>
-<pattern>2sinf</pattern>
-<pattern>sing4</pattern>
-<pattern>3sing </pattern>
-<pattern>s3inga</pattern>
-<pattern>s5ingeni</pattern>
-<pattern>sin3gl</pattern>
-<pattern>s3in5gr</pattern>
-<pattern>s3inh</pattern>
-<pattern>4si2ni</pattern>
-<pattern>4s3inko</pattern>
-<pattern>sin5kr</pattern>
-<pattern>4s3inm</pattern>
-<pattern>s4inn</pattern>
-<pattern>4sinr</pattern>
-<pattern>2s1ins</pattern>
-<pattern>2sint</pattern>
-<pattern>4s5inv</pattern>
-<pattern>4s3inz</pattern>
-<pattern>3sir</pattern>
-<pattern>5siro</pattern>
-<pattern>s3irr</pattern>
-<pattern>si4s</pattern>
-<pattern>sis3e4</pattern>
-<pattern>sis5ee</pattern>
-<pattern>sis3i</pattern>
-<pattern>sis5tr</pattern>
-<pattern>3sit</pattern>
-<pattern>si5to</pattern>
-<pattern>sito5v</pattern>
-<pattern>si3tr</pattern>
-<pattern>si4tru</pattern>
-<pattern>si5tu</pattern>
-<pattern>3siu</pattern>
-<pattern>3siz</pattern>
-<pattern>sj2</pattern>
-<pattern>4sj </pattern>
-<pattern>3s4ja </pattern>
-<pattern>5sjab</pattern>
-<pattern>4sj3d</pattern>
-<pattern>s1je</pattern>
-<pattern>2s3je </pattern>
-<pattern>s5jeb</pattern>
-<pattern>3sjee</pattern>
-<pattern>3s2jei</pattern>
-<pattern>1sjer</pattern>
-<pattern>sje4ri</pattern>
-<pattern>s3jes</pattern>
-<pattern>3sjew</pattern>
-<pattern>3s4jez</pattern>
-<pattern>4sj5k4</pattern>
-<pattern>5sjof</pattern>
-<pattern>4s3jon</pattern>
-<pattern>sj3s2</pattern>
-<pattern>sjt4</pattern>
-<pattern>s5ju</pattern>
-<pattern>2s1k2</pattern>
-<pattern>skaart5j</pattern>
-<pattern>s5kad</pattern>
-<pattern>s4kele</pattern>
-<pattern>s5ken</pattern>
-<pattern>3s2kes</pattern>
-<pattern>sk4i</pattern>
-<pattern>3s2ki </pattern>
-<pattern>3skied</pattern>
-<pattern>skie3s</pattern>
-<pattern>3skië</pattern>
-<pattern>ski5sc</pattern>
-<pattern>s2k3j</pattern>
-<pattern>s3ko</pattern>
-<pattern>s5kre</pattern>
-<pattern>sk5ruim</pattern>
-<pattern>sk3ste</pattern>
-<pattern>4sku</pattern>
-<pattern>s3k4w</pattern>
-<pattern>s2l4</pattern>
-<pattern>3s4la </pattern>
-<pattern>5s4laan</pattern>
-<pattern>5slaap</pattern>
-<pattern>4s5laar</pattern>
-<pattern>4slab</pattern>
-<pattern>s4lac</pattern>
-<pattern>4s3lad</pattern>
-<pattern>3s4lag</pattern>
-<pattern>5slagm</pattern>
-<pattern>sla4me</pattern>
-<pattern>s5lamp </pattern>
-<pattern>s5lampe</pattern>
-<pattern>4s5land</pattern>
-<pattern>3slang</pattern>
-<pattern>3slap</pattern>
-<pattern>5slape</pattern>
-<pattern>sla3pl</pattern>
-<pattern>4s3las</pattern>
-<pattern>2s3lat</pattern>
-<pattern>3s4la5v</pattern>
-<pattern>4slaw</pattern>
-<pattern>3s4laz</pattern>
-<pattern>s3led</pattern>
-<pattern>3s4lee </pattern>
-<pattern>5sleep</pattern>
-<pattern>4s5leer</pattern>
-<pattern>s4leet</pattern>
-<pattern>slee5tj</pattern>
-<pattern>4s3leg</pattern>
-<pattern>2s5lei</pattern>
-<pattern>s5leng</pattern>
-<pattern>s3leni</pattern>
-<pattern>slen4st</pattern>
-<pattern>slens5te </pattern>
-<pattern>3slent</pattern>
-<pattern>s4lep</pattern>
-<pattern>4s5ler</pattern>
-<pattern>s5les</pattern>
-<pattern>sle4t3j</pattern>
-<pattern>3s4leu</pattern>
-<pattern>s5leug</pattern>
-<pattern>s5leus</pattern>
-<pattern>5sleut</pattern>
-<pattern>2s5lev</pattern>
-<pattern>s3li </pattern>
-<pattern>4s3lic</pattern>
-<pattern>4slid</pattern>
-<pattern>2slie</pattern>
-<pattern>s5lied</pattern>
-<pattern>s3lief</pattern>
-<pattern>3s4lier</pattern>
-<pattern>s3lif</pattern>
-<pattern>s5lig</pattern>
-<pattern>4s3lijf</pattern>
-<pattern>5slijp</pattern>
-<pattern>4s5lijs</pattern>
-<pattern>s4li4k</pattern>
-<pattern>sli2m</pattern>
-<pattern>slim5a</pattern>
-<pattern>s5lini</pattern>
-<pattern>4slinn</pattern>
-<pattern>s4lip</pattern>
-<pattern>4s3lit</pattern>
-<pattern>slo4b5</pattern>
-<pattern>2s3loc</pattern>
-<pattern>3s4loe</pattern>
-<pattern>3slof</pattern>
-<pattern>4s3log</pattern>
-<pattern>s3lol</pattern>
-<pattern>s3lood</pattern>
-<pattern>s5loon</pattern>
-<pattern>s5loos</pattern>
-<pattern>5s4loot3</pattern>
-<pattern>s3los</pattern>
-<pattern>3slot</pattern>
-<pattern>slo4tr</pattern>
-<pattern>4s3lou</pattern>
-<pattern>4s5loz</pattern>
-<pattern>4s5luc</pattern>
-<pattern>1s4lui</pattern>
-<pattern>4s5lui </pattern>
-<pattern>4sluid</pattern>
-<pattern>5sluis </pattern>
-<pattern>sluis4t</pattern>
-<pattern>slui5ste</pattern>
-<pattern>5sluit</pattern>
-<pattern>5sluiz</pattern>
-<pattern>4slun</pattern>
-<pattern>2s5lus</pattern>
-<pattern>4s3ly</pattern>
-<pattern>s1m</pattern>
-<pattern>4s5maat</pattern>
-<pattern>3smad</pattern>
-<pattern>3smak </pattern>
-<pattern>3smal</pattern>
-<pattern>2s5man</pattern>
-<pattern>s5map</pattern>
-<pattern>s4mart</pattern>
-<pattern>4s5mat</pattern>
-<pattern>4s5mec</pattern>
-<pattern>5smeden</pattern>
-<pattern>3smeed</pattern>
-<pattern>5s4meet</pattern>
-<pattern>4s5mei</pattern>
-<pattern>4smelo</pattern>
-<pattern>4s5men</pattern>
-<pattern>4s5mes3</pattern>
-<pattern>5smid </pattern>
-<pattern>smie2</pattern>
-<pattern>smies5</pattern>
-<pattern>s4mij</pattern>
-<pattern>s5min</pattern>
-<pattern>5smok</pattern>
-<pattern>s3mon</pattern>
-<pattern>5smuilden</pattern>
-<pattern>s5muile</pattern>
-<pattern>5smuilt</pattern>
-<pattern>s2n4</pattern>
-<pattern>s5nam</pattern>
-<pattern>5s4nap</pattern>
-<pattern>s4nar</pattern>
-<pattern>3snau</pattern>
-<pattern>3s4nav</pattern>
-<pattern>3s4ned</pattern>
-<pattern>3snee</pattern>
-<pattern>snee5t</pattern>
-<pattern>s5neg</pattern>
-<pattern>5s4nel</pattern>
-<pattern>2s5nes</pattern>
-<pattern>4s5net</pattern>
-<pattern>sneus4</pattern>
-<pattern>sneu5st</pattern>
-<pattern>s5neuz</pattern>
-<pattern>s3nie</pattern>
-<pattern>1s4nij</pattern>
-<pattern>s5nim</pattern>
-<pattern>3s4nip</pattern>
-<pattern>4s5niv</pattern>
-<pattern>4snod</pattern>
-<pattern>3s4noe</pattern>
-<pattern>s3nog</pattern>
-<pattern>2snoo</pattern>
-<pattern>s4nor </pattern>
-<pattern>s3norm</pattern>
-<pattern>sno5v</pattern>
-<pattern>3snuf</pattern>
-<pattern>s4nui</pattern>
-<pattern>2snum</pattern>
-<pattern>3so </pattern>
-<pattern>so4bl</pattern>
-<pattern>so1c</pattern>
-<pattern>s3oce</pattern>
-<pattern>3s4o3d</pattern>
-<pattern>1soe</pattern>
-<pattern>2soef</pattern>
-<pattern>3soep</pattern>
-<pattern>soes3</pattern>
-<pattern>2s1off</pattern>
-<pattern>3soft</pattern>
-<pattern>2so2g</pattern>
-<pattern>3so3ga</pattern>
-<pattern>s1oge</pattern>
-<pattern>so3gl</pattern>
-<pattern>3sogy</pattern>
-<pattern>5soi</pattern>
-<pattern>3soï</pattern>
-<pattern>3sok</pattern>
-<pattern>s2ol</pattern>
-<pattern>5sol </pattern>
-<pattern>so3la</pattern>
-<pattern>so3le</pattern>
-<pattern>so3lis</pattern>
-<pattern>3so5l4o3</pattern>
-<pattern>solo5v</pattern>
-<pattern>5sols</pattern>
-<pattern>s2om</pattern>
-<pattern>3s4om </pattern>
-<pattern>5somm</pattern>
-<pattern>2s3oms</pattern>
-<pattern>s3omv</pattern>
-<pattern>2somz</pattern>
-<pattern>5s4on </pattern>
-<pattern>3sona</pattern>
-<pattern>so5nar</pattern>
-<pattern>s3onb</pattern>
-<pattern>2s1ond</pattern>
-<pattern>2song</pattern>
-<pattern>3sonn</pattern>
-<pattern>3so3no</pattern>
-<pattern>s4ons</pattern>
-<pattern>2s1on4t3</pattern>
-<pattern>4s3onv</pattern>
-<pattern>s3onw</pattern>
-<pattern>3soo</pattern>
-<pattern>4s5oog</pattern>
-<pattern>4s3ook</pattern>
-<pattern>4s3oor </pattern>
-<pattern>s3oord</pattern>
-<pattern>4s3oorl</pattern>
-<pattern>5soort</pattern>
-<pattern>2s1op</pattern>
-<pattern>3s4op </pattern>
-<pattern>4s5ope</pattern>
-<pattern>so3phi</pattern>
-<pattern>s2o5po</pattern>
-<pattern>so3pr</pattern>
-<pattern>3s4opra</pattern>
-<pattern>sop4re</pattern>
-<pattern>s2orb</pattern>
-<pattern>s3ord</pattern>
-<pattern>2s1or3g</pattern>
-<pattern>4s5ork</pattern>
-<pattern>sor4o</pattern>
-<pattern>so3ror</pattern>
-<pattern>sor4st</pattern>
-<pattern>3s2ort</pattern>
-<pattern>sos4</pattern>
-<pattern>so3sf</pattern>
-<pattern>s4ot</pattern>
-<pattern>s3oud</pattern>
-<pattern>sou2l</pattern>
-<pattern>sou3t</pattern>
-<pattern>2sov</pattern>
-<pattern>s1ove</pattern>
-<pattern>3so5z</pattern>
-<pattern>4sp </pattern>
-<pattern>sp4a</pattern>
-<pattern>5spaak</pattern>
-<pattern>s3paal</pattern>
-<pattern>5spaan</pattern>
-<pattern>5spaat</pattern>
-<pattern>2spad</pattern>
-<pattern>2spak</pattern>
-<pattern>5spake</pattern>
-<pattern>s4pan</pattern>
-<pattern>3spann</pattern>
-<pattern>4s5pap</pattern>
-<pattern>5spar </pattern>
-<pattern>s4pari</pattern>
-<pattern>5sparr</pattern>
-<pattern>2spas5</pattern>
-<pattern>5spatt</pattern>
-<pattern>s3pau</pattern>
-<pattern>5s4pea</pattern>
-<pattern>4spectu</pattern>
-<pattern>3s4pee</pattern>
-<pattern>speet3</pattern>
-<pattern>4s3pei</pattern>
-<pattern>s4pek</pattern>
-<pattern>5spell</pattern>
-<pattern>4s3pen</pattern>
-<pattern>s5pen </pattern>
-<pattern>spe4na</pattern>
-<pattern>s5pep</pattern>
-<pattern>4sper</pattern>
-<pattern>s4per </pattern>
-<pattern>s5peri</pattern>
-<pattern>s4perm</pattern>
-<pattern>5s4perr</pattern>
-<pattern>4spes</pattern>
-<pattern>s3pez</pattern>
-<pattern>s3pid</pattern>
-<pattern>1s4pie</pattern>
-<pattern>spie5tj</pattern>
-<pattern>4spijn</pattern>
-<pattern>4spijp</pattern>
-<pattern>s5ping</pattern>
-<pattern>5s2pio</pattern>
-<pattern>s3pis</pattern>
-<pattern>spi5sto</pattern>
-<pattern>2s1p4l</pattern>
-<pattern>4s5pla</pattern>
-<pattern>s4plet</pattern>
-<pattern>s2pli4</pattern>
-<pattern>5splin</pattern>
-<pattern>3split</pattern>
-<pattern>s3plo</pattern>
-<pattern>s3plu</pattern>
-<pattern>sp4o</pattern>
-<pattern>s2poe</pattern>
-<pattern>s3poes</pattern>
-<pattern>4spoë</pattern>
-<pattern>4spog</pattern>
-<pattern>4spol</pattern>
-<pattern>2s3pom</pattern>
-<pattern>s4pon </pattern>
-<pattern>s4ponn</pattern>
-<pattern>s2poo</pattern>
-<pattern>s3pop</pattern>
-<pattern>5s4pore</pattern>
-<pattern>s4pori</pattern>
-<pattern>4s3pos</pattern>
-<pattern>5spots</pattern>
-<pattern>4spou</pattern>
-<pattern>4sprakt</pattern>
-<pattern>5spray</pattern>
-<pattern>s5pred</pattern>
-<pattern>5sprei</pattern>
-<pattern>s4prek</pattern>
-<pattern>4sprem</pattern>
-<pattern>4spres</pattern>
-<pattern>5spreu</pattern>
-<pattern>5spriet</pattern>
-<pattern>4s5prij</pattern>
-<pattern>4sprik</pattern>
-<pattern>4sprob</pattern>
-<pattern>4sproc</pattern>
-<pattern>4s5prod</pattern>
-<pattern>4sprof</pattern>
-<pattern>4sprog</pattern>
-<pattern>5s4pron</pattern>
-<pattern>s4proo</pattern>
-<pattern>4spros</pattern>
-<pattern>4s3ps</pattern>
-<pattern>4spt</pattern>
-<pattern>s2p4u</pattern>
-<pattern>4spub</pattern>
-<pattern>5s4pui</pattern>
-<pattern>4spun</pattern>
-<pattern>s4pur</pattern>
-<pattern>5spuw</pattern>
-<pattern>s4q</pattern>
-<pattern>4s5r</pattern>
-<pattern>sraads5l</pattern>
-<pattern>sro5v</pattern>
-<pattern>4s3s4</pattern>
-<pattern>ssa1s2</pattern>
-<pattern>s4sco</pattern>
-<pattern>s4s5cu</pattern>
-<pattern>s5se</pattern>
-<pattern>ssei3s</pattern>
-<pattern>sseo4</pattern>
-<pattern>s5si</pattern>
-<pattern>s5sl</pattern>
-<pattern>s4spa</pattern>
-<pattern>s5spaa</pattern>
-<pattern>ss5pas</pattern>
-<pattern>s5su</pattern>
-<pattern>s5sy</pattern>
-<pattern>s2t</pattern>
-<pattern>4st </pattern>
-<pattern>5staaf</pattern>
-<pattern>5staan </pattern>
-<pattern>4staang</pattern>
-<pattern>4staanw</pattern>
-<pattern>staart5j</pattern>
-<pattern>s4taat</pattern>
-<pattern>staat5j</pattern>
-<pattern>st3abo</pattern>
-<pattern>2s4t1ac</pattern>
-<pattern>3stad</pattern>
-<pattern>5stads</pattern>
-<pattern>2staf</pattern>
-<pattern>5staf </pattern>
-<pattern>sta4fo</pattern>
-<pattern>s4tag</pattern>
-<pattern>s4tak</pattern>
-<pattern>5staki</pattern>
-<pattern>4stakk</pattern>
-<pattern>st3akt</pattern>
-<pattern>4s3tali</pattern>
-<pattern>5stam </pattern>
-<pattern>5stamm</pattern>
-<pattern>3stamp</pattern>
-<pattern>3s4tand</pattern>
-<pattern>stan4s</pattern>
-<pattern>s4tap</pattern>
-<pattern>4stapo</pattern>
-<pattern>s4t3arc</pattern>
-<pattern>4stari</pattern>
-<pattern>2stas</pattern>
-<pattern>stasie4</pattern>
-<pattern>5statio</pattern>
-<pattern>4stau</pattern>
-<pattern>st3aut</pattern>
-<pattern>s4tav</pattern>
-<pattern>4stavo</pattern>
-<pattern>4s5tax</pattern>
-<pattern>4staz</pattern>
-<pattern>2stb</pattern>
-<pattern>2st5c</pattern>
-<pattern>2std</pattern>
-<pattern>4stea</pattern>
-<pattern>5steak</pattern>
-<pattern>4stec</pattern>
-<pattern>s5tech</pattern>
-<pattern>5steco</pattern>
-<pattern>3s4ted</pattern>
-<pattern>4stedu</pattern>
-<pattern>3steek</pattern>
-<pattern>3steen</pattern>
-<pattern>4steenh</pattern>
-<pattern>s5teer</pattern>
-<pattern>stee5t</pattern>
-<pattern>5stein</pattern>
-<pattern>5stekar</pattern>
-<pattern>5stekk</pattern>
-<pattern>5steldh</pattern>
-<pattern>ste4lee</pattern>
-<pattern>st5elem</pattern>
-<pattern>3stell</pattern>
-<pattern>5stem </pattern>
-<pattern>5stemd</pattern>
-<pattern>5stemm</pattern>
-<pattern>4stemo</pattern>
-<pattern>4stent</pattern>
-<pattern>4stenu</pattern>
-<pattern>ste5ran</pattern>
-<pattern>4sterm</pattern>
-<pattern>ster5og</pattern>
-<pattern>st5e4ros</pattern>
-<pattern>5sterren</pattern>
-<pattern>s5teru</pattern>
-<pattern>4ste4s</pattern>
-<pattern>4s4t3ex</pattern>
-<pattern>s4t3e2z</pattern>
-<pattern>2stf</pattern>
-<pattern>4stg</pattern>
-<pattern>4sth</pattern>
-<pattern>s4tha</pattern>
-<pattern>st3hed</pattern>
-<pattern>st5heer</pattern>
-<pattern>st3hek</pattern>
-<pattern>s5them</pattern>
-<pattern>s3ther</pattern>
-<pattern>st1hi</pattern>
-<pattern>s4t1ho</pattern>
-<pattern>s4t1hu</pattern>
-<pattern>s4t3hy</pattern>
-<pattern>2stia</pattern>
-<pattern>2stib</pattern>
-<pattern>4sticu</pattern>
-<pattern>s4t3id</pattern>
-<pattern>5stiefe</pattern>
-<pattern>s5tiev</pattern>
-<pattern>4stijd</pattern>
-<pattern>3s4tijg</pattern>
-<pattern>5s4tijl</pattern>
-<pattern>st3ijs</pattern>
-<pattern>3stils</pattern>
-<pattern>s4tim</pattern>
-<pattern>st3imp</pattern>
-<pattern>sti5ni</pattern>
-<pattern>4stins</pattern>
-<pattern>4s5tint</pattern>
-<pattern>4stite</pattern>
-<pattern>2stiv</pattern>
-<pattern>st3ivo</pattern>
-<pattern>4s4t1j</pattern>
-<pattern>2stk</pattern>
-<pattern>4stl</pattern>
-<pattern>2stm</pattern>
-<pattern>2stn</pattern>
-<pattern>2stob</pattern>
-<pattern>2stoc</pattern>
-<pattern>4stoef</pattern>
-<pattern>3stoel</pattern>
-<pattern>5stoel </pattern>
-<pattern>5stoele</pattern>
-<pattern>4stoen</pattern>
-<pattern>4stoer</pattern>
-<pattern>4stoes</pattern>
-<pattern>4stoez</pattern>
-<pattern>3s4tof</pattern>
-<pattern>st3o4ge</pattern>
-<pattern>5s4tok</pattern>
-<pattern>s4tol</pattern>
-<pattern>sto5li</pattern>
-<pattern>4stoma</pattern>
-<pattern>4stomz</pattern>
-<pattern>s4tong</pattern>
-<pattern>3s4too</pattern>
-<pattern>4st3oog</pattern>
-<pattern>stoot5j</pattern>
-<pattern>s4top</pattern>
-<pattern>st3o5pe</pattern>
-<pattern>st5opto</pattern>
-<pattern>4stora</pattern>
-<pattern>sto4rat</pattern>
-<pattern>4stord</pattern>
-<pattern>sto5ri</pattern>
-<pattern>4s5tos</pattern>
-<pattern>s4tov</pattern>
-<pattern>2stp</pattern>
-<pattern>1s4tr</pattern>
-<pattern>4stra </pattern>
-<pattern>straat5j</pattern>
-<pattern>4st4rad</pattern>
-<pattern>3stra4f</pattern>
-<pattern>5straf </pattern>
-<pattern>s5trag</pattern>
-<pattern>4strai</pattern>
-<pattern>4st3rec</pattern>
-<pattern>s5tref</pattern>
-<pattern>4streg</pattern>
-<pattern>4s3trei</pattern>
-<pattern>5strel</pattern>
-<pattern>3strep</pattern>
-<pattern>st3rif</pattern>
-<pattern>st5rijp</pattern>
-<pattern>s5tris</pattern>
-<pattern>4s3troe</pattern>
-<pattern>s5troep</pattern>
-<pattern>st4rom</pattern>
-<pattern>5strook</pattern>
-<pattern>5stroom</pattern>
-<pattern>4stroos</pattern>
-<pattern>st5roos </pattern>
-<pattern>4s5trou</pattern>
-<pattern>4stroz</pattern>
-<pattern>3stru</pattern>
-<pattern>4strui </pattern>
-<pattern>5struik</pattern>
-<pattern>4st1s4</pattern>
-<pattern>st3sc</pattern>
-<pattern>st5se</pattern>
-<pattern>st3sf</pattern>
-<pattern>st3sk</pattern>
-<pattern>st3sl</pattern>
-<pattern>st3so</pattern>
-<pattern>st5sp</pattern>
-<pattern>st5st</pattern>
-<pattern>2st5t2</pattern>
-<pattern>1stu</pattern>
-<pattern>4stub</pattern>
-<pattern>4stuc</pattern>
-<pattern>5s4tud</pattern>
-<pattern>4stuin</pattern>
-<pattern>stui5tj</pattern>
-<pattern>st5uitk</pattern>
-<pattern>5stuk</pattern>
-<pattern>2s4tun</pattern>
-<pattern>st3uni</pattern>
-<pattern>stu4nie</pattern>
-<pattern>4stus</pattern>
-<pattern>2stv</pattern>
-<pattern>2st3w</pattern>
-<pattern>2s4ty</pattern>
-<pattern>1styl</pattern>
-<pattern>s5typ</pattern>
-<pattern>2stz</pattern>
-<pattern>1su</pattern>
-<pattern>5su </pattern>
-<pattern>5sua</pattern>
-<pattern>5su4b1</pattern>
-<pattern>suba4</pattern>
-<pattern>sub5e</pattern>
-<pattern>su5bl</pattern>
-<pattern>5suc</pattern>
-<pattern>5sud</pattern>
-<pattern>3sug</pattern>
-<pattern>2sui</pattern>
-<pattern>5suik</pattern>
-<pattern>4s1uit</pattern>
-<pattern>5suit </pattern>
-<pattern>s5uitl</pattern>
-<pattern>5suits </pattern>
-<pattern>5suk</pattern>
-<pattern>3sul</pattern>
-<pattern>5sum</pattern>
-<pattern>4s1u2n</pattern>
-<pattern>5sup</pattern>
-<pattern>5surv</pattern>
-<pattern>su4s</pattern>
-<pattern>sus3e</pattern>
-<pattern>suur5</pattern>
-<pattern>4s5v</pattern>
-<pattern>svaat5</pattern>
-<pattern>svari5</pattern>
-<pattern>sve4r</pattern>
-<pattern>sve5ri</pattern>
-<pattern>4s1w</pattern>
-<pattern>s5wo</pattern>
-<pattern>s4y</pattern>
-<pattern>3sy </pattern>
-<pattern>4syc</pattern>
-<pattern>3syn</pattern>
-<pattern>sy4n3e</pattern>
-<pattern>1sys5</pattern>
-<pattern>4s5z</pattern>
-<pattern>4t </pattern>
-<pattern>3taak </pattern>
-<pattern>t4aal</pattern>
-<pattern>t5aando</pattern>
-<pattern>t3aank</pattern>
-<pattern>taan4st</pattern>
-<pattern>t3aanw</pattern>
-<pattern>t3aap</pattern>
-<pattern>taar5sp</pattern>
-<pattern>4t3aas</pattern>
-<pattern>taat4st</pattern>
-<pattern>taats5ta</pattern>
-<pattern>3tabe</pattern>
-<pattern>3tabl</pattern>
-<pattern>2tac</pattern>
-<pattern>ta2ca</pattern>
-<pattern>3t4aci</pattern>
-<pattern>4tad</pattern>
-<pattern>ta4de</pattern>
-<pattern>t3ader</pattern>
-<pattern>5tado</pattern>
-<pattern>t3adr</pattern>
-<pattern>tad4s3</pattern>
-<pattern>t3adve</pattern>
-<pattern>2taf </pattern>
-<pattern>2t3afd</pattern>
-<pattern>5ta3fe</pattern>
-<pattern>4taff</pattern>
-<pattern>t3afha</pattern>
-<pattern>t4afr</pattern>
-<pattern>ta3fro</pattern>
-<pattern>4t1afs</pattern>
-<pattern>2t3afw</pattern>
-<pattern>4tafz</pattern>
-<pattern>ta4gaa</pattern>
-<pattern>5tagee</pattern>
-<pattern>5ta5g4l</pattern>
-<pattern>tag3r</pattern>
-<pattern>5taka</pattern>
-<pattern>5takg</pattern>
-<pattern>5takken</pattern>
-<pattern>ta3kl</pattern>
-<pattern>5takn</pattern>
-<pattern>5takp</pattern>
-<pattern>5tak3r</pattern>
-<pattern>5taks</pattern>
-<pattern>t2al</pattern>
-<pattern>ta3laa</pattern>
-<pattern>ta5lact</pattern>
-<pattern>4talb</pattern>
-<pattern>5tale </pattern>
-<pattern>5talent</pattern>
-<pattern>ta3li</pattern>
-<pattern>5talig</pattern>
-<pattern>t5allia</pattern>
-<pattern>talm3a</pattern>
-<pattern>4talt</pattern>
-<pattern>ta4mak</pattern>
-<pattern>4tamb</pattern>
-<pattern>t3amba</pattern>
-<pattern>5tamen</pattern>
-<pattern>tament5j</pattern>
-<pattern>4tamp</pattern>
-<pattern>t3ampu</pattern>
-<pattern>5tan </pattern>
-<pattern>4t3a2na</pattern>
-<pattern>ta3nag</pattern>
-<pattern>ta3nat</pattern>
-<pattern>tan4d3r</pattern>
-<pattern>tan4k5r</pattern>
-<pattern>ta3o</pattern>
-<pattern>t4ape</pattern>
-<pattern>5tapi</pattern>
-<pattern>ta3pl</pattern>
-<pattern>5tapo</pattern>
-<pattern>ta3q</pattern>
-<pattern>ta3ra</pattern>
-<pattern>4t3arb</pattern>
-<pattern>5tari</pattern>
-<pattern>4t1arm</pattern>
-<pattern>ta2ro4</pattern>
-<pattern>tar5sp</pattern>
-<pattern>tar5taa</pattern>
-<pattern>t3arti</pattern>
-<pattern>3tarw</pattern>
-<pattern>3tas</pattern>
-<pattern>5tasa</pattern>
-<pattern>5tasj</pattern>
-<pattern>5taso</pattern>
-<pattern>ta3s2p</pattern>
-<pattern>ta3sta</pattern>
-<pattern>ta3str</pattern>
-<pattern>ta3sy</pattern>
-<pattern>4tata</pattern>
-<pattern>4tatio</pattern>
-<pattern>tat5j</pattern>
-<pattern>4t3atl</pattern>
-<pattern>3tatr</pattern>
-<pattern>3tau</pattern>
-<pattern>4taut</pattern>
-<pattern>2t1avo</pattern>
-<pattern>3tax</pattern>
-<pattern>t3a2z</pattern>
-<pattern>4t3b</pattern>
-<pattern>tba2l</pattern>
-<pattern>4t3c</pattern>
-<pattern>t4ch</pattern>
-<pattern>t5cha</pattern>
-<pattern>t5che</pattern>
-<pattern>t5chi</pattern>
-<pattern>t5chu</pattern>
-<pattern>4t3d2</pattern>
-<pattern>tdor5st</pattern>
-<pattern>tdo3v</pattern>
-<pattern>1te</pattern>
-<pattern>3tea</pattern>
-<pattern>te3akt</pattern>
-<pattern>5tea4m</pattern>
-<pattern>3tec</pattern>
-<pattern>4t3echt</pattern>
-<pattern>4teco</pattern>
-<pattern>te4dit</pattern>
-<pattern>t3edu</pattern>
-<pattern>tee2</pattern>
-<pattern>teeds5te </pattern>
-<pattern>tee4g</pattern>
-<pattern>4teek</pattern>
-<pattern>tee4k3l</pattern>
-<pattern>teem1</pattern>
-<pattern>4tee4n</pattern>
-<pattern>t5eenhe</pattern>
-<pattern>3teer</pattern>
-<pattern>tee5rin</pattern>
-<pattern>tee4t</pattern>
-<pattern>4t3eeu</pattern>
-<pattern>t4ef</pattern>
-<pattern>t5eff</pattern>
-<pattern>3tefl</pattern>
-<pattern>3teh</pattern>
-<pattern>4t3eier</pattern>
-<pattern>4teig</pattern>
-<pattern>tei4lo</pattern>
-<pattern>t4ein</pattern>
-<pattern>t5eind</pattern>
-<pattern>5teit</pattern>
-<pattern>tei5tj</pattern>
-<pattern>2t3eiw</pattern>
-<pattern>5tekene</pattern>
-<pattern>5tekens</pattern>
-<pattern>4teker</pattern>
-<pattern>4tekk</pattern>
-<pattern>3teko</pattern>
-<pattern>te4k3om</pattern>
-<pattern>3teks</pattern>
-<pattern>te3kw</pattern>
-<pattern>te4k3wi</pattern>
-<pattern>t4el</pattern>
-<pattern>tel5ant</pattern>
-<pattern>te4lap</pattern>
-<pattern>tel5da</pattern>
-<pattern>4telec</pattern>
-<pattern>5teleco</pattern>
-<pattern>t5elect</pattern>
-<pattern>tel5een</pattern>
-<pattern>5telef</pattern>
-<pattern>5teleg</pattern>
-<pattern>tel5ei </pattern>
-<pattern>tel5eie</pattern>
-<pattern>tel5eit</pattern>
-<pattern>te5lel</pattern>
-<pattern>5telev</pattern>
-<pattern>5te5lex</pattern>
-<pattern>tel3f</pattern>
-<pattern>tel5k</pattern>
-<pattern>te4loe</pattern>
-<pattern>te4l3o4g</pattern>
-<pattern>tel5oog</pattern>
-<pattern>te4l3op</pattern>
-<pattern>telo4r</pattern>
-<pattern>tels4</pattern>
-<pattern>4telse</pattern>
-<pattern>tel3so</pattern>
-<pattern>tel5su</pattern>
-<pattern>te4l3uu</pattern>
-<pattern>t4em</pattern>
-<pattern>2temb</pattern>
-<pattern>4temm</pattern>
-<pattern>te4mor</pattern>
-<pattern>tem3ov</pattern>
-<pattern>5temper</pattern>
-<pattern>5tempo</pattern>
-<pattern>t4en</pattern>
-<pattern>ten4ach</pattern>
-<pattern>ten3a4g</pattern>
-<pattern>te3nak</pattern>
-<pattern>te5nare</pattern>
-<pattern>te4nau</pattern>
-<pattern>tene2</pattern>
-<pattern>ten3ed</pattern>
-<pattern>ten3el</pattern>
-<pattern>tene4t</pattern>
-<pattern>3tenh</pattern>
-<pattern>ten5k4</pattern>
-<pattern>te5nore</pattern>
-<pattern>4t5enq</pattern>
-<pattern>ten5scr</pattern>
-<pattern>ten3sn</pattern>
-<pattern>ten3sp</pattern>
-<pattern>tensu4</pattern>
-<pattern>tens5uu</pattern>
-<pattern>3tent</pattern>
-<pattern>5tenta</pattern>
-<pattern>5tenten </pattern>
-<pattern>ten5to</pattern>
-<pattern>t3entw</pattern>
-<pattern>5tenu</pattern>
-<pattern>t2er</pattern>
-<pattern>teraads5</pattern>
-<pattern>te4r5aak</pattern>
-<pattern>ter3a4b</pattern>
-<pattern>tera5ca</pattern>
-<pattern>te4rad</pattern>
-<pattern>tera4de</pattern>
-<pattern>te4r5af</pattern>
-<pattern>ter3ag</pattern>
-<pattern>te3ral</pattern>
-<pattern>te4ran</pattern>
-<pattern>ter3ap</pattern>
-<pattern>ter3as</pattern>
-<pattern>5terec</pattern>
-<pattern>te4rei</pattern>
-<pattern>ter5eik</pattern>
-<pattern>te4rel</pattern>
-<pattern>te4rem</pattern>
-<pattern>te5ren </pattern>
-<pattern>te4r5enk</pattern>
-<pattern>te4r5env</pattern>
-<pattern>4t4erf </pattern>
-<pattern>4terfd</pattern>
-<pattern>ter3fr</pattern>
-<pattern>4t4erft</pattern>
-<pattern>te4r5in </pattern>
-<pattern>3terj</pattern>
-<pattern>4terk </pattern>
-<pattern>4terkt</pattern>
-<pattern>ter3k4w</pattern>
-<pattern>3term</pattern>
-<pattern>5term </pattern>
-<pattern>5termi</pattern>
-<pattern>ter5oc</pattern>
-<pattern>te3rod</pattern>
-<pattern>te3rof</pattern>
-<pattern>te3rog</pattern>
-<pattern>5teron</pattern>
-<pattern>te5rons</pattern>
-<pattern>tero5pe</pattern>
-<pattern>tero4r</pattern>
-<pattern>te3ros</pattern>
-<pattern>5terrei</pattern>
-<pattern>5terreu</pattern>
-<pattern>5terror</pattern>
-<pattern>ter4spr</pattern>
-<pattern>ter5ste </pattern>
-<pattern>ter5ston</pattern>
-<pattern>3tes</pattern>
-<pattern>te3s4ap</pattern>
-<pattern>tes3m</pattern>
-<pattern>te3so</pattern>
-<pattern>tes3ta</pattern>
-<pattern>te5stel</pattern>
-<pattern>tes5ten</pattern>
-<pattern>test5op</pattern>
-<pattern>test5ri</pattern>
-<pattern>test3u</pattern>
-<pattern>te3ta</pattern>
-<pattern>te5tr</pattern>
-<pattern>4t3euv</pattern>
-<pattern>t4ev</pattern>
-<pattern>t5e4van</pattern>
-<pattern>teve4r</pattern>
-<pattern>5tevl</pattern>
-<pattern>3tevr</pattern>
-<pattern>2tex</pattern>
-<pattern>3tex </pattern>
-<pattern>4t3exe</pattern>
-<pattern>4texp</pattern>
-<pattern>1té</pattern>
-<pattern>tè3</pattern>
-<pattern>4t3f</pattern>
-<pattern>4t3g2</pattern>
-<pattern>tgaat5</pattern>
-<pattern>t5ge</pattern>
-<pattern>tge3la</pattern>
-<pattern>tger4</pattern>
-<pattern>4th </pattern>
-<pattern>2t1ha</pattern>
-<pattern>t3haa</pattern>
-<pattern>t4haan</pattern>
-<pattern>t4had</pattern>
-<pattern>t3hak</pattern>
-<pattern>t5ham</pattern>
-<pattern>t4hans</pattern>
-<pattern>t3har</pattern>
-<pattern>t3hav</pattern>
-<pattern>5thea</pattern>
-<pattern>t3heb</pattern>
-<pattern>5thee </pattern>
-<pattern>4t3hei</pattern>
-<pattern>4t3hel</pattern>
-<pattern>3t2hen</pattern>
-<pattern>5theo</pattern>
-<pattern>1t2her</pattern>
-<pattern>5the3ra</pattern>
-<pattern>4t3here</pattern>
-<pattern>3thes</pattern>
-<pattern>3thet</pattern>
-<pattern>t4hin</pattern>
-<pattern>4thm</pattern>
-<pattern>t1hoe</pattern>
-<pattern>t2hog</pattern>
-<pattern>t3hok</pattern>
-<pattern>t1hoo</pattern>
-<pattern>thoof5di</pattern>
-<pattern>4t1hou</pattern>
-<pattern>t3houd</pattern>
-<pattern>5thous</pattern>
-<pattern>4t3hov</pattern>
-<pattern>3thr</pattern>
-<pattern>2thu</pattern>
-<pattern>t1hul</pattern>
-<pattern>4thum</pattern>
-<pattern>t4hur</pattern>
-<pattern>3ti</pattern>
-<pattern>5ti </pattern>
-<pattern>5tia</pattern>
-<pattern>ti5ab</pattern>
-<pattern>ti5ae</pattern>
-<pattern>ti3ap</pattern>
-<pattern>5tib</pattern>
-<pattern>5tica</pattern>
-<pattern>5tice</pattern>
-<pattern>5tici</pattern>
-<pattern>5ticu</pattern>
-<pattern>ti3d4</pattern>
-<pattern>5tie </pattern>
-<pattern>tie5d4</pattern>
-<pattern>5tiefs</pattern>
-<pattern>tie3kn</pattern>
-<pattern>tie4kon</pattern>
-<pattern>ti3enc</pattern>
-<pattern>tien5st</pattern>
-<pattern>5tiep</pattern>
-<pattern>5ties</pattern>
-<pattern>tie5s4l</pattern>
-<pattern>tie5ta</pattern>
-<pattern>tie5to</pattern>
-<pattern>tie5tw</pattern>
-<pattern>ti1eu</pattern>
-<pattern>5tieven</pattern>
-<pattern>ti3fe</pattern>
-<pattern>ti3fr</pattern>
-<pattern>ti2ga</pattern>
-<pattern>tig5aa</pattern>
-<pattern>4tigm</pattern>
-<pattern>ti4gu4</pattern>
-<pattern>tig3ur</pattern>
-<pattern>5tijd</pattern>
-<pattern>tije4</pattern>
-<pattern>tij5ka</pattern>
-<pattern>tij4kl</pattern>
-<pattern>5tijn</pattern>
-<pattern>tij5p</pattern>
-<pattern>t3ijs </pattern>
-<pattern>tij3st</pattern>
-<pattern>tij3t2</pattern>
-<pattern>tij5tr</pattern>
-<pattern>tij5tw</pattern>
-<pattern>4t1ijz</pattern>
-<pattern>ti3ko</pattern>
-<pattern>ti5kr</pattern>
-<pattern>t4il</pattern>
-<pattern>4tils</pattern>
-<pattern>5timm</pattern>
-<pattern>5timo</pattern>
-<pattern>tina4d</pattern>
-<pattern>tin3as</pattern>
-<pattern>4t3incu</pattern>
-<pattern>4t1ind</pattern>
-<pattern>4tinf</pattern>
-<pattern>tin4g3i</pattern>
-<pattern>ting4sa</pattern>
-<pattern>t3inh</pattern>
-<pattern>ti4nit</pattern>
-<pattern>4t3inj</pattern>
-<pattern>t3inko</pattern>
-<pattern>4t3inl</pattern>
-<pattern>t3inq</pattern>
-<pattern>4tinr</pattern>
-<pattern>4t3ins</pattern>
-<pattern>ti3nu</pattern>
-<pattern>4t3inv</pattern>
-<pattern>4tinw</pattern>
-<pattern>ti5om</pattern>
-<pattern>ti3o4p5</pattern>
-<pattern>t2is</pattern>
-<pattern>ti5sa</pattern>
-<pattern>ti3s4j</pattern>
-<pattern>ti3sl</pattern>
-<pattern>ti3so</pattern>
-<pattern>ti4son</pattern>
-<pattern>ti3s4p</pattern>
-<pattern>ti3sta</pattern>
-<pattern>5tite</pattern>
-<pattern>ti3th</pattern>
-<pattern>ti1t2r</pattern>
-<pattern>5tivi</pattern>
-<pattern>ti4vo</pattern>
-<pattern>1tj2</pattern>
-<pattern>2t1ja</pattern>
-<pattern>t5jaa</pattern>
-<pattern>t5jee</pattern>
-<pattern>t5jek</pattern>
-<pattern>t3jen</pattern>
-<pattern>t5jet</pattern>
-<pattern>4tjeu</pattern>
-<pattern>2tjo</pattern>
-<pattern>t1jou</pattern>
-<pattern>2tju</pattern>
-<pattern>4t3k2</pattern>
-<pattern>tkars3</pattern>
-<pattern>4t3l</pattern>
-<pattern>t5le </pattern>
-<pattern>5tleb</pattern>
-<pattern>t5les</pattern>
-<pattern>tli4n</pattern>
-<pattern>4t3m</pattern>
-<pattern>tmen4st</pattern>
-<pattern>tmens5te</pattern>
-<pattern>tmos5</pattern>
-<pattern>4t3n</pattern>
-<pattern>tna4m3o</pattern>
-<pattern>tne4r</pattern>
-<pattern>tnes4</pattern>
-<pattern>5to </pattern>
-<pattern>toa2</pattern>
-<pattern>to3ac</pattern>
-<pattern>to3ar</pattern>
-<pattern>to5bl</pattern>
-<pattern>3toc</pattern>
-<pattern>1toch</pattern>
-<pattern>3tod</pattern>
-<pattern>to3da</pattern>
-<pattern>t4oe</pattern>
-<pattern>toe5d4</pattern>
-<pattern>3toej</pattern>
-<pattern>toe5k</pattern>
-<pattern>5toe3l4a</pattern>
-<pattern>toe5le</pattern>
-<pattern>5toelic</pattern>
-<pattern>toemaat5</pattern>
-<pattern>5toen</pattern>
-<pattern>to5ende</pattern>
-<pattern>toe5pl</pattern>
-<pattern>3toer</pattern>
-<pattern>5toeri</pattern>
-<pattern>5toern</pattern>
-<pattern>5toe1s4</pattern>
-<pattern>toe5st</pattern>
-<pattern>toe3tj</pattern>
-<pattern>3toets</pattern>
-<pattern>5toets </pattern>
-<pattern>5toetse</pattern>
-<pattern>toets5te </pattern>
-<pattern>3toev</pattern>
-<pattern>5toez</pattern>
-<pattern>to2f</pattern>
-<pattern>tof5ar</pattern>
-<pattern>tof5d</pattern>
-<pattern>to4fr</pattern>
-<pattern>tof3th</pattern>
-<pattern>3togn</pattern>
-<pattern>5togr</pattern>
-<pattern>3toi</pattern>
-<pattern>to4kan</pattern>
-<pattern>tok3s</pattern>
-<pattern>t2ol</pattern>
-<pattern>to3la</pattern>
-<pattern>5tolaa</pattern>
-<pattern>to5le</pattern>
-<pattern>5tolet</pattern>
-<pattern>t3olf</pattern>
-<pattern>2toli</pattern>
-<pattern>5tolic</pattern>
-<pattern>to4lie</pattern>
-<pattern>tolk5s</pattern>
-<pattern>5tolo</pattern>
-<pattern>tolp3r</pattern>
-<pattern>t3oly</pattern>
-<pattern>4tom </pattern>
-<pattern>5tomaa</pattern>
-<pattern>tomaat5</pattern>
-<pattern>t3oml</pattern>
-<pattern>to3mo</pattern>
-<pattern>tom4p3j</pattern>
-<pattern>4t3om5s</pattern>
-<pattern>5ton </pattern>
-<pattern>4tond</pattern>
-<pattern>3t2one</pattern>
-<pattern>5tonee</pattern>
-<pattern>5to5nen</pattern>
-<pattern>to5ner</pattern>
-<pattern>3t4ong</pattern>
-<pattern>5tong </pattern>
-<pattern>3t4oni</pattern>
-<pattern>5t4onn</pattern>
-<pattern>to3no</pattern>
-<pattern>5tons</pattern>
-<pattern>ton3sk</pattern>
-<pattern>too4m</pattern>
-<pattern>toom3e</pattern>
-<pattern>5toon</pattern>
-<pattern>t4op </pattern>
-<pattern>top5art</pattern>
-<pattern>top3as</pattern>
-<pattern>to3pen</pattern>
-<pattern>to3pet</pattern>
-<pattern>to3pi</pattern>
-<pattern>2topm</pattern>
-<pattern>to4po</pattern>
-<pattern>to5pos</pattern>
-<pattern>t4opp</pattern>
-<pattern>to4pu</pattern>
-<pattern>to5pus</pattern>
-<pattern>t3opva</pattern>
-<pattern>5tor </pattern>
-<pattern>to3ra</pattern>
-<pattern>to4r3ag</pattern>
-<pattern>t3ord</pattern>
-<pattern>to5rec</pattern>
-<pattern>5torens</pattern>
-<pattern>4t1org</pattern>
-<pattern>t5orga</pattern>
-<pattern>t4ori</pattern>
-<pattern>3toria</pattern>
-<pattern>to4rië</pattern>
-<pattern>tor3k</pattern>
-<pattern>tor4m3a</pattern>
-<pattern>toro4</pattern>
-<pattern>to4r5oli</pattern>
-<pattern>to3rom</pattern>
-<pattern>5torr</pattern>
-<pattern>3tors</pattern>
-<pattern>tors5te </pattern>
-<pattern>to3r2u</pattern>
-<pattern>3tos4</pattern>
-<pattern>to3sa</pattern>
-<pattern>to1sl</pattern>
-<pattern>to1s2p</pattern>
-<pattern>tos5te</pattern>
-<pattern>5tota</pattern>
-<pattern>to3tr</pattern>
-<pattern>2t3oud</pattern>
-<pattern>3tour</pattern>
-<pattern>tou4r3e</pattern>
-<pattern>to3v</pattern>
-<pattern>tove5na</pattern>
-<pattern>to4vens</pattern>
-<pattern>4toverg</pattern>
-<pattern>to3w4</pattern>
-<pattern>4t3p4</pattern>
-<pattern>tpe4t3</pattern>
-<pattern>tpi3s</pattern>
-<pattern>tr4</pattern>
-<pattern>3tra </pattern>
-<pattern>4t3raad</pattern>
-<pattern>5tracé</pattern>
-<pattern>5trafo </pattern>
-<pattern>3trag</pattern>
-<pattern>4tragez</pattern>
-<pattern>3t4rai</pattern>
-<pattern>5train</pattern>
-<pattern>5traka</pattern>
-<pattern>t3rake</pattern>
-<pattern>3trakt</pattern>
-<pattern>3trans</pattern>
-<pattern>5transa</pattern>
-<pattern>5trap </pattern>
-<pattern>5trau</pattern>
-<pattern>4t3raz</pattern>
-<pattern>3t4re </pattern>
-<pattern>4trea</pattern>
-<pattern>2trec</pattern>
-<pattern>5tred </pattern>
-<pattern>4treda</pattern>
-<pattern>t5redes</pattern>
-<pattern>4tredu</pattern>
-<pattern>3tref</pattern>
-<pattern>4t5reg</pattern>
-<pattern>4t3reis</pattern>
-<pattern>4treiz</pattern>
-<pattern>4trel</pattern>
-<pattern>t3rese</pattern>
-<pattern>t3resu</pattern>
-<pattern>tre2t3</pattern>
-<pattern>t4reu</pattern>
-<pattern>t3rib </pattern>
-<pattern>5tribu</pattern>
-<pattern>5trico</pattern>
-<pattern>trie5ta</pattern>
-<pattern>trig2</pattern>
-<pattern>2trij</pattern>
-<pattern>5t4ril</pattern>
-<pattern>tri5ni</pattern>
-<pattern>5t4rio4</pattern>
-<pattern>t3risi</pattern>
-<pattern>t3rit </pattern>
-<pattern>5t4riti</pattern>
-<pattern>5trody</pattern>
-<pattern>t3roed</pattern>
-<pattern>t3roes</pattern>
-<pattern>5trofy</pattern>
-<pattern>3trog</pattern>
-<pattern>t4roï</pattern>
-<pattern>5troj</pattern>
-<pattern>4trol </pattern>
-<pattern>5trola</pattern>
-<pattern>5trolo</pattern>
-<pattern>5tromm</pattern>
-<pattern>5tron </pattern>
-<pattern>5trona</pattern>
-<pattern>t5rond</pattern>
-<pattern>3trone</pattern>
-<pattern>5tronn</pattern>
-<pattern>5trono</pattern>
-<pattern>5trons</pattern>
-<pattern>tront5j</pattern>
-<pattern>t3rood</pattern>
-<pattern>5troon</pattern>
-<pattern>t4roos</pattern>
-<pattern>tro5pi</pattern>
-<pattern>t4ros</pattern>
-<pattern>5trotu</pattern>
-<pattern>3trou</pattern>
-<pattern>4t5rout</pattern>
-<pattern>tro5v</pattern>
-<pattern>5truc </pattern>
-<pattern>5truf</pattern>
-<pattern>4trug</pattern>
-<pattern>5trui </pattern>
-<pattern>5truie</pattern>
-<pattern>t3ruim</pattern>
-<pattern>trui5t4</pattern>
-<pattern>t3ruk</pattern>
-<pattern>t4rum</pattern>
-<pattern>4ts</pattern>
-<pattern>ts3a2d</pattern>
-<pattern>tsa4g</pattern>
-<pattern>ts1am</pattern>
-<pattern>t3sap</pattern>
-<pattern>ts3as</pattern>
-<pattern>tse4d</pattern>
-<pattern>ts5een</pattern>
-<pattern>t4s3ei</pattern>
-<pattern>ts5eind</pattern>
-<pattern>t4s5ene</pattern>
-<pattern>t4s3eng</pattern>
-<pattern>t4s3erg</pattern>
-<pattern>ts5erge</pattern>
-<pattern>t4s3e2v</pattern>
-<pattern>t2sij</pattern>
-<pattern>t4s3ink</pattern>
-<pattern>ts3int</pattern>
-<pattern>ts2j</pattern>
-<pattern>ts3ja</pattern>
-<pattern>t3sjen</pattern>
-<pattern>3tsji</pattern>
-<pattern>t1sl</pattern>
-<pattern>ts4laa</pattern>
-<pattern>t3slac</pattern>
-<pattern>t5slag </pattern>
-<pattern>ts3lam</pattern>
-<pattern>t2s3le</pattern>
-<pattern>t5slib</pattern>
-<pattern>t5sloe</pattern>
-<pattern>t3s4lu</pattern>
-<pattern>ts2me</pattern>
-<pattern>ts4moe</pattern>
-<pattern>ts3neu</pattern>
-<pattern>ts4no</pattern>
-<pattern>ts5nor</pattern>
-<pattern>ts5not</pattern>
-<pattern>ts3nu</pattern>
-<pattern>ts3ob</pattern>
-<pattern>tso2l</pattern>
-<pattern>ts3oli</pattern>
-<pattern>ts3om</pattern>
-<pattern>ts1on</pattern>
-<pattern>ts4opp</pattern>
-<pattern>ts1o4r</pattern>
-<pattern>ts1ov</pattern>
-<pattern>ts3pad</pattern>
-<pattern>t3span</pattern>
-<pattern>t5spec</pattern>
-<pattern>t4s3pet</pattern>
-<pattern>t3spi</pattern>
-<pattern>t4s3pil</pattern>
-<pattern>t3spoe</pattern>
-<pattern>t3spoo</pattern>
-<pattern>t5s4por</pattern>
-<pattern>ts3pot</pattern>
-<pattern>t4spro</pattern>
-<pattern>ts4pru</pattern>
-<pattern>ts5q</pattern>
-<pattern>ts5s</pattern>
-<pattern>t3sta</pattern>
-<pattern>t4staak</pattern>
-<pattern>t4s5tank</pattern>
-<pattern>ts5tant</pattern>
-<pattern>t4star</pattern>
-<pattern>t4stas</pattern>
-<pattern>t3ste</pattern>
-<pattern>t5sted</pattern>
-<pattern>t5stee</pattern>
-<pattern>ts5teko</pattern>
-<pattern>t5stell</pattern>
-<pattern>t5stels</pattern>
-<pattern>t5stem</pattern>
-<pattern>t5ster </pattern>
-<pattern>t4sterr</pattern>
-<pattern>t5sters</pattern>
-<pattern>t5s4tes </pattern>
-<pattern>t5steu</pattern>
-<pattern>ts3th</pattern>
-<pattern>t1s4ti</pattern>
-<pattern>t3stij</pattern>
-<pattern>t5stijg</pattern>
-<pattern>t5stil</pattern>
-<pattern>ts5tin</pattern>
-<pattern>ts5t4j</pattern>
-<pattern>t1sto</pattern>
-<pattern>ts5toep</pattern>
-<pattern>ts5tong</pattern>
-<pattern>t4store</pattern>
-<pattern>ts5trad</pattern>
-<pattern>ts5trei</pattern>
-<pattern>t3stri</pattern>
-<pattern>ts5troe</pattern>
-<pattern>ts5ty</pattern>
-<pattern>t4su4</pattern>
-<pattern>ts3ur</pattern>
-<pattern>ts3us</pattern>
-<pattern>ts3uu</pattern>
-<pattern>t1sy</pattern>
-<pattern>4t3t</pattern>
-<pattern>t5t4a</pattern>
-<pattern>t5te</pattern>
-<pattern>tte5loe</pattern>
-<pattern>tte5l4op</pattern>
-<pattern>tte2n</pattern>
-<pattern>tten4t5j</pattern>
-<pattern>tte5ri</pattern>
-<pattern>t5tlet</pattern>
-<pattern>tt3oog</pattern>
-<pattern>ttop2</pattern>
-<pattern>t5t4r</pattern>
-<pattern>t5tum</pattern>
-<pattern>tt3uu</pattern>
-<pattern>3tua</pattern>
-<pattern>3tub</pattern>
-<pattern>3tuch</pattern>
-<pattern>3tu3e</pattern>
-<pattern>5tueu</pattern>
-<pattern>tu3és</pattern>
-<pattern>3tuig</pattern>
-<pattern>5tuin</pattern>
-<pattern>4tuip</pattern>
-<pattern>2tuit</pattern>
-<pattern>tuit4j</pattern>
-<pattern>4tuk</pattern>
-<pattern>tu4k3i</pattern>
-<pattern>tul5pi</pattern>
-<pattern>t4um</pattern>
-<pattern>5tune</pattern>
-<pattern>5tunn</pattern>
-<pattern>tu1o</pattern>
-<pattern>5turb</pattern>
-<pattern>tu3ri</pattern>
-<pattern>3tu4s3</pattern>
-<pattern>tut3j</pattern>
-<pattern>tuurs5la</pattern>
-<pattern>tu3wa</pattern>
-<pattern>4tv</pattern>
-<pattern>tvaat5</pattern>
-<pattern>t3ve</pattern>
-<pattern>4t1w</pattern>
-<pattern>3t4wijf</pattern>
-<pattern>t2win</pattern>
-<pattern>1ty1</pattern>
-<pattern>3typ</pattern>
-<pattern>tys4</pattern>
-<pattern>4tz</pattern>
-<pattern>t3za</pattern>
-<pattern>t3zi</pattern>
-<pattern>t5zw</pattern>
-<pattern>u1a</pattern>
-<pattern>u3ac</pattern>
-<pattern>u3an</pattern>
-<pattern>ua5ne</pattern>
-<pattern>ua3p</pattern>
-<pattern>u5ar </pattern>
-<pattern>uar5t</pattern>
-<pattern>ua3sa</pattern>
-<pattern>uat4</pattern>
-<pattern>2u2b</pattern>
-<pattern>ub3ac</pattern>
-<pattern>ube4li</pattern>
-<pattern>ub5em</pattern>
-<pattern>u5bi</pattern>
-<pattern>u3bo</pattern>
-<pattern>ub5or</pattern>
-<pattern>4uc</pattern>
-<pattern>u1che</pattern>
-<pattern>ucht5sl</pattern>
-<pattern>uc4ki</pattern>
-<pattern>ucle3</pattern>
-<pattern>uc4t3a</pattern>
-<pattern>uc4tin</pattern>
-<pattern>u1d</pattern>
-<pattern>uda2</pattern>
-<pattern>u5da </pattern>
-<pattern>ud5am</pattern>
-<pattern>ud3ei</pattern>
-<pattern>ud3ess</pattern>
-<pattern>u4de4z</pattern>
-<pattern>ud3eze</pattern>
-<pattern>udi4o</pattern>
-<pattern>udi5ologe</pattern>
-<pattern>udi3om</pattern>
-<pattern>udoe2</pattern>
-<pattern>ud3ond</pattern>
-<pattern>ud3oo</pattern>
-<pattern>ud3ov</pattern>
-<pattern>u4d1r</pattern>
-<pattern>uds5lo</pattern>
-<pattern>uds4m</pattern>
-<pattern>uds5ma</pattern>
-<pattern>ud3sme</pattern>
-<pattern>ud3smi</pattern>
-<pattern>ud1st</pattern>
-<pattern>ud4sta</pattern>
-<pattern>uds5tak</pattern>
-<pattern>ud4sti</pattern>
-<pattern>ud1w</pattern>
-<pattern>u3ec</pattern>
-<pattern>ue2co</pattern>
-<pattern>u1ee4</pattern>
-<pattern>u3ef</pattern>
-<pattern>u3ei</pattern>
-<pattern>u1el</pattern>
-<pattern>u4ene</pattern>
-<pattern>u1er</pattern>
-<pattern>uer3il</pattern>
-<pattern>ue3st</pattern>
-<pattern>u1eu</pattern>
-<pattern>u5eul</pattern>
-<pattern>u3ez</pattern>
-<pattern>u3è</pattern>
-<pattern>u4f3an</pattern>
-<pattern>u1fl</pattern>
-<pattern>u1f4r</pattern>
-<pattern>uf2s</pattern>
-<pattern>u5ga</pattern>
-<pattern>ug4da2</pattern>
-<pattern>ug4der</pattern>
-<pattern>ug2do</pattern>
-<pattern>ug4dr</pattern>
-<pattern>uge4l5o</pattern>
-<pattern>ug3ij</pattern>
-<pattern>ug1l</pattern>
-<pattern>u2go</pattern>
-<pattern>ug3or</pattern>
-<pattern>u2g1r</pattern>
-<pattern>ug5sce</pattern>
-<pattern>ug4sec</pattern>
-<pattern>ugs4p</pattern>
-<pattern>ugs5pa</pattern>
-<pattern>ug1s4t</pattern>
-<pattern>ugs5tra</pattern>
-<pattern>u1h</pattern>
-<pattern>u2i</pattern>
-<pattern>ui5ac</pattern>
-<pattern>ui2d3a</pattern>
-<pattern>ui2d1o</pattern>
-<pattern>uid4s</pattern>
-<pattern>uid3sp</pattern>
-<pattern>uid5spre</pattern>
-<pattern>uid5ste </pattern>
-<pattern>uid3u</pattern>
-<pattern>ui3e</pattern>
-<pattern>uien4t</pattern>
-<pattern>ui2fa</pattern>
-<pattern>uif1l</pattern>
-<pattern>uif5r</pattern>
-<pattern>ui2fu</pattern>
-<pattern>4uig</pattern>
-<pattern>ui4g5aa</pattern>
-<pattern>uig1l</pattern>
-<pattern>ui2g3o</pattern>
-<pattern>ui4g3r</pattern>
-<pattern>ui4gu</pattern>
-<pattern>4uik</pattern>
-<pattern>ui2k3a</pattern>
-<pattern>ui4k3l</pattern>
-<pattern>ui2ko</pattern>
-<pattern>ui2ku</pattern>
-<pattern>ui2la</pattern>
-<pattern>uil5aa</pattern>
-<pattern>ui4l3em</pattern>
-<pattern>uil5m</pattern>
-<pattern>ui4l3og</pattern>
-<pattern>ui4loo</pattern>
-<pattern>uil3ov</pattern>
-<pattern>4uim</pattern>
-<pattern>ui2m3a</pattern>
-<pattern>ui3mag</pattern>
-<pattern>ui4n1a</pattern>
-<pattern>uin5g</pattern>
-<pattern>ui2no</pattern>
-<pattern>uin5og</pattern>
-<pattern>uin3or</pattern>
-<pattern>uin4s5lo</pattern>
-<pattern>uin5to</pattern>
-<pattern>ui2p3l</pattern>
-<pattern>ui4p3o4</pattern>
-<pattern>ui2p3r</pattern>
-<pattern>4uis</pattern>
-<pattern>ui2s3a</pattern>
-<pattern>uis5c</pattern>
-<pattern>ui4sl</pattern>
-<pattern>ui5slu</pattern>
-<pattern>uis5p</pattern>
-<pattern>ui4st</pattern>
-<pattern>ui4t3a4</pattern>
-<pattern>uit5aa</pattern>
-<pattern>uit5al</pattern>
-<pattern>ui5tar</pattern>
-<pattern>1uitg</pattern>
-<pattern>uit1j</pattern>
-<pattern>3uitl</pattern>
-<pattern>ui2t1o</pattern>
-<pattern>1uit5r</pattern>
-<pattern>uit3sl</pattern>
-<pattern>uit3sn</pattern>
-<pattern>uit5sp</pattern>
-<pattern>uits5te </pattern>
-<pattern>3uitw</pattern>
-<pattern>3uitz</pattern>
-<pattern>ui3v</pattern>
-<pattern>4u3j</pattern>
-<pattern>2uk</pattern>
-<pattern>u2k3al</pattern>
-<pattern>uk3as</pattern>
-<pattern>ukkers5</pattern>
-<pattern>u2k3l</pattern>
-<pattern>u3klas</pattern>
-<pattern>u2k3n</pattern>
-<pattern>u2k3o</pattern>
-<pattern>u3koc</pattern>
-<pattern>uko2p</pattern>
-<pattern>uk4o3pl</pattern>
-<pattern>u4k3r</pattern>
-<pattern>uk3s2m</pattern>
-<pattern>uk3spa</pattern>
-<pattern>uk3spl</pattern>
-<pattern>uk4sti</pattern>
-<pattern>uk1w</pattern>
-<pattern>u1la</pattern>
-<pattern>ul3ac</pattern>
-<pattern>ulam4</pattern>
-<pattern>ula4p</pattern>
-<pattern>ul4d3a</pattern>
-<pattern>uld5erk</pattern>
-<pattern>ul5dop</pattern>
-<pattern>ul4d3u</pattern>
-<pattern>u1le</pattern>
-<pattern>ule5sp</pattern>
-<pattern>ul3fl</pattern>
-<pattern>ul5fo</pattern>
-<pattern>ul3fr</pattern>
-<pattern>ul3in </pattern>
-<pattern>u5ling</pattern>
-<pattern>ul3inn</pattern>
-<pattern>ul3k2a</pattern>
-<pattern>ul5ke</pattern>
-<pattern>ul2k3l</pattern>
-<pattern>u1lo</pattern>
-<pattern>ul3o2p</pattern>
-<pattern>u3los</pattern>
-<pattern>ul2pa</pattern>
-<pattern>ulp3ac</pattern>
-<pattern>ul4pi</pattern>
-<pattern>ul2p3l</pattern>
-<pattern>ul2po</pattern>
-<pattern>ul4p3r</pattern>
-<pattern>ul3sa</pattern>
-<pattern>ul3so</pattern>
-<pattern>ul2s3p</pattern>
-<pattern>uls5te </pattern>
-<pattern>uls5tel</pattern>
-<pattern>u3lu</pattern>
-<pattern>um3af</pattern>
-<pattern>um3ar</pattern>
-<pattern>3umda</pattern>
-<pattern>2ume</pattern>
-<pattern>umee4</pattern>
-<pattern>umes4</pattern>
-<pattern>ume3st</pattern>
-<pattern>um3om</pattern>
-<pattern>um3op</pattern>
-<pattern>um3so</pattern>
-<pattern>um3st</pattern>
-<pattern>u2m3ui</pattern>
-<pattern>un3ac</pattern>
-<pattern>un2c</pattern>
-<pattern>unch3r</pattern>
-<pattern>un4dra</pattern>
-<pattern>und4s</pattern>
-<pattern>unds5ta</pattern>
-<pattern>und5ste</pattern>
-<pattern>une4t</pattern>
-<pattern>un3g</pattern>
-<pattern>1univ</pattern>
-<pattern>un4k3r</pattern>
-<pattern>un4o</pattern>
-<pattern>uno3g</pattern>
-<pattern>un5o2p</pattern>
-<pattern>unst3a</pattern>
-<pattern>un4ste </pattern>
-<pattern>unst3o</pattern>
-<pattern>un4st5r</pattern>
-<pattern>unst5ui</pattern>
-<pattern>un4tag</pattern>
-<pattern>unt5een</pattern>
-<pattern>un2tj</pattern>
-<pattern>un4t5o4</pattern>
-<pattern>unt3s4m</pattern>
-<pattern>un4t3u</pattern>
-<pattern>u3ol</pattern>
-<pattern>u3on</pattern>
-<pattern>u3oo</pattern>
-<pattern>u1or</pattern>
-<pattern>uo3ru</pattern>
-<pattern>u3os</pattern>
-<pattern>uota3</pattern>
-<pattern>4up</pattern>
-<pattern>u1pa</pattern>
-<pattern>u1pe</pattern>
-<pattern>upe3k</pattern>
-<pattern>upe4ro</pattern>
-<pattern>uper5st</pattern>
-<pattern>u3ph</pattern>
-<pattern>u3pi</pattern>
-<pattern>u1pl</pattern>
-<pattern>u4p3lei</pattern>
-<pattern>u1po</pattern>
-<pattern>u3pol</pattern>
-<pattern>up3om</pattern>
-<pattern>up3op</pattern>
-<pattern>u1pr</pattern>
-<pattern>up4tr</pattern>
-<pattern>u1ra</pattern>
-<pattern>ur3aan</pattern>
-<pattern>ur1ac</pattern>
-<pattern>ur3ada</pattern>
-<pattern>ur3adv</pattern>
-<pattern>u2r3a4r</pattern>
-<pattern>uras3</pattern>
-<pattern>u4r3a2z</pattern>
-<pattern>urd4o</pattern>
-<pattern>u1r2e</pattern>
-<pattern>ur3ech</pattern>
-<pattern>ur3een</pattern>
-<pattern>uree5s</pattern>
-<pattern>ure5lu</pattern>
-<pattern>urelu5r</pattern>
-<pattern>u4rem</pattern>
-<pattern>ur3emb</pattern>
-<pattern>ure4n</pattern>
-<pattern>u3res</pattern>
-<pattern>ur3ess</pattern>
-<pattern>ure3st</pattern>
-<pattern>ur3eta</pattern>
-<pattern>4urf</pattern>
-<pattern>ur2fa</pattern>
-<pattern>ur3gi</pattern>
-<pattern>u1ri</pattern>
-<pattern>uri4gl</pattern>
-<pattern>ur3ijz</pattern>
-<pattern>ur3ind</pattern>
-<pattern>ur3int</pattern>
-<pattern>4urk</pattern>
-<pattern>urken5s</pattern>
-<pattern>ur4kie</pattern>
-<pattern>ur3k4l</pattern>
-<pattern>urk4s5t</pattern>
-<pattern>u1ro</pattern>
-<pattern>ur5opb</pattern>
-<pattern>ur3or</pattern>
-<pattern>uro5s</pattern>
-<pattern>ur5pr</pattern>
-<pattern>ur4serv</pattern>
-<pattern>ur4s3ev</pattern>
-<pattern>ur3s4fe</pattern>
-<pattern>ur2sl</pattern>
-<pattern>urs5laa</pattern>
-<pattern>urs5li</pattern>
-<pattern>ur4s5m</pattern>
-<pattern>ur2sn</pattern>
-<pattern>ur4sp</pattern>
-<pattern>urs5pa</pattern>
-<pattern>ur5spel</pattern>
-<pattern>ur5spor</pattern>
-<pattern>urs5take</pattern>
-<pattern>urs5th</pattern>
-<pattern>ur4sti</pattern>
-<pattern>urs5tik</pattern>
-<pattern>ur3ta</pattern>
-<pattern>ur4tro</pattern>
-<pattern>ur5troe</pattern>
-<pattern>u3ru</pattern>
-<pattern>ur3ui</pattern>
-<pattern>4urv</pattern>
-<pattern>u1r4y</pattern>
-<pattern>4usaa</pattern>
-<pattern>us3ad</pattern>
-<pattern>us3a2m</pattern>
-<pattern>us1ap</pattern>
-<pattern>u4sc</pattern>
-<pattern>u5s2cr</pattern>
-<pattern>use5tj</pattern>
-<pattern>u5sie</pattern>
-<pattern>u4sj</pattern>
-<pattern>u4s5l</pattern>
-<pattern>u4sm</pattern>
-<pattern>u2s5n</pattern>
-<pattern>uso2</pattern>
-<pattern>us3oï</pattern>
-<pattern>us3os</pattern>
-<pattern>u2s3p</pattern>
-<pattern>us5pi</pattern>
-<pattern>us5pu</pattern>
-<pattern>us4ta</pattern>
-<pattern>us5tag</pattern>
-<pattern>ust3al</pattern>
-<pattern>u2s3te</pattern>
-<pattern>us4t3ei</pattern>
-<pattern>u4sti</pattern>
-<pattern>ust3oo</pattern>
-<pattern>us5tra </pattern>
-<pattern>us5tre </pattern>
-<pattern>us5tro</pattern>
-<pattern>us5tru</pattern>
-<pattern>ustu4</pattern>
-<pattern>ust3ur</pattern>
-<pattern>ust3uu</pattern>
-<pattern>u1ta</pattern>
-<pattern>ut3aan</pattern>
-<pattern>utaar5</pattern>
-<pattern>ut1ac</pattern>
-<pattern>ut3af</pattern>
-<pattern>u3tan</pattern>
-<pattern>uta3s4</pattern>
-<pattern>ut5c</pattern>
-<pattern>u4t3ees</pattern>
-<pattern>u4tek</pattern>
-<pattern>ut3eks</pattern>
-<pattern>ut3em</pattern>
-<pattern>ut5emm</pattern>
-<pattern>uter5an</pattern>
-<pattern>ut3ex</pattern>
-<pattern>ut2h</pattern>
-<pattern>ut3ho</pattern>
-<pattern>u2tj</pattern>
-<pattern>u1to</pattern>
-<pattern>uto5f</pattern>
-<pattern>ut3oog</pattern>
-<pattern>uto3pe</pattern>
-<pattern>utop4l</pattern>
-<pattern>uto5po</pattern>
-<pattern>utop4r</pattern>
-<pattern>uto5s</pattern>
-<pattern>ut3saa</pattern>
-<pattern>ut3s2c</pattern>
-<pattern>uts5eng</pattern>
-<pattern>uts2m</pattern>
-<pattern>ut1sn</pattern>
-<pattern>ut3sp</pattern>
-<pattern>ut4spa</pattern>
-<pattern>ut4spo</pattern>
-<pattern>ut2st</pattern>
-<pattern>uts5tak</pattern>
-<pattern>ut4ste </pattern>
-<pattern>ut5sten</pattern>
-<pattern>ut3str</pattern>
-<pattern>ut5su</pattern>
-<pattern>utt4</pattern>
-<pattern>u1tu</pattern>
-<pattern>ut5w</pattern>
-<pattern>u4u4</pattern>
-<pattern>uur3a4</pattern>
-<pattern>uur3e4</pattern>
-<pattern>uur5i</pattern>
-<pattern>uur3k</pattern>
-<pattern>uur1o2</pattern>
-<pattern>uur5ste</pattern>
-<pattern>uur5sti</pattern>
-<pattern>4uut</pattern>
-<pattern>uut3a</pattern>
-<pattern>uut3r</pattern>
-<pattern>uvel4s</pattern>
-<pattern>uve5na</pattern>
-<pattern>uw1a</pattern>
-<pattern>u3wag</pattern>
-<pattern>uw3ar</pattern>
-<pattern>uw5art</pattern>
-<pattern>u1we</pattern>
-<pattern>uw3ec</pattern>
-<pattern>uwe5d</pattern>
-<pattern>uw3een</pattern>
-<pattern>u2w3ei</pattern>
-<pattern>uwe4nen</pattern>
-<pattern>uwes4</pattern>
-<pattern>u1wi</pattern>
-<pattern>u2w3ij</pattern>
-<pattern>uw5ijz</pattern>
-<pattern>u4wind</pattern>
-<pattern>u3wing</pattern>
-<pattern>u4wins</pattern>
-<pattern>uw3inz</pattern>
-<pattern>uw1o</pattern>
-<pattern>u3woe</pattern>
-<pattern>uwo4ge</pattern>
-<pattern>uw1r</pattern>
-<pattern>uw3u</pattern>
-<pattern>uxa3</pattern>
-<pattern>u3ya</pattern>
-<pattern>4uz</pattern>
-<pattern>uze3t4</pattern>
-<pattern>uzie2</pattern>
-<pattern>ût3s4</pattern>
-<pattern>1ü</pattern>
-<pattern>ü4b</pattern>
-<pattern>ü1n</pattern>
-<pattern>ü3ri</pattern>
-<pattern>üs3l</pattern>
-<pattern>1v2</pattern>
-<pattern>2v </pattern>
-<pattern>vaar4ta</pattern>
-<pattern>vaart5r</pattern>
-<pattern>va3de</pattern>
-<pattern>va3g4</pattern>
-<pattern>va2ki</pattern>
-<pattern>va4kl</pattern>
-<pattern>va2ko</pattern>
-<pattern>va2l3a</pattern>
-<pattern>val5m</pattern>
-<pattern>va3lo</pattern>
-<pattern>va4loe</pattern>
-<pattern>val5si</pattern>
-<pattern>val4s5p</pattern>
-<pattern>vals5tek</pattern>
-<pattern>valu5</pattern>
-<pattern>va2n</pattern>
-<pattern>van3ac</pattern>
-<pattern>vand4</pattern>
-<pattern>vang3a</pattern>
-<pattern>van4gr</pattern>
-<pattern>va3no</pattern>
-<pattern>va4noc</pattern>
-<pattern>va1p</pattern>
-<pattern>va3re</pattern>
-<pattern>va5se</pattern>
-<pattern>va3s4o</pattern>
-<pattern>vast3r</pattern>
-<pattern>va3su</pattern>
-<pattern>va3te</pattern>
-<pattern>va2t3h</pattern>
-<pattern>vat5j</pattern>
-<pattern>va3z</pattern>
-<pattern>v4b</pattern>
-<pattern>4v3c</pattern>
-<pattern>v4e</pattern>
-<pattern>3ve </pattern>
-<pattern>5veb</pattern>
-<pattern>vee4l</pattern>
-<pattern>veel5e</pattern>
-<pattern>vee3p4</pattern>
-<pattern>vees4</pattern>
-<pattern>ve3g4h</pattern>
-<pattern>vei3s4</pattern>
-<pattern>vei5tj</pattern>
-<pattern>3vek</pattern>
-<pattern>5vel</pattern>
-<pattern>ve4l3a4g</pattern>
-<pattern>vel4d3o</pattern>
-<pattern>ve3le</pattern>
-<pattern>vel3k</pattern>
-<pattern>5vem</pattern>
-<pattern>vem4a</pattern>
-<pattern>ve4na</pattern>
-<pattern>ve5nare</pattern>
-<pattern>5vend</pattern>
-<pattern>ven5k</pattern>
-<pattern>ve2n3o</pattern>
-<pattern>2venr</pattern>
-<pattern>ven4s3e</pattern>
-<pattern>ven4sl</pattern>
-<pattern>vens5lan</pattern>
-<pattern>vens5lo</pattern>
-<pattern>ven4sp</pattern>
-<pattern>vens5taak</pattern>
-<pattern>vens5take</pattern>
-<pattern>vens5tek</pattern>
-<pattern>ven4s3u4</pattern>
-<pattern>ve2r</pattern>
-<pattern>ver1a</pattern>
-<pattern>ver5aas</pattern>
-<pattern>ve4rad</pattern>
-<pattern>vera4g</pattern>
-<pattern>ve4rand</pattern>
-<pattern>ver5do</pattern>
-<pattern>ve3rec</pattern>
-<pattern>ver3ed</pattern>
-<pattern>ve3reg</pattern>
-<pattern>ve3rei</pattern>
-<pattern>ver5eis</pattern>
-<pattern>ve5ren </pattern>
-<pattern>ve5rend</pattern>
-<pattern>ver3e4t</pattern>
-<pattern>ver5ijd</pattern>
-<pattern>ver5ijl</pattern>
-<pattern>ver5ijs</pattern>
-<pattern>ve5ring</pattern>
-<pattern>ver5k4</pattern>
-<pattern>ver3o</pattern>
-<pattern>ve3rom</pattern>
-<pattern>vero5v</pattern>
-<pattern>ver5p</pattern>
-<pattern>ver5spe</pattern>
-<pattern>ver5sta</pattern>
-<pattern>ver5sto</pattern>
-<pattern>ver5tw</pattern>
-<pattern>ver1u</pattern>
-<pattern>ve3ry</pattern>
-<pattern>ve2s3</pattern>
-<pattern>ves5ti</pattern>
-<pattern>ve2tj</pattern>
-<pattern>ve2to4</pattern>
-<pattern>vet3og</pattern>
-<pattern>vet3oo</pattern>
-<pattern>ve3tor</pattern>
-<pattern>ve2t3r</pattern>
-<pattern>vet4roe</pattern>
-<pattern>vet5ste</pattern>
-<pattern>5ve5z</pattern>
-<pattern>3vi</pattern>
-<pattern>4vicepa</pattern>
-<pattern>vid5st</pattern>
-<pattern>vie4r3a</pattern>
-<pattern>vie4s3</pattern>
-<pattern>vies5n</pattern>
-<pattern>vie4tj</pattern>
-<pattern>vi3eu</pattern>
-<pattern>vijf5</pattern>
-<pattern>vik4s</pattern>
-<pattern>vil4t3j</pattern>
-<pattern>ving4</pattern>
-<pattern>vings3</pattern>
-<pattern>vi3o</pattern>
-<pattern>vi5om</pattern>
-<pattern>vi4s3an</pattern>
-<pattern>vi1so</pattern>
-<pattern>vis5ot</pattern>
-<pattern>vis5p</pattern>
-<pattern>vi4st</pattern>
-<pattern>vis5tr</pattern>
-<pattern>vi1tr</pattern>
-<pattern>v3j</pattern>
-<pattern>vje4</pattern>
-<pattern>vjet1</pattern>
-<pattern>3vl</pattern>
-<pattern>v3lar</pattern>
-<pattern>vlei3s4</pattern>
-<pattern>vlie4s5</pattern>
-<pattern>vlot5s</pattern>
-<pattern>v3lov</pattern>
-<pattern>5vo </pattern>
-<pattern>3voe</pattern>
-<pattern>voe4t3a</pattern>
-<pattern>voe4t3r</pattern>
-<pattern>voet5sp</pattern>
-<pattern>3vog</pattern>
-<pattern>voge4</pattern>
-<pattern>3voi</pattern>
-<pattern>vo2le</pattern>
-<pattern>vol4g3a</pattern>
-<pattern>vol4gra</pattern>
-<pattern>vo2li</pattern>
-<pattern>vol3ij</pattern>
-<pattern>vol5p</pattern>
-<pattern>von4det</pattern>
-<pattern>vond5u</pattern>
-<pattern>3voo</pattern>
-<pattern>voo5d</pattern>
-<pattern>vooi5t</pattern>
-<pattern>voorn4</pattern>
-<pattern>voor5na</pattern>
-<pattern>vo3ra</pattern>
-<pattern>vorm3a</pattern>
-<pattern>vors5te </pattern>
-<pattern>vor5sten</pattern>
-<pattern>vos3</pattern>
-<pattern>3vot</pattern>
-<pattern>vot3j</pattern>
-<pattern>3vou</pattern>
-<pattern>vous5</pattern>
-<pattern>3v4r2</pattern>
-<pattern>vrei5</pattern>
-<pattern>vrie4s</pattern>
-<pattern>vrij5k4</pattern>
-<pattern>vrijs4</pattern>
-<pattern>vrij5ste</pattern>
-<pattern>v3t</pattern>
-<pattern>vues4</pattern>
-<pattern>vu2l</pattern>
-<pattern>vul5p</pattern>
-<pattern>vuur5s</pattern>
-<pattern>vy3</pattern>
-<pattern>2w </pattern>
-<pattern>waad3</pattern>
-<pattern>w2aar</pattern>
-<pattern>waar5e</pattern>
-<pattern>waar5ste</pattern>
-<pattern>wa4b3</pattern>
-<pattern>wa2ba</pattern>
-<pattern>wa5bl</pattern>
-<pattern>w2ad</pattern>
-<pattern>wa3dr</pattern>
-<pattern>w4ag</pattern>
-<pattern>wa2la</pattern>
-<pattern>wa3lan</pattern>
-<pattern>4wam</pattern>
-<pattern>wan4d5r</pattern>
-<pattern>wan4gr</pattern>
-<pattern>wang5sl</pattern>
-<pattern>wa2n1o</pattern>
-<pattern>wan3s4</pattern>
-<pattern>3wap</pattern>
-<pattern>w4ar</pattern>
-<pattern>w5arc</pattern>
-<pattern>5ward</pattern>
-<pattern>war4st</pattern>
-<pattern>wars5te</pattern>
-<pattern>wart3j</pattern>
-<pattern>war4to</pattern>
-<pattern>wa2si</pattern>
-<pattern>wa4s5l</pattern>
-<pattern>wa4s5p</pattern>
-<pattern>was5tr</pattern>
-<pattern>1wate</pattern>
-<pattern>wat5j</pattern>
-<pattern>wa3tr</pattern>
-<pattern>3way</pattern>
-<pattern>2wb</pattern>
-<pattern>w1c</pattern>
-<pattern>2w1d</pattern>
-<pattern>w4doo</pattern>
-<pattern>wd3oom</pattern>
-<pattern>we2a</pattern>
-<pattern>2we2c</pattern>
-<pattern>3wed</pattern>
-<pattern>wede4</pattern>
-<pattern>we2d3i</pattern>
-<pattern>we4d3r</pattern>
-<pattern>wee4ki</pattern>
-<pattern>wee4k3r</pattern>
-<pattern>wee3lo</pattern>
-<pattern>wee3s4t</pattern>
-<pattern>wee5ste</pattern>
-<pattern>3weg</pattern>
-<pattern>we4g1a</pattern>
-<pattern>we4gerv</pattern>
-<pattern>weg3l</pattern>
-<pattern>we2g3o</pattern>
-<pattern>we4g5r</pattern>
-<pattern>wei3s</pattern>
-<pattern>wei5tj</pattern>
-<pattern>we4k3r</pattern>
-<pattern>we4le2</pattern>
-<pattern>4welem</pattern>
-<pattern>we3li</pattern>
-<pattern>we2lo</pattern>
-<pattern>wel3s</pattern>
-<pattern>we2m</pattern>
-<pattern>wem3a</pattern>
-<pattern>we3me</pattern>
-<pattern>we2n</pattern>
-<pattern>wena4</pattern>
-<pattern>wen3ad</pattern>
-<pattern>we3ne4</pattern>
-<pattern>we4nem</pattern>
-<pattern>we5nen </pattern>
-<pattern>wen5enk</pattern>
-<pattern>we3ni</pattern>
-<pattern>wen4k3a</pattern>
-<pattern>wen3o</pattern>
-<pattern>wen5to</pattern>
-<pattern>wer2f</pattern>
-<pattern>4werg</pattern>
-<pattern>wer4ka</pattern>
-<pattern>wer4k5l</pattern>
-<pattern>wer4kn</pattern>
-<pattern>wer4k3o</pattern>
-<pattern>wer4k3r</pattern>
-<pattern>werk5ru</pattern>
-<pattern>wer4k3u4</pattern>
-<pattern>wer4k3w</pattern>
-<pattern>wer4p3a</pattern>
-<pattern>wer4p3l</pattern>
-<pattern>wer4pr</pattern>
-<pattern>wer4s</pattern>
-<pattern>wer5ste</pattern>
-<pattern>we2s3</pattern>
-<pattern>we3spo</pattern>
-<pattern>wes4t5o</pattern>
-<pattern>3wet </pattern>
-<pattern>we2th</pattern>
-<pattern>we2t3j</pattern>
-<pattern>wet4st</pattern>
-<pattern>we2t3u</pattern>
-<pattern>2wex</pattern>
-<pattern>wezen4s5</pattern>
-<pattern>2w1f</pattern>
-<pattern>w1g</pattern>
-<pattern>w1h</pattern>
-<pattern>wie4la</pattern>
-<pattern>wie4t</pattern>
-<pattern>w4ij</pattern>
-<pattern>3wijd</pattern>
-<pattern>wij4ka</pattern>
-<pattern>wij4s</pattern>
-<pattern>wijs3l</pattern>
-<pattern>wijs3p</pattern>
-<pattern>wijs5ta</pattern>
-<pattern>wi4k</pattern>
-<pattern>3wil</pattern>
-<pattern>wind3a</pattern>
-<pattern>win4d3r</pattern>
-<pattern>w4ing</pattern>
-<pattern>2winr</pattern>
-<pattern>win2s</pattern>
-<pattern>winst5aa</pattern>
-<pattern>winst5r</pattern>
-<pattern>wi4t3h</pattern>
-<pattern>wit3j</pattern>
-<pattern>wi2t3o4</pattern>
-<pattern>wit3r</pattern>
-<pattern>w1j</pattern>
-<pattern>2w1k</pattern>
-<pattern>2w1l</pattern>
-<pattern>4w1m</pattern>
-<pattern>2wn</pattern>
-<pattern>wn3ac</pattern>
-<pattern>w3ne</pattern>
-<pattern>w3ni</pattern>
-<pattern>w3no</pattern>
-<pattern>w3ob</pattern>
-<pattern>w2oe</pattern>
-<pattern>woes3</pattern>
-<pattern>woest5a</pattern>
-<pattern>wo4l</pattern>
-<pattern>wol3a</pattern>
-<pattern>wolf4s5</pattern>
-<pattern>woon5sf</pattern>
-<pattern>woor4d5r</pattern>
-<pattern>wor4g3e</pattern>
-<pattern>w1p</pattern>
-<pattern>wren4st</pattern>
-<pattern>wrens5te </pattern>
-<pattern>2ws</pattern>
-<pattern>ws3a2</pattern>
-<pattern>w3sc</pattern>
-<pattern>w1sl</pattern>
-<pattern>w2s3le</pattern>
-<pattern>w3som</pattern>
-<pattern>w3sp</pattern>
-<pattern>ws2pl</pattern>
-<pattern>w4spr</pattern>
-<pattern>w5spra</pattern>
-<pattern>w1s4t</pattern>
-<pattern>w4stij</pattern>
-<pattern>2wt</pattern>
-<pattern>wtes3</pattern>
-<pattern>wtje5sp</pattern>
-<pattern>w1to</pattern>
-<pattern>w1tr</pattern>
-<pattern>wu2</pattern>
-<pattern>wva2</pattern>
-<pattern>w1w</pattern>
-<pattern>xaf4</pattern>
-<pattern>xa3g</pattern>
-<pattern>xamen5t</pattern>
-<pattern>xan3</pattern>
-<pattern>xan5t</pattern>
-<pattern>x1c</pattern>
-<pattern>x4e</pattern>
-<pattern>xen4d</pattern>
-<pattern>xe3ro</pattern>
-<pattern>x1f</pattern>
-<pattern>x1h</pattern>
-<pattern>xie4t</pattern>
-<pattern>xi3g</pattern>
-<pattern>xi5o</pattern>
-<pattern>xi3sta</pattern>
-<pattern>xi3sto</pattern>
-<pattern>xi4t3i</pattern>
-<pattern>x3l</pattern>
-<pattern>x1m</pattern>
-<pattern>xo3no</pattern>
-<pattern>x4op</pattern>
-<pattern>xo3s4</pattern>
-<pattern>x1p</pattern>
-<pattern>xpre2</pattern>
-<pattern>xpres5</pattern>
-<pattern>x3r</pattern>
-<pattern>x3so</pattern>
-<pattern>x3sp</pattern>
-<pattern>x1t</pattern>
-<pattern>x2tak</pattern>
-<pattern>xtie2</pattern>
-<pattern>x3w</pattern>
-<pattern>xy3</pattern>
-<pattern>y1a</pattern>
-<pattern>ya3s4</pattern>
-<pattern>ya4s5p</pattern>
-<pattern>y3at</pattern>
-<pattern>yba2l3</pattern>
-<pattern>yber4t3</pattern>
-<pattern>y1c</pattern>
-<pattern>ycho3</pattern>
-<pattern>y3co</pattern>
-<pattern>y1d4</pattern>
-<pattern>ydi3a</pattern>
-<pattern>y5dr</pattern>
-<pattern>ydro3</pattern>
-<pattern>y1e</pattern>
-<pattern>yes3</pattern>
-<pattern>y3és</pattern>
-<pattern>y3è</pattern>
-<pattern>y1f</pattern>
-<pattern>y1g</pattern>
-<pattern>ygu2</pattern>
-<pattern>y1h</pattern>
-<pattern>y1i</pattern>
-<pattern>y4in</pattern>
-<pattern>y5is</pattern>
-<pattern>yksge4</pattern>
-<pattern>y3la</pattern>
-<pattern>yl3al</pattern>
-<pattern>y3le</pattern>
-<pattern>y4l3et</pattern>
-<pattern>y3lo</pattern>
-<pattern>ylo3l</pattern>
-<pattern>ym2f5l</pattern>
-<pattern>ym5pa</pattern>
-<pattern>y3na</pattern>
-<pattern>yn3er</pattern>
-<pattern>y3no</pattern>
-<pattern>yn1t</pattern>
-<pattern>y1o</pattern>
-<pattern>y3on</pattern>
-<pattern>y3os</pattern>
-<pattern>yo3t</pattern>
-<pattern>y1p</pattern>
-<pattern>y3p4h</pattern>
-<pattern>ypo3</pattern>
-<pattern>ypot4</pattern>
-<pattern>yp3s</pattern>
-<pattern>yp5si</pattern>
-<pattern>y1r</pattern>
-<pattern>y3r4e</pattern>
-<pattern>y5ri</pattern>
-<pattern>ys3</pattern>
-<pattern>y1s4a</pattern>
-<pattern>y3s4c</pattern>
-<pattern>y5s4e</pattern>
-<pattern>yse5t</pattern>
-<pattern>y3s4f</pattern>
-<pattern>y3s4h</pattern>
-<pattern>ys4i</pattern>
-<pattern>y3s4o</pattern>
-<pattern>y3s4p</pattern>
-<pattern>ys5pl</pattern>
-<pattern>ys4ta</pattern>
-<pattern>ys5tr</pattern>
-<pattern>y3sy</pattern>
-<pattern>y1t</pattern>
-<pattern>yt3hu</pattern>
-<pattern>yto3</pattern>
-<pattern>y2tof</pattern>
-<pattern>ytop4</pattern>
-<pattern>yu5a</pattern>
-<pattern>y3ui</pattern>
-<pattern>y3u2r</pattern>
-<pattern>yvari5</pattern>
-<pattern>y1w4</pattern>
-<pattern>1z</pattern>
-<pattern>4z </pattern>
-<pattern>zaar5t</pattern>
-<pattern>za3f2</pattern>
-<pattern>zags4t</pattern>
-<pattern>za2k3a</pattern>
-<pattern>zak3r</pattern>
-<pattern>zan2d</pattern>
-<pattern>zand5a4</pattern>
-<pattern>zan3di</pattern>
-<pattern>zan4dr</pattern>
-<pattern>zang3s</pattern>
-<pattern>za3po</pattern>
-<pattern>za3s4</pattern>
-<pattern>4zb</pattern>
-<pattern>4zc</pattern>
-<pattern>4zd</pattern>
-<pattern>z4e</pattern>
-<pattern>zee3k</pattern>
-<pattern>zeel5d</pattern>
-<pattern>zee3r4o</pattern>
-<pattern>zeero5v</pattern>
-<pattern>zeer5s</pattern>
-<pattern>zee3s4</pattern>
-<pattern>ze5ge</pattern>
-<pattern>zeg4sl</pattern>
-<pattern>zei3sp</pattern>
-<pattern>ze5k</pattern>
-<pattern>zel5dr</pattern>
-<pattern>ze3lem</pattern>
-<pattern>zel2f1</pattern>
-<pattern>zel4so</pattern>
-<pattern>zen4d3a</pattern>
-<pattern>ze4nin</pattern>
-<pattern>zen5k</pattern>
-<pattern>zen3o4</pattern>
-<pattern>zen4og</pattern>
-<pattern>ze3non</pattern>
-<pattern>ze4r3a</pattern>
-<pattern>ze3ro</pattern>
-<pattern>zer2s</pattern>
-<pattern>zer4s5e</pattern>
-<pattern>ze4s3</pattern>
-<pattern>ze5sch</pattern>
-<pattern>zes5e</pattern>
-<pattern>zes5l</pattern>
-<pattern>ze5ste</pattern>
-<pattern>ze2t3a</pattern>
-<pattern>ze2t3h</pattern>
-<pattern>ze4ti</pattern>
-<pattern>ze2t3j</pattern>
-<pattern>ze2t3r</pattern>
-<pattern>zeve2</pattern>
-<pattern>zeven3</pattern>
-<pattern>4zf</pattern>
-<pattern>4zg</pattern>
-<pattern>2z3h</pattern>
-<pattern>z2i</pattern>
-<pattern>ziek3l</pattern>
-<pattern>zie4k3o</pattern>
-<pattern>ziek3w</pattern>
-<pattern>ziel4s</pattern>
-<pattern>zie5sl</pattern>
-<pattern>3zif</pattern>
-<pattern>zi2g5a</pattern>
-<pattern>zij5kl</pattern>
-<pattern>zij3po</pattern>
-<pattern>zij5s4</pattern>
-<pattern>zik2w</pattern>
-<pattern>zi4n3a4</pattern>
-<pattern>zings3</pattern>
-<pattern>zin4k3l</pattern>
-<pattern>zin4s</pattern>
-<pattern>zins3t</pattern>
-<pattern>zins5ta</pattern>
-<pattern>zin5str</pattern>
-<pattern>zi3o5</pattern>
-<pattern>zipi3</pattern>
-<pattern>zi4t</pattern>
-<pattern>zit3e</pattern>
-<pattern>zit3j</pattern>
-<pattern>zit3u4</pattern>
-<pattern>4z3k</pattern>
-<pattern>4z3l</pattern>
-<pattern>4zm</pattern>
-<pattern>zodi5</pattern>
-<pattern>zoet3j</pattern>
-<pattern>zoet5ste</pattern>
-<pattern>zo3f2</pattern>
-<pattern>zoi4</pattern>
-<pattern>zo5ie</pattern>
-<pattern>zo3la</pattern>
-<pattern>zome4</pattern>
-<pattern>zo2na</pattern>
-<pattern>zon3sf</pattern>
-<pattern>zon5ta</pattern>
-<pattern>zooi5tj</pattern>
-<pattern>zo1p</pattern>
-<pattern>zor4g3a</pattern>
-<pattern>zor4gl</pattern>
-<pattern>zor4gr</pattern>
-<pattern>zo2t</pattern>
-<pattern>zot3h</pattern>
-<pattern>zo3tr</pattern>
-<pattern>zo3v</pattern>
-<pattern>4z3p</pattern>
-<pattern>4z3r</pattern>
-<pattern>2zs</pattern>
-<pattern>4z5t</pattern>
-<pattern>zui4d3i</pattern>
-<pattern>zui4dr</pattern>
-<pattern>zus3</pattern>
-<pattern>2zv</pattern>
-<pattern>z4w</pattern>
-<pattern>zwets5te </pattern>
-<pattern>5zy</pattern>
-<pattern>2z3z</pattern>
-<pattern>zz3in</pattern>
-<pattern>zz3or</pattern>
-<pattern>z4z5w</pattern>
+  <pattern> a4</pattern>
+  <pattern> aan5</pattern>
+  <pattern> aarts5</pattern>
+  <pattern> aat5</pattern>
+  <pattern> ab5l</pattern>
+  <pattern> acht5end</pattern>
+  <pattern> ac5re</pattern>
+  <pattern> adi5</pattern>
+  <pattern> af3</pattern>
+  <pattern> af5l</pattern>
+  <pattern> af5s</pattern>
+  <pattern> aftu5re</pattern>
+  <pattern> al3ee</pattern>
+  <pattern> al3f</pattern>
+  <pattern> alk4</pattern>
+  <pattern> al5ko</pattern>
+  <pattern> alko5v</pattern>
+  <pattern> al5ma</pattern>
+  <pattern> al3om</pattern>
+  <pattern> al4st</pattern>
+  <pattern> ana3s</pattern>
+  <pattern> an3d2</pattern>
+  <pattern> an3en</pattern>
+  <pattern> an3gl</pattern>
+  <pattern> an5th</pattern>
+  <pattern> ar5d</pattern>
+  <pattern> ar5tr</pattern>
+  <pattern> as5h</pattern>
+  <pattern> as5l</pattern>
+  <pattern> as3t</pattern>
+  <pattern> as5tra</pattern>
+  <pattern> as3u</pattern>
+  <pattern> at4a</pattern>
+  <pattern> ave5n</pattern>
+  <pattern> b4</pattern>
+  <pattern> be3la</pattern>
+  <pattern> be5ra</pattern>
+  <pattern> be5ri</pattern>
+  <pattern> bos1</pattern>
+  <pattern> c4</pattern>
+  <pattern> coo5</pattern>
+  <pattern> co3ro</pattern>
+  <pattern> cus5</pattern>
+  <pattern> d4</pattern>
+  <pattern> daar5</pattern>
+  <pattern> da4gi</pattern>
+  <pattern> dag5r</pattern>
+  <pattern> da2k</pattern>
+  <pattern> dan2</pattern>
+  <pattern> debe4</pattern>
+  <pattern> de2k</pattern>
+  <pattern> dek5l</pattern>
+  <pattern> dek5s</pattern>
+  <pattern> den4k5r</pattern>
+  <pattern> de5od</pattern>
+  <pattern> de3ro</pattern>
+  <pattern> de5sta</pattern>
+  <pattern> di4a</pattern>
+  <pattern> die4p</pattern>
+  <pattern> di3o</pattern>
+  <pattern> doet3</pattern>
+  <pattern> do3v</pattern>
+  <pattern> du4w</pattern>
+  <pattern> e4</pattern>
+  <pattern> ede2</pattern>
+  <pattern> edel5a</pattern>
+  <pattern> ed3w</pattern>
+  <pattern> ee4n</pattern>
+  <pattern> eer5ste</pattern>
+  <pattern> eest3</pattern>
+  <pattern> eesto4</pattern>
+  <pattern> eet3</pattern>
+  <pattern> ei3l</pattern>
+  <pattern> ei5sc</pattern>
+  <pattern> ei3sp</pattern>
+  <pattern> ei5t</pattern>
+  <pattern> el4s5</pattern>
+  <pattern> en5s</pattern>
+  <pattern> en5th</pattern>
+  <pattern> ep4a</pattern>
+  <pattern> ere5s</pattern>
+  <pattern> er2f</pattern>
+  <pattern> erf3l</pattern>
+  <pattern> er3in</pattern>
+  <pattern> ert4</pattern>
+  <pattern> erts3</pattern>
+  <pattern> es3</pattern>
+  <pattern> es5c</pattern>
+  <pattern> es5pe</pattern>
+  <pattern> es5tr</pattern>
+  <pattern> eten4</pattern>
+  <pattern> et4h</pattern>
+  <pattern> ets5te </pattern>
+  <pattern> eu3</pattern>
+  <pattern> eus5</pattern>
+  <pattern> é2</pattern>
+  <pattern> f4</pattern>
+  <pattern> fel4s</pattern>
+  <pattern> g4</pattern>
+  <pattern> gaat5</pattern>
+  <pattern> gang5s</pattern>
+  <pattern> gea5v</pattern>
+  <pattern> ge3l4a</pattern>
+  <pattern> ge5le</pattern>
+  <pattern> gelo5v</pattern>
+  <pattern> ge3n4a</pattern>
+  <pattern> gena5z</pattern>
+  <pattern> ge5ne</pattern>
+  <pattern> ge5no</pattern>
+  <pattern> ge3ra</pattern>
+  <pattern> ge5r4e</pattern>
+  <pattern> ge5r4o</pattern>
+  <pattern> gerst5a</pattern>
+  <pattern> ge3s</pattern>
+  <pattern> ge5sk</pattern>
+  <pattern> ge5ta</pattern>
+  <pattern> ge5tj</pattern>
+  <pattern> ge5to</pattern>
+  <pattern> gid4</pattern>
+  <pattern> go4m</pattern>
+  <pattern> goot3</pattern>
+  <pattern> h2</pattern>
+  <pattern> handels5</pattern>
+  <pattern> her5in</pattern>
+  <pattern> hits5t</pattern>
+  <pattern> ho4lo</pattern>
+  <pattern> houd5s</pattern>
+  <pattern> i4</pattern>
+  <pattern> ide5o</pattern>
+  <pattern> ij4s</pattern>
+  <pattern> ijs5l</pattern>
+  <pattern> ijs3p</pattern>
+  <pattern> ijs3t</pattern>
+  <pattern> ik3</pattern>
+  <pattern> in1</pattern>
+  <pattern> in5d4</pattern>
+  <pattern> in3g4</pattern>
+  <pattern> in5gr</pattern>
+  <pattern> ink2</pattern>
+  <pattern> in5kr</pattern>
+  <pattern> in5kw</pattern>
+  <pattern> in3s4</pattern>
+  <pattern> in5sl</pattern>
+  <pattern> in5st</pattern>
+  <pattern> in5ta</pattern>
+  <pattern> is5c</pattern>
+  <pattern> j4</pattern>
+  <pattern> jor5</pattern>
+  <pattern> k4</pattern>
+  <pattern> ka3d</pattern>
+  <pattern> ka5g</pattern>
+  <pattern> ka4taa</pattern>
+  <pattern> kerk5l</pattern>
+  <pattern> kerk5r</pattern>
+  <pattern> kerk5u</pattern>
+  <pattern> ker5sten</pattern>
+  <pattern> ke4s</pattern>
+  <pattern> koot5</pattern>
+  <pattern> ko5pe</pattern>
+  <pattern> kop5l</pattern>
+  <pattern> ko3v</pattern>
+  <pattern> kun2</pattern>
+  <pattern> l4</pattern>
+  <pattern> laat5ste</pattern>
+  <pattern> le4b5</pattern>
+  <pattern> leg3o</pattern>
+  <pattern> le4g3r</pattern>
+  <pattern> leid5st</pattern>
+  <pattern> len4s3</pattern>
+  <pattern> le5r4</pattern>
+  <pattern> le4s3</pattern>
+  <pattern> le5th</pattern>
+  <pattern> lin5d</pattern>
+  <pattern> lof5</pattern>
+  <pattern> loot3</pattern>
+  <pattern> lo4s1</pattern>
+  <pattern> lu3e</pattern>
+  <pattern> lui5t4j</pattern>
+  <pattern> lu4s</pattern>
+  <pattern> m4</pattern>
+  <pattern> ma5d</pattern>
+  <pattern> ma5ï</pattern>
+  <pattern> meel5d</pattern>
+  <pattern> me5la</pattern>
+  <pattern> me5ni</pattern>
+  <pattern> merk5l</pattern>
+  <pattern> me2s</pattern>
+  <pattern> me4st</pattern>
+  <pattern> met5ee</pattern>
+  <pattern> mij4n5i</pattern>
+  <pattern> moot3</pattern>
+  <pattern> mor5sten</pattern>
+  <pattern> mo4s</pattern>
+  <pattern> n4</pattern>
+  <pattern> naat5</pattern>
+  <pattern> na3d</pattern>
+  <pattern> na3n</pattern>
+  <pattern> na3s4</pattern>
+  <pattern> nee5s</pattern>
+  <pattern> ne2p</pattern>
+  <pattern> nep3a</pattern>
+  <pattern> ne4s</pattern>
+  <pattern> ne5te</pattern>
+  <pattern> ne4t3j</pattern>
+  <pattern> neu4t5j</pattern>
+  <pattern> nie4t5j</pattern>
+  <pattern> noot5</pattern>
+  <pattern> nos5t</pattern>
+  <pattern> no5v</pattern>
+  <pattern> o4</pattern>
+  <pattern> oe4r5</pattern>
+  <pattern> oe4s5</pattern>
+  <pattern> oeve4</pattern>
+  <pattern> ol3f</pattern>
+  <pattern> om1</pattern>
+  <pattern> omme3</pattern>
+  <pattern> on3a</pattern>
+  <pattern> on3d</pattern>
+  <pattern> onde4r</pattern>
+  <pattern> on1e</pattern>
+  <pattern> on5g</pattern>
+  <pattern> on3i</pattern>
+  <pattern> on5k</pattern>
+  <pattern> on1o</pattern>
+  <pattern> ono5v</pattern>
+  <pattern> on2t3</pattern>
+  <pattern> on4tee</pattern>
+  <pattern> on4ter</pattern>
+  <pattern> ont5s</pattern>
+  <pattern> ooi5tj</pattern>
+  <pattern> oot5jes</pattern>
+  <pattern> op5ee</pattern>
+  <pattern> opi5</pattern>
+  <pattern> op5l</pattern>
+  <pattern> op3r</pattern>
+  <pattern> op5s</pattern>
+  <pattern> org4</pattern>
+  <pattern> os5</pattern>
+  <pattern> ove4</pattern>
+  <pattern> p4</pattern>
+  <pattern> pee5tj</pattern>
+  <pattern> peri5</pattern>
+  <pattern> pers5te </pattern>
+  <pattern> piet5j</pattern>
+  <pattern> pits5te </pattern>
+  <pattern> poort5j</pattern>
+  <pattern> po4st</pattern>
+  <pattern> puit4</pattern>
+  <pattern> pui5tj</pattern>
+  <pattern> pu2t</pattern>
+  <pattern> r4</pattern>
+  <pattern> raads5le</pattern>
+  <pattern> ran4d</pattern>
+  <pattern> rand5a</pattern>
+  <pattern> re4men</pattern>
+  <pattern> ren4o</pattern>
+  <pattern> reno5v</pattern>
+  <pattern> re5o</pattern>
+  <pattern> rie4t3</pattern>
+  <pattern> rij5sp</pattern>
+  <pattern> ring5s4</pattern>
+  <pattern> roe5tj</pattern>
+  <pattern> ro4l</pattern>
+  <pattern> ro4st</pattern>
+  <pattern> ro4t3h</pattern>
+  <pattern> ro5v</pattern>
+  <pattern> s4</pattern>
+  <pattern> sap3</pattern>
+  <pattern> sa5v</pattern>
+  <pattern> sci3</pattern>
+  <pattern> see3</pattern>
+  <pattern> seks5te</pattern>
+  <pattern> se5re</pattern>
+  <pattern> set3</pattern>
+  <pattern> se5v</pattern>
+  <pattern> side3</pattern>
+  <pattern> ski3s4</pattern>
+  <pattern> sneu3</pattern>
+  <pattern> sno2</pattern>
+  <pattern> so2k3</pattern>
+  <pattern> song5</pattern>
+  <pattern> spoor5tj</pattern>
+  <pattern> st4</pattern>
+  <pattern> ste4m</pattern>
+  <pattern> t4</pattern>
+  <pattern> taart5j</pattern>
+  <pattern> tan4da</pattern>
+  <pattern> te4a</pattern>
+  <pattern> te4f</pattern>
+  <pattern> tek2</pattern>
+  <pattern> te3le</pattern>
+  <pattern> ten5ac</pattern>
+  <pattern> te3no</pattern>
+  <pattern> ten4t5j</pattern>
+  <pattern> te3ra</pattern>
+  <pattern> ter4p5a</pattern>
+  <pattern> ter5s</pattern>
+  <pattern> te4s</pattern>
+  <pattern> ti2n</pattern>
+  <pattern> tin3a</pattern>
+  <pattern> tin3e</pattern>
+  <pattern> toe5pr</pattern>
+  <pattern> to4lo</pattern>
+  <pattern> to4p</pattern>
+  <pattern> to5v</pattern>
+  <pattern> tri3s4</pattern>
+  <pattern> ts4</pattern>
+  <pattern> tsa3</pattern>
+  <pattern> tuit5j</pattern>
+  <pattern> ty2r</pattern>
+  <pattern> u4</pattern>
+  <pattern> ui2</pattern>
+  <pattern> ui5s</pattern>
+  <pattern> uit1</pattern>
+  <pattern> uit4je</pattern>
+  <pattern> uke5</pattern>
+  <pattern> ur4a</pattern>
+  <pattern> vaat5j</pattern>
+  <pattern> ven4t5j</pattern>
+  <pattern> ve4r3</pattern>
+  <pattern> ves5p</pattern>
+  <pattern> vet3j</pattern>
+  <pattern> vie4r</pattern>
+  <pattern> vol5s</pattern>
+  <pattern> w4</pattern>
+  <pattern> wals5te </pattern>
+  <pattern> wee4ko</pattern>
+  <pattern> wee4t3</pattern>
+  <pattern> we4l3</pattern>
+  <pattern> wen4s5t</pattern>
+  <pattern> west5r</pattern>
+  <pattern> win4s</pattern>
+  <pattern> xe3</pattern>
+  <pattern> y2</pattern>
+  <pattern> z4</pattern>
+  <pattern> zes5</pattern>
+  <pattern> zit5</pattern>
+  <pattern> zooi5</pattern>
+  <pattern>4a </pattern>
+  <pattern>a4a4</pattern>
+  <pattern>4aad</pattern>
+  <pattern>aad1a</pattern>
+  <pattern>aad1o</pattern>
+  <pattern>aad1r</pattern>
+  <pattern>aad5sap</pattern>
+  <pattern>aaf5a</pattern>
+  <pattern>4aag</pattern>
+  <pattern>aag1a</pattern>
+  <pattern>aag3e</pattern>
+  <pattern>aag3o</pattern>
+  <pattern>aag5r</pattern>
+  <pattern>aags4</pattern>
+  <pattern>aag3sa</pattern>
+  <pattern>aag5so</pattern>
+  <pattern>aag3sp</pattern>
+  <pattern>aai3l</pattern>
+  <pattern>aak1a</pattern>
+  <pattern>aak3e2</pattern>
+  <pattern>aak1o</pattern>
+  <pattern>aak5r</pattern>
+  <pattern>aak3sp</pattern>
+  <pattern>aal5a2</pattern>
+  <pattern>aal1e</pattern>
+  <pattern>aal5f4o</pattern>
+  <pattern>aalfo5l</pattern>
+  <pattern>aal1i</pattern>
+  <pattern>aal5k</pattern>
+  <pattern>aal5m</pattern>
+  <pattern>aal1o2</pattern>
+  <pattern>aal3sl</pattern>
+  <pattern>aal5so</pattern>
+  <pattern>aal5spe</pattern>
+  <pattern>aal5ste</pattern>
+  <pattern>aal1u</pattern>
+  <pattern>aam1a</pattern>
+  <pattern>aam3o</pattern>
+  <pattern>aam4sta</pattern>
+  <pattern>aam4ste</pattern>
+  <pattern>aan1a</pattern>
+  <pattern>5aandee</pattern>
+  <pattern>aand4r</pattern>
+  <pattern>aan1e2</pattern>
+  <pattern>aan5g</pattern>
+  <pattern>aan5i</pattern>
+  <pattern>3aanj</pattern>
+  <pattern>aan5k4</pattern>
+  <pattern>3aann</pattern>
+  <pattern>aan3o</pattern>
+  <pattern>aan3sp</pattern>
+  <pattern>aans4po</pattern>
+  <pattern>aant4</pattern>
+  <pattern>3aanta</pattern>
+  <pattern>3aanv</pattern>
+  <pattern>aap1a</pattern>
+  <pattern>aap3i</pattern>
+  <pattern>aap3o2</pattern>
+  <pattern>aap3r</pattern>
+  <pattern>aar3a</pattern>
+  <pattern>aar4d5as</pattern>
+  <pattern>aar3e4</pattern>
+  <pattern>aar1i</pattern>
+  <pattern>4aarn</pattern>
+  <pattern>aar1o2</pattern>
+  <pattern>aar5spel</pattern>
+  <pattern>aar4t5on</pattern>
+  <pattern>aarts5l</pattern>
+  <pattern>aar3u</pattern>
+  <pattern>aas3e</pattern>
+  <pattern>aas3i</pattern>
+  <pattern>4aast</pattern>
+  <pattern>aas5tr</pattern>
+  <pattern>aat3a</pattern>
+  <pattern>aat5e</pattern>
+  <pattern>aat3h</pattern>
+  <pattern>aat3i</pattern>
+  <pattern>aat1o</pattern>
+  <pattern>aat5r</pattern>
+  <pattern>abak4s5</pattern>
+  <pattern>aba4l</pattern>
+  <pattern>abat4s</pattern>
+  <pattern>ab5eun</pattern>
+  <pattern>ab3ijz</pattern>
+  <pattern>a2bon</pattern>
+  <pattern>aboot4j</pattern>
+  <pattern>abot4j</pattern>
+  <pattern>2abr</pattern>
+  <pattern>ab3ru</pattern>
+  <pattern>4ac </pattern>
+  <pattern>a3cal</pattern>
+  <pattern>a3car</pattern>
+  <pattern>4ace</pattern>
+  <pattern>ace3st</pattern>
+  <pattern>4ach </pattern>
+  <pattern>a3cha</pattern>
+  <pattern>2a1che</pattern>
+  <pattern>4a1chi</pattern>
+  <pattern>ach3l</pattern>
+  <pattern>a1cho</pattern>
+  <pattern>a3chr</pattern>
+  <pattern>4achs</pattern>
+  <pattern>ach5tec</pattern>
+  <pattern>a1chu</pattern>
+  <pattern>achuut5</pattern>
+  <pattern>4ack</pattern>
+  <pattern>ac3kl</pattern>
+  <pattern>2acl</pattern>
+  <pattern>2a3co</pattern>
+  <pattern>2acr</pattern>
+  <pattern>ac5res</pattern>
+  <pattern>4acta</pattern>
+  <pattern>4acu</pattern>
+  <pattern>4ad </pattern>
+  <pattern>a5da </pattern>
+  <pattern>ad3ac</pattern>
+  <pattern>ada2d</pattern>
+  <pattern>ada4l</pattern>
+  <pattern>ada2r3</pattern>
+  <pattern>adas5</pattern>
+  <pattern>2add</pattern>
+  <pattern>a5de </pattern>
+  <pattern>ad3ei</pattern>
+  <pattern>ade5re</pattern>
+  <pattern>a5des</pattern>
+  <pattern>a3det</pattern>
+  <pattern>a5deta</pattern>
+  <pattern>ad3e4te</pattern>
+  <pattern>2adh</pattern>
+  <pattern>4ad4i</pattern>
+  <pattern>adi3al</pattern>
+  <pattern>adi4oc</pattern>
+  <pattern>adi4od</pattern>
+  <pattern>4adk</pattern>
+  <pattern>2adl</pattern>
+  <pattern>4ado </pattern>
+  <pattern>a3doo</pattern>
+  <pattern>2adp</pattern>
+  <pattern>ad3rei</pattern>
+  <pattern>a3d4ri</pattern>
+  <pattern>ad3rol</pattern>
+  <pattern>2ads</pattern>
+  <pattern>ad5se</pattern>
+  <pattern>ad3so</pattern>
+  <pattern>ad1s4t</pattern>
+  <pattern>ad5sta</pattern>
+  <pattern>ad3ui</pattern>
+  <pattern>ad3w</pattern>
+  <pattern>2ady</pattern>
+  <pattern>4ae</pattern>
+  <pattern>aege4</pattern>
+  <pattern>ae5k4</pattern>
+  <pattern>a3e2p</pattern>
+  <pattern>ae3r</pattern>
+  <pattern>ae2s3</pattern>
+  <pattern>ae4s5t</pattern>
+  <pattern>a3eu</pattern>
+  <pattern>a2ë</pattern>
+  <pattern>a4ër</pattern>
+  <pattern>4afa</pattern>
+  <pattern>af3aa</pattern>
+  <pattern>a2f3ac</pattern>
+  <pattern>af4as</pattern>
+  <pattern>af4at</pattern>
+  <pattern>afd4i</pattern>
+  <pattern>afd2r</pattern>
+  <pattern>af5d4w</pattern>
+  <pattern>4afe</pattern>
+  <pattern>afee4</pattern>
+  <pattern>4afi</pattern>
+  <pattern>af3l</pattern>
+  <pattern>4afo</pattern>
+  <pattern>a5fo </pattern>
+  <pattern>a2foe</pattern>
+  <pattern>afon4d</pattern>
+  <pattern>af3op</pattern>
+  <pattern>af5org</pattern>
+  <pattern>af1r</pattern>
+  <pattern>af3s4</pattern>
+  <pattern>afs2c</pattern>
+  <pattern>af5se</pattern>
+  <pattern>3afsl</pattern>
+  <pattern>3afsp</pattern>
+  <pattern>aft4a</pattern>
+  <pattern>af5tr</pattern>
+  <pattern>af3ui</pattern>
+  <pattern>2afy</pattern>
+  <pattern>4ag </pattern>
+  <pattern>ag1a2d</pattern>
+  <pattern>ag3af</pattern>
+  <pattern>ag3a2m</pattern>
+  <pattern>ag3ar</pattern>
+  <pattern>ag3di</pattern>
+  <pattern>a5ge </pattern>
+  <pattern>agee5t</pattern>
+  <pattern>4a5gen </pattern>
+  <pattern>ager4s</pattern>
+  <pattern>ag3ex</pattern>
+  <pattern>a4gil</pattern>
+  <pattern>ag3ind</pattern>
+  <pattern>a4g3ins</pattern>
+  <pattern>agi5ot</pattern>
+  <pattern>4ag1l</pattern>
+  <pattern>ag3of</pattern>
+  <pattern>a4g3or</pattern>
+  <pattern>ag4o3v</pattern>
+  <pattern>a2gr</pattern>
+  <pattern>ag4ra</pattern>
+  <pattern>ag5rap</pattern>
+  <pattern>ag3ru</pattern>
+  <pattern>ag3sl</pattern>
+  <pattern>ag4sle</pattern>
+  <pattern>ag5slu</pattern>
+  <pattern>ags2p</pattern>
+  <pattern>ag3spe</pattern>
+  <pattern>ag3spi</pattern>
+  <pattern>ag1st</pattern>
+  <pattern>ag3sta</pattern>
+  <pattern>ag5str</pattern>
+  <pattern>2agt</pattern>
+  <pattern>agu5a</pattern>
+  <pattern>a2g3ui</pattern>
+  <pattern>ag3u4r</pattern>
+  <pattern>a2g3uu</pattern>
+  <pattern>2ah</pattern>
+  <pattern>4a1ha</pattern>
+  <pattern>4a5he</pattern>
+  <pattern>ahe5ri</pattern>
+  <pattern>a1hi</pattern>
+  <pattern>ah3l</pattern>
+  <pattern>a3ho</pattern>
+  <pattern>ah5r</pattern>
+  <pattern>ah5t2</pattern>
+  <pattern>a3hu</pattern>
+  <pattern>a3hy</pattern>
+  <pattern>ai5a2</pattern>
+  <pattern>ai4dr</pattern>
+  <pattern>ai1e</pattern>
+  <pattern>a1ij</pattern>
+  <pattern>ai5k</pattern>
+  <pattern>ail3m</pattern>
+  <pattern>ai2lo</pattern>
+  <pattern>a2in</pattern>
+  <pattern>aio4</pattern>
+  <pattern>ai3ov</pattern>
+  <pattern>ai3s4</pattern>
+  <pattern>ai5sc</pattern>
+  <pattern>ai4s5l</pattern>
+  <pattern>ai5sn</pattern>
+  <pattern>ai1so</pattern>
+  <pattern>ai1st</pattern>
+  <pattern>ai5tj</pattern>
+  <pattern>ai3tr</pattern>
+  <pattern>aiu4</pattern>
+  <pattern>aïn4</pattern>
+  <pattern>aïns5</pattern>
+  <pattern>aïs3o4</pattern>
+  <pattern>2a1j</pattern>
+  <pattern>ajaars5</pattern>
+  <pattern>aka2</pattern>
+  <pattern>ak3af</pattern>
+  <pattern>ak3ag</pattern>
+  <pattern>a4k3ar</pattern>
+  <pattern>a4k3ed</pattern>
+  <pattern>ak3emi</pattern>
+  <pattern>ake2t</pattern>
+  <pattern>ak3id</pattern>
+  <pattern>ak3ink</pattern>
+  <pattern>ak5is</pattern>
+  <pattern>1akko</pattern>
+  <pattern>4a2k3l</pattern>
+  <pattern>a2k3n</pattern>
+  <pattern>ak5ne</pattern>
+  <pattern>ak4ni</pattern>
+  <pattern>a3kof</pattern>
+  <pattern>ak3on</pattern>
+  <pattern>ak3o2p</pattern>
+  <pattern>a2kr</pattern>
+  <pattern>ak5ru</pattern>
+  <pattern>2aks</pattern>
+  <pattern>ak4so</pattern>
+  <pattern>ak5spe</pattern>
+  <pattern>ak1st</pattern>
+  <pattern>ak5to</pattern>
+  <pattern>ak5t4w</pattern>
+  <pattern>a2k3u4</pattern>
+  <pattern>ak1w</pattern>
+  <pattern>ak3wi</pattern>
+  <pattern>a1la</pattern>
+  <pattern>a4l3ach</pattern>
+  <pattern>al3adr</pattern>
+  <pattern>a3l4ag</pattern>
+  <pattern>a3lal</pattern>
+  <pattern>a5lapr</pattern>
+  <pattern>al3art</pattern>
+  <pattern>4ald</pattern>
+  <pattern>a1le</pattern>
+  <pattern>a5le </pattern>
+  <pattern>al3eff</pattern>
+  <pattern>2aleg</pattern>
+  <pattern>a2l3el</pattern>
+  <pattern>ale5ro</pattern>
+  <pattern>ale5ste</pattern>
+  <pattern>ale4tj</pattern>
+  <pattern>a3lè</pattern>
+  <pattern>al4fen</pattern>
+  <pattern>alf3l</pattern>
+  <pattern>al5fon</pattern>
+  <pattern>alfu4</pattern>
+  <pattern>al2gl</pattern>
+  <pattern>a3lie</pattern>
+  <pattern>al3int</pattern>
+  <pattern>alk5ei</pattern>
+  <pattern>al5kle</pattern>
+  <pattern>alk3s</pattern>
+  <pattern>al4kui</pattern>
+  <pattern>al5le</pattern>
+  <pattern>al4mac</pattern>
+  <pattern>al5me</pattern>
+  <pattern>a1lo</pattern>
+  <pattern>a4l3ol</pattern>
+  <pattern>alo2n</pattern>
+  <pattern>al3ou</pattern>
+  <pattern>a4l3o4v</pattern>
+  <pattern>2alp</pattern>
+  <pattern>al3s4ag</pattern>
+  <pattern>al3san</pattern>
+  <pattern>al3scr</pattern>
+  <pattern>als5j</pattern>
+  <pattern>al2sl</pattern>
+  <pattern>als5li</pattern>
+  <pattern>als5m</pattern>
+  <pattern>al4sn</pattern>
+  <pattern>al4s3oo</pattern>
+  <pattern>al4stem</pattern>
+  <pattern>al5sten</pattern>
+  <pattern>als5tou</pattern>
+  <pattern>altaar5</pattern>
+  <pattern>al3tha</pattern>
+  <pattern>al4t3ro</pattern>
+  <pattern>alt4st</pattern>
+  <pattern>a1lu</pattern>
+  <pattern>a2lui</pattern>
+  <pattern>al3uit</pattern>
+  <pattern>al3u4r</pattern>
+  <pattern>alu2s5</pattern>
+  <pattern>4am </pattern>
+  <pattern>a4m3ac</pattern>
+  <pattern>am3adr</pattern>
+  <pattern>ama4f</pattern>
+  <pattern>4amag</pattern>
+  <pattern>am3art</pattern>
+  <pattern>5ambt</pattern>
+  <pattern>ament4j</pattern>
+  <pattern>ame4ran</pattern>
+  <pattern>ame5tj</pattern>
+  <pattern>a2meu</pattern>
+  <pattern>am4i</pattern>
+  <pattern>4amm</pattern>
+  <pattern>am3oli</pattern>
+  <pattern>a2m3o4v</pattern>
+  <pattern>3ampè</pattern>
+  <pattern>am2pl</pattern>
+  <pattern>am4ple</pattern>
+  <pattern>am4sm</pattern>
+  <pattern>am4s3o</pattern>
+  <pattern>am4spr</pattern>
+  <pattern>ams5te </pattern>
+  <pattern>a2m3ui</pattern>
+  <pattern>a3nad</pattern>
+  <pattern>an3alg</pattern>
+  <pattern>an4a3n</pattern>
+  <pattern>an3arc</pattern>
+  <pattern>2anc</pattern>
+  <pattern>4anda</pattern>
+  <pattern>anda4d</pattern>
+  <pattern>and5ank</pattern>
+  <pattern>an4d3e4d</pattern>
+  <pattern>an4dex</pattern>
+  <pattern>2andj</pattern>
+  <pattern>an4dom</pattern>
+  <pattern>an5d4ri</pattern>
+  <pattern>and5roo</pattern>
+  <pattern>ands5lo</pattern>
+  <pattern>an4d3ul</pattern>
+  <pattern>a4nem</pattern>
+  <pattern>a3nen</pattern>
+  <pattern>anen3i</pattern>
+  <pattern>4aner</pattern>
+  <pattern>an3est</pattern>
+  <pattern>ane3us</pattern>
+  <pattern>4ang </pattern>
+  <pattern>an4gan</pattern>
+  <pattern>anga5p</pattern>
+  <pattern>ange5st</pattern>
+  <pattern>ang5le</pattern>
+  <pattern>an2gr</pattern>
+  <pattern>ang5sna</pattern>
+  <pattern>angs4te</pattern>
+  <pattern>aniet3</pattern>
+  <pattern>anij4</pattern>
+  <pattern>3anima</pattern>
+  <pattern>an5ion</pattern>
+  <pattern>a4n5isl</pattern>
+  <pattern>ani5t</pattern>
+  <pattern>4aniv</pattern>
+  <pattern>4ank </pattern>
+  <pattern>an4kaa</pattern>
+  <pattern>anka4n</pattern>
+  <pattern>an4k3as</pattern>
+  <pattern>an2k3j</pattern>
+  <pattern>an4klu</pattern>
+  <pattern>ank3of</pattern>
+  <pattern>an2k3r</pattern>
+  <pattern>a1no</pattern>
+  <pattern>an3och</pattern>
+  <pattern>a4n3oor</pattern>
+  <pattern>an3ork</pattern>
+  <pattern>ano3s</pattern>
+  <pattern>ano3t4</pattern>
+  <pattern>a4n3ou</pattern>
+  <pattern>ano5v</pattern>
+  <pattern>4ans</pattern>
+  <pattern>an3san</pattern>
+  <pattern>ans3cr</pattern>
+  <pattern>an4seg</pattern>
+  <pattern>an4serv</pattern>
+  <pattern>an4sid</pattern>
+  <pattern>an2so4</pattern>
+  <pattern>ans5or</pattern>
+  <pattern>ans3pi</pattern>
+  <pattern>ans5pir</pattern>
+  <pattern>an1st</pattern>
+  <pattern>an4s5te </pattern>
+  <pattern>an5stru</pattern>
+  <pattern>an4tac</pattern>
+  <pattern>ante4n</pattern>
+  <pattern>an3th</pattern>
+  <pattern>2anti</pattern>
+  <pattern>ant5sl</pattern>
+  <pattern>ant3w</pattern>
+  <pattern>4a1nu</pattern>
+  <pattern>a5nuf</pattern>
+  <pattern>an3ui</pattern>
+  <pattern>an3ur</pattern>
+  <pattern>an3uu</pattern>
+  <pattern>anze5s</pattern>
+  <pattern>2a1o</pattern>
+  <pattern>ao4g</pattern>
+  <pattern>ao2l</pattern>
+  <pattern>a4om</pattern>
+  <pattern>a2op2</pattern>
+  <pattern>aor5t</pattern>
+  <pattern>a3os</pattern>
+  <pattern>aos3p</pattern>
+  <pattern>aos5t</pattern>
+  <pattern>4ap </pattern>
+  <pattern>a1pa</pattern>
+  <pattern>a4pak</pattern>
+  <pattern>a4pas</pattern>
+  <pattern>ap3as </pattern>
+  <pattern>ap3ass</pattern>
+  <pattern>a1pe</pattern>
+  <pattern>ap5eten</pattern>
+  <pattern>4a1pi</pattern>
+  <pattern>apij4t5j</pattern>
+  <pattern>ap3ijz</pattern>
+  <pattern>ap1j</pattern>
+  <pattern>2apl</pattern>
+  <pattern>ap3le</pattern>
+  <pattern>ap3li</pattern>
+  <pattern>ap3lo</pattern>
+  <pattern>a1plu</pattern>
+  <pattern>apon5</pattern>
+  <pattern>ap3oo</pattern>
+  <pattern>apo3p</pattern>
+  <pattern>apo5sta</pattern>
+  <pattern>ap3o4v</pattern>
+  <pattern>1appa</pattern>
+  <pattern>4appen</pattern>
+  <pattern>4apr</pattern>
+  <pattern>ap3ra</pattern>
+  <pattern>a3pre</pattern>
+  <pattern>a4prem</pattern>
+  <pattern>a5p4ris</pattern>
+  <pattern>ap3ru</pattern>
+  <pattern>ap2sa</pattern>
+  <pattern>ap4si</pattern>
+  <pattern>ap2s3l</pattern>
+  <pattern>ap3sn</pattern>
+  <pattern>ap4ste </pattern>
+  <pattern>2apt</pattern>
+  <pattern>ap3tj</pattern>
+  <pattern>2apu</pattern>
+  <pattern>a2q</pattern>
+  <pattern>4ar </pattern>
+  <pattern>a1ra</pattern>
+  <pattern>araat5j</pattern>
+  <pattern>a4r3app</pattern>
+  <pattern>ara3s4</pattern>
+  <pattern>ar2da</pattern>
+  <pattern>ard3ac</pattern>
+  <pattern>ard3ak</pattern>
+  <pattern>ardo4</pattern>
+  <pattern>ar4d3om</pattern>
+  <pattern>ar4d3op</pattern>
+  <pattern>ar4d3ov</pattern>
+  <pattern>ar2d1r</pattern>
+  <pattern>ar4dra</pattern>
+  <pattern>ard3re</pattern>
+  <pattern>ar4du</pattern>
+  <pattern>ard3w</pattern>
+  <pattern>a1re</pattern>
+  <pattern>5a2rea</pattern>
+  <pattern>a3reg</pattern>
+  <pattern>a3rem</pattern>
+  <pattern>ar4en</pattern>
+  <pattern>are4no</pattern>
+  <pattern>are3sp</pattern>
+  <pattern>a3rev</pattern>
+  <pattern>ar3gh</pattern>
+  <pattern>ar2gl</pattern>
+  <pattern>a1ri</pattern>
+  <pattern>arie4tj</pattern>
+  <pattern>arij3s</pattern>
+  <pattern>ar3ins</pattern>
+  <pattern>ark2</pattern>
+  <pattern>ark3ac</pattern>
+  <pattern>ar3k4l</pattern>
+  <pattern>ar4map</pattern>
+  <pattern>arm3u</pattern>
+  <pattern>a1ro</pattern>
+  <pattern>a2r3ob</pattern>
+  <pattern>ar3oge</pattern>
+  <pattern>a3rok</pattern>
+  <pattern>aro4ko</pattern>
+  <pattern>ar3oog</pattern>
+  <pattern>a2r1o2p</pattern>
+  <pattern>a3rot</pattern>
+  <pattern>arpi4</pattern>
+  <pattern>ar2s</pattern>
+  <pattern>ar5sch</pattern>
+  <pattern>ar3scr</pattern>
+  <pattern>ars2e</pattern>
+  <pattern>ar5see</pattern>
+  <pattern>ar3si</pattern>
+  <pattern>ars3l</pattern>
+  <pattern>ar4sla</pattern>
+  <pattern>ars5m</pattern>
+  <pattern>ar3sni</pattern>
+  <pattern>ar4so</pattern>
+  <pattern>ar4sp</pattern>
+  <pattern>ar5spo</pattern>
+  <pattern>ars3ta</pattern>
+  <pattern>ars5tal</pattern>
+  <pattern>ar4s5tek</pattern>
+  <pattern>ar4str</pattern>
+  <pattern>ar4su</pattern>
+  <pattern>art4aa</pattern>
+  <pattern>ar4t3ak</pattern>
+  <pattern>ar4tan</pattern>
+  <pattern>art5ank</pattern>
+  <pattern>ar4tap</pattern>
+  <pattern>ar3tar</pattern>
+  <pattern>4arte</pattern>
+  <pattern>ar4tei</pattern>
+  <pattern>ar2th</pattern>
+  <pattern>ar5tij</pattern>
+  <pattern>4ar4tj</pattern>
+  <pattern>art5jesv</pattern>
+  <pattern>4arto</pattern>
+  <pattern>ar5tof</pattern>
+  <pattern>art5o4ge</pattern>
+  <pattern>art5oog</pattern>
+  <pattern>ar4t3o4v</pattern>
+  <pattern>ar2t3r</pattern>
+  <pattern>ar4tro</pattern>
+  <pattern>art5ru</pattern>
+  <pattern>art4sl</pattern>
+  <pattern>art5ste</pattern>
+  <pattern>a3ru</pattern>
+  <pattern>ar3ui</pattern>
+  <pattern>4arw</pattern>
+  <pattern>arwe3s</pattern>
+  <pattern>a1ry</pattern>
+  <pattern>4asa</pattern>
+  <pattern>as3ad</pattern>
+  <pattern>as4ag</pattern>
+  <pattern>as3ak</pattern>
+  <pattern>as1ap</pattern>
+  <pattern>a2sc</pattern>
+  <pattern>as5ce</pattern>
+  <pattern>2ase</pattern>
+  <pattern>a4sec</pattern>
+  <pattern>a4s3eg</pattern>
+  <pattern>aser5a</pattern>
+  <pattern>ase5tj</pattern>
+  <pattern>aseve4</pattern>
+  <pattern>as5ha</pattern>
+  <pattern>asis1</pattern>
+  <pattern>a4sj</pattern>
+  <pattern>as5ja</pattern>
+  <pattern>as3ji</pattern>
+  <pattern>as3k</pattern>
+  <pattern>as5ka</pattern>
+  <pattern>as5ki</pattern>
+  <pattern>as3l</pattern>
+  <pattern>as4lu</pattern>
+  <pattern>as3m</pattern>
+  <pattern>as5mi</pattern>
+  <pattern>as3n</pattern>
+  <pattern>as4ne</pattern>
+  <pattern>as4ni</pattern>
+  <pattern>4aso</pattern>
+  <pattern>as3ob</pattern>
+  <pattern>aso2l</pattern>
+  <pattern>aso4r</pattern>
+  <pattern>as1p</pattern>
+  <pattern>as3pl</pattern>
+  <pattern>a4s5q</pattern>
+  <pattern>as5sa</pattern>
+  <pattern>4assm</pattern>
+  <pattern>3assu</pattern>
+  <pattern>a2st</pattern>
+  <pattern>4as3ta</pattern>
+  <pattern>a4sta </pattern>
+  <pattern>as5tag</pattern>
+  <pattern>as4tas</pattern>
+  <pattern>as4tat</pattern>
+  <pattern>as3te</pattern>
+  <pattern>a3stek</pattern>
+  <pattern>a3stem</pattern>
+  <pattern>as5ten</pattern>
+  <pattern>as3tè</pattern>
+  <pattern>asting5sp</pattern>
+  <pattern>as1to</pattern>
+  <pattern>as3tob</pattern>
+  <pattern>ast3op</pattern>
+  <pattern>4astr</pattern>
+  <pattern>ast5rem</pattern>
+  <pattern>as5tro </pattern>
+  <pattern>as4tu</pattern>
+  <pattern>a1t</pattern>
+  <pattern>ataart5j</pattern>
+  <pattern>at1ac</pattern>
+  <pattern>at3ade</pattern>
+  <pattern>at3af </pattern>
+  <pattern>at3ank</pattern>
+  <pattern>ata3s</pattern>
+  <pattern>2atek</pattern>
+  <pattern>a5tell</pattern>
+  <pattern>ate2n</pattern>
+  <pattern>ate3no</pattern>
+  <pattern>aten4t5r</pattern>
+  <pattern>ater5ad</pattern>
+  <pattern>ater5sl</pattern>
+  <pattern>at4eu</pattern>
+  <pattern>2atg</pattern>
+  <pattern>at3hu</pattern>
+  <pattern>ati5ni</pattern>
+  <pattern>a2t3j</pattern>
+  <pattern>at4je</pattern>
+  <pattern>atjes5</pattern>
+  <pattern>at5jesb</pattern>
+  <pattern>at5jesh</pattern>
+  <pattern>at5jesm</pattern>
+  <pattern>at5jesp</pattern>
+  <pattern>2atm</pattern>
+  <pattern>2atn</pattern>
+  <pattern>a2too</pattern>
+  <pattern>at3oog</pattern>
+  <pattern>atos5f</pattern>
+  <pattern>ato3st</pattern>
+  <pattern>at3rac</pattern>
+  <pattern>at3rei</pattern>
+  <pattern>at3rib</pattern>
+  <pattern>at4roe</pattern>
+  <pattern>at5ru</pattern>
+  <pattern>at4s3a2</pattern>
+  <pattern>at4s3ec</pattern>
+  <pattern>atsi4</pattern>
+  <pattern>at4s3id</pattern>
+  <pattern>at2s3l</pattern>
+  <pattern>at4slo</pattern>
+  <pattern>ats5m</pattern>
+  <pattern>ats3n</pattern>
+  <pattern>at4sne</pattern>
+  <pattern>ats3pr</pattern>
+  <pattern>at2st</pattern>
+  <pattern>at4staa</pattern>
+  <pattern>at4s5tak</pattern>
+  <pattern>at4ste </pattern>
+  <pattern>at5sten</pattern>
+  <pattern>at5stij</pattern>
+  <pattern>ats5tol</pattern>
+  <pattern>ats5top </pattern>
+  <pattern>ats5trek</pattern>
+  <pattern>at4t3u4</pattern>
+  <pattern>a2t3ui</pattern>
+  <pattern>at3w</pattern>
+  <pattern>aua4</pattern>
+  <pattern>au3ch</pattern>
+  <pattern>au3co</pattern>
+  <pattern>au5de</pattern>
+  <pattern>aud4j</pattern>
+  <pattern>1aug</pattern>
+  <pattern>au3na</pattern>
+  <pattern>aun3t</pattern>
+  <pattern>aup2</pattern>
+  <pattern>aur4</pattern>
+  <pattern>au5re</pattern>
+  <pattern>aure3u</pattern>
+  <pattern>4aus</pattern>
+  <pattern>au3so</pattern>
+  <pattern>au4s5p</pattern>
+  <pattern>au3sto</pattern>
+  <pattern>au3t4</pattern>
+  <pattern>4aut </pattern>
+  <pattern>1auto</pattern>
+  <pattern>auto3p</pattern>
+  <pattern>2auts3</pattern>
+  <pattern>auw3a</pattern>
+  <pattern>4auz</pattern>
+  <pattern>a4ü</pattern>
+  <pattern>avast4</pattern>
+  <pattern>ave3c</pattern>
+  <pattern>avee4</pattern>
+  <pattern>ave4n3i</pattern>
+  <pattern>aven5sp</pattern>
+  <pattern>aver3a</pattern>
+  <pattern>ave3re</pattern>
+  <pattern>ave3r4u</pattern>
+  <pattern>4avi</pattern>
+  <pattern>a2vo</pattern>
+  <pattern>1a4von</pattern>
+  <pattern>a5voo</pattern>
+  <pattern>a5vor</pattern>
+  <pattern>4avy</pattern>
+  <pattern>2a1w</pattern>
+  <pattern>axis4</pattern>
+  <pattern>ay2a</pattern>
+  <pattern>4azif</pattern>
+  <pattern>ä3h</pattern>
+  <pattern>ämme3</pattern>
+  <pattern>ä3r</pattern>
+  <pattern>1b</pattern>
+  <pattern>4b </pattern>
+  <pattern>3ba</pattern>
+  <pattern>baar5ste</pattern>
+  <pattern>baar5tj</pattern>
+  <pattern>ba4da</pattern>
+  <pattern>bad3ar</pattern>
+  <pattern>ba4d3r</pattern>
+  <pattern>bad3s</pattern>
+  <pattern>ba3g4h</pattern>
+  <pattern>ba3gl</pattern>
+  <pattern>5b2ak</pattern>
+  <pattern>ba4k3o4</pattern>
+  <pattern>bak4sp</pattern>
+  <pattern>ba3lan</pattern>
+  <pattern>ba4lar</pattern>
+  <pattern>bal3dw</pattern>
+  <pattern>bale4</pattern>
+  <pattern>bal3ev</pattern>
+  <pattern>ba3lië</pattern>
+  <pattern>bal4kl</pattern>
+  <pattern>ba3lo</pattern>
+  <pattern>bals4</pattern>
+  <pattern>bal3sf</pattern>
+  <pattern>ba4me</pattern>
+  <pattern>ba5n2a</pattern>
+  <pattern>ban4k3a</pattern>
+  <pattern>ban4kl</pattern>
+  <pattern>ban4k3o</pattern>
+  <pattern>ban4kr</pattern>
+  <pattern>bank3w</pattern>
+  <pattern>ba3sa</pattern>
+  <pattern>ba4st</pattern>
+  <pattern>ba2tr</pattern>
+  <pattern>ba3tro</pattern>
+  <pattern>4bb</pattern>
+  <pattern>bbe4l5ag</pattern>
+  <pattern>bbe4l5ee</pattern>
+  <pattern>bbe2n</pattern>
+  <pattern>bben3a</pattern>
+  <pattern>4b1c</pattern>
+  <pattern>4b1d4</pattern>
+  <pattern>b5de</pattern>
+  <pattern>bdi5a</pattern>
+  <pattern>3b4e</pattern>
+  <pattern>be1a</pattern>
+  <pattern>be3as</pattern>
+  <pattern>be2au</pattern>
+  <pattern>be3ch</pattern>
+  <pattern>be5dwe</pattern>
+  <pattern>be5dwi</pattern>
+  <pattern>be5dwo</pattern>
+  <pattern>bee4</pattern>
+  <pattern>beet1</pattern>
+  <pattern>be5g</pattern>
+  <pattern>beie4</pattern>
+  <pattern>bei3s</pattern>
+  <pattern>bei5tj</pattern>
+  <pattern>be5ki</pattern>
+  <pattern>be3k4l</pattern>
+  <pattern>be1kw</pattern>
+  <pattern>be3lar</pattern>
+  <pattern>be5l4as</pattern>
+  <pattern>bel5dr</pattern>
+  <pattern>be3le</pattern>
+  <pattern>be4l3ec</pattern>
+  <pattern>be4lex</pattern>
+  <pattern>bel5f</pattern>
+  <pattern>be3li</pattern>
+  <pattern>be4l5int</pattern>
+  <pattern>bel3k</pattern>
+  <pattern>bel4o</pattern>
+  <pattern>be3lo5v</pattern>
+  <pattern>bel3sc</pattern>
+  <pattern>bel3sp</pattern>
+  <pattern>belt4</pattern>
+  <pattern>bemen4s</pattern>
+  <pattern>be3nep</pattern>
+  <pattern>be5n4o</pattern>
+  <pattern>be5ot</pattern>
+  <pattern>be1ra</pattern>
+  <pattern>bere5s4</pattern>
+  <pattern>ber4g5af</pattern>
+  <pattern>ber4g5et</pattern>
+  <pattern>ber4gl</pattern>
+  <pattern>ber4gr</pattern>
+  <pattern>ber4i</pattern>
+  <pattern>be1r4o</pattern>
+  <pattern>bero5v</pattern>
+  <pattern>be3ru</pattern>
+  <pattern>be3ry</pattern>
+  <pattern>be1s4</pattern>
+  <pattern>bes5ac</pattern>
+  <pattern>be4sh</pattern>
+  <pattern>be4sje</pattern>
+  <pattern>be3so</pattern>
+  <pattern>be5sp</pattern>
+  <pattern>bes5s</pattern>
+  <pattern>bes5te </pattern>
+  <pattern>bes5ten </pattern>
+  <pattern>be5stie</pattern>
+  <pattern>bet2</pattern>
+  <pattern>be3t4h</pattern>
+  <pattern>be5ton</pattern>
+  <pattern>bet5ren</pattern>
+  <pattern>be3tw</pattern>
+  <pattern>be5twi</pattern>
+  <pattern>be3und</pattern>
+  <pattern>beur4s</pattern>
+  <pattern>4b3f</pattern>
+  <pattern>2b1g</pattern>
+  <pattern>4b3h</pattern>
+  <pattern>3b2i</pattern>
+  <pattern>bid3s</pattern>
+  <pattern>bi2du</pattern>
+  <pattern>bie4li</pattern>
+  <pattern>bi4en</pattern>
+  <pattern>bie4t3j</pattern>
+  <pattern>bij5d</pattern>
+  <pattern>bij3f</pattern>
+  <pattern>bij3g4</pattern>
+  <pattern>bij5k4</pattern>
+  <pattern>bij1p</pattern>
+  <pattern>bij1s2</pattern>
+  <pattern>bik4a</pattern>
+  <pattern>5bil</pattern>
+  <pattern>bi3lo</pattern>
+  <pattern>bil3s2</pattern>
+  <pattern>bin4dr</pattern>
+  <pattern>bin4st</pattern>
+  <pattern>bin4t3j</pattern>
+  <pattern>bi5ob</pattern>
+  <pattern>bi3ok</pattern>
+  <pattern>bi5om</pattern>
+  <pattern>bi3oso</pattern>
+  <pattern>bi5ow</pattern>
+  <pattern>bir3</pattern>
+  <pattern>bi4st</pattern>
+  <pattern>bis5troo</pattern>
+  <pattern>bi1tr</pattern>
+  <pattern>bit4se</pattern>
+  <pattern>bit4s3p</pattern>
+  <pattern>4b1j</pattern>
+  <pattern>4b1k</pattern>
+  <pattern>3b4l</pattern>
+  <pattern>blad5ij</pattern>
+  <pattern>2b5lap</pattern>
+  <pattern>b5led</pattern>
+  <pattern>bles3</pattern>
+  <pattern>ble5spe</pattern>
+  <pattern>ble2t3</pattern>
+  <pattern>b5lid</pattern>
+  <pattern>blijs4</pattern>
+  <pattern>blij5ste</pattern>
+  <pattern>bli2k</pattern>
+  <pattern>4b5loi</pattern>
+  <pattern>blok5l</pattern>
+  <pattern>bloot5j</pattern>
+  <pattern>blu2s</pattern>
+  <pattern>2b1m</pattern>
+  <pattern>4b1n</pattern>
+  <pattern>b4o</pattern>
+  <pattern>bo4d3ec</pattern>
+  <pattern>body3</pattern>
+  <pattern>boe4g3a</pattern>
+  <pattern>boe4kn</pattern>
+  <pattern>boe4ko</pattern>
+  <pattern>boes4</pattern>
+  <pattern>boe3st</pattern>
+  <pattern>boet5st</pattern>
+  <pattern>bo3f4l</pattern>
+  <pattern>bo2k</pattern>
+  <pattern>bok3an</pattern>
+  <pattern>bokje5</pattern>
+  <pattern>bok4st</pattern>
+  <pattern>bolk4</pattern>
+  <pattern>bo2m3a4</pattern>
+  <pattern>bo2m3o</pattern>
+  <pattern>bo5na</pattern>
+  <pattern>bond2</pattern>
+  <pattern>bond4s5</pattern>
+  <pattern>3bone</pattern>
+  <pattern>bo3no</pattern>
+  <pattern>bon4t3j</pattern>
+  <pattern>bon4t5o4</pattern>
+  <pattern>boot3j</pattern>
+  <pattern>boots5te </pattern>
+  <pattern>bo3p2</pattern>
+  <pattern>bor4sta</pattern>
+  <pattern>borst5o</pattern>
+  <pattern>bor4st5r</pattern>
+  <pattern>bo4s</pattern>
+  <pattern>bos3a</pattern>
+  <pattern>bo5sco</pattern>
+  <pattern>bo5si</pattern>
+  <pattern>bo5so</pattern>
+  <pattern>bos5p</pattern>
+  <pattern>bos5to</pattern>
+  <pattern>bot3j</pattern>
+  <pattern>bo4to</pattern>
+  <pattern>bot3r</pattern>
+  <pattern>bot4sp</pattern>
+  <pattern>bot4st</pattern>
+  <pattern>bo2tu</pattern>
+  <pattern>bou5ta</pattern>
+  <pattern>bouw5s</pattern>
+  <pattern>bo3v</pattern>
+  <pattern>bove4</pattern>
+  <pattern>4b1p</pattern>
+  <pattern>3br4</pattern>
+  <pattern>braad5s</pattern>
+  <pattern>bran4da</pattern>
+  <pattern>bra5str</pattern>
+  <pattern>brei5s4</pattern>
+  <pattern>brie4t</pattern>
+  <pattern>brie5tje </pattern>
+  <pattern>bri4l</pattern>
+  <pattern>bro2n</pattern>
+  <pattern>bron3o4</pattern>
+  <pattern>bru2l</pattern>
+  <pattern>4b1s4</pattern>
+  <pattern>b2s5a</pattern>
+  <pattern>b5sc</pattern>
+  <pattern>b3si</pattern>
+  <pattern>bsi3d</pattern>
+  <pattern>bs5je</pattern>
+  <pattern>b2s5la</pattern>
+  <pattern>b2s5m</pattern>
+  <pattern>bs5s</pattern>
+  <pattern>b4stij</pattern>
+  <pattern>4bt4</pattern>
+  <pattern>b3ta</pattern>
+  <pattern>b1tr</pattern>
+  <pattern>bts5</pattern>
+  <pattern>3b4u</pattern>
+  <pattern>buit4j</pattern>
+  <pattern>bul4k</pattern>
+  <pattern>bu4lu</pattern>
+  <pattern>bune5t</pattern>
+  <pattern>b5urb</pattern>
+  <pattern>bu5ri</pattern>
+  <pattern>bus5c</pattern>
+  <pattern>bus3o</pattern>
+  <pattern>but4a</pattern>
+  <pattern>but3j</pattern>
+  <pattern>bu2to</pattern>
+  <pattern>but4s</pattern>
+  <pattern>buts5te</pattern>
+  <pattern>buur4tj</pattern>
+  <pattern>4bv</pattern>
+  <pattern>2b3w</pattern>
+  <pattern>by3</pattern>
+  <pattern>4bz</pattern>
+  <pattern>4c </pattern>
+  <pattern>1ca</pattern>
+  <pattern>3ca </pattern>
+  <pattern>ca3b</pattern>
+  <pattern>ca1ch</pattern>
+  <pattern>5cada</pattern>
+  <pattern>ca3do</pattern>
+  <pattern>ca3dr</pattern>
+  <pattern>cae3</pattern>
+  <pattern>ca3g2</pattern>
+  <pattern>cal4l3</pattern>
+  <pattern>ca3lo</pattern>
+  <pattern>came5r</pattern>
+  <pattern>ca3na</pattern>
+  <pattern>cant4</pattern>
+  <pattern>ca2of</pattern>
+  <pattern>ca1pr</pattern>
+  <pattern>ca4pra</pattern>
+  <pattern>ca5pri</pattern>
+  <pattern>ca3ra</pattern>
+  <pattern>car4u</pattern>
+  <pattern>ca5se</pattern>
+  <pattern>ca3s2p</pattern>
+  <pattern>cas3t</pattern>
+  <pattern>cas5tr</pattern>
+  <pattern>ca3ta</pattern>
+  <pattern>cate4n</pattern>
+  <pattern>ca3t4h</pattern>
+  <pattern>cau3</pattern>
+  <pattern>cau4st</pattern>
+  <pattern>ca3v</pattern>
+  <pattern>2cb</pattern>
+  <pattern>4c1c</pattern>
+  <pattern>cca3</pattern>
+  <pattern>cces5</pattern>
+  <pattern>c4d</pattern>
+  <pattern>c5do</pattern>
+  <pattern>1ce</pattern>
+  <pattern>3ced</pattern>
+  <pattern>cee4</pattern>
+  <pattern>3ceel</pattern>
+  <pattern>3cel</pattern>
+  <pattern>cel3d</pattern>
+  <pattern>celes5</pattern>
+  <pattern>ce5li</pattern>
+  <pattern>cel5k</pattern>
+  <pattern>ce4l3o</pattern>
+  <pattern>2ce3n4a</pattern>
+  <pattern>2cene</pattern>
+  <pattern>ce3no</pattern>
+  <pattern>5cent</pattern>
+  <pattern>cen4t3j</pattern>
+  <pattern>ceo4</pattern>
+  <pattern>ce3ra</pattern>
+  <pattern>cer2n</pattern>
+  <pattern>ce5ro</pattern>
+  <pattern>cer4t3r</pattern>
+  <pattern>ce2s</pattern>
+  <pattern>ce3s2a</pattern>
+  <pattern>ce5sc</pattern>
+  <pattern>ce3s2h</pattern>
+  <pattern>ce3sta</pattern>
+  <pattern>ce3s4ti</pattern>
+  <pattern>cesu5r</pattern>
+  <pattern>ce3ta</pattern>
+  <pattern>ce4t3j</pattern>
+  <pattern>ceto4</pattern>
+  <pattern>cet3og</pattern>
+  <pattern>cet3oo</pattern>
+  <pattern>1cé</pattern>
+  <pattern>c3g</pattern>
+  <pattern>4ch </pattern>
+  <pattern>3chaï</pattern>
+  <pattern>5chao</pattern>
+  <pattern>3chas</pattern>
+  <pattern>1chau</pattern>
+  <pattern>5chauf</pattern>
+  <pattern>2chc</pattern>
+  <pattern>1chef</pattern>
+  <pattern>5chef </pattern>
+  <pattern>5chefs</pattern>
+  <pattern>5chemi</pattern>
+  <pattern>5cheq</pattern>
+  <pattern>che5ri</pattern>
+  <pattern>che3ru</pattern>
+  <pattern>5ches</pattern>
+  <pattern>che3us</pattern>
+  <pattern>1ché</pattern>
+  <pattern>5chir</pattern>
+  <pattern>4chn</pattern>
+  <pattern>2chp</pattern>
+  <pattern>5chromo</pattern>
+  <pattern>4cht</pattern>
+  <pattern>4chw</pattern>
+  <pattern>1chy</pattern>
+  <pattern>3ci</pattern>
+  <pattern>ci5ab</pattern>
+  <pattern>ci3am</pattern>
+  <pattern>cie3k</pattern>
+  <pattern>cier4s5</pattern>
+  <pattern>ci1eu</pattern>
+  <pattern>5cij</pattern>
+  <pattern>5cil</pattern>
+  <pattern>ci5le</pattern>
+  <pattern>cil3m</pattern>
+  <pattern>4cind</pattern>
+  <pattern>ci3o</pattern>
+  <pattern>ci5om</pattern>
+  <pattern>5cir</pattern>
+  <pattern>ci3t2</pattern>
+  <pattern>ci5ta</pattern>
+  <pattern>c3j</pattern>
+  <pattern>c2k3a</pattern>
+  <pattern>c4k3ed</pattern>
+  <pattern>ck3ef</pattern>
+  <pattern>cke5re</pattern>
+  <pattern>c5k4et</pattern>
+  <pattern>ck3id</pattern>
+  <pattern>c2k3l</pattern>
+  <pattern>ck4le</pattern>
+  <pattern>c2k3n</pattern>
+  <pattern>c2k3o4</pattern>
+  <pattern>c4k3r</pattern>
+  <pattern>ck5se</pattern>
+  <pattern>ck3so</pattern>
+  <pattern>ck5st</pattern>
+  <pattern>c3ky</pattern>
+  <pattern>1c4l</pattern>
+  <pattern>cla2n</pattern>
+  <pattern>cle3u</pattern>
+  <pattern>5clu</pattern>
+  <pattern>2c1n</pattern>
+  <pattern>1co</pattern>
+  <pattern>co3ad</pattern>
+  <pattern>co3d</pattern>
+  <pattern>co4i</pattern>
+  <pattern>coin5</pattern>
+  <pattern>co3k4</pattern>
+  <pattern>co3la</pattern>
+  <pattern>5com</pattern>
+  <pattern>5cond</pattern>
+  <pattern>con1g</pattern>
+  <pattern>2co1no</pattern>
+  <pattern>5cons</pattern>
+  <pattern>3con5t4</pattern>
+  <pattern>2coo</pattern>
+  <pattern>2co1p2</pattern>
+  <pattern>3copa</pattern>
+  <pattern>4copi</pattern>
+  <pattern>cor4dr</pattern>
+  <pattern>co4rel</pattern>
+  <pattern>co5ri</pattern>
+  <pattern>cor2o</pattern>
+  <pattern>5corr</pattern>
+  <pattern>cors4</pattern>
+  <pattern>co3ru</pattern>
+  <pattern>co5sc</pattern>
+  <pattern>co5se</pattern>
+  <pattern>co5sp</pattern>
+  <pattern>co3th</pattern>
+  <pattern>co3tr</pattern>
+  <pattern>5coun</pattern>
+  <pattern>2cout</pattern>
+  <pattern>co5v</pattern>
+  <pattern>c3p4</pattern>
+  <pattern>1c4r2</pattern>
+  <pattern>3cras</pattern>
+  <pattern>cre5d</pattern>
+  <pattern>2crip</pattern>
+  <pattern>3cris</pattern>
+  <pattern>cro5f</pattern>
+  <pattern>cro5k</pattern>
+  <pattern>croo3</pattern>
+  <pattern>cro5v</pattern>
+  <pattern>crus5</pattern>
+  <pattern>c3so</pattern>
+  <pattern>c3sp</pattern>
+  <pattern>c3ste</pattern>
+  <pattern>2c1t</pattern>
+  <pattern>ct3act</pattern>
+  <pattern>ct3ad</pattern>
+  <pattern>ct5c</pattern>
+  <pattern>ctee5t</pattern>
+  <pattern>cte2n3</pattern>
+  <pattern>c2t1h</pattern>
+  <pattern>c2t3j</pattern>
+  <pattern>c4t3of</pattern>
+  <pattern>c3tol</pattern>
+  <pattern>c2t1on</pattern>
+  <pattern>ct4or</pattern>
+  <pattern>ct3rap</pattern>
+  <pattern>c4t3re</pattern>
+  <pattern>ct3sl</pattern>
+  <pattern>ct3sp</pattern>
+  <pattern>1c2u</pattern>
+  <pattern>cu5d4</pattern>
+  <pattern>cu3en</pattern>
+  <pattern>cu3és</pattern>
+  <pattern>cui5s</pattern>
+  <pattern>cui2t</pattern>
+  <pattern>cuit5e</pattern>
+  <pattern>cu3k4</pattern>
+  <pattern>cula5p</pattern>
+  <pattern>cu3ra</pattern>
+  <pattern>5cur3s</pattern>
+  <pattern>cus3o</pattern>
+  <pattern>c3w</pattern>
+  <pattern>1cy</pattern>
+  <pattern>1ç</pattern>
+  <pattern>ça4o</pattern>
+  <pattern>4d </pattern>
+  <pattern>1da</pattern>
+  <pattern>3da </pattern>
+  <pattern>3daag</pattern>
+  <pattern>d4aal</pattern>
+  <pattern>d3aap</pattern>
+  <pattern>daar5e</pattern>
+  <pattern>5daat</pattern>
+  <pattern>4dabo</pattern>
+  <pattern>2d3acc</pattern>
+  <pattern>da4ce</pattern>
+  <pattern>da5den</pattern>
+  <pattern>4dadr</pattern>
+  <pattern>3dae</pattern>
+  <pattern>2d1af</pattern>
+  <pattern>3dag</pattern>
+  <pattern>da2g3a4</pattern>
+  <pattern>da3ge</pattern>
+  <pattern>da4g3ed</pattern>
+  <pattern>da4g3e4t</pattern>
+  <pattern>da4g3on</pattern>
+  <pattern>da4g3r</pattern>
+  <pattern>dag4s3t</pattern>
+  <pattern>da2gu</pattern>
+  <pattern>3dai</pattern>
+  <pattern>da3ï</pattern>
+  <pattern>da3ke</pattern>
+  <pattern>da4ker</pattern>
+  <pattern>2dakk</pattern>
+  <pattern>da4k1r</pattern>
+  <pattern>4dala</pattern>
+  <pattern>d3alar</pattern>
+  <pattern>d3alc</pattern>
+  <pattern>da3le</pattern>
+  <pattern>4dalf</pattern>
+  <pattern>da3li</pattern>
+  <pattern>2dalm</pattern>
+  <pattern>da2l3u</pattern>
+  <pattern>d4am</pattern>
+  <pattern>dam4a</pattern>
+  <pattern>da5mac</pattern>
+  <pattern>d3a4mat</pattern>
+  <pattern>d2a5me4</pattern>
+  <pattern>dames3</pattern>
+  <pattern>dam4pl</pattern>
+  <pattern>2da2na</pattern>
+  <pattern>dan3as</pattern>
+  <pattern>dank3l</pattern>
+  <pattern>danoot5</pattern>
+  <pattern>dan4si</pattern>
+  <pattern>dan4sm</pattern>
+  <pattern>dan4s3p</pattern>
+  <pattern>dan4st</pattern>
+  <pattern>dans5ta</pattern>
+  <pattern>4d3antw</pattern>
+  <pattern>2d1ap</pattern>
+  <pattern>4d3a2pe</pattern>
+  <pattern>5dapu</pattern>
+  <pattern>da2r3a</pattern>
+  <pattern>d3arb</pattern>
+  <pattern>3dare</pattern>
+  <pattern>3dari</pattern>
+  <pattern>dar4mo</pattern>
+  <pattern>darm5on</pattern>
+  <pattern>3daro</pattern>
+  <pattern>dar3s</pattern>
+  <pattern>dar5st</pattern>
+  <pattern>3das3</pattern>
+  <pattern>5dasa</pattern>
+  <pattern>da3stu</pattern>
+  <pattern>3d4at</pattern>
+  <pattern>da3ta</pattern>
+  <pattern>dat5j</pattern>
+  <pattern>4d5atl</pattern>
+  <pattern>4d5atm</pattern>
+  <pattern>da2t3r</pattern>
+  <pattern>5daue</pattern>
+  <pattern>4d1aut</pattern>
+  <pattern>3dauw</pattern>
+  <pattern>2db</pattern>
+  <pattern>dbei5</pattern>
+  <pattern>dbou4w5i</pattern>
+  <pattern>2d5c</pattern>
+  <pattern>4d3d4</pattern>
+  <pattern>ddags4</pattern>
+  <pattern>ddag5sp</pattern>
+  <pattern>ddel5ev</pattern>
+  <pattern>dde2n</pattern>
+  <pattern>dden5a</pattern>
+  <pattern>ddera4</pattern>
+  <pattern>dder5al</pattern>
+  <pattern>ddere4</pattern>
+  <pattern>dder5ee</pattern>
+  <pattern>dder5ep</pattern>
+  <pattern>dder3o</pattern>
+  <pattern>ddi3a</pattern>
+  <pattern>d5dles</pattern>
+  <pattern>d5do</pattern>
+  <pattern>ddo3p</pattern>
+  <pattern>1de</pattern>
+  <pattern>3de </pattern>
+  <pattern>de2al</pattern>
+  <pattern>de1ch</pattern>
+  <pattern>d4e5den</pattern>
+  <pattern>5dedir</pattern>
+  <pattern>de4dit</pattern>
+  <pattern>dee4g3</pattern>
+  <pattern>dee4l</pattern>
+  <pattern>deel3i</pattern>
+  <pattern>4d3een</pattern>
+  <pattern>dee4r</pattern>
+  <pattern>4d3eff</pattern>
+  <pattern>de3g</pattern>
+  <pattern>4d5eg </pattern>
+  <pattern>4d5egg</pattern>
+  <pattern>2d5egy</pattern>
+  <pattern>2dei</pattern>
+  <pattern>d3eie</pattern>
+  <pattern>d3eig</pattern>
+  <pattern>d3eil</pattern>
+  <pattern>d1eis</pattern>
+  <pattern>d3eiw</pattern>
+  <pattern>5dek</pattern>
+  <pattern>de3ke</pattern>
+  <pattern>dek3lu</pattern>
+  <pattern>dek3w</pattern>
+  <pattern>del4aa</pattern>
+  <pattern>del5da</pattern>
+  <pattern>del5dr</pattern>
+  <pattern>del5eek</pattern>
+  <pattern>4d3e4lek</pattern>
+  <pattern>4delem</pattern>
+  <pattern>de4lev</pattern>
+  <pattern>4d3e4lit</pattern>
+  <pattern>del3k</pattern>
+  <pattern>del2s</pattern>
+  <pattern>del4s3e</pattern>
+  <pattern>dels3i</pattern>
+  <pattern>del4so</pattern>
+  <pattern>4d3e4mai</pattern>
+  <pattern>2demh</pattern>
+  <pattern>5demi</pattern>
+  <pattern>dem5ond</pattern>
+  <pattern>d2en </pattern>
+  <pattern>den4ac</pattern>
+  <pattern>den5ate</pattern>
+  <pattern>den3ei</pattern>
+  <pattern>den3e4p</pattern>
+  <pattern>den3ev</pattern>
+  <pattern>4d3engt</pattern>
+  <pattern>den4k5of</pattern>
+  <pattern>de4noc</pattern>
+  <pattern>den3o4r</pattern>
+  <pattern>den3sh</pattern>
+  <pattern>den5str</pattern>
+  <pattern>de3nu</pattern>
+  <pattern>5denvl</pattern>
+  <pattern>de4o</pattern>
+  <pattern>de5ofo</pattern>
+  <pattern>de5ol</pattern>
+  <pattern>deo4li</pattern>
+  <pattern>deo3v</pattern>
+  <pattern>de3rab</pattern>
+  <pattern>de4r3ad</pattern>
+  <pattern>der3a4g</pattern>
+  <pattern>de3rak</pattern>
+  <pattern>de3ram</pattern>
+  <pattern>de3ran</pattern>
+  <pattern>de3rap</pattern>
+  <pattern>de3ras</pattern>
+  <pattern>de4r5as </pattern>
+  <pattern>de4r5ass</pattern>
+  <pattern>der2e</pattern>
+  <pattern>der5ede</pattern>
+  <pattern>der5egd</pattern>
+  <pattern>de4r3ei</pattern>
+  <pattern>de4r3em</pattern>
+  <pattern>de5re4n</pattern>
+  <pattern>de4rep</pattern>
+  <pattern>de4ret</pattern>
+  <pattern>de5rij</pattern>
+  <pattern>de4r3im</pattern>
+  <pattern>der3k4</pattern>
+  <pattern>der3on</pattern>
+  <pattern>dero4r</pattern>
+  <pattern>4d3eros</pattern>
+  <pattern>der4s3a</pattern>
+  <pattern>der4s5om</pattern>
+  <pattern>der5ste</pattern>
+  <pattern>der5sto</pattern>
+  <pattern>der5stra</pattern>
+  <pattern>der5th</pattern>
+  <pattern>4d3erts</pattern>
+  <pattern>der5tw</pattern>
+  <pattern>de2r3u</pattern>
+  <pattern>de3rup</pattern>
+  <pattern>de2s</pattern>
+  <pattern>de3sav</pattern>
+  <pattern>des3m</pattern>
+  <pattern>des3n</pattern>
+  <pattern>des3p</pattern>
+  <pattern>de3spe</pattern>
+  <pattern>de5spel</pattern>
+  <pattern>de4spl</pattern>
+  <pattern>des5sm</pattern>
+  <pattern>de3st</pattern>
+  <pattern>des5tak</pattern>
+  <pattern>de5stal</pattern>
+  <pattern>de4s3te</pattern>
+  <pattern>de4sti</pattern>
+  <pattern>de5stic</pattern>
+  <pattern>des5top</pattern>
+  <pattern>de3t4</pattern>
+  <pattern>4d3e4tap</pattern>
+  <pattern>de5tw</pattern>
+  <pattern>deu4r3o4</pattern>
+  <pattern>de3us </pattern>
+  <pattern>deu4tj</pattern>
+  <pattern>deve4</pattern>
+  <pattern>2dex</pattern>
+  <pattern>4d1exa</pattern>
+  <pattern>4dexp</pattern>
+  <pattern>3dè</pattern>
+  <pattern>2d1f</pattern>
+  <pattern>2d3g</pattern>
+  <pattern>d4gaf</pattern>
+  <pattern>dge3la</pattern>
+  <pattern>dge2t</pattern>
+  <pattern>dgeto4</pattern>
+  <pattern>dget5on</pattern>
+  <pattern>dget5ov</pattern>
+  <pattern>dge4tr</pattern>
+  <pattern>dg4l</pattern>
+  <pattern>2d1h</pattern>
+  <pattern>d5he</pattern>
+  <pattern>dheer4</pattern>
+  <pattern>3d4hi </pattern>
+  <pattern>1di</pattern>
+  <pattern>di2a</pattern>
+  <pattern>di5ae</pattern>
+  <pattern>di4ak</pattern>
+  <pattern>di4ano</pattern>
+  <pattern>dia3s4</pattern>
+  <pattern>di4atr</pattern>
+  <pattern>5dich</pattern>
+  <pattern>di4do</pattern>
+  <pattern>die2f</pattern>
+  <pattern>die4r3o</pattern>
+  <pattern>di3esr</pattern>
+  <pattern>die3st</pattern>
+  <pattern>die2t</pattern>
+  <pattern>diet3r</pattern>
+  <pattern>di1eu</pattern>
+  <pattern>3dig</pattern>
+  <pattern>di2ga</pattern>
+  <pattern>dig5aa</pattern>
+  <pattern>diges5</pattern>
+  <pattern>dijk3r</pattern>
+  <pattern>di3jo</pattern>
+  <pattern>2d3ijz</pattern>
+  <pattern>di2k3o4</pattern>
+  <pattern>5dil</pattern>
+  <pattern>2d3imp</pattern>
+  <pattern>di5n2a</pattern>
+  <pattern>2d3ind</pattern>
+  <pattern>2dinf</pattern>
+  <pattern>3d4ing </pattern>
+  <pattern>4d5ingel</pattern>
+  <pattern>4d3inj</pattern>
+  <pattern>4d3inko</pattern>
+  <pattern>2d5inr</pattern>
+  <pattern>2d3ins</pattern>
+  <pattern>4d3int</pattern>
+  <pattern>dintel5</pattern>
+  <pattern>2d3inv</pattern>
+  <pattern>2d3inw</pattern>
+  <pattern>2d3inz</pattern>
+  <pattern>di2o</pattern>
+  <pattern>di5ofon</pattern>
+  <pattern>di4ol</pattern>
+  <pattern>di4one</pattern>
+  <pattern>di4oni</pattern>
+  <pattern>dio1s</pattern>
+  <pattern>dio5sc</pattern>
+  <pattern>2d3i2ro</pattern>
+  <pattern>2d3irr</pattern>
+  <pattern>3di4s</pattern>
+  <pattern>dis5ag</pattern>
+  <pattern>di5se</pattern>
+  <pattern>di5si</pattern>
+  <pattern>dis4kr</pattern>
+  <pattern>dis5p</pattern>
+  <pattern>dis1t</pattern>
+  <pattern>dis5tr</pattern>
+  <pattern>di3th</pattern>
+  <pattern>dit3j</pattern>
+  <pattern>dit3r</pattern>
+  <pattern>5div</pattern>
+  <pattern>2d1j</pattern>
+  <pattern>2d3k2</pattern>
+  <pattern>4d3l</pattern>
+  <pattern>d5le </pattern>
+  <pattern>dli4n</pattern>
+  <pattern>dlot4s</pattern>
+  <pattern>2d1m</pattern>
+  <pattern>2d3n2</pattern>
+  <pattern>d5ne</pattern>
+  <pattern>dni3s</pattern>
+  <pattern>1do</pattern>
+  <pattern>3do </pattern>
+  <pattern>do3a</pattern>
+  <pattern>2dobj</pattern>
+  <pattern>4d3obs</pattern>
+  <pattern>3d4oe</pattern>
+  <pattern>5doe </pattern>
+  <pattern>doe5d</pattern>
+  <pattern>4doef</pattern>
+  <pattern>d5oefe</pattern>
+  <pattern>5doek</pattern>
+  <pattern>5doen</pattern>
+  <pattern>5doet</pattern>
+  <pattern>4d5oev</pattern>
+  <pattern>3doi</pattern>
+  <pattern>d4ole</pattern>
+  <pattern>2do2li</pattern>
+  <pattern>d4olin</pattern>
+  <pattern>dolk5s</pattern>
+  <pattern>5dol5s</pattern>
+  <pattern>3d4om </pattern>
+  <pattern>5domi</pattern>
+  <pattern>do4m3o4</pattern>
+  <pattern>d3omr</pattern>
+  <pattern>dom4sn</pattern>
+  <pattern>5domu</pattern>
+  <pattern>d3omv</pattern>
+  <pattern>4domz</pattern>
+  <pattern>5don </pattern>
+  <pattern>d4ona</pattern>
+  <pattern>5done</pattern>
+  <pattern>do5ni</pattern>
+  <pattern>5d4onn</pattern>
+  <pattern>5do3n4o</pattern>
+  <pattern>do3nu</pattern>
+  <pattern>do5ny</pattern>
+  <pattern>5donz</pattern>
+  <pattern>2dop</pattern>
+  <pattern>do3pa</pattern>
+  <pattern>d3opb</pattern>
+  <pattern>d3opd</pattern>
+  <pattern>do3pee</pattern>
+  <pattern>5dopj</pattern>
+  <pattern>4d1opl</pattern>
+  <pattern>3dopo</pattern>
+  <pattern>d3ops</pattern>
+  <pattern>d3opz</pattern>
+  <pattern>4d5org</pattern>
+  <pattern>do4rië</pattern>
+  <pattern>d3ork</pattern>
+  <pattern>dors5m</pattern>
+  <pattern>do3sp</pattern>
+  <pattern>do3sta</pattern>
+  <pattern>dot3j</pattern>
+  <pattern>5dou</pattern>
+  <pattern>2dov</pattern>
+  <pattern>dover5s</pattern>
+  <pattern>3dovl</pattern>
+  <pattern>3dovo</pattern>
+  <pattern>2d3p</pattern>
+  <pattern>dpren4</pattern>
+  <pattern>1dr4</pattern>
+  <pattern>3dra</pattern>
+  <pattern>5dra </pattern>
+  <pattern>d3raam</pattern>
+  <pattern>d3raap</pattern>
+  <pattern>d4rac</pattern>
+  <pattern>d5race</pattern>
+  <pattern>5drach</pattern>
+  <pattern>d3rad </pattern>
+  <pattern>d3rada</pattern>
+  <pattern>5draf</pattern>
+  <pattern>5d4rag</pattern>
+  <pattern>d4rama</pattern>
+  <pattern>d3rame</pattern>
+  <pattern>4d3rand</pattern>
+  <pattern>4drap</pattern>
+  <pattern>4dras</pattern>
+  <pattern>4d3raz</pattern>
+  <pattern>2dre</pattern>
+  <pattern>4d1rec</pattern>
+  <pattern>d5reco</pattern>
+  <pattern>d1red</pattern>
+  <pattern>d2ree</pattern>
+  <pattern>4d3reek</pattern>
+  <pattern>4drend</pattern>
+  <pattern>d4ress</pattern>
+  <pattern>4dret</pattern>
+  <pattern>3d2rev</pattern>
+  <pattern>5dreve</pattern>
+  <pattern>d3ric</pattern>
+  <pattern>dries4</pattern>
+  <pattern>5d2rif</pattern>
+  <pattern>dri5ga</pattern>
+  <pattern>d3rijd</pattern>
+  <pattern>d3rijk</pattern>
+  <pattern>d3rijm</pattern>
+  <pattern>d3rijs</pattern>
+  <pattern>5d4rin</pattern>
+  <pattern>3dris</pattern>
+  <pattern>4d3rit</pattern>
+  <pattern>4d3roei</pattern>
+  <pattern>d3roer</pattern>
+  <pattern>5d2rog</pattern>
+  <pattern>4d3rok</pattern>
+  <pattern>d3roma</pattern>
+  <pattern>d3rond</pattern>
+  <pattern>3droog</pattern>
+  <pattern>4droos</pattern>
+  <pattern>5drop</pattern>
+  <pattern>2drou</pattern>
+  <pattern>2d3ro5v</pattern>
+  <pattern>2droz</pattern>
+  <pattern>drug4s</pattern>
+  <pattern>d3ruim</pattern>
+  <pattern>d3ruit</pattern>
+  <pattern>5d4ru4k</pattern>
+  <pattern>4d3rus</pattern>
+  <pattern>2ds</pattern>
+  <pattern>d2s1a2</pattern>
+  <pattern>d4saa</pattern>
+  <pattern>dsa4b</pattern>
+  <pattern>d3sal</pattern>
+  <pattern>ds4ate</pattern>
+  <pattern>ds2ch</pattern>
+  <pattern>d5schi</pattern>
+  <pattern>dse2</pattern>
+  <pattern>ds3eco</pattern>
+  <pattern>d4s3ed</pattern>
+  <pattern>d4s5ee</pattern>
+  <pattern>d4sef</pattern>
+  <pattern>d4sei</pattern>
+  <pattern>ds3eis</pattern>
+  <pattern>ds3elf</pattern>
+  <pattern>dse4li</pattern>
+  <pattern>d5sen</pattern>
+  <pattern>d4s3es</pattern>
+  <pattern>d4set</pattern>
+  <pattern>d2sh</pattern>
+  <pattern>ds3ho</pattern>
+  <pattern>d2s1i2</pattern>
+  <pattern>d4s5id</pattern>
+  <pattern>dsig5a</pattern>
+  <pattern>ds2im</pattern>
+  <pattern>ds4ing</pattern>
+  <pattern>ds5is</pattern>
+  <pattern>d4s3j</pattern>
+  <pattern>ds4jo</pattern>
+  <pattern>ds5jon</pattern>
+  <pattern>ds4l</pattern>
+  <pattern>d1sla</pattern>
+  <pattern>ds5las</pattern>
+  <pattern>ds5lic</pattern>
+  <pattern>d4s5lie</pattern>
+  <pattern>ds5lim</pattern>
+  <pattern>d3slin</pattern>
+  <pattern>d2sm</pattern>
+  <pattern>ds4mak</pattern>
+  <pattern>d3smij</pattern>
+  <pattern>ds5mo</pattern>
+  <pattern>ds3n</pattern>
+  <pattern>ds4ne</pattern>
+  <pattern>ds5neu</pattern>
+  <pattern>d3snu</pattern>
+  <pattern>ds1o4</pattern>
+  <pattern>ds3ob</pattern>
+  <pattern>ds3om</pattern>
+  <pattern>d4son</pattern>
+  <pattern>ds2oo</pattern>
+  <pattern>ds3op</pattern>
+  <pattern>d4spa</pattern>
+  <pattern>d5span</pattern>
+  <pattern>ds5pati</pattern>
+  <pattern>d5spec</pattern>
+  <pattern>d5s4pel</pattern>
+  <pattern>d4s3pet</pattern>
+  <pattern>d1spi</pattern>
+  <pattern>d4s3pl</pattern>
+  <pattern>d5spoe</pattern>
+  <pattern>d5spok</pattern>
+  <pattern>d5spor</pattern>
+  <pattern>ds5s</pattern>
+  <pattern>dst4</pattern>
+  <pattern>d1sta</pattern>
+  <pattern>d5staat</pattern>
+  <pattern>d4stab</pattern>
+  <pattern>ds3tak</pattern>
+  <pattern>d4s3tal</pattern>
+  <pattern>ds4tan</pattern>
+  <pattern>d3s4tat</pattern>
+  <pattern>d5stav</pattern>
+  <pattern>d3ste</pattern>
+  <pattern>ds4te </pattern>
+  <pattern>d5stee</pattern>
+  <pattern>d4stek</pattern>
+  <pattern>ds4ter</pattern>
+  <pattern>d4sterr</pattern>
+  <pattern>d4stev</pattern>
+  <pattern>ds3th</pattern>
+  <pattern>d3s4ti</pattern>
+  <pattern>d4stit</pattern>
+  <pattern>d1sto</pattern>
+  <pattern>ds5tram</pattern>
+  <pattern>ds5trekk</pattern>
+  <pattern>ds5ty</pattern>
+  <pattern>d2su4</pattern>
+  <pattern>ds3ure</pattern>
+  <pattern>ds3uu</pattern>
+  <pattern>d1sy</pattern>
+  <pattern>2dt</pattern>
+  <pattern>d1ta</pattern>
+  <pattern>dtaart5j</pattern>
+  <pattern>d1th</pattern>
+  <pattern>d2tj</pattern>
+  <pattern>d1to</pattern>
+  <pattern>d1tr</pattern>
+  <pattern>d1tu</pattern>
+  <pattern>1du</pattern>
+  <pattern>2duca</pattern>
+  <pattern>5due</pattern>
+  <pattern>du3en</pattern>
+  <pattern>du3et</pattern>
+  <pattern>5duid</pattern>
+  <pattern>5duif</pattern>
+  <pattern>5duik</pattern>
+  <pattern>d3uil</pattern>
+  <pattern>2duit</pattern>
+  <pattern>4duit </pattern>
+  <pattern>d3uitd</pattern>
+  <pattern>5duite</pattern>
+  <pattern>4duitg</pattern>
+  <pattern>d3uitv</pattern>
+  <pattern>5duiv</pattern>
+  <pattern>du4n</pattern>
+  <pattern>dun5i</pattern>
+  <pattern>du2o</pattern>
+  <pattern>du4ol</pattern>
+  <pattern>3durf</pattern>
+  <pattern>3durv</pattern>
+  <pattern>5du1s</pattern>
+  <pattern>dut3j</pattern>
+  <pattern>du5wen</pattern>
+  <pattern>2dv</pattern>
+  <pattern>dvaat5</pattern>
+  <pattern>dvee3</pattern>
+  <pattern>dve5na</pattern>
+  <pattern>dvies5</pattern>
+  <pattern>2dw</pattern>
+  <pattern>d3wac</pattern>
+  <pattern>d3was</pattern>
+  <pattern>d3wat</pattern>
+  <pattern>d1we</pattern>
+  <pattern>3d2wei</pattern>
+  <pattern>d3wek</pattern>
+  <pattern>d3wet</pattern>
+  <pattern>d3wez</pattern>
+  <pattern>d1wi</pattern>
+  <pattern>4d1wo</pattern>
+  <pattern>d3wor</pattern>
+  <pattern>d3wr</pattern>
+  <pattern>1dy</pattern>
+  <pattern>4d3yo</pattern>
+  <pattern>dy4sp</pattern>
+  <pattern>dy2s4t</pattern>
+  <pattern>2dz</pattern>
+  <pattern>4e </pattern>
+  <pattern>4ea</pattern>
+  <pattern>e3aa</pattern>
+  <pattern>e1ab</pattern>
+  <pattern>ea3bo</pattern>
+  <pattern>e3ac</pattern>
+  <pattern>ea4ca</pattern>
+  <pattern>eac5t</pattern>
+  <pattern>e1ad</pattern>
+  <pattern>ea3da</pattern>
+  <pattern>e5adem</pattern>
+  <pattern>ea3do</pattern>
+  <pattern>ead3s2</pattern>
+  <pattern>ead5sh</pattern>
+  <pattern>e1af</pattern>
+  <pattern>e1ag</pattern>
+  <pattern>e3ai</pattern>
+  <pattern>ea4k3o4</pattern>
+  <pattern>e1al</pattern>
+  <pattern>ea3la</pattern>
+  <pattern>e3ali</pattern>
+  <pattern>e4als</pattern>
+  <pattern>ea5mi</pattern>
+  <pattern>e3an</pattern>
+  <pattern>e4an </pattern>
+  <pattern>eang3</pattern>
+  <pattern>ean4s</pattern>
+  <pattern>e5ap</pattern>
+  <pattern>ea3pr</pattern>
+  <pattern>e3aq</pattern>
+  <pattern>e1ar</pattern>
+  <pattern>ear2c</pattern>
+  <pattern>e1as</pattern>
+  <pattern>e2asc</pattern>
+  <pattern>ea5s4e</pattern>
+  <pattern>ease5t</pattern>
+  <pattern>ea3so</pattern>
+  <pattern>e1at</pattern>
+  <pattern>e4at </pattern>
+  <pattern>eat3s</pattern>
+  <pattern>eau3s4t</pattern>
+  <pattern>e1av</pattern>
+  <pattern>e3bo</pattern>
+  <pattern>ebots5te </pattern>
+  <pattern>e5br</pattern>
+  <pattern>3ecd</pattern>
+  <pattern>e3ce</pattern>
+  <pattern>e1che</pattern>
+  <pattern>e1chi</pattern>
+  <pattern>echt5ec</pattern>
+  <pattern>echts5o</pattern>
+  <pattern>e3chu</pattern>
+  <pattern>4eck</pattern>
+  <pattern>ec5le</pattern>
+  <pattern>4ecor</pattern>
+  <pattern>4ect</pattern>
+  <pattern>ec3ta</pattern>
+  <pattern>ec4taa</pattern>
+  <pattern>3ecz</pattern>
+  <pattern>e1d</pattern>
+  <pattern>ed4ag</pattern>
+  <pattern>e3dam</pattern>
+  <pattern>e3d4an</pattern>
+  <pattern>e4d4as</pattern>
+  <pattern>ede3a</pattern>
+  <pattern>ed3ei </pattern>
+  <pattern>ede5le</pattern>
+  <pattern>edem4</pattern>
+  <pattern>ede5nac</pattern>
+  <pattern>ede5o</pattern>
+  <pattern>ed4er</pattern>
+  <pattern>e4d5erns</pattern>
+  <pattern>ede5rog</pattern>
+  <pattern>edi3al</pattern>
+  <pattern>edi3am</pattern>
+  <pattern>e5die</pattern>
+  <pattern>4edir</pattern>
+  <pattern>edoe5tj</pattern>
+  <pattern>e3d4oo</pattern>
+  <pattern>ed3opv</pattern>
+  <pattern>edors5te</pattern>
+  <pattern>ed3ov</pattern>
+  <pattern>e3d2r</pattern>
+  <pattern>ed3rod</pattern>
+  <pattern>ed3rol</pattern>
+  <pattern>ed1s</pattern>
+  <pattern>ed5se</pattern>
+  <pattern>ed2sl</pattern>
+  <pattern>ed4so</pattern>
+  <pattern>ed5sp</pattern>
+  <pattern>ed3su</pattern>
+  <pattern>ed3uit</pattern>
+  <pattern>e4d2w</pattern>
+  <pattern>e5dwan</pattern>
+  <pattern>e4e</pattern>
+  <pattern>eea4</pattern>
+  <pattern>ee5b</pattern>
+  <pattern>ee5ca</pattern>
+  <pattern>ee5che</pattern>
+  <pattern>ee2d3a</pattern>
+  <pattern>eed4ac</pattern>
+  <pattern>eed5as</pattern>
+  <pattern>ee5de</pattern>
+  <pattern>ee5do</pattern>
+  <pattern>eed3ru</pattern>
+  <pattern>eed3si</pattern>
+  <pattern>eed3w</pattern>
+  <pattern>ee2f</pattern>
+  <pattern>ee3fa</pattern>
+  <pattern>eef3ac</pattern>
+  <pattern>ee3fi</pattern>
+  <pattern>eef3l</pattern>
+  <pattern>eef3r</pattern>
+  <pattern>ee4gap</pattern>
+  <pattern>eeg3l</pattern>
+  <pattern>ee3i</pattern>
+  <pattern>ee2k</pattern>
+  <pattern>ee3ka</pattern>
+  <pattern>ee5kaa</pattern>
+  <pattern>eek3ak</pattern>
+  <pattern>eek5all</pattern>
+  <pattern>eek1e</pattern>
+  <pattern>ee5ket</pattern>
+  <pattern>ee3ki</pattern>
+  <pattern>ee3kl</pattern>
+  <pattern>ee4k3lo</pattern>
+  <pattern>eek3n</pattern>
+  <pattern>eek3re</pattern>
+  <pattern>ee3kri</pattern>
+  <pattern>eek3ro</pattern>
+  <pattern>eek5st</pattern>
+  <pattern>eek3w</pattern>
+  <pattern>ee2l</pattern>
+  <pattern>eel3a</pattern>
+  <pattern>ee3lad</pattern>
+  <pattern>eel4as </pattern>
+  <pattern>eel5d4u</pattern>
+  <pattern>ee3le</pattern>
+  <pattern>eel4ee</pattern>
+  <pattern>ee3li</pattern>
+  <pattern>ee5lij</pattern>
+  <pattern>eel5k4</pattern>
+  <pattern>ee3lob</pattern>
+  <pattern>eel3og</pattern>
+  <pattern>eelo4ge</pattern>
+  <pattern>ee3lu4</pattern>
+  <pattern>eel3ur</pattern>
+  <pattern>eel3uu</pattern>
+  <pattern>4eem</pattern>
+  <pattern>eema4</pattern>
+  <pattern>ee2n</pattern>
+  <pattern>een3a</pattern>
+  <pattern>eena4r</pattern>
+  <pattern>een3e2</pattern>
+  <pattern>een5g</pattern>
+  <pattern>ee3ni</pattern>
+  <pattern>een5ie</pattern>
+  <pattern>een5k</pattern>
+  <pattern>ee5o2</pattern>
+  <pattern>ee2pa</pattern>
+  <pattern>eep3an</pattern>
+  <pattern>ee3pl</pattern>
+  <pattern>eepo4</pattern>
+  <pattern>ee4p3re</pattern>
+  <pattern>eep3ru</pattern>
+  <pattern>ee2r</pattern>
+  <pattern>eer1a</pattern>
+  <pattern>eer3aa</pattern>
+  <pattern>ee4rad</pattern>
+  <pattern>eera4l</pattern>
+  <pattern>ee3ram</pattern>
+  <pattern>ee3ran</pattern>
+  <pattern>ee3re</pattern>
+  <pattern>ee4ree</pattern>
+  <pattern>ee5rei</pattern>
+  <pattern>ee4r3i</pattern>
+  <pattern>ee5ric</pattern>
+  <pattern>eer5k</pattern>
+  <pattern>eer3og</pattern>
+  <pattern>eer5oom</pattern>
+  <pattern>ee3rot</pattern>
+  <pattern>eer5ston</pattern>
+  <pattern>eer5str</pattern>
+  <pattern>ee2s3</pattern>
+  <pattern>ee5sch</pattern>
+  <pattern>ee4s5em</pattern>
+  <pattern>ees5et</pattern>
+  <pattern>ee3sj</pattern>
+  <pattern>ees5lo</pattern>
+  <pattern>ee3sn</pattern>
+  <pattern>ee3s4p</pattern>
+  <pattern>ees5pl</pattern>
+  <pattern>ees5pot</pattern>
+  <pattern>ees5ten</pattern>
+  <pattern>ee3stu</pattern>
+  <pattern>ee2t</pattern>
+  <pattern>eet5aa</pattern>
+  <pattern>ee3tal</pattern>
+  <pattern>ee3tan</pattern>
+  <pattern>ee5te</pattern>
+  <pattern>eet5h</pattern>
+  <pattern>ee3tj</pattern>
+  <pattern>eetna4</pattern>
+  <pattern>ee3to</pattern>
+  <pattern>eet3og</pattern>
+  <pattern>eeto4ge</pattern>
+  <pattern>eet3oo</pattern>
+  <pattern>eeto4r</pattern>
+  <pattern>ee3tr</pattern>
+  <pattern>ee4tro</pattern>
+  <pattern>eet5rok</pattern>
+  <pattern>eet3sp</pattern>
+  <pattern>eet5ste</pattern>
+  <pattern>ee5v</pattern>
+  <pattern>ee5z</pattern>
+  <pattern>eën3</pattern>
+  <pattern>e5ër</pattern>
+  <pattern>ef3ad</pattern>
+  <pattern>efa4z</pattern>
+  <pattern>efde5l</pattern>
+  <pattern>ef3do</pattern>
+  <pattern>ef3ei</pattern>
+  <pattern>e5fer</pattern>
+  <pattern>4efi</pattern>
+  <pattern>efie4t</pattern>
+  <pattern>efiet5j</pattern>
+  <pattern>ef3ins</pattern>
+  <pattern>e3fis5</pattern>
+  <pattern>e1fl</pattern>
+  <pattern>ef3li</pattern>
+  <pattern>ef3loo</pattern>
+  <pattern>e3flu</pattern>
+  <pattern>ef3om</pattern>
+  <pattern>e3foo</pattern>
+  <pattern>ef3op</pattern>
+  <pattern>e1fr</pattern>
+  <pattern>ef3rij</pattern>
+  <pattern>e5fron</pattern>
+  <pattern>ef3sf</pattern>
+  <pattern>4e1g</pattern>
+  <pattern>egas4</pattern>
+  <pattern>eg3as </pattern>
+  <pattern>ega5sk</pattern>
+  <pattern>eg3ebb</pattern>
+  <pattern>e4ge4c</pattern>
+  <pattern>eg3eig</pattern>
+  <pattern>egel5ei </pattern>
+  <pattern>ege4l5ov</pattern>
+  <pattern>ege4net</pattern>
+  <pattern>egen5of</pattern>
+  <pattern>ege4ra</pattern>
+  <pattern>eger5eng</pattern>
+  <pattern>ege4ro</pattern>
+  <pattern>eger5on</pattern>
+  <pattern>e3g4i</pattern>
+  <pattern>eg3ijz</pattern>
+  <pattern>egip4</pattern>
+  <pattern>egiste4</pattern>
+  <pattern>e2gl</pattern>
+  <pattern>e4go </pattern>
+  <pattern>eg3org</pattern>
+  <pattern>e2gos</pattern>
+  <pattern>eg3oud</pattern>
+  <pattern>e5graf</pattern>
+  <pattern>eg3s4</pattern>
+  <pattern>eg5sle</pattern>
+  <pattern>eg5so</pattern>
+  <pattern>e2g3u4r</pattern>
+  <pattern>egut4</pattern>
+  <pattern>e4g3uu</pattern>
+  <pattern>e1h4</pattern>
+  <pattern>e5ha</pattern>
+  <pattern>eheis5</pattern>
+  <pattern>ehit4</pattern>
+  <pattern>e2i</pattern>
+  <pattern>ei5a</pattern>
+  <pattern>4eid</pattern>
+  <pattern>ei3do</pattern>
+  <pattern>eid4sc</pattern>
+  <pattern>ei1e</pattern>
+  <pattern>4eien</pattern>
+  <pattern>eien5s</pattern>
+  <pattern>eie5re</pattern>
+  <pattern>ei3f4</pattern>
+  <pattern>ei3gl</pattern>
+  <pattern>4eign</pattern>
+  <pattern>e3ij</pattern>
+  <pattern>eik4l</pattern>
+  <pattern>ei3kn</pattern>
+  <pattern>ei5kr</pattern>
+  <pattern>eiks4</pattern>
+  <pattern>4eil </pattern>
+  <pattern>eil5ant</pattern>
+  <pattern>4eild4</pattern>
+  <pattern>eil5dr</pattern>
+  <pattern>4eile</pattern>
+  <pattern>ei4lev</pattern>
+  <pattern>eil5m</pattern>
+  <pattern>ei2l3o</pattern>
+  <pattern>ei4n3ab</pattern>
+  <pattern>ei3n4ac</pattern>
+  <pattern>ein4do</pattern>
+  <pattern>eind5oo</pattern>
+  <pattern>ein4d3r</pattern>
+  <pattern>ein5gr</pattern>
+  <pattern>ein5k</pattern>
+  <pattern>ei2no</pattern>
+  <pattern>ein5sl</pattern>
+  <pattern>ei3o</pattern>
+  <pattern>ei2sa</pattern>
+  <pattern>ei5sha</pattern>
+  <pattern>ei3s4la</pattern>
+  <pattern>ei3slo</pattern>
+  <pattern>eis4p</pattern>
+  <pattern>ei3s4ta</pattern>
+  <pattern>4eit2</pattern>
+  <pattern>ei4too</pattern>
+  <pattern>eit4s3</pattern>
+  <pattern>eits5c</pattern>
+  <pattern>eits5n</pattern>
+  <pattern>eits5te </pattern>
+  <pattern>eit5sten</pattern>
+  <pattern>eits5tr</pattern>
+  <pattern>eive4</pattern>
+  <pattern>4eiz</pattern>
+  <pattern>e1j2</pattern>
+  <pattern>e3je</pattern>
+  <pattern>ek3aan</pattern>
+  <pattern>ekaart5j</pattern>
+  <pattern>ekaat4</pattern>
+  <pattern>ek3af </pattern>
+  <pattern>e4k3a4g</pattern>
+  <pattern>ek3al </pattern>
+  <pattern>ek3alt</pattern>
+  <pattern>e5kam</pattern>
+  <pattern>ek3ang</pattern>
+  <pattern>ek4ee</pattern>
+  <pattern>ek1ei</pattern>
+  <pattern>e3kem</pattern>
+  <pattern>e5ker </pattern>
+  <pattern>e5kers</pattern>
+  <pattern>ekes3</pattern>
+  <pattern>ekes4t</pattern>
+  <pattern>ekes5tr</pattern>
+  <pattern>e3ket</pattern>
+  <pattern>ek5eter</pattern>
+  <pattern>e5kic</pattern>
+  <pattern>e4kil</pattern>
+  <pattern>e5kis</pattern>
+  <pattern>ekla4m</pattern>
+  <pattern>eklam5a</pattern>
+  <pattern>ek3lev</pattern>
+  <pattern>e5klim</pattern>
+  <pattern>ek5loos</pattern>
+  <pattern>ek4ni</pattern>
+  <pattern>e3ko</pattern>
+  <pattern>e4k3ob</pattern>
+  <pattern>e5kof</pattern>
+  <pattern>ek3oli</pattern>
+  <pattern>ek3opz</pattern>
+  <pattern>e5kor</pattern>
+  <pattern>ek5os </pattern>
+  <pattern>ek5oss</pattern>
+  <pattern>e5kran</pattern>
+  <pattern>ek3roz</pattern>
+  <pattern>eks4e</pattern>
+  <pattern>eks5erv</pattern>
+  <pattern>ek5set</pattern>
+  <pattern>ek4str</pattern>
+  <pattern>eks5tra</pattern>
+  <pattern>ek5t4e</pattern>
+  <pattern>ek3to</pattern>
+  <pattern>eku4</pattern>
+  <pattern>ek3uit</pattern>
+  <pattern>ek3ur</pattern>
+  <pattern>ek1uu</pattern>
+  <pattern>ekwet5ste</pattern>
+  <pattern>ek3win</pattern>
+  <pattern>e1la</pattern>
+  <pattern>el3aan</pattern>
+  <pattern>el5aand</pattern>
+  <pattern>el1ac</pattern>
+  <pattern>el4ade</pattern>
+  <pattern>el3adj</pattern>
+  <pattern>el3adm</pattern>
+  <pattern>el3adr</pattern>
+  <pattern>el3adv</pattern>
+  <pattern>el1a4f</pattern>
+  <pattern>el1al</pattern>
+  <pattern>e3lan</pattern>
+  <pattern>el5ana</pattern>
+  <pattern>e3lap</pattern>
+  <pattern>e5lap </pattern>
+  <pattern>e4lapp</pattern>
+  <pattern>el3arb</pattern>
+  <pattern>el3arc</pattern>
+  <pattern>el3arm</pattern>
+  <pattern>el3art</pattern>
+  <pattern>e4l3as </pattern>
+  <pattern>el3asi</pattern>
+  <pattern>e4l3asp</pattern>
+  <pattern>e4l3ass</pattern>
+  <pattern>el1au</pattern>
+  <pattern>e4laut</pattern>
+  <pattern>e3laz</pattern>
+  <pattern>el5azi</pattern>
+  <pattern>el4dec</pattern>
+  <pattern>el4dr</pattern>
+  <pattern>el4du</pattern>
+  <pattern>e1le</pattern>
+  <pattern>e3le </pattern>
+  <pattern>el3eeu</pattern>
+  <pattern>el5eff</pattern>
+  <pattern>e5leid</pattern>
+  <pattern>el5eier</pattern>
+  <pattern>el3eig</pattern>
+  <pattern>el3ei5s</pattern>
+  <pattern>e4lel</pattern>
+  <pattern>3e2lem</pattern>
+  <pattern>el3emp</pattern>
+  <pattern>e5l4en</pattern>
+  <pattern>e3ler</pattern>
+  <pattern>ele5r4a</pattern>
+  <pattern>eler4s</pattern>
+  <pattern>el3erv</pattern>
+  <pattern>e3les</pattern>
+  <pattern>eles4t</pattern>
+  <pattern>e4l3eta</pattern>
+  <pattern>ele4tr</pattern>
+  <pattern>e4l3etu</pattern>
+  <pattern>el3exc</pattern>
+  <pattern>e3lé</pattern>
+  <pattern>elfi4d</pattern>
+  <pattern>el1fl</pattern>
+  <pattern>elf3s4</pattern>
+  <pattern>el3gu</pattern>
+  <pattern>2eli</pattern>
+  <pattern>e5lie</pattern>
+  <pattern>e5lig</pattern>
+  <pattern>eli5kw</pattern>
+  <pattern>el3imp</pattern>
+  <pattern>e4l3ind</pattern>
+  <pattern>e3ling</pattern>
+  <pattern>e4l5inkt</pattern>
+  <pattern>el5inz</pattern>
+  <pattern>3elix</pattern>
+  <pattern>el4kee</pattern>
+  <pattern>elk3s</pattern>
+  <pattern>el4k3u4r</pattern>
+  <pattern>el4kw</pattern>
+  <pattern>4e1lo</pattern>
+  <pattern>e5loep</pattern>
+  <pattern>el3oes</pattern>
+  <pattern>e3lok</pattern>
+  <pattern>el3ol</pattern>
+  <pattern>el3oms</pattern>
+  <pattern>el5ond</pattern>
+  <pattern>el5ont</pattern>
+  <pattern>e3loo</pattern>
+  <pattern>e5lood</pattern>
+  <pattern>e5loos</pattern>
+  <pattern>el3ops</pattern>
+  <pattern>el5opt</pattern>
+  <pattern>el5opv</pattern>
+  <pattern>el3o2r</pattern>
+  <pattern>el5org</pattern>
+  <pattern>elot4j</pattern>
+  <pattern>e5lou</pattern>
+  <pattern>el3o4ve</pattern>
+  <pattern>e5loz</pattern>
+  <pattern>elp4o</pattern>
+  <pattern>el4ps</pattern>
+  <pattern>el4s5em</pattern>
+  <pattern>el4s3k</pattern>
+  <pattern>el5smed</pattern>
+  <pattern>el5twe</pattern>
+  <pattern>4e1lu</pattern>
+  <pattern>el3uit</pattern>
+  <pattern>eluks5</pattern>
+  <pattern>2ema</pattern>
+  <pattern>e4mana</pattern>
+  <pattern>ema3sc</pattern>
+  <pattern>ema5to</pattern>
+  <pattern>emees5</pattern>
+  <pattern>emens5te</pattern>
+  <pattern>emer4s</pattern>
+  <pattern>emes3</pattern>
+  <pattern>emie4tj</pattern>
+  <pattern>e5mok</pattern>
+  <pattern>em3oli</pattern>
+  <pattern>em3op</pattern>
+  <pattern>em3org</pattern>
+  <pattern>emor5sten</pattern>
+  <pattern>e4mo4v</pattern>
+  <pattern>em3sa</pattern>
+  <pattern>em5sc</pattern>
+  <pattern>em4sli</pattern>
+  <pattern>em4sm</pattern>
+  <pattern>em1st</pattern>
+  <pattern>em3su</pattern>
+  <pattern>em3uit</pattern>
+  <pattern>emut4</pattern>
+  <pattern>en3aap</pattern>
+  <pattern>e3naar</pattern>
+  <pattern>e4n3aas</pattern>
+  <pattern>en1ac</pattern>
+  <pattern>e5n4acc</pattern>
+  <pattern>en5af</pattern>
+  <pattern>e2n1ak</pattern>
+  <pattern>e2nal</pattern>
+  <pattern>en3al </pattern>
+  <pattern>en3als</pattern>
+  <pattern>en3amb</pattern>
+  <pattern>en4ame</pattern>
+  <pattern>e2nan</pattern>
+  <pattern>e4n3ang</pattern>
+  <pattern>en1a2p</pattern>
+  <pattern>e5nari</pattern>
+  <pattern>en3ars</pattern>
+  <pattern>e2n3a2s</pattern>
+  <pattern>enas3p</pattern>
+  <pattern>e3nat</pattern>
+  <pattern>ena4tel</pattern>
+  <pattern>e4n3att</pattern>
+  <pattern>en1av</pattern>
+  <pattern>e2n3a2z</pattern>
+  <pattern>enci4</pattern>
+  <pattern>3ency </pattern>
+  <pattern>en3da</pattern>
+  <pattern>en5daa</pattern>
+  <pattern>end5ama</pattern>
+  <pattern>5enderti</pattern>
+  <pattern>en3d4o</pattern>
+  <pattern>en3dr</pattern>
+  <pattern>en5drek</pattern>
+  <pattern>e2n3e2c</pattern>
+  <pattern>enede4</pattern>
+  <pattern>e3nee</pattern>
+  <pattern>en3eed</pattern>
+  <pattern>enee5t</pattern>
+  <pattern>en5eg </pattern>
+  <pattern>en5egg</pattern>
+  <pattern>en3ela</pattern>
+  <pattern>en3elf</pattern>
+  <pattern>en3ema</pattern>
+  <pattern>e4n3en5t</pattern>
+  <pattern>e2ne2p</pattern>
+  <pattern>en3epo</pattern>
+  <pattern>e5nere</pattern>
+  <pattern>5energ</pattern>
+  <pattern>e4nerv</pattern>
+  <pattern>en3eta</pattern>
+  <pattern>en3ete</pattern>
+  <pattern>ene4ten</pattern>
+  <pattern>e3neu</pattern>
+  <pattern>4enf</pattern>
+  <pattern>en5ga</pattern>
+  <pattern>en3gl</pattern>
+  <pattern>en4g5le</pattern>
+  <pattern>eng4r</pattern>
+  <pattern>en5gri</pattern>
+  <pattern>engs4</pattern>
+  <pattern>eng5se</pattern>
+  <pattern>eng3sm</pattern>
+  <pattern>e3nie</pattern>
+  <pattern>e5nijd</pattern>
+  <pattern>e2n3im</pattern>
+  <pattern>e4ninga</pattern>
+  <pattern>e4n3ink</pattern>
+  <pattern>e3niv</pattern>
+  <pattern>e4n3i4vo</pattern>
+  <pattern>en3k2a</pattern>
+  <pattern>e4n3och</pattern>
+  <pattern>en3off</pattern>
+  <pattern>e4n3oli</pattern>
+  <pattern>e2n1on</pattern>
+  <pattern>e4n3oor</pattern>
+  <pattern>enoot5</pattern>
+  <pattern>e2n1o2p</pattern>
+  <pattern>e3nor </pattern>
+  <pattern>en3ord</pattern>
+  <pattern>eno3s</pattern>
+  <pattern>en3ou</pattern>
+  <pattern>e2n1ov</pattern>
+  <pattern>3enq</pattern>
+  <pattern>en5sce</pattern>
+  <pattern>en4sei</pattern>
+  <pattern>ens5ein</pattern>
+  <pattern>ensek5</pattern>
+  <pattern>3ensem</pattern>
+  <pattern>ens4fe</pattern>
+  <pattern>en4sin</pattern>
+  <pattern>en5slak</pattern>
+  <pattern>en4s3on</pattern>
+  <pattern>en1s2p</pattern>
+  <pattern>ens5pot</pattern>
+  <pattern>en5stan</pattern>
+  <pattern>en5sten</pattern>
+  <pattern>enst5ijv</pattern>
+  <pattern>en4stin</pattern>
+  <pattern>en4stu4r</pattern>
+  <pattern>en3su</pattern>
+  <pattern>en4tac</pattern>
+  <pattern>en5tee</pattern>
+  <pattern>en5tei</pattern>
+  <pattern>ente5re</pattern>
+  <pattern>en4terv</pattern>
+  <pattern>3entè</pattern>
+  <pattern>en1t2h</pattern>
+  <pattern>en5tom</pattern>
+  <pattern>ent4r</pattern>
+  <pattern>en3tre</pattern>
+  <pattern>ent5rol</pattern>
+  <pattern>ent4sl</pattern>
+  <pattern>ents3m</pattern>
+  <pattern>ent4s3p</pattern>
+  <pattern>en3tw</pattern>
+  <pattern>e1nu</pattern>
+  <pattern>e4n1ui</pattern>
+  <pattern>e2nun</pattern>
+  <pattern>en3ur</pattern>
+  <pattern>en3uu</pattern>
+  <pattern>5envelo</pattern>
+  <pattern>eny4</pattern>
+  <pattern>e3o</pattern>
+  <pattern>eo3d</pattern>
+  <pattern>eodo3</pattern>
+  <pattern>e5oe</pattern>
+  <pattern>eoes3</pattern>
+  <pattern>e5off</pattern>
+  <pattern>eo3fr</pattern>
+  <pattern>e4o3k4</pattern>
+  <pattern>e5on</pattern>
+  <pattern>eo5ni</pattern>
+  <pattern>e5oo</pattern>
+  <pattern>eo3pa</pattern>
+  <pattern>eo3pe</pattern>
+  <pattern>eo3pl</pattern>
+  <pattern>eop4la</pattern>
+  <pattern>eo3p2r</pattern>
+  <pattern>e5ops</pattern>
+  <pattern>eor5d</pattern>
+  <pattern>e5org</pattern>
+  <pattern>e5ori</pattern>
+  <pattern>eo3ro</pattern>
+  <pattern>eo3s4</pattern>
+  <pattern>eo5st</pattern>
+  <pattern>e4ot</pattern>
+  <pattern>eo5te</pattern>
+  <pattern>e5o3t4h</pattern>
+  <pattern>e1pa</pattern>
+  <pattern>e3paa</pattern>
+  <pattern>ep3aak</pattern>
+  <pattern>ep3ac</pattern>
+  <pattern>e4paf</pattern>
+  <pattern>epa4k</pattern>
+  <pattern>ep5ake</pattern>
+  <pattern>e3pal</pattern>
+  <pattern>e3pap</pattern>
+  <pattern>e4p3app</pattern>
+  <pattern>e3par</pattern>
+  <pattern>ep3asp</pattern>
+  <pattern>e1pe</pattern>
+  <pattern>e5pe </pattern>
+  <pattern>ep5een</pattern>
+  <pattern>e5per</pattern>
+  <pattern>epers5te </pattern>
+  <pattern>e1pi</pattern>
+  <pattern>3epid</pattern>
+  <pattern>ep3ijs</pattern>
+  <pattern>ep3ijz</pattern>
+  <pattern>ep5ingr</pattern>
+  <pattern>ep3ins</pattern>
+  <pattern>epit4s</pattern>
+  <pattern>epits5te</pattern>
+  <pattern>ep1j</pattern>
+  <pattern>e1pl</pattern>
+  <pattern>ep3led</pattern>
+  <pattern>e4p3lod</pattern>
+  <pattern>e5ploe</pattern>
+  <pattern>ep3lus</pattern>
+  <pattern>e1po</pattern>
+  <pattern>e4p5o4ge</pattern>
+  <pattern>epoort5j</pattern>
+  <pattern>epoot4j</pattern>
+  <pattern>3e4pos </pattern>
+  <pattern>e3pot</pattern>
+  <pattern>epou4</pattern>
+  <pattern>e1pr</pattern>
+  <pattern>ep4ra</pattern>
+  <pattern>e3pri</pattern>
+  <pattern>ep5rode</pattern>
+  <pattern>eprot4</pattern>
+  <pattern>ep2s</pattern>
+  <pattern>ep4s5ee</pattern>
+  <pattern>ep4ser</pattern>
+  <pattern>eps3l</pattern>
+  <pattern>eps5n</pattern>
+  <pattern>eps3p</pattern>
+  <pattern>eps3ta</pattern>
+  <pattern>eps5taa</pattern>
+  <pattern>eps5tal</pattern>
+  <pattern>eps5to</pattern>
+  <pattern>eps3tr</pattern>
+  <pattern>eps5tro</pattern>
+  <pattern>ep4tak</pattern>
+  <pattern>ep2tj</pattern>
+  <pattern>ep4tr</pattern>
+  <pattern>ept3ra</pattern>
+  <pattern>ep5tro</pattern>
+  <pattern>ep3uit</pattern>
+  <pattern>4equa</pattern>
+  <pattern>e3ra </pattern>
+  <pattern>e1raa</pattern>
+  <pattern>e5raad</pattern>
+  <pattern>e4raak </pattern>
+  <pattern>er3aan</pattern>
+  <pattern>er5aanp</pattern>
+  <pattern>e4raap </pattern>
+  <pattern>e5raat</pattern>
+  <pattern>e4r1ac</pattern>
+  <pattern>e5rac </pattern>
+  <pattern>e5race</pattern>
+  <pattern>e5raco</pattern>
+  <pattern>e3rad</pattern>
+  <pattern>e5rad </pattern>
+  <pattern>er3ado</pattern>
+  <pattern>er3af</pattern>
+  <pattern>e3raff</pattern>
+  <pattern>era4gen</pattern>
+  <pattern>e1rai</pattern>
+  <pattern>e4r3all</pattern>
+  <pattern>er3ama</pattern>
+  <pattern>er3ana</pattern>
+  <pattern>e5randa</pattern>
+  <pattern>e5rane</pattern>
+  <pattern>e5ra3pl</pattern>
+  <pattern>er3arc</pattern>
+  <pattern>e3rare</pattern>
+  <pattern>e3rari</pattern>
+  <pattern>e1rat4</pattern>
+  <pattern>er3a4tr</pattern>
+  <pattern>er3azi</pattern>
+  <pattern>er3d2a</pattern>
+  <pattern>er3d4i</pattern>
+  <pattern>erd4o</pattern>
+  <pattern>er3d2r</pattern>
+  <pattern>erd5uit </pattern>
+  <pattern>er3d4w</pattern>
+  <pattern>e1re</pattern>
+  <pattern>er5eat</pattern>
+  <pattern>4erec</pattern>
+  <pattern>er5editi</pattern>
+  <pattern>er3een</pattern>
+  <pattern>e5reep</pattern>
+  <pattern>er5eers</pattern>
+  <pattern>er3eet</pattern>
+  <pattern>er3ef</pattern>
+  <pattern>er5eff</pattern>
+  <pattern>er5eg </pattern>
+  <pattern>er3egd</pattern>
+  <pattern>er5egg</pattern>
+  <pattern>er5egt</pattern>
+  <pattern>er3eie</pattern>
+  <pattern>er3eig</pattern>
+  <pattern>er3eil</pattern>
+  <pattern>er5eind</pattern>
+  <pattern>ere3kl</pattern>
+  <pattern>er3elk</pattern>
+  <pattern>e4r3emm</pattern>
+  <pattern>er3emp</pattern>
+  <pattern>e3rend</pattern>
+  <pattern>e5rendel</pattern>
+  <pattern>ere4ne</pattern>
+  <pattern>eren5eg</pattern>
+  <pattern>er5enen </pattern>
+  <pattern>e3renm</pattern>
+  <pattern>e3rent</pattern>
+  <pattern>er5enth</pattern>
+  <pattern>e5rento</pattern>
+  <pattern>eren5tw</pattern>
+  <pattern>ere2o</pattern>
+  <pattern>ere4og</pattern>
+  <pattern>er3epi</pattern>
+  <pattern>er3e2q</pattern>
+  <pattern>er3eri</pattern>
+  <pattern>e3res </pattern>
+  <pattern>er3esk</pattern>
+  <pattern>e3ress</pattern>
+  <pattern>ere4st</pattern>
+  <pattern>ere4t3j</pattern>
+  <pattern>er3etn</pattern>
+  <pattern>e4r3ets</pattern>
+  <pattern>e4r5ex</pattern>
+  <pattern>erg2l</pattern>
+  <pattern>e3ri</pattern>
+  <pattern>eri5ab</pattern>
+  <pattern>e5rif</pattern>
+  <pattern>e5rig</pattern>
+  <pattern>erig5a</pattern>
+  <pattern>er3ijl</pattern>
+  <pattern>er3ijs</pattern>
+  <pattern>e4rijs </pattern>
+  <pattern>er3ijv</pattern>
+  <pattern>e4r3ijz</pattern>
+  <pattern>e5rik</pattern>
+  <pattern>er5ind</pattern>
+  <pattern>e4r3ini</pattern>
+  <pattern>er5inkt</pattern>
+  <pattern>er3ins</pattern>
+  <pattern>er3int</pattern>
+  <pattern>e5rio</pattern>
+  <pattern>e5ris</pattern>
+  <pattern>erkeers5</pattern>
+  <pattern>er2kn</pattern>
+  <pattern>er3m4i</pattern>
+  <pattern>er5mo</pattern>
+  <pattern>er5nu</pattern>
+  <pattern>e1ro </pattern>
+  <pattern>e3rob</pattern>
+  <pattern>er3oc</pattern>
+  <pattern>e4r3oed</pattern>
+  <pattern>er3oef</pattern>
+  <pattern>e5roep</pattern>
+  <pattern>eroe5tj</pattern>
+  <pattern>er3oev</pattern>
+  <pattern>er3of</pattern>
+  <pattern>ero2g</pattern>
+  <pattern>e3rok</pattern>
+  <pattern>e1ro2l</pattern>
+  <pattern>e5rol </pattern>
+  <pattern>er3oli</pattern>
+  <pattern>e5roll</pattern>
+  <pattern>er3om</pattern>
+  <pattern>er1on</pattern>
+  <pattern>e3ron </pattern>
+  <pattern>e3rone</pattern>
+  <pattern>er3onv</pattern>
+  <pattern>er3oog</pattern>
+  <pattern>er3oor</pattern>
+  <pattern>e5roos</pattern>
+  <pattern>e4r3op</pattern>
+  <pattern>erop3a</pattern>
+  <pattern>ero5pen</pattern>
+  <pattern>e2r3or</pattern>
+  <pattern>er1ov</pattern>
+  <pattern>er3oxi</pattern>
+  <pattern>e3roz</pattern>
+  <pattern>e3rö</pattern>
+  <pattern>er4plu</pattern>
+  <pattern>errie5tj</pattern>
+  <pattern>er3scr</pattern>
+  <pattern>er3sj</pattern>
+  <pattern>er5slag</pattern>
+  <pattern>er5span</pattern>
+  <pattern>ers4pot</pattern>
+  <pattern>er5stem</pattern>
+  <pattern>er5te</pattern>
+  <pattern>er3t2h</pattern>
+  <pattern>er5t4i</pattern>
+  <pattern>er5t4o</pattern>
+  <pattern>er3tr</pattern>
+  <pattern>ert5se</pattern>
+  <pattern>erts5l</pattern>
+  <pattern>er3t4u</pattern>
+  <pattern>er3t4w</pattern>
+  <pattern>e1ru</pattern>
+  <pattern>e3rub</pattern>
+  <pattern>e3rug5</pattern>
+  <pattern>e2rui</pattern>
+  <pattern>er3uit</pattern>
+  <pattern>erui5t4j</pattern>
+  <pattern>e2run</pattern>
+  <pattern>e3runs</pattern>
+  <pattern>e4r3ur</pattern>
+  <pattern>e3rus</pattern>
+  <pattern>er5uu</pattern>
+  <pattern>3ervar</pattern>
+  <pattern>3erwt</pattern>
+  <pattern>e4saf</pattern>
+  <pattern>e4s3a2g</pattern>
+  <pattern>e3sam</pattern>
+  <pattern>e5san</pattern>
+  <pattern>es3ap</pattern>
+  <pattern>es3arr</pattern>
+  <pattern>e3sa3s</pattern>
+  <pattern>e3scop</pattern>
+  <pattern>e3s2cr</pattern>
+  <pattern>es4e</pattern>
+  <pattern>e5sec</pattern>
+  <pattern>es5een</pattern>
+  <pattern>e5sel</pattern>
+  <pattern>es5ene</pattern>
+  <pattern>e4s5eng</pattern>
+  <pattern>es5ex</pattern>
+  <pattern>es2fe</pattern>
+  <pattern>es5he</pattern>
+  <pattern>e4shi</pattern>
+  <pattern>e3sid</pattern>
+  <pattern>e3sie</pattern>
+  <pattern>es1in</pattern>
+  <pattern>e4sir</pattern>
+  <pattern>es5je </pattern>
+  <pattern>es5jes</pattern>
+  <pattern>e3s4jo</pattern>
+  <pattern>es5jon</pattern>
+  <pattern>e4s3ka</pattern>
+  <pattern>es5kr</pattern>
+  <pattern>e3sl</pattern>
+  <pattern>es4la</pattern>
+  <pattern>e5sla </pattern>
+  <pattern>e5slag</pattern>
+  <pattern>es3lak</pattern>
+  <pattern>es5lat</pattern>
+  <pattern>es4le</pattern>
+  <pattern>es5leg</pattern>
+  <pattern>es2m</pattern>
+  <pattern>es4mui</pattern>
+  <pattern>e5smuil </pattern>
+  <pattern>e1sn</pattern>
+  <pattern>e3s4ne</pattern>
+  <pattern>e1so</pattern>
+  <pattern>e3sol</pattern>
+  <pattern>es4oo</pattern>
+  <pattern>es5oor </pattern>
+  <pattern>eso4p</pattern>
+  <pattern>es3ore</pattern>
+  <pattern>e1sp</pattern>
+  <pattern>es5pas</pattern>
+  <pattern>es4pel</pattern>
+  <pattern>espit5ste</pattern>
+  <pattern>e3spl</pattern>
+  <pattern>e4sprie</pattern>
+  <pattern>esp5riem</pattern>
+  <pattern>es4sm</pattern>
+  <pattern>e3stak</pattern>
+  <pattern>e3s4tal</pattern>
+  <pattern>e3stap</pattern>
+  <pattern>es4tar</pattern>
+  <pattern>es5tatie</pattern>
+  <pattern>e4s3te </pattern>
+  <pattern>es4tea</pattern>
+  <pattern>es4teel</pattern>
+  <pattern>est5ei </pattern>
+  <pattern>e4steka</pattern>
+  <pattern>es5tekam</pattern>
+  <pattern>e3s4tem</pattern>
+  <pattern>es5temo</pattern>
+  <pattern>es3ten</pattern>
+  <pattern>e4sten </pattern>
+  <pattern>es5tenb</pattern>
+  <pattern>es3ter</pattern>
+  <pattern>estere5o</pattern>
+  <pattern>es5tes</pattern>
+  <pattern>es4tet</pattern>
+  <pattern>e3steu</pattern>
+  <pattern>es4tic</pattern>
+  <pattern>e4stie</pattern>
+  <pattern>e3stot</pattern>
+  <pattern>es5tra </pattern>
+  <pattern>es5trac</pattern>
+  <pattern>es5trak</pattern>
+  <pattern>e5stral</pattern>
+  <pattern>est5rap</pattern>
+  <pattern>es5trei</pattern>
+  <pattern>est4sc</pattern>
+  <pattern>es4tur</pattern>
+  <pattern>e3sty</pattern>
+  <pattern>e3su</pattern>
+  <pattern>esu4r</pattern>
+  <pattern>e3sy</pattern>
+  <pattern>e1ta</pattern>
+  <pattern>e3ta </pattern>
+  <pattern>et3aan</pattern>
+  <pattern>et3ac</pattern>
+  <pattern>et3ad</pattern>
+  <pattern>et3afz</pattern>
+  <pattern>3e2tag</pattern>
+  <pattern>e3tak</pattern>
+  <pattern>e5tak </pattern>
+  <pattern>et4ana</pattern>
+  <pattern>e5tand</pattern>
+  <pattern>e2tap</pattern>
+  <pattern>e4tapp</pattern>
+  <pattern>e5tat</pattern>
+  <pattern>e4tau</pattern>
+  <pattern>e2tav</pattern>
+  <pattern>e3te</pattern>
+  <pattern>e5tea</pattern>
+  <pattern>et3edi</pattern>
+  <pattern>e5tek</pattern>
+  <pattern>4etel</pattern>
+  <pattern>e5tel </pattern>
+  <pattern>e4t5elf</pattern>
+  <pattern>e5tels</pattern>
+  <pattern>et5emb</pattern>
+  <pattern>et5emm</pattern>
+  <pattern>etens5u</pattern>
+  <pattern>eten5tj</pattern>
+  <pattern>ete5r4a</pattern>
+  <pattern>ete3ro</pattern>
+  <pattern>eters5la</pattern>
+  <pattern>eter5sm</pattern>
+  <pattern>e5tes</pattern>
+  <pattern>e1th</pattern>
+  <pattern>et3ha</pattern>
+  <pattern>et3hor</pattern>
+  <pattern>et5hu</pattern>
+  <pattern>e4t5i4d</pattern>
+  <pattern>e5tie</pattern>
+  <pattern>e4t3inc</pattern>
+  <pattern>e4tiq</pattern>
+  <pattern>e5tis</pattern>
+  <pattern>e4tja</pattern>
+  <pattern>e1to</pattern>
+  <pattern>e5toc</pattern>
+  <pattern>e3toe</pattern>
+  <pattern>e5toev</pattern>
+  <pattern>e3tol</pattern>
+  <pattern>eto4p</pattern>
+  <pattern>et3ope</pattern>
+  <pattern>et3opl</pattern>
+  <pattern>e4t3ork</pattern>
+  <pattern>eto3sf</pattern>
+  <pattern>e1tr</pattern>
+  <pattern>et3rec</pattern>
+  <pattern>e4t5res</pattern>
+  <pattern>e3troe</pattern>
+  <pattern>e5tron</pattern>
+  <pattern>e5troo</pattern>
+  <pattern>etros4</pattern>
+  <pattern>e4t3ru</pattern>
+  <pattern>et4sl</pattern>
+  <pattern>ets5lap</pattern>
+  <pattern>et5slu</pattern>
+  <pattern>ets3n</pattern>
+  <pattern>et4s3oo</pattern>
+  <pattern>et3spe</pattern>
+  <pattern>ets3pr</pattern>
+  <pattern>et3spu</pattern>
+  <pattern>et4ste</pattern>
+  <pattern>ets5tek</pattern>
+  <pattern>et5sten</pattern>
+  <pattern>et5sti</pattern>
+  <pattern>ets4u</pattern>
+  <pattern>et5su5r</pattern>
+  <pattern>et5suu</pattern>
+  <pattern>e1tu</pattern>
+  <pattern>etui5tj</pattern>
+  <pattern>etu4r</pattern>
+  <pattern>et3we</pattern>
+  <pattern>et2wi</pattern>
+  <pattern>1eua4</pattern>
+  <pattern>1euc</pattern>
+  <pattern>eudi5o</pattern>
+  <pattern>eu5dr</pattern>
+  <pattern>eu3e</pattern>
+  <pattern>eugd3r</pattern>
+  <pattern>eu3g2r</pattern>
+  <pattern>eu4ler</pattern>
+  <pattern>eu4li</pattern>
+  <pattern>e1um</pattern>
+  <pattern>e3um </pattern>
+  <pattern>e2umd</pattern>
+  <pattern>eu2na</pattern>
+  <pattern>eun3t</pattern>
+  <pattern>1eu1o</pattern>
+  <pattern>eu2po</pattern>
+  <pattern>eu4rad</pattern>
+  <pattern>eu4rec</pattern>
+  <pattern>eu3ren</pattern>
+  <pattern>eu4res</pattern>
+  <pattern>eu4rij</pattern>
+  <pattern>eur5k</pattern>
+  <pattern>euro5v</pattern>
+  <pattern>eur4sta</pattern>
+  <pattern>eurs5taa</pattern>
+  <pattern>eurs5te </pattern>
+  <pattern>eur4s5tr</pattern>
+  <pattern>eur4su</pattern>
+  <pattern>eu5sch</pattern>
+  <pattern>eus4p</pattern>
+  <pattern>eu3spa</pattern>
+  <pattern>eu4st</pattern>
+  <pattern>eu5str</pattern>
+  <pattern>eu3tj</pattern>
+  <pattern>eu1tr</pattern>
+  <pattern>e3uu</pattern>
+  <pattern>2euw</pattern>
+  <pattern>eu4wa</pattern>
+  <pattern>eu5win</pattern>
+  <pattern>euw4str</pattern>
+  <pattern>evaar5tj</pattern>
+  <pattern>eval4s</pattern>
+  <pattern>evari5</pattern>
+  <pattern>eve4lo</pattern>
+  <pattern>evel5op</pattern>
+  <pattern>eve5n4aa</pattern>
+  <pattern>4ever</pattern>
+  <pattern>eve3ra</pattern>
+  <pattern>4e1w</pattern>
+  <pattern>e5wa</pattern>
+  <pattern>e5we</pattern>
+  <pattern>ewen4s</pattern>
+  <pattern>ewens5te </pattern>
+  <pattern>ewest5r</pattern>
+  <pattern>ew2h</pattern>
+  <pattern>e5wi</pattern>
+  <pattern>ewo3v</pattern>
+  <pattern>4ex </pattern>
+  <pattern>2ex3aa</pattern>
+  <pattern>ex3af</pattern>
+  <pattern>4exco</pattern>
+  <pattern>3exeg</pattern>
+  <pattern>3exem</pattern>
+  <pattern>4exi</pattern>
+  <pattern>ex3in</pattern>
+  <pattern>ex5op</pattern>
+  <pattern>1exp</pattern>
+  <pattern>e3y4o</pattern>
+  <pattern>eys4</pattern>
+  <pattern>ey3st</pattern>
+  <pattern>e5za</pattern>
+  <pattern>e3zee</pattern>
+  <pattern>4e3zen</pattern>
+  <pattern>ezers5</pattern>
+  <pattern>e3zo</pattern>
+  <pattern>ezz4</pattern>
+  <pattern>é3a</pattern>
+  <pattern>é1d</pattern>
+  <pattern>édee4</pattern>
+  <pattern>édi3</pattern>
+  <pattern>é1g</pattern>
+  <pattern>égee5</pattern>
+  <pattern>é3h</pattern>
+  <pattern>é3j</pattern>
+  <pattern>é3n</pattern>
+  <pattern>é3p</pattern>
+  <pattern>é3r</pattern>
+  <pattern>é1t</pattern>
+  <pattern>è1</pattern>
+  <pattern>4èc</pattern>
+  <pattern>è2l</pattern>
+  <pattern>è2s</pattern>
+  <pattern>è5t</pattern>
+  <pattern>èta5</pattern>
+  <pattern>ê1</pattern>
+  <pattern>ê2p</pattern>
+  <pattern>ê3per</pattern>
+  <pattern>ê5t</pattern>
+  <pattern>3ë</pattern>
+  <pattern>4ë </pattern>
+  <pattern>ë2b</pattern>
+  <pattern>ë3c</pattern>
+  <pattern>ë3d</pattern>
+  <pattern>ëe2</pattern>
+  <pattern>ëen3</pattern>
+  <pattern>ë3j</pattern>
+  <pattern>ë1l</pattern>
+  <pattern>5ën</pattern>
+  <pattern>ënce3</pattern>
+  <pattern>ën4e</pattern>
+  <pattern>ëns2</pattern>
+  <pattern>ën5sc</pattern>
+  <pattern>ënt2</pattern>
+  <pattern>ën5th</pattern>
+  <pattern>ën5tw</pattern>
+  <pattern>ë3p</pattern>
+  <pattern>ë1ra</pattern>
+  <pattern>ë1re</pattern>
+  <pattern>ë1ri</pattern>
+  <pattern>ë1ro</pattern>
+  <pattern>ëro1g2</pattern>
+  <pattern>ëro3s</pattern>
+  <pattern>ë2s</pattern>
+  <pattern>ë3si</pattern>
+  <pattern>ës3t</pattern>
+  <pattern>ë1t</pattern>
+  <pattern>ët4s</pattern>
+  <pattern>ëts3te</pattern>
+  <pattern>ëve5</pattern>
+  <pattern>ëven4</pattern>
+  <pattern>4ëzu</pattern>
+  <pattern>4f </pattern>
+  <pattern>1fa</pattern>
+  <pattern>f3aanb</pattern>
+  <pattern>f4aat</pattern>
+  <pattern>3fab</pattern>
+  <pattern>fa2bo</pattern>
+  <pattern>f3acc</pattern>
+  <pattern>face4</pattern>
+  <pattern>f1ach</pattern>
+  <pattern>2fad</pattern>
+  <pattern>2f1af</pattern>
+  <pattern>fa3g</pattern>
+  <pattern>fal3s</pattern>
+  <pattern>fa3m</pattern>
+  <pattern>f3ang</pattern>
+  <pattern>fant2</pattern>
+  <pattern>fan4t3j</pattern>
+  <pattern>fant4s5</pattern>
+  <pattern>2f3a2p</pattern>
+  <pattern>f4arm</pattern>
+  <pattern>3fa5se</pattern>
+  <pattern>fa2to</pattern>
+  <pattern>fa3v</pattern>
+  <pattern>4fb</pattern>
+  <pattern>fbe5dw</pattern>
+  <pattern>f1c</pattern>
+  <pattern>4fd</pattern>
+  <pattern>f3da</pattern>
+  <pattern>fda4g</pattern>
+  <pattern>f5dan</pattern>
+  <pattern>fd1ar</pattern>
+  <pattern>fde4k</pattern>
+  <pattern>fdek3l</pattern>
+  <pattern>fde4s3</pattern>
+  <pattern>fdes5e</pattern>
+  <pattern>fdes5l</pattern>
+  <pattern>fde5sm</pattern>
+  <pattern>fdes5t</pattern>
+  <pattern>f2d3in</pattern>
+  <pattern>fd3of</pattern>
+  <pattern>fdors5te</pattern>
+  <pattern>fd4ra</pattern>
+  <pattern>f3d4ru</pattern>
+  <pattern>fd5se</pattern>
+  <pattern>fd3si</pattern>
+  <pattern>fd3so</pattern>
+  <pattern>fd3sp</pattern>
+  <pattern>f4d2w</pattern>
+  <pattern>fd3wo</pattern>
+  <pattern>1fe</pattern>
+  <pattern>fe2a</pattern>
+  <pattern>fec4tr</pattern>
+  <pattern>fede3</pattern>
+  <pattern>fe4del</pattern>
+  <pattern>f3een</pattern>
+  <pattern>5fees</pattern>
+  <pattern>feest5r</pattern>
+  <pattern>fel5dr</pattern>
+  <pattern>fe4l3ee</pattern>
+  <pattern>3feli</pattern>
+  <pattern>fe4lom</pattern>
+  <pattern>fe4l3op</pattern>
+  <pattern>fel3sp</pattern>
+  <pattern>fe3no</pattern>
+  <pattern>f4er</pattern>
+  <pattern>fe3rab</pattern>
+  <pattern>fe3ran</pattern>
+  <pattern>fe4r3et</pattern>
+  <pattern>fe3rom</pattern>
+  <pattern>fe3ron</pattern>
+  <pattern>3fes3</pattern>
+  <pattern>fe4t3j</pattern>
+  <pattern>fetu5r</pattern>
+  <pattern>2f3ex</pattern>
+  <pattern>1fé</pattern>
+  <pattern>3fè</pattern>
+  <pattern>3fê</pattern>
+  <pattern>4f1f</pattern>
+  <pattern>f5fe</pattern>
+  <pattern>f5fi</pattern>
+  <pattern>ffs2</pattern>
+  <pattern>ff3sh</pattern>
+  <pattern>ff3si</pattern>
+  <pattern>f3fu</pattern>
+  <pattern>f3g2</pattern>
+  <pattern>fge3</pattern>
+  <pattern>fge5r4</pattern>
+  <pattern>fge5t</pattern>
+  <pattern>4f5h</pattern>
+  <pattern>1fi</pattern>
+  <pattern>fi5ac</pattern>
+  <pattern>fi4al</pattern>
+  <pattern>fi3am</pattern>
+  <pattern>fi3apa</pattern>
+  <pattern>fi3apo</pattern>
+  <pattern>fia4s</pattern>
+  <pattern>3fib</pattern>
+  <pattern>fi1ch</pattern>
+  <pattern>5fie</pattern>
+  <pattern>5fig</pattern>
+  <pattern>f3ijs</pattern>
+  <pattern>2f1ijz</pattern>
+  <pattern>fik4st</pattern>
+  <pattern>3f2il</pattern>
+  <pattern>fil4m3a</pattern>
+  <pattern>film5on</pattern>
+  <pattern>fi3lo</pattern>
+  <pattern>4find</pattern>
+  <pattern>3fini</pattern>
+  <pattern>f3inj</pattern>
+  <pattern>4fink</pattern>
+  <pattern>2finr</pattern>
+  <pattern>fi3o</pattern>
+  <pattern>fi4r</pattern>
+  <pattern>fi4s</pattern>
+  <pattern>fi5se</pattern>
+  <pattern>f5iso</pattern>
+  <pattern>f1j</pattern>
+  <pattern>fjes5</pattern>
+  <pattern>4f1k4</pattern>
+  <pattern>f3ke</pattern>
+  <pattern>f2l2</pattern>
+  <pattern>4f3laa</pattern>
+  <pattern>f1laf</pattern>
+  <pattern>f4lam</pattern>
+  <pattern>f3lei</pattern>
+  <pattern>flen4st</pattern>
+  <pattern>flens5te </pattern>
+  <pattern>f4les</pattern>
+  <pattern>fle2t</pattern>
+  <pattern>flet3j</pattern>
+  <pattern>4flev</pattern>
+  <pattern>f4lex</pattern>
+  <pattern>f3lez</pattern>
+  <pattern>2flie</pattern>
+  <pattern>2flij</pattern>
+  <pattern>f4lik</pattern>
+  <pattern>f4lip</pattern>
+  <pattern>f4lit</pattern>
+  <pattern>f3lok</pattern>
+  <pattern>3f4lor</pattern>
+  <pattern>flu4t3</pattern>
+  <pattern>4f1m</pattern>
+  <pattern>f1n</pattern>
+  <pattern>1fo</pattern>
+  <pattern>3fob</pattern>
+  <pattern>5foc</pattern>
+  <pattern>foe5d</pattern>
+  <pattern>foe5ta</pattern>
+  <pattern>2f3of</pattern>
+  <pattern>5fok</pattern>
+  <pattern>2foms</pattern>
+  <pattern>fo5na</pattern>
+  <pattern>fond5en</pattern>
+  <pattern>fonds5l</pattern>
+  <pattern>fon5eng</pattern>
+  <pattern>fo1no</pattern>
+  <pattern>4font</pattern>
+  <pattern>fon5te</pattern>
+  <pattern>foo4</pattern>
+  <pattern>fooi5</pattern>
+  <pattern>f3oom</pattern>
+  <pattern>5foon</pattern>
+  <pattern>2fo4p</pattern>
+  <pattern>fop5s4</pattern>
+  <pattern>f4or</pattern>
+  <pattern>3fo5re</pattern>
+  <pattern>fo5ri</pattern>
+  <pattern>5form</pattern>
+  <pattern>for4t3j</pattern>
+  <pattern>fo1ru</pattern>
+  <pattern>fo3t</pattern>
+  <pattern>2f3oud</pattern>
+  <pattern>4f1ov</pattern>
+  <pattern>3fö</pattern>
+  <pattern>4f5p4</pattern>
+  <pattern>fpers5te </pattern>
+  <pattern>fpits5te </pattern>
+  <pattern>fr4</pattern>
+  <pattern>f4raak </pattern>
+  <pattern>fraam5</pattern>
+  <pattern>5frac</pattern>
+  <pattern>f3rad</pattern>
+  <pattern>f2ras</pattern>
+  <pattern>5frau</pattern>
+  <pattern>f1rec</pattern>
+  <pattern>f3rek</pattern>
+  <pattern>5freq</pattern>
+  <pattern>frie4s</pattern>
+  <pattern>frie4t</pattern>
+  <pattern>friet5j</pattern>
+  <pattern>f4rik</pattern>
+  <pattern>f4rod</pattern>
+  <pattern>4f3rol</pattern>
+  <pattern>f4rolo</pattern>
+  <pattern>f3roma</pattern>
+  <pattern>frus3</pattern>
+  <pattern>4f1s</pattern>
+  <pattern>f2sa4</pattern>
+  <pattern>fs3ad</pattern>
+  <pattern>fs3an</pattern>
+  <pattern>fs3ar</pattern>
+  <pattern>f3sc</pattern>
+  <pattern>f5sch</pattern>
+  <pattern>f4scr</pattern>
+  <pattern>fse2</pattern>
+  <pattern>f4s3ec</pattern>
+  <pattern>f4s5ee</pattern>
+  <pattern>f4sei</pattern>
+  <pattern>f4s3eth</pattern>
+  <pattern>fs4fe</pattern>
+  <pattern>f2sh</pattern>
+  <pattern>fs5he</pattern>
+  <pattern>f2si</pattern>
+  <pattern>f3sie</pattern>
+  <pattern>fs3im</pattern>
+  <pattern>fs1in</pattern>
+  <pattern>f5slaa</pattern>
+  <pattern>f5slac</pattern>
+  <pattern>f5slag</pattern>
+  <pattern>fs3lap</pattern>
+  <pattern>fs2m</pattern>
+  <pattern>fs3ma</pattern>
+  <pattern>fs4mi</pattern>
+  <pattern>fs3mo</pattern>
+  <pattern>fs3mu</pattern>
+  <pattern>f2s1o4</pattern>
+  <pattern>fs3ob</pattern>
+  <pattern>fs3om</pattern>
+  <pattern>fs4oo</pattern>
+  <pattern>fs2p</pattern>
+  <pattern>fs4pre</pattern>
+  <pattern>fs4t</pattern>
+  <pattern>fst3as</pattern>
+  <pattern>f3ste</pattern>
+  <pattern>fs5tec</pattern>
+  <pattern>f5stell</pattern>
+  <pattern>fste4m3</pattern>
+  <pattern>f4sterr</pattern>
+  <pattern>f3sti</pattern>
+  <pattern>f5stif</pattern>
+  <pattern>f3sto</pattern>
+  <pattern>f4st3oc</pattern>
+  <pattern>f4ston</pattern>
+  <pattern>f3str</pattern>
+  <pattern>f3stu</pattern>
+  <pattern>f3sy</pattern>
+  <pattern>4ft</pattern>
+  <pattern>f1ta</pattern>
+  <pattern>ft1ac</pattern>
+  <pattern>fta4kl</pattern>
+  <pattern>fta4p</pattern>
+  <pattern>ft3art</pattern>
+  <pattern>fter5sh</pattern>
+  <pattern>ft3h</pattern>
+  <pattern>f1to</pattern>
+  <pattern>f5tond</pattern>
+  <pattern>f4tont</pattern>
+  <pattern>f1tr</pattern>
+  <pattern>ft2s3l</pattern>
+  <pattern>ft4sm</pattern>
+  <pattern>fts3n</pattern>
+  <pattern>ft4so</pattern>
+  <pattern>fts3p</pattern>
+  <pattern>f1tu</pattern>
+  <pattern>ftu4r</pattern>
+  <pattern>1fu</pattern>
+  <pattern>2fuit</pattern>
+  <pattern>fu4ma</pattern>
+  <pattern>fum3ac</pattern>
+  <pattern>3f2un</pattern>
+  <pattern>fur4o</pattern>
+  <pattern>3fus</pattern>
+  <pattern>2fuu</pattern>
+  <pattern>4fv</pattern>
+  <pattern>fva2</pattern>
+  <pattern>fval3</pattern>
+  <pattern>4f1w4</pattern>
+  <pattern>3fy1</pattern>
+  <pattern>2fz</pattern>
+  <pattern>fzet5</pattern>
+  <pattern>4g </pattern>
+  <pattern>1ga</pattern>
+  <pattern>3ga </pattern>
+  <pattern>gaar5tj</pattern>
+  <pattern>g4aat</pattern>
+  <pattern>2g1ac</pattern>
+  <pattern>4g3adm</pattern>
+  <pattern>g4af </pattern>
+  <pattern>g3afd</pattern>
+  <pattern>ga3fr</pattern>
+  <pattern>4g3afs</pattern>
+  <pattern>4g3afw</pattern>
+  <pattern>2g3a4h</pattern>
+  <pattern>4gal </pattern>
+  <pattern>ga3la</pattern>
+  <pattern>ga4l3ap</pattern>
+  <pattern>ga5ler</pattern>
+  <pattern>gal3s</pattern>
+  <pattern>4gamb</pattern>
+  <pattern>g4a3mi</pattern>
+  <pattern>3gan</pattern>
+  <pattern>gan5d</pattern>
+  <pattern>5gane</pattern>
+  <pattern>gan4s5t</pattern>
+  <pattern>ga3pl</pattern>
+  <pattern>3gar </pattern>
+  <pattern>4g3arb</pattern>
+  <pattern>ga3re</pattern>
+  <pattern>g1arm</pattern>
+  <pattern>3gars</pattern>
+  <pattern>2g3art</pattern>
+  <pattern>gar5tj</pattern>
+  <pattern>ga4s</pattern>
+  <pattern>gas5c</pattern>
+  <pattern>gas3i</pattern>
+  <pattern>ga5sla </pattern>
+  <pattern>ga3sli</pattern>
+  <pattern>ga5slo</pattern>
+  <pattern>gas3o</pattern>
+  <pattern>gas3p</pattern>
+  <pattern>gas3tr</pattern>
+  <pattern>gas5tra</pattern>
+  <pattern>gast5rol</pattern>
+  <pattern>3gat</pattern>
+  <pattern>gat5j</pattern>
+  <pattern>gat3s</pattern>
+  <pattern>4gaut</pattern>
+  <pattern>ga5ve</pattern>
+  <pattern>g1avo</pattern>
+  <pattern>2g5b</pattern>
+  <pattern>2g1c</pattern>
+  <pattern>4gd</pattern>
+  <pattern>g5dac</pattern>
+  <pattern>g5dag</pattern>
+  <pattern>gd3art</pattern>
+  <pattern>gd3at</pattern>
+  <pattern>gd5ate</pattern>
+  <pattern>g3de</pattern>
+  <pattern>g4d3elf</pattern>
+  <pattern>g5der </pattern>
+  <pattern>gd3erv</pattern>
+  <pattern>g4d3id</pattern>
+  <pattern>gd3im</pattern>
+  <pattern>g2din</pattern>
+  <pattern>g3dr</pattern>
+  <pattern>g5dru</pattern>
+  <pattern>gd3sa</pattern>
+  <pattern>gd5sp</pattern>
+  <pattern>g3du</pattern>
+  <pattern>1ge</pattern>
+  <pattern>3ge </pattern>
+  <pattern>ge3a</pattern>
+  <pattern>gea3dr</pattern>
+  <pattern>gea5na</pattern>
+  <pattern>gea3q</pattern>
+  <pattern>ge4ari</pattern>
+  <pattern>ge5au</pattern>
+  <pattern>4g3eb </pattern>
+  <pattern>2gebb</pattern>
+  <pattern>ge3c</pattern>
+  <pattern>ge3d4</pattern>
+  <pattern>gedi3a</pattern>
+  <pattern>ge4dit</pattern>
+  <pattern>ge5dr</pattern>
+  <pattern>ge5dw</pattern>
+  <pattern>3gee4</pattern>
+  <pattern>geest5r</pattern>
+  <pattern>geet3a</pattern>
+  <pattern>ge3f4</pattern>
+  <pattern>2g3eff</pattern>
+  <pattern>ge5g4</pattern>
+  <pattern>gege4s</pattern>
+  <pattern>4geig</pattern>
+  <pattern>2g3eik</pattern>
+  <pattern>gei4l5a</pattern>
+  <pattern>5geit</pattern>
+  <pattern>geit3j</pattern>
+  <pattern>ge3k4a</pattern>
+  <pattern>ge3ke</pattern>
+  <pattern>ge5ki</pattern>
+  <pattern>ge5k4l</pattern>
+  <pattern>ge3kr</pattern>
+  <pattern>gek4st</pattern>
+  <pattern>gek4u</pattern>
+  <pattern>ge3k4w</pattern>
+  <pattern>ge3lau</pattern>
+  <pattern>gel4d3a4</pattern>
+  <pattern>ge3l4e</pattern>
+  <pattern>4ge4lem</pattern>
+  <pattern>gel5f</pattern>
+  <pattern>gel5k</pattern>
+  <pattern>5ge3l4o</pattern>
+  <pattern>gel5si</pattern>
+  <pattern>gel3sl</pattern>
+  <pattern>gel3sp</pattern>
+  <pattern>gel5ste</pattern>
+  <pattern>ge5ma</pattern>
+  <pattern>4gemb</pattern>
+  <pattern>4g3emf</pattern>
+  <pattern>ge5mo</pattern>
+  <pattern>2g3emp</pattern>
+  <pattern>gems3</pattern>
+  <pattern>ge3m4u</pattern>
+  <pattern>g4en </pattern>
+  <pattern>ge3nak</pattern>
+  <pattern>gen4az</pattern>
+  <pattern>3ge3ne</pattern>
+  <pattern>ge4n3ed</pattern>
+  <pattern>ge4nend</pattern>
+  <pattern>4g3engt</pattern>
+  <pattern>3geni</pattern>
+  <pattern>gen5k</pattern>
+  <pattern>ge1no</pattern>
+  <pattern>ge4n4of</pattern>
+  <pattern>ge4nog</pattern>
+  <pattern>gen5sfe</pattern>
+  <pattern>gen5ston</pattern>
+  <pattern>gen5stu</pattern>
+  <pattern>genstu5r</pattern>
+  <pattern>5genw</pattern>
+  <pattern>ge5om</pattern>
+  <pattern>geo5pe</pattern>
+  <pattern>georke5</pattern>
+  <pattern>ge5os</pattern>
+  <pattern>ge5ot</pattern>
+  <pattern>ge5p4</pattern>
+  <pattern>ge1ra</pattern>
+  <pattern>ger5aal</pattern>
+  <pattern>ger5aap </pattern>
+  <pattern>ge4r3a4l</pattern>
+  <pattern>gera4p</pattern>
+  <pattern>ger5ape</pattern>
+  <pattern>ger5as </pattern>
+  <pattern>ge5reg</pattern>
+  <pattern>ge3rem</pattern>
+  <pattern>ge5ren </pattern>
+  <pattern>ger4i</pattern>
+  <pattern>ger5ini</pattern>
+  <pattern>ge1r2o</pattern>
+  <pattern>ger4of</pattern>
+  <pattern>ge5rol</pattern>
+  <pattern>ger5slan</pattern>
+  <pattern>ger4sli</pattern>
+  <pattern>gers5lij</pattern>
+  <pattern>ger4sp</pattern>
+  <pattern>4g3erts</pattern>
+  <pattern>ge3r4u</pattern>
+  <pattern>3ge1s4</pattern>
+  <pattern>ge3sa</pattern>
+  <pattern>ge3sc</pattern>
+  <pattern>ge5se</pattern>
+  <pattern>ge3si</pattern>
+  <pattern>4ge3sk</pattern>
+  <pattern>ge5sl</pattern>
+  <pattern>ge3sn</pattern>
+  <pattern>ge3so</pattern>
+  <pattern>ge5spend</pattern>
+  <pattern>ge5sper</pattern>
+  <pattern>ge5spo</pattern>
+  <pattern>ge5stan</pattern>
+  <pattern>ges5te </pattern>
+  <pattern>ges5ten </pattern>
+  <pattern>ge3str</pattern>
+  <pattern>ge5sw</pattern>
+  <pattern>ge3ta</pattern>
+  <pattern>get4aa</pattern>
+  <pattern>ge5tam</pattern>
+  <pattern>ge2th</pattern>
+  <pattern>ge5t4i</pattern>
+  <pattern>ge3t4j</pattern>
+  <pattern>get4o</pattern>
+  <pattern>ge3tr</pattern>
+  <pattern>ge5tra</pattern>
+  <pattern>ge5tro</pattern>
+  <pattern>ge5tru</pattern>
+  <pattern>ge5tsj</pattern>
+  <pattern>ge5tu</pattern>
+  <pattern>ge5t4w</pattern>
+  <pattern>ge3ui</pattern>
+  <pattern>5g4ev</pattern>
+  <pattern>4gex</pattern>
+  <pattern>5g4ez</pattern>
+  <pattern>1gé</pattern>
+  <pattern>gédi4</pattern>
+  <pattern>3gè</pattern>
+  <pattern>4g1f</pattern>
+  <pattern>gfijn5ste</pattern>
+  <pattern>4g3g4</pattern>
+  <pattern>g5ge</pattern>
+  <pattern>gge3la</pattern>
+  <pattern>gge4r5on</pattern>
+  <pattern>gges5ti</pattern>
+  <pattern>g4g5h</pattern>
+  <pattern>g5gi</pattern>
+  <pattern>ggings5</pattern>
+  <pattern>g5gl</pattern>
+  <pattern>2g1h</pattern>
+  <pattern>g2het</pattern>
+  <pattern>ght4</pattern>
+  <pattern>gh5te</pattern>
+  <pattern>g2hum</pattern>
+  <pattern>1gi</pattern>
+  <pattern>gids5te</pattern>
+  <pattern>gie5ra</pattern>
+  <pattern>gier4s</pattern>
+  <pattern>gi1eu</pattern>
+  <pattern>gi2f</pattern>
+  <pattern>gif5r</pattern>
+  <pattern>gi3ga</pattern>
+  <pattern>5gigere</pattern>
+  <pattern>5gigste</pattern>
+  <pattern>2gij</pattern>
+  <pattern>g3ijs</pattern>
+  <pattern>4gijz</pattern>
+  <pattern>gi2m</pattern>
+  <pattern>gi3na</pattern>
+  <pattern>4g3inb</pattern>
+  <pattern>4g3inf</pattern>
+  <pattern>g5infe</pattern>
+  <pattern>g5infr</pattern>
+  <pattern>5ging</pattern>
+  <pattern>2g3inh</pattern>
+  <pattern>gin3o</pattern>
+  <pattern>2ginr</pattern>
+  <pattern>gi4oc</pattern>
+  <pattern>gi2od</pattern>
+  <pattern>gi4onet</pattern>
+  <pattern>gi2or</pattern>
+  <pattern>gip4st</pattern>
+  <pattern>5gir</pattern>
+  <pattern>3gis</pattern>
+  <pattern>4g1j</pattern>
+  <pattern>4g1k</pattern>
+  <pattern>gl4</pattern>
+  <pattern>g5lab</pattern>
+  <pattern>3glai</pattern>
+  <pattern>1gla4s</pattern>
+  <pattern>glas3e</pattern>
+  <pattern>g5lat</pattern>
+  <pattern>3g4laz</pattern>
+  <pattern>3gle </pattern>
+  <pattern>g5leer</pattern>
+  <pattern>glee5t</pattern>
+  <pattern>g3len</pattern>
+  <pattern>2g5lep</pattern>
+  <pattern>4g5ler</pattern>
+  <pattern>g3les</pattern>
+  <pattern>3gle4t</pattern>
+  <pattern>glet3j</pattern>
+  <pattern>g5lev</pattern>
+  <pattern>g5lice</pattern>
+  <pattern>g5lich</pattern>
+  <pattern>3glië</pattern>
+  <pattern>g2lif</pattern>
+  <pattern>g5lijs</pattern>
+  <pattern>g2lim</pattern>
+  <pattern>3g4lio</pattern>
+  <pattern>g2lob</pattern>
+  <pattern>3glof</pattern>
+  <pattern>g5log</pattern>
+  <pattern>3glom</pattern>
+  <pattern>4g3lon</pattern>
+  <pattern>g3loon</pattern>
+  <pattern>g3lop</pattern>
+  <pattern>3g2los</pattern>
+  <pattern>g5loz</pattern>
+  <pattern>3g2ly</pattern>
+  <pattern>4g1m</pattern>
+  <pattern>gmaat5j</pattern>
+  <pattern>2g1n</pattern>
+  <pattern>g3na</pattern>
+  <pattern>gn4e</pattern>
+  <pattern>gne5g</pattern>
+  <pattern>gne5m</pattern>
+  <pattern>gne4t3j</pattern>
+  <pattern>gnie4tj</pattern>
+  <pattern>4gnu</pattern>
+  <pattern>1go</pattern>
+  <pattern>3go </pattern>
+  <pattern>3go2a</pattern>
+  <pattern>3gob</pattern>
+  <pattern>2goc</pattern>
+  <pattern>g1och</pattern>
+  <pattern>go4d3a</pattern>
+  <pattern>god4s3</pattern>
+  <pattern>gods5t</pattern>
+  <pattern>4goef</pattern>
+  <pattern>goe1r</pattern>
+  <pattern>2gof</pattern>
+  <pattern>go3f2r</pattern>
+  <pattern>g4og</pattern>
+  <pattern>4goh</pattern>
+  <pattern>go2k</pattern>
+  <pattern>5gom </pattern>
+  <pattern>go2ma</pattern>
+  <pattern>g3oml</pattern>
+  <pattern>4gomz</pattern>
+  <pattern>go4n3az</pattern>
+  <pattern>2g3ong</pattern>
+  <pattern>go5no</pattern>
+  <pattern>2g1ont</pattern>
+  <pattern>g2oo</pattern>
+  <pattern>2g3oor</pattern>
+  <pattern>3goot</pattern>
+  <pattern>2g1op</pattern>
+  <pattern>go3pa</pattern>
+  <pattern>g4opr</pattern>
+  <pattern>g4ora</pattern>
+  <pattern>4go4re</pattern>
+  <pattern>go5re </pattern>
+  <pattern>5g4ori</pattern>
+  <pattern>gor2s</pattern>
+  <pattern>gos1</pattern>
+  <pattern>go3tr</pattern>
+  <pattern>gou4d5ee</pattern>
+  <pattern>2g3ov</pattern>
+  <pattern>2g5p</pattern>
+  <pattern>gpes3</pattern>
+  <pattern>1gr4</pattern>
+  <pattern>3gra</pattern>
+  <pattern>5gra </pattern>
+  <pattern>graat5j</pattern>
+  <pattern>g5rak</pattern>
+  <pattern>gra2m</pattern>
+  <pattern>g4ram </pattern>
+  <pattern>gram3a</pattern>
+  <pattern>g3ramp</pattern>
+  <pattern>gra4s3</pattern>
+  <pattern>5grav</pattern>
+  <pattern>2g3rec</pattern>
+  <pattern>2g3red</pattern>
+  <pattern>5gredi</pattern>
+  <pattern>g5redu</pattern>
+  <pattern>g3reek</pattern>
+  <pattern>g3reel</pattern>
+  <pattern>g4reep</pattern>
+  <pattern>g3reis</pattern>
+  <pattern>4g3rek</pattern>
+  <pattern>2g3rem</pattern>
+  <pattern>gren4s</pattern>
+  <pattern>gre4s</pattern>
+  <pattern>g4reu</pattern>
+  <pattern>g3rev</pattern>
+  <pattern>5gria</pattern>
+  <pattern>grie4t5j</pattern>
+  <pattern>g5rijd</pattern>
+  <pattern>g5rijk</pattern>
+  <pattern>g5rijm</pattern>
+  <pattern>g5ring</pattern>
+  <pattern>5g4ris</pattern>
+  <pattern>grit5s</pattern>
+  <pattern>2g3riv</pattern>
+  <pattern>groet5j</pattern>
+  <pattern>grof5</pattern>
+  <pattern>g3rok</pattern>
+  <pattern>g3rook</pattern>
+  <pattern>g3room</pattern>
+  <pattern>groot5j</pattern>
+  <pattern>2grou</pattern>
+  <pattern>gro5v</pattern>
+  <pattern>2g3rug</pattern>
+  <pattern>g3ruim</pattern>
+  <pattern>g3rup</pattern>
+  <pattern>4gs</pattern>
+  <pattern>gs1a2</pattern>
+  <pattern>gsa4g</pattern>
+  <pattern>gs5alar</pattern>
+  <pattern>gs3alt</pattern>
+  <pattern>g2sc</pattern>
+  <pattern>gse4</pattern>
+  <pattern>gs3eco</pattern>
+  <pattern>g4s3ed</pattern>
+  <pattern>gs5een</pattern>
+  <pattern>gs3ei</pattern>
+  <pattern>gs3en</pattern>
+  <pattern>gs5ene</pattern>
+  <pattern>gs3erv</pattern>
+  <pattern>gs3et</pattern>
+  <pattern>gs3ev</pattern>
+  <pattern>gs5he</pattern>
+  <pattern>g2s1i2</pattern>
+  <pattern>g3sie</pattern>
+  <pattern>gs5is</pattern>
+  <pattern>gs1j</pattern>
+  <pattern>g3s4ke </pattern>
+  <pattern>gs3l</pattern>
+  <pattern>gs4la</pattern>
+  <pattern>gs5laag</pattern>
+  <pattern>gs5lam</pattern>
+  <pattern>gs5las</pattern>
+  <pattern>gs1le</pattern>
+  <pattern>g3slep</pattern>
+  <pattern>g4sleu</pattern>
+  <pattern>gs5lie</pattern>
+  <pattern>gs4lin</pattern>
+  <pattern>g5sling</pattern>
+  <pattern>gs4lo</pattern>
+  <pattern>gs5log</pattern>
+  <pattern>gs5lok</pattern>
+  <pattern>gs5lon</pattern>
+  <pattern>gs4lu</pattern>
+  <pattern>g4s5ma</pattern>
+  <pattern>gs3n</pattern>
+  <pattern>g4sna</pattern>
+  <pattern>g3snij</pattern>
+  <pattern>g4s1o4</pattern>
+  <pattern>g5sol</pattern>
+  <pattern>g5som </pattern>
+  <pattern>gs5ons</pattern>
+  <pattern>gs3op</pattern>
+  <pattern>gs3p</pattern>
+  <pattern>gs5pand</pattern>
+  <pattern>g3spec</pattern>
+  <pattern>g3s4pel</pattern>
+  <pattern>g3s4pet</pattern>
+  <pattern>gs4pi</pattern>
+  <pattern>g3spie</pattern>
+  <pattern>g3spil</pattern>
+  <pattern>g5spin </pattern>
+  <pattern>g5spinn</pattern>
+  <pattern>gs5pir</pattern>
+  <pattern>gs5pol</pattern>
+  <pattern>g3s4pon</pattern>
+  <pattern>gs5ps</pattern>
+  <pattern>gs5q</pattern>
+  <pattern>gs5sc</pattern>
+  <pattern>gst2a</pattern>
+  <pattern>gs5taal</pattern>
+  <pattern>gst5aang</pattern>
+  <pattern>gs5tac</pattern>
+  <pattern>g5stad</pattern>
+  <pattern>g5s4tan</pattern>
+  <pattern>g4st3ap</pattern>
+  <pattern>g5stat</pattern>
+  <pattern>g1ste</pattern>
+  <pattern>g5s4te </pattern>
+  <pattern>g5sted</pattern>
+  <pattern>g5stee</pattern>
+  <pattern>g3stei</pattern>
+  <pattern>gs3tek</pattern>
+  <pattern>g5stel</pattern>
+  <pattern>g3sten</pattern>
+  <pattern>g3ster</pattern>
+  <pattern>g5ster </pattern>
+  <pattern>gs5terr</pattern>
+  <pattern>g5sters</pattern>
+  <pattern>gs3th</pattern>
+  <pattern>g5s4tic</pattern>
+  <pattern>g3s4tig</pattern>
+  <pattern>gs5tijg</pattern>
+  <pattern>g5stof</pattern>
+  <pattern>g5stop</pattern>
+  <pattern>g5stor</pattern>
+  <pattern>gst3o4v</pattern>
+  <pattern>g4s3tra</pattern>
+  <pattern>gs5trad</pattern>
+  <pattern>gs5trak</pattern>
+  <pattern>gst5ram</pattern>
+  <pattern>gs5trap</pattern>
+  <pattern>g5strat</pattern>
+  <pattern>gst5res</pattern>
+  <pattern>gs5troe</pattern>
+  <pattern>gs5tron</pattern>
+  <pattern>g4stru</pattern>
+  <pattern>g5struc</pattern>
+  <pattern>g3stu</pattern>
+  <pattern>gs5ty</pattern>
+  <pattern>g2s1u4</pattern>
+  <pattern>gsver3</pattern>
+  <pattern>gs5w</pattern>
+  <pattern>g5sy</pattern>
+  <pattern>4gt</pattern>
+  <pattern>g1ta</pattern>
+  <pattern>g2t3ap</pattern>
+  <pattern>g3te</pattern>
+  <pattern>gte3ro</pattern>
+  <pattern>gtes4</pattern>
+  <pattern>gte3st</pattern>
+  <pattern>g1to</pattern>
+  <pattern>g3tr</pattern>
+  <pattern>g1tu</pattern>
+  <pattern>1gu</pattern>
+  <pattern>5gu </pattern>
+  <pattern>3gue</pattern>
+  <pattern>gu4eu</pattern>
+  <pattern>2guit</pattern>
+  <pattern>gu4ni</pattern>
+  <pattern>gu2s3</pattern>
+  <pattern>gut4st</pattern>
+  <pattern>guts5te </pattern>
+  <pattern>4gv</pattern>
+  <pattern>g5vo</pattern>
+  <pattern>4g1w</pattern>
+  <pattern>g5wa</pattern>
+  <pattern>1gy</pattern>
+  <pattern>4gyp</pattern>
+  <pattern>2gz</pattern>
+  <pattern>4h </pattern>
+  <pattern>haams5ta</pattern>
+  <pattern>haar5sl</pattern>
+  <pattern>haar5sp</pattern>
+  <pattern>haars5te</pattern>
+  <pattern>haar5tj</pattern>
+  <pattern>haats5te </pattern>
+  <pattern>h3afd</pattern>
+  <pattern>haf4t3u</pattern>
+  <pattern>ha3g</pattern>
+  <pattern>ha5ge</pattern>
+  <pattern>hal2f1</pattern>
+  <pattern>5hals</pattern>
+  <pattern>hal4sto</pattern>
+  <pattern>5halz</pattern>
+  <pattern>2hamp</pattern>
+  <pattern>4han </pattern>
+  <pattern>han4dr</pattern>
+  <pattern>hand5sl</pattern>
+  <pattern>han3ga</pattern>
+  <pattern>hang5l</pattern>
+  <pattern>hang5s</pattern>
+  <pattern>han4s3l</pattern>
+  <pattern>han3so</pattern>
+  <pattern>han4st</pattern>
+  <pattern>hap2s</pattern>
+  <pattern>hap4se</pattern>
+  <pattern>har4ta</pattern>
+  <pattern>harte5l</pattern>
+  <pattern>hart3j</pattern>
+  <pattern>har4t3o4</pattern>
+  <pattern>har5tre</pattern>
+  <pattern>hart5sl</pattern>
+  <pattern>hat5j</pattern>
+  <pattern>ha2t3r</pattern>
+  <pattern>hat3s</pattern>
+  <pattern>ha3v</pattern>
+  <pattern>4have </pattern>
+  <pattern>4hb</pattern>
+  <pattern>2hd</pattern>
+  <pattern>h4e</pattern>
+  <pattern>2hea</pattern>
+  <pattern>he2ar</pattern>
+  <pattern>3hech</pattern>
+  <pattern>he3co</pattern>
+  <pattern>4hee </pattern>
+  <pattern>hee3g4</pattern>
+  <pattern>hee4k</pattern>
+  <pattern>heek3a</pattern>
+  <pattern>heek5l</pattern>
+  <pattern>hee4l3o</pattern>
+  <pattern>heep4s</pattern>
+  <pattern>heeps5c</pattern>
+  <pattern>heers5tak</pattern>
+  <pattern>hee5sto</pattern>
+  <pattern>hee5tjes</pattern>
+  <pattern>he2f</pattern>
+  <pattern>he4i</pattern>
+  <pattern>heids5p</pattern>
+  <pattern>heis4</pattern>
+  <pattern>hei5tj</pattern>
+  <pattern>he2k3a</pattern>
+  <pattern>he2kl</pattern>
+  <pattern>hek4st</pattern>
+  <pattern>heks5te </pattern>
+  <pattern>hek5sten</pattern>
+  <pattern>hek3w</pattern>
+  <pattern>he3le</pattern>
+  <pattern>he4l3ee</pattern>
+  <pattern>he3li</pattern>
+  <pattern>hel4m3a</pattern>
+  <pattern>helo4</pattern>
+  <pattern>hel4p3a</pattern>
+  <pattern>hel3sm</pattern>
+  <pattern>he5mo</pattern>
+  <pattern>he5ne</pattern>
+  <pattern>hen4kr</pattern>
+  <pattern>he3n4o</pattern>
+  <pattern>4he5o</pattern>
+  <pattern>he4pij</pattern>
+  <pattern>he2p3l</pattern>
+  <pattern>he2pr</pattern>
+  <pattern>he1ra</pattern>
+  <pattern>her4aa</pattern>
+  <pattern>he4r3ad</pattern>
+  <pattern>he3r4au</pattern>
+  <pattern>he4r3i</pattern>
+  <pattern>herm5eng</pattern>
+  <pattern>he3ros</pattern>
+  <pattern>hero5v</pattern>
+  <pattern>her4p5aa</pattern>
+  <pattern>3herst</pattern>
+  <pattern>hert4</pattern>
+  <pattern>herts5te</pattern>
+  <pattern>he2ru</pattern>
+  <pattern>he5se</pattern>
+  <pattern>he2sp</pattern>
+  <pattern>he2s5t</pattern>
+  <pattern>hets5te </pattern>
+  <pattern>heu5le</pattern>
+  <pattern>2h3f</pattern>
+  <pattern>4h5g</pattern>
+  <pattern>h3h</pattern>
+  <pattern>hi5d</pattern>
+  <pattern>hie4f3</pattern>
+  <pattern>hielsges5</pattern>
+  <pattern>hie4r3</pattern>
+  <pattern>hie5ren</pattern>
+  <pattern>hier5u</pattern>
+  <pattern>hie4t5o</pattern>
+  <pattern>hie4tr</pattern>
+  <pattern>hiet5s</pattern>
+  <pattern>hij4sl</pattern>
+  <pattern>hik4s5</pattern>
+  <pattern>hi3kw</pattern>
+  <pattern>hil3m</pattern>
+  <pattern>him4pl</pattern>
+  <pattern>him4pr</pattern>
+  <pattern>hin5d</pattern>
+  <pattern>h3ins</pattern>
+  <pattern>hin4t3j</pattern>
+  <pattern>hi2p5l</pattern>
+  <pattern>2hir2</pattern>
+  <pattern>his5p</pattern>
+  <pattern>hi3tr</pattern>
+  <pattern>hit4st</pattern>
+  <pattern>hits5te </pattern>
+  <pattern>hit5sten</pattern>
+  <pattern>h3j</pattern>
+  <pattern>2hl</pattern>
+  <pattern>h3la</pattern>
+  <pattern>h4lag</pattern>
+  <pattern>h3lep</pattern>
+  <pattern>h3loc</pattern>
+  <pattern>2h2m</pattern>
+  <pattern>h3ma</pattern>
+  <pattern>h3me</pattern>
+  <pattern>h4mer</pattern>
+  <pattern>h1n</pattern>
+  <pattern>h2na</pattern>
+  <pattern>hno3</pattern>
+  <pattern>2ho </pattern>
+  <pattern>ho3a</pattern>
+  <pattern>hoa3n</pattern>
+  <pattern>hoboot4</pattern>
+  <pattern>ho3ch</pattern>
+  <pattern>hoe4ker</pattern>
+  <pattern>hoe4s</pattern>
+  <pattern>hoes5l</pattern>
+  <pattern>hoe3t</pattern>
+  <pattern>ho2f</pattern>
+  <pattern>hof5d</pattern>
+  <pattern>hof3e</pattern>
+  <pattern>ho3g2</pattern>
+  <pattern>ho2ka</pattern>
+  <pattern>ho5mo</pattern>
+  <pattern>hon3dr</pattern>
+  <pattern>hond4s</pattern>
+  <pattern>hon3g</pattern>
+  <pattern>honi4</pattern>
+  <pattern>ho1no</pattern>
+  <pattern>hool3e</pattern>
+  <pattern>4hoom</pattern>
+  <pattern>hoort4</pattern>
+  <pattern>hoor5tr</pattern>
+  <pattern>2hoot</pattern>
+  <pattern>ho3pa</pattern>
+  <pattern>ho1pe</pattern>
+  <pattern>ho2p3o</pattern>
+  <pattern>hop3r</pattern>
+  <pattern>hop4str</pattern>
+  <pattern>hor5de</pattern>
+  <pattern>5horl</pattern>
+  <pattern>ho3ro</pattern>
+  <pattern>hor4st</pattern>
+  <pattern>hors5te </pattern>
+  <pattern>hor5sten</pattern>
+  <pattern>hor4t3j</pattern>
+  <pattern>ho3ru</pattern>
+  <pattern>ho3sa</pattern>
+  <pattern>hot3j</pattern>
+  <pattern>ho3tr</pattern>
+  <pattern>ho4t3re</pattern>
+  <pattern>hot4st</pattern>
+  <pattern>hots5te </pattern>
+  <pattern>ho3v</pattern>
+  <pattern>2ho4w</pattern>
+  <pattern>how3o</pattern>
+  <pattern>2h1p</pattern>
+  <pattern>hpi4</pattern>
+  <pattern>2hr</pattern>
+  <pattern>hra4b</pattern>
+  <pattern>h4re</pattern>
+  <pattern>h5rea</pattern>
+  <pattern>hri4</pattern>
+  <pattern>hro2k</pattern>
+  <pattern>hrok3o</pattern>
+  <pattern>hroot3</pattern>
+  <pattern>4hs</pattern>
+  <pattern>h3sa</pattern>
+  <pattern>h3sp</pattern>
+  <pattern>h3st</pattern>
+  <pattern>2ht</pattern>
+  <pattern>h4t1a2</pattern>
+  <pattern>ht3ac</pattern>
+  <pattern>h3tal</pattern>
+  <pattern>ht3ala</pattern>
+  <pattern>h5tans</pattern>
+  <pattern>h3te </pattern>
+  <pattern>h4t3ec</pattern>
+  <pattern>ht4eco</pattern>
+  <pattern>h2t3ee</pattern>
+  <pattern>h2t3ef</pattern>
+  <pattern>h2t3ei</pattern>
+  <pattern>ht5em</pattern>
+  <pattern>h3ten</pattern>
+  <pattern>h4ten5t</pattern>
+  <pattern>ht5entw</pattern>
+  <pattern>hter3a</pattern>
+  <pattern>hte4r5o</pattern>
+  <pattern>h4t3esk</pattern>
+  <pattern>h4tev</pattern>
+  <pattern>ht5eve</pattern>
+  <pattern>h5tevo</pattern>
+  <pattern>ht3ex</pattern>
+  <pattern>h2t5h</pattern>
+  <pattern>h4t3int</pattern>
+  <pattern>h2t1j</pattern>
+  <pattern>ht1o4</pattern>
+  <pattern>ht5oef</pattern>
+  <pattern>ht5op</pattern>
+  <pattern>h4t1r</pattern>
+  <pattern>ht5roo</pattern>
+  <pattern>ht4sap</pattern>
+  <pattern>htse4</pattern>
+  <pattern>ht4ser</pattern>
+  <pattern>ht2si</pattern>
+  <pattern>ht4sl</pattern>
+  <pattern>ht5sla</pattern>
+  <pattern>ht5slot</pattern>
+  <pattern>ht3sme</pattern>
+  <pattern>ht5smij</pattern>
+  <pattern>ht4s3o</pattern>
+  <pattern>ht3spe</pattern>
+  <pattern>hts3pl</pattern>
+  <pattern>ht3spr</pattern>
+  <pattern>hts5taal</pattern>
+  <pattern>ht4s5tak</pattern>
+  <pattern>ht4s5tek</pattern>
+  <pattern>ht4sti</pattern>
+  <pattern>hts5tore</pattern>
+  <pattern>hts5trekk</pattern>
+  <pattern>ht1u2</pattern>
+  <pattern>ht3w</pattern>
+  <pattern>hu4ba</pattern>
+  <pattern>3huiz</pattern>
+  <pattern>hul4der</pattern>
+  <pattern>hur4t5</pattern>
+  <pattern>hut3j</pattern>
+  <pattern>huts5te </pattern>
+  <pattern>huur5s</pattern>
+  <pattern>4h1w</pattern>
+  <pattern>hy4la</pattern>
+  <pattern>3hyp</pattern>
+  <pattern>hypo1</pattern>
+  <pattern>4i </pattern>
+  <pattern>i1a</pattern>
+  <pattern>i3aa</pattern>
+  <pattern>i4ab</pattern>
+  <pattern>i5abi</pattern>
+  <pattern>i4ac</pattern>
+  <pattern>i3ady</pattern>
+  <pattern>i3ae</pattern>
+  <pattern>i5ae </pattern>
+  <pattern>i2a3f4</pattern>
+  <pattern>i2a3g2</pattern>
+  <pattern>i3agr</pattern>
+  <pattern>i3ai</pattern>
+  <pattern>i5ak </pattern>
+  <pattern>i3ake4</pattern>
+  <pattern>ia4kem</pattern>
+  <pattern>ia3kl</pattern>
+  <pattern>ia3kr</pattern>
+  <pattern>i3al </pattern>
+  <pattern>i4a3la</pattern>
+  <pattern>i3ali</pattern>
+  <pattern>i2am</pattern>
+  <pattern>i5am </pattern>
+  <pattern>i3ami</pattern>
+  <pattern>i3an</pattern>
+  <pattern>ian4o</pattern>
+  <pattern>ia3o</pattern>
+  <pattern>i2a1p4</pattern>
+  <pattern>ia5pa</pattern>
+  <pattern>i5api</pattern>
+  <pattern>ia3sc</pattern>
+  <pattern>ia5se</pattern>
+  <pattern>ia3so</pattern>
+  <pattern>ia4s5po</pattern>
+  <pattern>ia3sta</pattern>
+  <pattern>i3at</pattern>
+  <pattern>ia3t2h</pattern>
+  <pattern>i5atri</pattern>
+  <pattern>iave4</pattern>
+  <pattern>i5ble</pattern>
+  <pattern>iboot4</pattern>
+  <pattern>4ic</pattern>
+  <pattern>i3ce</pattern>
+  <pattern>5i4cepa</pattern>
+  <pattern>i1cha</pattern>
+  <pattern>i1che</pattern>
+  <pattern>ichee4t</pattern>
+  <pattern>i1chi</pattern>
+  <pattern>i1cho</pattern>
+  <pattern>i3chr</pattern>
+  <pattern>ick5l</pattern>
+  <pattern>icos4</pattern>
+  <pattern>ic4t3op</pattern>
+  <pattern>ict4s5c</pattern>
+  <pattern>i3dam</pattern>
+  <pattern>idde4r5a</pattern>
+  <pattern>ide3a</pattern>
+  <pattern>i4dee </pattern>
+  <pattern>ider4sp</pattern>
+  <pattern>ider4st</pattern>
+  <pattern>ides4</pattern>
+  <pattern>idi3a</pattern>
+  <pattern>idi5ab</pattern>
+  <pattern>i2di5o</pattern>
+  <pattern>id4mak</pattern>
+  <pattern>i3dok</pattern>
+  <pattern>i2dr</pattern>
+  <pattern>id3ran</pattern>
+  <pattern>id3ru</pattern>
+  <pattern>id2s1</pattern>
+  <pattern>id4s3a</pattern>
+  <pattern>id4ser</pattern>
+  <pattern>ids5i</pattern>
+  <pattern>ids5j</pattern>
+  <pattern>ids5l</pattern>
+  <pattern>id4sm</pattern>
+  <pattern>ids5ma</pattern>
+  <pattern>id5s4mee</pattern>
+  <pattern>id4s3o</pattern>
+  <pattern>ids3ta</pattern>
+  <pattern>ids5tak</pattern>
+  <pattern>ids5tek</pattern>
+  <pattern>id4stem</pattern>
+  <pattern>id4sti</pattern>
+  <pattern>ids5tr</pattern>
+  <pattern>id3u4r</pattern>
+  <pattern>id3uu</pattern>
+  <pattern>idu3w</pattern>
+  <pattern>id3w</pattern>
+  <pattern>4ie</pattern>
+  <pattern>ie1a2</pattern>
+  <pattern>ie4d3ac</pattern>
+  <pattern>ie3de</pattern>
+  <pattern>ie4dro</pattern>
+  <pattern>ied3w</pattern>
+  <pattern>i1ee4</pattern>
+  <pattern>ieë2</pattern>
+  <pattern>ie3fi</pattern>
+  <pattern>ie2fl</pattern>
+  <pattern>ie3fle</pattern>
+  <pattern>ie3fon</pattern>
+  <pattern>ie4fr</pattern>
+  <pattern>ie4gas</pattern>
+  <pattern>ie3ge</pattern>
+  <pattern>ie4g5ins</pattern>
+  <pattern>i2ek</pattern>
+  <pattern>iek3e4v</pattern>
+  <pattern>ie4kl</pattern>
+  <pattern>iek3li</pattern>
+  <pattern>ie5klu</pattern>
+  <pattern>ie2kn</pattern>
+  <pattern>iek5ond</pattern>
+  <pattern>iek4s5n</pattern>
+  <pattern>iek4sp</pattern>
+  <pattern>ie2ku</pattern>
+  <pattern>ie3kwa</pattern>
+  <pattern>ie5lan</pattern>
+  <pattern>ie5lap</pattern>
+  <pattern>iel5do</pattern>
+  <pattern>iel5d4r</pattern>
+  <pattern>iel4e</pattern>
+  <pattern>iel5ei </pattern>
+  <pattern>iel5k</pattern>
+  <pattern>iel3sc</pattern>
+  <pattern>ie3ma</pattern>
+  <pattern>iem3ov</pattern>
+  <pattern>ien4dr</pattern>
+  <pattern>ien3ij</pattern>
+  <pattern>i3enn</pattern>
+  <pattern>i5enne </pattern>
+  <pattern>ien3s4m</pattern>
+  <pattern>ien5sp</pattern>
+  <pattern>ien4sta</pattern>
+  <pattern>ien4st5o</pattern>
+  <pattern>ien4str</pattern>
+  <pattern>ienst5ur</pattern>
+  <pattern>ieo4</pattern>
+  <pattern>i4ep</pattern>
+  <pattern>ie5pen</pattern>
+  <pattern>iepiet5</pattern>
+  <pattern>iep5oog</pattern>
+  <pattern>iepou5</pattern>
+  <pattern>iep5rel</pattern>
+  <pattern>iepro4s</pattern>
+  <pattern>iep3s4</pattern>
+  <pattern>iep5st</pattern>
+  <pattern>iep5tr</pattern>
+  <pattern>ie4pui</pattern>
+  <pattern>ie5r4ad</pattern>
+  <pattern>ier3a4l</pattern>
+  <pattern>ie3ram</pattern>
+  <pattern>ie3rap</pattern>
+  <pattern>ier3as</pattern>
+  <pattern>ie4rat</pattern>
+  <pattern>ier5el </pattern>
+  <pattern>ier5els</pattern>
+  <pattern>ie5ren </pattern>
+  <pattern>ie5ring</pattern>
+  <pattern>ierk4</pattern>
+  <pattern>ie3r2o</pattern>
+  <pattern>ie4rof</pattern>
+  <pattern>ier4sl</pattern>
+  <pattern>ier5slu</pattern>
+  <pattern>ie3ru</pattern>
+  <pattern>ier4ui</pattern>
+  <pattern>ie3sf</pattern>
+  <pattern>ie2si</pattern>
+  <pattern>ie4sl</pattern>
+  <pattern>ie5sle</pattern>
+  <pattern>ies3li</pattern>
+  <pattern>ies3m</pattern>
+  <pattern>ie2s3n</pattern>
+  <pattern>ie2so4</pattern>
+  <pattern>ie4s3pl</pattern>
+  <pattern>ie3sta</pattern>
+  <pattern>ies5te </pattern>
+  <pattern>ie5stel</pattern>
+  <pattern>ies5tere</pattern>
+  <pattern>ie3sto</pattern>
+  <pattern>ie4taa</pattern>
+  <pattern>ie5tal</pattern>
+  <pattern>iet5ant</pattern>
+  <pattern>ie5ten</pattern>
+  <pattern>ie3tj</pattern>
+  <pattern>ie3to4</pattern>
+  <pattern>ie4t3og</pattern>
+  <pattern>ie4too</pattern>
+  <pattern>ie4top</pattern>
+  <pattern>ie4tor</pattern>
+  <pattern>ieto5re</pattern>
+  <pattern>ie4t3ov</pattern>
+  <pattern>ie5troe</pattern>
+  <pattern>iets5te </pattern>
+  <pattern>iet3ur</pattern>
+  <pattern>iet3uu</pattern>
+  <pattern>ie3twi</pattern>
+  <pattern>i3ety</pattern>
+  <pattern>ie2u</pattern>
+  <pattern>ieu3k</pattern>
+  <pattern>i1eur</pattern>
+  <pattern>ieu5r4e</pattern>
+  <pattern>i1eus</pattern>
+  <pattern>ieu3sp</pattern>
+  <pattern>i1euz</pattern>
+  <pattern>ie3v</pattern>
+  <pattern>ie3z</pattern>
+  <pattern>iezel5a</pattern>
+  <pattern>i3és</pattern>
+  <pattern>i1ét</pattern>
+  <pattern>i1è</pattern>
+  <pattern>i4ëg</pattern>
+  <pattern>i4ëva</pattern>
+  <pattern>4if</pattern>
+  <pattern>if3aa</pattern>
+  <pattern>if3ad</pattern>
+  <pattern>if3l</pattern>
+  <pattern>if3r</pattern>
+  <pattern>if4ra</pattern>
+  <pattern>if4taa</pattern>
+  <pattern>if4tar</pattern>
+  <pattern>if4tre</pattern>
+  <pattern>iftu5r</pattern>
+  <pattern>if3ui</pattern>
+  <pattern>ig4a</pattern>
+  <pattern>ig3aa</pattern>
+  <pattern>ig5ac</pattern>
+  <pattern>i5gal</pattern>
+  <pattern>i4g5av</pattern>
+  <pattern>i3ge</pattern>
+  <pattern>ige2s</pattern>
+  <pattern>ig3esk</pattern>
+  <pattern>ig3ij</pattern>
+  <pattern>i4gind</pattern>
+  <pattern>igi3o</pattern>
+  <pattern>ig5no</pattern>
+  <pattern>i3g4om</pattern>
+  <pattern>ig4op</pattern>
+  <pattern>igs4</pattern>
+  <pattern>ig3sk</pattern>
+  <pattern>ig3sl</pattern>
+  <pattern>ig3sp</pattern>
+  <pattern>ig3sto</pattern>
+  <pattern>ig3un</pattern>
+  <pattern>i1h</pattern>
+  <pattern>i3i</pattern>
+  <pattern>i5ie</pattern>
+  <pattern>ii2n</pattern>
+  <pattern>i5is</pattern>
+  <pattern>i2j</pattern>
+  <pattern>4ij </pattern>
+  <pattern>ij5a</pattern>
+  <pattern>ija4d</pattern>
+  <pattern>4ijd</pattern>
+  <pattern>4ije</pattern>
+  <pattern>ij3ef</pattern>
+  <pattern>ij3ei</pattern>
+  <pattern>ij3el</pattern>
+  <pattern>ij5e4n3</pattern>
+  <pattern>ij1er</pattern>
+  <pattern>ij3i</pattern>
+  <pattern>4ijn</pattern>
+  <pattern>ij3o4</pattern>
+  <pattern>i3jou</pattern>
+  <pattern>4ijso</pattern>
+  <pattern>4ijsp</pattern>
+  <pattern>4ijst</pattern>
+  <pattern>ij5te</pattern>
+  <pattern>ij4tr</pattern>
+  <pattern>ij5u</pattern>
+  <pattern>4ijvo</pattern>
+  <pattern>4ijzo</pattern>
+  <pattern>4ik</pattern>
+  <pattern>ik3aar</pattern>
+  <pattern>i4kam</pattern>
+  <pattern>i3ke</pattern>
+  <pattern>ik3ef</pattern>
+  <pattern>ike4ra</pattern>
+  <pattern>iket3</pattern>
+  <pattern>i2kij</pattern>
+  <pattern>i3kl</pattern>
+  <pattern>ik3la</pattern>
+  <pattern>i4k3lo</pattern>
+  <pattern>i4k3lu</pattern>
+  <pattern>i2k4n</pattern>
+  <pattern>i4k5na</pattern>
+  <pattern>ik5o2g</pattern>
+  <pattern>i3kom</pattern>
+  <pattern>i2koo</pattern>
+  <pattern>iko2p</pattern>
+  <pattern>ik3ope</pattern>
+  <pattern>ik3ord</pattern>
+  <pattern>i4kr</pattern>
+  <pattern>ik3re</pattern>
+  <pattern>ik3ri</pattern>
+  <pattern>ik3ro</pattern>
+  <pattern>ik5se</pattern>
+  <pattern>ik5si</pattern>
+  <pattern>ik3s4l</pattern>
+  <pattern>iks3n</pattern>
+  <pattern>ik3sno</pattern>
+  <pattern>ik3sp</pattern>
+  <pattern>ik4spa</pattern>
+  <pattern>ik1st</pattern>
+  <pattern>ik5sta</pattern>
+  <pattern>iks5te </pattern>
+  <pattern>ik1w</pattern>
+  <pattern>ik5war</pattern>
+  <pattern>i1la</pattern>
+  <pattern>i3la </pattern>
+  <pattern>il4aa</pattern>
+  <pattern>il5aan</pattern>
+  <pattern>il3ac</pattern>
+  <pattern>il4act</pattern>
+  <pattern>il3ad</pattern>
+  <pattern>il3af</pattern>
+  <pattern>i3lak</pattern>
+  <pattern>il3al</pattern>
+  <pattern>i5land</pattern>
+  <pattern>il2da</pattern>
+  <pattern>il4d3r</pattern>
+  <pattern>ilds4</pattern>
+  <pattern>4i3le</pattern>
+  <pattern>il3een</pattern>
+  <pattern>ile3l</pattern>
+  <pattern>i4l3erv</pattern>
+  <pattern>ile4t</pattern>
+  <pattern>ilet5r</pattern>
+  <pattern>ile3u</pattern>
+  <pattern>il3e4ve</pattern>
+  <pattern>ilevin4</pattern>
+  <pattern>i4l3e2z</pattern>
+  <pattern>i3lé</pattern>
+  <pattern>il5f</pattern>
+  <pattern>i3li</pattern>
+  <pattern>ilie5g</pattern>
+  <pattern>ilie5t</pattern>
+  <pattern>il3ink</pattern>
+  <pattern>ilk4l</pattern>
+  <pattern>ilk3s2</pattern>
+  <pattern>illa3s</pattern>
+  <pattern>1illu</pattern>
+  <pattern>il2m</pattern>
+  <pattern>ilme2</pattern>
+  <pattern>il4min</pattern>
+  <pattern>il4mo</pattern>
+  <pattern>i1lo</pattern>
+  <pattern>ilo4ge</pattern>
+  <pattern>il3ond</pattern>
+  <pattern>i3loo</pattern>
+  <pattern>i5loon</pattern>
+  <pattern>il3oor</pattern>
+  <pattern>il1or</pattern>
+  <pattern>ilo4re</pattern>
+  <pattern>ilo4ve</pattern>
+  <pattern>il3s2h</pattern>
+  <pattern>ils5j</pattern>
+  <pattern>il4sti</pattern>
+  <pattern>il2th</pattern>
+  <pattern>i1lu</pattern>
+  <pattern>4im </pattern>
+  <pattern>i2mag</pattern>
+  <pattern>i4mago</pattern>
+  <pattern>im5au</pattern>
+  <pattern>imee4</pattern>
+  <pattern>im3een</pattern>
+  <pattern>i4m3em</pattern>
+  <pattern>im3enc</pattern>
+  <pattern>im3ex</pattern>
+  <pattern>4imf</pattern>
+  <pattern>i2m3of</pattern>
+  <pattern>im3op</pattern>
+  <pattern>im3org</pattern>
+  <pattern>im5pa</pattern>
+  <pattern>im4s3oo</pattern>
+  <pattern>im1st</pattern>
+  <pattern>i3mu</pattern>
+  <pattern>in1ac</pattern>
+  <pattern>i2nau</pattern>
+  <pattern>ind4aa</pattern>
+  <pattern>in4dene</pattern>
+  <pattern>ind3sc</pattern>
+  <pattern>ind5ste</pattern>
+  <pattern>1indu</pattern>
+  <pattern>in3e4de</pattern>
+  <pattern>in3edi</pattern>
+  <pattern>in3eed</pattern>
+  <pattern>inek4</pattern>
+  <pattern>ineo2</pattern>
+  <pattern>inet4s</pattern>
+  <pattern>i5neu</pattern>
+  <pattern>1inf</pattern>
+  <pattern>in2ga4</pattern>
+  <pattern>ing3aa</pattern>
+  <pattern>ing3ag</pattern>
+  <pattern>ing3al</pattern>
+  <pattern>3ingan</pattern>
+  <pattern>ing5lo</pattern>
+  <pattern>in2go</pattern>
+  <pattern>in4gr</pattern>
+  <pattern>ing4st</pattern>
+  <pattern>4ini </pattern>
+  <pattern>i3nie</pattern>
+  <pattern>ini5on</pattern>
+  <pattern>ini5sl</pattern>
+  <pattern>ini5sta</pattern>
+  <pattern>4inkj</pattern>
+  <pattern>in2kn</pattern>
+  <pattern>3inkom</pattern>
+  <pattern>in4kri</pattern>
+  <pattern>3inno</pattern>
+  <pattern>i1no</pattern>
+  <pattern>i3noc</pattern>
+  <pattern>i3nod</pattern>
+  <pattern>in4o2g</pattern>
+  <pattern>in1on</pattern>
+  <pattern>ino5pe</pattern>
+  <pattern>ino3s4t</pattern>
+  <pattern>in3ov</pattern>
+  <pattern>1inri</pattern>
+  <pattern>4ins </pattern>
+  <pattern>in5sch</pattern>
+  <pattern>in5se</pattern>
+  <pattern>in3sl</pattern>
+  <pattern>in3smi</pattern>
+  <pattern>in3so</pattern>
+  <pattern>in1sp</pattern>
+  <pattern>in5spo</pattern>
+  <pattern>in5sten</pattern>
+  <pattern>in5swi</pattern>
+  <pattern>in4t3ap</pattern>
+  <pattern>in5te</pattern>
+  <pattern>intes5</pattern>
+  <pattern>in3th</pattern>
+  <pattern>1int4r</pattern>
+  <pattern>i1nu</pattern>
+  <pattern>inuut3</pattern>
+  <pattern>4i1o</pattern>
+  <pattern>io5a</pattern>
+  <pattern>ioas5</pattern>
+  <pattern>io5b</pattern>
+  <pattern>i3o1c</pattern>
+  <pattern>i3ode</pattern>
+  <pattern>ioes3</pattern>
+  <pattern>io3f</pattern>
+  <pattern>io3g2</pattern>
+  <pattern>i3ol</pattern>
+  <pattern>i5ol </pattern>
+  <pattern>i5olen</pattern>
+  <pattern>i5olus</pattern>
+  <pattern>i3on</pattern>
+  <pattern>ioneel4</pattern>
+  <pattern>i5ong</pattern>
+  <pattern>ion4s3</pattern>
+  <pattern>ions5c</pattern>
+  <pattern>i5oo</pattern>
+  <pattern>i2op4</pattern>
+  <pattern>io3pa</pattern>
+  <pattern>io3pr</pattern>
+  <pattern>i3opt</pattern>
+  <pattern>io3ra</pattern>
+  <pattern>i3ori</pattern>
+  <pattern>io3ru</pattern>
+  <pattern>io4s</pattern>
+  <pattern>i3os </pattern>
+  <pattern>ios3c</pattern>
+  <pattern>i3o5se</pattern>
+  <pattern>i3o5sf</pattern>
+  <pattern>io5sh</pattern>
+  <pattern>io5si</pattern>
+  <pattern>i5osi </pattern>
+  <pattern>io5so</pattern>
+  <pattern>io5sp</pattern>
+  <pattern>io5s4t</pattern>
+  <pattern>i5o5su</pattern>
+  <pattern>i3osy</pattern>
+  <pattern>i5othek</pattern>
+  <pattern>i3oti</pattern>
+  <pattern>iot3j</pattern>
+  <pattern>i5otorens</pattern>
+  <pattern>io3tr</pattern>
+  <pattern>i2o3v</pattern>
+  <pattern>i3ox</pattern>
+  <pattern>i2oz</pattern>
+  <pattern>i1pa</pattern>
+  <pattern>i2p1ac</pattern>
+  <pattern>ip3af</pattern>
+  <pattern>i3pap</pattern>
+  <pattern>i1pe</pattern>
+  <pattern>i4perw</pattern>
+  <pattern>ipe4t3j</pattern>
+  <pattern>i1pi</pattern>
+  <pattern>ip1j</pattern>
+  <pattern>i1pl</pattern>
+  <pattern>ip3lu</pattern>
+  <pattern>i1po</pattern>
+  <pattern>ipo4g</pattern>
+  <pattern>i1pr</pattern>
+  <pattern>i2pri</pattern>
+  <pattern>ip3ru</pattern>
+  <pattern>i4ps</pattern>
+  <pattern>ipse4</pattern>
+  <pattern>ip4si</pattern>
+  <pattern>ip4sle</pattern>
+  <pattern>ips5te </pattern>
+  <pattern>ip5sten</pattern>
+  <pattern>i3ra</pattern>
+  <pattern>ira3k</pattern>
+  <pattern>i1r2e</pattern>
+  <pattern>ires4</pattern>
+  <pattern>ire3st</pattern>
+  <pattern>i3ré</pattern>
+  <pattern>i1ri</pattern>
+  <pattern>irk4s</pattern>
+  <pattern>i1ro</pattern>
+  <pattern>iro3p</pattern>
+  <pattern>iro5v</pattern>
+  <pattern>ir2s</pattern>
+  <pattern>ir4sc</pattern>
+  <pattern>ir3sp</pattern>
+  <pattern>ir5ste</pattern>
+  <pattern>irt3r</pattern>
+  <pattern>i1ru</pattern>
+  <pattern>4is</pattern>
+  <pattern>i1sa</pattern>
+  <pattern>i2saa</pattern>
+  <pattern>i4s3ad</pattern>
+  <pattern>is3a2g</pattern>
+  <pattern>is3ap</pattern>
+  <pattern>i2s1ar</pattern>
+  <pattern>i2s3as</pattern>
+  <pattern>i4sc</pattern>
+  <pattern>i5scha</pattern>
+  <pattern>i5schr</pattern>
+  <pattern>is5col</pattern>
+  <pattern>i5scoo</pattern>
+  <pattern>i5scope</pattern>
+  <pattern>ise2d</pattern>
+  <pattern>i4s3ei</pattern>
+  <pattern>is3ell</pattern>
+  <pattern>is5eng</pattern>
+  <pattern>i4s3erv</pattern>
+  <pattern>ise3st</pattern>
+  <pattern>iset3j</pattern>
+  <pattern>is4fee</pattern>
+  <pattern>is4fer</pattern>
+  <pattern>i4sh</pattern>
+  <pattern>is5ho</pattern>
+  <pattern>isi2d</pattern>
+  <pattern>i2sij</pattern>
+  <pattern>i2s3im</pattern>
+  <pattern>is3ja</pattern>
+  <pattern>i4sk</pattern>
+  <pattern>is3ka</pattern>
+  <pattern>is3ke</pattern>
+  <pattern>is3l</pattern>
+  <pattern>is5lag</pattern>
+  <pattern>is5las</pattern>
+  <pattern>is5le</pattern>
+  <pattern>i4s5m</pattern>
+  <pattern>i4s3n</pattern>
+  <pattern>is5ned</pattern>
+  <pattern>is5nij</pattern>
+  <pattern>is5no</pattern>
+  <pattern>5isol</pattern>
+  <pattern>i4soo</pattern>
+  <pattern>is4oor</pattern>
+  <pattern>iso3s</pattern>
+  <pattern>i2sot</pattern>
+  <pattern>is3ott</pattern>
+  <pattern>is3p</pattern>
+  <pattern>is5pas</pattern>
+  <pattern>is2pi</pattern>
+  <pattern>is5pl</pattern>
+  <pattern>is5q</pattern>
+  <pattern>is5sa</pattern>
+  <pattern>is5so</pattern>
+  <pattern>i2s3t</pattern>
+  <pattern>is1ta</pattern>
+  <pattern>i3stak</pattern>
+  <pattern>ist3ap</pattern>
+  <pattern>i4s5tas</pattern>
+  <pattern>is4tat</pattern>
+  <pattern>is5terd</pattern>
+  <pattern>is5tere</pattern>
+  <pattern>is4th</pattern>
+  <pattern>is1to</pattern>
+  <pattern>ist5ong</pattern>
+  <pattern>i3str</pattern>
+  <pattern>is5tri</pattern>
+  <pattern>i5stro </pattern>
+  <pattern>i3sty</pattern>
+  <pattern>isu2m</pattern>
+  <pattern>i5sy</pattern>
+  <pattern>4it</pattern>
+  <pattern>i1ta</pattern>
+  <pattern>it3ac</pattern>
+  <pattern>ita5d</pattern>
+  <pattern>it3een</pattern>
+  <pattern>i3ten</pattern>
+  <pattern>i3ter</pattern>
+  <pattern>ite5rei</pattern>
+  <pattern>ites4</pattern>
+  <pattern>ite3st</pattern>
+  <pattern>ite4t</pattern>
+  <pattern>it3hie</pattern>
+  <pattern>it1ho</pattern>
+  <pattern>it1hu</pattern>
+  <pattern>it2i</pattern>
+  <pattern>itie5st</pattern>
+  <pattern>i4tj</pattern>
+  <pattern>i1to</pattern>
+  <pattern>it5oef</pattern>
+  <pattern>it3oog</pattern>
+  <pattern>i3t2ou</pattern>
+  <pattern>i4to4v</pattern>
+  <pattern>itper5st</pattern>
+  <pattern>it3red</pattern>
+  <pattern>it1ru</pattern>
+  <pattern>it3sje</pattern>
+  <pattern>it3sli</pattern>
+  <pattern>it3sop</pattern>
+  <pattern>it1sp</pattern>
+  <pattern>its4te</pattern>
+  <pattern>it4ste </pattern>
+  <pattern>it4too</pattern>
+  <pattern>i3tu</pattern>
+  <pattern>it3w</pattern>
+  <pattern>4i3u2</pattern>
+  <pattern>iu4m</pattern>
+  <pattern>ium3a4</pattern>
+  <pattern>ium3e</pattern>
+  <pattern>ium3o</pattern>
+  <pattern>iu3r</pattern>
+  <pattern>i3ve</pattern>
+  <pattern>iven5s</pattern>
+  <pattern>ive3re</pattern>
+  <pattern>i5w</pattern>
+  <pattern>iwi2</pattern>
+  <pattern>iwie2</pattern>
+  <pattern>iwit3</pattern>
+  <pattern>4iz</pattern>
+  <pattern>i3ze</pattern>
+  <pattern>ize3t</pattern>
+  <pattern>î3</pattern>
+  <pattern>ît4</pattern>
+  <pattern>1ï</pattern>
+  <pattern>2ï </pattern>
+  <pattern>ï5a</pattern>
+  <pattern>ï1c</pattern>
+  <pattern>ï1d</pattern>
+  <pattern>ïe4n3</pattern>
+  <pattern>ïe5nen </pattern>
+  <pattern>ï2n3a</pattern>
+  <pattern>ïns5m</pattern>
+  <pattern>ïn3sp</pattern>
+  <pattern>ïn3u</pattern>
+  <pattern>ï3n4ur</pattern>
+  <pattern>ï3o</pattern>
+  <pattern>ï3ri</pattern>
+  <pattern>ï3ro</pattern>
+  <pattern>4ïs </pattern>
+  <pattern>ïs3a</pattern>
+  <pattern>ï4sc</pattern>
+  <pattern>ï5sche</pattern>
+  <pattern>ïs3l</pattern>
+  <pattern>ï3so</pattern>
+  <pattern>ïs3t</pattern>
+  <pattern>ï1t</pattern>
+  <pattern>ï5z</pattern>
+  <pattern>4j </pattern>
+  <pattern>1jaar</pattern>
+  <pattern>jaar5tj</pattern>
+  <pattern>ja3b</pattern>
+  <pattern>2jaf</pattern>
+  <pattern>1jag</pattern>
+  <pattern>jagers5</pattern>
+  <pattern>ja3kn</pattern>
+  <pattern>ja3mi</pattern>
+  <pattern>jan4s3l</pattern>
+  <pattern>jan4st</pattern>
+  <pattern>ja3pl</pattern>
+  <pattern>ja1po</pattern>
+  <pattern>1jar</pattern>
+  <pattern>jare4</pattern>
+  <pattern>1jas3</pattern>
+  <pattern>jas5p</pattern>
+  <pattern>3jaw</pattern>
+  <pattern>jaz4</pattern>
+  <pattern>j3b</pattern>
+  <pattern>jba4l</pattern>
+  <pattern>jbe4l3i</pattern>
+  <pattern>j1c</pattern>
+  <pattern>jda2</pattern>
+  <pattern>j2d3aa</pattern>
+  <pattern>jd3an</pattern>
+  <pattern>j4d3ar</pattern>
+  <pattern>j2d3ee</pattern>
+  <pattern>jde4n3e</pattern>
+  <pattern>jden4s</pattern>
+  <pattern>jdens5p</pattern>
+  <pattern>j4d3erv</pattern>
+  <pattern>jdes4</pattern>
+  <pattern>jde3sp</pattern>
+  <pattern>jde5st</pattern>
+  <pattern>jdi3a</pattern>
+  <pattern>j2do4</pattern>
+  <pattern>j3dom</pattern>
+  <pattern>jd5on</pattern>
+  <pattern>jd3op</pattern>
+  <pattern>j3dr</pattern>
+  <pattern>j4d3re</pattern>
+  <pattern>j4d1ri</pattern>
+  <pattern>j4d3ro</pattern>
+  <pattern>j4d3ru</pattern>
+  <pattern>jd5sei</pattern>
+  <pattern>jd3spo</pattern>
+  <pattern>jd1st</pattern>
+  <pattern>j2d3u</pattern>
+  <pattern>jd3w</pattern>
+  <pattern>j3d4wan</pattern>
+  <pattern>jea4</pattern>
+  <pattern>3jeba</pattern>
+  <pattern>je3ch</pattern>
+  <pattern>jec4ta</pattern>
+  <pattern>2j1ee</pattern>
+  <pattern>jel4</pattern>
+  <pattern>je3la</pattern>
+  <pattern>j1en</pattern>
+  <pattern>je2na2</pattern>
+  <pattern>je3n4o</pattern>
+  <pattern>5jep</pattern>
+  <pattern>jepiet5</pattern>
+  <pattern>je3ro</pattern>
+  <pattern>jers4</pattern>
+  <pattern>jer3sp</pattern>
+  <pattern>je4s3</pattern>
+  <pattern>3jesa</pattern>
+  <pattern>5jesal</pattern>
+  <pattern>je5sch</pattern>
+  <pattern>3jeskn</pattern>
+  <pattern>jes5l</pattern>
+  <pattern>jes5m</pattern>
+  <pattern>jeso2</pattern>
+  <pattern>jes5pa</pattern>
+  <pattern>jes4pr</pattern>
+  <pattern>3jesr</pattern>
+  <pattern>jes5tr</pattern>
+  <pattern>5jesvo</pattern>
+  <pattern>3jeswa</pattern>
+  <pattern>3jeswi</pattern>
+  <pattern>je2t</pattern>
+  <pattern>jet3er</pattern>
+  <pattern>jeto4v</pattern>
+  <pattern>jet5st</pattern>
+  <pattern>5jeu</pattern>
+  <pattern>3jevr</pattern>
+  <pattern>2jew</pattern>
+  <pattern>j3ex</pattern>
+  <pattern>j2f1a</pattern>
+  <pattern>j2f3ei</pattern>
+  <pattern>j2f1en5</pattern>
+  <pattern>j4f3ij</pattern>
+  <pattern>jf3ink</pattern>
+  <pattern>jf3l</pattern>
+  <pattern>j3f4lat</pattern>
+  <pattern>jf5le</pattern>
+  <pattern>j2f3o4</pattern>
+  <pattern>jf3r</pattern>
+  <pattern>j3f4ra</pattern>
+  <pattern>j3f4ro</pattern>
+  <pattern>jf2s</pattern>
+  <pattern>jfs3a</pattern>
+  <pattern>jf4sc</pattern>
+  <pattern>jf4s3er</pattern>
+  <pattern>jfs5f</pattern>
+  <pattern>jfs3l</pattern>
+  <pattern>jfs5m</pattern>
+  <pattern>jfs3n</pattern>
+  <pattern>jfs3p</pattern>
+  <pattern>jfs5pa</pattern>
+  <pattern>jf3st</pattern>
+  <pattern>jf4sta</pattern>
+  <pattern>jfs5tak</pattern>
+  <pattern>jf5stan</pattern>
+  <pattern>jf4stel</pattern>
+  <pattern>jf4sti</pattern>
+  <pattern>jf4s5to</pattern>
+  <pattern>jft2</pattern>
+  <pattern>jf5ti</pattern>
+  <pattern>jf5tw</pattern>
+  <pattern>j1g</pattern>
+  <pattern>j3ge</pattern>
+  <pattern>jger5sl</pattern>
+  <pattern>j2g3l</pattern>
+  <pattern>jg4s5e</pattern>
+  <pattern>jg3sn</pattern>
+  <pattern>jg2st</pattern>
+  <pattern>jg3s4te</pattern>
+  <pattern>j3h</pattern>
+  <pattern>jif3</pattern>
+  <pattern>j3ig</pattern>
+  <pattern>jin3g</pattern>
+  <pattern>ji5t2j</pattern>
+  <pattern>j3j</pattern>
+  <pattern>2jk</pattern>
+  <pattern>j3ka</pattern>
+  <pattern>j4kaa</pattern>
+  <pattern>jk5aard</pattern>
+  <pattern>j4kar</pattern>
+  <pattern>jk3arb</pattern>
+  <pattern>j4kau</pattern>
+  <pattern>j4kav</pattern>
+  <pattern>j2kij</pattern>
+  <pattern>j2k4l</pattern>
+  <pattern>j3klaa</pattern>
+  <pattern>jk5lak</pattern>
+  <pattern>jk5lap</pattern>
+  <pattern>jk5las</pattern>
+  <pattern>j4kle</pattern>
+  <pattern>j5kled</pattern>
+  <pattern>jk5les</pattern>
+  <pattern>jk5li</pattern>
+  <pattern>j3klon</pattern>
+  <pattern>jk5lop</pattern>
+  <pattern>jk5luc</pattern>
+  <pattern>j2kna</pattern>
+  <pattern>j2k3of</pattern>
+  <pattern>j4k3o4l</pattern>
+  <pattern>j2k3on</pattern>
+  <pattern>j2ko4p</pattern>
+  <pattern>jk3opb</pattern>
+  <pattern>jk3ope</pattern>
+  <pattern>jk3opl</pattern>
+  <pattern>j3kops</pattern>
+  <pattern>j2kr</pattern>
+  <pattern>j4kra</pattern>
+  <pattern>jk3raa</pattern>
+  <pattern>j5kran</pattern>
+  <pattern>jk3re</pattern>
+  <pattern>jk3ro</pattern>
+  <pattern>j4k5ru</pattern>
+  <pattern>jk3slo</pattern>
+  <pattern>jks3pl</pattern>
+  <pattern>jk4sta</pattern>
+  <pattern>jks5taak</pattern>
+  <pattern>jks5taal</pattern>
+  <pattern>jks5tak</pattern>
+  <pattern>jk5stan</pattern>
+  <pattern>j2k3ui</pattern>
+  <pattern>jk3w</pattern>
+  <pattern>j3k4was</pattern>
+  <pattern>j1la</pattern>
+  <pattern>j3laa</pattern>
+  <pattern>jl5ana</pattern>
+  <pattern>j1le</pattern>
+  <pattern>j2l3ef</pattern>
+  <pattern>j2l3el</pattern>
+  <pattern>jl5f</pattern>
+  <pattern>jl3ink</pattern>
+  <pattern>j1lo</pattern>
+  <pattern>j2loe</pattern>
+  <pattern>j3lu</pattern>
+  <pattern>j2m3af</pattern>
+  <pattern>j5m4ar</pattern>
+  <pattern>j3mi</pattern>
+  <pattern>jm3op</pattern>
+  <pattern>jm3s</pattern>
+  <pattern>j2n1a4</pattern>
+  <pattern>j4naa</pattern>
+  <pattern>jn5ac</pattern>
+  <pattern>j3na5g</pattern>
+  <pattern>jn3ak</pattern>
+  <pattern>jn2am</pattern>
+  <pattern>jna5me</pattern>
+  <pattern>j3n4an</pattern>
+  <pattern>jn5d2r</pattern>
+  <pattern>j2nef</pattern>
+  <pattern>jne4n</pattern>
+  <pattern>j4n3erk</pattern>
+  <pattern>j4n3erv</pattern>
+  <pattern>jn3gl</pattern>
+  <pattern>j4n3im</pattern>
+  <pattern>j4n3ink</pattern>
+  <pattern>jn3k4</pattern>
+  <pattern>j2n1o4</pattern>
+  <pattern>jn4si</pattern>
+  <pattern>jn2s3l</pattern>
+  <pattern>jns5lac</pattern>
+  <pattern>jn3slu</pattern>
+  <pattern>jns5or</pattern>
+  <pattern>jn2sp</pattern>
+  <pattern>jns3pl</pattern>
+  <pattern>jn1st</pattern>
+  <pattern>jn4ste </pattern>
+  <pattern>jnt4</pattern>
+  <pattern>jn3tr</pattern>
+  <pattern>joet3</pattern>
+  <pattern>4joi</pattern>
+  <pattern>jol4e</pattern>
+  <pattern>jo5lij</pattern>
+  <pattern>j3om</pattern>
+  <pattern>1j4on</pattern>
+  <pattern>jone2</pattern>
+  <pattern>j3op</pattern>
+  <pattern>jo3pe</pattern>
+  <pattern>jo3ra</pattern>
+  <pattern>jo3ru</pattern>
+  <pattern>j4ou</pattern>
+  <pattern>1jour</pattern>
+  <pattern>jou5re</pattern>
+  <pattern>joy3</pattern>
+  <pattern>j3pa</pattern>
+  <pattern>j4p3ac</pattern>
+  <pattern>jp3arm</pattern>
+  <pattern>j1pe</pattern>
+  <pattern>j2p3em</pattern>
+  <pattern>jp3ij</pattern>
+  <pattern>j1pin</pattern>
+  <pattern>j3pio</pattern>
+  <pattern>jp1j</pattern>
+  <pattern>j1pla</pattern>
+  <pattern>jp3li</pattern>
+  <pattern>j1po</pattern>
+  <pattern>j2p3or</pattern>
+  <pattern>j4pre</pattern>
+  <pattern>jp3ri</pattern>
+  <pattern>jp3rok</pattern>
+  <pattern>jps4</pattern>
+  <pattern>j3r</pattern>
+  <pattern>jraads5</pattern>
+  <pattern>2js</pattern>
+  <pattern>js1a</pattern>
+  <pattern>j4sef</pattern>
+  <pattern>j4s3ela</pattern>
+  <pattern>j5seli</pattern>
+  <pattern>j4s5em</pattern>
+  <pattern>j4s3e4r</pattern>
+  <pattern>j2s1i</pattern>
+  <pattern>js5in</pattern>
+  <pattern>js4ir</pattern>
+  <pattern>js4le</pattern>
+  <pattern>js3lee</pattern>
+  <pattern>js3li</pattern>
+  <pattern>js5lie</pattern>
+  <pattern>js4me</pattern>
+  <pattern>js5mel</pattern>
+  <pattern>js5met</pattern>
+  <pattern>js3n</pattern>
+  <pattern>j4s1o4</pattern>
+  <pattern>j5soe</pattern>
+  <pattern>js3ol</pattern>
+  <pattern>js3pac</pattern>
+  <pattern>js3par</pattern>
+  <pattern>j3spe</pattern>
+  <pattern>js3pl</pattern>
+  <pattern>j4spo</pattern>
+  <pattern>js3poo</pattern>
+  <pattern>jspoort5j</pattern>
+  <pattern>j5spor</pattern>
+  <pattern>j1sta</pattern>
+  <pattern>j4star</pattern>
+  <pattern>j2s3te</pattern>
+  <pattern>j3stee</pattern>
+  <pattern>j3s4tek</pattern>
+  <pattern>j3s4tel</pattern>
+  <pattern>j5s4teng</pattern>
+  <pattern>js3th</pattern>
+  <pattern>js4tij</pattern>
+  <pattern>j5stond</pattern>
+  <pattern>j4stoo</pattern>
+  <pattern>js3tou</pattern>
+  <pattern>jst5ran</pattern>
+  <pattern>j5strok</pattern>
+  <pattern>j2su</pattern>
+  <pattern>j3sy</pattern>
+  <pattern>j3taal</pattern>
+  <pattern>jt3aar</pattern>
+  <pattern>jt1ac</pattern>
+  <pattern>j1tag</pattern>
+  <pattern>j3tak</pattern>
+  <pattern>j3tan</pattern>
+  <pattern>j3te </pattern>
+  <pattern>jt1h</pattern>
+  <pattern>j3toe</pattern>
+  <pattern>jt3opt</pattern>
+  <pattern>j3tr</pattern>
+  <pattern>jt3ra</pattern>
+  <pattern>j5tred</pattern>
+  <pattern>j5tree</pattern>
+  <pattern>jt3rei</pattern>
+  <pattern>j5trek</pattern>
+  <pattern>jt3ri</pattern>
+  <pattern>j5trok</pattern>
+  <pattern>jt3rot</pattern>
+  <pattern>jt1s</pattern>
+  <pattern>j1tu</pattern>
+  <pattern>1j4u</pattern>
+  <pattern>ju3d</pattern>
+  <pattern>4jum</pattern>
+  <pattern>jus3</pattern>
+  <pattern>juve5</pattern>
+  <pattern>j3v</pattern>
+  <pattern>jve2n</pattern>
+  <pattern>jver4s</pattern>
+  <pattern>jvers5p</pattern>
+  <pattern>jve3t</pattern>
+  <pattern>jvie5s</pattern>
+  <pattern>j1w</pattern>
+  <pattern>jze4r5o</pattern>
+  <pattern>4k </pattern>
+  <pattern>1ka</pattern>
+  <pattern>k3aanb</pattern>
+  <pattern>k3aanl</pattern>
+  <pattern>5kaart</pattern>
+  <pattern>kaart5jes</pattern>
+  <pattern>kaats5te </pattern>
+  <pattern>kabe2</pattern>
+  <pattern>ka3bo</pattern>
+  <pattern>2k1ac</pattern>
+  <pattern>kade4t5</pattern>
+  <pattern>4k3adm</pattern>
+  <pattern>ka3do</pattern>
+  <pattern>k3adv</pattern>
+  <pattern>2kaf</pattern>
+  <pattern>k3afd</pattern>
+  <pattern>k4aff</pattern>
+  <pattern>ka3fl</pattern>
+  <pattern>3k4aft</pattern>
+  <pattern>ka4ga</pattern>
+  <pattern>k3a4gen</pattern>
+  <pattern>k3ah</pattern>
+  <pattern>ka3i</pattern>
+  <pattern>2k3alb</pattern>
+  <pattern>ka3le</pattern>
+  <pattern>5kalf</pattern>
+  <pattern>kalf4s5</pattern>
+  <pattern>ka3l4i</pattern>
+  <pattern>kal2k</pattern>
+  <pattern>kalk3a</pattern>
+  <pattern>4kalt</pattern>
+  <pattern>5kalv</pattern>
+  <pattern>3kam</pattern>
+  <pattern>4kamb</pattern>
+  <pattern>kamen4</pattern>
+  <pattern>kame4re</pattern>
+  <pattern>kam4pa</pattern>
+  <pattern>kam4pl</pattern>
+  <pattern>kam4pr</pattern>
+  <pattern>ka5naa</pattern>
+  <pattern>kan5d</pattern>
+  <pattern>4kang</pattern>
+  <pattern>kan4sl</pattern>
+  <pattern>kan4st</pattern>
+  <pattern>kan4t3j</pattern>
+  <pattern>kao3</pattern>
+  <pattern>5kap </pattern>
+  <pattern>ka3pe</pattern>
+  <pattern>kap3l</pattern>
+  <pattern>ka1po</pattern>
+  <pattern>4kappa</pattern>
+  <pattern>ka3pr</pattern>
+  <pattern>kap3s</pattern>
+  <pattern>k3arc</pattern>
+  <pattern>k4a3ro</pattern>
+  <pattern>kart4</pattern>
+  <pattern>4k3arti</pattern>
+  <pattern>kar3tr</pattern>
+  <pattern>ka4s</pattern>
+  <pattern>kas5c</pattern>
+  <pattern>4k3asi</pattern>
+  <pattern>kast3o4</pattern>
+  <pattern>ka3str</pattern>
+  <pattern>kast5ra</pattern>
+  <pattern>ka5stro</pattern>
+  <pattern>kas3u4r</pattern>
+  <pattern>kat5aal</pattern>
+  <pattern>ka4t5a4le</pattern>
+  <pattern>ka4tan</pattern>
+  <pattern>kati4</pattern>
+  <pattern>ka4t5io</pattern>
+  <pattern>kat5j</pattern>
+  <pattern>k3atl</pattern>
+  <pattern>kato4</pattern>
+  <pattern>ka4t3og</pattern>
+  <pattern>ka5tr</pattern>
+  <pattern>kat3s</pattern>
+  <pattern>2k1aut</pattern>
+  <pattern>2kavo</pattern>
+  <pattern>2k3b</pattern>
+  <pattern>2k1c</pattern>
+  <pattern>k3ca</pattern>
+  <pattern>2k5d</pattern>
+  <pattern>kdi3a</pattern>
+  <pattern>1ke</pattern>
+  <pattern>k4eb</pattern>
+  <pattern>2k3ec</pattern>
+  <pattern>ke4di</pattern>
+  <pattern>2k3een</pattern>
+  <pattern>kee4p5l</pattern>
+  <pattern>kee4r</pattern>
+  <pattern>keer4s</pattern>
+  <pattern>keers5to</pattern>
+  <pattern>2kef</pattern>
+  <pattern>4keff</pattern>
+  <pattern>k4ei </pattern>
+  <pattern>k4eie</pattern>
+  <pattern>k2eil</pattern>
+  <pattern>kei3s4</pattern>
+  <pattern>kei5t</pattern>
+  <pattern>ke4lap</pattern>
+  <pattern>kel5da</pattern>
+  <pattern>kel5dr</pattern>
+  <pattern>ke5lel</pattern>
+  <pattern>4kelem</pattern>
+  <pattern>kel5f</pattern>
+  <pattern>ke4l5int</pattern>
+  <pattern>ke4lom</pattern>
+  <pattern>ke4l3op</pattern>
+  <pattern>kel3sp</pattern>
+  <pattern>5k4ema</pattern>
+  <pattern>2kemm</pattern>
+  <pattern>2kemp</pattern>
+  <pattern>ke4n3an</pattern>
+  <pattern>ke4nau</pattern>
+  <pattern>ken4ei </pattern>
+  <pattern>ke5nen</pattern>
+  <pattern>ken5k</pattern>
+  <pattern>ke2n1o</pattern>
+  <pattern>kens5po</pattern>
+  <pattern>kepie5t</pattern>
+  <pattern>4k3e4q</pattern>
+  <pattern>ke3ram</pattern>
+  <pattern>ke4r5enk</pattern>
+  <pattern>ker3kl</pattern>
+  <pattern>ker4kle</pattern>
+  <pattern>ker4kn</pattern>
+  <pattern>ker4k3r</pattern>
+  <pattern>ker4ku</pattern>
+  <pattern>ker4kw</pattern>
+  <pattern>ker4n3a</pattern>
+  <pattern>ker4no</pattern>
+  <pattern>ker3o4</pattern>
+  <pattern>ke3ros</pattern>
+  <pattern>ker4sm</pattern>
+  <pattern>ker5spe</pattern>
+  <pattern>ker4spr</pattern>
+  <pattern>ker4sta</pattern>
+  <pattern>ker5ste </pattern>
+  <pattern>ker4sti</pattern>
+  <pattern>4k3erts</pattern>
+  <pattern>4kerva</pattern>
+  <pattern>4kerwt</pattern>
+  <pattern>ke2s</pattern>
+  <pattern>ke3s4p</pattern>
+  <pattern>ke3sta</pattern>
+  <pattern>kes5ten</pattern>
+  <pattern>ke3sto</pattern>
+  <pattern>ke5straa</pattern>
+  <pattern>k2et</pattern>
+  <pattern>5ketel</pattern>
+  <pattern>ke2t3j</pattern>
+  <pattern>ke3to</pattern>
+  <pattern>ke2t3r</pattern>
+  <pattern>kets5te </pattern>
+  <pattern>ketting5s</pattern>
+  <pattern>4k3e2tu</pattern>
+  <pattern>ket3w</pattern>
+  <pattern>3k2eu</pattern>
+  <pattern>keviet5</pattern>
+  <pattern>ke4vl</pattern>
+  <pattern>4k1ex</pattern>
+  <pattern>2k3e2z</pattern>
+  <pattern>2k1f</pattern>
+  <pattern>2k3g</pattern>
+  <pattern>2k1h4</pattern>
+  <pattern>k3ho</pattern>
+  <pattern>khoud5s</pattern>
+  <pattern>1ki</pattern>
+  <pattern>2ki2d</pattern>
+  <pattern>4kied</pattern>
+  <pattern>kie4sp</pattern>
+  <pattern>kie4s4t</pattern>
+  <pattern>kie5ste</pattern>
+  <pattern>kie4tj</pattern>
+  <pattern>kieze4</pattern>
+  <pattern>2kië</pattern>
+  <pattern>kijk5l</pattern>
+  <pattern>k3ijs</pattern>
+  <pattern>4kijv</pattern>
+  <pattern>4k1ijz</pattern>
+  <pattern>ki3lo</pattern>
+  <pattern>kilo5v</pattern>
+  <pattern>ki3na</pattern>
+  <pattern>4kinb</pattern>
+  <pattern>4k5indel</pattern>
+  <pattern>kinds5te </pattern>
+  <pattern>4kindu</pattern>
+  <pattern>kin3en</pattern>
+  <pattern>5king</pattern>
+  <pattern>kings5l</pattern>
+  <pattern>2k3inh</pattern>
+  <pattern>kinie4</pattern>
+  <pattern>k3inko</pattern>
+  <pattern>4k1inr</pattern>
+  <pattern>2k1ins</pattern>
+  <pattern>2k3int</pattern>
+  <pattern>4k3inv</pattern>
+  <pattern>ki3o</pattern>
+  <pattern>ki2p3l</pattern>
+  <pattern>ki5se</pattern>
+  <pattern>ki3s4p</pattern>
+  <pattern>kit4s</pattern>
+  <pattern>kits5te</pattern>
+  <pattern>k1j</pattern>
+  <pattern>2k3ja</pattern>
+  <pattern>k3jew</pattern>
+  <pattern>k3jo</pattern>
+  <pattern>2k3ju</pattern>
+  <pattern>4k5k4</pattern>
+  <pattern>kke5nei</pattern>
+  <pattern>kker4s</pattern>
+  <pattern>kkers5ten</pattern>
+  <pattern>kke3st</pattern>
+  <pattern>1k2l4</pattern>
+  <pattern>5klac</pattern>
+  <pattern>k3ladi</pattern>
+  <pattern>kla2p1</pattern>
+  <pattern>k4las</pattern>
+  <pattern>5klas </pattern>
+  <pattern>5klass</pattern>
+  <pattern>k3last</pattern>
+  <pattern>k3lat </pattern>
+  <pattern>k3latt</pattern>
+  <pattern>3k4lav</pattern>
+  <pattern>3k4led</pattern>
+  <pattern>5kledi</pattern>
+  <pattern>5kleed</pattern>
+  <pattern>k5leer </pattern>
+  <pattern>4k5leg</pattern>
+  <pattern>5klem</pattern>
+  <pattern>4k5len</pattern>
+  <pattern>k3ler </pattern>
+  <pattern>4klera</pattern>
+  <pattern>k3lers</pattern>
+  <pattern>k3les</pattern>
+  <pattern>5k4le4u</pattern>
+  <pattern>k5lic</pattern>
+  <pattern>4klid</pattern>
+  <pattern>k3lig</pattern>
+  <pattern>2k3lij</pattern>
+  <pattern>4klijs</pattern>
+  <pattern>k4lim</pattern>
+  <pattern>kli4me</pattern>
+  <pattern>3k4lin</pattern>
+  <pattern>k5lob</pattern>
+  <pattern>4klod</pattern>
+  <pattern>3klok</pattern>
+  <pattern>5klok </pattern>
+  <pattern>k5loka</pattern>
+  <pattern>k3loke</pattern>
+  <pattern>k3lood</pattern>
+  <pattern>5kloof</pattern>
+  <pattern>k3lope</pattern>
+  <pattern>5klos</pattern>
+  <pattern>klots5te </pattern>
+  <pattern>2k5loz</pattern>
+  <pattern>4kluc</pattern>
+  <pattern>4kluih</pattern>
+  <pattern>2k1m</pattern>
+  <pattern>k3ma</pattern>
+  <pattern>1k2n4</pattern>
+  <pattern>4knam</pattern>
+  <pattern>k4nap</pattern>
+  <pattern>3k4nar</pattern>
+  <pattern>5knec</pattern>
+  <pattern>k5nem</pattern>
+  <pattern>kni2</pattern>
+  <pattern>5knie </pattern>
+  <pattern>knip1</pattern>
+  <pattern>4k5niv</pattern>
+  <pattern>3knol</pattern>
+  <pattern>k3note</pattern>
+  <pattern>2knum</pattern>
+  <pattern>1ko</pattern>
+  <pattern>ko4bl</pattern>
+  <pattern>k4oc</pattern>
+  <pattern>2k5oct</pattern>
+  <pattern>4k1oef</pattern>
+  <pattern>5koek</pattern>
+  <pattern>koe4ket</pattern>
+  <pattern>koers5p</pattern>
+  <pattern>koes3</pattern>
+  <pattern>koe3tj</pattern>
+  <pattern>koets5te </pattern>
+  <pattern>koge4</pattern>
+  <pattern>5ko5gr</pattern>
+  <pattern>3k4ok</pattern>
+  <pattern>ko5ko</pattern>
+  <pattern>kol2e2</pattern>
+  <pattern>kolen3</pattern>
+  <pattern>2kolm</pattern>
+  <pattern>5kolo</pattern>
+  <pattern>ko4ly</pattern>
+  <pattern>ko2m3a</pattern>
+  <pattern>4komg</pattern>
+  <pattern>kom5p</pattern>
+  <pattern>k3omsl</pattern>
+  <pattern>kom4str</pattern>
+  <pattern>4komz</pattern>
+  <pattern>konge4</pattern>
+  <pattern>k4oni</pattern>
+  <pattern>k3ontb</pattern>
+  <pattern>kon4t3j</pattern>
+  <pattern>kon4t3r</pattern>
+  <pattern>koo4</pattern>
+  <pattern>2k1oog</pattern>
+  <pattern>kooi5tj</pattern>
+  <pattern>koot3</pattern>
+  <pattern>koot4j</pattern>
+  <pattern>ko3pa</pattern>
+  <pattern>4kopb</pattern>
+  <pattern>4k3opd</pattern>
+  <pattern>ko1pe</pattern>
+  <pattern>ko5pen </pattern>
+  <pattern>4kopg</pattern>
+  <pattern>3ko5pi</pattern>
+  <pattern>5kopj</pattern>
+  <pattern>ko2pl</pattern>
+  <pattern>2kops</pattern>
+  <pattern>4kopz</pattern>
+  <pattern>2kord</pattern>
+  <pattern>kor5do</pattern>
+  <pattern>2k1org</pattern>
+  <pattern>2k3ork</pattern>
+  <pattern>kors5te </pattern>
+  <pattern>kor4ta</pattern>
+  <pattern>kor4t3o4</pattern>
+  <pattern>kor4tr</pattern>
+  <pattern>ko3ru</pattern>
+  <pattern>3k4o4s3</pattern>
+  <pattern>4k3os </pattern>
+  <pattern>kos4j</pattern>
+  <pattern>ko5sjere</pattern>
+  <pattern>koso4</pattern>
+  <pattern>4koss</pattern>
+  <pattern>kot4st</pattern>
+  <pattern>kots5te </pattern>
+  <pattern>4k1ov</pattern>
+  <pattern>4k3ox</pattern>
+  <pattern>2k3p</pattern>
+  <pattern>kpi3s</pattern>
+  <pattern>k4plam</pattern>
+  <pattern>kpren4</pattern>
+  <pattern>1kr4</pattern>
+  <pattern>3kra</pattern>
+  <pattern>k5raad</pattern>
+  <pattern>kraads5</pattern>
+  <pattern>kra4b</pattern>
+  <pattern>4k5rad</pattern>
+  <pattern>k5rand</pattern>
+  <pattern>2k1rea</pattern>
+  <pattern>2k3rec</pattern>
+  <pattern>4k3rede</pattern>
+  <pattern>k4ree4</pattern>
+  <pattern>k5reep</pattern>
+  <pattern>kreet3</pattern>
+  <pattern>k3ref</pattern>
+  <pattern>k2reg</pattern>
+  <pattern>2k3rel</pattern>
+  <pattern>2k1ric</pattern>
+  <pattern>k3rijk</pattern>
+  <pattern>k3rijp</pattern>
+  <pattern>krij4t</pattern>
+  <pattern>krijt5j</pattern>
+  <pattern>k4rit</pattern>
+  <pattern>k5ritm</pattern>
+  <pattern>kroet5j</pattern>
+  <pattern>2krol</pattern>
+  <pattern>k4ron</pattern>
+  <pattern>kron3t</pattern>
+  <pattern>5kroon</pattern>
+  <pattern>krop3a</pattern>
+  <pattern>kro4to</pattern>
+  <pattern>2krou</pattern>
+  <pattern>k3ro5v</pattern>
+  <pattern>3k4ru</pattern>
+  <pattern>k5rub</pattern>
+  <pattern>5kruis</pattern>
+  <pattern>kru4l</pattern>
+  <pattern>krul5a</pattern>
+  <pattern>2ks</pattern>
+  <pattern>k3sal</pattern>
+  <pattern>ks3alm</pattern>
+  <pattern>ks3an</pattern>
+  <pattern>ks3ap</pattern>
+  <pattern>ks1ar</pattern>
+  <pattern>ks3as</pattern>
+  <pattern>ks2e2</pattern>
+  <pattern>k5sec</pattern>
+  <pattern>ks3ed</pattern>
+  <pattern>ks5ei </pattern>
+  <pattern>ks3ep</pattern>
+  <pattern>k4serv</pattern>
+  <pattern>ks3et</pattern>
+  <pattern>kse3v</pattern>
+  <pattern>ksges5t</pattern>
+  <pattern>k4si</pattern>
+  <pattern>k5sil</pattern>
+  <pattern>ks1in</pattern>
+  <pattern>k5sis</pattern>
+  <pattern>k5sit</pattern>
+  <pattern>ks1j</pattern>
+  <pattern>k1sla</pattern>
+  <pattern>ks3lab</pattern>
+  <pattern>k4slan</pattern>
+  <pattern>ks3le</pattern>
+  <pattern>ks3li</pattern>
+  <pattern>k4smo</pattern>
+  <pattern>ks3na</pattern>
+  <pattern>ks3no</pattern>
+  <pattern>ks3nu</pattern>
+  <pattern>kso4</pattern>
+  <pattern>ks3om</pattern>
+  <pattern>k5song</pattern>
+  <pattern>k2s3pa</pattern>
+  <pattern>ks5pand</pattern>
+  <pattern>k4spar</pattern>
+  <pattern>k1spe</pattern>
+  <pattern>k3spi</pattern>
+  <pattern>ks3poo</pattern>
+  <pattern>k5spor</pattern>
+  <pattern>ks3pot</pattern>
+  <pattern>ks3pru</pattern>
+  <pattern>k3spu</pattern>
+  <pattern>ks5s</pattern>
+  <pattern>ks4t</pattern>
+  <pattern>k1sta</pattern>
+  <pattern>k5staan</pattern>
+  <pattern>k5staat</pattern>
+  <pattern>k1ste</pattern>
+  <pattern>ks5tec</pattern>
+  <pattern>k4st3ed</pattern>
+  <pattern>k3sten</pattern>
+  <pattern>ks5tent</pattern>
+  <pattern>kste4r</pattern>
+  <pattern>kster5a</pattern>
+  <pattern>k4sterr</pattern>
+  <pattern>ks3th</pattern>
+  <pattern>k3sti</pattern>
+  <pattern>k3sto</pattern>
+  <pattern>ks5ton</pattern>
+  <pattern>k5stoo</pattern>
+  <pattern>k4stop</pattern>
+  <pattern>k5stot</pattern>
+  <pattern>ks5trek</pattern>
+  <pattern>ks3tri</pattern>
+  <pattern>k3stue</pattern>
+  <pattern>kst5uit</pattern>
+  <pattern>k1sy</pattern>
+  <pattern>4kt</pattern>
+  <pattern>k1ta</pattern>
+  <pattern>kt3aan</pattern>
+  <pattern>k3taar</pattern>
+  <pattern>ktaat5</pattern>
+  <pattern>kt3ac</pattern>
+  <pattern>kt3art</pattern>
+  <pattern>k3te</pattern>
+  <pattern>kte2c</pattern>
+  <pattern>kt3eco</pattern>
+  <pattern>k4tex</pattern>
+  <pattern>kt1h</pattern>
+  <pattern>k5tij</pattern>
+  <pattern>kt3im</pattern>
+  <pattern>kt3in</pattern>
+  <pattern>k5tit</pattern>
+  <pattern>kt3j</pattern>
+  <pattern>k1to</pattern>
+  <pattern>kt3om</pattern>
+  <pattern>kto4p</pattern>
+  <pattern>kt4or</pattern>
+  <pattern>kt5ord</pattern>
+  <pattern>kt5org</pattern>
+  <pattern>kt5ori</pattern>
+  <pattern>kt3o4v</pattern>
+  <pattern>k1tr</pattern>
+  <pattern>kt3res</pattern>
+  <pattern>k5troll</pattern>
+  <pattern>ktro3s</pattern>
+  <pattern>k3tu</pattern>
+  <pattern>1ku</pattern>
+  <pattern>ku5be</pattern>
+  <pattern>kui2f</pattern>
+  <pattern>2kuit</pattern>
+  <pattern>ku5k</pattern>
+  <pattern>ku5me</pattern>
+  <pattern>3k4u2n</pattern>
+  <pattern>4k5uni</pattern>
+  <pattern>5kuns</pattern>
+  <pattern>ku2r</pattern>
+  <pattern>ku3ra</pattern>
+  <pattern>ku3re</pattern>
+  <pattern>kur3s</pattern>
+  <pattern>3ku2s</pattern>
+  <pattern>kut3</pattern>
+  <pattern>2kû</pattern>
+  <pattern>2kv</pattern>
+  <pattern>k3ve</pattern>
+  <pattern>kven4t3</pattern>
+  <pattern>5k4waal</pattern>
+  <pattern>2k3wac</pattern>
+  <pattern>k2wad</pattern>
+  <pattern>k1wag</pattern>
+  <pattern>5k2wal</pattern>
+  <pattern>5k2wam</pattern>
+  <pattern>3k4war</pattern>
+  <pattern>k5ware</pattern>
+  <pattern>4kwat</pattern>
+  <pattern>k3weer</pattern>
+  <pattern>2kweg</pattern>
+  <pattern>k1wei</pattern>
+  <pattern>5kwel</pattern>
+  <pattern>kwen4st</pattern>
+  <pattern>kwens5te </pattern>
+  <pattern>4k1wer</pattern>
+  <pattern>5k2wes1</pattern>
+  <pattern>kwes5tr</pattern>
+  <pattern>5kwets</pattern>
+  <pattern>k2wie</pattern>
+  <pattern>k3wijz</pattern>
+  <pattern>k4wik</pattern>
+  <pattern>2kwil</pattern>
+  <pattern>2kwin</pattern>
+  <pattern>k3wind</pattern>
+  <pattern>4k1wo</pattern>
+  <pattern>ky3</pattern>
+  <pattern>2kz</pattern>
+  <pattern>4l </pattern>
+  <pattern>2laan</pattern>
+  <pattern>4laand</pattern>
+  <pattern>l3aanh</pattern>
+  <pattern>laa5re</pattern>
+  <pattern>laar5tj</pattern>
+  <pattern>laat5sta</pattern>
+  <pattern>l3abon</pattern>
+  <pattern>2lac</pattern>
+  <pattern>la4ca</pattern>
+  <pattern>5lach </pattern>
+  <pattern>la4cha</pattern>
+  <pattern>5lache</pattern>
+  <pattern>lach5te</pattern>
+  <pattern>lacht4s</pattern>
+  <pattern>l4aci</pattern>
+  <pattern>la2d5a</pattern>
+  <pattern>la4det</pattern>
+  <pattern>2ladj</pattern>
+  <pattern>4ladm</pattern>
+  <pattern>la2d3o</pattern>
+  <pattern>4la2dr</pattern>
+  <pattern>lad5s</pattern>
+  <pattern>la2du</pattern>
+  <pattern>4ladv</pattern>
+  <pattern>3lae3</pattern>
+  <pattern>2laf</pattern>
+  <pattern>la2fa</pattern>
+  <pattern>la3fl</pattern>
+  <pattern>lafo2</pattern>
+  <pattern>4l3afs</pattern>
+  <pattern>la2g3a</pattern>
+  <pattern>la4gent</pattern>
+  <pattern>la2go</pattern>
+  <pattern>lag3r</pattern>
+  <pattern>lags4</pattern>
+  <pattern>lag5sa</pattern>
+  <pattern>la2k3a</pattern>
+  <pattern>la4ki</pattern>
+  <pattern>la3kr</pattern>
+  <pattern>2lal</pattern>
+  <pattern>3lald</pattern>
+  <pattern>lal4o</pattern>
+  <pattern>lam4p3j</pattern>
+  <pattern>lam4p5l</pattern>
+  <pattern>lam4po4</pattern>
+  <pattern>lam4s3p</pattern>
+  <pattern>l4an</pattern>
+  <pattern>4la2na</pattern>
+  <pattern>lan3ac</pattern>
+  <pattern>3land</pattern>
+  <pattern>lan4da</pattern>
+  <pattern>land5aa</pattern>
+  <pattern>lan4d5oo</pattern>
+  <pattern>lan4d3r</pattern>
+  <pattern>lands5te </pattern>
+  <pattern>la4n3ec</pattern>
+  <pattern>lanel5</pattern>
+  <pattern>5lange </pattern>
+  <pattern>lang5l</pattern>
+  <pattern>lang5sp</pattern>
+  <pattern>lang5sta</pattern>
+  <pattern>lan4k3a</pattern>
+  <pattern>lan4k3l</pattern>
+  <pattern>lank3w</pattern>
+  <pattern>4lann</pattern>
+  <pattern>la4nor</pattern>
+  <pattern>lan2s</pattern>
+  <pattern>lans3l</pattern>
+  <pattern>lan4st</pattern>
+  <pattern>lan4t3j</pattern>
+  <pattern>lap3ac</pattern>
+  <pattern>la3pi</pattern>
+  <pattern>lap3l</pattern>
+  <pattern>lap3o4</pattern>
+  <pattern>la5pre</pattern>
+  <pattern>la2p3u</pattern>
+  <pattern>la3q</pattern>
+  <pattern>lar3da</pattern>
+  <pattern>2larm</pattern>
+  <pattern>4larm </pattern>
+  <pattern>lar5st</pattern>
+  <pattern>las3a4</pattern>
+  <pattern>lase4</pattern>
+  <pattern>la2si</pattern>
+  <pattern>las3to</pattern>
+  <pattern>5lastt</pattern>
+  <pattern>la3te</pattern>
+  <pattern>la4t3he</pattern>
+  <pattern>lat5j</pattern>
+  <pattern>la4t3ro</pattern>
+  <pattern>4lats4</pattern>
+  <pattern>lat3sl</pattern>
+  <pattern>2lau</pattern>
+  <pattern>5lauf</pattern>
+  <pattern>lau4st</pattern>
+  <pattern>l2auw</pattern>
+  <pattern>la3v</pattern>
+  <pattern>lava3</pattern>
+  <pattern>la4vo</pattern>
+  <pattern>5law</pattern>
+  <pattern>l4az</pattern>
+  <pattern>4lazi</pattern>
+  <pattern>la4zij</pattern>
+  <pattern>2lb4</pattern>
+  <pattern>lber4t</pattern>
+  <pattern>lbert5j</pattern>
+  <pattern>lboot4</pattern>
+  <pattern>2l1c</pattern>
+  <pattern>lce4l5</pattern>
+  <pattern>4ld</pattern>
+  <pattern>ldaat5</pattern>
+  <pattern>l2d3ac</pattern>
+  <pattern>ldak4</pattern>
+  <pattern>ld3alf</pattern>
+  <pattern>l4da4r</pattern>
+  <pattern>ld3arc</pattern>
+  <pattern>ld3ari</pattern>
+  <pattern>ld3art</pattern>
+  <pattern>l2dau</pattern>
+  <pattern>ld3eco</pattern>
+  <pattern>ldeks5</pattern>
+  <pattern>l4d3e4z</pattern>
+  <pattern>ldi3a</pattern>
+  <pattern>ld5oef</pattern>
+  <pattern>ld3oli</pattern>
+  <pattern>l2d3om</pattern>
+  <pattern>l2d3on</pattern>
+  <pattern>ld3oog</pattern>
+  <pattern>l4do4p</pattern>
+  <pattern>ld3opi</pattern>
+  <pattern>ld3ord</pattern>
+  <pattern>ld1ov</pattern>
+  <pattern>l3dr</pattern>
+  <pattern>l5drade</pattern>
+  <pattern>ld3ram</pattern>
+  <pattern>ld5rang</pattern>
+  <pattern>ld3rat</pattern>
+  <pattern>ld1re</pattern>
+  <pattern>l5dree</pattern>
+  <pattern>ld3rij</pattern>
+  <pattern>ld3roe</pattern>
+  <pattern>ld3rol</pattern>
+  <pattern>ld3rom</pattern>
+  <pattern>ld3rui</pattern>
+  <pattern>ld3sa</pattern>
+  <pattern>ld3sl</pattern>
+  <pattern>ld3sma</pattern>
+  <pattern>ld5sp</pattern>
+  <pattern>ld5ste</pattern>
+  <pattern>l3du</pattern>
+  <pattern>ld3uit</pattern>
+  <pattern>ld3uu</pattern>
+  <pattern>ld1w</pattern>
+  <pattern>le2a</pattern>
+  <pattern>le4ane</pattern>
+  <pattern>le3at</pattern>
+  <pattern>leba4l</pattern>
+  <pattern>lecht5st</pattern>
+  <pattern>lee4</pattern>
+  <pattern>leeg3</pattern>
+  <pattern>leege4</pattern>
+  <pattern>leeg5i</pattern>
+  <pattern>4leekh</pattern>
+  <pattern>lee5l</pattern>
+  <pattern>leem3</pattern>
+  <pattern>3leen</pattern>
+  <pattern>4leep</pattern>
+  <pattern>leep3o</pattern>
+  <pattern>lees5e</pattern>
+  <pattern>lees5l</pattern>
+  <pattern>lees5po</pattern>
+  <pattern>2leeu</pattern>
+  <pattern>2leff</pattern>
+  <pattern>lega5s</pattern>
+  <pattern>leg3ec</pattern>
+  <pattern>leg3l</pattern>
+  <pattern>le4go</pattern>
+  <pattern>le5go </pattern>
+  <pattern>leg5s</pattern>
+  <pattern>3leidi</pattern>
+  <pattern>4leier</pattern>
+  <pattern>4leig</pattern>
+  <pattern>lei5tj</pattern>
+  <pattern>leit5s</pattern>
+  <pattern>le4ko4</pattern>
+  <pattern>4leks</pattern>
+  <pattern>lek5str</pattern>
+  <pattern>5leld</pattern>
+  <pattern>le2le</pattern>
+  <pattern>5leli</pattern>
+  <pattern>l3elp</pattern>
+  <pattern>le4n3a4d</pattern>
+  <pattern>len3a4k</pattern>
+  <pattern>3lene</pattern>
+  <pattern>le4n3e4m</pattern>
+  <pattern>len5kw</pattern>
+  <pattern>le2no</pattern>
+  <pattern>len3op</pattern>
+  <pattern>len3sf</pattern>
+  <pattern>len3sm</pattern>
+  <pattern>4l3en5th</pattern>
+  <pattern>le5o</pattern>
+  <pattern>4lep </pattern>
+  <pattern>3le1ra</pattern>
+  <pattern>le4r3a4k</pattern>
+  <pattern>le5rei</pattern>
+  <pattern>le4r3e4v</pattern>
+  <pattern>ler5g4</pattern>
+  <pattern>le3r4o</pattern>
+  <pattern>le4ron</pattern>
+  <pattern>ler4sl</pattern>
+  <pattern>ler5spo</pattern>
+  <pattern>4l3erts</pattern>
+  <pattern>le2s</pattern>
+  <pattern>le4sa</pattern>
+  <pattern>le3sc</pattern>
+  <pattern>les5et</pattern>
+  <pattern>le3s4h</pattern>
+  <pattern>les3m</pattern>
+  <pattern>le4sp</pattern>
+  <pattern>le3spe</pattern>
+  <pattern>4l3essa</pattern>
+  <pattern>les3t</pattern>
+  <pattern>les4ta</pattern>
+  <pattern>les5taa</pattern>
+  <pattern>le5s4tel</pattern>
+  <pattern>le3str</pattern>
+  <pattern>le4s3u</pattern>
+  <pattern>le4t4h</pattern>
+  <pattern>le3tha</pattern>
+  <pattern>let4i</pattern>
+  <pattern>le5tin</pattern>
+  <pattern>le4top</pattern>
+  <pattern>le2t3r</pattern>
+  <pattern>le3t4re</pattern>
+  <pattern>let4st</pattern>
+  <pattern>lets5te </pattern>
+  <pattern>le2t3u</pattern>
+  <pattern>leu3ko</pattern>
+  <pattern>leum3a</pattern>
+  <pattern>leur4o</pattern>
+  <pattern>leus4</pattern>
+  <pattern>leu5ste</pattern>
+  <pattern>5leuz</pattern>
+  <pattern>leven4s</pattern>
+  <pattern>levink5j</pattern>
+  <pattern>4lexc</pattern>
+  <pattern>4lexp</pattern>
+  <pattern>l2fac</pattern>
+  <pattern>l3f4ag</pattern>
+  <pattern>lfa3s</pattern>
+  <pattern>l2fau</pattern>
+  <pattern>lfe4n</pattern>
+  <pattern>l4f3end</pattern>
+  <pattern>lf3ene</pattern>
+  <pattern>l2fe2z</pattern>
+  <pattern>lf3li</pattern>
+  <pattern>l3f4lo</pattern>
+  <pattern>lf3lu</pattern>
+  <pattern>l4fo</pattern>
+  <pattern>l5foe</pattern>
+  <pattern>lf3o4l</pattern>
+  <pattern>lf1op</pattern>
+  <pattern>lf5ord</pattern>
+  <pattern>lf5org</pattern>
+  <pattern>l5fou</pattern>
+  <pattern>l1fra</pattern>
+  <pattern>l3fru</pattern>
+  <pattern>lfs5ei</pattern>
+  <pattern>lf4sl</pattern>
+  <pattern>lfs3le</pattern>
+  <pattern>lf2s3m</pattern>
+  <pattern>lf4so</pattern>
+  <pattern>lft4</pattern>
+  <pattern>lf5ta</pattern>
+  <pattern>lf5tw</pattern>
+  <pattern>lf3uu</pattern>
+  <pattern>2l1g</pattern>
+  <pattern>l5gaar</pattern>
+  <pattern>l4gap</pattern>
+  <pattern>lge4n5a</pattern>
+  <pattern>l3gla</pattern>
+  <pattern>l3g4oe</pattern>
+  <pattern>l3gog</pattern>
+  <pattern>l3goo</pattern>
+  <pattern>lg3s4</pattern>
+  <pattern>lgse5</pattern>
+  <pattern>4l1h</pattern>
+  <pattern>1li</pattern>
+  <pattern>li3ag</pattern>
+  <pattern>li3am</pattern>
+  <pattern>licht5st</pattern>
+  <pattern>3lid</pattern>
+  <pattern>5lid </pattern>
+  <pattern>5lidm</pattern>
+  <pattern>lid3s4</pattern>
+  <pattern>lie4g3a</pattern>
+  <pattern>lie4gr</pattern>
+  <pattern>lie3ka</pattern>
+  <pattern>lie4sp</pattern>
+  <pattern>lie3s4t</pattern>
+  <pattern>lie4to</pattern>
+  <pattern>li3eu</pattern>
+  <pattern>3liè</pattern>
+  <pattern>3lift</pattern>
+  <pattern>l4ig</pattern>
+  <pattern>li3go</pattern>
+  <pattern>lijk3a</pattern>
+  <pattern>lij4m3a</pattern>
+  <pattern>4lijmv</pattern>
+  <pattern>5lijn</pattern>
+  <pattern>4lijp</pattern>
+  <pattern>3lij2s</pattern>
+  <pattern>lijst5a</pattern>
+  <pattern>4lijt</pattern>
+  <pattern>4l3ijz</pattern>
+  <pattern>li5kr</pattern>
+  <pattern>lik5sp</pattern>
+  <pattern>li4kw</pattern>
+  <pattern>li3kwi</pattern>
+  <pattern>lim4a</pattern>
+  <pattern>li3mi</pattern>
+  <pattern>2limp</pattern>
+  <pattern>lim4p3j</pattern>
+  <pattern>lin4da</pattern>
+  <pattern>4linf</pattern>
+  <pattern>4l3inh</pattern>
+  <pattern>li5ni</pattern>
+  <pattern>lin4k3a</pattern>
+  <pattern>3linn</pattern>
+  <pattern>l3inna</pattern>
+  <pattern>2linr</pattern>
+  <pattern>2l3ins</pattern>
+  <pattern>lin4t3j</pattern>
+  <pattern>l3inv</pattern>
+  <pattern>4linz</pattern>
+  <pattern>li3ob</pattern>
+  <pattern>li5om</pattern>
+  <pattern>li5o5s4</pattern>
+  <pattern>li3ot</pattern>
+  <pattern>li2pa</pattern>
+  <pattern>li3pi</pattern>
+  <pattern>li2p3l</pattern>
+  <pattern>li5see</pattern>
+  <pattern>2liso</pattern>
+  <pattern>l5isw</pattern>
+  <pattern>li1t2h</pattern>
+  <pattern>lit3r</pattern>
+  <pattern>lit4sa</pattern>
+  <pattern>lit4sl</pattern>
+  <pattern>lit4st</pattern>
+  <pattern>lits5te </pattern>
+  <pattern>lit5sten</pattern>
+  <pattern>2lix</pattern>
+  <pattern>4l1j2</pattern>
+  <pattern>lk3af</pattern>
+  <pattern>l4k3ank</pattern>
+  <pattern>lk3arm</pattern>
+  <pattern>lk3art</pattern>
+  <pattern>l3ke</pattern>
+  <pattern>l4k3ei</pattern>
+  <pattern>l4k3em</pattern>
+  <pattern>lken5e</pattern>
+  <pattern>lken4s</pattern>
+  <pattern>l4k3ep</pattern>
+  <pattern>l3ki</pattern>
+  <pattern>lking4</pattern>
+  <pattern>lk3laa</pattern>
+  <pattern>lk3lag</pattern>
+  <pattern>l5klas</pattern>
+  <pattern>l4k3lev</pattern>
+  <pattern>l5klim</pattern>
+  <pattern>l3ko</pattern>
+  <pattern>l5koe</pattern>
+  <pattern>lk3ont</pattern>
+  <pattern>lkooi5</pattern>
+  <pattern>lk3opb</pattern>
+  <pattern>l5kor</pattern>
+  <pattern>l5kou</pattern>
+  <pattern>l5kra</pattern>
+  <pattern>l2kre</pattern>
+  <pattern>lk3rep</pattern>
+  <pattern>lk3res</pattern>
+  <pattern>lk3rij</pattern>
+  <pattern>l2k3ro</pattern>
+  <pattern>lk2s</pattern>
+  <pattern>lk4se</pattern>
+  <pattern>lk4so</pattern>
+  <pattern>lk3son</pattern>
+  <pattern>lks3oo</pattern>
+  <pattern>lks5taa</pattern>
+  <pattern>lk3ste</pattern>
+  <pattern>lks5tel</pattern>
+  <pattern>lks5tr</pattern>
+  <pattern>l4k3uu</pattern>
+  <pattern>l3kw</pattern>
+  <pattern>lk3wi</pattern>
+  <pattern>l3ky</pattern>
+  <pattern>2l1l</pattern>
+  <pattern>l5la</pattern>
+  <pattern>lla3d</pattern>
+  <pattern>lla3g4</pattern>
+  <pattern>lla5tr</pattern>
+  <pattern>ll3eig</pattern>
+  <pattern>lle3k</pattern>
+  <pattern>ll4el</pattern>
+  <pattern>lleo4</pattern>
+  <pattern>ller5on</pattern>
+  <pattern>lle3s4m</pattern>
+  <pattern>lle5th</pattern>
+  <pattern>llevie5</pattern>
+  <pattern>l3l4i</pattern>
+  <pattern>l3lo</pattern>
+  <pattern>llo5f</pattern>
+  <pattern>l5lon</pattern>
+  <pattern>ll3sh</pattern>
+  <pattern>2lm</pattern>
+  <pattern>l3maa</pattern>
+  <pattern>lmaat5</pattern>
+  <pattern>lm3a4ca</pattern>
+  <pattern>lm3af</pattern>
+  <pattern>lma5ï</pattern>
+  <pattern>l3mak</pattern>
+  <pattern>lm3arc</pattern>
+  <pattern>lm3art</pattern>
+  <pattern>lma3s2</pattern>
+  <pattern>lm3au</pattern>
+  <pattern>l3me</pattern>
+  <pattern>l4med</pattern>
+  <pattern>lm3edi</pattern>
+  <pattern>l4m3ep</pattern>
+  <pattern>lme2s</pattern>
+  <pattern>lme5te</pattern>
+  <pattern>l3mi</pattern>
+  <pattern>l3mo</pattern>
+  <pattern>l5mog</pattern>
+  <pattern>lm3oli</pattern>
+  <pattern>lm3or</pattern>
+  <pattern>lmro4z</pattern>
+  <pattern>lm5sc</pattern>
+  <pattern>lm3sh</pattern>
+  <pattern>lm3su</pattern>
+  <pattern>2l3n</pattern>
+  <pattern>lni4s</pattern>
+  <pattern>lo3a</pattern>
+  <pattern>2lobj</pattern>
+  <pattern>lo4boo</pattern>
+  <pattern>loe4d5a</pattern>
+  <pattern>loed3r</pattern>
+  <pattern>4loeg</pattern>
+  <pattern>loe4gr</pattern>
+  <pattern>loen4st</pattern>
+  <pattern>loens5te </pattern>
+  <pattern>4loes</pattern>
+  <pattern>l3oeu</pattern>
+  <pattern>5loev</pattern>
+  <pattern>lo4faa</pattern>
+  <pattern>lof5d2</pattern>
+  <pattern>lof4s4</pattern>
+  <pattern>log4</pattern>
+  <pattern>log5l</pattern>
+  <pattern>lo3go</pattern>
+  <pattern>5logr</pattern>
+  <pattern>log2s3</pattern>
+  <pattern>lo4k3ar</pattern>
+  <pattern>lo2k3o2</pattern>
+  <pattern>lo4kr</pattern>
+  <pattern>lo2ku</pattern>
+  <pattern>2lo2l</pattern>
+  <pattern>lo3la</pattern>
+  <pattern>l3oml</pattern>
+  <pattern>lom4p3j</pattern>
+  <pattern>lom4p3l</pattern>
+  <pattern>l3omt</pattern>
+  <pattern>l3omv</pattern>
+  <pattern>4lomz</pattern>
+  <pattern>3lon </pattern>
+  <pattern>4lond</pattern>
+  <pattern>5long</pattern>
+  <pattern>lon4gaa</pattern>
+  <pattern>lon4g3o</pattern>
+  <pattern>lon4gr</pattern>
+  <pattern>lon3o</pattern>
+  <pattern>2lont</pattern>
+  <pattern>lon4t3j</pattern>
+  <pattern>3look</pattern>
+  <pattern>loo5pi</pattern>
+  <pattern>3loosh</pattern>
+  <pattern>loot3e</pattern>
+  <pattern>lo3pa</pattern>
+  <pattern>4lopb</pattern>
+  <pattern>l3opd</pattern>
+  <pattern>lo1pe</pattern>
+  <pattern>2l3oph</pattern>
+  <pattern>2l3opl</pattern>
+  <pattern>lop4la</pattern>
+  <pattern>2lopn</pattern>
+  <pattern>lo3p2r</pattern>
+  <pattern>4lopt</pattern>
+  <pattern>4l3opv</pattern>
+  <pattern>4l3opw</pattern>
+  <pattern>2lor</pattern>
+  <pattern>3l4or </pattern>
+  <pattern>lo3re</pattern>
+  <pattern>4l1org</pattern>
+  <pattern>lo3ri</pattern>
+  <pattern>l4o1r2o3</pattern>
+  <pattern>3l4ors</pattern>
+  <pattern>lo3ru</pattern>
+  <pattern>lo3spe</pattern>
+  <pattern>lost4</pattern>
+  <pattern>los5to</pattern>
+  <pattern>lo4s5tr</pattern>
+  <pattern>lo5s2u</pattern>
+  <pattern>lo2ta</pattern>
+  <pattern>lot3a4l</pattern>
+  <pattern>lo4tet</pattern>
+  <pattern>lo2t3h</pattern>
+  <pattern>lot3j</pattern>
+  <pattern>lo4tof</pattern>
+  <pattern>lot3r</pattern>
+  <pattern>lou3s</pattern>
+  <pattern>lo3v</pattern>
+  <pattern>2love</pattern>
+  <pattern>3lo5z</pattern>
+  <pattern>4lp</pattern>
+  <pattern>l1pa</pattern>
+  <pattern>l3paa</pattern>
+  <pattern>lp3aan</pattern>
+  <pattern>lp3a4g</pattern>
+  <pattern>lp3am</pattern>
+  <pattern>l3par</pattern>
+  <pattern>l3pas</pattern>
+  <pattern>l1pe</pattern>
+  <pattern>lpe2n</pattern>
+  <pattern>l2pex</pattern>
+  <pattern>l3pi</pattern>
+  <pattern>l5ping</pattern>
+  <pattern>lp3ins</pattern>
+  <pattern>lp3j</pattern>
+  <pattern>l1pl</pattern>
+  <pattern>l3p4la</pattern>
+  <pattern>l4plam</pattern>
+  <pattern>l1po</pattern>
+  <pattern>lp3of</pattern>
+  <pattern>l3pom</pattern>
+  <pattern>lp3on</pattern>
+  <pattern>lp3ope</pattern>
+  <pattern>l3pos</pattern>
+  <pattern>l3pot</pattern>
+  <pattern>l1pr</pattern>
+  <pattern>lp3ram</pattern>
+  <pattern>4l3r</pattern>
+  <pattern>lraads5</pattern>
+  <pattern>lrus5</pattern>
+  <pattern>4ls</pattern>
+  <pattern>l4saa</pattern>
+  <pattern>ls1a2d</pattern>
+  <pattern>ls3a2g</pattern>
+  <pattern>l1sam</pattern>
+  <pattern>ls3an</pattern>
+  <pattern>l3sap</pattern>
+  <pattern>ls3as</pattern>
+  <pattern>l2sat</pattern>
+  <pattern>ls4cor</pattern>
+  <pattern>ls4cu</pattern>
+  <pattern>ls3eco</pattern>
+  <pattern>l4s3e2d</pattern>
+  <pattern>l4sef</pattern>
+  <pattern>l5sen</pattern>
+  <pattern>l4s3e2p</pattern>
+  <pattern>lsge4st</pattern>
+  <pattern>l3s2hi</pattern>
+  <pattern>l3si</pattern>
+  <pattern>l4s3im</pattern>
+  <pattern>l4sin</pattern>
+  <pattern>ls3inj</pattern>
+  <pattern>ls3ink</pattern>
+  <pattern>ls3int</pattern>
+  <pattern>ls4j</pattern>
+  <pattern>ls5ja</pattern>
+  <pattern>l3s4kel</pattern>
+  <pattern>l3s2ki</pattern>
+  <pattern>l1sl</pattern>
+  <pattern>l3sla</pattern>
+  <pattern>l2s4le</pattern>
+  <pattern>ls5led</pattern>
+  <pattern>ls5lee</pattern>
+  <pattern>ls5leg</pattern>
+  <pattern>ls5len</pattern>
+  <pattern>l2s3li</pattern>
+  <pattern>ls4lin</pattern>
+  <pattern>l3slo</pattern>
+  <pattern>ls4maak</pattern>
+  <pattern>ls4med</pattern>
+  <pattern>ls4mee</pattern>
+  <pattern>l3smid</pattern>
+  <pattern>ls3na</pattern>
+  <pattern>l3sne</pattern>
+  <pattern>l3sno</pattern>
+  <pattern>ls3nor</pattern>
+  <pattern>l3soc</pattern>
+  <pattern>ls3of</pattern>
+  <pattern>l3sol</pattern>
+  <pattern>ls3op</pattern>
+  <pattern>ls3o4r</pattern>
+  <pattern>ls1ov</pattern>
+  <pattern>l1sp</pattern>
+  <pattern>l2spa</pattern>
+  <pattern>ls3pac</pattern>
+  <pattern>l3span</pattern>
+  <pattern>ls3par</pattern>
+  <pattern>ls4pe</pattern>
+  <pattern>l3spi</pattern>
+  <pattern>ls3pli</pattern>
+  <pattern>l3spoo</pattern>
+  <pattern>l4s5poot</pattern>
+  <pattern>l3spor</pattern>
+  <pattern>l2spr</pattern>
+  <pattern>ls3pra</pattern>
+  <pattern>l1st</pattern>
+  <pattern>l3sta</pattern>
+  <pattern>l4staf</pattern>
+  <pattern>l4stak</pattern>
+  <pattern>ls5tak </pattern>
+  <pattern>l3ste</pattern>
+  <pattern>l4stek</pattern>
+  <pattern>l4stev</pattern>
+  <pattern>ls4ti</pattern>
+  <pattern>l3sto</pattern>
+  <pattern>l5straa</pattern>
+  <pattern>ls5trak</pattern>
+  <pattern>l5strat</pattern>
+  <pattern>l3stu</pattern>
+  <pattern>ls5ty</pattern>
+  <pattern>l2su</pattern>
+  <pattern>l3sur</pattern>
+  <pattern>ls3us</pattern>
+  <pattern>l3sy</pattern>
+  <pattern>4l1t</pattern>
+  <pattern>lt4aa</pattern>
+  <pattern>lt1ac</pattern>
+  <pattern>l4tam</pattern>
+  <pattern>l5tame</pattern>
+  <pattern>l5t4an</pattern>
+  <pattern>lt4han</pattern>
+  <pattern>l4t3hi</pattern>
+  <pattern>l2t3ho</pattern>
+  <pattern>l3thu</pattern>
+  <pattern>lto4l</pattern>
+  <pattern>lt3oli</pattern>
+  <pattern>l2t3o4v</pattern>
+  <pattern>l3tr</pattern>
+  <pattern>ltra3s</pattern>
+  <pattern>lt3rug</pattern>
+  <pattern>lt3sl</pattern>
+  <pattern>lt3sp</pattern>
+  <pattern>lts5te </pattern>
+  <pattern>l3tu</pattern>
+  <pattern>lu4b1</pattern>
+  <pattern>lub5e</pattern>
+  <pattern>lub5l</pattern>
+  <pattern>lu1en</pattern>
+  <pattern>3lui </pattern>
+  <pattern>5luia</pattern>
+  <pattern>5luid</pattern>
+  <pattern>luids3</pattern>
+  <pattern>5luie </pattern>
+  <pattern>2luit</pattern>
+  <pattern>luk2s</pattern>
+  <pattern>luks3t</pattern>
+  <pattern>lu3na</pattern>
+  <pattern>3lunc</pattern>
+  <pattern>2l3u2ni</pattern>
+  <pattern>lu3sta</pattern>
+  <pattern>lu3ta</pattern>
+  <pattern>lut3j</pattern>
+  <pattern>lut4st</pattern>
+  <pattern>luts5te </pattern>
+  <pattern>lu3wi</pattern>
+  <pattern>lven5s</pattern>
+  <pattern>lvera4</pattern>
+  <pattern>l1w</pattern>
+  <pattern>1ly</pattern>
+  <pattern>ly5i</pattern>
+  <pattern>ly3st</pattern>
+  <pattern>4lz</pattern>
+  <pattern>lzooi5</pattern>
+  <pattern>4m </pattern>
+  <pattern>1ma</pattern>
+  <pattern>maas3</pattern>
+  <pattern>maat5st</pattern>
+  <pattern>m3act</pattern>
+  <pattern>2m3adv</pattern>
+  <pattern>ma5esto</pattern>
+  <pattern>m3afl</pattern>
+  <pattern>ma3fr</pattern>
+  <pattern>2m3afs</pattern>
+  <pattern>4m3afw</pattern>
+  <pattern>m4ag</pattern>
+  <pattern>ma3gl</pattern>
+  <pattern>ma5go</pattern>
+  <pattern>ma3gr</pattern>
+  <pattern>maï4</pattern>
+  <pattern>ma5ka</pattern>
+  <pattern>ma5ke</pattern>
+  <pattern>5ma3k4r</pattern>
+  <pattern>ma3kw</pattern>
+  <pattern>ma3l4a</pattern>
+  <pattern>ma5lac</pattern>
+  <pattern>ma4l5ent</pattern>
+  <pattern>mal5st</pattern>
+  <pattern>5m4an </pattern>
+  <pattern>man3ac</pattern>
+  <pattern>m3anal</pattern>
+  <pattern>man5da</pattern>
+  <pattern>man5do</pattern>
+  <pattern>mand4s</pattern>
+  <pattern>5m4ann</pattern>
+  <pattern>ma5no</pattern>
+  <pattern>5man2s</pattern>
+  <pattern>man4se</pattern>
+  <pattern>mans5ee</pattern>
+  <pattern>man4so</pattern>
+  <pattern>mans3p</pattern>
+  <pattern>man4s3t</pattern>
+  <pattern>mans5ta</pattern>
+  <pattern>man4th</pattern>
+  <pattern>mant4r</pattern>
+  <pattern>ma5pa</pattern>
+  <pattern>ma3pr</pattern>
+  <pattern>ma3q</pattern>
+  <pattern>m4a5ri</pattern>
+  <pattern>mariet5</pattern>
+  <pattern>5m4ark</pattern>
+  <pattern>mar3sh</pattern>
+  <pattern>mar4s5t</pattern>
+  <pattern>mar5ti</pattern>
+  <pattern>ma1so</pattern>
+  <pattern>ma3s4po</pattern>
+  <pattern>5mass</pattern>
+  <pattern>ma4ste</pattern>
+  <pattern>ma3str</pattern>
+  <pattern>ma5ta</pattern>
+  <pattern>5mater</pattern>
+  <pattern>mat5j</pattern>
+  <pattern>ma4tom</pattern>
+  <pattern>ma3tr</pattern>
+  <pattern>mat4st</pattern>
+  <pattern>mats5te </pattern>
+  <pattern>ma3v</pattern>
+  <pattern>4mb</pattern>
+  <pattern>m5bl</pattern>
+  <pattern>mboot4j</pattern>
+  <pattern>mbo5st</pattern>
+  <pattern>mb4r</pattern>
+  <pattern>2m1c</pattern>
+  <pattern>2m1d</pattern>
+  <pattern>m5da</pattern>
+  <pattern>mdi3a</pattern>
+  <pattern>mdis5</pattern>
+  <pattern>m3do</pattern>
+  <pattern>mdo3p</pattern>
+  <pattern>m3dr</pattern>
+  <pattern>m3dw</pattern>
+  <pattern>1me</pattern>
+  <pattern>me1c</pattern>
+  <pattern>me5de</pattern>
+  <pattern>5media</pattern>
+  <pattern>5mediu</pattern>
+  <pattern>mee5g</pattern>
+  <pattern>mee3k4r</pattern>
+  <pattern>mee5las</pattern>
+  <pattern>mee3lo</pattern>
+  <pattern>mee5re</pattern>
+  <pattern>mee5ri</pattern>
+  <pattern>5mees</pattern>
+  <pattern>meest5al</pattern>
+  <pattern>mee5stov</pattern>
+  <pattern>mee5str</pattern>
+  <pattern>m5eg </pattern>
+  <pattern>me3g2a</pattern>
+  <pattern>mega5s</pattern>
+  <pattern>m5egd</pattern>
+  <pattern>m5egg</pattern>
+  <pattern>m5egt</pattern>
+  <pattern>me4i</pattern>
+  <pattern>mei2n</pattern>
+  <pattern>mei5tj</pattern>
+  <pattern>m2el</pattern>
+  <pattern>me4l4as</pattern>
+  <pattern>mel5as </pattern>
+  <pattern>mel5dr</pattern>
+  <pattern>mel4ko</pattern>
+  <pattern>mel4kr</pattern>
+  <pattern>5melo</pattern>
+  <pattern>mel3s4m</pattern>
+  <pattern>me4mi</pattern>
+  <pattern>3men</pattern>
+  <pattern>m4en </pattern>
+  <pattern>me3na</pattern>
+  <pattern>men4as</pattern>
+  <pattern>meng5ra</pattern>
+  <pattern>men5k</pattern>
+  <pattern>me5nor</pattern>
+  <pattern>4menq</pattern>
+  <pattern>men4s5uu</pattern>
+  <pattern>men4t3j</pattern>
+  <pattern>ment3w</pattern>
+  <pattern>me5nu</pattern>
+  <pattern>me3p2j</pattern>
+  <pattern>2m3e2q</pattern>
+  <pattern>me1ra</pattern>
+  <pattern>me4r5aak</pattern>
+  <pattern>me4r3a4k</pattern>
+  <pattern>me4r4am</pattern>
+  <pattern>mer5ante</pattern>
+  <pattern>me4rap</pattern>
+  <pattern>me3rau</pattern>
+  <pattern>me4rav</pattern>
+  <pattern>mer3ei</pattern>
+  <pattern>5merk</pattern>
+  <pattern>mer4kl</pattern>
+  <pattern>mer4kn</pattern>
+  <pattern>mer4kw</pattern>
+  <pattern>mer5oc</pattern>
+  <pattern>me5rong</pattern>
+  <pattern>me3roo</pattern>
+  <pattern>4m3eros</pattern>
+  <pattern>me3rot</pattern>
+  <pattern>mer4si</pattern>
+  <pattern>mer4sl</pattern>
+  <pattern>mers5m</pattern>
+  <pattern>mers5ta</pattern>
+  <pattern>me2ru4</pattern>
+  <pattern>m4es</pattern>
+  <pattern>me3s4h</pattern>
+  <pattern>me4s4l</pattern>
+  <pattern>mes5li</pattern>
+  <pattern>me5slo</pattern>
+  <pattern>mes3m</pattern>
+  <pattern>me3so</pattern>
+  <pattern>me4sp</pattern>
+  <pattern>mes3pa</pattern>
+  <pattern>me5spe</pattern>
+  <pattern>me5spot</pattern>
+  <pattern>me5stel</pattern>
+  <pattern>mesto4</pattern>
+  <pattern>mest5ov</pattern>
+  <pattern>me3stu</pattern>
+  <pattern>me5ta5n</pattern>
+  <pattern>me3t4h</pattern>
+  <pattern>3meti</pattern>
+  <pattern>me5tr</pattern>
+  <pattern>mets5te </pattern>
+  <pattern>meve4</pattern>
+  <pattern>m3e4ven</pattern>
+  <pattern>2mex</pattern>
+  <pattern>3mé</pattern>
+  <pattern>3mè</pattern>
+  <pattern>3mê</pattern>
+  <pattern>2m1f</pattern>
+  <pattern>mfa3t</pattern>
+  <pattern>mf4l</pattern>
+  <pattern>mf3li</pattern>
+  <pattern>mf5lie</pattern>
+  <pattern>m5fo</pattern>
+  <pattern>2m5g</pattern>
+  <pattern>mger4</pattern>
+  <pattern>2m1h</pattern>
+  <pattern>1mi</pattern>
+  <pattern>3mid</pattern>
+  <pattern>4mid </pattern>
+  <pattern>5midd</pattern>
+  <pattern>mie5kl</pattern>
+  <pattern>mie3st</pattern>
+  <pattern>4m3ijs</pattern>
+  <pattern>4m3ijz</pattern>
+  <pattern>mi3kn</pattern>
+  <pattern>5mili</pattern>
+  <pattern>mi3lo</pattern>
+  <pattern>mimie4</pattern>
+  <pattern>m3imp</pattern>
+  <pattern>mi5nar</pattern>
+  <pattern>2minf</pattern>
+  <pattern>5ming</pattern>
+  <pattern>4minh</pattern>
+  <pattern>2m5inr</pattern>
+  <pattern>2m3ins</pattern>
+  <pattern>mi5nu</pattern>
+  <pattern>4m3inw</pattern>
+  <pattern>m2is</pattern>
+  <pattern>mis5f</pattern>
+  <pattern>mi2s3i</pattern>
+  <pattern>mi3s4la</pattern>
+  <pattern>mi4st</pattern>
+  <pattern>mi5stra</pattern>
+  <pattern>mis5tro</pattern>
+  <pattern>mi3t4a</pattern>
+  <pattern>mi1tr</pattern>
+  <pattern>mit4st</pattern>
+  <pattern>mits5te </pattern>
+  <pattern>mit5sten</pattern>
+  <pattern>2m1j</pattern>
+  <pattern>2m3k2</pattern>
+  <pattern>mkaart5j</pattern>
+  <pattern>2m3l</pattern>
+  <pattern>2m1m</pattern>
+  <pattern>2m1n</pattern>
+  <pattern>m5na</pattern>
+  <pattern>1mo</pattern>
+  <pattern>5mo </pattern>
+  <pattern>mo3a</pattern>
+  <pattern>5moda</pattern>
+  <pattern>5mode</pattern>
+  <pattern>moed4s</pattern>
+  <pattern>2moef</pattern>
+  <pattern>5moei</pattern>
+  <pattern>moers5t</pattern>
+  <pattern>moe2s</pattern>
+  <pattern>moes3p</pattern>
+  <pattern>moes4te</pattern>
+  <pattern>mog2</pattern>
+  <pattern>5moge</pattern>
+  <pattern>mogen4s</pattern>
+  <pattern>mo3gl</pattern>
+  <pattern>4mok</pattern>
+  <pattern>5mole</pattern>
+  <pattern>2moli</pattern>
+  <pattern>mo4lie</pattern>
+  <pattern>mol4m3a</pattern>
+  <pattern>4molt</pattern>
+  <pattern>3mom</pattern>
+  <pattern>4m3omv</pattern>
+  <pattern>mond3r</pattern>
+  <pattern>mo5no</pattern>
+  <pattern>5mons</pattern>
+  <pattern>mon4so</pattern>
+  <pattern>mon5ta</pattern>
+  <pattern>3mooi</pattern>
+  <pattern>2mop</pattern>
+  <pattern>mo3pa</pattern>
+  <pattern>m1ope</pattern>
+  <pattern>m4opp</pattern>
+  <pattern>mop4s</pattern>
+  <pattern>mo3ra</pattern>
+  <pattern>mo3r4e</pattern>
+  <pattern>mo3ro</pattern>
+  <pattern>mor4sp</pattern>
+  <pattern>mor4st</pattern>
+  <pattern>mors5te </pattern>
+  <pattern>5mos</pattern>
+  <pattern>mo5sc</pattern>
+  <pattern>mo4s5l</pattern>
+  <pattern>mo3sta</pattern>
+  <pattern>mo3t2h</pattern>
+  <pattern>mot3j</pattern>
+  <pattern>mot3ol</pattern>
+  <pattern>mot4st</pattern>
+  <pattern>mots5te </pattern>
+  <pattern>2m3oud</pattern>
+  <pattern>5mouw</pattern>
+  <pattern>mou4wi</pattern>
+  <pattern>mo3v</pattern>
+  <pattern>m3ox</pattern>
+  <pattern>2m1p</pattern>
+  <pattern>mp3ach</pattern>
+  <pattern>m4p3af</pattern>
+  <pattern>m5pan</pattern>
+  <pattern>mp3arm</pattern>
+  <pattern>mp5arts</pattern>
+  <pattern>m4p3ec</pattern>
+  <pattern>m5pen</pattern>
+  <pattern>m4p3erv</pattern>
+  <pattern>mp3ins</pattern>
+  <pattern>m3pl</pattern>
+  <pattern>mp3lam</pattern>
+  <pattern>m5plan</pattern>
+  <pattern>mp3leg</pattern>
+  <pattern>mp3lei</pattern>
+  <pattern>mp3lev</pattern>
+  <pattern>mp3lie</pattern>
+  <pattern>m4plu</pattern>
+  <pattern>mp5olie</pattern>
+  <pattern>m5pon</pattern>
+  <pattern>mpon4g</pattern>
+  <pattern>mp3ope</pattern>
+  <pattern>mp2r</pattern>
+  <pattern>mp3rec</pattern>
+  <pattern>mp3red</pattern>
+  <pattern>m5pres</pattern>
+  <pattern>m4ps2</pattern>
+  <pattern>mp5sc</pattern>
+  <pattern>m5p4se</pattern>
+  <pattern>mp3sh</pattern>
+  <pattern>mp5su</pattern>
+  <pattern>2m1r</pattern>
+  <pattern>2ms</pattern>
+  <pattern>m3sam</pattern>
+  <pattern>ms3ana</pattern>
+  <pattern>ms3ap</pattern>
+  <pattern>ms2c</pattern>
+  <pattern>ms3co</pattern>
+  <pattern>ms3cu</pattern>
+  <pattern>ms2j</pattern>
+  <pattern>m3sje</pattern>
+  <pattern>m1sl</pattern>
+  <pattern>m2sle</pattern>
+  <pattern>ms3len</pattern>
+  <pattern>ms3lie</pattern>
+  <pattern>m3s2m</pattern>
+  <pattern>ms3ma</pattern>
+  <pattern>m1sn</pattern>
+  <pattern>ms3nee</pattern>
+  <pattern>mso4</pattern>
+  <pattern>m3sol</pattern>
+  <pattern>ms3or</pattern>
+  <pattern>m3s2p</pattern>
+  <pattern>ms4t</pattern>
+  <pattern>m3sta</pattern>
+  <pattern>m1ste</pattern>
+  <pattern>ms5tec</pattern>
+  <pattern>m5stel</pattern>
+  <pattern>m5sten</pattern>
+  <pattern>m1sti</pattern>
+  <pattern>m1sto</pattern>
+  <pattern>ms5toc</pattern>
+  <pattern>m4s5ton</pattern>
+  <pattern>mst5s</pattern>
+  <pattern>m3sy</pattern>
+  <pattern>2mt</pattern>
+  <pattern>m1ta</pattern>
+  <pattern>mte5re</pattern>
+  <pattern>mtes4</pattern>
+  <pattern>mte5sta</pattern>
+  <pattern>m1th</pattern>
+  <pattern>m1to</pattern>
+  <pattern>m3tr</pattern>
+  <pattern>m1tu</pattern>
+  <pattern>1mu</pattern>
+  <pattern>mu5da</pattern>
+  <pattern>mue4</pattern>
+  <pattern>5muilde </pattern>
+  <pattern>2muit</pattern>
+  <pattern>2muk</pattern>
+  <pattern>mul3p</pattern>
+  <pattern>mu2m3</pattern>
+  <pattern>mu3no</pattern>
+  <pattern>munt3j</pattern>
+  <pattern>mu3sa</pattern>
+  <pattern>mus5ta</pattern>
+  <pattern>5mut</pattern>
+  <pattern>mut3j</pattern>
+  <pattern>muts2</pattern>
+  <pattern>muts5te</pattern>
+  <pattern>3muu</pattern>
+  <pattern>5muz</pattern>
+  <pattern>2mv</pattern>
+  <pattern>mvari5</pattern>
+  <pattern>mve4</pattern>
+  <pattern>mvee3</pattern>
+  <pattern>mver3e</pattern>
+  <pattern>2m1w</pattern>
+  <pattern>1my</pattern>
+  <pattern>my3e</pattern>
+  <pattern>2mz</pattern>
+  <pattern>mze4</pattern>
+  <pattern>mzet5</pattern>
+  <pattern>4n </pattern>
+  <pattern>1na</pattern>
+  <pattern>3na </pattern>
+  <pattern>3naal</pattern>
+  <pattern>5n4aam</pattern>
+  <pattern>4n1aan</pattern>
+  <pattern>2naap</pattern>
+  <pattern>n4aar </pattern>
+  <pattern>4n3aard</pattern>
+  <pattern>5naars</pattern>
+  <pattern>naars5tr</pattern>
+  <pattern>naar5tj</pattern>
+  <pattern>5naast</pattern>
+  <pattern>5naat</pattern>
+  <pattern>n3abd</pattern>
+  <pattern>5nabe</pattern>
+  <pattern>2nac</pattern>
+  <pattern>na2ca</pattern>
+  <pattern>nacee5t</pattern>
+  <pattern>n2aci</pattern>
+  <pattern>3naco</pattern>
+  <pattern>4n3act</pattern>
+  <pattern>na5d4a</pattern>
+  <pattern>nad4e</pattern>
+  <pattern>3nade </pattern>
+  <pattern>5n4a5den</pattern>
+  <pattern>3nades</pattern>
+  <pattern>3nadi</pattern>
+  <pattern>4n3adm</pattern>
+  <pattern>na5dra</pattern>
+  <pattern>2n1adv</pattern>
+  <pattern>5nae</pattern>
+  <pattern>n3aë</pattern>
+  <pattern>4n1af</pattern>
+  <pattern>na3f4lu</pattern>
+  <pattern>n2a3g4</pattern>
+  <pattern>na1h</pattern>
+  <pattern>3nai</pattern>
+  <pattern>3naï</pattern>
+  <pattern>n2ake</pattern>
+  <pattern>na3k4l</pattern>
+  <pattern>na3kr</pattern>
+  <pattern>n3alb</pattern>
+  <pattern>3n4ale</pattern>
+  <pattern>5nalen</pattern>
+  <pattern>4n3alf</pattern>
+  <pattern>n3alm</pattern>
+  <pattern>2naly</pattern>
+  <pattern>4nalys</pattern>
+  <pattern>3nam</pattern>
+  <pattern>4namb</pattern>
+  <pattern>name5st</pattern>
+  <pattern>n4ami</pattern>
+  <pattern>n3amp</pattern>
+  <pattern>n3a2na</pattern>
+  <pattern>n3ank</pattern>
+  <pattern>3nant</pattern>
+  <pattern>5nant </pattern>
+  <pattern>5nante</pattern>
+  <pattern>n5antenn</pattern>
+  <pattern>nan4t3j</pattern>
+  <pattern>2nap</pattern>
+  <pattern>nap3ac</pattern>
+  <pattern>3na3p4l</pattern>
+  <pattern>na3p4r</pattern>
+  <pattern>nap3s</pattern>
+  <pattern>nap5st</pattern>
+  <pattern>2n1arb</pattern>
+  <pattern>5nares</pattern>
+  <pattern>2n3arg</pattern>
+  <pattern>narie5t</pattern>
+  <pattern>2n1arm</pattern>
+  <pattern>3naro</pattern>
+  <pattern>4nars</pattern>
+  <pattern>nar4st</pattern>
+  <pattern>nars5te </pattern>
+  <pattern>nar5sten</pattern>
+  <pattern>4n1art</pattern>
+  <pattern>nas2</pattern>
+  <pattern>3na3sa</pattern>
+  <pattern>na1s4l</pattern>
+  <pattern>na1sp</pattern>
+  <pattern>na3sta</pattern>
+  <pattern>na3stu</pattern>
+  <pattern>n4at </pattern>
+  <pattern>3n4ati</pattern>
+  <pattern>nat5j</pattern>
+  <pattern>4n3atl</pattern>
+  <pattern>na3to</pattern>
+  <pattern>nats4</pattern>
+  <pattern>nat3sp</pattern>
+  <pattern>5nau </pattern>
+  <pattern>5naus</pattern>
+  <pattern>2na3v</pattern>
+  <pattern>5naven</pattern>
+  <pattern>3navi</pattern>
+  <pattern>3nazif</pattern>
+  <pattern>na4zij</pattern>
+  <pattern>2nb</pattern>
+  <pattern>nbe5st</pattern>
+  <pattern>nbe5t</pattern>
+  <pattern>nbots5te </pattern>
+  <pattern>2n1c</pattern>
+  <pattern>n3ce</pattern>
+  <pattern>nces4t</pattern>
+  <pattern>n3che</pattern>
+  <pattern>ncht2</pattern>
+  <pattern>nch5tr</pattern>
+  <pattern>nch3u</pattern>
+  <pattern>n5co</pattern>
+  <pattern>4nd</pattern>
+  <pattern>n5da </pattern>
+  <pattern>nd3aan</pattern>
+  <pattern>nd5aas</pattern>
+  <pattern>nd3abo</pattern>
+  <pattern>nd3act</pattern>
+  <pattern>nd5adel</pattern>
+  <pattern>nd3adr</pattern>
+  <pattern>ndags5p</pattern>
+  <pattern>nd3alf</pattern>
+  <pattern>nd3alm</pattern>
+  <pattern>n4d3ana</pattern>
+  <pattern>n4dap</pattern>
+  <pattern>n2dar</pattern>
+  <pattern>nd3art</pattern>
+  <pattern>n4das</pattern>
+  <pattern>nd3ass</pattern>
+  <pattern>nda3st</pattern>
+  <pattern>n4dav</pattern>
+  <pattern>n4d3a4z</pattern>
+  <pattern>n3de</pattern>
+  <pattern>n4d3edi</pattern>
+  <pattern>n4d1ei</pattern>
+  <pattern>nde5laa</pattern>
+  <pattern>n4d3emm</pattern>
+  <pattern>n5den </pattern>
+  <pattern>ndera4</pattern>
+  <pattern>nder5aal</pattern>
+  <pattern>nder5al</pattern>
+  <pattern>nde4r5an</pattern>
+  <pattern>n4d5e4rec</pattern>
+  <pattern>nder5in </pattern>
+  <pattern>nder5og</pattern>
+  <pattern>nde4ten</pattern>
+  <pattern>ndi3a</pattern>
+  <pattern>ndie4tj</pattern>
+  <pattern>n4dijs</pattern>
+  <pattern>nd5ijs </pattern>
+  <pattern>n4d3ink</pattern>
+  <pattern>ndi3o</pattern>
+  <pattern>n3d2ji</pattern>
+  <pattern>n5do </pattern>
+  <pattern>n5doc</pattern>
+  <pattern>n4d5of</pattern>
+  <pattern>nd3oli</pattern>
+  <pattern>nd3omd</pattern>
+  <pattern>n4don</pattern>
+  <pattern>n5dona</pattern>
+  <pattern>nd5ond</pattern>
+  <pattern>n5dons</pattern>
+  <pattern>nd3ont</pattern>
+  <pattern>nd3oog</pattern>
+  <pattern>nd3ope</pattern>
+  <pattern>nd3opp</pattern>
+  <pattern>nd3ov</pattern>
+  <pattern>nd5rap</pattern>
+  <pattern>nd3rat</pattern>
+  <pattern>nd1re</pattern>
+  <pattern>nd4rek</pattern>
+  <pattern>n4dres</pattern>
+  <pattern>nd3rot</pattern>
+  <pattern>nd3rug</pattern>
+  <pattern>nd3s4cu</pattern>
+  <pattern>nd4sec</pattern>
+  <pattern>nd5set</pattern>
+  <pattern>nd3s4i</pattern>
+  <pattern>nd3sjo</pattern>
+  <pattern>nd4sm</pattern>
+  <pattern>nd3sp</pattern>
+  <pattern>nd4spo</pattern>
+  <pattern>nd4spra</pattern>
+  <pattern>nds5taal</pattern>
+  <pattern>nd3su</pattern>
+  <pattern>nd3uit</pattern>
+  <pattern>n2d3u4r</pattern>
+  <pattern>nd5ure</pattern>
+  <pattern>n4d3uu</pattern>
+  <pattern>nd1w</pattern>
+  <pattern>n3dy</pattern>
+  <pattern>1ne</pattern>
+  <pattern>3ne </pattern>
+  <pattern>ne5ac</pattern>
+  <pattern>ne3am</pattern>
+  <pattern>nebe4s</pattern>
+  <pattern>3neck</pattern>
+  <pattern>ne2cl</pattern>
+  <pattern>ne4dit</pattern>
+  <pattern>ne3do</pattern>
+  <pattern>n3edu</pattern>
+  <pattern>ne5dw</pattern>
+  <pattern>nee4</pattern>
+  <pattern>4need</pattern>
+  <pattern>nee5k</pattern>
+  <pattern>neel5d</pattern>
+  <pattern>neel3o</pattern>
+  <pattern>3neem</pattern>
+  <pattern>4n1een</pattern>
+  <pattern>nee5ri</pattern>
+  <pattern>nee5se</pattern>
+  <pattern>neet3a</pattern>
+  <pattern>neet5o</pattern>
+  <pattern>neet3r</pattern>
+  <pattern>neet5s</pattern>
+  <pattern>4n1eff</pattern>
+  <pattern>ne3g2</pattern>
+  <pattern>ne4gel</pattern>
+  <pattern>negen5en</pattern>
+  <pattern>nege4re</pattern>
+  <pattern>4n1ei</pattern>
+  <pattern>5neien</pattern>
+  <pattern>n5eier</pattern>
+  <pattern>n2eig</pattern>
+  <pattern>5neigd</pattern>
+  <pattern>5nei5t</pattern>
+  <pattern>ne4k3r</pattern>
+  <pattern>ne2la</pattern>
+  <pattern>4nelem</pattern>
+  <pattern>4nelf</pattern>
+  <pattern>3nem</pattern>
+  <pattern>4n3emb</pattern>
+  <pattern>5n4eme</pattern>
+  <pattern>4n3e4mig</pattern>
+  <pattern>4n3emm</pattern>
+  <pattern>4n3emp</pattern>
+  <pattern>ne2n</pattern>
+  <pattern>3n4en </pattern>
+  <pattern>5nenb</pattern>
+  <pattern>5n4end </pattern>
+  <pattern>nen5do</pattern>
+  <pattern>ne4n5enk</pattern>
+  <pattern>ne4ni</pattern>
+  <pattern>ne5nig</pattern>
+  <pattern>nen5k4</pattern>
+  <pattern>nen1o4</pattern>
+  <pattern>5nenp</pattern>
+  <pattern>nen5t4a</pattern>
+  <pattern>ne5oc</pattern>
+  <pattern>ne5ok</pattern>
+  <pattern>ne5om</pattern>
+  <pattern>neo5p</pattern>
+  <pattern>ne5os</pattern>
+  <pattern>ne5ot</pattern>
+  <pattern>nep3ag</pattern>
+  <pattern>ne3pe</pattern>
+  <pattern>nepi3s</pattern>
+  <pattern>ne1ra</pattern>
+  <pattern>nera4d</pattern>
+  <pattern>3n2e5re</pattern>
+  <pattern>n3erfe</pattern>
+  <pattern>2nerg</pattern>
+  <pattern>ne4r3id</pattern>
+  <pattern>ne3ros</pattern>
+  <pattern>ner4sl</pattern>
+  <pattern>ner4sp</pattern>
+  <pattern>ner4st</pattern>
+  <pattern>ners5te</pattern>
+  <pattern>ner3u</pattern>
+  <pattern>ne3ry</pattern>
+  <pattern>3nes</pattern>
+  <pattern>ness5a</pattern>
+  <pattern>ness5t</pattern>
+  <pattern>ne3sta</pattern>
+  <pattern>nes3te</pattern>
+  <pattern>nes4tei</pattern>
+  <pattern>ne5s4tek</pattern>
+  <pattern>ne4ter</pattern>
+  <pattern>net3on</pattern>
+  <pattern>net4si</pattern>
+  <pattern>ne2u</pattern>
+  <pattern>4neum</pattern>
+  <pattern>ne3ums</pattern>
+  <pattern>neu5ste</pattern>
+  <pattern>2nex</pattern>
+  <pattern>3né</pattern>
+  <pattern>2n3f</pattern>
+  <pattern>2ng</pattern>
+  <pattern>ngaat5j</pattern>
+  <pattern>n2g1a2d</pattern>
+  <pattern>ng3af</pattern>
+  <pattern>ng3ana</pattern>
+  <pattern>n4ga4p</pattern>
+  <pattern>n2gar</pattern>
+  <pattern>nga5sl</pattern>
+  <pattern>n3gav</pattern>
+  <pattern>nge4ad</pattern>
+  <pattern>n4g3een</pattern>
+  <pattern>ngels5te </pattern>
+  <pattern>ng3emb</pattern>
+  <pattern>n5gen</pattern>
+  <pattern>nge4rap</pattern>
+  <pattern>nge4ras</pattern>
+  <pattern>n4giger</pattern>
+  <pattern>n4gigs</pattern>
+  <pattern>ng3ij</pattern>
+  <pattern>n4gind</pattern>
+  <pattern>ng3ink</pattern>
+  <pattern>n4g3ins</pattern>
+  <pattern>ng4l</pattern>
+  <pattern>ng5lad</pattern>
+  <pattern>ng5lam</pattern>
+  <pattern>ng5lan</pattern>
+  <pattern>ng5led</pattern>
+  <pattern>ng5leu</pattern>
+  <pattern>ng2li</pattern>
+  <pattern>ng5lin</pattern>
+  <pattern>ng5lop</pattern>
+  <pattern>n3goe</pattern>
+  <pattern>ng3of</pattern>
+  <pattern>n3goï</pattern>
+  <pattern>n2g1on</pattern>
+  <pattern>ng5oor</pattern>
+  <pattern>ng5op</pattern>
+  <pattern>ng3ore</pattern>
+  <pattern>ng3org</pattern>
+  <pattern>n3got</pattern>
+  <pattern>n3gr</pattern>
+  <pattern>ng3rac</pattern>
+  <pattern>ng3rad</pattern>
+  <pattern>ng3rai</pattern>
+  <pattern>n4gras</pattern>
+  <pattern>ng5rass</pattern>
+  <pattern>ng4red</pattern>
+  <pattern>n4g4ri</pattern>
+  <pattern>ng5rie</pattern>
+  <pattern>ng3rij</pattern>
+  <pattern>n5gron</pattern>
+  <pattern>ng3rui</pattern>
+  <pattern>ng2s</pattern>
+  <pattern>ng4se</pattern>
+  <pattern>ngs5lop</pattern>
+  <pattern>ngs5lu</pattern>
+  <pattern>ng4s5ne</pattern>
+  <pattern>ngs5tak </pattern>
+  <pattern>ngs5take</pattern>
+  <pattern>ngs5trek</pattern>
+  <pattern>ng5stri</pattern>
+  <pattern>ng3uit</pattern>
+  <pattern>4n3h</pattern>
+  <pattern>nhek5</pattern>
+  <pattern>1ni</pattern>
+  <pattern>n4i2d</pattern>
+  <pattern>nie5kle</pattern>
+  <pattern>ni3eri</pattern>
+  <pattern>nie4s3p</pattern>
+  <pattern>nie4tr</pattern>
+  <pattern>3nieu</pattern>
+  <pattern>ni4g3ee</pattern>
+  <pattern>nig3ra</pattern>
+  <pattern>nij3f</pattern>
+  <pattern>nij3k</pattern>
+  <pattern>2n3ijz</pattern>
+  <pattern>ni5kr</pattern>
+  <pattern>nik4s</pattern>
+  <pattern>niks3p</pattern>
+  <pattern>3nil</pattern>
+  <pattern>3nim </pattern>
+  <pattern>5nimf</pattern>
+  <pattern>n3imp</pattern>
+  <pattern>2n3in </pattern>
+  <pattern>n3inb</pattern>
+  <pattern>2n1ind</pattern>
+  <pattern>2ninf</pattern>
+  <pattern>ning3r</pattern>
+  <pattern>2n3inh</pattern>
+  <pattern>n3inj</pattern>
+  <pattern>2ninr</pattern>
+  <pattern>2n1ins</pattern>
+  <pattern>2n1int</pattern>
+  <pattern>2n3inv</pattern>
+  <pattern>ni3o</pattern>
+  <pattern>ni4on </pattern>
+  <pattern>ni4one</pattern>
+  <pattern>ni5or</pattern>
+  <pattern>ni5o5s4</pattern>
+  <pattern>nip3l</pattern>
+  <pattern>3nis</pattern>
+  <pattern>ni4sau</pattern>
+  <pattern>ni4sel</pattern>
+  <pattern>ni4s3ev</pattern>
+  <pattern>ni3sfe</pattern>
+  <pattern>ni2s3i</pattern>
+  <pattern>ni4sl</pattern>
+  <pattern>nis5n</pattern>
+  <pattern>ni3sot</pattern>
+  <pattern>ni5stel</pattern>
+  <pattern>nis5to</pattern>
+  <pattern>ni3t2h</pattern>
+  <pattern>ni1tr</pattern>
+  <pattern>nits4</pattern>
+  <pattern>n1j4</pattern>
+  <pattern>n3je</pattern>
+  <pattern>njes4</pattern>
+  <pattern>nje5sp</pattern>
+  <pattern>nje5st</pattern>
+  <pattern>nje3t</pattern>
+  <pattern>4n1k</pattern>
+  <pattern>nk3aan</pattern>
+  <pattern>nk5aard</pattern>
+  <pattern>nkaart5j</pattern>
+  <pattern>nk3af</pattern>
+  <pattern>n5k4am</pattern>
+  <pattern>n4k3arb</pattern>
+  <pattern>nkar5s</pattern>
+  <pattern>n4k3asp</pattern>
+  <pattern>n3kef</pattern>
+  <pattern>nk3eff</pattern>
+  <pattern>nk3emp</pattern>
+  <pattern>n3ken</pattern>
+  <pattern>nken4e</pattern>
+  <pattern>nker5ku</pattern>
+  <pattern>nk3id</pattern>
+  <pattern>nk2j</pattern>
+  <pattern>nk3lad</pattern>
+  <pattern>nk3lod</pattern>
+  <pattern>nk3luc</pattern>
+  <pattern>nk3lus</pattern>
+  <pattern>n2k3na</pattern>
+  <pattern>n3kne</pattern>
+  <pattern>n4ko4g</pattern>
+  <pattern>nk3oge</pattern>
+  <pattern>nkoot5</pattern>
+  <pattern>nk4ra</pattern>
+  <pattern>n4krim</pattern>
+  <pattern>nk3rol</pattern>
+  <pattern>nk5se</pattern>
+  <pattern>nk5si</pattern>
+  <pattern>nk3sl</pattern>
+  <pattern>nk3s4m</pattern>
+  <pattern>nk3sn</pattern>
+  <pattern>nk4s5o</pattern>
+  <pattern>nk1sp</pattern>
+  <pattern>nk1st</pattern>
+  <pattern>n4kw</pattern>
+  <pattern>nk3waa</pattern>
+  <pattern>nk3wez</pattern>
+  <pattern>nk3wi</pattern>
+  <pattern>2n3l</pattern>
+  <pattern>2n3m4</pattern>
+  <pattern>n3n</pattern>
+  <pattern>n5n2e</pattern>
+  <pattern>nnee5t</pattern>
+  <pattern>nne3ne</pattern>
+  <pattern>nnepo4</pattern>
+  <pattern>nne4p5ol</pattern>
+  <pattern>nne5te</pattern>
+  <pattern>nnet4j</pattern>
+  <pattern>nn4i</pattern>
+  <pattern>nning5r</pattern>
+  <pattern>nnoot5</pattern>
+  <pattern>nno5v</pattern>
+  <pattern>3no </pattern>
+  <pattern>1noc</pattern>
+  <pattern>1no3d</pattern>
+  <pattern>2noef</pattern>
+  <pattern>noen5s</pattern>
+  <pattern>noes3</pattern>
+  <pattern>noet5s</pattern>
+  <pattern>n5offi</pattern>
+  <pattern>n3o2ge</pattern>
+  <pattern>n5ogi</pattern>
+  <pattern>1nogr</pattern>
+  <pattern>3noï</pattern>
+  <pattern>no3kl</pattern>
+  <pattern>no3k2w</pattern>
+  <pattern>no2li</pattern>
+  <pattern>1nolo</pattern>
+  <pattern>1nom</pattern>
+  <pattern>4n3om </pattern>
+  <pattern>n2oma</pattern>
+  <pattern>n3oml</pattern>
+  <pattern>n1oms</pattern>
+  <pattern>n3omv</pattern>
+  <pattern>2n3omw</pattern>
+  <pattern>2nomz</pattern>
+  <pattern>3n2on </pattern>
+  <pattern>3n4onb</pattern>
+  <pattern>3nonc</pattern>
+  <pattern>4n5ond</pattern>
+  <pattern>n4o5ni</pattern>
+  <pattern>4nont</pattern>
+  <pattern>3nood</pattern>
+  <pattern>4n5oof</pattern>
+  <pattern>4n1oog</pattern>
+  <pattern>nooi5tj</pattern>
+  <pattern>3noot3</pattern>
+  <pattern>noot4j</pattern>
+  <pattern>3no3pa</pattern>
+  <pattern>no4p3as</pattern>
+  <pattern>4n3opb</pattern>
+  <pattern>no1pe</pattern>
+  <pattern>n1opg</pattern>
+  <pattern>n5opleidi</pattern>
+  <pattern>no4poo</pattern>
+  <pattern>no4por</pattern>
+  <pattern>2nops</pattern>
+  <pattern>2n3opz</pattern>
+  <pattern>2nord</pattern>
+  <pattern>no3re</pattern>
+  <pattern>2n1org</pattern>
+  <pattern>1norm</pattern>
+  <pattern>4norr</pattern>
+  <pattern>3nors</pattern>
+  <pattern>3norz</pattern>
+  <pattern>1nos</pattern>
+  <pattern>no3sf</pattern>
+  <pattern>no3sn</pattern>
+  <pattern>no3sp</pattern>
+  <pattern>1not</pattern>
+  <pattern>3nota</pattern>
+  <pattern>not5a4p</pattern>
+  <pattern>5noti</pattern>
+  <pattern>not3j</pattern>
+  <pattern>not3r</pattern>
+  <pattern>3nou </pattern>
+  <pattern>no3v</pattern>
+  <pattern>3nova</pattern>
+  <pattern>no4ve</pattern>
+  <pattern>3nox</pattern>
+  <pattern>3noz</pattern>
+  <pattern>2n1p</pattern>
+  <pattern>npers5te </pattern>
+  <pattern>npi4s5</pattern>
+  <pattern>npoor4</pattern>
+  <pattern>npoort5j</pattern>
+  <pattern>n3ps</pattern>
+  <pattern>2n3r</pattern>
+  <pattern>nraads5l</pattern>
+  <pattern>n5re</pattern>
+  <pattern>n5ri</pattern>
+  <pattern>2ns</pattern>
+  <pattern>ns3a4d</pattern>
+  <pattern>n3sag</pattern>
+  <pattern>n1sal</pattern>
+  <pattern>ns3alp</pattern>
+  <pattern>n1sam</pattern>
+  <pattern>ns3an</pattern>
+  <pattern>n3sanc</pattern>
+  <pattern>n1sap</pattern>
+  <pattern>n3s4cal</pattern>
+  <pattern>n5scho</pattern>
+  <pattern>ns4ci</pattern>
+  <pattern>n4sco</pattern>
+  <pattern>nsee5t</pattern>
+  <pattern>n4sef</pattern>
+  <pattern>nse4g</pattern>
+  <pattern>ns5ege</pattern>
+  <pattern>ns3eis</pattern>
+  <pattern>ns5emp</pattern>
+  <pattern>n3si</pattern>
+  <pattern>ns3idi</pattern>
+  <pattern>n2sin</pattern>
+  <pattern>n5sing</pattern>
+  <pattern>ns3inj</pattern>
+  <pattern>ns3ink</pattern>
+  <pattern>ns3int</pattern>
+  <pattern>n1sjo</pattern>
+  <pattern>n1sl</pattern>
+  <pattern>n5sla </pattern>
+  <pattern>n3s4laa</pattern>
+  <pattern>ns5laag</pattern>
+  <pattern>n5slag</pattern>
+  <pattern>ns5lap </pattern>
+  <pattern>ns5lapp</pattern>
+  <pattern>n4sle</pattern>
+  <pattern>n5slep</pattern>
+  <pattern>ns4let</pattern>
+  <pattern>n5sleu</pattern>
+  <pattern>n5slib</pattern>
+  <pattern>ns3lie</pattern>
+  <pattern>n5s4liep</pattern>
+  <pattern>n5slim</pattern>
+  <pattern>n5slip</pattern>
+  <pattern>ns5lot </pattern>
+  <pattern>ns3m</pattern>
+  <pattern>ns5mac</pattern>
+  <pattern>n3s4me</pattern>
+  <pattern>n3smij</pattern>
+  <pattern>n3smol</pattern>
+  <pattern>n4smu</pattern>
+  <pattern>n1sn</pattern>
+  <pattern>n2sna</pattern>
+  <pattern>n5sne</pattern>
+  <pattern>ns3nod</pattern>
+  <pattern>n4snoo</pattern>
+  <pattern>n4snot</pattern>
+  <pattern>n1so</pattern>
+  <pattern>n2s3ob</pattern>
+  <pattern>n2sof</pattern>
+  <pattern>n3sol</pattern>
+  <pattern>n2son</pattern>
+  <pattern>ns3ong</pattern>
+  <pattern>ns3onz</pattern>
+  <pattern>ns4opp</pattern>
+  <pattern>ns4or</pattern>
+  <pattern>n2s3ou</pattern>
+  <pattern>ns1ov</pattern>
+  <pattern>n4s3paa</pattern>
+  <pattern>ns3pad</pattern>
+  <pattern>n1spe</pattern>
+  <pattern>n5spee</pattern>
+  <pattern>n5spel</pattern>
+  <pattern>ns3per</pattern>
+  <pattern>n4spet</pattern>
+  <pattern>ns4pi</pattern>
+  <pattern>ns1po</pattern>
+  <pattern>ns3pol</pattern>
+  <pattern>n4spot</pattern>
+  <pattern>n1spr</pattern>
+  <pattern>ns5q</pattern>
+  <pattern>ns5s</pattern>
+  <pattern>ns4t</pattern>
+  <pattern>n1sta</pattern>
+  <pattern>nst5aang</pattern>
+  <pattern>nst5aans</pattern>
+  <pattern>nst3a4g</pattern>
+  <pattern>n3stal</pattern>
+  <pattern>n3ste</pattern>
+  <pattern>ns5tec</pattern>
+  <pattern>n4st3ei</pattern>
+  <pattern>n4s5teko</pattern>
+  <pattern>ns5teks</pattern>
+  <pattern>n5sten </pattern>
+  <pattern>ns5tent</pattern>
+  <pattern>n5ster </pattern>
+  <pattern>ns5tes</pattern>
+  <pattern>ns3the</pattern>
+  <pattern>n1sti</pattern>
+  <pattern>n3stig</pattern>
+  <pattern>n4stijv</pattern>
+  <pattern>n1sto</pattern>
+  <pattern>nst5oef</pattern>
+  <pattern>n4ston</pattern>
+  <pattern>n3stor</pattern>
+  <pattern>nst5rade</pattern>
+  <pattern>n5stree</pattern>
+  <pattern>ns5trekk</pattern>
+  <pattern>ns5troe</pattern>
+  <pattern>ns5trog</pattern>
+  <pattern>nst5roos</pattern>
+  <pattern>ns5ty</pattern>
+  <pattern>ns3uil</pattern>
+  <pattern>n3sy</pattern>
+  <pattern>2nt</pattern>
+  <pattern>n3ta</pattern>
+  <pattern>n5taal</pattern>
+  <pattern>n4t5aard</pattern>
+  <pattern>ntaar5tj</pattern>
+  <pattern>n5tab</pattern>
+  <pattern>nt3ach</pattern>
+  <pattern>nt4act</pattern>
+  <pattern>nt1ad</pattern>
+  <pattern>nt3aga</pattern>
+  <pattern>n4t3art</pattern>
+  <pattern>nt4as</pattern>
+  <pattern>n5t4at</pattern>
+  <pattern>n3te</pattern>
+  <pattern>n5tec</pattern>
+  <pattern>n4t3ei</pattern>
+  <pattern>nte4lo</pattern>
+  <pattern>n5tem</pattern>
+  <pattern>n5te2n</pattern>
+  <pattern>nte5nach</pattern>
+  <pattern>ntene5ten</pattern>
+  <pattern>nte5rad</pattern>
+  <pattern>nte4rof</pattern>
+  <pattern>n3tè</pattern>
+  <pattern>nt3ha</pattern>
+  <pattern>n4tho</pattern>
+  <pattern>n5thol</pattern>
+  <pattern>n5tig</pattern>
+  <pattern>nt3inw</pattern>
+  <pattern>nt4jo</pattern>
+  <pattern>n3to</pattern>
+  <pattern>nt4og</pattern>
+  <pattern>nt4ol</pattern>
+  <pattern>n4t5oli</pattern>
+  <pattern>n5ton</pattern>
+  <pattern>nt4oo</pattern>
+  <pattern>nt5oog</pattern>
+  <pattern>n4top</pattern>
+  <pattern>nt3opl</pattern>
+  <pattern>nt3opm</pattern>
+  <pattern>nt3opt</pattern>
+  <pattern>n1tr</pattern>
+  <pattern>nt3rec</pattern>
+  <pattern>nt3rei</pattern>
+  <pattern>nt3rel</pattern>
+  <pattern>ntre4s</pattern>
+  <pattern>nt5ribb</pattern>
+  <pattern>nt5rij</pattern>
+  <pattern>n5troos</pattern>
+  <pattern>nt4rou</pattern>
+  <pattern>nt3rus</pattern>
+  <pattern>n5try</pattern>
+  <pattern>nts3a</pattern>
+  <pattern>nt5slu</pattern>
+  <pattern>nt1sn</pattern>
+  <pattern>nt4sno</pattern>
+  <pattern>nt1sp</pattern>
+  <pattern>nt4spr</pattern>
+  <pattern>nts5pre</pattern>
+  <pattern>nt1st</pattern>
+  <pattern>nt5ste</pattern>
+  <pattern>n3tu</pattern>
+  <pattern>n4t3uit</pattern>
+  <pattern>ntu4n</pattern>
+  <pattern>n5twijf</pattern>
+  <pattern>n5t4wis</pattern>
+  <pattern>3nu </pattern>
+  <pattern>3nuc</pattern>
+  <pattern>3nue</pattern>
+  <pattern>nu3en</pattern>
+  <pattern>nu3et</pattern>
+  <pattern>4nuf</pattern>
+  <pattern>2nui</pattern>
+  <pattern>4n3uil</pattern>
+  <pattern>nu2lo</pattern>
+  <pattern>3num</pattern>
+  <pattern>nu2m3a</pattern>
+  <pattern>5numm</pattern>
+  <pattern>nu2n</pattern>
+  <pattern>3nunc</pattern>
+  <pattern>n3uni</pattern>
+  <pattern>2nu4r</pattern>
+  <pattern>3n4u5ri</pattern>
+  <pattern>nu5ro</pattern>
+  <pattern>1nus</pattern>
+  <pattern>nu4s3o</pattern>
+  <pattern>nu3tr</pattern>
+  <pattern>nut4st</pattern>
+  <pattern>4nuu</pattern>
+  <pattern>5nuut</pattern>
+  <pattern>nuw5a</pattern>
+  <pattern>nu2w3i</pattern>
+  <pattern>2nv</pattern>
+  <pattern>nve5na</pattern>
+  <pattern>2n1w</pattern>
+  <pattern>nx3</pattern>
+  <pattern>n3xe</pattern>
+  <pattern>nxo4</pattern>
+  <pattern>1ny</pattern>
+  <pattern>4n3yi</pattern>
+  <pattern>4n3yo</pattern>
+  <pattern>2nz</pattern>
+  <pattern>nzet5s</pattern>
+  <pattern>3ñ</pattern>
+  <pattern>4o </pattern>
+  <pattern>4oa</pattern>
+  <pattern>o3aa</pattern>
+  <pattern>o2ad</pattern>
+  <pattern>o3af</pattern>
+  <pattern>o1ag</pattern>
+  <pattern>o3ah</pattern>
+  <pattern>o3ai</pattern>
+  <pattern>o1al</pattern>
+  <pattern>oa2m</pattern>
+  <pattern>o1a2n</pattern>
+  <pattern>oa4tiev</pattern>
+  <pattern>o3au</pattern>
+  <pattern>o3av</pattern>
+  <pattern>o3ax</pattern>
+  <pattern>2o3b</pattern>
+  <pattern>4ob </pattern>
+  <pattern>obal4</pattern>
+  <pattern>obalt3</pattern>
+  <pattern>3obj</pattern>
+  <pattern>1o4bli</pattern>
+  <pattern>ob5oor</pattern>
+  <pattern>o4b5o4r</pattern>
+  <pattern>4obr</pattern>
+  <pattern>4oca</pattern>
+  <pattern>ocaat5</pattern>
+  <pattern>5o2cea</pattern>
+  <pattern>o3cha</pattern>
+  <pattern>o1che</pattern>
+  <pattern>o3chi</pattern>
+  <pattern>o3cho</pattern>
+  <pattern>o3chr</pattern>
+  <pattern>ocke4</pattern>
+  <pattern>4o3co</pattern>
+  <pattern>oco3a</pattern>
+  <pattern>oco3s4</pattern>
+  <pattern>oc3t4</pattern>
+  <pattern>od5ac</pattern>
+  <pattern>oda3g</pattern>
+  <pattern>ode4m5ar</pattern>
+  <pattern>ode4mo</pattern>
+  <pattern>ode5re</pattern>
+  <pattern>odes4</pattern>
+  <pattern>odi3a</pattern>
+  <pattern>o5dru</pattern>
+  <pattern>od5sc</pattern>
+  <pattern>od5sei</pattern>
+  <pattern>od3s4i</pattern>
+  <pattern>od2sl</pattern>
+  <pattern>ods5lam</pattern>
+  <pattern>od5slan</pattern>
+  <pattern>od3sli</pattern>
+  <pattern>od5smak</pattern>
+  <pattern>od4s3o</pattern>
+  <pattern>od3spo</pattern>
+  <pattern>od4spr</pattern>
+  <pattern>ods4t</pattern>
+  <pattern>od5sta</pattern>
+  <pattern>od4ste</pattern>
+  <pattern>ods5te </pattern>
+  <pattern>od5stek</pattern>
+  <pattern>od5sten</pattern>
+  <pattern>od3w</pattern>
+  <pattern>o4e</pattern>
+  <pattern>oe5an</pattern>
+  <pattern>oe3as</pattern>
+  <pattern>oe2d3a</pattern>
+  <pattern>oeda4d</pattern>
+  <pattern>oede4n</pattern>
+  <pattern>oe2d3o2</pattern>
+  <pattern>oe4dr</pattern>
+  <pattern>oed3re</pattern>
+  <pattern>oed3ri</pattern>
+  <pattern>oed3ro</pattern>
+  <pattern>oe2d3u</pattern>
+  <pattern>oed3w</pattern>
+  <pattern>oe3e</pattern>
+  <pattern>oe5er</pattern>
+  <pattern>oe4f1a</pattern>
+  <pattern>1oefe</pattern>
+  <pattern>oe2fi</pattern>
+  <pattern>oe2fl</pattern>
+  <pattern>oef3la</pattern>
+  <pattern>oef5le</pattern>
+  <pattern>oef3lo</pattern>
+  <pattern>oe4f5o4</pattern>
+  <pattern>oe2f3r</pattern>
+  <pattern>oege3l</pattern>
+  <pattern>oeg5ij</pattern>
+  <pattern>oeg1l</pattern>
+  <pattern>oe4gou</pattern>
+  <pattern>oeii4</pattern>
+  <pattern>oei3n</pattern>
+  <pattern>oei5s4</pattern>
+  <pattern>oei5tj</pattern>
+  <pattern>oei3tr</pattern>
+  <pattern>oe4kaa</pattern>
+  <pattern>oek5erk</pattern>
+  <pattern>oeke4t</pattern>
+  <pattern>oe2k3l</pattern>
+  <pattern>oe4k3op</pattern>
+  <pattern>oe4k3r</pattern>
+  <pattern>oe2ku</pattern>
+  <pattern>oek1w</pattern>
+  <pattern>oe4lap</pattern>
+  <pattern>oe4lar</pattern>
+  <pattern>oel5dr</pattern>
+  <pattern>oe4l3ei</pattern>
+  <pattern>oe3lem</pattern>
+  <pattern>oel5f</pattern>
+  <pattern>oelo4</pattern>
+  <pattern>oe5loe</pattern>
+  <pattern>oelo5p</pattern>
+  <pattern>oel3sp</pattern>
+  <pattern>oe4m3ac</pattern>
+  <pattern>oem3o4</pattern>
+  <pattern>oen3al</pattern>
+  <pattern>oe5n4e</pattern>
+  <pattern>oen5gr</pattern>
+  <pattern>oen3o</pattern>
+  <pattern>oen4sn</pattern>
+  <pattern>2oep</pattern>
+  <pattern>oep5ind</pattern>
+  <pattern>oe4pl</pattern>
+  <pattern>oe5plo</pattern>
+  <pattern>oe4p3r</pattern>
+  <pattern>oe3pra</pattern>
+  <pattern>oe4ps</pattern>
+  <pattern>oeps3e</pattern>
+  <pattern>oe2p3u</pattern>
+  <pattern>4oer</pattern>
+  <pattern>oe1ra</pattern>
+  <pattern>oe4raa</pattern>
+  <pattern>oer5aal</pattern>
+  <pattern>oe4r3a4l</pattern>
+  <pattern>oer4e</pattern>
+  <pattern>oer5ei </pattern>
+  <pattern>oer5eie</pattern>
+  <pattern>oero2</pattern>
+  <pattern>oe3roe</pattern>
+  <pattern>oer3og</pattern>
+  <pattern>oer5om</pattern>
+  <pattern>oer4sl</pattern>
+  <pattern>oer4sp</pattern>
+  <pattern>oer4sta</pattern>
+  <pattern>oers5tak</pattern>
+  <pattern>oers5te </pattern>
+  <pattern>4oes </pattern>
+  <pattern>oe3sfe</pattern>
+  <pattern>oe3si</pattern>
+  <pattern>oe4sli</pattern>
+  <pattern>oe4s3o4</pattern>
+  <pattern>oes4ta</pattern>
+  <pattern>oes4th</pattern>
+  <pattern>oe3sto</pattern>
+  <pattern>oe4taa</pattern>
+  <pattern>oe2t3h</pattern>
+  <pattern>oe5t4i</pattern>
+  <pattern>oe2tj</pattern>
+  <pattern>oe4t3o4</pattern>
+  <pattern>oe5toe</pattern>
+  <pattern>oe4t3ra</pattern>
+  <pattern>oet4s3p</pattern>
+  <pattern>oet3w</pattern>
+  <pattern>2oë</pattern>
+  <pattern>of3ar</pattern>
+  <pattern>of3at</pattern>
+  <pattern>o4fav</pattern>
+  <pattern>of4d1a4</pattern>
+  <pattern>ofd3ei</pattern>
+  <pattern>of2d3o</pattern>
+  <pattern>of2d3r</pattern>
+  <pattern>ofd3w</pattern>
+  <pattern>of3l</pattern>
+  <pattern>o4fli</pattern>
+  <pattern>o4flo</pattern>
+  <pattern>4ofo</pattern>
+  <pattern>of3om</pattern>
+  <pattern>o3foo</pattern>
+  <pattern>of3op</pattern>
+  <pattern>o3for</pattern>
+  <pattern>of3ox</pattern>
+  <pattern>of1r</pattern>
+  <pattern>o3f2ra</pattern>
+  <pattern>of5se</pattern>
+  <pattern>of4sl</pattern>
+  <pattern>of5sla</pattern>
+  <pattern>ofs3le</pattern>
+  <pattern>of2sp</pattern>
+  <pattern>of3spe</pattern>
+  <pattern>ofs3pl</pattern>
+  <pattern>of3spo</pattern>
+  <pattern>ofs3pr</pattern>
+  <pattern>ofs3tr</pattern>
+  <pattern>ofs5tra</pattern>
+  <pattern>4oft</pattern>
+  <pattern>of4tu</pattern>
+  <pattern>oft3ur</pattern>
+  <pattern>oft3uu</pattern>
+  <pattern>of3ui</pattern>
+  <pattern>og5ac</pattern>
+  <pattern>oga4l</pattern>
+  <pattern>og3al </pattern>
+  <pattern>og5de</pattern>
+  <pattern>og3di</pattern>
+  <pattern>oge4d</pattern>
+  <pattern>oge5laa</pattern>
+  <pattern>ogel5ei</pattern>
+  <pattern>2ogem</pattern>
+  <pattern>o3ger</pattern>
+  <pattern>oge4ro</pattern>
+  <pattern>oger5on</pattern>
+  <pattern>oge4s3t</pattern>
+  <pattern>2og5h</pattern>
+  <pattern>1ogig</pattern>
+  <pattern>og1l</pattern>
+  <pattern>og5ne</pattern>
+  <pattern>og3op</pattern>
+  <pattern>og3sp</pattern>
+  <pattern>og3sta</pattern>
+  <pattern>og4st5ei</pattern>
+  <pattern>og3sto</pattern>
+  <pattern>og4ston</pattern>
+  <pattern>og4str</pattern>
+  <pattern>ogs5tro</pattern>
+  <pattern>og3ui</pattern>
+  <pattern>o3gy</pattern>
+  <pattern>2o1h</pattern>
+  <pattern>3ohm</pattern>
+  <pattern>4oi</pattern>
+  <pattern>oi3do</pattern>
+  <pattern>oi1e</pattern>
+  <pattern>oi3j</pattern>
+  <pattern>oi5k</pattern>
+  <pattern>o3ing</pattern>
+  <pattern>oi3o4</pattern>
+  <pattern>oi3s4</pattern>
+  <pattern>oi5sc</pattern>
+  <pattern>ois2p</pattern>
+  <pattern>oist2</pattern>
+  <pattern>ois5tj</pattern>
+  <pattern>o3ï</pattern>
+  <pattern>2o1j</pattern>
+  <pattern>2ok</pattern>
+  <pattern>o3ka </pattern>
+  <pattern>o3kaa</pattern>
+  <pattern>o4k3aas</pattern>
+  <pattern>ok3ab</pattern>
+  <pattern>ok3ag</pattern>
+  <pattern>o3kal</pattern>
+  <pattern>ok3ank</pattern>
+  <pattern>o4k3a4z</pattern>
+  <pattern>ok3ef</pattern>
+  <pattern>o2k4l</pattern>
+  <pattern>ok5let</pattern>
+  <pattern>o4kli</pattern>
+  <pattern>ok5lu</pattern>
+  <pattern>o2k3n</pattern>
+  <pattern>ok3o2l</pattern>
+  <pattern>ok3op </pattern>
+  <pattern>ok3o4pe</pattern>
+  <pattern>okos5</pattern>
+  <pattern>o2k3ou</pattern>
+  <pattern>o2k3r</pattern>
+  <pattern>ok4ra</pattern>
+  <pattern>ok1sa</pattern>
+  <pattern>ok3s4l</pattern>
+  <pattern>ok3sn</pattern>
+  <pattern>ok5spri</pattern>
+  <pattern>ok1st4</pattern>
+  <pattern>oks5te </pattern>
+  <pattern>ok5sten</pattern>
+  <pattern>ok4s5tr</pattern>
+  <pattern>ok5te</pattern>
+  <pattern>okter4s</pattern>
+  <pattern>oku4</pattern>
+  <pattern>ok3ur</pattern>
+  <pattern>ok3uu</pattern>
+  <pattern>ok1w</pattern>
+  <pattern>ok2wi</pattern>
+  <pattern>o1la</pattern>
+  <pattern>o3l4ab</pattern>
+  <pattern>ol3ac</pattern>
+  <pattern>o3lal</pattern>
+  <pattern>ol3a2p</pattern>
+  <pattern>ol3arm</pattern>
+  <pattern>ola3s4m</pattern>
+  <pattern>4old</pattern>
+  <pattern>ol3d4o</pattern>
+  <pattern>ol3d2w</pattern>
+  <pattern>o1le</pattern>
+  <pattern>o3le </pattern>
+  <pattern>ole5g</pattern>
+  <pattern>ol1ei</pattern>
+  <pattern>ol3eks</pattern>
+  <pattern>ol3emm</pattern>
+  <pattern>o3len</pattern>
+  <pattern>o5ler</pattern>
+  <pattern>oleu2</pattern>
+  <pattern>ole3um</pattern>
+  <pattern>ol3exa</pattern>
+  <pattern>ol2fa</pattern>
+  <pattern>olf3l</pattern>
+  <pattern>ol3fr</pattern>
+  <pattern>olf5sl</pattern>
+  <pattern>ol2gl</pattern>
+  <pattern>ol2g1o</pattern>
+  <pattern>olg5rap</pattern>
+  <pattern>ol4gre</pattern>
+  <pattern>ol4g3ri</pattern>
+  <pattern>ol2g3u</pattern>
+  <pattern>o3lia</pattern>
+  <pattern>o3lic</pattern>
+  <pattern>o5lid</pattern>
+  <pattern>o3lik</pattern>
+  <pattern>o3lin</pattern>
+  <pattern>o5ling</pattern>
+  <pattern>ol3int</pattern>
+  <pattern>o3lit</pattern>
+  <pattern>ol3kaf</pattern>
+  <pattern>ol5ke</pattern>
+  <pattern>ol2kr</pattern>
+  <pattern>olk4s</pattern>
+  <pattern>olk2v</pattern>
+  <pattern>ollie4</pattern>
+  <pattern>o3lo</pattern>
+  <pattern>o5loc</pattern>
+  <pattern>olo3k</pattern>
+  <pattern>ol4om</pattern>
+  <pattern>o4lop</pattern>
+  <pattern>ol3op </pattern>
+  <pattern>ol3opp</pattern>
+  <pattern>olo3s4t</pattern>
+  <pattern>olo4ve</pattern>
+  <pattern>ol4pra</pattern>
+  <pattern>4ols</pattern>
+  <pattern>ol5se</pattern>
+  <pattern>ol4s5h</pattern>
+  <pattern>ol5si</pattern>
+  <pattern>ol1sj</pattern>
+  <pattern>ol3s4l</pattern>
+  <pattern>ol3s4n</pattern>
+  <pattern>ol3so</pattern>
+  <pattern>ol3sp</pattern>
+  <pattern>ol5ster</pattern>
+  <pattern>4o1lu</pattern>
+  <pattern>ol3uit</pattern>
+  <pattern>olu4r</pattern>
+  <pattern>4oma</pattern>
+  <pattern>om2aa</pattern>
+  <pattern>om1ac</pattern>
+  <pattern>om1af</pattern>
+  <pattern>o3man</pattern>
+  <pattern>4ome</pattern>
+  <pattern>o4m3ef</pattern>
+  <pattern>om3ela</pattern>
+  <pattern>omen4s</pattern>
+  <pattern>omen5ste </pattern>
+  <pattern>ome5ren</pattern>
+  <pattern>omer5kl</pattern>
+  <pattern>ome5sp</pattern>
+  <pattern>ome5t</pattern>
+  <pattern>om2i</pattern>
+  <pattern>o4m3int</pattern>
+  <pattern>4omm</pattern>
+  <pattern>4omo</pattern>
+  <pattern>omo5l</pattern>
+  <pattern>omo3s</pattern>
+  <pattern>om4p5ei</pattern>
+  <pattern>5omro</pattern>
+  <pattern>om3sl</pattern>
+  <pattern>om4ste </pattern>
+  <pattern>om3ui</pattern>
+  <pattern>3omz</pattern>
+  <pattern>on1ac</pattern>
+  <pattern>on4ag</pattern>
+  <pattern>o4n3am</pattern>
+  <pattern>on4an</pattern>
+  <pattern>on3ap</pattern>
+  <pattern>ona3th</pattern>
+  <pattern>2onc</pattern>
+  <pattern>on4d3ac</pattern>
+  <pattern>on5d4as</pattern>
+  <pattern>on5der</pattern>
+  <pattern>ond5ete</pattern>
+  <pattern>on4d3id</pattern>
+  <pattern>ond5ijs</pattern>
+  <pattern>ond5om </pattern>
+  <pattern>on2dr</pattern>
+  <pattern>ond3re</pattern>
+  <pattern>ond3ro</pattern>
+  <pattern>ond5sj</pattern>
+  <pattern>ond5slo</pattern>
+  <pattern>on3d4u</pattern>
+  <pattern>on4dur</pattern>
+  <pattern>o5ne </pattern>
+  <pattern>o3neb</pattern>
+  <pattern>o2n1e2c</pattern>
+  <pattern>on3ei</pattern>
+  <pattern>on3erf</pattern>
+  <pattern>on3erv</pattern>
+  <pattern>one3st</pattern>
+  <pattern>4onet </pattern>
+  <pattern>on1e3v</pattern>
+  <pattern>ong5aan</pattern>
+  <pattern>ong5aap</pattern>
+  <pattern>ong3ap</pattern>
+  <pattern>4ongen</pattern>
+  <pattern>ong5le</pattern>
+  <pattern>ong2r</pattern>
+  <pattern>ongs4</pattern>
+  <pattern>ong5se</pattern>
+  <pattern>ong3sp</pattern>
+  <pattern>ong3st</pattern>
+  <pattern>on5id</pattern>
+  <pattern>o5nig</pattern>
+  <pattern>on4k3ap</pattern>
+  <pattern>onke5lap</pattern>
+  <pattern>on3k2i</pattern>
+  <pattern>on4k3lo</pattern>
+  <pattern>on3kn</pattern>
+  <pattern>on5kw</pattern>
+  <pattern>onnes4</pattern>
+  <pattern>onne5st</pattern>
+  <pattern>o4n3of</pattern>
+  <pattern>ono3l</pattern>
+  <pattern>on1on</pattern>
+  <pattern>o2n1ov</pattern>
+  <pattern>on3sc</pattern>
+  <pattern>ons4e</pattern>
+  <pattern>on5sei</pattern>
+  <pattern>ons2f</pattern>
+  <pattern>on3s4m</pattern>
+  <pattern>on2s3n</pattern>
+  <pattern>ons5op</pattern>
+  <pattern>on3sor</pattern>
+  <pattern>on1s2p</pattern>
+  <pattern>ons4pe</pattern>
+  <pattern>on3spl</pattern>
+  <pattern>on1st</pattern>
+  <pattern>on5sten</pattern>
+  <pattern>on5str</pattern>
+  <pattern>4ont </pattern>
+  <pattern>on4taa</pattern>
+  <pattern>3ont1h</pattern>
+  <pattern>on4tid</pattern>
+  <pattern>3ont1s4</pattern>
+  <pattern>ont5sp</pattern>
+  <pattern>3ontv</pattern>
+  <pattern>1ont3w</pattern>
+  <pattern>on1ui</pattern>
+  <pattern>on3ur</pattern>
+  <pattern>o4o2</pattern>
+  <pattern>4oo </pattern>
+  <pattern>oo3c</pattern>
+  <pattern>4oo4d</pattern>
+  <pattern>ood1a</pattern>
+  <pattern>ood1e4</pattern>
+  <pattern>oo5de </pattern>
+  <pattern>ood1o</pattern>
+  <pattern>ood1r</pattern>
+  <pattern>ood3sl</pattern>
+  <pattern>ood3sp</pattern>
+  <pattern>4oof</pattern>
+  <pattern>oo3fi</pattern>
+  <pattern>oo4g</pattern>
+  <pattern>oog1a</pattern>
+  <pattern>oog3e</pattern>
+  <pattern>oo5gi</pattern>
+  <pattern>oog1r</pattern>
+  <pattern>oogs4</pattern>
+  <pattern>oog3sh</pattern>
+  <pattern>oog3sl</pattern>
+  <pattern>ook3a</pattern>
+  <pattern>oo3ke</pattern>
+  <pattern>ook5l</pattern>
+  <pattern>ook3s4</pattern>
+  <pattern>ook5st</pattern>
+  <pattern>oo4k5w</pattern>
+  <pattern>oo4l</pattern>
+  <pattern>ool5a2</pattern>
+  <pattern>oole2</pattern>
+  <pattern>ool3ed</pattern>
+  <pattern>ool5f</pattern>
+  <pattern>ool5g</pattern>
+  <pattern>oo5lig</pattern>
+  <pattern>ool3ij</pattern>
+  <pattern>ool3k</pattern>
+  <pattern>ool1o4</pattern>
+  <pattern>ool1u</pattern>
+  <pattern>oom5a4</pattern>
+  <pattern>oo3me</pattern>
+  <pattern>oom3i</pattern>
+  <pattern>oom1o4</pattern>
+  <pattern>ooms5te </pattern>
+  <pattern>4oon</pattern>
+  <pattern>oon5a</pattern>
+  <pattern>oon5du</pattern>
+  <pattern>oon3in5</pattern>
+  <pattern>oon5k4</pattern>
+  <pattern>oon1o</pattern>
+  <pattern>oon5ta</pattern>
+  <pattern>oo4p1</pattern>
+  <pattern>oopa2</pattern>
+  <pattern>oop5ee</pattern>
+  <pattern>oop3o4</pattern>
+  <pattern>oop3r</pattern>
+  <pattern>oop4sp</pattern>
+  <pattern>oor3a</pattern>
+  <pattern>oord5aa</pattern>
+  <pattern>oor5dop</pattern>
+  <pattern>oor1e4</pattern>
+  <pattern>oor3g4</pattern>
+  <pattern>oor5i</pattern>
+  <pattern>oor5k</pattern>
+  <pattern>oor5m</pattern>
+  <pattern>oor1o</pattern>
+  <pattern>oor3sm</pattern>
+  <pattern>oor5ste</pattern>
+  <pattern>oor5sto</pattern>
+  <pattern>4oort</pattern>
+  <pattern>oor4th</pattern>
+  <pattern>oo4s</pattern>
+  <pattern>oos3a</pattern>
+  <pattern>oo5se</pattern>
+  <pattern>oos5n</pattern>
+  <pattern>oo4t</pattern>
+  <pattern>oot1a</pattern>
+  <pattern>oot3es</pattern>
+  <pattern>oot3h</pattern>
+  <pattern>oot5o</pattern>
+  <pattern>oot3r</pattern>
+  <pattern>oot4sl</pattern>
+  <pattern>o1ö</pattern>
+  <pattern>2opa</pattern>
+  <pattern>o4p3ac</pattern>
+  <pattern>op3ad</pattern>
+  <pattern>o4p3af</pattern>
+  <pattern>o4p3ak</pattern>
+  <pattern>op3am</pattern>
+  <pattern>o3pan</pattern>
+  <pattern>op3and</pattern>
+  <pattern>op3at </pattern>
+  <pattern>op3att</pattern>
+  <pattern>3opbre</pattern>
+  <pattern>3opdr</pattern>
+  <pattern>o3pe </pattern>
+  <pattern>op3ee</pattern>
+  <pattern>op5eet</pattern>
+  <pattern>op3ei</pattern>
+  <pattern>o1pel</pattern>
+  <pattern>o3pen </pattern>
+  <pattern>3o4peni</pattern>
+  <pattern>o5per </pattern>
+  <pattern>o4pera</pattern>
+  <pattern>op3e4te</pattern>
+  <pattern>op3e4v</pattern>
+  <pattern>4opf</pattern>
+  <pattern>o1pi</pattern>
+  <pattern>o5pic</pattern>
+  <pattern>op3i2d</pattern>
+  <pattern>opie5t</pattern>
+  <pattern>op3ijz</pattern>
+  <pattern>op3in </pattern>
+  <pattern>o5pina</pattern>
+  <pattern>o5pis</pattern>
+  <pattern>4op1j</pattern>
+  <pattern>op3l</pattern>
+  <pattern>op5los</pattern>
+  <pattern>1opn</pattern>
+  <pattern>o1po</pattern>
+  <pattern>opoe3</pattern>
+  <pattern>op1of</pattern>
+  <pattern>o5pog</pattern>
+  <pattern>o5poi</pattern>
+  <pattern>o5pol</pattern>
+  <pattern>op3ond</pattern>
+  <pattern>o5poni</pattern>
+  <pattern>op3ont</pattern>
+  <pattern>op3ord</pattern>
+  <pattern>op3o4re</pattern>
+  <pattern>op3o4v</pattern>
+  <pattern>op1r</pattern>
+  <pattern>op3ric</pattern>
+  <pattern>o4pru</pattern>
+  <pattern>o4ps</pattern>
+  <pattern>op5s2c</pattern>
+  <pattern>op5se</pattern>
+  <pattern>op5si</pattern>
+  <pattern>3ops4l</pattern>
+  <pattern>ops4m</pattern>
+  <pattern>op3sma</pattern>
+  <pattern>op3sn</pattern>
+  <pattern>op3so</pattern>
+  <pattern>op3sp</pattern>
+  <pattern>op3sta</pattern>
+  <pattern>op3su</pattern>
+  <pattern>2opt</pattern>
+  <pattern>4opt </pattern>
+  <pattern>op5tr</pattern>
+  <pattern>op3ui</pattern>
+  <pattern>o2p3u2n</pattern>
+  <pattern>o1ra</pattern>
+  <pattern>or3ach</pattern>
+  <pattern>or3act</pattern>
+  <pattern>or3adm</pattern>
+  <pattern>or1af</pattern>
+  <pattern>ora4g</pattern>
+  <pattern>o4r3alg</pattern>
+  <pattern>or3ana</pattern>
+  <pattern>o5rate</pattern>
+  <pattern>or4daa</pattern>
+  <pattern>or4d3as</pattern>
+  <pattern>or4denv</pattern>
+  <pattern>or4do</pattern>
+  <pattern>ord5ond</pattern>
+  <pattern>ord3or</pattern>
+  <pattern>ord3o4v</pattern>
+  <pattern>or3dr</pattern>
+  <pattern>or4drad</pattern>
+  <pattern>ord3w</pattern>
+  <pattern>o1re</pattern>
+  <pattern>ore5ad</pattern>
+  <pattern>4orec</pattern>
+  <pattern>oree4</pattern>
+  <pattern>ore4no</pattern>
+  <pattern>or2gl</pattern>
+  <pattern>o1ri</pattern>
+  <pattern>o5ria</pattern>
+  <pattern>3orië</pattern>
+  <pattern>o5rig </pattern>
+  <pattern>o5rigere</pattern>
+  <pattern>o4r3ink</pattern>
+  <pattern>or3ins</pattern>
+  <pattern>ork2a</pattern>
+  <pattern>or5k4e</pattern>
+  <pattern>or3kl</pattern>
+  <pattern>or5kn</pattern>
+  <pattern>or3kw</pattern>
+  <pattern>or4m3ac</pattern>
+  <pattern>or4mas</pattern>
+  <pattern>or4m3ei</pattern>
+  <pattern>or4n3ac</pattern>
+  <pattern>or3ni</pattern>
+  <pattern>orno3s4</pattern>
+  <pattern>or3oe</pattern>
+  <pattern>o3rol</pattern>
+  <pattern>or1on</pattern>
+  <pattern>or3ont</pattern>
+  <pattern>or1oo</pattern>
+  <pattern>or1o2p</pattern>
+  <pattern>or3or</pattern>
+  <pattern>o3ros</pattern>
+  <pattern>or5ov</pattern>
+  <pattern>4orp</pattern>
+  <pattern>or4p3ac</pattern>
+  <pattern>orp4s5c</pattern>
+  <pattern>or3sag</pattern>
+  <pattern>or5sc</pattern>
+  <pattern>or5se</pattern>
+  <pattern>or3sli</pattern>
+  <pattern>or3smi</pattern>
+  <pattern>or3so</pattern>
+  <pattern>or4son</pattern>
+  <pattern>or3sp</pattern>
+  <pattern>or5s4pa</pattern>
+  <pattern>or5spu</pattern>
+  <pattern>or4t3ak</pattern>
+  <pattern>ort5een</pattern>
+  <pattern>or4t5ijl</pattern>
+  <pattern>or2to</pattern>
+  <pattern>or4tof</pattern>
+  <pattern>or4t3oo</pattern>
+  <pattern>or4tred</pattern>
+  <pattern>ort5sp</pattern>
+  <pattern>ort5ste</pattern>
+  <pattern>or1u</pattern>
+  <pattern>o3ry</pattern>
+  <pattern>orzet5</pattern>
+  <pattern>2os</pattern>
+  <pattern>o4sac</pattern>
+  <pattern>o5sas</pattern>
+  <pattern>o3sau</pattern>
+  <pattern>4o3s2c</pattern>
+  <pattern>osca4</pattern>
+  <pattern>o4sci</pattern>
+  <pattern>o5s4cl</pattern>
+  <pattern>os3cu</pattern>
+  <pattern>o5sed</pattern>
+  <pattern>os4el</pattern>
+  <pattern>o5ser</pattern>
+  <pattern>os3f</pattern>
+  <pattern>os4fe</pattern>
+  <pattern>o4sha</pattern>
+  <pattern>o3shi</pattern>
+  <pattern>os2ho</pattern>
+  <pattern>o3si</pattern>
+  <pattern>o4sj</pattern>
+  <pattern>os5jer </pattern>
+  <pattern>o4sk</pattern>
+  <pattern>os5ko</pattern>
+  <pattern>os3l</pattern>
+  <pattern>os5li4</pattern>
+  <pattern>o4s3m</pattern>
+  <pattern>os4n</pattern>
+  <pattern>os5no</pattern>
+  <pattern>o3s2o</pattern>
+  <pattern>os3pa</pattern>
+  <pattern>os3per</pattern>
+  <pattern>os1pi</pattern>
+  <pattern>os4pir</pattern>
+  <pattern>o4spr</pattern>
+  <pattern>os4s5m</pattern>
+  <pattern>o2s3t</pattern>
+  <pattern>os4ta</pattern>
+  <pattern>os5taal</pattern>
+  <pattern>os5taar</pattern>
+  <pattern>osta3c</pattern>
+  <pattern>ost3a4g</pattern>
+  <pattern>os5tan</pattern>
+  <pattern>os5tar</pattern>
+  <pattern>o3stas</pattern>
+  <pattern>o3stat</pattern>
+  <pattern>os5te </pattern>
+  <pattern>os4tem</pattern>
+  <pattern>o5steroï</pattern>
+  <pattern>os4th</pattern>
+  <pattern>os4to</pattern>
+  <pattern>os5toli</pattern>
+  <pattern>os5tou</pattern>
+  <pattern>ost3o4v</pattern>
+  <pattern>os5tra </pattern>
+  <pattern>os5traa</pattern>
+  <pattern>ost3re</pattern>
+  <pattern>ost3ri</pattern>
+  <pattern>o3stro</pattern>
+  <pattern>os5trum</pattern>
+  <pattern>os1tu</pattern>
+  <pattern>o3sty</pattern>
+  <pattern>o3su</pattern>
+  <pattern>o5sy</pattern>
+  <pattern>4o1ta</pattern>
+  <pattern>ot3aar</pattern>
+  <pattern>ot1ac</pattern>
+  <pattern>ot3af</pattern>
+  <pattern>o3tag</pattern>
+  <pattern>ot3akt</pattern>
+  <pattern>ot3app</pattern>
+  <pattern>ot3art</pattern>
+  <pattern>otas4</pattern>
+  <pattern>o5tat</pattern>
+  <pattern>o3te</pattern>
+  <pattern>ot3e2d</pattern>
+  <pattern>o5tee </pattern>
+  <pattern>o5tees</pattern>
+  <pattern>o5teg</pattern>
+  <pattern>ot3ei</pattern>
+  <pattern>ote4lan</pattern>
+  <pattern>o5ten</pattern>
+  <pattern>o5ter</pattern>
+  <pattern>oter5sp</pattern>
+  <pattern>ote4st</pattern>
+  <pattern>ote4t</pattern>
+  <pattern>ot3eta</pattern>
+  <pattern>o1th</pattern>
+  <pattern>o2t1ho</pattern>
+  <pattern>ot3hu</pattern>
+  <pattern>o4tj</pattern>
+  <pattern>otje5sp</pattern>
+  <pattern>otli2</pattern>
+  <pattern>o1to</pattern>
+  <pattern>ot3off</pattern>
+  <pattern>ot3olv</pattern>
+  <pattern>o5tom</pattern>
+  <pattern>ot3ont</pattern>
+  <pattern>ot3opm</pattern>
+  <pattern>oto5po</pattern>
+  <pattern>ot3opr</pattern>
+  <pattern>o5t4or</pattern>
+  <pattern>oto3s</pattern>
+  <pattern>2otr</pattern>
+  <pattern>o1t4ro</pattern>
+  <pattern>ot3ru</pattern>
+  <pattern>ot5s4i</pattern>
+  <pattern>ot2sl</pattern>
+  <pattern>ot3sla</pattern>
+  <pattern>ots3li</pattern>
+  <pattern>ot3smo</pattern>
+  <pattern>ot3sn</pattern>
+  <pattern>ot3sp</pattern>
+  <pattern>ot4s3pa</pattern>
+  <pattern>ot4ste </pattern>
+  <pattern>ots5tek</pattern>
+  <pattern>ot5sten</pattern>
+  <pattern>ot4stu</pattern>
+  <pattern>o1tu</pattern>
+  <pattern>ot3ui</pattern>
+  <pattern>o3tul</pattern>
+  <pattern>ot5w</pattern>
+  <pattern>4ou </pattern>
+  <pattern>ou5a</pattern>
+  <pattern>ou1c</pattern>
+  <pattern>ou4d1a</pattern>
+  <pattern>ou4des</pattern>
+  <pattern>ou2do</pattern>
+  <pattern>ou1e</pattern>
+  <pattern>oue2t3</pattern>
+  <pattern>ou3k4</pattern>
+  <pattern>ou4ren</pattern>
+  <pattern>ou5ren </pattern>
+  <pattern>ou5renn</pattern>
+  <pattern>ou2r3o2</pattern>
+  <pattern>4ous</pattern>
+  <pattern>ou3sa</pattern>
+  <pattern>ous5c</pattern>
+  <pattern>oust4</pattern>
+  <pattern>ou2ta</pattern>
+  <pattern>out3h</pattern>
+  <pattern>out1j</pattern>
+  <pattern>ou2t3o</pattern>
+  <pattern>out1r</pattern>
+  <pattern>out5sp</pattern>
+  <pattern>out5ste</pattern>
+  <pattern>ouw3a</pattern>
+  <pattern>ouw5do</pattern>
+  <pattern>ouw5ins</pattern>
+  <pattern>o2v</pattern>
+  <pattern>2o3va</pattern>
+  <pattern>o5ve </pattern>
+  <pattern>2o5vee</pattern>
+  <pattern>3o4verg</pattern>
+  <pattern>over5sp</pattern>
+  <pattern>over5ste</pattern>
+  <pattern>o5ves</pattern>
+  <pattern>2ovi</pattern>
+  <pattern>ovi5so</pattern>
+  <pattern>4ovl</pattern>
+  <pattern>4o3vo</pattern>
+  <pattern>4ovr</pattern>
+  <pattern>ovu3</pattern>
+  <pattern>4ow</pattern>
+  <pattern>o1wa</pattern>
+  <pattern>o1we</pattern>
+  <pattern>o5wen</pattern>
+  <pattern>ow3h</pattern>
+  <pattern>o1wi</pattern>
+  <pattern>ow2n</pattern>
+  <pattern>o3wo</pattern>
+  <pattern>ow3r</pattern>
+  <pattern>o4x</pattern>
+  <pattern>oys4</pattern>
+  <pattern>ozet5</pattern>
+  <pattern>ö3l</pattern>
+  <pattern>ö1p</pattern>
+  <pattern>öpe1</pattern>
+  <pattern>ö4r</pattern>
+  <pattern>ös4</pattern>
+  <pattern>ös5t</pattern>
+  <pattern>ö5su</pattern>
+  <pattern>4p </pattern>
+  <pattern>4paan</pattern>
+  <pattern>paar5du</pattern>
+  <pattern>paar5tj</pattern>
+  <pattern>5paas</pattern>
+  <pattern>3pab</pattern>
+  <pattern>p3acc</pattern>
+  <pattern>2pach</pattern>
+  <pattern>pacht5s</pattern>
+  <pattern>p4aci</pattern>
+  <pattern>5pacu</pattern>
+  <pattern>3pad </pattern>
+  <pattern>pa4da</pattern>
+  <pattern>4padv</pattern>
+  <pattern>pa3e</pattern>
+  <pattern>4p3afd</pattern>
+  <pattern>1pag</pattern>
+  <pattern>pag2a</pattern>
+  <pattern>pa4gen</pattern>
+  <pattern>pa3gh</pattern>
+  <pattern>p4a5gi</pattern>
+  <pattern>3pak</pattern>
+  <pattern>pa2k3a</pattern>
+  <pattern>4p4ake</pattern>
+  <pattern>pa4ki</pattern>
+  <pattern>pa4k5l</pattern>
+  <pattern>2p3alb</pattern>
+  <pattern>3pale</pattern>
+  <pattern>pal3f</pattern>
+  <pattern>pa3li</pattern>
+  <pattern>paling5s</pattern>
+  <pattern>palle4</pattern>
+  <pattern>palm5ac</pattern>
+  <pattern>pal4mo</pattern>
+  <pattern>pa4m</pattern>
+  <pattern>pa3na</pattern>
+  <pattern>pa4n3a4d</pattern>
+  <pattern>5panee</pattern>
+  <pattern>5panel</pattern>
+  <pattern>4pank</pattern>
+  <pattern>pan5sp</pattern>
+  <pattern>pan4tr</pattern>
+  <pattern>1pap</pattern>
+  <pattern>pa4pe4t</pattern>
+  <pattern>5papi</pattern>
+  <pattern>pap3l</pattern>
+  <pattern>pa3po</pattern>
+  <pattern>pa3pr</pattern>
+  <pattern>4par </pattern>
+  <pattern>3pa3ra</pattern>
+  <pattern>p3arb</pattern>
+  <pattern>pard4</pattern>
+  <pattern>par3da</pattern>
+  <pattern>3park</pattern>
+  <pattern>par4ka</pattern>
+  <pattern>par4k5l</pattern>
+  <pattern>3parl</pattern>
+  <pattern>4parm</pattern>
+  <pattern>pa5ro</pattern>
+  <pattern>4parr</pattern>
+  <pattern>par5ta</pattern>
+  <pattern>3parti</pattern>
+  <pattern>part3j</pattern>
+  <pattern>3partn</pattern>
+  <pattern>pa5ru</pattern>
+  <pattern>paru5r</pattern>
+  <pattern>1pa4s3</pattern>
+  <pattern>pa5sa</pattern>
+  <pattern>pas5c</pattern>
+  <pattern>pa5se</pattern>
+  <pattern>pa5so</pattern>
+  <pattern>pas4th</pattern>
+  <pattern>pas5to</pattern>
+  <pattern>pas5tr</pattern>
+  <pattern>pa5te</pattern>
+  <pattern>1path</pattern>
+  <pattern>p3atl</pattern>
+  <pattern>3pa3tr</pattern>
+  <pattern>pats5te </pattern>
+  <pattern>2paut</pattern>
+  <pattern>5pauz</pattern>
+  <pattern>pa4vl</pattern>
+  <pattern>5paz</pattern>
+  <pattern>2pb4</pattern>
+  <pattern>2p1c</pattern>
+  <pattern>2p3d2</pattern>
+  <pattern>pe4al</pattern>
+  <pattern>4peci</pattern>
+  <pattern>p3e2co</pattern>
+  <pattern>3pectu</pattern>
+  <pattern>1ped</pattern>
+  <pattern>pe3de</pattern>
+  <pattern>pe3do</pattern>
+  <pattern>p4ee4</pattern>
+  <pattern>3pee </pattern>
+  <pattern>3peeë</pattern>
+  <pattern>pee5li</pattern>
+  <pattern>4peen</pattern>
+  <pattern>5pees</pattern>
+  <pattern>3peg</pattern>
+  <pattern>1p4eil</pattern>
+  <pattern>pei4l3a</pattern>
+  <pattern>4peis</pattern>
+  <pattern>pek5ee</pattern>
+  <pattern>pe2k3l</pattern>
+  <pattern>pe2k3n</pattern>
+  <pattern>pek5s</pattern>
+  <pattern>p4el</pattern>
+  <pattern>pe3l4aa</pattern>
+  <pattern>pe4l3ak</pattern>
+  <pattern>pel5dr</pattern>
+  <pattern>pe3le</pattern>
+  <pattern>pe4l3ee</pattern>
+  <pattern>pe4l3e4t</pattern>
+  <pattern>pe3l4i</pattern>
+  <pattern>pe3l4or</pattern>
+  <pattern>pel5si</pattern>
+  <pattern>pel3so</pattern>
+  <pattern>pel3sp</pattern>
+  <pattern>2p3emm</pattern>
+  <pattern>pe3na</pattern>
+  <pattern>pe4nak</pattern>
+  <pattern>pe4nap</pattern>
+  <pattern>pe4nau</pattern>
+  <pattern>pe4naz</pattern>
+  <pattern>p3ency</pattern>
+  <pattern>pen5d4r</pattern>
+  <pattern>penge5</pattern>
+  <pattern>pen5k</pattern>
+  <pattern>5penn</pattern>
+  <pattern>pen3sa</pattern>
+  <pattern>pen5sl</pattern>
+  <pattern>pen3sm</pattern>
+  <pattern>pen5sp</pattern>
+  <pattern>pent4</pattern>
+  <pattern>pen5to</pattern>
+  <pattern>2p3epi</pattern>
+  <pattern>pep3o</pattern>
+  <pattern>pep5s</pattern>
+  <pattern>p4er </pattern>
+  <pattern>pe1ra</pattern>
+  <pattern>pera3s4</pattern>
+  <pattern>per4at</pattern>
+  <pattern>3perc</pattern>
+  <pattern>pe4r5eg</pattern>
+  <pattern>pe5req</pattern>
+  <pattern>1peri</pattern>
+  <pattern>peri3s</pattern>
+  <pattern>per1o</pattern>
+  <pattern>pe3ron</pattern>
+  <pattern>pe5ros</pattern>
+  <pattern>3pers</pattern>
+  <pattern>per4sm</pattern>
+  <pattern>per5sti</pattern>
+  <pattern>per4str</pattern>
+  <pattern>p2ert</pattern>
+  <pattern>3pes</pattern>
+  <pattern>pe3sa</pattern>
+  <pattern>3pet </pattern>
+  <pattern>pe5ta</pattern>
+  <pattern>5pe5ter</pattern>
+  <pattern>3peti</pattern>
+  <pattern>pe4t3ra</pattern>
+  <pattern>pets5te</pattern>
+  <pattern>petu5</pattern>
+  <pattern>3peuk</pattern>
+  <pattern>5peut</pattern>
+  <pattern>1pé</pattern>
+  <pattern>3pê</pattern>
+  <pattern>2p1f</pattern>
+  <pattern>2p1g</pattern>
+  <pattern>pge5s</pattern>
+  <pattern>2p1h4</pattern>
+  <pattern>4p3ha</pattern>
+  <pattern>3p4hec</pattern>
+  <pattern>p4his</pattern>
+  <pattern>4pho</pattern>
+  <pattern>pi3am</pattern>
+  <pattern>pi5an</pattern>
+  <pattern>pi4at</pattern>
+  <pattern>2pid</pattern>
+  <pattern>piek5la</pattern>
+  <pattern>5piep</pattern>
+  <pattern>pie4r3o</pattern>
+  <pattern>pie4s3p</pattern>
+  <pattern>pie4tj</pattern>
+  <pattern>pi2g5a</pattern>
+  <pattern>pi3gl</pattern>
+  <pattern>3pij </pattern>
+  <pattern>pij3k</pattern>
+  <pattern>pij5ke</pattern>
+  <pattern>pij4li</pattern>
+  <pattern>3pijn</pattern>
+  <pattern>5pijp</pattern>
+  <pattern>pij4p3a</pattern>
+  <pattern>2pijz</pattern>
+  <pattern>pi4k3l</pattern>
+  <pattern>pilo5g</pattern>
+  <pattern>pi5nam</pattern>
+  <pattern>2pind</pattern>
+  <pattern>3pinda</pattern>
+  <pattern>3p4ing</pattern>
+  <pattern>5ping </pattern>
+  <pattern>pin4ga</pattern>
+  <pattern>pin5gri</pattern>
+  <pattern>4p3inj</pattern>
+  <pattern>pink3r</pattern>
+  <pattern>pink5s</pattern>
+  <pattern>4pinr</pattern>
+  <pattern>2pins</pattern>
+  <pattern>pin4ta</pattern>
+  <pattern>pi5o</pattern>
+  <pattern>pis5n</pattern>
+  <pattern>pis5ta</pattern>
+  <pattern>pi3th</pattern>
+  <pattern>pit3j</pattern>
+  <pattern>pit3r</pattern>
+  <pattern>pit4sp</pattern>
+  <pattern>2p1ja</pattern>
+  <pattern>pjes5</pattern>
+  <pattern>p3ji</pattern>
+  <pattern>p1jo</pattern>
+  <pattern>2p1k</pattern>
+  <pattern>pkaart5j</pattern>
+  <pattern>p2l2</pattern>
+  <pattern>p3la </pattern>
+  <pattern>plaat5j</pattern>
+  <pattern>2p3lad</pattern>
+  <pattern>pla3di</pattern>
+  <pattern>4p3lamp</pattern>
+  <pattern>4p3lang</pattern>
+  <pattern>p4lant</pattern>
+  <pattern>p3lap</pattern>
+  <pattern>1p4las</pattern>
+  <pattern>3p4lat</pattern>
+  <pattern>pla4t3r</pattern>
+  <pattern>5p4lay</pattern>
+  <pattern>p4lec</pattern>
+  <pattern>plee5tj</pattern>
+  <pattern>p3leid</pattern>
+  <pattern>3p4len</pattern>
+  <pattern>p3lep</pattern>
+  <pattern>pleu5ro</pattern>
+  <pattern>p4lex</pattern>
+  <pattern>2p3lig</pattern>
+  <pattern>4plij</pattern>
+  <pattern>p4lom</pattern>
+  <pattern>p3lone</pattern>
+  <pattern>p5lood</pattern>
+  <pattern>plooi5tj</pattern>
+  <pattern>p3loon</pattern>
+  <pattern>p3luie</pattern>
+  <pattern>2p1m</pattern>
+  <pattern>pmans5t</pattern>
+  <pattern>2p1n</pattern>
+  <pattern>p3na</pattern>
+  <pattern>3pneum</pattern>
+  <pattern>3po </pattern>
+  <pattern>poda5</pattern>
+  <pattern>3poei</pattern>
+  <pattern>poe2s3</pattern>
+  <pattern>poes5t</pattern>
+  <pattern>poets5te </pattern>
+  <pattern>3poez</pattern>
+  <pattern>3poë</pattern>
+  <pattern>p2ofa</pattern>
+  <pattern>3pogi</pattern>
+  <pattern>po5gr</pattern>
+  <pattern>po2k3i2</pattern>
+  <pattern>po4kol</pattern>
+  <pattern>1pol</pattern>
+  <pattern>po5l4o</pattern>
+  <pattern>polo3p</pattern>
+  <pattern>pol4s</pattern>
+  <pattern>pols5te </pattern>
+  <pattern>1pom</pattern>
+  <pattern>2p3oml</pattern>
+  <pattern>3ponds</pattern>
+  <pattern>pon4sm</pattern>
+  <pattern>pon4st</pattern>
+  <pattern>pons5te </pattern>
+  <pattern>pon5ta</pattern>
+  <pattern>5pony</pattern>
+  <pattern>poo3d</pattern>
+  <pattern>poo5de</pattern>
+  <pattern>4poog </pattern>
+  <pattern>3pool</pattern>
+  <pattern>poo5len</pattern>
+  <pattern>4poor </pattern>
+  <pattern>poor4tj</pattern>
+  <pattern>poot3</pattern>
+  <pattern>po4p3a</pattern>
+  <pattern>4popd</pattern>
+  <pattern>2pope</pattern>
+  <pattern>pop5h</pattern>
+  <pattern>2p3org</pattern>
+  <pattern>2p3ork</pattern>
+  <pattern>po3ro</pattern>
+  <pattern>p4ort</pattern>
+  <pattern>5portef</pattern>
+  <pattern>por4to</pattern>
+  <pattern>por4t5ra</pattern>
+  <pattern>po3ru</pattern>
+  <pattern>1pos</pattern>
+  <pattern>po1sa</pattern>
+  <pattern>po3sf</pattern>
+  <pattern>po4taa</pattern>
+  <pattern>po4t3as</pattern>
+  <pattern>po5te</pattern>
+  <pattern>potes5t</pattern>
+  <pattern>pot1j</pattern>
+  <pattern>pot3r</pattern>
+  <pattern>3poul</pattern>
+  <pattern>po3v</pattern>
+  <pattern>4p3p</pattern>
+  <pattern>p5pa</pattern>
+  <pattern>p5pe</pattern>
+  <pattern>ppe4l3o</pattern>
+  <pattern>ppe5ni</pattern>
+  <pattern>pper5ste</pattern>
+  <pattern>ppie5k</pattern>
+  <pattern>ppij5p</pattern>
+  <pattern>p4ps</pattern>
+  <pattern>pr4</pattern>
+  <pattern>p2ra</pattern>
+  <pattern>3pra </pattern>
+  <pattern>p5raad</pattern>
+  <pattern>praat5j</pattern>
+  <pattern>p5rad</pattern>
+  <pattern>3prakt</pattern>
+  <pattern>4pram</pattern>
+  <pattern>p5rand</pattern>
+  <pattern>3prao</pattern>
+  <pattern>4p3rap</pattern>
+  <pattern>p4rat</pattern>
+  <pattern>p4rax</pattern>
+  <pattern>4preeku</pattern>
+  <pattern>1prem</pattern>
+  <pattern>p3remm</pattern>
+  <pattern>3prent</pattern>
+  <pattern>pren4t5j</pattern>
+  <pattern>3pres</pattern>
+  <pattern>p3reso</pattern>
+  <pattern>3pret</pattern>
+  <pattern>pre4t3j</pattern>
+  <pattern>pret3r</pattern>
+  <pattern>4pric</pattern>
+  <pattern>4p3riek</pattern>
+  <pattern>4priet</pattern>
+  <pattern>prie4t5j</pattern>
+  <pattern>1prij</pattern>
+  <pattern>3prik</pattern>
+  <pattern>3princ</pattern>
+  <pattern>pring5s4</pattern>
+  <pattern>5prins</pattern>
+  <pattern>3p4rio</pattern>
+  <pattern>3p4riu</pattern>
+  <pattern>5priv</pattern>
+  <pattern>5p4rob</pattern>
+  <pattern>3p2roc</pattern>
+  <pattern>1p2rod</pattern>
+  <pattern>p3roed</pattern>
+  <pattern>3proef</pattern>
+  <pattern>proet5j</pattern>
+  <pattern>3proev</pattern>
+  <pattern>5p4rof</pattern>
+  <pattern>5p2rog</pattern>
+  <pattern>1proj</pattern>
+  <pattern>pro3la</pattern>
+  <pattern>3prom</pattern>
+  <pattern>p3rood</pattern>
+  <pattern>prooi5</pattern>
+  <pattern>pro5pa</pattern>
+  <pattern>p4roq</pattern>
+  <pattern>3pros</pattern>
+  <pattern>pro5sc</pattern>
+  <pattern>pro4s5t</pattern>
+  <pattern>pro3t4a</pattern>
+  <pattern>3proto</pattern>
+  <pattern>3pro5v</pattern>
+  <pattern>4proy</pattern>
+  <pattern>pru2t</pattern>
+  <pattern>prut3o4</pattern>
+  <pattern>2ps</pattern>
+  <pattern>p3sab</pattern>
+  <pattern>ps3a2g</pattern>
+  <pattern>p3sak</pattern>
+  <pattern>ps3ar</pattern>
+  <pattern>ps3ass</pattern>
+  <pattern>4pse</pattern>
+  <pattern>ps3erk</pattern>
+  <pattern>p4s3et</pattern>
+  <pattern>p3si</pattern>
+  <pattern>p4s3i2d</pattern>
+  <pattern>p4sin</pattern>
+  <pattern>p5sis</pattern>
+  <pattern>p1sl</pattern>
+  <pattern>ps3le</pattern>
+  <pattern>ps2me</pattern>
+  <pattern>ps5mi</pattern>
+  <pattern>p4s3na</pattern>
+  <pattern>ps3neu</pattern>
+  <pattern>p4sof</pattern>
+  <pattern>p3sol</pattern>
+  <pattern>ps3opt</pattern>
+  <pattern>pso4r</pattern>
+  <pattern>p1sp</pattern>
+  <pattern>ps2pl</pattern>
+  <pattern>ps3ple</pattern>
+  <pattern>p1s4t</pattern>
+  <pattern>p3stat</pattern>
+  <pattern>p3ste</pattern>
+  <pattern>ps5tent</pattern>
+  <pattern>ps5tes</pattern>
+  <pattern>ps5th</pattern>
+  <pattern>ps3tor</pattern>
+  <pattern>ps5tron</pattern>
+  <pattern>p3stu</pattern>
+  <pattern>ps5ty</pattern>
+  <pattern>3psy</pattern>
+  <pattern>5psyc</pattern>
+  <pattern>p3sys</pattern>
+  <pattern>4p1t</pattern>
+  <pattern>pt3ad</pattern>
+  <pattern>pt3alb</pattern>
+  <pattern>p3te</pattern>
+  <pattern>p2t1h</pattern>
+  <pattern>p5ti</pattern>
+  <pattern>pt3j</pattern>
+  <pattern>p4t3o4v</pattern>
+  <pattern>p3tr</pattern>
+  <pattern>pt3ric</pattern>
+  <pattern>1p2u</pattern>
+  <pattern>3pub</pattern>
+  <pattern>pu3ch</pattern>
+  <pattern>pu3e</pattern>
+  <pattern>puil3o</pattern>
+  <pattern>pul4st</pattern>
+  <pattern>3pun</pattern>
+  <pattern>4pun </pattern>
+  <pattern>punt3j</pattern>
+  <pattern>3put </pattern>
+  <pattern>puter5in</pattern>
+  <pattern>put1j</pattern>
+  <pattern>pu2t3o</pattern>
+  <pattern>put3r</pattern>
+  <pattern>put4st</pattern>
+  <pattern>puts5te </pattern>
+  <pattern>2pv</pattern>
+  <pattern>pvan4</pattern>
+  <pattern>pvari5</pattern>
+  <pattern>2p1w</pattern>
+  <pattern>1py1</pattern>
+  <pattern>2p5z</pattern>
+  <pattern>1q</pattern>
+  <pattern>5qe</pattern>
+  <pattern>qu4</pattern>
+  <pattern>que4s</pattern>
+  <pattern>5quo</pattern>
+  <pattern>4r </pattern>
+  <pattern>r2aa</pattern>
+  <pattern>2raan</pattern>
+  <pattern>4raand</pattern>
+  <pattern>3raar</pattern>
+  <pattern>5raar </pattern>
+  <pattern>4r3aard</pattern>
+  <pattern>5raars</pattern>
+  <pattern>raar5tj</pattern>
+  <pattern>2rac</pattern>
+  <pattern>ra4ca</pattern>
+  <pattern>ra3ce</pattern>
+  <pattern>5racl</pattern>
+  <pattern>rad4a</pattern>
+  <pattern>3radb</pattern>
+  <pattern>ra5den</pattern>
+  <pattern>ra3di</pattern>
+  <pattern>5radia</pattern>
+  <pattern>3radio</pattern>
+  <pattern>4radm</pattern>
+  <pattern>4r3adr</pattern>
+  <pattern>3rad3s</pattern>
+  <pattern>4radv</pattern>
+  <pattern>2rafd</pattern>
+  <pattern>r4aff</pattern>
+  <pattern>raf5ond</pattern>
+  <pattern>ra3fra</pattern>
+  <pattern>3ragez</pattern>
+  <pattern>ra5gi</pattern>
+  <pattern>ra3g2n</pattern>
+  <pattern>ra5go</pattern>
+  <pattern>rag4s</pattern>
+  <pattern>3rais</pattern>
+  <pattern>raket3</pattern>
+  <pattern>ra3k4l</pattern>
+  <pattern>rak5r</pattern>
+  <pattern>4r3a2la</pattern>
+  <pattern>ra4l3ee</pattern>
+  <pattern>4r3alf</pattern>
+  <pattern>r3a4lim</pattern>
+  <pattern>r3alt</pattern>
+  <pattern>ra4man</pattern>
+  <pattern>r5ameu</pattern>
+  <pattern>ra3mi</pattern>
+  <pattern>r2amp</pattern>
+  <pattern>4rana</pattern>
+  <pattern>ran4dr</pattern>
+  <pattern>ran4g3o</pattern>
+  <pattern>ran4gr</pattern>
+  <pattern>r5angst </pattern>
+  <pattern>ra4nim</pattern>
+  <pattern>4ranj</pattern>
+  <pattern>ran4kl</pattern>
+  <pattern>rank3w</pattern>
+  <pattern>ran4sa</pattern>
+  <pattern>ran4st</pattern>
+  <pattern>ran4t3j</pattern>
+  <pattern>r3antw</pattern>
+  <pattern>ra3o</pattern>
+  <pattern>4rap </pattern>
+  <pattern>ra3po</pattern>
+  <pattern>4rappa</pattern>
+  <pattern>rap5roe</pattern>
+  <pattern>ra3q</pattern>
+  <pattern>2r3arb</pattern>
+  <pattern>r4a5re</pattern>
+  <pattern>4rarit</pattern>
+  <pattern>2r1arm</pattern>
+  <pattern>4r3arr</pattern>
+  <pattern>2r1art</pattern>
+  <pattern>ra5sei</pattern>
+  <pattern>ra4sk</pattern>
+  <pattern>ra4sl</pattern>
+  <pattern>ra1so</pattern>
+  <pattern>ra2sp</pattern>
+  <pattern>ras3po</pattern>
+  <pattern>rast5ri</pattern>
+  <pattern>r4ati</pattern>
+  <pattern>rat5j</pattern>
+  <pattern>ra4tom</pattern>
+  <pattern>ra4tra</pattern>
+  <pattern>ra5tri</pattern>
+  <pattern>rat3sp</pattern>
+  <pattern>rat4st</pattern>
+  <pattern>rats5te </pattern>
+  <pattern>ra3t4u</pattern>
+  <pattern>2rau</pattern>
+  <pattern>3raus</pattern>
+  <pattern>r1aut</pattern>
+  <pattern>5ravr</pattern>
+  <pattern>ra4zij</pattern>
+  <pattern>rbe4ti</pattern>
+  <pattern>r1c</pattern>
+  <pattern>r3ce</pattern>
+  <pattern>rces3</pattern>
+  <pattern>r3chi</pattern>
+  <pattern>r3co</pattern>
+  <pattern>2r1d</pattern>
+  <pattern>r4d3act</pattern>
+  <pattern>rd3alk</pattern>
+  <pattern>rda2m</pattern>
+  <pattern>rd5ama</pattern>
+  <pattern>r3dan</pattern>
+  <pattern>r2d3ar</pattern>
+  <pattern>rd3ei</pattern>
+  <pattern>r4d5e4las</pattern>
+  <pattern>rden5dr</pattern>
+  <pattern>rde5o4</pattern>
+  <pattern>r4derva</pattern>
+  <pattern>rde5s4t</pattern>
+  <pattern>rdi3a</pattern>
+  <pattern>rdi5o</pattern>
+  <pattern>rd5l</pattern>
+  <pattern>r3do</pattern>
+  <pattern>r5doc</pattern>
+  <pattern>r4d3ol</pattern>
+  <pattern>rd5olie</pattern>
+  <pattern>rd3ont</pattern>
+  <pattern>rd3oos</pattern>
+  <pattern>rdo3pe</pattern>
+  <pattern>rdo3v</pattern>
+  <pattern>rd3ras</pattern>
+  <pattern>rd3res</pattern>
+  <pattern>rd5roos</pattern>
+  <pattern>rd2ru</pattern>
+  <pattern>rd3sa</pattern>
+  <pattern>rd3s4c</pattern>
+  <pattern>rd3so</pattern>
+  <pattern>rd1sp</pattern>
+  <pattern>rds4t</pattern>
+  <pattern>rd5sta</pattern>
+  <pattern>rd5ste</pattern>
+  <pattern>rd3su</pattern>
+  <pattern>r3du</pattern>
+  <pattern>rd2wi</pattern>
+  <pattern>rd5wo</pattern>
+  <pattern>3re </pattern>
+  <pattern>1reac</pattern>
+  <pattern>re4ade</pattern>
+  <pattern>4reak</pattern>
+  <pattern>re3amb</pattern>
+  <pattern>4re5at</pattern>
+  <pattern>re3co</pattern>
+  <pattern>3recr</pattern>
+  <pattern>rec5ta</pattern>
+  <pattern>3reda</pattern>
+  <pattern>3redd</pattern>
+  <pattern>rede4s3</pattern>
+  <pattern>4re4diti</pattern>
+  <pattern>3redu</pattern>
+  <pattern>re5dw</pattern>
+  <pattern>ree4k</pattern>
+  <pattern>2r1een</pattern>
+  <pattern>ree3n4e</pattern>
+  <pattern>r5eenh</pattern>
+  <pattern>ree2p</pattern>
+  <pattern>reeps5</pattern>
+  <pattern>ree5r4ad</pattern>
+  <pattern>4reers</pattern>
+  <pattern>reer5ste</pattern>
+  <pattern>r3eerw</pattern>
+  <pattern>ree4s</pattern>
+  <pattern>ree5sh</pattern>
+  <pattern>r4ef</pattern>
+  <pattern>4refb</pattern>
+  <pattern>2reff</pattern>
+  <pattern>3refl</pattern>
+  <pattern>re3fu</pattern>
+  <pattern>1reg</pattern>
+  <pattern>4reg </pattern>
+  <pattern>4regd</pattern>
+  <pattern>rege5ne</pattern>
+  <pattern>rege4s</pattern>
+  <pattern>4regg</pattern>
+  <pattern>3regi</pattern>
+  <pattern>re3gl</pattern>
+  <pattern>4regt</pattern>
+  <pattern>4reie</pattern>
+  <pattern>4reil</pattern>
+  <pattern>4reind</pattern>
+  <pattern>rei5tj</pattern>
+  <pattern>5reiz</pattern>
+  <pattern>re4kap</pattern>
+  <pattern>5rekeni</pattern>
+  <pattern>re2k3l</pattern>
+  <pattern>re2k5n</pattern>
+  <pattern>re4ko</pattern>
+  <pattern>re4k3re</pattern>
+  <pattern>rek3sp</pattern>
+  <pattern>re4ku</pattern>
+  <pattern>re1kw</pattern>
+  <pattern>rel4di</pattern>
+  <pattern>rel4d3o</pattern>
+  <pattern>reld3r</pattern>
+  <pattern>re4l3ei</pattern>
+  <pattern>rel5k</pattern>
+  <pattern>re4lu4r</pattern>
+  <pattern>3rem </pattern>
+  <pattern>re4mai</pattern>
+  <pattern>remie5tj</pattern>
+  <pattern>re5mo5v</pattern>
+  <pattern>2remp</pattern>
+  <pattern>3r4en </pattern>
+  <pattern>re2na</pattern>
+  <pattern>re4naa</pattern>
+  <pattern>ren5aar</pattern>
+  <pattern>re5nade</pattern>
+  <pattern>re3nal</pattern>
+  <pattern>re4n3an</pattern>
+  <pattern>ren3a4r</pattern>
+  <pattern>r4end</pattern>
+  <pattern>5rendee</pattern>
+  <pattern>r5endert</pattern>
+  <pattern>re5ne </pattern>
+  <pattern>re4nel</pattern>
+  <pattern>re5nen </pattern>
+  <pattern>ren5enk</pattern>
+  <pattern>ren3e4p</pattern>
+  <pattern>re5ner </pattern>
+  <pattern>ren5erf</pattern>
+  <pattern>ren5erv</pattern>
+  <pattern>5renf</pattern>
+  <pattern>2r1eni</pattern>
+  <pattern>5r4enkl</pattern>
+  <pattern>r4enn</pattern>
+  <pattern>re4noc</pattern>
+  <pattern>ren4og</pattern>
+  <pattern>ren4opl</pattern>
+  <pattern>re3nov</pattern>
+  <pattern>5r4enp</pattern>
+  <pattern>4renq</pattern>
+  <pattern>ren4sl</pattern>
+  <pattern>r4ento</pattern>
+  <pattern>r3entw</pattern>
+  <pattern>r5enveer</pattern>
+  <pattern>re4of</pattern>
+  <pattern>re4op4</pattern>
+  <pattern>re5pa</pattern>
+  <pattern>3repet</pattern>
+  <pattern>re4pie</pattern>
+  <pattern>4req</pattern>
+  <pattern>re3qua</pattern>
+  <pattern>4r1erf</pattern>
+  <pattern>2r1erg</pattern>
+  <pattern>re3r2o</pattern>
+  <pattern>rer4s</pattern>
+  <pattern>2r3ert</pattern>
+  <pattern>4r5erv</pattern>
+  <pattern>2rerw</pattern>
+  <pattern>re3sa</pattern>
+  <pattern>re5se</pattern>
+  <pattern>re4sl</pattern>
+  <pattern>res5le</pattern>
+  <pattern>res3m</pattern>
+  <pattern>re2s1p</pattern>
+  <pattern>res3t</pattern>
+  <pattern>re4tem</pattern>
+  <pattern>re3t4h</pattern>
+  <pattern>ret4i</pattern>
+  <pattern>re4tik</pattern>
+  <pattern>re5tin</pattern>
+  <pattern>2retn</pattern>
+  <pattern>re4t3o4g</pattern>
+  <pattern>re4t3oo</pattern>
+  <pattern>rets5te </pattern>
+  <pattern>re2u</pattern>
+  <pattern>reur5es</pattern>
+  <pattern>reus4t</pattern>
+  <pattern>reu5ste</pattern>
+  <pattern>3revis</pattern>
+  <pattern>3revo</pattern>
+  <pattern>2r3ex</pattern>
+  <pattern>r4f3aa</pattern>
+  <pattern>rf3act</pattern>
+  <pattern>r2f3a4g</pattern>
+  <pattern>rf3al</pattern>
+  <pattern>r3fas</pattern>
+  <pattern>r3fe</pattern>
+  <pattern>r4f3eng</pattern>
+  <pattern>r1fl</pattern>
+  <pattern>r4f3lag</pattern>
+  <pattern>rf3lev</pattern>
+  <pattern>r2f3li</pattern>
+  <pattern>rf3lus</pattern>
+  <pattern>r4f3op</pattern>
+  <pattern>r1fr</pattern>
+  <pattern>r4f3re</pattern>
+  <pattern>r5frea</pattern>
+  <pattern>rf2s2</pattern>
+  <pattern>rf3sm</pattern>
+  <pattern>rf3sp</pattern>
+  <pattern>r4f3u4r</pattern>
+  <pattern>rf3uu</pattern>
+  <pattern>r1g</pattern>
+  <pattern>r4g3ab</pattern>
+  <pattern>rg3amb</pattern>
+  <pattern>r4g3een</pattern>
+  <pattern>rg3ei</pattern>
+  <pattern>rg4eis</pattern>
+  <pattern>rgel5dr</pattern>
+  <pattern>r5gen </pattern>
+  <pattern>rge4ra</pattern>
+  <pattern>rge5rap</pattern>
+  <pattern>r4g3ins</pattern>
+  <pattern>r5glas</pattern>
+  <pattern>r3glo</pattern>
+  <pattern>r4g3lu</pattern>
+  <pattern>rg4o3v</pattern>
+  <pattern>r5grij</pattern>
+  <pattern>rg3rit</pattern>
+  <pattern>r3g4ro</pattern>
+  <pattern>rg1s4</pattern>
+  <pattern>rg2sm</pattern>
+  <pattern>rg5so</pattern>
+  <pattern>rg4s5pr</pattern>
+  <pattern>r3h</pattern>
+  <pattern>ri5abel</pattern>
+  <pattern>ri4ag</pattern>
+  <pattern>ri2ak</pattern>
+  <pattern>ri5an</pattern>
+  <pattern>rias4</pattern>
+  <pattern>ri4av</pattern>
+  <pattern>ri4bl</pattern>
+  <pattern>4rice</pattern>
+  <pattern>ri3co</pattern>
+  <pattern>ridde4</pattern>
+  <pattern>ri3di</pattern>
+  <pattern>ri4dol</pattern>
+  <pattern>ri4doo</pattern>
+  <pattern>rie5dr</pattern>
+  <pattern>rie4k5ap</pattern>
+  <pattern>rie5kl</pattern>
+  <pattern>rie3kw</pattern>
+  <pattern>rie4la</pattern>
+  <pattern>riel5aa</pattern>
+  <pattern>rie4lei</pattern>
+  <pattern>rie4ro</pattern>
+  <pattern>rie4ta</pattern>
+  <pattern>riet3o</pattern>
+  <pattern>ri1eu</pattern>
+  <pattern>ri3fl</pattern>
+  <pattern>ri3fr</pattern>
+  <pattern>r4ig</pattern>
+  <pattern>ri4gaa</pattern>
+  <pattern>ri3gl</pattern>
+  <pattern>5rigste</pattern>
+  <pattern>r4ijl</pattern>
+  <pattern>4r5ijl </pattern>
+  <pattern>r5ijld</pattern>
+  <pattern>r5ijlt</pattern>
+  <pattern>rij5o</pattern>
+  <pattern>rij3pl</pattern>
+  <pattern>rij3pr</pattern>
+  <pattern>rij3sp</pattern>
+  <pattern>rij5ster</pattern>
+  <pattern>rij4str</pattern>
+  <pattern>4rijv</pattern>
+  <pattern>ri4k5l</pattern>
+  <pattern>rik5n</pattern>
+  <pattern>ri3k4o</pattern>
+  <pattern>ril5m</pattern>
+  <pattern>ri3ma</pattern>
+  <pattern>rim4pr</pattern>
+  <pattern>4r3inb</pattern>
+  <pattern>4rind</pattern>
+  <pattern>ri5ne</pattern>
+  <pattern>4r5inf</pattern>
+  <pattern>r4ing</pattern>
+  <pattern>4r5ingan</pattern>
+  <pattern>r5ingeni</pattern>
+  <pattern>ring5l</pattern>
+  <pattern>4r3inh</pattern>
+  <pattern>ri4nit</pattern>
+  <pattern>rin4k3l</pattern>
+  <pattern>r3inko</pattern>
+  <pattern>4rinkt</pattern>
+  <pattern>r3inl</pattern>
+  <pattern>4r3inna</pattern>
+  <pattern>4r1inr</pattern>
+  <pattern>4rins</pattern>
+  <pattern>r3inst</pattern>
+  <pattern>4rint</pattern>
+  <pattern>4r1inv</pattern>
+  <pattern>ri5on</pattern>
+  <pattern>ri3o5s</pattern>
+  <pattern>ri4sam</pattern>
+  <pattern>ri3sc</pattern>
+  <pattern>ri3sot</pattern>
+  <pattern>ris5to</pattern>
+  <pattern>rit3j</pattern>
+  <pattern>rit3ov</pattern>
+  <pattern>rit4st</pattern>
+  <pattern>rits5te </pattern>
+  <pattern>rit5sten</pattern>
+  <pattern>3ritt</pattern>
+  <pattern>r5j4</pattern>
+  <pattern>rjaars5</pattern>
+  <pattern>r5ka </pattern>
+  <pattern>rkaart5j</pattern>
+  <pattern>rk3adr</pattern>
+  <pattern>rk3af</pattern>
+  <pattern>r2kah</pattern>
+  <pattern>rk3ang</pattern>
+  <pattern>r4k3art</pattern>
+  <pattern>r2k3ei</pattern>
+  <pattern>rke4n</pattern>
+  <pattern>rken4s</pattern>
+  <pattern>rker4sl</pattern>
+  <pattern>r4k3erv</pattern>
+  <pattern>rke4s</pattern>
+  <pattern>rke5stree</pattern>
+  <pattern>rke5strer</pattern>
+  <pattern>rk5iep</pattern>
+  <pattern>rk3ijv</pattern>
+  <pattern>rk3inb</pattern>
+  <pattern>r4k3ink</pattern>
+  <pattern>rkjes5</pattern>
+  <pattern>rk3lag</pattern>
+  <pattern>r4k3lat</pattern>
+  <pattern>rk5leid</pattern>
+  <pattern>r2klo</pattern>
+  <pattern>rk3loo</pattern>
+  <pattern>rk3lus</pattern>
+  <pattern>r3kn</pattern>
+  <pattern>r4kne</pattern>
+  <pattern>r2kob</pattern>
+  <pattern>rk3olm</pattern>
+  <pattern>rk3omg</pattern>
+  <pattern>rkoot5</pattern>
+  <pattern>rk3opg</pattern>
+  <pattern>rk3ord</pattern>
+  <pattern>rk5os </pattern>
+  <pattern>rk5oss</pattern>
+  <pattern>rk2r</pattern>
+  <pattern>r5k4ran</pattern>
+  <pattern>rk4ri</pattern>
+  <pattern>r5kris</pattern>
+  <pattern>r5kron</pattern>
+  <pattern>rk1s</pattern>
+  <pattern>rk3s4f</pattern>
+  <pattern>rk5si</pattern>
+  <pattern>rks4p</pattern>
+  <pattern>rk4t5e4v</pattern>
+  <pattern>rkt3h</pattern>
+  <pattern>rk4ti</pattern>
+  <pattern>rkt3o</pattern>
+  <pattern>rkt1r</pattern>
+  <pattern>rk3uit</pattern>
+  <pattern>r1kwa</pattern>
+  <pattern>rk3waa</pattern>
+  <pattern>rk5wat</pattern>
+  <pattern>rk3wee</pattern>
+  <pattern>r1kwi</pattern>
+  <pattern>rk3win</pattern>
+  <pattern>r3l</pattern>
+  <pattern>rlaat5ste</pattern>
+  <pattern>rle4g3r</pattern>
+  <pattern>rlink4s</pattern>
+  <pattern>rlinks5te</pattern>
+  <pattern>rlofs5</pattern>
+  <pattern>rlui5t4</pattern>
+  <pattern>r1m</pattern>
+  <pattern>rmaf4r</pattern>
+  <pattern>r4m3art</pattern>
+  <pattern>r2m3eb</pattern>
+  <pattern>r2m5eg</pattern>
+  <pattern>rme4r3a4</pattern>
+  <pattern>rmes3</pattern>
+  <pattern>rme4t3j</pattern>
+  <pattern>rmet5st</pattern>
+  <pattern>rm3inh</pattern>
+  <pattern>rmi2s</pattern>
+  <pattern>r3mo</pattern>
+  <pattern>r5moe</pattern>
+  <pattern>r4mop</pattern>
+  <pattern>rm3opm</pattern>
+  <pattern>rmors5te</pattern>
+  <pattern>rmos5f</pattern>
+  <pattern>rm3s4a</pattern>
+  <pattern>rm1st</pattern>
+  <pattern>rm3uit</pattern>
+  <pattern>rmun4</pattern>
+  <pattern>2r1n</pattern>
+  <pattern>r3na</pattern>
+  <pattern>r5n4am</pattern>
+  <pattern>r4n3ap</pattern>
+  <pattern>rn3ars</pattern>
+  <pattern>rnee5t</pattern>
+  <pattern>r4n3ene</pattern>
+  <pattern>rnes3</pattern>
+  <pattern>rne5te</pattern>
+  <pattern>rne4t3j</pattern>
+  <pattern>r2n5id</pattern>
+  <pattern>r2nin</pattern>
+  <pattern>r2n1on</pattern>
+  <pattern>rn3oor</pattern>
+  <pattern>r5noot</pattern>
+  <pattern>rn3ops</pattern>
+  <pattern>r5not</pattern>
+  <pattern>rn3ove</pattern>
+  <pattern>rns4</pattern>
+  <pattern>rn3sm</pattern>
+  <pattern>rn3sp</pattern>
+  <pattern>rn1st</pattern>
+  <pattern>rn3sta</pattern>
+  <pattern>rn3th</pattern>
+  <pattern>rn5tj</pattern>
+  <pattern>rn5to</pattern>
+  <pattern>r3nu</pattern>
+  <pattern>rnu5r</pattern>
+  <pattern>ro1a</pattern>
+  <pattern>ro5ac</pattern>
+  <pattern>r4oc</pattern>
+  <pattern>ro1ch</pattern>
+  <pattern>ro3d4o</pattern>
+  <pattern>3roe </pattern>
+  <pattern>4roef</pattern>
+  <pattern>4roeg</pattern>
+  <pattern>roe4g3r</pattern>
+  <pattern>3roem</pattern>
+  <pattern>roens4</pattern>
+  <pattern>roen5sm</pattern>
+  <pattern>roep3l</pattern>
+  <pattern>roe4rei</pattern>
+  <pattern>roet4j</pattern>
+  <pattern>4roev</pattern>
+  <pattern>3roë</pattern>
+  <pattern>r5offi</pattern>
+  <pattern>r4ofi</pattern>
+  <pattern>ro3fl</pattern>
+  <pattern>roges5</pattern>
+  <pattern>1roï</pattern>
+  <pattern>ro3kl</pattern>
+  <pattern>3rokm</pattern>
+  <pattern>rok3sp</pattern>
+  <pattern>r4ol </pattern>
+  <pattern>ro2l3a</pattern>
+  <pattern>role5st</pattern>
+  <pattern>rol3g2</pattern>
+  <pattern>2roli</pattern>
+  <pattern>rol3ov</pattern>
+  <pattern>ro5ma</pattern>
+  <pattern>ro3mo</pattern>
+  <pattern>4romz</pattern>
+  <pattern>r2on </pattern>
+  <pattern>ron3a4d</pattern>
+  <pattern>5r4onal</pattern>
+  <pattern>ron4da</pattern>
+  <pattern>ron4d3o</pattern>
+  <pattern>ron4d3r</pattern>
+  <pattern>ron4d5u</pattern>
+  <pattern>r2one</pattern>
+  <pattern>r2oni</pattern>
+  <pattern>r2onk</pattern>
+  <pattern>ron4ka</pattern>
+  <pattern>r2onn</pattern>
+  <pattern>r2o1no</pattern>
+  <pattern>r2ons</pattern>
+  <pattern>ron4ste</pattern>
+  <pattern>rons5te </pattern>
+  <pattern>4ron2t</pattern>
+  <pattern>ront3j</pattern>
+  <pattern>ront3r</pattern>
+  <pattern>ro3nu</pattern>
+  <pattern>4ronv</pattern>
+  <pattern>3roof</pattern>
+  <pattern>2roog</pattern>
+  <pattern>4roon</pattern>
+  <pattern>2r1oor</pattern>
+  <pattern>root5ste</pattern>
+  <pattern>ro3pa</pattern>
+  <pattern>ro4paa</pattern>
+  <pattern>ro4pan</pattern>
+  <pattern>4ropb</pattern>
+  <pattern>ro1pe</pattern>
+  <pattern>ro5pee</pattern>
+  <pattern>ro4pin</pattern>
+  <pattern>ro3p4la</pattern>
+  <pattern>4ropn</pattern>
+  <pattern>r4opo</pattern>
+  <pattern>rop5rak</pattern>
+  <pattern>rop3sh</pattern>
+  <pattern>r4opte</pattern>
+  <pattern>ro4pu</pattern>
+  <pattern>ror5d</pattern>
+  <pattern>ro3ro</pattern>
+  <pattern>ro3sa</pattern>
+  <pattern>ro5se</pattern>
+  <pattern>ro3sf</pattern>
+  <pattern>ro3sh</pattern>
+  <pattern>r4o5si</pattern>
+  <pattern>ro3sp</pattern>
+  <pattern>ros4s5t</pattern>
+  <pattern>ro5stel</pattern>
+  <pattern>ros5tra</pattern>
+  <pattern>ro5te</pattern>
+  <pattern>ro3t2h</pattern>
+  <pattern>rot3j</pattern>
+  <pattern>ro5ton</pattern>
+  <pattern>ro3tr</pattern>
+  <pattern>rot4ste</pattern>
+  <pattern>rots5te </pattern>
+  <pattern>r1oud</pattern>
+  <pattern>3rou5t4</pattern>
+  <pattern>ro3v</pattern>
+  <pattern>ro4ve</pattern>
+  <pattern>ro5veri</pattern>
+  <pattern>4roxi</pattern>
+  <pattern>3roy</pattern>
+  <pattern>r1p</pattern>
+  <pattern>r3pa</pattern>
+  <pattern>rp3aan</pattern>
+  <pattern>rp3adv</pattern>
+  <pattern>rp3ank</pattern>
+  <pattern>r5pee</pattern>
+  <pattern>rp3eis</pattern>
+  <pattern>rpi3s</pattern>
+  <pattern>r2p3j</pattern>
+  <pattern>rp4lo</pattern>
+  <pattern>rp5lod</pattern>
+  <pattern>rpoort5j</pattern>
+  <pattern>r4p3o4v</pattern>
+  <pattern>r4p3rec</pattern>
+  <pattern>rp3ric</pattern>
+  <pattern>rp4ro</pattern>
+  <pattern>r3psa</pattern>
+  <pattern>rp4si</pattern>
+  <pattern>rp2sl</pattern>
+  <pattern>rp3sli</pattern>
+  <pattern>rp5spe</pattern>
+  <pattern>rp4s5to</pattern>
+  <pattern>2r5r</pattern>
+  <pattern>rre4l3u</pattern>
+  <pattern>rren5s4</pattern>
+  <pattern>rre5o</pattern>
+  <pattern>rreu2</pattern>
+  <pattern>rri5er </pattern>
+  <pattern>rrie4t</pattern>
+  <pattern>rron5k</pattern>
+  <pattern>rrot4j</pattern>
+  <pattern>4rs</pattern>
+  <pattern>rs3a2d</pattern>
+  <pattern>rs3a2g</pattern>
+  <pattern>r3sal</pattern>
+  <pattern>rs3alm</pattern>
+  <pattern>rs3amb</pattern>
+  <pattern>r3san</pattern>
+  <pattern>rs3ana</pattern>
+  <pattern>rs3ap</pattern>
+  <pattern>rs3ar</pattern>
+  <pattern>rs3as</pattern>
+  <pattern>rs4asse</pattern>
+  <pattern>rsa4te</pattern>
+  <pattern>r5schi</pattern>
+  <pattern>rs2cr</pattern>
+  <pattern>r4s3eis</pattern>
+  <pattern>rsek5ste</pattern>
+  <pattern>rs4et</pattern>
+  <pattern>rseve3</pattern>
+  <pattern>r2s3ez</pattern>
+  <pattern>rs4fer</pattern>
+  <pattern>rs4hal</pattern>
+  <pattern>r3s2hi</pattern>
+  <pattern>r3s4hoc</pattern>
+  <pattern>rs3hot</pattern>
+  <pattern>rs3ini</pattern>
+  <pattern>rs3int</pattern>
+  <pattern>r4sj4</pattern>
+  <pattern>r5sjac</pattern>
+  <pattern>r5sjou</pattern>
+  <pattern>r5sjt</pattern>
+  <pattern>r3s4kat</pattern>
+  <pattern>r1sl</pattern>
+  <pattern>r4slan</pattern>
+  <pattern>r5slec</pattern>
+  <pattern>r5slep</pattern>
+  <pattern>r5sleu</pattern>
+  <pattern>r5slib</pattern>
+  <pattern>rs4lie</pattern>
+  <pattern>r5sling</pattern>
+  <pattern>rs3lob</pattern>
+  <pattern>rs5loep</pattern>
+  <pattern>r4s3loo</pattern>
+  <pattern>r5sluis</pattern>
+  <pattern>rs4m</pattern>
+  <pattern>r5smaak</pattern>
+  <pattern>rs5maal</pattern>
+  <pattern>rs5mak</pattern>
+  <pattern>r3sme</pattern>
+  <pattern>r3smij</pattern>
+  <pattern>rs5mis</pattern>
+  <pattern>r5smit</pattern>
+  <pattern>rs5mu</pattern>
+  <pattern>r1sn</pattern>
+  <pattern>r2s3na</pattern>
+  <pattern>rs3neu</pattern>
+  <pattern>r2s3no</pattern>
+  <pattern>r1so</pattern>
+  <pattern>r5sol</pattern>
+  <pattern>rs3ong</pattern>
+  <pattern>r2sor</pattern>
+  <pattern>rsorkes5</pattern>
+  <pattern>rs1ov</pattern>
+  <pattern>r1sp</pattern>
+  <pattern>r3spaa</pattern>
+  <pattern>rs3pad</pattern>
+  <pattern>r4s3par</pattern>
+  <pattern>rs4pare</pattern>
+  <pattern>r3spe</pattern>
+  <pattern>r5spec</pattern>
+  <pattern>r5spee</pattern>
+  <pattern>r5spek</pattern>
+  <pattern>rs4pene</pattern>
+  <pattern>r4s3pet</pattern>
+  <pattern>r5spit</pattern>
+  <pattern>r5spoe</pattern>
+  <pattern>r5spog</pattern>
+  <pattern>r5spon</pattern>
+  <pattern>r5spoo</pattern>
+  <pattern>rs3pot</pattern>
+  <pattern>r5spraa</pattern>
+  <pattern>r4spu</pattern>
+  <pattern>r5spul</pattern>
+  <pattern>rs3put</pattern>
+  <pattern>r1s4t</pattern>
+  <pattern>r4s5taak</pattern>
+  <pattern>rst5aang</pattern>
+  <pattern>rs5tas</pattern>
+  <pattern>r5stat</pattern>
+  <pattern>r3ste</pattern>
+  <pattern>r4s3te </pattern>
+  <pattern>r5ster </pattern>
+  <pattern>r5sterk</pattern>
+  <pattern>rs5term</pattern>
+  <pattern>r5sters</pattern>
+  <pattern>r5stes</pattern>
+  <pattern>rste5st</pattern>
+  <pattern>r4steva</pattern>
+  <pattern>r3sti</pattern>
+  <pattern>r4stit</pattern>
+  <pattern>r3sto</pattern>
+  <pattern>rs5toma</pattern>
+  <pattern>r4ston</pattern>
+  <pattern>rst5ora</pattern>
+  <pattern>r3str</pattern>
+  <pattern>rs5trap</pattern>
+  <pattern>r4st5red</pattern>
+  <pattern>rs5trei</pattern>
+  <pattern>r5stren</pattern>
+  <pattern>rs5trog</pattern>
+  <pattern>rst5roz</pattern>
+  <pattern>r3sty</pattern>
+  <pattern>r3su</pattern>
+  <pattern>rs3usa</pattern>
+  <pattern>r3sy</pattern>
+  <pattern>4rt</pattern>
+  <pattern>r1ta</pattern>
+  <pattern>r5ta </pattern>
+  <pattern>r4t3aan</pattern>
+  <pattern>rt5aand</pattern>
+  <pattern>rt5aanv</pattern>
+  <pattern>r4t1ac</pattern>
+  <pattern>rt1ad</pattern>
+  <pattern>rt3af </pattern>
+  <pattern>rt3aff</pattern>
+  <pattern>rt3am</pattern>
+  <pattern>r5tans</pattern>
+  <pattern>r2tar</pattern>
+  <pattern>rt3art</pattern>
+  <pattern>r4tau</pattern>
+  <pattern>r2tav</pattern>
+  <pattern>rt5c</pattern>
+  <pattern>r5teco</pattern>
+  <pattern>rt3eig</pattern>
+  <pattern>rt3eil</pattern>
+  <pattern>rte4lei</pattern>
+  <pattern>rt5emb</pattern>
+  <pattern>r5ten </pattern>
+  <pattern>rte5nach</pattern>
+  <pattern>rte3no</pattern>
+  <pattern>rte3ro</pattern>
+  <pattern>rtes4</pattern>
+  <pattern>rte5sta</pattern>
+  <pattern>r2t5e2v</pattern>
+  <pattern>r4tha</pattern>
+  <pattern>rt1he</pattern>
+  <pattern>r3ther</pattern>
+  <pattern>rt3hi</pattern>
+  <pattern>r1tho</pattern>
+  <pattern>rt3hol</pattern>
+  <pattern>rt3hu</pattern>
+  <pattern>rt3hy</pattern>
+  <pattern>rt4ij</pattern>
+  <pattern>rtij3k</pattern>
+  <pattern>r4t3ini</pattern>
+  <pattern>r4t3ink</pattern>
+  <pattern>rt5jesc</pattern>
+  <pattern>r3to</pattern>
+  <pattern>rt3off</pattern>
+  <pattern>r5tofo</pattern>
+  <pattern>r5tok</pattern>
+  <pattern>rt3om </pattern>
+  <pattern>rt3ond</pattern>
+  <pattern>r4t3op</pattern>
+  <pattern>r5tori</pattern>
+  <pattern>r1tr</pattern>
+  <pattern>r3tra</pattern>
+  <pattern>rt4rap</pattern>
+  <pattern>r4t3ras</pattern>
+  <pattern>rt3rec</pattern>
+  <pattern>r5treden </pattern>
+  <pattern>r3t4rek</pattern>
+  <pattern>r4t3res</pattern>
+  <pattern>rt3ri</pattern>
+  <pattern>r4t3rol</pattern>
+  <pattern>r2t4ru</pattern>
+  <pattern>rt5ruk</pattern>
+  <pattern>rt5rus</pattern>
+  <pattern>rt4s5eco</pattern>
+  <pattern>rt5sei</pattern>
+  <pattern>rt2s3l</pattern>
+  <pattern>rt3sle</pattern>
+  <pattern>rts5li</pattern>
+  <pattern>rt4slu</pattern>
+  <pattern>rts5m</pattern>
+  <pattern>rts5no</pattern>
+  <pattern>rt4soo</pattern>
+  <pattern>rt1sp</pattern>
+  <pattern>rt4s3pr</pattern>
+  <pattern>rts5ten</pattern>
+  <pattern>r1tu</pattern>
+  <pattern>rt3ui4t</pattern>
+  <pattern>rt3w</pattern>
+  <pattern>rt2wi</pattern>
+  <pattern>5rubr</pattern>
+  <pattern>rude3r</pattern>
+  <pattern>ru1e</pattern>
+  <pattern>4ruf</pattern>
+  <pattern>ru2g</pattern>
+  <pattern>ru4gr</pattern>
+  <pattern>r5uitr</pattern>
+  <pattern>ru2k</pattern>
+  <pattern>4ru3ke</pattern>
+  <pattern>ruk3i</pattern>
+  <pattern>rul3aa</pattern>
+  <pattern>rul3ap</pattern>
+  <pattern>ru2li</pattern>
+  <pattern>ru4l3ij</pattern>
+  <pattern>ru3lin</pattern>
+  <pattern>rul5s</pattern>
+  <pattern>r2um</pattern>
+  <pattern>ru2mi</pattern>
+  <pattern>3run </pattern>
+  <pattern>r2und</pattern>
+  <pattern>runet3</pattern>
+  <pattern>4r5u2ni</pattern>
+  <pattern>ru3niv</pattern>
+  <pattern>ru4r</pattern>
+  <pattern>ru5ra</pattern>
+  <pattern>ru5re </pattern>
+  <pattern>ru5res</pattern>
+  <pattern>r2u4s</pattern>
+  <pattern>rus3e</pattern>
+  <pattern>rus5tr</pattern>
+  <pattern>4rut</pattern>
+  <pattern>rut3j</pattern>
+  <pattern>rut4st</pattern>
+  <pattern>ruts5te </pattern>
+  <pattern>4ruu</pattern>
+  <pattern>ru3wa</pattern>
+  <pattern>rvaat5</pattern>
+  <pattern>rval4st</pattern>
+  <pattern>rvals5te </pattern>
+  <pattern>rvers5te </pattern>
+  <pattern>rves4</pattern>
+  <pattern>rve3sp</pattern>
+  <pattern>rvloot5</pattern>
+  <pattern>r1w</pattern>
+  <pattern>rwen4st</pattern>
+  <pattern>rwens5te </pattern>
+  <pattern>r4wh</pattern>
+  <pattern>rw2t3j</pattern>
+  <pattern>r3x</pattern>
+  <pattern>r3yu</pattern>
+  <pattern>4rz</pattern>
+  <pattern>rzet5st</pattern>
+  <pattern>4s </pattern>
+  <pattern>5sa </pattern>
+  <pattern>s1aa</pattern>
+  <pattern>1saag</pattern>
+  <pattern>5s2aai</pattern>
+  <pattern>saai4s</pattern>
+  <pattern>3s2aal</pattern>
+  <pattern>3s4aat</pattern>
+  <pattern>1sab</pattern>
+  <pattern>sa3bo</pattern>
+  <pattern>2s1ac</pattern>
+  <pattern>sa2ca</pattern>
+  <pattern>3sacr</pattern>
+  <pattern>s1adv</pattern>
+  <pattern>2s1af</pattern>
+  <pattern>3safe</pattern>
+  <pattern>3safo</pattern>
+  <pattern>sa3fr</pattern>
+  <pattern>s5agg</pattern>
+  <pattern>s4a3gi</pattern>
+  <pattern>3sagn</pattern>
+  <pattern>sa3go</pattern>
+  <pattern>3sah</pattern>
+  <pattern>3sai</pattern>
+  <pattern>3saj</pattern>
+  <pattern>2sak</pattern>
+  <pattern>3saks</pattern>
+  <pattern>s1akt</pattern>
+  <pattern>s2al</pattern>
+  <pattern>5sal </pattern>
+  <pattern>3sa3la</pattern>
+  <pattern>3sald</pattern>
+  <pattern>5salh</pattern>
+  <pattern>s3all</pattern>
+  <pattern>4salm</pattern>
+  <pattern>sal5ma</pattern>
+  <pattern>s3aln</pattern>
+  <pattern>3s4a3lo</pattern>
+  <pattern>3s2ame</pattern>
+  <pattern>5samm</pattern>
+  <pattern>sam5p</pattern>
+  <pattern>4sa2na</pattern>
+  <pattern>sa3nat</pattern>
+  <pattern>s4anc</pattern>
+  <pattern>s2a3ne</pattern>
+  <pattern>s4ant</pattern>
+  <pattern>san4t3j</pattern>
+  <pattern>sa2p</pattern>
+  <pattern>3sap </pattern>
+  <pattern>sa3pa</pattern>
+  <pattern>2s3ape</pattern>
+  <pattern>sa4pr</pattern>
+  <pattern>sa5pro</pattern>
+  <pattern>sa3ra</pattern>
+  <pattern>s1arb</pattern>
+  <pattern>3sard</pattern>
+  <pattern>sa2re</pattern>
+  <pattern>s1arm</pattern>
+  <pattern>saro4</pattern>
+  <pattern>sar3ol</pattern>
+  <pattern>s4ars</pattern>
+  <pattern>4s1art</pattern>
+  <pattern>sart5se</pattern>
+  <pattern>4sas </pattern>
+  <pattern>3sasa</pattern>
+  <pattern>sa3sc</pattern>
+  <pattern>3s4ast</pattern>
+  <pattern>1sat</pattern>
+  <pattern>3sa3te</pattern>
+  <pattern>5sati</pattern>
+  <pattern>2s3atl</pattern>
+  <pattern>2s1att</pattern>
+  <pattern>s3aud</pattern>
+  <pattern>1saur</pattern>
+  <pattern>3s2aus</pattern>
+  <pattern>s1aut</pattern>
+  <pattern>3sauz</pattern>
+  <pattern>1sax</pattern>
+  <pattern>4s3b</pattern>
+  <pattern>s5ba</pattern>
+  <pattern>s5be</pattern>
+  <pattern>s5bo</pattern>
+  <pattern>1sc</pattern>
+  <pattern>2sca</pattern>
+  <pattern>4sce</pattern>
+  <pattern>5scena</pattern>
+  <pattern>5scè</pattern>
+  <pattern>3s4ch2</pattern>
+  <pattern>4sch </pattern>
+  <pattern>sch4a</pattern>
+  <pattern>5schak</pattern>
+  <pattern>5schap</pattern>
+  <pattern>4schau</pattern>
+  <pattern>5sche </pattern>
+  <pattern>s5chec</pattern>
+  <pattern>4schef</pattern>
+  <pattern>5schen</pattern>
+  <pattern>4scheq</pattern>
+  <pattern>5scher</pattern>
+  <pattern>5schev</pattern>
+  <pattern>5schew</pattern>
+  <pattern>s2chi</pattern>
+  <pattern>4schir</pattern>
+  <pattern>5schol</pattern>
+  <pattern>5schoo</pattern>
+  <pattern>5schot</pattern>
+  <pattern>sch5ta</pattern>
+  <pattern>2sci</pattern>
+  <pattern>4scl</pattern>
+  <pattern>2sco</pattern>
+  <pattern>3s4cola</pattern>
+  <pattern>3scoo</pattern>
+  <pattern>3scope</pattern>
+  <pattern>5scopi</pattern>
+  <pattern>3s4co5re</pattern>
+  <pattern>3scout</pattern>
+  <pattern>2scr</pattern>
+  <pattern>4scris</pattern>
+  <pattern>2scu</pattern>
+  <pattern>2scy</pattern>
+  <pattern>4s1d</pattern>
+  <pattern>s5de</pattern>
+  <pattern>s4dh</pattern>
+  <pattern>sdi5a</pattern>
+  <pattern>sdis5</pattern>
+  <pattern>s3do</pattern>
+  <pattern>s5dr</pattern>
+  <pattern>s3dw</pattern>
+  <pattern>3se</pattern>
+  <pattern>5se </pattern>
+  <pattern>se2a</pattern>
+  <pattern>se3ak</pattern>
+  <pattern>se3al</pattern>
+  <pattern>sear4</pattern>
+  <pattern>se3au</pattern>
+  <pattern>s4eb</pattern>
+  <pattern>4s3ech</pattern>
+  <pattern>se3cr</pattern>
+  <pattern>5sect</pattern>
+  <pattern>4secz</pattern>
+  <pattern>s4ee</pattern>
+  <pattern>4s5eed</pattern>
+  <pattern>5seei</pattern>
+  <pattern>4s1een</pattern>
+  <pattern>s5eenh</pattern>
+  <pattern>see4t</pattern>
+  <pattern>see5ts</pattern>
+  <pattern>4seev</pattern>
+  <pattern>s1eff</pattern>
+  <pattern>se3ge</pattern>
+  <pattern>2s5e2go</pattern>
+  <pattern>seg2r</pattern>
+  <pattern>4s3ei </pattern>
+  <pattern>4s3eig</pattern>
+  <pattern>s4ein</pattern>
+  <pattern>5sein </pattern>
+  <pattern>5seine</pattern>
+  <pattern>2seis</pattern>
+  <pattern>seis4t</pattern>
+  <pattern>sei5tj</pattern>
+  <pattern>5seiz</pattern>
+  <pattern>sek4st</pattern>
+  <pattern>seks5ten</pattern>
+  <pattern>se1kw</pattern>
+  <pattern>s2el</pattern>
+  <pattern>5s4el </pattern>
+  <pattern>sel3ad</pattern>
+  <pattern>se4l3a4g</pattern>
+  <pattern>se4lak</pattern>
+  <pattern>se4las</pattern>
+  <pattern>se3le</pattern>
+  <pattern>4s3e4lek</pattern>
+  <pattern>sel3el</pattern>
+  <pattern>4se4lem</pattern>
+  <pattern>4self</pattern>
+  <pattern>se5ling</pattern>
+  <pattern>4s3elit</pattern>
+  <pattern>sel5k</pattern>
+  <pattern>5selm</pattern>
+  <pattern>selo4</pattern>
+  <pattern>5selp</pattern>
+  <pattern>5s4els</pattern>
+  <pattern>sel3sp</pattern>
+  <pattern>5selt</pattern>
+  <pattern>se2l3u</pattern>
+  <pattern>s4em</pattern>
+  <pattern>se4m3ac</pattern>
+  <pattern>s5emm</pattern>
+  <pattern>sem3oo</pattern>
+  <pattern>s4en</pattern>
+  <pattern>5sen </pattern>
+  <pattern>se4n3a4g</pattern>
+  <pattern>se5nan</pattern>
+  <pattern>se4net</pattern>
+  <pattern>5sengr</pattern>
+  <pattern>5senh</pattern>
+  <pattern>sen5k</pattern>
+  <pattern>se4n3o</pattern>
+  <pattern>4s5enq</pattern>
+  <pattern>sen5tw</pattern>
+  <pattern>5s4er </pattern>
+  <pattern>se1r4a</pattern>
+  <pattern>ser5au</pattern>
+  <pattern>5se3r4e</pattern>
+  <pattern>se4ree</pattern>
+  <pattern>se5ren</pattern>
+  <pattern>s4erg</pattern>
+  <pattern>5sergl</pattern>
+  <pattern>s5ergo</pattern>
+  <pattern>5sergr</pattern>
+  <pattern>ser4i</pattern>
+  <pattern>se5rij</pattern>
+  <pattern>4s3ern</pattern>
+  <pattern>se3ro</pattern>
+  <pattern>se5rop</pattern>
+  <pattern>ser2s</pattern>
+  <pattern>sers3p</pattern>
+  <pattern>ser3st</pattern>
+  <pattern>sert5w</pattern>
+  <pattern>se3ru</pattern>
+  <pattern>s4es</pattern>
+  <pattern>se5sc</pattern>
+  <pattern>se3sf</pattern>
+  <pattern>2s5esk</pattern>
+  <pattern>5sess</pattern>
+  <pattern>se4t</pattern>
+  <pattern>se5ta</pattern>
+  <pattern>4s3ete</pattern>
+  <pattern>se5ti</pattern>
+  <pattern>se3tj</pattern>
+  <pattern>set3r</pattern>
+  <pattern>se5t4ra</pattern>
+  <pattern>set5st</pattern>
+  <pattern>4s5etu</pattern>
+  <pattern>set3w</pattern>
+  <pattern>se3um</pattern>
+  <pattern>se4ven</pattern>
+  <pattern>4s1ex</pattern>
+  <pattern>4sez</pattern>
+  <pattern>se2ze</pattern>
+  <pattern>3sé</pattern>
+  <pattern>3sè</pattern>
+  <pattern>2s1f</pattern>
+  <pattern>4sfed</pattern>
+  <pattern>s5fei</pattern>
+  <pattern>4sfi</pattern>
+  <pattern>4s5fr</pattern>
+  <pattern>4sfu</pattern>
+  <pattern>sfu5m</pattern>
+  <pattern>4s5g</pattern>
+  <pattern>sgue4</pattern>
+  <pattern>s1h</pattern>
+  <pattern>s4ha </pattern>
+  <pattern>sha4g</pattern>
+  <pattern>s5hal </pattern>
+  <pattern>3shamp</pattern>
+  <pattern>4she</pattern>
+  <pattern>sheid4</pattern>
+  <pattern>sheids5</pattern>
+  <pattern>s5hie</pattern>
+  <pattern>5s4hir</pattern>
+  <pattern>sh3l</pattern>
+  <pattern>4shm</pattern>
+  <pattern>s3hoe</pattern>
+  <pattern>s3hoo</pattern>
+  <pattern>3s4hop</pattern>
+  <pattern>s2hot</pattern>
+  <pattern>s3hote</pattern>
+  <pattern>3show</pattern>
+  <pattern>s5hul</pattern>
+  <pattern>1si</pattern>
+  <pattern>5si </pattern>
+  <pattern>5s4ia</pattern>
+  <pattern>si5ac</pattern>
+  <pattern>si3am</pattern>
+  <pattern>si5an</pattern>
+  <pattern>5sic</pattern>
+  <pattern>sici4</pattern>
+  <pattern>si3co</pattern>
+  <pattern>3sie </pattern>
+  <pattern>3sieë</pattern>
+  <pattern>sie5fr</pattern>
+  <pattern>sie5kl</pattern>
+  <pattern>siep4</pattern>
+  <pattern>sies4</pattern>
+  <pattern>sie5sl</pattern>
+  <pattern>sie3so</pattern>
+  <pattern>sie3st</pattern>
+  <pattern>sie5ta</pattern>
+  <pattern>sie5to</pattern>
+  <pattern>si5è</pattern>
+  <pattern>si1f4</pattern>
+  <pattern>5s2ig</pattern>
+  <pattern>si5go5</pattern>
+  <pattern>s3ijv</pattern>
+  <pattern>4s1ijz</pattern>
+  <pattern>5sile</pattern>
+  <pattern>4s5imper</pattern>
+  <pattern>3simu</pattern>
+  <pattern>5sina</pattern>
+  <pattern>s3inb</pattern>
+  <pattern>4s3inc</pattern>
+  <pattern>4s1ind</pattern>
+  <pattern>2sinf</pattern>
+  <pattern>sing4</pattern>
+  <pattern>3sing </pattern>
+  <pattern>s3inga</pattern>
+  <pattern>s5ingeni</pattern>
+  <pattern>sin3gl</pattern>
+  <pattern>s3in5gr</pattern>
+  <pattern>s3inh</pattern>
+  <pattern>4si2ni</pattern>
+  <pattern>4s3inko</pattern>
+  <pattern>sin5kr</pattern>
+  <pattern>4s3inm</pattern>
+  <pattern>s4inn</pattern>
+  <pattern>4sinr</pattern>
+  <pattern>2s1ins</pattern>
+  <pattern>2sint</pattern>
+  <pattern>4s5inv</pattern>
+  <pattern>4s3inz</pattern>
+  <pattern>3sir</pattern>
+  <pattern>5siro</pattern>
+  <pattern>s3irr</pattern>
+  <pattern>si4s</pattern>
+  <pattern>sis3e4</pattern>
+  <pattern>sis5ee</pattern>
+  <pattern>sis3i</pattern>
+  <pattern>sis5tr</pattern>
+  <pattern>3sit</pattern>
+  <pattern>si5to</pattern>
+  <pattern>sito5v</pattern>
+  <pattern>si3tr</pattern>
+  <pattern>si4tru</pattern>
+  <pattern>si5tu</pattern>
+  <pattern>3siu</pattern>
+  <pattern>3siz</pattern>
+  <pattern>sj2</pattern>
+  <pattern>4sj </pattern>
+  <pattern>3s4ja </pattern>
+  <pattern>5sjab</pattern>
+  <pattern>4sj3d</pattern>
+  <pattern>s1je</pattern>
+  <pattern>2s3je </pattern>
+  <pattern>s5jeb</pattern>
+  <pattern>3sjee</pattern>
+  <pattern>3s2jei</pattern>
+  <pattern>1sjer</pattern>
+  <pattern>sje4ri</pattern>
+  <pattern>s3jes</pattern>
+  <pattern>3sjew</pattern>
+  <pattern>3s4jez</pattern>
+  <pattern>4sj5k4</pattern>
+  <pattern>5sjof</pattern>
+  <pattern>4s3jon</pattern>
+  <pattern>sj3s2</pattern>
+  <pattern>sjt4</pattern>
+  <pattern>s5ju</pattern>
+  <pattern>2s1k2</pattern>
+  <pattern>skaart5j</pattern>
+  <pattern>s5kad</pattern>
+  <pattern>s4kele</pattern>
+  <pattern>s5ken</pattern>
+  <pattern>3s2kes</pattern>
+  <pattern>sk4i</pattern>
+  <pattern>3s2ki </pattern>
+  <pattern>3skied</pattern>
+  <pattern>skie3s</pattern>
+  <pattern>3skië</pattern>
+  <pattern>ski5sc</pattern>
+  <pattern>s2k3j</pattern>
+  <pattern>s3ko</pattern>
+  <pattern>s5kre</pattern>
+  <pattern>sk5ruim</pattern>
+  <pattern>sk3ste</pattern>
+  <pattern>4sku</pattern>
+  <pattern>s3k4w</pattern>
+  <pattern>s2l4</pattern>
+  <pattern>3s4la </pattern>
+  <pattern>5s4laan</pattern>
+  <pattern>5slaap</pattern>
+  <pattern>4s5laar</pattern>
+  <pattern>4slab</pattern>
+  <pattern>s4lac</pattern>
+  <pattern>4s3lad</pattern>
+  <pattern>3s4lag</pattern>
+  <pattern>5slagm</pattern>
+  <pattern>sla4me</pattern>
+  <pattern>s5lamp </pattern>
+  <pattern>s5lampe</pattern>
+  <pattern>4s5land</pattern>
+  <pattern>3slang</pattern>
+  <pattern>3slap</pattern>
+  <pattern>5slape</pattern>
+  <pattern>sla3pl</pattern>
+  <pattern>4s3las</pattern>
+  <pattern>2s3lat</pattern>
+  <pattern>3s4la5v</pattern>
+  <pattern>4slaw</pattern>
+  <pattern>3s4laz</pattern>
+  <pattern>s3led</pattern>
+  <pattern>3s4lee </pattern>
+  <pattern>5sleep</pattern>
+  <pattern>4s5leer</pattern>
+  <pattern>s4leet</pattern>
+  <pattern>slee5tj</pattern>
+  <pattern>4s3leg</pattern>
+  <pattern>2s5lei</pattern>
+  <pattern>s5leng</pattern>
+  <pattern>s3leni</pattern>
+  <pattern>slen4st</pattern>
+  <pattern>slens5te </pattern>
+  <pattern>3slent</pattern>
+  <pattern>s4lep</pattern>
+  <pattern>4s5ler</pattern>
+  <pattern>s5les</pattern>
+  <pattern>sle4t3j</pattern>
+  <pattern>3s4leu</pattern>
+  <pattern>s5leug</pattern>
+  <pattern>s5leus</pattern>
+  <pattern>5sleut</pattern>
+  <pattern>2s5lev</pattern>
+  <pattern>s3li </pattern>
+  <pattern>4s3lic</pattern>
+  <pattern>4slid</pattern>
+  <pattern>2slie</pattern>
+  <pattern>s5lied</pattern>
+  <pattern>s3lief</pattern>
+  <pattern>3s4lier</pattern>
+  <pattern>s3lif</pattern>
+  <pattern>s5lig</pattern>
+  <pattern>4s3lijf</pattern>
+  <pattern>5slijp</pattern>
+  <pattern>4s5lijs</pattern>
+  <pattern>s4li4k</pattern>
+  <pattern>sli2m</pattern>
+  <pattern>slim5a</pattern>
+  <pattern>s5lini</pattern>
+  <pattern>4slinn</pattern>
+  <pattern>s4lip</pattern>
+  <pattern>4s3lit</pattern>
+  <pattern>slo4b5</pattern>
+  <pattern>2s3loc</pattern>
+  <pattern>3s4loe</pattern>
+  <pattern>3slof</pattern>
+  <pattern>4s3log</pattern>
+  <pattern>s3lol</pattern>
+  <pattern>s3lood</pattern>
+  <pattern>s5loon</pattern>
+  <pattern>s5loos</pattern>
+  <pattern>5s4loot3</pattern>
+  <pattern>s3los</pattern>
+  <pattern>3slot</pattern>
+  <pattern>slo4tr</pattern>
+  <pattern>4s3lou</pattern>
+  <pattern>4s5loz</pattern>
+  <pattern>4s5luc</pattern>
+  <pattern>1s4lui</pattern>
+  <pattern>4s5lui </pattern>
+  <pattern>4sluid</pattern>
+  <pattern>5sluis </pattern>
+  <pattern>sluis4t</pattern>
+  <pattern>slui5ste</pattern>
+  <pattern>5sluit</pattern>
+  <pattern>5sluiz</pattern>
+  <pattern>4slun</pattern>
+  <pattern>2s5lus</pattern>
+  <pattern>4s3ly</pattern>
+  <pattern>s1m</pattern>
+  <pattern>4s5maat</pattern>
+  <pattern>3smad</pattern>
+  <pattern>3smak </pattern>
+  <pattern>3smal</pattern>
+  <pattern>2s5man</pattern>
+  <pattern>s5map</pattern>
+  <pattern>s4mart</pattern>
+  <pattern>4s5mat</pattern>
+  <pattern>4s5mec</pattern>
+  <pattern>5smeden</pattern>
+  <pattern>3smeed</pattern>
+  <pattern>5s4meet</pattern>
+  <pattern>4s5mei</pattern>
+  <pattern>4smelo</pattern>
+  <pattern>4s5men</pattern>
+  <pattern>4s5mes3</pattern>
+  <pattern>5smid </pattern>
+  <pattern>smie2</pattern>
+  <pattern>smies5</pattern>
+  <pattern>s4mij</pattern>
+  <pattern>s5min</pattern>
+  <pattern>5smok</pattern>
+  <pattern>s3mon</pattern>
+  <pattern>5smuilden</pattern>
+  <pattern>s5muile</pattern>
+  <pattern>5smuilt</pattern>
+  <pattern>s2n4</pattern>
+  <pattern>s5nam</pattern>
+  <pattern>5s4nap</pattern>
+  <pattern>s4nar</pattern>
+  <pattern>3snau</pattern>
+  <pattern>3s4nav</pattern>
+  <pattern>3s4ned</pattern>
+  <pattern>3snee</pattern>
+  <pattern>snee5t</pattern>
+  <pattern>s5neg</pattern>
+  <pattern>5s4nel</pattern>
+  <pattern>2s5nes</pattern>
+  <pattern>4s5net</pattern>
+  <pattern>sneus4</pattern>
+  <pattern>sneu5st</pattern>
+  <pattern>s5neuz</pattern>
+  <pattern>s3nie</pattern>
+  <pattern>1s4nij</pattern>
+  <pattern>s5nim</pattern>
+  <pattern>3s4nip</pattern>
+  <pattern>4s5niv</pattern>
+  <pattern>4snod</pattern>
+  <pattern>3s4noe</pattern>
+  <pattern>s3nog</pattern>
+  <pattern>2snoo</pattern>
+  <pattern>s4nor </pattern>
+  <pattern>s3norm</pattern>
+  <pattern>sno5v</pattern>
+  <pattern>3snuf</pattern>
+  <pattern>s4nui</pattern>
+  <pattern>2snum</pattern>
+  <pattern>3so </pattern>
+  <pattern>so4bl</pattern>
+  <pattern>so1c</pattern>
+  <pattern>s3oce</pattern>
+  <pattern>3s4o3d</pattern>
+  <pattern>1soe</pattern>
+  <pattern>2soef</pattern>
+  <pattern>3soep</pattern>
+  <pattern>soes3</pattern>
+  <pattern>2s1off</pattern>
+  <pattern>3soft</pattern>
+  <pattern>2so2g</pattern>
+  <pattern>3so3ga</pattern>
+  <pattern>s1oge</pattern>
+  <pattern>so3gl</pattern>
+  <pattern>3sogy</pattern>
+  <pattern>5soi</pattern>
+  <pattern>3soï</pattern>
+  <pattern>3sok</pattern>
+  <pattern>s2ol</pattern>
+  <pattern>5sol </pattern>
+  <pattern>so3la</pattern>
+  <pattern>so3le</pattern>
+  <pattern>so3lis</pattern>
+  <pattern>3so5l4o3</pattern>
+  <pattern>solo5v</pattern>
+  <pattern>5sols</pattern>
+  <pattern>s2om</pattern>
+  <pattern>3s4om </pattern>
+  <pattern>5somm</pattern>
+  <pattern>2s3oms</pattern>
+  <pattern>s3omv</pattern>
+  <pattern>2somz</pattern>
+  <pattern>5s4on </pattern>
+  <pattern>3sona</pattern>
+  <pattern>so5nar</pattern>
+  <pattern>s3onb</pattern>
+  <pattern>2s1ond</pattern>
+  <pattern>2song</pattern>
+  <pattern>3sonn</pattern>
+  <pattern>3so3no</pattern>
+  <pattern>s4ons</pattern>
+  <pattern>2s1on4t3</pattern>
+  <pattern>4s3onv</pattern>
+  <pattern>s3onw</pattern>
+  <pattern>3soo</pattern>
+  <pattern>4s5oog</pattern>
+  <pattern>4s3ook</pattern>
+  <pattern>4s3oor </pattern>
+  <pattern>s3oord</pattern>
+  <pattern>4s3oorl</pattern>
+  <pattern>5soort</pattern>
+  <pattern>2s1op</pattern>
+  <pattern>3s4op </pattern>
+  <pattern>4s5ope</pattern>
+  <pattern>so3phi</pattern>
+  <pattern>s2o5po</pattern>
+  <pattern>so3pr</pattern>
+  <pattern>3s4opra</pattern>
+  <pattern>sop4re</pattern>
+  <pattern>s2orb</pattern>
+  <pattern>s3ord</pattern>
+  <pattern>2s1or3g</pattern>
+  <pattern>4s5ork</pattern>
+  <pattern>sor4o</pattern>
+  <pattern>so3ror</pattern>
+  <pattern>sor4st</pattern>
+  <pattern>3s2ort</pattern>
+  <pattern>sos4</pattern>
+  <pattern>so3sf</pattern>
+  <pattern>s4ot</pattern>
+  <pattern>s3oud</pattern>
+  <pattern>sou2l</pattern>
+  <pattern>sou3t</pattern>
+  <pattern>2sov</pattern>
+  <pattern>s1ove</pattern>
+  <pattern>3so5z</pattern>
+  <pattern>4sp </pattern>
+  <pattern>sp4a</pattern>
+  <pattern>5spaak</pattern>
+  <pattern>s3paal</pattern>
+  <pattern>5spaan</pattern>
+  <pattern>5spaat</pattern>
+  <pattern>2spad</pattern>
+  <pattern>2spak</pattern>
+  <pattern>5spake</pattern>
+  <pattern>s4pan</pattern>
+  <pattern>3spann</pattern>
+  <pattern>4s5pap</pattern>
+  <pattern>5spar </pattern>
+  <pattern>s4pari</pattern>
+  <pattern>5sparr</pattern>
+  <pattern>2spas5</pattern>
+  <pattern>5spatt</pattern>
+  <pattern>s3pau</pattern>
+  <pattern>5s4pea</pattern>
+  <pattern>4spectu</pattern>
+  <pattern>3s4pee</pattern>
+  <pattern>speet3</pattern>
+  <pattern>4s3pei</pattern>
+  <pattern>s4pek</pattern>
+  <pattern>5spell</pattern>
+  <pattern>4s3pen</pattern>
+  <pattern>s5pen </pattern>
+  <pattern>spe4na</pattern>
+  <pattern>s5pep</pattern>
+  <pattern>4sper</pattern>
+  <pattern>s4per </pattern>
+  <pattern>s5peri</pattern>
+  <pattern>s4perm</pattern>
+  <pattern>5s4perr</pattern>
+  <pattern>4spes</pattern>
+  <pattern>s3pez</pattern>
+  <pattern>s3pid</pattern>
+  <pattern>1s4pie</pattern>
+  <pattern>spie5tj</pattern>
+  <pattern>4spijn</pattern>
+  <pattern>4spijp</pattern>
+  <pattern>s5ping</pattern>
+  <pattern>5s2pio</pattern>
+  <pattern>s3pis</pattern>
+  <pattern>spi5sto</pattern>
+  <pattern>2s1p4l</pattern>
+  <pattern>4s5pla</pattern>
+  <pattern>s4plet</pattern>
+  <pattern>s2pli4</pattern>
+  <pattern>5splin</pattern>
+  <pattern>3split</pattern>
+  <pattern>s3plo</pattern>
+  <pattern>s3plu</pattern>
+  <pattern>sp4o</pattern>
+  <pattern>s2poe</pattern>
+  <pattern>s3poes</pattern>
+  <pattern>4spoë</pattern>
+  <pattern>4spog</pattern>
+  <pattern>4spol</pattern>
+  <pattern>2s3pom</pattern>
+  <pattern>s4pon </pattern>
+  <pattern>s4ponn</pattern>
+  <pattern>s2poo</pattern>
+  <pattern>s3pop</pattern>
+  <pattern>5s4pore</pattern>
+  <pattern>s4pori</pattern>
+  <pattern>4s3pos</pattern>
+  <pattern>5spots</pattern>
+  <pattern>4spou</pattern>
+  <pattern>4sprakt</pattern>
+  <pattern>5spray</pattern>
+  <pattern>s5pred</pattern>
+  <pattern>5sprei</pattern>
+  <pattern>s4prek</pattern>
+  <pattern>4sprem</pattern>
+  <pattern>4spres</pattern>
+  <pattern>5spreu</pattern>
+  <pattern>5spriet</pattern>
+  <pattern>4s5prij</pattern>
+  <pattern>4sprik</pattern>
+  <pattern>4sprob</pattern>
+  <pattern>4sproc</pattern>
+  <pattern>4s5prod</pattern>
+  <pattern>4sprof</pattern>
+  <pattern>4sprog</pattern>
+  <pattern>5s4pron</pattern>
+  <pattern>s4proo</pattern>
+  <pattern>4spros</pattern>
+  <pattern>4s3ps</pattern>
+  <pattern>4spt</pattern>
+  <pattern>s2p4u</pattern>
+  <pattern>4spub</pattern>
+  <pattern>5s4pui</pattern>
+  <pattern>4spun</pattern>
+  <pattern>s4pur</pattern>
+  <pattern>5spuw</pattern>
+  <pattern>s4q</pattern>
+  <pattern>4s5r</pattern>
+  <pattern>sraads5l</pattern>
+  <pattern>sro5v</pattern>
+  <pattern>4s3s4</pattern>
+  <pattern>ssa1s2</pattern>
+  <pattern>s4sco</pattern>
+  <pattern>s4s5cu</pattern>
+  <pattern>s5se</pattern>
+  <pattern>ssei3s</pattern>
+  <pattern>sseo4</pattern>
+  <pattern>s5si</pattern>
+  <pattern>s5sl</pattern>
+  <pattern>s4spa</pattern>
+  <pattern>s5spaa</pattern>
+  <pattern>ss5pas</pattern>
+  <pattern>s5su</pattern>
+  <pattern>s5sy</pattern>
+  <pattern>s2t</pattern>
+  <pattern>4st </pattern>
+  <pattern>5staaf</pattern>
+  <pattern>5staan </pattern>
+  <pattern>4staang</pattern>
+  <pattern>4staanw</pattern>
+  <pattern>staart5j</pattern>
+  <pattern>s4taat</pattern>
+  <pattern>staat5j</pattern>
+  <pattern>st3abo</pattern>
+  <pattern>2s4t1ac</pattern>
+  <pattern>3stad</pattern>
+  <pattern>5stads</pattern>
+  <pattern>2staf</pattern>
+  <pattern>5staf </pattern>
+  <pattern>sta4fo</pattern>
+  <pattern>s4tag</pattern>
+  <pattern>s4tak</pattern>
+  <pattern>5staki</pattern>
+  <pattern>4stakk</pattern>
+  <pattern>st3akt</pattern>
+  <pattern>4s3tali</pattern>
+  <pattern>5stam </pattern>
+  <pattern>5stamm</pattern>
+  <pattern>3stamp</pattern>
+  <pattern>3s4tand</pattern>
+  <pattern>stan4s</pattern>
+  <pattern>s4tap</pattern>
+  <pattern>4stapo</pattern>
+  <pattern>s4t3arc</pattern>
+  <pattern>4stari</pattern>
+  <pattern>2stas</pattern>
+  <pattern>stasie4</pattern>
+  <pattern>5statio</pattern>
+  <pattern>4stau</pattern>
+  <pattern>st3aut</pattern>
+  <pattern>s4tav</pattern>
+  <pattern>4stavo</pattern>
+  <pattern>4s5tax</pattern>
+  <pattern>4staz</pattern>
+  <pattern>2stb</pattern>
+  <pattern>2st5c</pattern>
+  <pattern>2std</pattern>
+  <pattern>4stea</pattern>
+  <pattern>5steak</pattern>
+  <pattern>4stec</pattern>
+  <pattern>s5tech</pattern>
+  <pattern>5steco</pattern>
+  <pattern>3s4ted</pattern>
+  <pattern>4stedu</pattern>
+  <pattern>3steek</pattern>
+  <pattern>3steen</pattern>
+  <pattern>4steenh</pattern>
+  <pattern>s5teer</pattern>
+  <pattern>stee5t</pattern>
+  <pattern>5stein</pattern>
+  <pattern>5stekar</pattern>
+  <pattern>5stekk</pattern>
+  <pattern>5steldh</pattern>
+  <pattern>ste4lee</pattern>
+  <pattern>st5elem</pattern>
+  <pattern>3stell</pattern>
+  <pattern>5stem </pattern>
+  <pattern>5stemd</pattern>
+  <pattern>5stemm</pattern>
+  <pattern>4stemo</pattern>
+  <pattern>4stent</pattern>
+  <pattern>4stenu</pattern>
+  <pattern>ste5ran</pattern>
+  <pattern>4sterm</pattern>
+  <pattern>ster5og</pattern>
+  <pattern>st5e4ros</pattern>
+  <pattern>5sterren</pattern>
+  <pattern>s5teru</pattern>
+  <pattern>4ste4s</pattern>
+  <pattern>4s4t3ex</pattern>
+  <pattern>s4t3e2z</pattern>
+  <pattern>2stf</pattern>
+  <pattern>4stg</pattern>
+  <pattern>4sth</pattern>
+  <pattern>s4tha</pattern>
+  <pattern>st3hed</pattern>
+  <pattern>st5heer</pattern>
+  <pattern>st3hek</pattern>
+  <pattern>s5them</pattern>
+  <pattern>s3ther</pattern>
+  <pattern>st1hi</pattern>
+  <pattern>s4t1ho</pattern>
+  <pattern>s4t1hu</pattern>
+  <pattern>s4t3hy</pattern>
+  <pattern>2stia</pattern>
+  <pattern>2stib</pattern>
+  <pattern>4sticu</pattern>
+  <pattern>s4t3id</pattern>
+  <pattern>5stiefe</pattern>
+  <pattern>s5tiev</pattern>
+  <pattern>4stijd</pattern>
+  <pattern>3s4tijg</pattern>
+  <pattern>5s4tijl</pattern>
+  <pattern>st3ijs</pattern>
+  <pattern>3stils</pattern>
+  <pattern>s4tim</pattern>
+  <pattern>st3imp</pattern>
+  <pattern>sti5ni</pattern>
+  <pattern>4stins</pattern>
+  <pattern>4s5tint</pattern>
+  <pattern>4stite</pattern>
+  <pattern>2stiv</pattern>
+  <pattern>st3ivo</pattern>
+  <pattern>4s4t1j</pattern>
+  <pattern>2stk</pattern>
+  <pattern>4stl</pattern>
+  <pattern>2stm</pattern>
+  <pattern>2stn</pattern>
+  <pattern>2stob</pattern>
+  <pattern>2stoc</pattern>
+  <pattern>4stoef</pattern>
+  <pattern>3stoel</pattern>
+  <pattern>5stoel </pattern>
+  <pattern>5stoele</pattern>
+  <pattern>4stoen</pattern>
+  <pattern>4stoer</pattern>
+  <pattern>4stoes</pattern>
+  <pattern>4stoez</pattern>
+  <pattern>3s4tof</pattern>
+  <pattern>st3o4ge</pattern>
+  <pattern>5s4tok</pattern>
+  <pattern>s4tol</pattern>
+  <pattern>sto5li</pattern>
+  <pattern>4stoma</pattern>
+  <pattern>4stomz</pattern>
+  <pattern>s4tong</pattern>
+  <pattern>3s4too</pattern>
+  <pattern>4st3oog</pattern>
+  <pattern>stoot5j</pattern>
+  <pattern>s4top</pattern>
+  <pattern>st3o5pe</pattern>
+  <pattern>st5opto</pattern>
+  <pattern>4stora</pattern>
+  <pattern>sto4rat</pattern>
+  <pattern>4stord</pattern>
+  <pattern>sto5ri</pattern>
+  <pattern>4s5tos</pattern>
+  <pattern>s4tov</pattern>
+  <pattern>2stp</pattern>
+  <pattern>1s4tr</pattern>
+  <pattern>4stra </pattern>
+  <pattern>straat5j</pattern>
+  <pattern>4st4rad</pattern>
+  <pattern>3stra4f</pattern>
+  <pattern>5straf </pattern>
+  <pattern>s5trag</pattern>
+  <pattern>4strai</pattern>
+  <pattern>4st3rec</pattern>
+  <pattern>s5tref</pattern>
+  <pattern>4streg</pattern>
+  <pattern>4s3trei</pattern>
+  <pattern>5strel</pattern>
+  <pattern>3strep</pattern>
+  <pattern>st3rif</pattern>
+  <pattern>st5rijp</pattern>
+  <pattern>s5tris</pattern>
+  <pattern>4s3troe</pattern>
+  <pattern>s5troep</pattern>
+  <pattern>st4rom</pattern>
+  <pattern>5strook</pattern>
+  <pattern>5stroom</pattern>
+  <pattern>4stroos</pattern>
+  <pattern>st5roos </pattern>
+  <pattern>4s5trou</pattern>
+  <pattern>4stroz</pattern>
+  <pattern>3stru</pattern>
+  <pattern>4strui </pattern>
+  <pattern>5struik</pattern>
+  <pattern>4st1s4</pattern>
+  <pattern>st3sc</pattern>
+  <pattern>st5se</pattern>
+  <pattern>st3sf</pattern>
+  <pattern>st3sk</pattern>
+  <pattern>st3sl</pattern>
+  <pattern>st3so</pattern>
+  <pattern>st5sp</pattern>
+  <pattern>st5st</pattern>
+  <pattern>2st5t2</pattern>
+  <pattern>1stu</pattern>
+  <pattern>4stub</pattern>
+  <pattern>4stuc</pattern>
+  <pattern>5s4tud</pattern>
+  <pattern>4stuin</pattern>
+  <pattern>stui5tj</pattern>
+  <pattern>st5uitk</pattern>
+  <pattern>5stuk</pattern>
+  <pattern>2s4tun</pattern>
+  <pattern>st3uni</pattern>
+  <pattern>stu4nie</pattern>
+  <pattern>4stus</pattern>
+  <pattern>2stv</pattern>
+  <pattern>2st3w</pattern>
+  <pattern>2s4ty</pattern>
+  <pattern>1styl</pattern>
+  <pattern>s5typ</pattern>
+  <pattern>2stz</pattern>
+  <pattern>1su</pattern>
+  <pattern>5su </pattern>
+  <pattern>5sua</pattern>
+  <pattern>5su4b1</pattern>
+  <pattern>suba4</pattern>
+  <pattern>sub5e</pattern>
+  <pattern>su5bl</pattern>
+  <pattern>5suc</pattern>
+  <pattern>5sud</pattern>
+  <pattern>3sug</pattern>
+  <pattern>2sui</pattern>
+  <pattern>5suik</pattern>
+  <pattern>4s1uit</pattern>
+  <pattern>5suit </pattern>
+  <pattern>s5uitl</pattern>
+  <pattern>5suits </pattern>
+  <pattern>5suk</pattern>
+  <pattern>3sul</pattern>
+  <pattern>5sum</pattern>
+  <pattern>4s1u2n</pattern>
+  <pattern>5sup</pattern>
+  <pattern>5surv</pattern>
+  <pattern>su4s</pattern>
+  <pattern>sus3e</pattern>
+  <pattern>suur5</pattern>
+  <pattern>4s5v</pattern>
+  <pattern>svaat5</pattern>
+  <pattern>svari5</pattern>
+  <pattern>sve4r</pattern>
+  <pattern>sve5ri</pattern>
+  <pattern>4s1w</pattern>
+  <pattern>s5wo</pattern>
+  <pattern>s4y</pattern>
+  <pattern>3sy </pattern>
+  <pattern>4syc</pattern>
+  <pattern>3syn</pattern>
+  <pattern>sy4n3e</pattern>
+  <pattern>1sys5</pattern>
+  <pattern>4s5z</pattern>
+  <pattern>4t </pattern>
+  <pattern>3taak </pattern>
+  <pattern>t4aal</pattern>
+  <pattern>t5aando</pattern>
+  <pattern>t3aank</pattern>
+  <pattern>taan4st</pattern>
+  <pattern>t3aanw</pattern>
+  <pattern>t3aap</pattern>
+  <pattern>taar5sp</pattern>
+  <pattern>4t3aas</pattern>
+  <pattern>taat4st</pattern>
+  <pattern>taats5ta</pattern>
+  <pattern>3tabe</pattern>
+  <pattern>3tabl</pattern>
+  <pattern>2tac</pattern>
+  <pattern>ta2ca</pattern>
+  <pattern>3t4aci</pattern>
+  <pattern>4tad</pattern>
+  <pattern>ta4de</pattern>
+  <pattern>t3ader</pattern>
+  <pattern>5tado</pattern>
+  <pattern>t3adr</pattern>
+  <pattern>tad4s3</pattern>
+  <pattern>t3adve</pattern>
+  <pattern>2taf </pattern>
+  <pattern>2t3afd</pattern>
+  <pattern>5ta3fe</pattern>
+  <pattern>4taff</pattern>
+  <pattern>t3afha</pattern>
+  <pattern>t4afr</pattern>
+  <pattern>ta3fro</pattern>
+  <pattern>4t1afs</pattern>
+  <pattern>2t3afw</pattern>
+  <pattern>4tafz</pattern>
+  <pattern>ta4gaa</pattern>
+  <pattern>5tagee</pattern>
+  <pattern>5ta5g4l</pattern>
+  <pattern>tag3r</pattern>
+  <pattern>5taka</pattern>
+  <pattern>5takg</pattern>
+  <pattern>5takken</pattern>
+  <pattern>ta3kl</pattern>
+  <pattern>5takn</pattern>
+  <pattern>5takp</pattern>
+  <pattern>5tak3r</pattern>
+  <pattern>5taks</pattern>
+  <pattern>t2al</pattern>
+  <pattern>ta3laa</pattern>
+  <pattern>ta5lact</pattern>
+  <pattern>4talb</pattern>
+  <pattern>5tale </pattern>
+  <pattern>5talent</pattern>
+  <pattern>ta3li</pattern>
+  <pattern>5talig</pattern>
+  <pattern>t5allia</pattern>
+  <pattern>talm3a</pattern>
+  <pattern>4talt</pattern>
+  <pattern>ta4mak</pattern>
+  <pattern>4tamb</pattern>
+  <pattern>t3amba</pattern>
+  <pattern>5tamen</pattern>
+  <pattern>tament5j</pattern>
+  <pattern>4tamp</pattern>
+  <pattern>t3ampu</pattern>
+  <pattern>5tan </pattern>
+  <pattern>4t3a2na</pattern>
+  <pattern>ta3nag</pattern>
+  <pattern>ta3nat</pattern>
+  <pattern>tan4d3r</pattern>
+  <pattern>tan4k5r</pattern>
+  <pattern>ta3o</pattern>
+  <pattern>t4ape</pattern>
+  <pattern>5tapi</pattern>
+  <pattern>ta3pl</pattern>
+  <pattern>5tapo</pattern>
+  <pattern>ta3q</pattern>
+  <pattern>ta3ra</pattern>
+  <pattern>4t3arb</pattern>
+  <pattern>5tari</pattern>
+  <pattern>4t1arm</pattern>
+  <pattern>ta2ro4</pattern>
+  <pattern>tar5sp</pattern>
+  <pattern>tar5taa</pattern>
+  <pattern>t3arti</pattern>
+  <pattern>3tarw</pattern>
+  <pattern>3tas</pattern>
+  <pattern>5tasa</pattern>
+  <pattern>5tasj</pattern>
+  <pattern>5taso</pattern>
+  <pattern>ta3s2p</pattern>
+  <pattern>ta3sta</pattern>
+  <pattern>ta3str</pattern>
+  <pattern>ta3sy</pattern>
+  <pattern>4tata</pattern>
+  <pattern>4tatio</pattern>
+  <pattern>tat5j</pattern>
+  <pattern>4t3atl</pattern>
+  <pattern>3tatr</pattern>
+  <pattern>3tau</pattern>
+  <pattern>4taut</pattern>
+  <pattern>2t1avo</pattern>
+  <pattern>3tax</pattern>
+  <pattern>t3a2z</pattern>
+  <pattern>4t3b</pattern>
+  <pattern>tba2l</pattern>
+  <pattern>4t3c</pattern>
+  <pattern>t4ch</pattern>
+  <pattern>t5cha</pattern>
+  <pattern>t5che</pattern>
+  <pattern>t5chi</pattern>
+  <pattern>t5chu</pattern>
+  <pattern>4t3d2</pattern>
+  <pattern>tdor5st</pattern>
+  <pattern>tdo3v</pattern>
+  <pattern>1te</pattern>
+  <pattern>3tea</pattern>
+  <pattern>te3akt</pattern>
+  <pattern>5tea4m</pattern>
+  <pattern>3tec</pattern>
+  <pattern>4t3echt</pattern>
+  <pattern>4teco</pattern>
+  <pattern>te4dit</pattern>
+  <pattern>t3edu</pattern>
+  <pattern>tee2</pattern>
+  <pattern>teeds5te </pattern>
+  <pattern>tee4g</pattern>
+  <pattern>4teek</pattern>
+  <pattern>tee4k3l</pattern>
+  <pattern>teem1</pattern>
+  <pattern>4tee4n</pattern>
+  <pattern>t5eenhe</pattern>
+  <pattern>3teer</pattern>
+  <pattern>tee5rin</pattern>
+  <pattern>tee4t</pattern>
+  <pattern>4t3eeu</pattern>
+  <pattern>t4ef</pattern>
+  <pattern>t5eff</pattern>
+  <pattern>3tefl</pattern>
+  <pattern>3teh</pattern>
+  <pattern>4t3eier</pattern>
+  <pattern>4teig</pattern>
+  <pattern>tei4lo</pattern>
+  <pattern>t4ein</pattern>
+  <pattern>t5eind</pattern>
+  <pattern>5teit</pattern>
+  <pattern>tei5tj</pattern>
+  <pattern>2t3eiw</pattern>
+  <pattern>5tekene</pattern>
+  <pattern>5tekens</pattern>
+  <pattern>4teker</pattern>
+  <pattern>4tekk</pattern>
+  <pattern>3teko</pattern>
+  <pattern>te4k3om</pattern>
+  <pattern>3teks</pattern>
+  <pattern>te3kw</pattern>
+  <pattern>te4k3wi</pattern>
+  <pattern>t4el</pattern>
+  <pattern>tel5ant</pattern>
+  <pattern>te4lap</pattern>
+  <pattern>tel5da</pattern>
+  <pattern>4telec</pattern>
+  <pattern>5teleco</pattern>
+  <pattern>t5elect</pattern>
+  <pattern>tel5een</pattern>
+  <pattern>5telef</pattern>
+  <pattern>5teleg</pattern>
+  <pattern>tel5ei </pattern>
+  <pattern>tel5eie</pattern>
+  <pattern>tel5eit</pattern>
+  <pattern>te5lel</pattern>
+  <pattern>5telev</pattern>
+  <pattern>5te5lex</pattern>
+  <pattern>tel3f</pattern>
+  <pattern>tel5k</pattern>
+  <pattern>te4loe</pattern>
+  <pattern>te4l3o4g</pattern>
+  <pattern>tel5oog</pattern>
+  <pattern>te4l3op</pattern>
+  <pattern>telo4r</pattern>
+  <pattern>tels4</pattern>
+  <pattern>4telse</pattern>
+  <pattern>tel3so</pattern>
+  <pattern>tel5su</pattern>
+  <pattern>te4l3uu</pattern>
+  <pattern>t4em</pattern>
+  <pattern>2temb</pattern>
+  <pattern>4temm</pattern>
+  <pattern>te4mor</pattern>
+  <pattern>tem3ov</pattern>
+  <pattern>5temper</pattern>
+  <pattern>5tempo</pattern>
+  <pattern>t4en</pattern>
+  <pattern>ten4ach</pattern>
+  <pattern>ten3a4g</pattern>
+  <pattern>te3nak</pattern>
+  <pattern>te5nare</pattern>
+  <pattern>te4nau</pattern>
+  <pattern>tene2</pattern>
+  <pattern>ten3ed</pattern>
+  <pattern>ten3el</pattern>
+  <pattern>tene4t</pattern>
+  <pattern>3tenh</pattern>
+  <pattern>ten5k4</pattern>
+  <pattern>te5nore</pattern>
+  <pattern>4t5enq</pattern>
+  <pattern>ten5scr</pattern>
+  <pattern>ten3sn</pattern>
+  <pattern>ten3sp</pattern>
+  <pattern>tensu4</pattern>
+  <pattern>tens5uu</pattern>
+  <pattern>3tent</pattern>
+  <pattern>5tenta</pattern>
+  <pattern>5tenten </pattern>
+  <pattern>ten5to</pattern>
+  <pattern>t3entw</pattern>
+  <pattern>5tenu</pattern>
+  <pattern>t2er</pattern>
+  <pattern>teraads5</pattern>
+  <pattern>te4r5aak</pattern>
+  <pattern>ter3a4b</pattern>
+  <pattern>tera5ca</pattern>
+  <pattern>te4rad</pattern>
+  <pattern>tera4de</pattern>
+  <pattern>te4r5af</pattern>
+  <pattern>ter3ag</pattern>
+  <pattern>te3ral</pattern>
+  <pattern>te4ran</pattern>
+  <pattern>ter3ap</pattern>
+  <pattern>ter3as</pattern>
+  <pattern>5terec</pattern>
+  <pattern>te4rei</pattern>
+  <pattern>ter5eik</pattern>
+  <pattern>te4rel</pattern>
+  <pattern>te4rem</pattern>
+  <pattern>te5ren </pattern>
+  <pattern>te4r5enk</pattern>
+  <pattern>te4r5env</pattern>
+  <pattern>4t4erf </pattern>
+  <pattern>4terfd</pattern>
+  <pattern>ter3fr</pattern>
+  <pattern>4t4erft</pattern>
+  <pattern>te4r5in </pattern>
+  <pattern>3terj</pattern>
+  <pattern>4terk </pattern>
+  <pattern>4terkt</pattern>
+  <pattern>ter3k4w</pattern>
+  <pattern>3term</pattern>
+  <pattern>5term </pattern>
+  <pattern>5termi</pattern>
+  <pattern>ter5oc</pattern>
+  <pattern>te3rod</pattern>
+  <pattern>te3rof</pattern>
+  <pattern>te3rog</pattern>
+  <pattern>5teron</pattern>
+  <pattern>te5rons</pattern>
+  <pattern>tero5pe</pattern>
+  <pattern>tero4r</pattern>
+  <pattern>te3ros</pattern>
+  <pattern>5terrei</pattern>
+  <pattern>5terreu</pattern>
+  <pattern>5terror</pattern>
+  <pattern>ter4spr</pattern>
+  <pattern>ter5ste </pattern>
+  <pattern>ter5ston</pattern>
+  <pattern>3tes</pattern>
+  <pattern>te3s4ap</pattern>
+  <pattern>tes3m</pattern>
+  <pattern>te3so</pattern>
+  <pattern>tes3ta</pattern>
+  <pattern>te5stel</pattern>
+  <pattern>tes5ten</pattern>
+  <pattern>test5op</pattern>
+  <pattern>test5ri</pattern>
+  <pattern>test3u</pattern>
+  <pattern>te3ta</pattern>
+  <pattern>te5tr</pattern>
+  <pattern>4t3euv</pattern>
+  <pattern>t4ev</pattern>
+  <pattern>t5e4van</pattern>
+  <pattern>teve4r</pattern>
+  <pattern>5tevl</pattern>
+  <pattern>3tevr</pattern>
+  <pattern>2tex</pattern>
+  <pattern>3tex </pattern>
+  <pattern>4t3exe</pattern>
+  <pattern>4texp</pattern>
+  <pattern>1té</pattern>
+  <pattern>tè3</pattern>
+  <pattern>4t3f</pattern>
+  <pattern>4t3g2</pattern>
+  <pattern>tgaat5</pattern>
+  <pattern>t5ge</pattern>
+  <pattern>tge3la</pattern>
+  <pattern>tger4</pattern>
+  <pattern>4th </pattern>
+  <pattern>2t1ha</pattern>
+  <pattern>t3haa</pattern>
+  <pattern>t4haan</pattern>
+  <pattern>t4had</pattern>
+  <pattern>t3hak</pattern>
+  <pattern>t5ham</pattern>
+  <pattern>t4hans</pattern>
+  <pattern>t3har</pattern>
+  <pattern>t3hav</pattern>
+  <pattern>5thea</pattern>
+  <pattern>t3heb</pattern>
+  <pattern>5thee </pattern>
+  <pattern>4t3hei</pattern>
+  <pattern>4t3hel</pattern>
+  <pattern>3t2hen</pattern>
+  <pattern>5theo</pattern>
+  <pattern>1t2her</pattern>
+  <pattern>5the3ra</pattern>
+  <pattern>4t3here</pattern>
+  <pattern>3thes</pattern>
+  <pattern>3thet</pattern>
+  <pattern>t4hin</pattern>
+  <pattern>4thm</pattern>
+  <pattern>t1hoe</pattern>
+  <pattern>t2hog</pattern>
+  <pattern>t3hok</pattern>
+  <pattern>t1hoo</pattern>
+  <pattern>thoof5di</pattern>
+  <pattern>4t1hou</pattern>
+  <pattern>t3houd</pattern>
+  <pattern>5thous</pattern>
+  <pattern>4t3hov</pattern>
+  <pattern>3thr</pattern>
+  <pattern>2thu</pattern>
+  <pattern>t1hul</pattern>
+  <pattern>4thum</pattern>
+  <pattern>t4hur</pattern>
+  <pattern>3ti</pattern>
+  <pattern>5ti </pattern>
+  <pattern>5tia</pattern>
+  <pattern>ti5ab</pattern>
+  <pattern>ti5ae</pattern>
+  <pattern>ti3ap</pattern>
+  <pattern>5tib</pattern>
+  <pattern>5tica</pattern>
+  <pattern>5tice</pattern>
+  <pattern>5tici</pattern>
+  <pattern>5ticu</pattern>
+  <pattern>ti3d4</pattern>
+  <pattern>5tie </pattern>
+  <pattern>tie5d4</pattern>
+  <pattern>5tiefs</pattern>
+  <pattern>tie3kn</pattern>
+  <pattern>tie4kon</pattern>
+  <pattern>ti3enc</pattern>
+  <pattern>tien5st</pattern>
+  <pattern>5tiep</pattern>
+  <pattern>5ties</pattern>
+  <pattern>tie5s4l</pattern>
+  <pattern>tie5ta</pattern>
+  <pattern>tie5to</pattern>
+  <pattern>tie5tw</pattern>
+  <pattern>ti1eu</pattern>
+  <pattern>5tieven</pattern>
+  <pattern>ti3fe</pattern>
+  <pattern>ti3fr</pattern>
+  <pattern>ti2ga</pattern>
+  <pattern>tig5aa</pattern>
+  <pattern>4tigm</pattern>
+  <pattern>ti4gu4</pattern>
+  <pattern>tig3ur</pattern>
+  <pattern>5tijd</pattern>
+  <pattern>tije4</pattern>
+  <pattern>tij5ka</pattern>
+  <pattern>tij4kl</pattern>
+  <pattern>5tijn</pattern>
+  <pattern>tij5p</pattern>
+  <pattern>t3ijs </pattern>
+  <pattern>tij3st</pattern>
+  <pattern>tij3t2</pattern>
+  <pattern>tij5tr</pattern>
+  <pattern>tij5tw</pattern>
+  <pattern>4t1ijz</pattern>
+  <pattern>ti3ko</pattern>
+  <pattern>ti5kr</pattern>
+  <pattern>t4il</pattern>
+  <pattern>4tils</pattern>
+  <pattern>5timm</pattern>
+  <pattern>5timo</pattern>
+  <pattern>tina4d</pattern>
+  <pattern>tin3as</pattern>
+  <pattern>4t3incu</pattern>
+  <pattern>4t1ind</pattern>
+  <pattern>4tinf</pattern>
+  <pattern>tin4g3i</pattern>
+  <pattern>ting4sa</pattern>
+  <pattern>t3inh</pattern>
+  <pattern>ti4nit</pattern>
+  <pattern>4t3inj</pattern>
+  <pattern>t3inko</pattern>
+  <pattern>4t3inl</pattern>
+  <pattern>t3inq</pattern>
+  <pattern>4tinr</pattern>
+  <pattern>4t3ins</pattern>
+  <pattern>ti3nu</pattern>
+  <pattern>4t3inv</pattern>
+  <pattern>4tinw</pattern>
+  <pattern>ti5om</pattern>
+  <pattern>ti3o4p5</pattern>
+  <pattern>t2is</pattern>
+  <pattern>ti5sa</pattern>
+  <pattern>ti3s4j</pattern>
+  <pattern>ti3sl</pattern>
+  <pattern>ti3so</pattern>
+  <pattern>ti4son</pattern>
+  <pattern>ti3s4p</pattern>
+  <pattern>ti3sta</pattern>
+  <pattern>5tite</pattern>
+  <pattern>ti3th</pattern>
+  <pattern>ti1t2r</pattern>
+  <pattern>5tivi</pattern>
+  <pattern>ti4vo</pattern>
+  <pattern>1tj2</pattern>
+  <pattern>2t1ja</pattern>
+  <pattern>t5jaa</pattern>
+  <pattern>t5jee</pattern>
+  <pattern>t5jek</pattern>
+  <pattern>t3jen</pattern>
+  <pattern>t5jet</pattern>
+  <pattern>4tjeu</pattern>
+  <pattern>2tjo</pattern>
+  <pattern>t1jou</pattern>
+  <pattern>2tju</pattern>
+  <pattern>4t3k2</pattern>
+  <pattern>tkars3</pattern>
+  <pattern>4t3l</pattern>
+  <pattern>t5le </pattern>
+  <pattern>5tleb</pattern>
+  <pattern>t5les</pattern>
+  <pattern>tli4n</pattern>
+  <pattern>4t3m</pattern>
+  <pattern>tmen4st</pattern>
+  <pattern>tmens5te</pattern>
+  <pattern>tmos5</pattern>
+  <pattern>4t3n</pattern>
+  <pattern>tna4m3o</pattern>
+  <pattern>tne4r</pattern>
+  <pattern>tnes4</pattern>
+  <pattern>5to </pattern>
+  <pattern>toa2</pattern>
+  <pattern>to3ac</pattern>
+  <pattern>to3ar</pattern>
+  <pattern>to5bl</pattern>
+  <pattern>3toc</pattern>
+  <pattern>1toch</pattern>
+  <pattern>3tod</pattern>
+  <pattern>to3da</pattern>
+  <pattern>t4oe</pattern>
+  <pattern>toe5d4</pattern>
+  <pattern>3toej</pattern>
+  <pattern>toe5k</pattern>
+  <pattern>5toe3l4a</pattern>
+  <pattern>toe5le</pattern>
+  <pattern>5toelic</pattern>
+  <pattern>toemaat5</pattern>
+  <pattern>5toen</pattern>
+  <pattern>to5ende</pattern>
+  <pattern>toe5pl</pattern>
+  <pattern>3toer</pattern>
+  <pattern>5toeri</pattern>
+  <pattern>5toern</pattern>
+  <pattern>5toe1s4</pattern>
+  <pattern>toe5st</pattern>
+  <pattern>toe3tj</pattern>
+  <pattern>3toets</pattern>
+  <pattern>5toets </pattern>
+  <pattern>5toetse</pattern>
+  <pattern>toets5te </pattern>
+  <pattern>3toev</pattern>
+  <pattern>5toez</pattern>
+  <pattern>to2f</pattern>
+  <pattern>tof5ar</pattern>
+  <pattern>tof5d</pattern>
+  <pattern>to4fr</pattern>
+  <pattern>tof3th</pattern>
+  <pattern>3togn</pattern>
+  <pattern>5togr</pattern>
+  <pattern>3toi</pattern>
+  <pattern>to4kan</pattern>
+  <pattern>tok3s</pattern>
+  <pattern>t2ol</pattern>
+  <pattern>to3la</pattern>
+  <pattern>5tolaa</pattern>
+  <pattern>to5le</pattern>
+  <pattern>5tolet</pattern>
+  <pattern>t3olf</pattern>
+  <pattern>2toli</pattern>
+  <pattern>5tolic</pattern>
+  <pattern>to4lie</pattern>
+  <pattern>tolk5s</pattern>
+  <pattern>5tolo</pattern>
+  <pattern>tolp3r</pattern>
+  <pattern>t3oly</pattern>
+  <pattern>4tom </pattern>
+  <pattern>5tomaa</pattern>
+  <pattern>tomaat5</pattern>
+  <pattern>t3oml</pattern>
+  <pattern>to3mo</pattern>
+  <pattern>tom4p3j</pattern>
+  <pattern>4t3om5s</pattern>
+  <pattern>5ton </pattern>
+  <pattern>4tond</pattern>
+  <pattern>3t2one</pattern>
+  <pattern>5tonee</pattern>
+  <pattern>5to5nen</pattern>
+  <pattern>to5ner</pattern>
+  <pattern>3t4ong</pattern>
+  <pattern>5tong </pattern>
+  <pattern>3t4oni</pattern>
+  <pattern>5t4onn</pattern>
+  <pattern>to3no</pattern>
+  <pattern>5tons</pattern>
+  <pattern>ton3sk</pattern>
+  <pattern>too4m</pattern>
+  <pattern>toom3e</pattern>
+  <pattern>5toon</pattern>
+  <pattern>t4op </pattern>
+  <pattern>top5art</pattern>
+  <pattern>top3as</pattern>
+  <pattern>to3pen</pattern>
+  <pattern>to3pet</pattern>
+  <pattern>to3pi</pattern>
+  <pattern>2topm</pattern>
+  <pattern>to4po</pattern>
+  <pattern>to5pos</pattern>
+  <pattern>t4opp</pattern>
+  <pattern>to4pu</pattern>
+  <pattern>to5pus</pattern>
+  <pattern>t3opva</pattern>
+  <pattern>5tor </pattern>
+  <pattern>to3ra</pattern>
+  <pattern>to4r3ag</pattern>
+  <pattern>t3ord</pattern>
+  <pattern>to5rec</pattern>
+  <pattern>5torens</pattern>
+  <pattern>4t1org</pattern>
+  <pattern>t5orga</pattern>
+  <pattern>t4ori</pattern>
+  <pattern>3toria</pattern>
+  <pattern>to4rië</pattern>
+  <pattern>tor3k</pattern>
+  <pattern>tor4m3a</pattern>
+  <pattern>toro4</pattern>
+  <pattern>to4r5oli</pattern>
+  <pattern>to3rom</pattern>
+  <pattern>5torr</pattern>
+  <pattern>3tors</pattern>
+  <pattern>tors5te </pattern>
+  <pattern>to3r2u</pattern>
+  <pattern>3tos4</pattern>
+  <pattern>to3sa</pattern>
+  <pattern>to1sl</pattern>
+  <pattern>to1s2p</pattern>
+  <pattern>tos5te</pattern>
+  <pattern>5tota</pattern>
+  <pattern>to3tr</pattern>
+  <pattern>2t3oud</pattern>
+  <pattern>3tour</pattern>
+  <pattern>tou4r3e</pattern>
+  <pattern>to3v</pattern>
+  <pattern>tove5na</pattern>
+  <pattern>to4vens</pattern>
+  <pattern>4toverg</pattern>
+  <pattern>to3w4</pattern>
+  <pattern>4t3p4</pattern>
+  <pattern>tpe4t3</pattern>
+  <pattern>tpi3s</pattern>
+  <pattern>tr4</pattern>
+  <pattern>3tra </pattern>
+  <pattern>4t3raad</pattern>
+  <pattern>5tracé</pattern>
+  <pattern>5trafo </pattern>
+  <pattern>3trag</pattern>
+  <pattern>4tragez</pattern>
+  <pattern>3t4rai</pattern>
+  <pattern>5train</pattern>
+  <pattern>5traka</pattern>
+  <pattern>t3rake</pattern>
+  <pattern>3trakt</pattern>
+  <pattern>3trans</pattern>
+  <pattern>5transa</pattern>
+  <pattern>5trap </pattern>
+  <pattern>5trau</pattern>
+  <pattern>4t3raz</pattern>
+  <pattern>3t4re </pattern>
+  <pattern>4trea</pattern>
+  <pattern>2trec</pattern>
+  <pattern>5tred </pattern>
+  <pattern>4treda</pattern>
+  <pattern>t5redes</pattern>
+  <pattern>4tredu</pattern>
+  <pattern>3tref</pattern>
+  <pattern>4t5reg</pattern>
+  <pattern>4t3reis</pattern>
+  <pattern>4treiz</pattern>
+  <pattern>4trel</pattern>
+  <pattern>t3rese</pattern>
+  <pattern>t3resu</pattern>
+  <pattern>tre2t3</pattern>
+  <pattern>t4reu</pattern>
+  <pattern>t3rib </pattern>
+  <pattern>5tribu</pattern>
+  <pattern>5trico</pattern>
+  <pattern>trie5ta</pattern>
+  <pattern>trig2</pattern>
+  <pattern>2trij</pattern>
+  <pattern>5t4ril</pattern>
+  <pattern>tri5ni</pattern>
+  <pattern>5t4rio4</pattern>
+  <pattern>t3risi</pattern>
+  <pattern>t3rit </pattern>
+  <pattern>5t4riti</pattern>
+  <pattern>5trody</pattern>
+  <pattern>t3roed</pattern>
+  <pattern>t3roes</pattern>
+  <pattern>5trofy</pattern>
+  <pattern>3trog</pattern>
+  <pattern>t4roï</pattern>
+  <pattern>5troj</pattern>
+  <pattern>4trol </pattern>
+  <pattern>5trola</pattern>
+  <pattern>5trolo</pattern>
+  <pattern>5tromm</pattern>
+  <pattern>5tron </pattern>
+  <pattern>5trona</pattern>
+  <pattern>t5rond</pattern>
+  <pattern>3trone</pattern>
+  <pattern>5tronn</pattern>
+  <pattern>5trono</pattern>
+  <pattern>5trons</pattern>
+  <pattern>tront5j</pattern>
+  <pattern>t3rood</pattern>
+  <pattern>5troon</pattern>
+  <pattern>t4roos</pattern>
+  <pattern>tro5pi</pattern>
+  <pattern>t4ros</pattern>
+  <pattern>5trotu</pattern>
+  <pattern>3trou</pattern>
+  <pattern>4t5rout</pattern>
+  <pattern>tro5v</pattern>
+  <pattern>5truc </pattern>
+  <pattern>5truf</pattern>
+  <pattern>4trug</pattern>
+  <pattern>5trui </pattern>
+  <pattern>5truie</pattern>
+  <pattern>t3ruim</pattern>
+  <pattern>trui5t4</pattern>
+  <pattern>t3ruk</pattern>
+  <pattern>t4rum</pattern>
+  <pattern>4ts</pattern>
+  <pattern>ts3a2d</pattern>
+  <pattern>tsa4g</pattern>
+  <pattern>ts1am</pattern>
+  <pattern>t3sap</pattern>
+  <pattern>ts3as</pattern>
+  <pattern>tse4d</pattern>
+  <pattern>ts5een</pattern>
+  <pattern>t4s3ei</pattern>
+  <pattern>ts5eind</pattern>
+  <pattern>t4s5ene</pattern>
+  <pattern>t4s3eng</pattern>
+  <pattern>t4s3erg</pattern>
+  <pattern>ts5erge</pattern>
+  <pattern>t4s3e2v</pattern>
+  <pattern>t2sij</pattern>
+  <pattern>t4s3ink</pattern>
+  <pattern>ts3int</pattern>
+  <pattern>ts2j</pattern>
+  <pattern>ts3ja</pattern>
+  <pattern>t3sjen</pattern>
+  <pattern>3tsji</pattern>
+  <pattern>t1sl</pattern>
+  <pattern>ts4laa</pattern>
+  <pattern>t3slac</pattern>
+  <pattern>t5slag </pattern>
+  <pattern>ts3lam</pattern>
+  <pattern>t2s3le</pattern>
+  <pattern>t5slib</pattern>
+  <pattern>t5sloe</pattern>
+  <pattern>t3s4lu</pattern>
+  <pattern>ts2me</pattern>
+  <pattern>ts4moe</pattern>
+  <pattern>ts3neu</pattern>
+  <pattern>ts4no</pattern>
+  <pattern>ts5nor</pattern>
+  <pattern>ts5not</pattern>
+  <pattern>ts3nu</pattern>
+  <pattern>ts3ob</pattern>
+  <pattern>tso2l</pattern>
+  <pattern>ts3oli</pattern>
+  <pattern>ts3om</pattern>
+  <pattern>ts1on</pattern>
+  <pattern>ts4opp</pattern>
+  <pattern>ts1o4r</pattern>
+  <pattern>ts1ov</pattern>
+  <pattern>ts3pad</pattern>
+  <pattern>t3span</pattern>
+  <pattern>t5spec</pattern>
+  <pattern>t4s3pet</pattern>
+  <pattern>t3spi</pattern>
+  <pattern>t4s3pil</pattern>
+  <pattern>t3spoe</pattern>
+  <pattern>t3spoo</pattern>
+  <pattern>t5s4por</pattern>
+  <pattern>ts3pot</pattern>
+  <pattern>t4spro</pattern>
+  <pattern>ts4pru</pattern>
+  <pattern>ts5q</pattern>
+  <pattern>ts5s</pattern>
+  <pattern>t3sta</pattern>
+  <pattern>t4staak</pattern>
+  <pattern>t4s5tank</pattern>
+  <pattern>ts5tant</pattern>
+  <pattern>t4star</pattern>
+  <pattern>t4stas</pattern>
+  <pattern>t3ste</pattern>
+  <pattern>t5sted</pattern>
+  <pattern>t5stee</pattern>
+  <pattern>ts5teko</pattern>
+  <pattern>t5stell</pattern>
+  <pattern>t5stels</pattern>
+  <pattern>t5stem</pattern>
+  <pattern>t5ster </pattern>
+  <pattern>t4sterr</pattern>
+  <pattern>t5sters</pattern>
+  <pattern>t5s4tes </pattern>
+  <pattern>t5steu</pattern>
+  <pattern>ts3th</pattern>
+  <pattern>t1s4ti</pattern>
+  <pattern>t3stij</pattern>
+  <pattern>t5stijg</pattern>
+  <pattern>t5stil</pattern>
+  <pattern>ts5tin</pattern>
+  <pattern>ts5t4j</pattern>
+  <pattern>t1sto</pattern>
+  <pattern>ts5toep</pattern>
+  <pattern>ts5tong</pattern>
+  <pattern>t4store</pattern>
+  <pattern>ts5trad</pattern>
+  <pattern>ts5trei</pattern>
+  <pattern>t3stri</pattern>
+  <pattern>ts5troe</pattern>
+  <pattern>ts5ty</pattern>
+  <pattern>t4su4</pattern>
+  <pattern>ts3ur</pattern>
+  <pattern>ts3us</pattern>
+  <pattern>ts3uu</pattern>
+  <pattern>t1sy</pattern>
+  <pattern>4t3t</pattern>
+  <pattern>t5t4a</pattern>
+  <pattern>t5te</pattern>
+  <pattern>tte5loe</pattern>
+  <pattern>tte5l4op</pattern>
+  <pattern>tte2n</pattern>
+  <pattern>tten4t5j</pattern>
+  <pattern>tte5ri</pattern>
+  <pattern>t5tlet</pattern>
+  <pattern>tt3oog</pattern>
+  <pattern>ttop2</pattern>
+  <pattern>t5t4r</pattern>
+  <pattern>t5tum</pattern>
+  <pattern>tt3uu</pattern>
+  <pattern>3tua</pattern>
+  <pattern>3tub</pattern>
+  <pattern>3tuch</pattern>
+  <pattern>3tu3e</pattern>
+  <pattern>5tueu</pattern>
+  <pattern>tu3és</pattern>
+  <pattern>3tuig</pattern>
+  <pattern>5tuin</pattern>
+  <pattern>4tuip</pattern>
+  <pattern>2tuit</pattern>
+  <pattern>tuit4j</pattern>
+  <pattern>4tuk</pattern>
+  <pattern>tu4k3i</pattern>
+  <pattern>tul5pi</pattern>
+  <pattern>t4um</pattern>
+  <pattern>5tune</pattern>
+  <pattern>5tunn</pattern>
+  <pattern>tu1o</pattern>
+  <pattern>5turb</pattern>
+  <pattern>tu3ri</pattern>
+  <pattern>3tu4s3</pattern>
+  <pattern>tut3j</pattern>
+  <pattern>tuurs5la</pattern>
+  <pattern>tu3wa</pattern>
+  <pattern>4tv</pattern>
+  <pattern>tvaat5</pattern>
+  <pattern>t3ve</pattern>
+  <pattern>4t1w</pattern>
+  <pattern>3t4wijf</pattern>
+  <pattern>t2win</pattern>
+  <pattern>1ty1</pattern>
+  <pattern>3typ</pattern>
+  <pattern>tys4</pattern>
+  <pattern>4tz</pattern>
+  <pattern>t3za</pattern>
+  <pattern>t3zi</pattern>
+  <pattern>t5zw</pattern>
+  <pattern>u1a</pattern>
+  <pattern>u3ac</pattern>
+  <pattern>u3an</pattern>
+  <pattern>ua5ne</pattern>
+  <pattern>ua3p</pattern>
+  <pattern>u5ar </pattern>
+  <pattern>uar5t</pattern>
+  <pattern>ua3sa</pattern>
+  <pattern>uat4</pattern>
+  <pattern>2u2b</pattern>
+  <pattern>ub3ac</pattern>
+  <pattern>ube4li</pattern>
+  <pattern>ub5em</pattern>
+  <pattern>u5bi</pattern>
+  <pattern>u3bo</pattern>
+  <pattern>ub5or</pattern>
+  <pattern>4uc</pattern>
+  <pattern>u1che</pattern>
+  <pattern>ucht5sl</pattern>
+  <pattern>uc4ki</pattern>
+  <pattern>ucle3</pattern>
+  <pattern>uc4t3a</pattern>
+  <pattern>uc4tin</pattern>
+  <pattern>u1d</pattern>
+  <pattern>uda2</pattern>
+  <pattern>u5da </pattern>
+  <pattern>ud5am</pattern>
+  <pattern>ud3ei</pattern>
+  <pattern>ud3ess</pattern>
+  <pattern>u4de4z</pattern>
+  <pattern>ud3eze</pattern>
+  <pattern>udi4o</pattern>
+  <pattern>udi5ologe</pattern>
+  <pattern>udi3om</pattern>
+  <pattern>udoe2</pattern>
+  <pattern>ud3ond</pattern>
+  <pattern>ud3oo</pattern>
+  <pattern>ud3ov</pattern>
+  <pattern>u4d1r</pattern>
+  <pattern>uds5lo</pattern>
+  <pattern>uds4m</pattern>
+  <pattern>uds5ma</pattern>
+  <pattern>ud3sme</pattern>
+  <pattern>ud3smi</pattern>
+  <pattern>ud1st</pattern>
+  <pattern>ud4sta</pattern>
+  <pattern>uds5tak</pattern>
+  <pattern>ud4sti</pattern>
+  <pattern>ud1w</pattern>
+  <pattern>u3ec</pattern>
+  <pattern>ue2co</pattern>
+  <pattern>u1ee4</pattern>
+  <pattern>u3ef</pattern>
+  <pattern>u3ei</pattern>
+  <pattern>u1el</pattern>
+  <pattern>u4ene</pattern>
+  <pattern>u1er</pattern>
+  <pattern>uer3il</pattern>
+  <pattern>ue3st</pattern>
+  <pattern>u1eu</pattern>
+  <pattern>u5eul</pattern>
+  <pattern>u3ez</pattern>
+  <pattern>u3è</pattern>
+  <pattern>u4f3an</pattern>
+  <pattern>u1fl</pattern>
+  <pattern>u1f4r</pattern>
+  <pattern>uf2s</pattern>
+  <pattern>u5ga</pattern>
+  <pattern>ug4da2</pattern>
+  <pattern>ug4der</pattern>
+  <pattern>ug2do</pattern>
+  <pattern>ug4dr</pattern>
+  <pattern>uge4l5o</pattern>
+  <pattern>ug3ij</pattern>
+  <pattern>ug1l</pattern>
+  <pattern>u2go</pattern>
+  <pattern>ug3or</pattern>
+  <pattern>u2g1r</pattern>
+  <pattern>ug5sce</pattern>
+  <pattern>ug4sec</pattern>
+  <pattern>ugs4p</pattern>
+  <pattern>ugs5pa</pattern>
+  <pattern>ug1s4t</pattern>
+  <pattern>ugs5tra</pattern>
+  <pattern>u1h</pattern>
+  <pattern>u2i</pattern>
+  <pattern>ui5ac</pattern>
+  <pattern>ui2d3a</pattern>
+  <pattern>ui2d1o</pattern>
+  <pattern>uid4s</pattern>
+  <pattern>uid3sp</pattern>
+  <pattern>uid5spre</pattern>
+  <pattern>uid5ste </pattern>
+  <pattern>uid3u</pattern>
+  <pattern>ui3e</pattern>
+  <pattern>uien4t</pattern>
+  <pattern>ui2fa</pattern>
+  <pattern>uif1l</pattern>
+  <pattern>uif5r</pattern>
+  <pattern>ui2fu</pattern>
+  <pattern>4uig</pattern>
+  <pattern>ui4g5aa</pattern>
+  <pattern>uig1l</pattern>
+  <pattern>ui2g3o</pattern>
+  <pattern>ui4g3r</pattern>
+  <pattern>ui4gu</pattern>
+  <pattern>4uik</pattern>
+  <pattern>ui2k3a</pattern>
+  <pattern>ui4k3l</pattern>
+  <pattern>ui2ko</pattern>
+  <pattern>ui2ku</pattern>
+  <pattern>ui2la</pattern>
+  <pattern>uil5aa</pattern>
+  <pattern>ui4l3em</pattern>
+  <pattern>uil5m</pattern>
+  <pattern>ui4l3og</pattern>
+  <pattern>ui4loo</pattern>
+  <pattern>uil3ov</pattern>
+  <pattern>4uim</pattern>
+  <pattern>ui2m3a</pattern>
+  <pattern>ui3mag</pattern>
+  <pattern>ui4n1a</pattern>
+  <pattern>uin5g</pattern>
+  <pattern>ui2no</pattern>
+  <pattern>uin5og</pattern>
+  <pattern>uin3or</pattern>
+  <pattern>uin4s5lo</pattern>
+  <pattern>uin5to</pattern>
+  <pattern>ui2p3l</pattern>
+  <pattern>ui4p3o4</pattern>
+  <pattern>ui2p3r</pattern>
+  <pattern>4uis</pattern>
+  <pattern>ui2s3a</pattern>
+  <pattern>uis5c</pattern>
+  <pattern>ui4sl</pattern>
+  <pattern>ui5slu</pattern>
+  <pattern>uis5p</pattern>
+  <pattern>ui4st</pattern>
+  <pattern>ui4t3a4</pattern>
+  <pattern>uit5aa</pattern>
+  <pattern>uit5al</pattern>
+  <pattern>ui5tar</pattern>
+  <pattern>1uitg</pattern>
+  <pattern>uit1j</pattern>
+  <pattern>3uitl</pattern>
+  <pattern>ui2t1o</pattern>
+  <pattern>1uit5r</pattern>
+  <pattern>uit3sl</pattern>
+  <pattern>uit3sn</pattern>
+  <pattern>uit5sp</pattern>
+  <pattern>uits5te </pattern>
+  <pattern>3uitw</pattern>
+  <pattern>3uitz</pattern>
+  <pattern>ui3v</pattern>
+  <pattern>4u3j</pattern>
+  <pattern>2uk</pattern>
+  <pattern>u2k3al</pattern>
+  <pattern>uk3as</pattern>
+  <pattern>ukkers5</pattern>
+  <pattern>u2k3l</pattern>
+  <pattern>u3klas</pattern>
+  <pattern>u2k3n</pattern>
+  <pattern>u2k3o</pattern>
+  <pattern>u3koc</pattern>
+  <pattern>uko2p</pattern>
+  <pattern>uk4o3pl</pattern>
+  <pattern>u4k3r</pattern>
+  <pattern>uk3s2m</pattern>
+  <pattern>uk3spa</pattern>
+  <pattern>uk3spl</pattern>
+  <pattern>uk4sti</pattern>
+  <pattern>uk1w</pattern>
+  <pattern>u1la</pattern>
+  <pattern>ul3ac</pattern>
+  <pattern>ulam4</pattern>
+  <pattern>ula4p</pattern>
+  <pattern>ul4d3a</pattern>
+  <pattern>uld5erk</pattern>
+  <pattern>ul5dop</pattern>
+  <pattern>ul4d3u</pattern>
+  <pattern>u1le</pattern>
+  <pattern>ule5sp</pattern>
+  <pattern>ul3fl</pattern>
+  <pattern>ul5fo</pattern>
+  <pattern>ul3fr</pattern>
+  <pattern>ul3in </pattern>
+  <pattern>u5ling</pattern>
+  <pattern>ul3inn</pattern>
+  <pattern>ul3k2a</pattern>
+  <pattern>ul5ke</pattern>
+  <pattern>ul2k3l</pattern>
+  <pattern>u1lo</pattern>
+  <pattern>ul3o2p</pattern>
+  <pattern>u3los</pattern>
+  <pattern>ul2pa</pattern>
+  <pattern>ulp3ac</pattern>
+  <pattern>ul4pi</pattern>
+  <pattern>ul2p3l</pattern>
+  <pattern>ul2po</pattern>
+  <pattern>ul4p3r</pattern>
+  <pattern>ul3sa</pattern>
+  <pattern>ul3so</pattern>
+  <pattern>ul2s3p</pattern>
+  <pattern>uls5te </pattern>
+  <pattern>uls5tel</pattern>
+  <pattern>u3lu</pattern>
+  <pattern>um3af</pattern>
+  <pattern>um3ar</pattern>
+  <pattern>3umda</pattern>
+  <pattern>2ume</pattern>
+  <pattern>umee4</pattern>
+  <pattern>umes4</pattern>
+  <pattern>ume3st</pattern>
+  <pattern>um3om</pattern>
+  <pattern>um3op</pattern>
+  <pattern>um3so</pattern>
+  <pattern>um3st</pattern>
+  <pattern>u2m3ui</pattern>
+  <pattern>un3ac</pattern>
+  <pattern>un2c</pattern>
+  <pattern>unch3r</pattern>
+  <pattern>un4dra</pattern>
+  <pattern>und4s</pattern>
+  <pattern>unds5ta</pattern>
+  <pattern>und5ste</pattern>
+  <pattern>une4t</pattern>
+  <pattern>un3g</pattern>
+  <pattern>1univ</pattern>
+  <pattern>un4k3r</pattern>
+  <pattern>un4o</pattern>
+  <pattern>uno3g</pattern>
+  <pattern>un5o2p</pattern>
+  <pattern>unst3a</pattern>
+  <pattern>un4ste </pattern>
+  <pattern>unst3o</pattern>
+  <pattern>un4st5r</pattern>
+  <pattern>unst5ui</pattern>
+  <pattern>un4tag</pattern>
+  <pattern>unt5een</pattern>
+  <pattern>un2tj</pattern>
+  <pattern>un4t5o4</pattern>
+  <pattern>unt3s4m</pattern>
+  <pattern>un4t3u</pattern>
+  <pattern>u3ol</pattern>
+  <pattern>u3on</pattern>
+  <pattern>u3oo</pattern>
+  <pattern>u1or</pattern>
+  <pattern>uo3ru</pattern>
+  <pattern>u3os</pattern>
+  <pattern>uota3</pattern>
+  <pattern>4up</pattern>
+  <pattern>u1pa</pattern>
+  <pattern>u1pe</pattern>
+  <pattern>upe3k</pattern>
+  <pattern>upe4ro</pattern>
+  <pattern>uper5st</pattern>
+  <pattern>u3ph</pattern>
+  <pattern>u3pi</pattern>
+  <pattern>u1pl</pattern>
+  <pattern>u4p3lei</pattern>
+  <pattern>u1po</pattern>
+  <pattern>u3pol</pattern>
+  <pattern>up3om</pattern>
+  <pattern>up3op</pattern>
+  <pattern>u1pr</pattern>
+  <pattern>up4tr</pattern>
+  <pattern>u1ra</pattern>
+  <pattern>ur3aan</pattern>
+  <pattern>ur1ac</pattern>
+  <pattern>ur3ada</pattern>
+  <pattern>ur3adv</pattern>
+  <pattern>u2r3a4r</pattern>
+  <pattern>uras3</pattern>
+  <pattern>u4r3a2z</pattern>
+  <pattern>urd4o</pattern>
+  <pattern>u1r2e</pattern>
+  <pattern>ur3ech</pattern>
+  <pattern>ur3een</pattern>
+  <pattern>uree5s</pattern>
+  <pattern>ure5lu</pattern>
+  <pattern>urelu5r</pattern>
+  <pattern>u4rem</pattern>
+  <pattern>ur3emb</pattern>
+  <pattern>ure4n</pattern>
+  <pattern>u3res</pattern>
+  <pattern>ur3ess</pattern>
+  <pattern>ure3st</pattern>
+  <pattern>ur3eta</pattern>
+  <pattern>4urf</pattern>
+  <pattern>ur2fa</pattern>
+  <pattern>ur3gi</pattern>
+  <pattern>u1ri</pattern>
+  <pattern>uri4gl</pattern>
+  <pattern>ur3ijz</pattern>
+  <pattern>ur3ind</pattern>
+  <pattern>ur3int</pattern>
+  <pattern>4urk</pattern>
+  <pattern>urken5s</pattern>
+  <pattern>ur4kie</pattern>
+  <pattern>ur3k4l</pattern>
+  <pattern>urk4s5t</pattern>
+  <pattern>u1ro</pattern>
+  <pattern>ur5opb</pattern>
+  <pattern>ur3or</pattern>
+  <pattern>uro5s</pattern>
+  <pattern>ur5pr</pattern>
+  <pattern>ur4serv</pattern>
+  <pattern>ur4s3ev</pattern>
+  <pattern>ur3s4fe</pattern>
+  <pattern>ur2sl</pattern>
+  <pattern>urs5laa</pattern>
+  <pattern>urs5li</pattern>
+  <pattern>ur4s5m</pattern>
+  <pattern>ur2sn</pattern>
+  <pattern>ur4sp</pattern>
+  <pattern>urs5pa</pattern>
+  <pattern>ur5spel</pattern>
+  <pattern>ur5spor</pattern>
+  <pattern>urs5take</pattern>
+  <pattern>urs5th</pattern>
+  <pattern>ur4sti</pattern>
+  <pattern>urs5tik</pattern>
+  <pattern>ur3ta</pattern>
+  <pattern>ur4tro</pattern>
+  <pattern>ur5troe</pattern>
+  <pattern>u3ru</pattern>
+  <pattern>ur3ui</pattern>
+  <pattern>4urv</pattern>
+  <pattern>u1r4y</pattern>
+  <pattern>4usaa</pattern>
+  <pattern>us3ad</pattern>
+  <pattern>us3a2m</pattern>
+  <pattern>us1ap</pattern>
+  <pattern>u4sc</pattern>
+  <pattern>u5s2cr</pattern>
+  <pattern>use5tj</pattern>
+  <pattern>u5sie</pattern>
+  <pattern>u4sj</pattern>
+  <pattern>u4s5l</pattern>
+  <pattern>u4sm</pattern>
+  <pattern>u2s5n</pattern>
+  <pattern>uso2</pattern>
+  <pattern>us3oï</pattern>
+  <pattern>us3os</pattern>
+  <pattern>u2s3p</pattern>
+  <pattern>us5pi</pattern>
+  <pattern>us5pu</pattern>
+  <pattern>us4ta</pattern>
+  <pattern>us5tag</pattern>
+  <pattern>ust3al</pattern>
+  <pattern>u2s3te</pattern>
+  <pattern>us4t3ei</pattern>
+  <pattern>u4sti</pattern>
+  <pattern>ust3oo</pattern>
+  <pattern>us5tra </pattern>
+  <pattern>us5tre </pattern>
+  <pattern>us5tro</pattern>
+  <pattern>us5tru</pattern>
+  <pattern>ustu4</pattern>
+  <pattern>ust3ur</pattern>
+  <pattern>ust3uu</pattern>
+  <pattern>u1ta</pattern>
+  <pattern>ut3aan</pattern>
+  <pattern>utaar5</pattern>
+  <pattern>ut1ac</pattern>
+  <pattern>ut3af</pattern>
+  <pattern>u3tan</pattern>
+  <pattern>uta3s4</pattern>
+  <pattern>ut5c</pattern>
+  <pattern>u4t3ees</pattern>
+  <pattern>u4tek</pattern>
+  <pattern>ut3eks</pattern>
+  <pattern>ut3em</pattern>
+  <pattern>ut5emm</pattern>
+  <pattern>uter5an</pattern>
+  <pattern>ut3ex</pattern>
+  <pattern>ut2h</pattern>
+  <pattern>ut3ho</pattern>
+  <pattern>u2tj</pattern>
+  <pattern>u1to</pattern>
+  <pattern>uto5f</pattern>
+  <pattern>ut3oog</pattern>
+  <pattern>uto3pe</pattern>
+  <pattern>utop4l</pattern>
+  <pattern>uto5po</pattern>
+  <pattern>utop4r</pattern>
+  <pattern>uto5s</pattern>
+  <pattern>ut3saa</pattern>
+  <pattern>ut3s2c</pattern>
+  <pattern>uts5eng</pattern>
+  <pattern>uts2m</pattern>
+  <pattern>ut1sn</pattern>
+  <pattern>ut3sp</pattern>
+  <pattern>ut4spa</pattern>
+  <pattern>ut4spo</pattern>
+  <pattern>ut2st</pattern>
+  <pattern>uts5tak</pattern>
+  <pattern>ut4ste </pattern>
+  <pattern>ut5sten</pattern>
+  <pattern>ut3str</pattern>
+  <pattern>ut5su</pattern>
+  <pattern>utt4</pattern>
+  <pattern>u1tu</pattern>
+  <pattern>ut5w</pattern>
+  <pattern>u4u4</pattern>
+  <pattern>uur3a4</pattern>
+  <pattern>uur3e4</pattern>
+  <pattern>uur5i</pattern>
+  <pattern>uur3k</pattern>
+  <pattern>uur1o2</pattern>
+  <pattern>uur5ste</pattern>
+  <pattern>uur5sti</pattern>
+  <pattern>4uut</pattern>
+  <pattern>uut3a</pattern>
+  <pattern>uut3r</pattern>
+  <pattern>uvel4s</pattern>
+  <pattern>uve5na</pattern>
+  <pattern>uw1a</pattern>
+  <pattern>u3wag</pattern>
+  <pattern>uw3ar</pattern>
+  <pattern>uw5art</pattern>
+  <pattern>u1we</pattern>
+  <pattern>uw3ec</pattern>
+  <pattern>uwe5d</pattern>
+  <pattern>uw3een</pattern>
+  <pattern>u2w3ei</pattern>
+  <pattern>uwe4nen</pattern>
+  <pattern>uwes4</pattern>
+  <pattern>u1wi</pattern>
+  <pattern>u2w3ij</pattern>
+  <pattern>uw5ijz</pattern>
+  <pattern>u4wind</pattern>
+  <pattern>u3wing</pattern>
+  <pattern>u4wins</pattern>
+  <pattern>uw3inz</pattern>
+  <pattern>uw1o</pattern>
+  <pattern>u3woe</pattern>
+  <pattern>uwo4ge</pattern>
+  <pattern>uw1r</pattern>
+  <pattern>uw3u</pattern>
+  <pattern>uxa3</pattern>
+  <pattern>u3ya</pattern>
+  <pattern>4uz</pattern>
+  <pattern>uze3t4</pattern>
+  <pattern>uzie2</pattern>
+  <pattern>ût3s4</pattern>
+  <pattern>1ü</pattern>
+  <pattern>ü4b</pattern>
+  <pattern>ü1n</pattern>
+  <pattern>ü3ri</pattern>
+  <pattern>üs3l</pattern>
+  <pattern>1v2</pattern>
+  <pattern>2v </pattern>
+  <pattern>vaar4ta</pattern>
+  <pattern>vaart5r</pattern>
+  <pattern>va3de</pattern>
+  <pattern>va3g4</pattern>
+  <pattern>va2ki</pattern>
+  <pattern>va4kl</pattern>
+  <pattern>va2ko</pattern>
+  <pattern>va2l3a</pattern>
+  <pattern>val5m</pattern>
+  <pattern>va3lo</pattern>
+  <pattern>va4loe</pattern>
+  <pattern>val5si</pattern>
+  <pattern>val4s5p</pattern>
+  <pattern>vals5tek</pattern>
+  <pattern>valu5</pattern>
+  <pattern>va2n</pattern>
+  <pattern>van3ac</pattern>
+  <pattern>vand4</pattern>
+  <pattern>vang3a</pattern>
+  <pattern>van4gr</pattern>
+  <pattern>va3no</pattern>
+  <pattern>va4noc</pattern>
+  <pattern>va1p</pattern>
+  <pattern>va3re</pattern>
+  <pattern>va5se</pattern>
+  <pattern>va3s4o</pattern>
+  <pattern>vast3r</pattern>
+  <pattern>va3su</pattern>
+  <pattern>va3te</pattern>
+  <pattern>va2t3h</pattern>
+  <pattern>vat5j</pattern>
+  <pattern>va3z</pattern>
+  <pattern>v4b</pattern>
+  <pattern>4v3c</pattern>
+  <pattern>v4e</pattern>
+  <pattern>3ve </pattern>
+  <pattern>5veb</pattern>
+  <pattern>vee4l</pattern>
+  <pattern>veel5e</pattern>
+  <pattern>vee3p4</pattern>
+  <pattern>vees4</pattern>
+  <pattern>ve3g4h</pattern>
+  <pattern>vei3s4</pattern>
+  <pattern>vei5tj</pattern>
+  <pattern>3vek</pattern>
+  <pattern>5vel</pattern>
+  <pattern>ve4l3a4g</pattern>
+  <pattern>vel4d3o</pattern>
+  <pattern>ve3le</pattern>
+  <pattern>vel3k</pattern>
+  <pattern>5vem</pattern>
+  <pattern>vem4a</pattern>
+  <pattern>ve4na</pattern>
+  <pattern>ve5nare</pattern>
+  <pattern>5vend</pattern>
+  <pattern>ven5k</pattern>
+  <pattern>ve2n3o</pattern>
+  <pattern>2venr</pattern>
+  <pattern>ven4s3e</pattern>
+  <pattern>ven4sl</pattern>
+  <pattern>vens5lan</pattern>
+  <pattern>vens5lo</pattern>
+  <pattern>ven4sp</pattern>
+  <pattern>vens5taak</pattern>
+  <pattern>vens5take</pattern>
+  <pattern>vens5tek</pattern>
+  <pattern>ven4s3u4</pattern>
+  <pattern>ve2r</pattern>
+  <pattern>ver1a</pattern>
+  <pattern>ver5aas</pattern>
+  <pattern>ve4rad</pattern>
+  <pattern>vera4g</pattern>
+  <pattern>ve4rand</pattern>
+  <pattern>ver5do</pattern>
+  <pattern>ve3rec</pattern>
+  <pattern>ver3ed</pattern>
+  <pattern>ve3reg</pattern>
+  <pattern>ve3rei</pattern>
+  <pattern>ver5eis</pattern>
+  <pattern>ve5ren </pattern>
+  <pattern>ve5rend</pattern>
+  <pattern>ver3e4t</pattern>
+  <pattern>ver5ijd</pattern>
+  <pattern>ver5ijl</pattern>
+  <pattern>ver5ijs</pattern>
+  <pattern>ve5ring</pattern>
+  <pattern>ver5k4</pattern>
+  <pattern>ver3o</pattern>
+  <pattern>ve3rom</pattern>
+  <pattern>vero5v</pattern>
+  <pattern>ver5p</pattern>
+  <pattern>ver5spe</pattern>
+  <pattern>ver5sta</pattern>
+  <pattern>ver5sto</pattern>
+  <pattern>ver5tw</pattern>
+  <pattern>ver1u</pattern>
+  <pattern>ve3ry</pattern>
+  <pattern>ve2s3</pattern>
+  <pattern>ves5ti</pattern>
+  <pattern>ve2tj</pattern>
+  <pattern>ve2to4</pattern>
+  <pattern>vet3og</pattern>
+  <pattern>vet3oo</pattern>
+  <pattern>ve3tor</pattern>
+  <pattern>ve2t3r</pattern>
+  <pattern>vet4roe</pattern>
+  <pattern>vet5ste</pattern>
+  <pattern>5ve5z</pattern>
+  <pattern>3vi</pattern>
+  <pattern>4vicepa</pattern>
+  <pattern>vid5st</pattern>
+  <pattern>vie4r3a</pattern>
+  <pattern>vie4s3</pattern>
+  <pattern>vies5n</pattern>
+  <pattern>vie4tj</pattern>
+  <pattern>vi3eu</pattern>
+  <pattern>vijf5</pattern>
+  <pattern>vik4s</pattern>
+  <pattern>vil4t3j</pattern>
+  <pattern>ving4</pattern>
+  <pattern>vings3</pattern>
+  <pattern>vi3o</pattern>
+  <pattern>vi5om</pattern>
+  <pattern>vi4s3an</pattern>
+  <pattern>vi1so</pattern>
+  <pattern>vis5ot</pattern>
+  <pattern>vis5p</pattern>
+  <pattern>vi4st</pattern>
+  <pattern>vis5tr</pattern>
+  <pattern>vi1tr</pattern>
+  <pattern>v3j</pattern>
+  <pattern>vje4</pattern>
+  <pattern>vjet1</pattern>
+  <pattern>3vl</pattern>
+  <pattern>v3lar</pattern>
+  <pattern>vlei3s4</pattern>
+  <pattern>vlie4s5</pattern>
+  <pattern>vlot5s</pattern>
+  <pattern>v3lov</pattern>
+  <pattern>5vo </pattern>
+  <pattern>3voe</pattern>
+  <pattern>voe4t3a</pattern>
+  <pattern>voe4t3r</pattern>
+  <pattern>voet5sp</pattern>
+  <pattern>3vog</pattern>
+  <pattern>voge4</pattern>
+  <pattern>3voi</pattern>
+  <pattern>vo2le</pattern>
+  <pattern>vol4g3a</pattern>
+  <pattern>vol4gra</pattern>
+  <pattern>vo2li</pattern>
+  <pattern>vol3ij</pattern>
+  <pattern>vol5p</pattern>
+  <pattern>von4det</pattern>
+  <pattern>vond5u</pattern>
+  <pattern>3voo</pattern>
+  <pattern>voo5d</pattern>
+  <pattern>vooi5t</pattern>
+  <pattern>voorn4</pattern>
+  <pattern>voor5na</pattern>
+  <pattern>vo3ra</pattern>
+  <pattern>vorm3a</pattern>
+  <pattern>vors5te </pattern>
+  <pattern>vor5sten</pattern>
+  <pattern>vos3</pattern>
+  <pattern>3vot</pattern>
+  <pattern>vot3j</pattern>
+  <pattern>3vou</pattern>
+  <pattern>vous5</pattern>
+  <pattern>3v4r2</pattern>
+  <pattern>vrei5</pattern>
+  <pattern>vrie4s</pattern>
+  <pattern>vrij5k4</pattern>
+  <pattern>vrijs4</pattern>
+  <pattern>vrij5ste</pattern>
+  <pattern>v3t</pattern>
+  <pattern>vues4</pattern>
+  <pattern>vu2l</pattern>
+  <pattern>vul5p</pattern>
+  <pattern>vuur5s</pattern>
+  <pattern>vy3</pattern>
+  <pattern>2w </pattern>
+  <pattern>waad3</pattern>
+  <pattern>w2aar</pattern>
+  <pattern>waar5e</pattern>
+  <pattern>waar5ste</pattern>
+  <pattern>wa4b3</pattern>
+  <pattern>wa2ba</pattern>
+  <pattern>wa5bl</pattern>
+  <pattern>w2ad</pattern>
+  <pattern>wa3dr</pattern>
+  <pattern>w4ag</pattern>
+  <pattern>wa2la</pattern>
+  <pattern>wa3lan</pattern>
+  <pattern>4wam</pattern>
+  <pattern>wan4d5r</pattern>
+  <pattern>wan4gr</pattern>
+  <pattern>wang5sl</pattern>
+  <pattern>wa2n1o</pattern>
+  <pattern>wan3s4</pattern>
+  <pattern>3wap</pattern>
+  <pattern>w4ar</pattern>
+  <pattern>w5arc</pattern>
+  <pattern>5ward</pattern>
+  <pattern>war4st</pattern>
+  <pattern>wars5te</pattern>
+  <pattern>wart3j</pattern>
+  <pattern>war4to</pattern>
+  <pattern>wa2si</pattern>
+  <pattern>wa4s5l</pattern>
+  <pattern>wa4s5p</pattern>
+  <pattern>was5tr</pattern>
+  <pattern>1wate</pattern>
+  <pattern>wat5j</pattern>
+  <pattern>wa3tr</pattern>
+  <pattern>3way</pattern>
+  <pattern>2wb</pattern>
+  <pattern>w1c</pattern>
+  <pattern>2w1d</pattern>
+  <pattern>w4doo</pattern>
+  <pattern>wd3oom</pattern>
+  <pattern>we2a</pattern>
+  <pattern>2we2c</pattern>
+  <pattern>3wed</pattern>
+  <pattern>wede4</pattern>
+  <pattern>we2d3i</pattern>
+  <pattern>we4d3r</pattern>
+  <pattern>wee4ki</pattern>
+  <pattern>wee4k3r</pattern>
+  <pattern>wee3lo</pattern>
+  <pattern>wee3s4t</pattern>
+  <pattern>wee5ste</pattern>
+  <pattern>3weg</pattern>
+  <pattern>we4g1a</pattern>
+  <pattern>we4gerv</pattern>
+  <pattern>weg3l</pattern>
+  <pattern>we2g3o</pattern>
+  <pattern>we4g5r</pattern>
+  <pattern>wei3s</pattern>
+  <pattern>wei5tj</pattern>
+  <pattern>we4k3r</pattern>
+  <pattern>we4le2</pattern>
+  <pattern>4welem</pattern>
+  <pattern>we3li</pattern>
+  <pattern>we2lo</pattern>
+  <pattern>wel3s</pattern>
+  <pattern>we2m</pattern>
+  <pattern>wem3a</pattern>
+  <pattern>we3me</pattern>
+  <pattern>we2n</pattern>
+  <pattern>wena4</pattern>
+  <pattern>wen3ad</pattern>
+  <pattern>we3ne4</pattern>
+  <pattern>we4nem</pattern>
+  <pattern>we5nen </pattern>
+  <pattern>wen5enk</pattern>
+  <pattern>we3ni</pattern>
+  <pattern>wen4k3a</pattern>
+  <pattern>wen3o</pattern>
+  <pattern>wen5to</pattern>
+  <pattern>wer2f</pattern>
+  <pattern>4werg</pattern>
+  <pattern>wer4ka</pattern>
+  <pattern>wer4k5l</pattern>
+  <pattern>wer4kn</pattern>
+  <pattern>wer4k3o</pattern>
+  <pattern>wer4k3r</pattern>
+  <pattern>werk5ru</pattern>
+  <pattern>wer4k3u4</pattern>
+  <pattern>wer4k3w</pattern>
+  <pattern>wer4p3a</pattern>
+  <pattern>wer4p3l</pattern>
+  <pattern>wer4pr</pattern>
+  <pattern>wer4s</pattern>
+  <pattern>wer5ste</pattern>
+  <pattern>we2s3</pattern>
+  <pattern>we3spo</pattern>
+  <pattern>wes4t5o</pattern>
+  <pattern>3wet </pattern>
+  <pattern>we2th</pattern>
+  <pattern>we2t3j</pattern>
+  <pattern>wet4st</pattern>
+  <pattern>we2t3u</pattern>
+  <pattern>2wex</pattern>
+  <pattern>wezen4s5</pattern>
+  <pattern>2w1f</pattern>
+  <pattern>w1g</pattern>
+  <pattern>w1h</pattern>
+  <pattern>wie4la</pattern>
+  <pattern>wie4t</pattern>
+  <pattern>w4ij</pattern>
+  <pattern>3wijd</pattern>
+  <pattern>wij4ka</pattern>
+  <pattern>wij4s</pattern>
+  <pattern>wijs3l</pattern>
+  <pattern>wijs3p</pattern>
+  <pattern>wijs5ta</pattern>
+  <pattern>wi4k</pattern>
+  <pattern>3wil</pattern>
+  <pattern>wind3a</pattern>
+  <pattern>win4d3r</pattern>
+  <pattern>w4ing</pattern>
+  <pattern>2winr</pattern>
+  <pattern>win2s</pattern>
+  <pattern>winst5aa</pattern>
+  <pattern>winst5r</pattern>
+  <pattern>wi4t3h</pattern>
+  <pattern>wit3j</pattern>
+  <pattern>wi2t3o4</pattern>
+  <pattern>wit3r</pattern>
+  <pattern>w1j</pattern>
+  <pattern>2w1k</pattern>
+  <pattern>2w1l</pattern>
+  <pattern>4w1m</pattern>
+  <pattern>2wn</pattern>
+  <pattern>wn3ac</pattern>
+  <pattern>w3ne</pattern>
+  <pattern>w3ni</pattern>
+  <pattern>w3no</pattern>
+  <pattern>w3ob</pattern>
+  <pattern>w2oe</pattern>
+  <pattern>woes3</pattern>
+  <pattern>woest5a</pattern>
+  <pattern>wo4l</pattern>
+  <pattern>wol3a</pattern>
+  <pattern>wolf4s5</pattern>
+  <pattern>woon5sf</pattern>
+  <pattern>woor4d5r</pattern>
+  <pattern>wor4g3e</pattern>
+  <pattern>w1p</pattern>
+  <pattern>wren4st</pattern>
+  <pattern>wrens5te </pattern>
+  <pattern>2ws</pattern>
+  <pattern>ws3a2</pattern>
+  <pattern>w3sc</pattern>
+  <pattern>w1sl</pattern>
+  <pattern>w2s3le</pattern>
+  <pattern>w3som</pattern>
+  <pattern>w3sp</pattern>
+  <pattern>ws2pl</pattern>
+  <pattern>w4spr</pattern>
+  <pattern>w5spra</pattern>
+  <pattern>w1s4t</pattern>
+  <pattern>w4stij</pattern>
+  <pattern>2wt</pattern>
+  <pattern>wtes3</pattern>
+  <pattern>wtje5sp</pattern>
+  <pattern>w1to</pattern>
+  <pattern>w1tr</pattern>
+  <pattern>wu2</pattern>
+  <pattern>wva2</pattern>
+  <pattern>w1w</pattern>
+  <pattern>xaf4</pattern>
+  <pattern>xa3g</pattern>
+  <pattern>xamen5t</pattern>
+  <pattern>xan3</pattern>
+  <pattern>xan5t</pattern>
+  <pattern>x1c</pattern>
+  <pattern>x4e</pattern>
+  <pattern>xen4d</pattern>
+  <pattern>xe3ro</pattern>
+  <pattern>x1f</pattern>
+  <pattern>x1h</pattern>
+  <pattern>xie4t</pattern>
+  <pattern>xi3g</pattern>
+  <pattern>xi5o</pattern>
+  <pattern>xi3sta</pattern>
+  <pattern>xi3sto</pattern>
+  <pattern>xi4t3i</pattern>
+  <pattern>x3l</pattern>
+  <pattern>x1m</pattern>
+  <pattern>xo3no</pattern>
+  <pattern>x4op</pattern>
+  <pattern>xo3s4</pattern>
+  <pattern>x1p</pattern>
+  <pattern>xpre2</pattern>
+  <pattern>xpres5</pattern>
+  <pattern>x3r</pattern>
+  <pattern>x3so</pattern>
+  <pattern>x3sp</pattern>
+  <pattern>x1t</pattern>
+  <pattern>x2tak</pattern>
+  <pattern>xtie2</pattern>
+  <pattern>x3w</pattern>
+  <pattern>xy3</pattern>
+  <pattern>y1a</pattern>
+  <pattern>ya3s4</pattern>
+  <pattern>ya4s5p</pattern>
+  <pattern>y3at</pattern>
+  <pattern>yba2l3</pattern>
+  <pattern>yber4t3</pattern>
+  <pattern>y1c</pattern>
+  <pattern>ycho3</pattern>
+  <pattern>y3co</pattern>
+  <pattern>y1d4</pattern>
+  <pattern>ydi3a</pattern>
+  <pattern>y5dr</pattern>
+  <pattern>ydro3</pattern>
+  <pattern>y1e</pattern>
+  <pattern>yes3</pattern>
+  <pattern>y3és</pattern>
+  <pattern>y3è</pattern>
+  <pattern>y1f</pattern>
+  <pattern>y1g</pattern>
+  <pattern>ygu2</pattern>
+  <pattern>y1h</pattern>
+  <pattern>y1i</pattern>
+  <pattern>y4in</pattern>
+  <pattern>y5is</pattern>
+  <pattern>yksge4</pattern>
+  <pattern>y3la</pattern>
+  <pattern>yl3al</pattern>
+  <pattern>y3le</pattern>
+  <pattern>y4l3et</pattern>
+  <pattern>y3lo</pattern>
+  <pattern>ylo3l</pattern>
+  <pattern>ym2f5l</pattern>
+  <pattern>ym5pa</pattern>
+  <pattern>y3na</pattern>
+  <pattern>yn3er</pattern>
+  <pattern>y3no</pattern>
+  <pattern>yn1t</pattern>
+  <pattern>y1o</pattern>
+  <pattern>y3on</pattern>
+  <pattern>y3os</pattern>
+  <pattern>yo3t</pattern>
+  <pattern>y1p</pattern>
+  <pattern>y3p4h</pattern>
+  <pattern>ypo3</pattern>
+  <pattern>ypot4</pattern>
+  <pattern>yp3s</pattern>
+  <pattern>yp5si</pattern>
+  <pattern>y1r</pattern>
+  <pattern>y3r4e</pattern>
+  <pattern>y5ri</pattern>
+  <pattern>ys3</pattern>
+  <pattern>y1s4a</pattern>
+  <pattern>y3s4c</pattern>
+  <pattern>y5s4e</pattern>
+  <pattern>yse5t</pattern>
+  <pattern>y3s4f</pattern>
+  <pattern>y3s4h</pattern>
+  <pattern>ys4i</pattern>
+  <pattern>y3s4o</pattern>
+  <pattern>y3s4p</pattern>
+  <pattern>ys5pl</pattern>
+  <pattern>ys4ta</pattern>
+  <pattern>ys5tr</pattern>
+  <pattern>y3sy</pattern>
+  <pattern>y1t</pattern>
+  <pattern>yt3hu</pattern>
+  <pattern>yto3</pattern>
+  <pattern>y2tof</pattern>
+  <pattern>ytop4</pattern>
+  <pattern>yu5a</pattern>
+  <pattern>y3ui</pattern>
+  <pattern>y3u2r</pattern>
+  <pattern>yvari5</pattern>
+  <pattern>y1w4</pattern>
+  <pattern>1z</pattern>
+  <pattern>4z </pattern>
+  <pattern>zaar5t</pattern>
+  <pattern>za3f2</pattern>
+  <pattern>zags4t</pattern>
+  <pattern>za2k3a</pattern>
+  <pattern>zak3r</pattern>
+  <pattern>zan2d</pattern>
+  <pattern>zand5a4</pattern>
+  <pattern>zan3di</pattern>
+  <pattern>zan4dr</pattern>
+  <pattern>zang3s</pattern>
+  <pattern>za3po</pattern>
+  <pattern>za3s4</pattern>
+  <pattern>4zb</pattern>
+  <pattern>4zc</pattern>
+  <pattern>4zd</pattern>
+  <pattern>z4e</pattern>
+  <pattern>zee3k</pattern>
+  <pattern>zeel5d</pattern>
+  <pattern>zee3r4o</pattern>
+  <pattern>zeero5v</pattern>
+  <pattern>zeer5s</pattern>
+  <pattern>zee3s4</pattern>
+  <pattern>ze5ge</pattern>
+  <pattern>zeg4sl</pattern>
+  <pattern>zei3sp</pattern>
+  <pattern>ze5k</pattern>
+  <pattern>zel5dr</pattern>
+  <pattern>ze3lem</pattern>
+  <pattern>zel2f1</pattern>
+  <pattern>zel4so</pattern>
+  <pattern>zen4d3a</pattern>
+  <pattern>ze4nin</pattern>
+  <pattern>zen5k</pattern>
+  <pattern>zen3o4</pattern>
+  <pattern>zen4og</pattern>
+  <pattern>ze3non</pattern>
+  <pattern>ze4r3a</pattern>
+  <pattern>ze3ro</pattern>
+  <pattern>zer2s</pattern>
+  <pattern>zer4s5e</pattern>
+  <pattern>ze4s3</pattern>
+  <pattern>ze5sch</pattern>
+  <pattern>zes5e</pattern>
+  <pattern>zes5l</pattern>
+  <pattern>ze5ste</pattern>
+  <pattern>ze2t3a</pattern>
+  <pattern>ze2t3h</pattern>
+  <pattern>ze4ti</pattern>
+  <pattern>ze2t3j</pattern>
+  <pattern>ze2t3r</pattern>
+  <pattern>zeve2</pattern>
+  <pattern>zeven3</pattern>
+  <pattern>4zf</pattern>
+  <pattern>4zg</pattern>
+  <pattern>2z3h</pattern>
+  <pattern>z2i</pattern>
+  <pattern>ziek3l</pattern>
+  <pattern>zie4k3o</pattern>
+  <pattern>ziek3w</pattern>
+  <pattern>ziel4s</pattern>
+  <pattern>zie5sl</pattern>
+  <pattern>3zif</pattern>
+  <pattern>zi2g5a</pattern>
+  <pattern>zij5kl</pattern>
+  <pattern>zij3po</pattern>
+  <pattern>zij5s4</pattern>
+  <pattern>zik2w</pattern>
+  <pattern>zi4n3a4</pattern>
+  <pattern>zings3</pattern>
+  <pattern>zin4k3l</pattern>
+  <pattern>zin4s</pattern>
+  <pattern>zins3t</pattern>
+  <pattern>zins5ta</pattern>
+  <pattern>zin5str</pattern>
+  <pattern>zi3o5</pattern>
+  <pattern>zipi3</pattern>
+  <pattern>zi4t</pattern>
+  <pattern>zit3e</pattern>
+  <pattern>zit3j</pattern>
+  <pattern>zit3u4</pattern>
+  <pattern>4z3k</pattern>
+  <pattern>4z3l</pattern>
+  <pattern>4zm</pattern>
+  <pattern>zodi5</pattern>
+  <pattern>zoet3j</pattern>
+  <pattern>zoet5ste</pattern>
+  <pattern>zo3f2</pattern>
+  <pattern>zoi4</pattern>
+  <pattern>zo5ie</pattern>
+  <pattern>zo3la</pattern>
+  <pattern>zome4</pattern>
+  <pattern>zo2na</pattern>
+  <pattern>zon3sf</pattern>
+  <pattern>zon5ta</pattern>
+  <pattern>zooi5tj</pattern>
+  <pattern>zo1p</pattern>
+  <pattern>zor4g3a</pattern>
+  <pattern>zor4gl</pattern>
+  <pattern>zor4gr</pattern>
+  <pattern>zo2t</pattern>
+  <pattern>zot3h</pattern>
+  <pattern>zo3tr</pattern>
+  <pattern>zo3v</pattern>
+  <pattern>4z3p</pattern>
+  <pattern>4z3r</pattern>
+  <pattern>2zs</pattern>
+  <pattern>4z5t</pattern>
+  <pattern>zui4d3i</pattern>
+  <pattern>zui4dr</pattern>
+  <pattern>zus3</pattern>
+  <pattern>2zv</pattern>
+  <pattern>z4w</pattern>
+  <pattern>zwets5te </pattern>
+  <pattern>5zy</pattern>
+  <pattern>2z3z</pattern>
+  <pattern>zz3in</pattern>
+  <pattern>zz3or</pattern>
+  <pattern>z4z5w</pattern>
 </HyphenationDescription>

--- a/cr3gui/data/hyph/Spanish.pattern
+++ b/cr3gui/data/hyph/Spanish.pattern
@@ -1,3405 +1,3640 @@
 <?xml version="1.0" encoding="utf8"?>
 <!--
+       hyphenations description for FBReader/CoolReader
+       from the original file:
 
-	hyphenations description for FBReader/CoolReader
-	from the original file:
-
-% DIVISI'ON DE PALABRAS
+% GUIONIZADO DE PALABRAS
 % ~~~~~~~~~~~~~~~~~~~~~
-% hyph-es.tex 4.6
-% This files corresponds to eshyph.tex 4.6.
+% hyph-es.tex 4.7
 %
-% (c) Javier Bezos 1993 1997.
-% (c) Javier Bezos and CervanTeX 2001-2010
-% Some parts, (c) by Francesc Carmona
-% Licence: LPPL
+% License: MIT/X11
 %
+% Copyright (c) 1993, 1997 Javier Bezos
+% Copyright (c) 2001-2015 Javier Bezos and CervanTeX
+%
+% Permission is hereby granted, free of charge, to any person obtaining a copy
+% of this software and associated documentation files (the "Software"), to deal
+% in the Software without restriction, including without limitation the rights
+% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+% copies of the Software, and to permit persons to whom the Software is
+% furnished to do so, subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+% SOFTWARE.
+% 
 % For further info, bug reports and comments:
 %
 %       http://www.tex-tipografia.com/spanish_hyphen.html
-%
+% 
 % I would like to thanks Francesc Carmona for his permission
-% to steal parts of his work without restrictions.
-%
-% 2010-05-18
-%
+% to steal parts of his work without restrictions. For his
+% patterns, (c) by Francesc Carmona
+% 
+% 2015-11-12
+% 
 % _____________________________________________________________
 % Javier Bezos                | http://www.cervantex.es/
 % .............................................................
 % TeX y tipografia            | http://www.tex-tipografia.com/
-% \message{UTF-8 hyphenation patterns for Spanish}
-%
 -->
 <HyphenationDescription>
-<pattern>1b</pattern>
-<pattern>4b </pattern>
-<pattern>2bb</pattern>
-<pattern>2bc</pattern>
-<pattern>2bd</pattern>
-<pattern>2bf</pattern>
-<pattern>2bg</pattern>
-<pattern>2b1h</pattern>
-<pattern>2bj</pattern>
-<pattern>2bk</pattern>
-<pattern>2bm</pattern>
-<pattern>2bn</pattern>
-<pattern>2bp</pattern>
-<pattern>2bq</pattern>
-<pattern>2bs</pattern>
-<pattern>2bt</pattern>
-<pattern>2bv</pattern>
-<pattern>2bw</pattern>
-<pattern>2bx</pattern>
-<pattern>2by</pattern>
-<pattern>2bz</pattern>
-<pattern>1c</pattern>
-<pattern>4c </pattern>
-<pattern>2cb</pattern>
-<pattern>2cc</pattern>
-<pattern>2cd</pattern>
-<pattern>2cf</pattern>
-<pattern>2cg</pattern>
-<pattern>2cj</pattern>
-<pattern>2ck</pattern>
-<pattern>2cm</pattern>
-<pattern>2cn</pattern>
-<pattern>2cp</pattern>
-<pattern>2cq</pattern>
-<pattern>2cs</pattern>
-<pattern>2ct</pattern>
-<pattern>2cv</pattern>
-<pattern>2cw</pattern>
-<pattern>2cx</pattern>
-<pattern>2cy</pattern>
-<pattern>2cz</pattern>
-<pattern>1d</pattern>
-<pattern>4d </pattern>
-<pattern>2db</pattern>
-<pattern>2dc</pattern>
-<pattern>2dd</pattern>
-<pattern>2df</pattern>
-<pattern>2dg</pattern>
-<pattern>2d1h</pattern>
-<pattern>2dj</pattern>
-<pattern>2dk</pattern>
-<pattern>2dl</pattern>
-<pattern>2dm</pattern>
-<pattern>2dn</pattern>
-<pattern>2dp</pattern>
-<pattern>2dq</pattern>
-<pattern>2ds</pattern>
-<pattern>2dt</pattern>
-<pattern>2dv</pattern>
-<pattern>2dw</pattern>
-<pattern>2dx</pattern>
-<pattern>2dy</pattern>
-<pattern>2dz</pattern>
-<pattern>1f</pattern>
-<pattern>4f </pattern>
-<pattern>2fb</pattern>
-<pattern>2fc</pattern>
-<pattern>2fd</pattern>
-<pattern>2ff</pattern>
-<pattern>2fg</pattern>
-<pattern>2f1h</pattern>
-<pattern>2fj</pattern>
-<pattern>2fk</pattern>
-<pattern>2fm</pattern>
-<pattern>2fn</pattern>
-<pattern>2fp</pattern>
-<pattern>2fq</pattern>
-<pattern>2fs</pattern>
-<pattern>2ft</pattern>
-<pattern>2fv</pattern>
-<pattern>2fw</pattern>
-<pattern>2fx</pattern>
-<pattern>2fy</pattern>
-<pattern>2fz</pattern>
-<pattern>1g</pattern>
-<pattern>4g </pattern>
-<pattern>2gb</pattern>
-<pattern>2gc</pattern>
-<pattern>2gd</pattern>
-<pattern>2gf</pattern>
-<pattern>2gg</pattern>
-<pattern>2g1h</pattern>
-<pattern>2gj</pattern>
-<pattern>2gk</pattern>
-<pattern>2gm</pattern>
-<pattern>2gn</pattern>
-<pattern>2gp</pattern>
-<pattern>2gq</pattern>
-<pattern>2gs</pattern>
-<pattern>2gt</pattern>
-<pattern>2gv</pattern>
-<pattern>2gw</pattern>
-<pattern>2gx</pattern>
-<pattern>2gy</pattern>
-<pattern>2gz</pattern>
-<pattern>4h </pattern>
-<pattern>2hb</pattern>
-<pattern>2hc</pattern>
-<pattern>2hd</pattern>
-<pattern>2hf</pattern>
-<pattern>2hg</pattern>
-<pattern>2h1h</pattern>
-<pattern>2hj</pattern>
-<pattern>2hk</pattern>
-<pattern>2hl</pattern>
-<pattern>2hm</pattern>
-<pattern>2hn</pattern>
-<pattern>2hp</pattern>
-<pattern>2hq</pattern>
-<pattern>2hr</pattern>
-<pattern>2hs</pattern>
-<pattern>2ht</pattern>
-<pattern>2hv</pattern>
-<pattern>2hw</pattern>
-<pattern>2hx</pattern>
-<pattern>2hy</pattern>
-<pattern>2hz</pattern>
-<pattern>1j</pattern>
-<pattern>4j </pattern>
-<pattern>2jb</pattern>
-<pattern>2jc</pattern>
-<pattern>2jd</pattern>
-<pattern>2jf</pattern>
-<pattern>2jg</pattern>
-<pattern>2j1h</pattern>
-<pattern>2jj</pattern>
-<pattern>2jk</pattern>
-<pattern>2jl</pattern>
-<pattern>2jm</pattern>
-<pattern>2jn</pattern>
-<pattern>2jp</pattern>
-<pattern>2jq</pattern>
-<pattern>2jr</pattern>
-<pattern>2js</pattern>
-<pattern>2jt</pattern>
-<pattern>2jv</pattern>
-<pattern>2jw</pattern>
-<pattern>2jx</pattern>
-<pattern>2jy</pattern>
-<pattern>2jz</pattern>
-<pattern>1k</pattern>
-<pattern>4k </pattern>
-<pattern>2kb</pattern>
-<pattern>2kc</pattern>
-<pattern>2kd</pattern>
-<pattern>2kf</pattern>
-<pattern>2kg</pattern>
-<pattern>2k1h</pattern>
-<pattern>2kj</pattern>
-<pattern>2kk</pattern>
-<pattern>2km</pattern>
-<pattern>2kn</pattern>
-<pattern>2kp</pattern>
-<pattern>2kq</pattern>
-<pattern>2ks</pattern>
-<pattern>2kt</pattern>
-<pattern>2kv</pattern>
-<pattern>2kw</pattern>
-<pattern>2kx</pattern>
-<pattern>2ky</pattern>
-<pattern>2kz</pattern>
-<pattern>1l</pattern>
-<pattern>4l </pattern>
-<pattern>2lb</pattern>
-<pattern>2lc</pattern>
-<pattern>2ld</pattern>
-<pattern>2lf</pattern>
-<pattern>2lg</pattern>
-<pattern>2l1h</pattern>
-<pattern>2lj</pattern>
-<pattern>2lk</pattern>
-<pattern>2lm</pattern>
-<pattern>2ln</pattern>
-<pattern>2lp</pattern>
-<pattern>2lq</pattern>
-<pattern>2lr</pattern>
-<pattern>2ls</pattern>
-<pattern>2lt</pattern>
-<pattern>2lv</pattern>
-<pattern>2lw</pattern>
-<pattern>2lx</pattern>
-<pattern>2ly</pattern>
-<pattern>2lz</pattern>
-<pattern>1m</pattern>
-<pattern>4m </pattern>
-<pattern>2mb</pattern>
-<pattern>2mc</pattern>
-<pattern>2md</pattern>
-<pattern>2mf</pattern>
-<pattern>2mg</pattern>
-<pattern>2m1h</pattern>
-<pattern>2mj</pattern>
-<pattern>2mk</pattern>
-<pattern>2ml</pattern>
-<pattern>2mm</pattern>
-<pattern>2mn</pattern>
-<pattern>2mp</pattern>
-<pattern>2mq</pattern>
-<pattern>2mr</pattern>
-<pattern>2ms</pattern>
-<pattern>2mt</pattern>
-<pattern>2mv</pattern>
-<pattern>2mw</pattern>
-<pattern>2mx</pattern>
-<pattern>2my</pattern>
-<pattern>2mz</pattern>
-<pattern>1n</pattern>
-<pattern>4n </pattern>
-<pattern>2nb</pattern>
-<pattern>2nc</pattern>
-<pattern>2nd</pattern>
-<pattern>2nf</pattern>
-<pattern>2ng</pattern>
-<pattern>2n1h</pattern>
-<pattern>2nj</pattern>
-<pattern>2nk</pattern>
-<pattern>2nl</pattern>
-<pattern>2nm</pattern>
-<pattern>2nn</pattern>
-<pattern>2np</pattern>
-<pattern>2nq</pattern>
-<pattern>2nr</pattern>
-<pattern>2ns</pattern>
-<pattern>2nt</pattern>
-<pattern>2nv</pattern>
-<pattern>2nw</pattern>
-<pattern>2nx</pattern>
-<pattern>2ny</pattern>
-<pattern>2nz</pattern>
-<pattern>1p</pattern>
-<pattern>4p </pattern>
-<pattern>2pb</pattern>
-<pattern>2pc</pattern>
-<pattern>2pd</pattern>
-<pattern>2pf</pattern>
-<pattern>2pg</pattern>
-<pattern>2p1h</pattern>
-<pattern>2pj</pattern>
-<pattern>2pk</pattern>
-<pattern>2pm</pattern>
-<pattern>2pn</pattern>
-<pattern>2pp</pattern>
-<pattern>2pq</pattern>
-<pattern>2ps</pattern>
-<pattern>2pt</pattern>
-<pattern>2pv</pattern>
-<pattern>2pw</pattern>
-<pattern>2px</pattern>
-<pattern>2py</pattern>
-<pattern>2pz</pattern>
-<pattern>1q</pattern>
-<pattern>4q </pattern>
-<pattern>2qb</pattern>
-<pattern>2qc</pattern>
-<pattern>2qd</pattern>
-<pattern>2qf</pattern>
-<pattern>2qg</pattern>
-<pattern>2q1h</pattern>
-<pattern>2qj</pattern>
-<pattern>2qk</pattern>
-<pattern>2ql</pattern>
-<pattern>2qm</pattern>
-<pattern>2qn</pattern>
-<pattern>2qp</pattern>
-<pattern>2qq</pattern>
-<pattern>2qr</pattern>
-<pattern>2qs</pattern>
-<pattern>2qt</pattern>
-<pattern>2qv</pattern>
-<pattern>2qw</pattern>
-<pattern>2qx</pattern>
-<pattern>2qy</pattern>
-<pattern>2qz</pattern>
-<pattern>1r</pattern>
-<pattern>4r </pattern>
-<pattern>2rb</pattern>
-<pattern>2rc</pattern>
-<pattern>2rd</pattern>
-<pattern>2rf</pattern>
-<pattern>2rg</pattern>
-<pattern>2r1h</pattern>
-<pattern>2rj</pattern>
-<pattern>2rk</pattern>
-<pattern>2rl</pattern>
-<pattern>2rm</pattern>
-<pattern>2rn</pattern>
-<pattern>2rp</pattern>
-<pattern>2rq</pattern>
-<pattern>2rs</pattern>
-<pattern>2rt</pattern>
-<pattern>2rv</pattern>
-<pattern>2rw</pattern>
-<pattern>2rx</pattern>
-<pattern>2ry</pattern>
-<pattern>2rz</pattern>
-<pattern>1s</pattern>
-<pattern>4s </pattern>
-<pattern>2sb</pattern>
-<pattern>2sc</pattern>
-<pattern>2sd</pattern>
-<pattern>2sf</pattern>
-<pattern>2sg</pattern>
-<pattern>2s1h</pattern>
-<pattern>2sj</pattern>
-<pattern>2sk</pattern>
-<pattern>2sl</pattern>
-<pattern>2sm</pattern>
-<pattern>2sn</pattern>
-<pattern>2sp</pattern>
-<pattern>2sq</pattern>
-<pattern>2sr</pattern>
-<pattern>2ss</pattern>
-<pattern>2st</pattern>
-<pattern>2sv</pattern>
-<pattern>2sw</pattern>
-<pattern>2sx</pattern>
-<pattern>2sy</pattern>
-<pattern>2sz</pattern>
-<pattern>1t</pattern>
-<pattern>4t </pattern>
-<pattern>2tb</pattern>
-<pattern>2tc</pattern>
-<pattern>2td</pattern>
-<pattern>2tf</pattern>
-<pattern>2tg</pattern>
-<pattern>2t1h</pattern>
-<pattern>2tj</pattern>
-<pattern>2tk</pattern>
-<pattern>2tm</pattern>
-<pattern>2tn</pattern>
-<pattern>2tp</pattern>
-<pattern>2tq</pattern>
-<pattern>2ts</pattern>
-<pattern>2tt</pattern>
-<pattern>2tv</pattern>
-<pattern>2tw</pattern>
-<pattern>2tx</pattern>
-<pattern>2ty</pattern>
-<pattern>2tz</pattern>
-<pattern>1v</pattern>
-<pattern>4v </pattern>
-<pattern>2vb</pattern>
-<pattern>2vc</pattern>
-<pattern>2vd</pattern>
-<pattern>2vf</pattern>
-<pattern>2vg</pattern>
-<pattern>2v1h</pattern>
-<pattern>2vj</pattern>
-<pattern>2vk</pattern>
-<pattern>2vm</pattern>
-<pattern>2vn</pattern>
-<pattern>2vp</pattern>
-<pattern>2vq</pattern>
-<pattern>2vs</pattern>
-<pattern>2vt</pattern>
-<pattern>2vv</pattern>
-<pattern>2vw</pattern>
-<pattern>2vx</pattern>
-<pattern>2vy</pattern>
-<pattern>2vz</pattern>
-<pattern>1w</pattern>
-<pattern>4w </pattern>
-<pattern>2wb</pattern>
-<pattern>2wc</pattern>
-<pattern>2wd</pattern>
-<pattern>2wf</pattern>
-<pattern>2wg</pattern>
-<pattern>2w1h</pattern>
-<pattern>2wj</pattern>
-<pattern>2wk</pattern>
-<pattern>2wl</pattern>
-<pattern>2wm</pattern>
-<pattern>2wn</pattern>
-<pattern>2wp</pattern>
-<pattern>2wq</pattern>
-<pattern>2wr</pattern>
-<pattern>2ws</pattern>
-<pattern>2wt</pattern>
-<pattern>2wv</pattern>
-<pattern>2ww</pattern>
-<pattern>2wx</pattern>
-<pattern>2wy</pattern>
-<pattern>2wz</pattern>
-<pattern>1x</pattern>
-<pattern>4x </pattern>
-<pattern>2xb</pattern>
-<pattern>2xc</pattern>
-<pattern>2xd</pattern>
-<pattern>2xf</pattern>
-<pattern>2xg</pattern>
-<pattern>2x1h</pattern>
-<pattern>2xj</pattern>
-<pattern>2xk</pattern>
-<pattern>2xl</pattern>
-<pattern>2xm</pattern>
-<pattern>2xn</pattern>
-<pattern>2xp</pattern>
-<pattern>2xq</pattern>
-<pattern>2xr</pattern>
-<pattern>2xs</pattern>
-<pattern>2xt</pattern>
-<pattern>2xv</pattern>
-<pattern>2xw</pattern>
-<pattern>2xx</pattern>
-<pattern>2xy</pattern>
-<pattern>2xz</pattern>
-<pattern>1y</pattern>
-<pattern>4y </pattern>
-<pattern>2yb</pattern>
-<pattern>2yc</pattern>
-<pattern>2yd</pattern>
-<pattern>2yf</pattern>
-<pattern>2yg</pattern>
-<pattern>2y1h</pattern>
-<pattern>2yj</pattern>
-<pattern>2yk</pattern>
-<pattern>2yl</pattern>
-<pattern>2ym</pattern>
-<pattern>2yn</pattern>
-<pattern>2yp</pattern>
-<pattern>2yq</pattern>
-<pattern>2yr</pattern>
-<pattern>2ys</pattern>
-<pattern>2yt</pattern>
-<pattern>2yv</pattern>
-<pattern>2yw</pattern>
-<pattern>2yx</pattern>
-<pattern>2yy</pattern>
-<pattern>2yz</pattern>
-<pattern>1z</pattern>
-<pattern>4z </pattern>
-<pattern>2zb</pattern>
-<pattern>2zc</pattern>
-<pattern>2zd</pattern>
-<pattern>2zf</pattern>
-<pattern>2zg</pattern>
-<pattern>2z1h</pattern>
-<pattern>2zj</pattern>
-<pattern>2zk</pattern>
-<pattern>2zl</pattern>
-<pattern>2zm</pattern>
-<pattern>2zn</pattern>
-<pattern>2zp</pattern>
-<pattern>2zq</pattern>
-<pattern>2zr</pattern>
-<pattern>2zs</pattern>
-<pattern>2zt</pattern>
-<pattern>2zv</pattern>
-<pattern>2zw</pattern>
-<pattern>2zx</pattern>
-<pattern>2zy</pattern>
-<pattern>2zz</pattern>
-<pattern>1ñ</pattern>
-<pattern>4ñ </pattern>
-<pattern>c4h</pattern>
-<pattern>4ch </pattern>
-<pattern>2chb</pattern>
-<pattern>2chc</pattern>
-<pattern>2chd</pattern>
-<pattern>2chf</pattern>
-<pattern>2chg</pattern>
-<pattern>2chh</pattern>
-<pattern>2chj</pattern>
-<pattern>2chk</pattern>
-<pattern>ch2l</pattern>
-<pattern>2chm</pattern>
-<pattern>2chn</pattern>
-<pattern>2chp</pattern>
-<pattern>2chq</pattern>
-<pattern>ch2r</pattern>
-<pattern>2chs</pattern>
-<pattern>2cht</pattern>
-<pattern>2chv</pattern>
-<pattern>2chw</pattern>
-<pattern>2chx</pattern>
-<pattern>2chy</pattern>
-<pattern>2chz</pattern>
-<pattern>l4l</pattern>
-<pattern>4ll </pattern>
-<pattern>2llb</pattern>
-<pattern>2llc</pattern>
-<pattern>2lld</pattern>
-<pattern>2llf</pattern>
-<pattern>2llg</pattern>
-<pattern>2llh</pattern>
-<pattern>2llj</pattern>
-<pattern>2llk</pattern>
-<pattern>2lll</pattern>
-<pattern>2llm</pattern>
-<pattern>2lln</pattern>
-<pattern>2llp</pattern>
-<pattern>2llq</pattern>
-<pattern>2llr</pattern>
-<pattern>2lls</pattern>
-<pattern>2llt</pattern>
-<pattern>2llv</pattern>
-<pattern>2llw</pattern>
-<pattern>2llx</pattern>
-<pattern>2lly</pattern>
-<pattern>2llz</pattern>
-<pattern>b2l</pattern>
-<pattern>4bl </pattern>
-<pattern>2bl2b</pattern>
-<pattern>2bl2c</pattern>
-<pattern>2bl2d</pattern>
-<pattern>2bl2f</pattern>
-<pattern>2bl2g</pattern>
-<pattern>2bl2h</pattern>
-<pattern>2bl2j</pattern>
-<pattern>2bl2k</pattern>
-<pattern>2bl2l</pattern>
-<pattern>2bl2m</pattern>
-<pattern>2bl2n</pattern>
-<pattern>2bl2p</pattern>
-<pattern>2bl2q</pattern>
-<pattern>2bl2r</pattern>
-<pattern>2bl2s</pattern>
-<pattern>2bl2t</pattern>
-<pattern>2bl2v</pattern>
-<pattern>2bl2w</pattern>
-<pattern>2bl2x</pattern>
-<pattern>2bl2y</pattern>
-<pattern>2bl2z</pattern>
-<pattern>c2l</pattern>
-<pattern>4cl </pattern>
-<pattern>2cl2b</pattern>
-<pattern>2cl2c</pattern>
-<pattern>2cl2d</pattern>
-<pattern>2cl2f</pattern>
-<pattern>2cl2g</pattern>
-<pattern>2cl2h</pattern>
-<pattern>2cl2j</pattern>
-<pattern>2cl2k</pattern>
-<pattern>2cl2l</pattern>
-<pattern>2cl2m</pattern>
-<pattern>2cl2n</pattern>
-<pattern>2cl2p</pattern>
-<pattern>2cl2q</pattern>
-<pattern>2cl2r</pattern>
-<pattern>2cl2s</pattern>
-<pattern>2cl2t</pattern>
-<pattern>2cl2v</pattern>
-<pattern>2cl2w</pattern>
-<pattern>2cl2x</pattern>
-<pattern>2cl2y</pattern>
-<pattern>2cl2z</pattern>
-<pattern>f2l</pattern>
-<pattern>4fl </pattern>
-<pattern>2fl2b</pattern>
-<pattern>2fl2c</pattern>
-<pattern>2fl2d</pattern>
-<pattern>2fl2f</pattern>
-<pattern>2fl2g</pattern>
-<pattern>2fl2h</pattern>
-<pattern>2fl2j</pattern>
-<pattern>2fl2k</pattern>
-<pattern>2fl2l</pattern>
-<pattern>2fl2m</pattern>
-<pattern>2fl2n</pattern>
-<pattern>2fl2p</pattern>
-<pattern>2fl2q</pattern>
-<pattern>2fl2r</pattern>
-<pattern>2fl2s</pattern>
-<pattern>2fl2t</pattern>
-<pattern>2fl2v</pattern>
-<pattern>2fl2w</pattern>
-<pattern>2fl2x</pattern>
-<pattern>2fl2y</pattern>
-<pattern>2fl2z</pattern>
-<pattern>g2l</pattern>
-<pattern>4gl </pattern>
-<pattern>2gl2b</pattern>
-<pattern>2gl2c</pattern>
-<pattern>2gl2d</pattern>
-<pattern>2gl2f</pattern>
-<pattern>2gl2g</pattern>
-<pattern>2gl2h</pattern>
-<pattern>2gl2j</pattern>
-<pattern>2gl2k</pattern>
-<pattern>2gl2l</pattern>
-<pattern>2gl2m</pattern>
-<pattern>2gl2n</pattern>
-<pattern>2gl2p</pattern>
-<pattern>2gl2q</pattern>
-<pattern>2gl2r</pattern>
-<pattern>2gl2s</pattern>
-<pattern>2gl2t</pattern>
-<pattern>2gl2v</pattern>
-<pattern>2gl2w</pattern>
-<pattern>2gl2x</pattern>
-<pattern>2gl2y</pattern>
-<pattern>2gl2z</pattern>
-<pattern>k2l</pattern>
-<pattern>4kl </pattern>
-<pattern>2kl2b</pattern>
-<pattern>2kl2c</pattern>
-<pattern>2kl2d</pattern>
-<pattern>2kl2f</pattern>
-<pattern>2kl2g</pattern>
-<pattern>2kl2h</pattern>
-<pattern>2kl2j</pattern>
-<pattern>2kl2k</pattern>
-<pattern>2kl2l</pattern>
-<pattern>2kl2m</pattern>
-<pattern>2kl2n</pattern>
-<pattern>2kl2p</pattern>
-<pattern>2kl2q</pattern>
-<pattern>2kl2r</pattern>
-<pattern>2kl2s</pattern>
-<pattern>2kl2t</pattern>
-<pattern>2kl2v</pattern>
-<pattern>2kl2w</pattern>
-<pattern>2kl2x</pattern>
-<pattern>2kl2y</pattern>
-<pattern>2kl2z</pattern>
-<pattern>p2l</pattern>
-<pattern>4pl </pattern>
-<pattern>2pl2b</pattern>
-<pattern>2pl2c</pattern>
-<pattern>2pl2d</pattern>
-<pattern>2pl2f</pattern>
-<pattern>2pl2g</pattern>
-<pattern>2pl2h</pattern>
-<pattern>2pl2j</pattern>
-<pattern>2pl2k</pattern>
-<pattern>2pl2l</pattern>
-<pattern>2pl2m</pattern>
-<pattern>2pl2n</pattern>
-<pattern>2pl2p</pattern>
-<pattern>2pl2q</pattern>
-<pattern>2pl2r</pattern>
-<pattern>2pl2s</pattern>
-<pattern>2pl2t</pattern>
-<pattern>2pl2v</pattern>
-<pattern>2pl2w</pattern>
-<pattern>2pl2x</pattern>
-<pattern>2pl2y</pattern>
-<pattern>2pl2z</pattern>
-<pattern>v2l</pattern>
-<pattern>4vl </pattern>
-<pattern>2vl2b</pattern>
-<pattern>2vl2c</pattern>
-<pattern>2vl2d</pattern>
-<pattern>2vl2f</pattern>
-<pattern>2vl2g</pattern>
-<pattern>2vl2h</pattern>
-<pattern>2vl2j</pattern>
-<pattern>2vl2k</pattern>
-<pattern>2vl2l</pattern>
-<pattern>2vl2m</pattern>
-<pattern>2vl2n</pattern>
-<pattern>2vl2p</pattern>
-<pattern>2vl2q</pattern>
-<pattern>2vl2r</pattern>
-<pattern>2vl2s</pattern>
-<pattern>2vl2t</pattern>
-<pattern>2vl2v</pattern>
-<pattern>2vl2w</pattern>
-<pattern>2vl2x</pattern>
-<pattern>2vl2y</pattern>
-<pattern>2vl2z</pattern>
-<pattern>b2r</pattern>
-<pattern>4br </pattern>
-<pattern>2br2b</pattern>
-<pattern>2br2c</pattern>
-<pattern>2br2d</pattern>
-<pattern>2br2f</pattern>
-<pattern>2br2g</pattern>
-<pattern>2br2h</pattern>
-<pattern>2br2j</pattern>
-<pattern>2br2k</pattern>
-<pattern>2br2l</pattern>
-<pattern>2br2m</pattern>
-<pattern>2br2n</pattern>
-<pattern>2br2p</pattern>
-<pattern>2br2q</pattern>
-<pattern>2br2r</pattern>
-<pattern>2br2s</pattern>
-<pattern>2br2t</pattern>
-<pattern>2br2v</pattern>
-<pattern>2br2w</pattern>
-<pattern>2br2x</pattern>
-<pattern>2br2y</pattern>
-<pattern>2br2z</pattern>
-<pattern>c2r</pattern>
-<pattern>4cr </pattern>
-<pattern>2cr2b</pattern>
-<pattern>2cr2c</pattern>
-<pattern>2cr2d</pattern>
-<pattern>2cr2f</pattern>
-<pattern>2cr2g</pattern>
-<pattern>2cr2h</pattern>
-<pattern>2cr2j</pattern>
-<pattern>2cr2k</pattern>
-<pattern>2cr2l</pattern>
-<pattern>2cr2m</pattern>
-<pattern>2cr2n</pattern>
-<pattern>2cr2p</pattern>
-<pattern>2cr2q</pattern>
-<pattern>2cr2r</pattern>
-<pattern>2cr2s</pattern>
-<pattern>2cr2t</pattern>
-<pattern>2cr2v</pattern>
-<pattern>2cr2w</pattern>
-<pattern>2cr2x</pattern>
-<pattern>2cr2y</pattern>
-<pattern>2cr2z</pattern>
-<pattern>d2r</pattern>
-<pattern>4dr </pattern>
-<pattern>2dr2b</pattern>
-<pattern>2dr2c</pattern>
-<pattern>2dr2d</pattern>
-<pattern>2dr2f</pattern>
-<pattern>2dr2g</pattern>
-<pattern>2dr2h</pattern>
-<pattern>2dr2j</pattern>
-<pattern>2dr2k</pattern>
-<pattern>2dr2l</pattern>
-<pattern>2dr2m</pattern>
-<pattern>2dr2n</pattern>
-<pattern>2dr2p</pattern>
-<pattern>2dr2q</pattern>
-<pattern>2dr2r</pattern>
-<pattern>2dr2s</pattern>
-<pattern>2dr2t</pattern>
-<pattern>2dr2v</pattern>
-<pattern>2dr2w</pattern>
-<pattern>2dr2x</pattern>
-<pattern>2dr2y</pattern>
-<pattern>2dr2z</pattern>
-<pattern>f2r</pattern>
-<pattern>4fr </pattern>
-<pattern>2fr2b</pattern>
-<pattern>2fr2c</pattern>
-<pattern>2fr2d</pattern>
-<pattern>2fr2f</pattern>
-<pattern>2fr2g</pattern>
-<pattern>2fr2h</pattern>
-<pattern>2fr2j</pattern>
-<pattern>2fr2k</pattern>
-<pattern>2fr2l</pattern>
-<pattern>2fr2m</pattern>
-<pattern>2fr2n</pattern>
-<pattern>2fr2p</pattern>
-<pattern>2fr2q</pattern>
-<pattern>2fr2r</pattern>
-<pattern>2fr2s</pattern>
-<pattern>2fr2t</pattern>
-<pattern>2fr2v</pattern>
-<pattern>2fr2w</pattern>
-<pattern>2fr2x</pattern>
-<pattern>2fr2y</pattern>
-<pattern>2fr2z</pattern>
-<pattern>g2r</pattern>
-<pattern>4gr </pattern>
-<pattern>2gr2b</pattern>
-<pattern>2gr2c</pattern>
-<pattern>2gr2d</pattern>
-<pattern>2gr2f</pattern>
-<pattern>2gr2g</pattern>
-<pattern>2gr2h</pattern>
-<pattern>2gr2j</pattern>
-<pattern>2gr2k</pattern>
-<pattern>2gr2l</pattern>
-<pattern>2gr2m</pattern>
-<pattern>2gr2n</pattern>
-<pattern>2gr2p</pattern>
-<pattern>2gr2q</pattern>
-<pattern>2gr2r</pattern>
-<pattern>2gr2s</pattern>
-<pattern>2gr2t</pattern>
-<pattern>2gr2v</pattern>
-<pattern>2gr2w</pattern>
-<pattern>2gr2x</pattern>
-<pattern>2gr2y</pattern>
-<pattern>2gr2z</pattern>
-<pattern>k2r</pattern>
-<pattern>4kr </pattern>
-<pattern>2kr2b</pattern>
-<pattern>2kr2c</pattern>
-<pattern>2kr2d</pattern>
-<pattern>2kr2f</pattern>
-<pattern>2kr2g</pattern>
-<pattern>2kr2h</pattern>
-<pattern>2kr2j</pattern>
-<pattern>2kr2k</pattern>
-<pattern>2kr2l</pattern>
-<pattern>2kr2m</pattern>
-<pattern>2kr2n</pattern>
-<pattern>2kr2p</pattern>
-<pattern>2kr2q</pattern>
-<pattern>2kr2r</pattern>
-<pattern>2kr2s</pattern>
-<pattern>2kr2t</pattern>
-<pattern>2kr2v</pattern>
-<pattern>2kr2w</pattern>
-<pattern>2kr2x</pattern>
-<pattern>2kr2y</pattern>
-<pattern>2kr2z</pattern>
-<pattern>p2r</pattern>
-<pattern>4pr </pattern>
-<pattern>2pr2b</pattern>
-<pattern>2pr2c</pattern>
-<pattern>2pr2d</pattern>
-<pattern>2pr2f</pattern>
-<pattern>2pr2g</pattern>
-<pattern>2pr2h</pattern>
-<pattern>2pr2j</pattern>
-<pattern>2pr2k</pattern>
-<pattern>2pr2l</pattern>
-<pattern>2pr2m</pattern>
-<pattern>2pr2n</pattern>
-<pattern>2pr2p</pattern>
-<pattern>2pr2q</pattern>
-<pattern>2pr2r</pattern>
-<pattern>2pr2s</pattern>
-<pattern>2pr2t</pattern>
-<pattern>2pr2v</pattern>
-<pattern>2pr2w</pattern>
-<pattern>2pr2x</pattern>
-<pattern>2pr2y</pattern>
-<pattern>2pr2z</pattern>
-<pattern>r2r</pattern>
-<pattern>4rr </pattern>
-<pattern>2rr2b</pattern>
-<pattern>2rr2c</pattern>
-<pattern>2rr2d</pattern>
-<pattern>2rr2f</pattern>
-<pattern>2rr2g</pattern>
-<pattern>2rr2h</pattern>
-<pattern>2rr2j</pattern>
-<pattern>2rr2k</pattern>
-<pattern>2rr2l</pattern>
-<pattern>2rr2m</pattern>
-<pattern>2rr2n</pattern>
-<pattern>2rr2p</pattern>
-<pattern>2rr2q</pattern>
-<pattern>2rr2r</pattern>
-<pattern>2rr2s</pattern>
-<pattern>2rr2t</pattern>
-<pattern>2rr2v</pattern>
-<pattern>2rr2w</pattern>
-<pattern>2rr2x</pattern>
-<pattern>2rr2y</pattern>
-<pattern>2rr2z</pattern>
-<pattern>t2r</pattern>
-<pattern>4tr </pattern>
-<pattern>2tr2b</pattern>
-<pattern>2tr2c</pattern>
-<pattern>2tr2d</pattern>
-<pattern>2tr2f</pattern>
-<pattern>2tr2g</pattern>
-<pattern>2tr2h</pattern>
-<pattern>2tr2j</pattern>
-<pattern>2tr2k</pattern>
-<pattern>2tr2l</pattern>
-<pattern>2tr2m</pattern>
-<pattern>2tr2n</pattern>
-<pattern>2tr2p</pattern>
-<pattern>2tr2q</pattern>
-<pattern>2tr2r</pattern>
-<pattern>2tr2s</pattern>
-<pattern>2tr2t</pattern>
-<pattern>2tr2v</pattern>
-<pattern>2tr2w</pattern>
-<pattern>2tr2x</pattern>
-<pattern>2tr2y</pattern>
-<pattern>2tr2z</pattern>
-<pattern>v2r</pattern>
-<pattern>4vr </pattern>
-<pattern>2vr2b</pattern>
-<pattern>2vr2c</pattern>
-<pattern>2vr2d</pattern>
-<pattern>2vr2f</pattern>
-<pattern>2vr2g</pattern>
-<pattern>2vr2h</pattern>
-<pattern>2vr2j</pattern>
-<pattern>2vr2k</pattern>
-<pattern>2vr2l</pattern>
-<pattern>2vr2m</pattern>
-<pattern>2vr2n</pattern>
-<pattern>2vr2p</pattern>
-<pattern>2vr2q</pattern>
-<pattern>2vr2r</pattern>
-<pattern>2vr2s</pattern>
-<pattern>2vr2t</pattern>
-<pattern>2vr2v</pattern>
-<pattern>2vr2w</pattern>
-<pattern>2vr2x</pattern>
-<pattern>2vr2y</pattern>
-<pattern>2vr2z</pattern>
-<pattern>2b3p2t</pattern>
-<pattern>2c3p2t</pattern>
-<pattern>2d3p2t</pattern>
-<pattern>2l3p2t</pattern>
-<pattern>2m3p2t</pattern>
-<pattern>2n3p2t</pattern>
-<pattern>2r3p2t</pattern>
-<pattern>2s3p2t</pattern>
-<pattern>2t3p2t</pattern>
-<pattern>2x3p2t</pattern>
-<pattern>2y3p2t</pattern>
-<pattern>4pt </pattern>
-<pattern>2b3c2t</pattern>
-<pattern>2c3c2t</pattern>
-<pattern>2d3c2t</pattern>
-<pattern>2l3c2t</pattern>
-<pattern>2m3c2t</pattern>
-<pattern>2n3c2t</pattern>
-<pattern>2r3c2t</pattern>
-<pattern>2s3c2t</pattern>
-<pattern>2t3c2t</pattern>
-<pattern>2x3c2t</pattern>
-<pattern>2y3c2t</pattern>
-<pattern>4ct </pattern>
-<pattern>2b3c2n</pattern>
-<pattern>2c3c2n</pattern>
-<pattern>2d3c2n</pattern>
-<pattern>2l3c2n</pattern>
-<pattern>2m3c2n</pattern>
-<pattern>2n3c2n</pattern>
-<pattern>2r3c2n</pattern>
-<pattern>2s3c2n</pattern>
-<pattern>2t3c2n</pattern>
-<pattern>2x3c2n</pattern>
-<pattern>2y3c2n</pattern>
-<pattern>4cn </pattern>
-<pattern>2b3p2s</pattern>
-<pattern>2c3p2s</pattern>
-<pattern>2d3p2s</pattern>
-<pattern>2l3p2s</pattern>
-<pattern>2m3p2s</pattern>
-<pattern>2n3p2s</pattern>
-<pattern>2r3p2s</pattern>
-<pattern>2s3p2s</pattern>
-<pattern>2t3p2s</pattern>
-<pattern>2x3p2s</pattern>
-<pattern>2y3p2s</pattern>
-<pattern>4ps </pattern>
-<pattern>2b3m2n</pattern>
-<pattern>2c3m2n</pattern>
-<pattern>2d3m2n</pattern>
-<pattern>2l3m2n</pattern>
-<pattern>2m3m2n</pattern>
-<pattern>2n3m2n</pattern>
-<pattern>2r3m2n</pattern>
-<pattern>2s3m2n</pattern>
-<pattern>2t3m2n</pattern>
-<pattern>2x3m2n</pattern>
-<pattern>2y3m2n</pattern>
-<pattern>4mn </pattern>
-<pattern>2b3g2n</pattern>
-<pattern>2c3g2n</pattern>
-<pattern>2d3g2n</pattern>
-<pattern>2l3g2n</pattern>
-<pattern>2m3g2n</pattern>
-<pattern>2n3g2n</pattern>
-<pattern>2r3g2n</pattern>
-<pattern>2s3g2n</pattern>
-<pattern>2t3g2n</pattern>
-<pattern>2x3g2n</pattern>
-<pattern>2y3g2n</pattern>
-<pattern>4gn </pattern>
-<pattern>2b3f2t</pattern>
-<pattern>2c3f2t</pattern>
-<pattern>2d3f2t</pattern>
-<pattern>2l3f2t</pattern>
-<pattern>2m3f2t</pattern>
-<pattern>2n3f2t</pattern>
-<pattern>2r3f2t</pattern>
-<pattern>2s3f2t</pattern>
-<pattern>2t3f2t</pattern>
-<pattern>2x3f2t</pattern>
-<pattern>2y3f2t</pattern>
-<pattern>4ft </pattern>
-<pattern>2b3p2n</pattern>
-<pattern>2c3p2n</pattern>
-<pattern>2d3p2n</pattern>
-<pattern>2l3p2n</pattern>
-<pattern>2m3p2n</pattern>
-<pattern>2n3p2n</pattern>
-<pattern>2r3p2n</pattern>
-<pattern>2s3p2n</pattern>
-<pattern>2t3p2n</pattern>
-<pattern>2x3p2n</pattern>
-<pattern>2y3p2n</pattern>
-<pattern>4pn </pattern>
-<pattern>2b3c2z</pattern>
-<pattern>2c3c2z</pattern>
-<pattern>2d3c2z</pattern>
-<pattern>2l3c2z</pattern>
-<pattern>2m3c2z</pattern>
-<pattern>2n3c2z</pattern>
-<pattern>2r3c2z</pattern>
-<pattern>2s3c2z</pattern>
-<pattern>2t3c2z</pattern>
-<pattern>2x3c2z</pattern>
-<pattern>2y3c2z</pattern>
-<pattern>4cz </pattern>
-<pattern>2b3t2z</pattern>
-<pattern>2c3t2z</pattern>
-<pattern>2d3t2z</pattern>
-<pattern>2l3t2z</pattern>
-<pattern>2m3t2z</pattern>
-<pattern>2n3t2z</pattern>
-<pattern>2r3t2z</pattern>
-<pattern>2s3t2z</pattern>
-<pattern>2t3t2z</pattern>
-<pattern>2x3t2z</pattern>
-<pattern>2y3t2z</pattern>
-<pattern>4tz </pattern>
-<pattern>2b3t2s</pattern>
-<pattern>2c3t2s</pattern>
-<pattern>2d3t2s</pattern>
-<pattern>2l3t2s</pattern>
-<pattern>2m3t2s</pattern>
-<pattern>2n3t2s</pattern>
-<pattern>2r3t2s</pattern>
-<pattern>2s3t2s</pattern>
-<pattern>2t3t2s</pattern>
-<pattern>2x3t2s</pattern>
-<pattern>2y3t2s</pattern>
-<pattern>4ts </pattern>
-<pattern>san4c5t</pattern>
-<pattern>plan4c5t</pattern>
-<pattern>2no </pattern>
-<pattern>2t2l</pattern>
-<pattern>4caca4</pattern>
-<pattern>4cago4</pattern>
-<pattern>4caga4</pattern>
-<pattern>4cagas </pattern>
-<pattern>4teta </pattern>
-<pattern>4tetas </pattern>
-<pattern>4puta4</pattern>
-<pattern>4puto4</pattern>
-<pattern> hu4mea</pattern>
-<pattern> hu4meo</pattern>
-<pattern> he4mee</pattern>
-<pattern>4meo </pattern>
-<pattern>4meable </pattern>
-<pattern>4meables </pattern>
-<pattern>4pedo4</pattern>
-<pattern>4culo4</pattern>
-<pattern>3mente </pattern>
-<pattern>4i3go </pattern>
-<pattern>4es </pattern>
-<pattern>4és</pattern>
-<pattern>4e </pattern>
-<pattern>4e3mos </pattern>
-<pattern>4éis </pattern>
-<pattern>4en </pattern>
-<pattern>4ía </pattern>
-<pattern>4ías </pattern>
-<pattern>4ía3mos </pattern>
-<pattern>4íais </pattern>
-<pattern>4ían </pattern>
-<pattern>4í </pattern>
-<pattern>4í4s3te </pattern>
-<pattern>4í4s3tes </pattern>
-<pattern>4í3tes </pattern>
-<pattern>4í3mos </pattern>
-<pattern>4ís3teis </pattern>
-<pattern>4e3ré </pattern>
-<pattern>4e3rás </pattern>
-<pattern>4e3rés </pattern>
-<pattern>4e3rís </pattern>
-<pattern>4e3rá </pattern>
-<pattern>4e3re3mos </pattern>
-<pattern>4e3réis </pattern>
-<pattern>4e3rán </pattern>
-<pattern>4i3ga </pattern>
-<pattern>4i3gas </pattern>
-<pattern>4i3gás </pattern>
-<pattern>4i3gamos </pattern>
-<pattern>4i3gáis </pattern>
-<pattern>4a4i3gan </pattern>
-<pattern>4e3ría </pattern>
-<pattern>4e3rías </pattern>
-<pattern>4e3ríamos </pattern>
-<pattern>4e3ríais </pattern>
-<pattern>4e3rían </pattern>
-<pattern>4i3gá3mosme </pattern>
-<pattern>4i3gá3mosmele </pattern>
-<pattern>4i3gá3mosmelo </pattern>
-<pattern>4i3gá3mos3mela </pattern>
-<pattern>4i3gá3mosmeles </pattern>
-<pattern>4i3gá3mosmelos </pattern>
-<pattern>4i3gá3mos3melas </pattern>
-<pattern>4i3gá3moste </pattern>
-<pattern>4i3gá3mostele </pattern>
-<pattern>4i3gá3mostelo </pattern>
-<pattern>4i3gá3mos3tela </pattern>
-<pattern>4i3gá3mosteles </pattern>
-<pattern>4i3gá3mostelos </pattern>
-<pattern>4i3gá3mos3telas </pattern>
-<pattern>4i3gá3mosle </pattern>
-<pattern>4i3gá3mosla </pattern>
-<pattern>4i3gá3moslo </pattern>
-<pattern>4i3gá3mosele </pattern>
-<pattern>4i3gá3moselo </pattern>
-<pattern>4i3gá3mosela </pattern>
-<pattern>4i3gá3moseles </pattern>
-<pattern>4i3gá3moselos </pattern>
-<pattern>4i3gá3moselas </pattern>
-<pattern>4i3gá3monos </pattern>
-<pattern>4i3gá3monosle </pattern>
-<pattern>4i3gá3monoslo </pattern>
-<pattern>4i3gá3monosla </pattern>
-<pattern>4i3gá3monosles </pattern>
-<pattern>4i3gá3monoslos </pattern>
-<pattern>4i3gá3monoslas </pattern>
-<pattern>4i3gá3moos </pattern>
-<pattern>4i3gá3moosle </pattern>
-<pattern>4i3gá3mooslo </pattern>
-<pattern>4i3gá3moosla </pattern>
-<pattern>4i3gá3moosles </pattern>
-<pattern>4i3gá3mooslos </pattern>
-<pattern>4i3gá3mooslas </pattern>
-<pattern>4i3gá3mosles </pattern>
-<pattern>4i3gá3moslas </pattern>
-<pattern>4i3gá3moslos </pattern>
-<pattern>4ed </pattern>
-<pattern>4é </pattern>
-<pattern>4edme </pattern>
-<pattern>4édmele </pattern>
-<pattern>4édmelo </pattern>
-<pattern>4éd3mela </pattern>
-<pattern>4édmeles </pattern>
-<pattern>4édmelos </pattern>
-<pattern>4éd3melas </pattern>
-<pattern>4edte </pattern>
-<pattern>4édtele </pattern>
-<pattern>4édtelo </pattern>
-<pattern>4éd3tela </pattern>
-<pattern>4édteles </pattern>
-<pattern>4édtelos </pattern>
-<pattern>4éd3telas </pattern>
-<pattern>4edle </pattern>
-<pattern>4eedla </pattern>
-<pattern>4edlo </pattern>
-<pattern>4édsele </pattern>
-<pattern>4édselo </pattern>
-<pattern>4édsela </pattern>
-<pattern>4édseles </pattern>
-<pattern>4édselos </pattern>
-<pattern>4édselas </pattern>
-<pattern>4ednos </pattern>
-<pattern>4édnosle </pattern>
-<pattern>4édnoslo </pattern>
-<pattern>4édnosla </pattern>
-<pattern>4édnosles </pattern>
-<pattern>4édnoslos </pattern>
-<pattern>4édnoslas </pattern>
-<pattern>4eos </pattern>
-<pattern>4éosle </pattern>
-<pattern>4éoslo </pattern>
-<pattern>4éosla </pattern>
-<pattern>4éosles </pattern>
-<pattern>4éoslos </pattern>
-<pattern>4éoslas </pattern>
-<pattern>4edles </pattern>
-<pattern>4edlas </pattern>
-<pattern>4edlos </pattern>
-<pattern>4er </pattern>
-<pattern>4erme </pattern>
-<pattern>4érmele </pattern>
-<pattern>4érmelo </pattern>
-<pattern>4ér3mela </pattern>
-<pattern>4érmeles </pattern>
-<pattern>4érmelos </pattern>
-<pattern>4ér3melas </pattern>
-<pattern>4erte </pattern>
-<pattern>4értele </pattern>
-<pattern>4értelo </pattern>
-<pattern>4ér3tela </pattern>
-<pattern>4érteles </pattern>
-<pattern>4értelos </pattern>
-<pattern>4ér3telas </pattern>
-<pattern>4erle </pattern>
-<pattern>4erla </pattern>
-<pattern>4erlo </pattern>
-<pattern>4erse </pattern>
-<pattern>4érsele </pattern>
-<pattern>4érselo </pattern>
-<pattern>4érsela </pattern>
-<pattern>4érseles </pattern>
-<pattern>4érselos </pattern>
-<pattern>4érselas </pattern>
-<pattern>4ernos </pattern>
-<pattern>4érnosle </pattern>
-<pattern>4érnoslo </pattern>
-<pattern>4érnosla </pattern>
-<pattern>4érnosles </pattern>
-<pattern>4érnoslos </pattern>
-<pattern>4érnoslas </pattern>
-<pattern>4e3ros </pattern>
-<pattern>4é3rosle </pattern>
-<pattern>4é3roslo </pattern>
-<pattern>4é3rosla </pattern>
-<pattern>4é3rosles </pattern>
-<pattern>4é3roslos </pattern>
-<pattern>4é3roslas </pattern>
-<pattern>4erles </pattern>
-<pattern>4erlas </pattern>
-<pattern>4erlos </pattern>
-<pattern>4í3do </pattern>
-<pattern>4í3da </pattern>
-<pattern>4í3dos </pattern>
-<pattern>4í3das </pattern>
-<pattern>4o </pattern>
-<pattern>4as </pattern>
-<pattern>4a </pattern>
-<pattern>4ás </pattern>
-<pattern>4a3mos </pattern>
-<pattern>4áis </pattern>
-<pattern>4an </pattern>
-<pattern>4aste </pattern>
-<pattern>4astes </pattern>
-<pattern>4ó </pattern>
-<pattern>4ates </pattern>
-<pattern>4asteis </pattern>
-<pattern>4a3ron </pattern>
-<pattern>4a3ba </pattern>
-<pattern>4a3bas </pattern>
-<pattern>4á3bamos </pattern>
-<pattern>4a3bais </pattern>
-<pattern>4a3ban </pattern>
-<pattern>4a3ría </pattern>
-<pattern>4a3rías </pattern>
-<pattern>4a3ríamos </pattern>
-<pattern>4a3ríais</pattern>
-<pattern>4a3rían </pattern>
-<pattern>4a3ré </pattern>
-<pattern>4a3rás </pattern>
-<pattern>4a3rés </pattern>
-<pattern>4a3rís </pattern>
-<pattern>4a3rá </pattern>
-<pattern>4a3remos </pattern>
-<pattern>4a3réis </pattern>
-<pattern>4a3rán </pattern>
-<pattern>4a3ra </pattern>
-<pattern>4a3ras </pattern>
-<pattern>4á3ramos </pattern>
-<pattern>4a3rais </pattern>
-<pattern>4a3ran </pattern>
-<pattern>4a3re </pattern>
-<pattern>4a3res </pattern>
-<pattern>4á3remos </pattern>
-<pattern>4a3reis </pattern>
-<pattern>4a3ren </pattern>
-<pattern>4a3se </pattern>
-<pattern>4a3ses </pattern>
-<pattern>4á3semos </pattern>
-<pattern>4a3seis </pattern>
-<pattern>4a3sen </pattern>
-<pattern>4ad </pattern>
-<pattern>e5r4as </pattern>
-<pattern>e5r4a3mos </pattern>
-<pattern>e5r4áis </pattern>
-<pattern>e5r4an </pattern>
-<pattern>e5r4aste </pattern>
-<pattern>e5r4astes </pattern>
-<pattern>e5r4ates </pattern>
-<pattern>e5r4asteis </pattern>
-<pattern>e5r4a3ron </pattern>
-<pattern>e5r4a3ba </pattern>
-<pattern>e5r4a3bas </pattern>
-<pattern>e5r4á3bamos </pattern>
-<pattern>e5r4a3bais </pattern>
-<pattern>e5r4a3ban </pattern>
-<pattern>e5r4a3ría </pattern>
-<pattern>e5r4a3rías </pattern>
-<pattern>e5r4a3ríamos </pattern>
-<pattern>e5r4a3ríais</pattern>
-<pattern>e5r4a3rían </pattern>
-<pattern>e5r4a3ré </pattern>
-<pattern>e5r4a3rás </pattern>
-<pattern>e5r4a3rés </pattern>
-<pattern>e5r4a3rís </pattern>
-<pattern>e5r4a3rá </pattern>
-<pattern>e5r4a3remos </pattern>
-<pattern>e5r4a3réis </pattern>
-<pattern>e5r4a3rán </pattern>
-<pattern>e5r4a3ra </pattern>
-<pattern>e5r4a3ras </pattern>
-<pattern>e5r4á3ramos </pattern>
-<pattern>e5r4a3rais </pattern>
-<pattern>e5r4a3ran </pattern>
-<pattern>e5r4a3re </pattern>
-<pattern>e5r4a3res </pattern>
-<pattern>e5r4á3remos </pattern>
-<pattern>e5r4a3reis </pattern>
-<pattern>e5r4a3ren </pattern>
-<pattern>e5r4a3se </pattern>
-<pattern>e5r4a3ses </pattern>
-<pattern>e5r4á3semos </pattern>
-<pattern>e5r4a3seis </pattern>
-<pattern>e5r4a3sen </pattern>
-<pattern>e5r4ad </pattern>
-<pattern>4adme </pattern>
-<pattern>4ádmele </pattern>
-<pattern>4ádmelo </pattern>
-<pattern>4ád3mela </pattern>
-<pattern>4ádmeles </pattern>
-<pattern>4ádmelos </pattern>
-<pattern>4ád3melas </pattern>
-<pattern>4adte </pattern>
-<pattern>4ádtele </pattern>
-<pattern>4ádtelo </pattern>
-<pattern>4ád3tela </pattern>
-<pattern>4ádteles </pattern>
-<pattern>4ádtelos </pattern>
-<pattern>4ád3telas </pattern>
-<pattern>4adle </pattern>
-<pattern>4eadla </pattern>
-<pattern>4adlo </pattern>
-<pattern>4ádsele </pattern>
-<pattern>4ádselo </pattern>
-<pattern>4ádsela </pattern>
-<pattern>4ádseles </pattern>
-<pattern>4ádselos </pattern>
-<pattern>4ádselas </pattern>
-<pattern>4adnos </pattern>
-<pattern>4ádnosle </pattern>
-<pattern>4ádnoslo </pattern>
-<pattern>4ádnosla </pattern>
-<pattern>4ádnosles </pattern>
-<pattern>4ádnoslos </pattern>
-<pattern>4ádnoslas </pattern>
-<pattern>4aos </pattern>
-<pattern>4áosle </pattern>
-<pattern>4áoslo </pattern>
-<pattern>4áosla </pattern>
-<pattern>4áosles </pattern>
-<pattern>4áoslos </pattern>
-<pattern>4áoslas </pattern>
-<pattern>4adles </pattern>
-<pattern>4adlas </pattern>
-<pattern>4adlos </pattern>
-<pattern>4ar </pattern>
-<pattern>4a4rme </pattern>
-<pattern>4á4rmele </pattern>
-<pattern>4á4rmelo </pattern>
-<pattern>4á4r3mela </pattern>
-<pattern>4á4r3meles </pattern>
-<pattern>4á4r3melos </pattern>
-<pattern>4á4r3melas </pattern>
-<pattern>4a4r3te </pattern>
-<pattern>4á4r3tele </pattern>
-<pattern>4á4r3telo </pattern>
-<pattern>4á4r3tela </pattern>
-<pattern>4á4r3teles </pattern>
-<pattern>4á4r3telos </pattern>
-<pattern>4á4r3telas </pattern>
-<pattern>4a4r3le </pattern>
-<pattern>4a4r3la </pattern>
-<pattern>4a4r3lo </pattern>
-<pattern>4a4r3se </pattern>
-<pattern>4á4r3sele </pattern>
-<pattern>4á4r3selo </pattern>
-<pattern>4á4r3sela </pattern>
-<pattern>4á4r3seles </pattern>
-<pattern>4á4r3selos </pattern>
-<pattern>4á4r3selas </pattern>
-<pattern>4a4r3nos </pattern>
-<pattern>4á4r3nosle </pattern>
-<pattern>4á4r3noslo </pattern>
-<pattern>4á4r3nosla </pattern>
-<pattern>4á4r3nosles </pattern>
-<pattern>4á4r3noslos </pattern>
-<pattern>4á4r3noslas </pattern>
-<pattern>4a3ros </pattern>
-<pattern>4árosle </pattern>
-<pattern>4ároslo </pattern>
-<pattern>4árosla </pattern>
-<pattern>4árosles </pattern>
-<pattern>4ároslos </pattern>
-<pattern>4ároslas </pattern>
-<pattern>4a4r3les </pattern>
-<pattern>4a4r3las </pattern>
-<pattern>4a4r3los </pattern>
-<pattern>4a3do </pattern>
-<pattern>4a3da </pattern>
-<pattern>4a3dos </pattern>
-<pattern>4a3das </pattern>
-<pattern>e5r4a3do </pattern>
-<pattern>e5r4a3da </pattern>
-<pattern>e5r4a3dos </pattern>
-<pattern>e5r4a3das </pattern>
-<pattern>4ando</pattern>
-<pattern>4ándole </pattern>
-<pattern>4ándolo </pattern>
-<pattern>4ándola </pattern>
-<pattern>4ándoles </pattern>
-<pattern>4ándolos </pattern>
-<pattern>4ándolas </pattern>
-<pattern>4ándonos </pattern>
-<pattern>4ándoos </pattern>
-<pattern>4ándome </pattern>
-<pattern>4ándomelo </pattern>
-<pattern>4ándomela </pattern>
-<pattern>4ándomele </pattern>
-<pattern>4ándomelos </pattern>
-<pattern>4ándomelas </pattern>
-<pattern>4ándomeles </pattern>
-<pattern>4ándote </pattern>
-<pattern>4ándoteme </pattern>
-<pattern>4ándotelo </pattern>
-<pattern>4ándotela </pattern>
-<pattern>4ándotele </pattern>
-<pattern>4ándotelos </pattern>
-<pattern>4ándotelas </pattern>
-<pattern>4ándoteles </pattern>
-<pattern>4ándotenos </pattern>
-<pattern>4ándose </pattern>
-<pattern>4ándoseme </pattern>
-<pattern>4ándoselo </pattern>
-<pattern>4ándosela </pattern>
-<pattern>4ándosele </pattern>
-<pattern>4ándoselos </pattern>
-<pattern>4ándoselas </pattern>
-<pattern>4ándoseles </pattern>
-<pattern>4ándosenos </pattern>
-<pattern>4a3dor </pattern>
-<pattern>4a3dora </pattern>
-<pattern>4a3dores </pattern>
-<pattern>4a3doras </pattern>
-<pattern>e5r4a3dor </pattern>
-<pattern>e5r4a3dora </pattern>
-<pattern>e5r4a3dores </pattern>
-<pattern>e5r4a3doras </pattern>
-<pattern>acto1h</pattern>
-<pattern>acto1a2</pattern>
-<pattern>acto1e2</pattern>
-<pattern>acto1i2</pattern>
-<pattern>acto1o2</pattern>
-<pattern>acto1u2</pattern>
-<pattern>acto1á2</pattern>
-<pattern>acto1é2</pattern>
-<pattern>acto1í2</pattern>
-<pattern>acto1ó2</pattern>
-<pattern>acto1ú2</pattern>
-<pattern>afro1h</pattern>
-<pattern>afro1a2</pattern>
-<pattern>afro1e2</pattern>
-<pattern>afro1i2</pattern>
-<pattern>afro1o2</pattern>
-<pattern>afro1u2</pattern>
-<pattern>afro1á2</pattern>
-<pattern>afro1é2</pattern>
-<pattern>afro1í2</pattern>
-<pattern>afro1ó2</pattern>
-<pattern>afro1ú2</pattern>
-<pattern> a2</pattern>
-<pattern> an2a2</pattern>
-<pattern> an2e2</pattern>
-<pattern> an2i2</pattern>
-<pattern> an2o2</pattern>
-<pattern> an2u2</pattern>
-<pattern> an2á2</pattern>
-<pattern> an2é2</pattern>
-<pattern> an2í2</pattern>
-<pattern> an2ó2</pattern>
-<pattern> an2ú2 </pattern>
-<pattern>ana3lí</pattern>
-<pattern> aná3li</pattern>
-<pattern> ana3li</pattern>
-<pattern> an3aero</pattern>
-<pattern> an3e2pigr</pattern>
-<pattern> ane3xa</pattern>
-<pattern> ane3xá</pattern>
-<pattern> ane3xe</pattern>
-<pattern> ane3xé</pattern>
-<pattern> ane3xio</pattern>
-<pattern> ane3xió</pattern>
-<pattern> an3h</pattern>
-<pattern> ani3mad</pattern>
-<pattern> ani3mád</pattern>
-<pattern> ani3dar</pattern>
-<pattern> ani3ll</pattern>
-<pattern> ani3m</pattern>
-<pattern> aniña</pattern>
-<pattern> ani3q</pattern>
-<pattern> an3i2so</pattern>
-<pattern> an3i2só</pattern>
-<pattern> ani3vel</pattern>
-<pattern> ano5che</pattern>
-<pattern> ano5din</pattern>
-<pattern> ano5mal</pattern>
-<pattern> ano5nad</pattern>
-<pattern> anó3nim</pattern>
-<pattern> anó5mal</pattern>
-<pattern> ano5nim</pattern>
-<pattern> ano5ta</pattern>
-<pattern> ano3tá</pattern>
-<pattern> anua3l</pattern>
-<pattern> anua4lm</pattern>
-<pattern> anu3bl</pattern>
-<pattern> anu3da</pattern>
-<pattern> anu3l</pattern>
-<pattern>asu3b2</pattern>
-<pattern>aero1h</pattern>
-<pattern>aero1a2</pattern>
-<pattern>aero1e2</pattern>
-<pattern>aero1i2</pattern>
-<pattern>aero1o2</pattern>
-<pattern>aero1u2</pattern>
-<pattern>aero1á2</pattern>
-<pattern>aero1é2</pattern>
-<pattern>aero1í2</pattern>
-<pattern>aero1ó2</pattern>
-<pattern>aero1ú2</pattern>
-<pattern>anfi1h</pattern>
-<pattern>anfi1a2</pattern>
-<pattern>anfi1e2</pattern>
-<pattern>anfi1i2</pattern>
-<pattern>anfi1o2</pattern>
-<pattern>anfi1u2</pattern>
-<pattern>anfi1á2</pattern>
-<pattern>anfi1é2</pattern>
-<pattern>anfi1í2</pattern>
-<pattern>anfi1ó2</pattern>
-<pattern>anfi1ú2</pattern>
-<pattern>anglo1h</pattern>
-<pattern>anglo1a2</pattern>
-<pattern>anglo1e2</pattern>
-<pattern>anglo1i2</pattern>
-<pattern>anglo1o2</pattern>
-<pattern>anglo1u2</pattern>
-<pattern>anglo1á2</pattern>
-<pattern>anglo1é2</pattern>
-<pattern>anglo1í2</pattern>
-<pattern>anglo1ó2</pattern>
-<pattern>anglo1ú2</pattern>
-<pattern>ante1h</pattern>
-<pattern>ante1a2</pattern>
-<pattern>ante1e2</pattern>
-<pattern>ante1i2</pattern>
-<pattern>ante1o2</pattern>
-<pattern>ante1u2</pattern>
-<pattern>ante1á2</pattern>
-<pattern>ante1é2</pattern>
-<pattern>ante1í2</pattern>
-<pattern>ante1ó2</pattern>
-<pattern>ante1ú2</pattern>
-<pattern> ante2o3je</pattern>
-<pattern>acante2</pattern>
-<pattern>4ísmo </pattern>
-<pattern>4ísmos </pattern>
-<pattern>4ísta </pattern>
-<pattern>4ístas </pattern>
-<pattern>4ístico </pattern>
-<pattern>4ísticos </pattern>
-<pattern>4ística </pattern>
-<pattern>4ísticas </pattern>
-<pattern>t4eo3nes </pattern>
-<pattern>mante4a</pattern>
-<pattern>e4a3miento</pattern>
-<pattern> anti1h</pattern>
-<pattern> anti1a2</pattern>
-<pattern> anti1e2</pattern>
-<pattern> anti1i2</pattern>
-<pattern> anti1o2</pattern>
-<pattern> anti1u2</pattern>
-<pattern> anti1á2</pattern>
-<pattern> anti1é2</pattern>
-<pattern> anti1í2</pattern>
-<pattern> anti1ó2</pattern>
-<pattern> anti1ú2</pattern>
-<pattern>ti2o3qu</pattern>
-<pattern>ti2o3co</pattern>
-<pattern>archi1h</pattern>
-<pattern>archi1a2</pattern>
-<pattern>archi1e2</pattern>
-<pattern>archi1i2</pattern>
-<pattern>archi1o2</pattern>
-<pattern>archi1u2</pattern>
-<pattern>archi1á2</pattern>
-<pattern>archi1é2</pattern>
-<pattern>archi1í2</pattern>
-<pattern>archi1ó2</pattern>
-<pattern>archi1ú2</pattern>
-<pattern>auto1h</pattern>
-<pattern>auto1a2</pattern>
-<pattern>auto1e2</pattern>
-<pattern>auto1i2</pattern>
-<pattern>auto1o2</pattern>
-<pattern>auto1u2</pattern>
-<pattern>auto1á2</pattern>
-<pattern>auto1é2</pattern>
-<pattern>auto1í2</pattern>
-<pattern>auto1ó2</pattern>
-<pattern>auto1ú2</pattern>
-<pattern>biblio1h</pattern>
-<pattern>biblio1a2</pattern>
-<pattern>biblio1e2</pattern>
-<pattern>biblio1i2</pattern>
-<pattern>biblio1o2</pattern>
-<pattern>biblio1u2</pattern>
-<pattern>biblio1á2</pattern>
-<pattern>biblio1é2</pattern>
-<pattern>biblio1í2</pattern>
-<pattern>biblio1ó2</pattern>
-<pattern>biblio1ú2</pattern>
-<pattern>bio1h</pattern>
-<pattern>bio1a2</pattern>
-<pattern>bio1e2</pattern>
-<pattern>bio1i2</pattern>
-<pattern>bio1o2</pattern>
-<pattern>bio1u2</pattern>
-<pattern>bio1á2</pattern>
-<pattern>bio1é2</pattern>
-<pattern>bio1í2</pattern>
-<pattern>bio1ó2</pattern>
-<pattern>bio1ú2</pattern>
-<pattern>bi1u2ní</pattern>
-<pattern>cardio1h</pattern>
-<pattern>cardio1a2</pattern>
-<pattern>cardio1e2</pattern>
-<pattern>cardio1i2</pattern>
-<pattern>cardio1o2</pattern>
-<pattern>cardio1u2</pattern>
-<pattern>cardio1á2</pattern>
-<pattern>cardio1é2</pattern>
-<pattern>cardio1í2</pattern>
-<pattern>cardio1ó2</pattern>
-<pattern>cardio1ú2</pattern>
-<pattern>cefalo1h</pattern>
-<pattern>cefalo1a2</pattern>
-<pattern>cefalo1e2</pattern>
-<pattern>cefalo1i2</pattern>
-<pattern>cefalo1o2</pattern>
-<pattern>cefalo1u2</pattern>
-<pattern>cefalo1á2</pattern>
-<pattern>cefalo1é2</pattern>
-<pattern>cefalo1í2</pattern>
-<pattern>cefalo1ó2</pattern>
-<pattern>cefalo1ú2</pattern>
-<pattern>centi1h</pattern>
-<pattern>centi1a2</pattern>
-<pattern>centi1e2</pattern>
-<pattern>centi1i2</pattern>
-<pattern>centi1o2</pattern>
-<pattern>centi1u2</pattern>
-<pattern>centi1á2</pattern>
-<pattern>centi1é2</pattern>
-<pattern>centi1í2</pattern>
-<pattern>centi1ó2</pattern>
-<pattern>centi1ú2</pattern>
-<pattern>centi5área</pattern>
-<pattern>ciclo1h</pattern>
-<pattern>ciclo1a2</pattern>
-<pattern>ciclo1e2</pattern>
-<pattern>ciclo1i2</pattern>
-<pattern>ciclo1o2</pattern>
-<pattern>ciclo1u2</pattern>
-<pattern>ciclo1á2</pattern>
-<pattern>ciclo1é2</pattern>
-<pattern>ciclo1í2</pattern>
-<pattern>ciclo1ó2</pattern>
-<pattern>ciclo1ú2</pattern>
-<pattern>o4i3dea </pattern>
-<pattern>o4i3deas </pattern>
-<pattern>o4i3dal </pattern>
-<pattern>o4i3dales </pattern>
-<pattern>4o2i3de </pattern>
-<pattern>4o2i3des </pattern>
-<pattern>4i2dal </pattern>
-<pattern>4i2dales </pattern>
-<pattern>4i3deo </pattern>
-<pattern>4i3deos </pattern>
-<pattern>cito1h</pattern>
-<pattern>cito1a2</pattern>
-<pattern>cito1e2</pattern>
-<pattern>cito1i2</pattern>
-<pattern>cito1o2</pattern>
-<pattern>cito1u2</pattern>
-<pattern>cito1á2</pattern>
-<pattern>cito1é2</pattern>
-<pattern>cito1í2</pattern>
-<pattern>cito1ó2</pattern>
-<pattern>cito1ú2</pattern>
-<pattern>3c2neor</pattern>
-<pattern>cnico1h</pattern>
-<pattern>cnico1a2</pattern>
-<pattern>cnico1e2</pattern>
-<pattern>cnico1i2</pattern>
-<pattern>cnico1o2</pattern>
-<pattern>cnico1u2</pattern>
-<pattern>cnico1á2</pattern>
-<pattern>cnico1é2</pattern>
-<pattern>cnico1í2</pattern>
-<pattern>cnico1ó2</pattern>
-<pattern>cnico1ú2</pattern>
-<pattern> co2a2</pattern>
-<pattern> co2e2</pattern>
-<pattern> co2i2</pattern>
-<pattern> co3o4</pattern>
-<pattern> co2u2</pattern>
-<pattern> co2á2</pattern>
-<pattern> co2é2</pattern>
-<pattern> co2í2</pattern>
-<pattern> co2ó2</pattern>
-<pattern> co2ú2</pattern>
-<pattern>co4á3gul</pattern>
-<pattern>co4acci</pattern>
-<pattern>co4acti</pattern>
-<pattern>co4adju</pattern>
-<pattern>co4a3dun</pattern>
-<pattern>co4adyu</pattern>
-<pattern>co3agen</pattern>
-<pattern>co4a3gul</pattern>
-<pattern>co4a3lic</pattern>
-<pattern>co4aptac</pattern>
-<pattern>co4art</pattern>
-<pattern>co4árt</pattern>
-<pattern>co4e3fic</pattern>
-<pattern>co4erc</pattern>
-<pattern>co4erz</pattern>
-<pattern>co4e3tá</pattern>
-<pattern>co3exis</pattern>
-<pattern>co4imbr</pattern>
-<pattern>co4inci</pattern>
-<pattern>co4i3to</pattern>
-<pattern>co3n4imbri</pattern>
-<pattern>co4o3per</pattern>
-<pattern>co4o3pér</pattern>
-<pattern>co4opt</pattern>
-<pattern>co4ord</pattern>
-<pattern>con1imbr</pattern>
-<pattern>con1urb</pattern>
-<pattern>cripto1h</pattern>
-<pattern>cripto1a2</pattern>
-<pattern>cripto1e2</pattern>
-<pattern>cripto1i2</pattern>
-<pattern>cripto1o2</pattern>
-<pattern>cripto1u2</pattern>
-<pattern>cripto1á2</pattern>
-<pattern>cripto1é2</pattern>
-<pattern>cripto1í2</pattern>
-<pattern>cripto1ó2</pattern>
-<pattern>cripto1ú2</pattern>
-<pattern>crono1h</pattern>
-<pattern>crono1a2</pattern>
-<pattern>crono1e2</pattern>
-<pattern>crono1i2</pattern>
-<pattern>crono1o2</pattern>
-<pattern>crono1u2</pattern>
-<pattern>crono1á2</pattern>
-<pattern>crono1é2</pattern>
-<pattern>crono1í2</pattern>
-<pattern>crono1ó2</pattern>
-<pattern>crono1ú2</pattern>
-<pattern>contra1h</pattern>
-<pattern>contra1a2</pattern>
-<pattern>contra1e2</pattern>
-<pattern>contra1i2</pattern>
-<pattern>contra1o2</pattern>
-<pattern>contra1u2</pattern>
-<pattern>contra1á2</pattern>
-<pattern>contra1é2</pattern>
-<pattern>contra1í2</pattern>
-<pattern>contra1ó2</pattern>
-<pattern>contra1ú2</pattern>
-<pattern>deca1h</pattern>
-<pattern>deca1a2</pattern>
-<pattern>deca1e2</pattern>
-<pattern>deca1i2</pattern>
-<pattern>deca1o2</pattern>
-<pattern>deca1u2</pattern>
-<pattern>deca1á2</pattern>
-<pattern>deca1é2</pattern>
-<pattern>deca1í2</pattern>
-<pattern>deca1ó2</pattern>
-<pattern>deca1ú2</pattern>
-<pattern>4e3dro </pattern>
-<pattern>4e3dros </pattern>
-<pattern>4é3drico </pattern>
-<pattern>4é3dricos </pattern>
-<pattern>4é3drica </pattern>
-<pattern>4é3dricas </pattern>
-<pattern> de2sa2</pattern>
-<pattern> de2se2</pattern>
-<pattern> de2si2</pattern>
-<pattern> de2so2</pattern>
-<pattern> de2su2</pattern>
-<pattern> de2sá2</pattern>
-<pattern> de2sé2</pattern>
-<pattern> de2sí2</pattern>
-<pattern> de2só2</pattern>
-<pattern> de2sú2</pattern>
-<pattern>deca2i3mient</pattern>
-<pattern>decimo1</pattern>
-<pattern>3sa </pattern>
-<pattern>3sas </pattern>
-<pattern>de2s3órde</pattern>
-<pattern>de2s3orde</pattern>
-<pattern>de2s3abast</pattern>
-<pattern>de2s3aboll</pattern>
-<pattern>de2s3aboto</pattern>
-<pattern>de2s3abr</pattern>
-<pattern>desa3brid</pattern>
-<pattern>de2s3abroch</pattern>
-<pattern>de2s3aceit</pattern>
-<pattern>de2s3aceler</pattern>
-<pattern>desa3cert</pattern>
-<pattern>desa3ciert</pattern>
-<pattern>de2s3acobar</pattern>
-<pattern>de2s3acomod</pattern>
-<pattern>de2s3acomp</pattern>
-<pattern>de2s3acons</pattern>
-<pattern>de2s3acopl</pattern>
-<pattern>de2s3acorr</pattern>
-<pattern>de2s3acostum</pattern>
-<pattern>de2s3acot</pattern>
-<pattern>desa3craliz</pattern>
-<pattern>de2s3acredit</pattern>
-<pattern>de2s3activ</pattern>
-<pattern>de2s3acuart</pattern>
-<pattern>de2s3aderez</pattern>
-<pattern>de2s3adeud</pattern>
-<pattern>de2s3adorar</pattern>
-<pattern>de2s3adormec</pattern>
-<pattern>de2s3adorn</pattern>
-<pattern>de2s3advert</pattern>
-<pattern>de2s3aferr</pattern>
-<pattern>de2s3afic</pattern>
-<pattern>de2s3afil</pattern>
-<pattern>de2s3afin</pattern>
-<pattern>de2s3afor</pattern>
-<pattern>desa3gú</pattern>
-<pattern>desa3garr</pattern>
-<pattern>de2s3agraci</pattern>
-<pattern>de2s3agrad</pattern>
-<pattern>de2s3agravi</pattern>
-<pattern>de2s3agreg</pattern>
-<pattern>de2s3agrup</pattern>
-<pattern>de2s3agu</pattern>
-<pattern>desa3guisado</pattern>
-<pattern>de2s3aherr</pattern>
-<pattern>de2s3ahij</pattern>
-<pattern>de2s3ajust</pattern>
-<pattern>de2s3alagar</pattern>
-<pattern>de2s3alent</pattern>
-<pattern>de2s3alfom</pattern>
-<pattern>de2s3alfor</pattern>
-<pattern>de2s3aliñ</pattern>
-<pattern>desa3lin</pattern>
-<pattern>de2s3alien</pattern>
-<pattern>de2s3aline</pattern>
-<pattern>desa3liv</pattern>
-<pattern>de2s3alm</pattern>
-<pattern>de2s3almid</pattern>
-<pattern>de2s3aloj</pattern>
-<pattern>de2s3alquil</pattern>
-<pattern>de2s3alter</pattern>
-<pattern>de2s3alumbr</pattern>
-<pattern>desa3marr</pattern>
-<pattern>desa3mobl</pattern>
-<pattern>de2s3amold</pattern>
-<pattern>de2s3amort</pattern>
-<pattern>de2s3amuebl</pattern>
-<pattern>de2s3ampa</pattern>
-<pattern>de2s3and</pattern>
-<pattern>de2s3angel</pattern>
-<pattern>de3sangr</pattern>
-<pattern>de2s3anid</pattern>
-<pattern>de2s3anim</pattern>
-<pattern>de2s3aním</pattern>
-<pattern>de2s3anud</pattern>
-<pattern>desa3pañ</pattern>
-<pattern>desa3pacib</pattern>
-<pattern>de2s3apadr</pattern>
-<pattern>de2s3apare</pattern>
-<pattern>de2s3aparec</pattern>
-<pattern>de2s3aparic</pattern>
-<pattern>de2s3apeg</pattern>
-<pattern>de2s3apercib</pattern>
-<pattern>de2s3apes</pattern>
-<pattern>de2s3aplic</pattern>
-<pattern>de2s3apolill</pattern>
-<pattern>de2s3apoy</pattern>
-<pattern>de2s3aprend</pattern>
-<pattern>de2s3apret</pattern>
-<pattern>de2s3apriet</pattern>
-<pattern>de2s3aprob</pattern>
-<pattern>de2s3apropi</pattern>
-<pattern>de2s3aprovech</pattern>
-<pattern>de2s3arbol</pattern>
-<pattern>de2s3aren</pattern>
-<pattern>de2s3arm</pattern>
-<pattern>des4arme</pattern>
-<pattern>de2s3arraig</pattern>
-<pattern>de2s3arregl</pattern>
-<pattern>de2s3arrend</pattern>
-<pattern>de2s3arrim</pattern>
-<pattern>desa3rroll</pattern>
-<pattern>de2s3arrop</pattern>
-<pattern>de2s3arrug</pattern>
-<pattern>de2s3articul</pattern>
-<pattern>de2s3asent</pattern>
-<pattern>de2s3asist</pattern>
-<pattern>de2s3asn</pattern>
-<pattern>desa3soseg</pattern>
-<pattern>desa3sosieg</pattern>
-<pattern>de2s3atenc</pattern>
-<pattern>de2s3atend</pattern>
-<pattern>de2s3atiend</pattern>
-<pattern>de2s3atent</pattern>
-<pattern>desa3tin</pattern>
-<pattern>de2s3atorn</pattern>
-<pattern>de2s3atranc</pattern>
-<pattern>de2s3autor</pattern>
-<pattern>de2s3avis</pattern>
-<pattern>desa3yun</pattern>
-<pattern>desa3zón</pattern>
-<pattern>desa3zon</pattern>
-<pattern>de2s3embal</pattern>
-<pattern>de2s3embál</pattern>
-<pattern>de2s3embar</pattern>
-<pattern>de2s3embár</pattern>
-<pattern>de2s3embarg</pattern>
-<pattern>de2s3embols</pattern>
-<pattern>de2s3emborr</pattern>
-<pattern>de2s3embosc</pattern>
-<pattern>de2s3embot</pattern>
-<pattern>de2s3embrag</pattern>
-<pattern>de2s3embrág</pattern>
-<pattern>de2s3embrave</pattern>
-<pattern>de2s3embráve</pattern>
-<pattern>de2s3embroll</pattern>
-<pattern>de2s3embróll</pattern>
-<pattern>de2s3embruj</pattern>
-<pattern>de2s3embrúj</pattern>
-<pattern>de3semej</pattern>
-<pattern>de2s3empañ</pattern>
-<pattern>de2s3empáñ</pattern>
-<pattern>de2s3empac</pattern>
-<pattern>de2s3empaquet</pattern>
-<pattern>de2s3empaquét</pattern>
-<pattern>de2s3emparej</pattern>
-<pattern>de2s3emparéj</pattern>
-<pattern>de2s3emparent</pattern>
-<pattern>de2s3empat</pattern>
-<pattern>de2s3empé</pattern>
-<pattern>de2s3empedr</pattern>
-<pattern>de2s3empeg</pattern>
-<pattern>de2s3empeor</pattern>
-<pattern>de2s3emperez</pattern>
-<pattern>de2s3empern</pattern>
-<pattern>de2s3emple</pattern>
-<pattern>de2s3empolv</pattern>
-<pattern>de2s3empotr</pattern>
-<pattern>de2s3empoz</pattern>
-<pattern>de2s3enam</pattern>
-<pattern>de2s3encab</pattern>
-<pattern>de2s3encad</pattern>
-<pattern>de2s3encaj</pattern>
-<pattern>de2s3encáj</pattern>
-<pattern>de2s3encall</pattern>
-<pattern>de2s3encáll</pattern>
-<pattern>de2s3encam</pattern>
-<pattern>de3sencant</pattern>
-<pattern>de2s3encap</pattern>
-<pattern>de2s3encar</pattern>
-<pattern>de2s3encár</pattern>
-<pattern>de2s3ench</pattern>
-<pattern>de2s3encl</pattern>
-<pattern>de2s3enco</pattern>
-<pattern>de2s3encr</pattern>
-<pattern>de2s3encu</pattern>
-<pattern>de2s3end</pattern>
-<pattern>de3senfad</pattern>
-<pattern>de3senfád</pattern>
-<pattern>de2s3enfi</pattern>
-<pattern>de2s3enfo</pattern>
-<pattern>de2s3enfó</pattern>
-<pattern>de3senfren</pattern>
-<pattern>de2s3enfund</pattern>
-<pattern>de2s3enfur</pattern>
-<pattern>de3sengañ</pattern>
-<pattern>de3sengáñ</pattern>
-<pattern>de2s3enganch</pattern>
-<pattern>de2s3engar</pattern>
-<pattern>de2s3engas</pattern>
-<pattern>de2s3engom</pattern>
-<pattern>de2s3engoz</pattern>
-<pattern>de2s3engra</pattern>
-<pattern>de2s3enhebr</pattern>
-<pattern>de2s3enj</pattern>
-<pattern>de2s3enlad</pattern>
-<pattern>de2s3enlaz</pattern>
-<pattern>de2s3enlo</pattern>
-<pattern>de2s3enm</pattern>
-<pattern>de2s3enr</pattern>
-<pattern>de2s3ens</pattern>
-<pattern>de2s3enta</pattern>
-<pattern>de3sentend</pattern>
-<pattern>de3sentien</pattern>
-<pattern>de3sentién</pattern>
-<pattern>de2s3enter</pattern>
-<pattern>de2s3entier</pattern>
-<pattern>de2s3entiér</pattern>
-<pattern>de2s3ento</pattern>
-<pattern>de2s3entr</pattern>
-<pattern>de2s3entu</pattern>
-<pattern>de2s3envain</pattern>
-<pattern>de3senvolvim</pattern>
-<pattern>de3seo</pattern>
-<pattern>de2s3eq</pattern>
-<pattern>de3s4erci</pattern>
-<pattern>de3s4ert</pattern>
-<pattern>de3s4ért</pattern>
-<pattern>de2s3espa</pattern>
-<pattern>de3sesperac</pattern>
-<pattern>de2s3esperanz</pattern>
-<pattern>de3sesper</pattern>
-<pattern>de2s3estabil</pattern>
-<pattern>de2s3estim</pattern>
-<pattern>de3sider</pattern>
-<pattern>de3sidia</pattern>
-<pattern>de3sidio</pattern>
-<pattern>de3siert</pattern>
-<pattern>de3sign</pattern>
-<pattern>de3sigual</pattern>
-<pattern>de3silusi</pattern>
-<pattern>de2s3imagin</pattern>
-<pattern>de2s3iman</pattern>
-<pattern>de2s3impon</pattern>
-<pattern>de2s3impres</pattern>
-<pattern>de2s3incent</pattern>
-<pattern>de2s3inclin</pattern>
-<pattern>de2s3incorp</pattern>
-<pattern>de2s3incrust</pattern>
-<pattern>de3sinenc</pattern>
-<pattern>de3sinfec</pattern>
-<pattern>de3su3dar</pattern>
-<pattern>de3su3das</pattern>
-<pattern>de3su3dan</pattern>
-<pattern>de2s3inflam</pattern>
-<pattern>de2s3infl</pattern>
-<pattern>de2s3inform</pattern>
-<pattern>de2s3inhib</pattern>
-<pattern>de2s3insect</pattern>
-<pattern>de2s3instal</pattern>
-<pattern>ini3ci</pattern>
-<pattern>iní3ci</pattern>
-<pattern>de3s4integr</pattern>
-<pattern>de3s4inter</pattern>
-<pattern>de2s3intox</pattern>
-<pattern>de2s3inver</pattern>
-<pattern>de3sisten</pattern>
-<pattern>de3isti</pattern>
-<pattern>de2s3obedec</pattern>
-<pattern>de2s3oblig</pattern>
-<pattern>de2s3obstr</pattern>
-<pattern>de3socup</pattern>
-<pattern>de2s3odor</pattern>
-<pattern>de3solac</pattern>
-<pattern>de3solad</pattern>
-<pattern>de3soll</pattern>
-<pattern>de2s3orej</pattern>
-<pattern>de2s3orient</pattern>
-<pattern>de3sortij</pattern>
-<pattern>de2s3organi</pattern>
-<pattern>de3suell</pattern>
-<pattern>de3sonce</pattern>
-<pattern>de2s3ovi</pattern>
-<pattern>de2s3oxi</pattern>
-<pattern>de2s3oye</pattern>
-<pattern>de2s3oyé</pattern>
-<pattern>de3s4ubstan</pattern>
-<pattern>de3s4ustan</pattern>
-<pattern>de3s4oseg</pattern>
-<pattern>de2s3ub4ic</pattern>
-<pattern>de2s3unir</pattern>
-<pattern>de2s3unier</pattern>
-<pattern>de2s3unim</pattern>
-<pattern> dieci1o2</pattern>
-<pattern>dodeca1h</pattern>
-<pattern>dodeca1a2</pattern>
-<pattern>dodeca1e2</pattern>
-<pattern>dodeca1i2</pattern>
-<pattern>dodeca1o2</pattern>
-<pattern>dodeca1u2</pattern>
-<pattern>dodeca1á2</pattern>
-<pattern>dodeca1é2</pattern>
-<pattern>dodeca1í2</pattern>
-<pattern>dodeca1ó2</pattern>
-<pattern>dodeca1ú2</pattern>
-<pattern>ecano1h</pattern>
-<pattern>ecano1a2</pattern>
-<pattern>ecano1e2</pattern>
-<pattern>ecano1i2</pattern>
-<pattern>ecano1o2</pattern>
-<pattern>ecano1u2</pattern>
-<pattern>ecano1á2</pattern>
-<pattern>ecano1é2</pattern>
-<pattern>ecano1í2</pattern>
-<pattern>ecano1ó2</pattern>
-<pattern>ecano1ú2</pattern>
-<pattern>eco1h</pattern>
-<pattern>eco1a2</pattern>
-<pattern>eco1e2</pattern>
-<pattern>eco1i2</pattern>
-<pattern>eco1o2</pattern>
-<pattern>eco1u2</pattern>
-<pattern>eco1á2</pattern>
-<pattern>eco1é2</pattern>
-<pattern>eco1í2</pattern>
-<pattern>eco1ó2</pattern>
-<pattern>eco1ú2</pattern>
-<pattern>ectro1h</pattern>
-<pattern>ectro1a2</pattern>
-<pattern>ectro1e2</pattern>
-<pattern>ectro1i2</pattern>
-<pattern>ectro1o2</pattern>
-<pattern>ectro1u2</pattern>
-<pattern>ectro1á2</pattern>
-<pattern>ectro1é2</pattern>
-<pattern>ectro1í2</pattern>
-<pattern>ectro1ó2</pattern>
-<pattern>ectro1ú2</pattern>
-<pattern> en2a2</pattern>
-<pattern> en2e2</pattern>
-<pattern> en2i2</pattern>
-<pattern> en2o2</pattern>
-<pattern> en2u2</pattern>
-<pattern> en2á2</pattern>
-<pattern> en2é2</pattern>
-<pattern> en2í2</pattern>
-<pattern> en2ó2</pattern>
-<pattern> en2ú2</pattern>
-<pattern> ene3mist</pattern>
-<pattern> ene3míst</pattern>
-<pattern> eno3jar</pattern>
-<pattern> enu3mera</pattern>
-<pattern> enu3merá</pattern>
-<pattern> enu3mere</pattern>
-<pattern>4o3lógico </pattern>
-<pattern>4o3lógica </pattern>
-<pattern>4o3lógicos </pattern>
-<pattern>4o3lógicas </pattern>
-<pattern>4o3lógicamente </pattern>
-<pattern>4o3logía </pattern>
-<pattern>4o3logías </pattern>
-<pattern>4ó3logo </pattern>
-<pattern>4ó3loga </pattern>
-<pattern>4ó3logos </pattern>
-<pattern>4ó3logas </pattern>
-<pattern>endo1h</pattern>
-<pattern>endo1a2</pattern>
-<pattern>endo1e2</pattern>
-<pattern>endo1i2</pattern>
-<pattern>endo1o2</pattern>
-<pattern>endo1u2</pattern>
-<pattern>endo1á2</pattern>
-<pattern>endo1é2</pattern>
-<pattern>endo1í2</pattern>
-<pattern>endo1ó2</pattern>
-<pattern>endo1ú2</pattern>
-<pattern>ento1h</pattern>
-<pattern>ento1a2</pattern>
-<pattern>ento1e2</pattern>
-<pattern>ento1i2</pattern>
-<pattern>ento1o2</pattern>
-<pattern>ento1u2</pattern>
-<pattern>ento1á2</pattern>
-<pattern>ento1é2</pattern>
-<pattern>ento1í2</pattern>
-<pattern>ento1ó2</pattern>
-<pattern>ento1ú2</pattern>
-<pattern>4emboca</pattern>
-<pattern>entre1h</pattern>
-<pattern>entre1a2</pattern>
-<pattern>entre1e2</pattern>
-<pattern>entre1i2</pattern>
-<pattern>entre1o2</pattern>
-<pattern>entre1u2</pattern>
-<pattern>entre1á2</pattern>
-<pattern>entre1é2</pattern>
-<pattern>entre1í2</pattern>
-<pattern>entre1ó2</pattern>
-<pattern>entre1ú2</pattern>
-<pattern>euco1h</pattern>
-<pattern>euco1a2</pattern>
-<pattern>euco1e2</pattern>
-<pattern>euco1i2</pattern>
-<pattern>euco1o2</pattern>
-<pattern>euco1u2</pattern>
-<pattern>euco1á2</pattern>
-<pattern>euco1é2</pattern>
-<pattern>euco1í2</pattern>
-<pattern>euco1ó2</pattern>
-<pattern>euco1ú2</pattern>
-<pattern>euro1h</pattern>
-<pattern>euro1a2</pattern>
-<pattern>euro1e2</pattern>
-<pattern>euro1i2</pattern>
-<pattern>euro1o2</pattern>
-<pattern>euro1u2</pattern>
-<pattern>euro1á2</pattern>
-<pattern>euro1é2</pattern>
-<pattern>euro1í2</pattern>
-<pattern>euro1ó2</pattern>
-<pattern>euro1ú2</pattern>
-<pattern>extra1h</pattern>
-<pattern>extra1a2</pattern>
-<pattern>extra1e2</pattern>
-<pattern>extra1i2</pattern>
-<pattern>extra1o2</pattern>
-<pattern>extra1u2</pattern>
-<pattern>extra1á2</pattern>
-<pattern>extra1é2</pattern>
-<pattern>extra1í2</pattern>
-<pattern>extra1ó2</pattern>
-<pattern>extra1ú2</pattern>
-<pattern>u4teri</pattern>
-<pattern> cau5t</pattern>
-<pattern> deu5t</pattern>
-<pattern>fono1h</pattern>
-<pattern>fono1a2</pattern>
-<pattern>fono1e2</pattern>
-<pattern>fono1i2</pattern>
-<pattern>fono1o2</pattern>
-<pattern>fono1u2</pattern>
-<pattern>fono1á2</pattern>
-<pattern>fono1é2</pattern>
-<pattern>fono1í2</pattern>
-<pattern>fono1ó2</pattern>
-<pattern>fono1ú2</pattern>
-<pattern>foto1h</pattern>
-<pattern>foto1a2</pattern>
-<pattern>foto1e2</pattern>
-<pattern>foto1i2</pattern>
-<pattern>foto1o2</pattern>
-<pattern>foto1u2</pattern>
-<pattern>foto1á2</pattern>
-<pattern>foto1é2</pattern>
-<pattern>foto1í2</pattern>
-<pattern>foto1ó2</pattern>
-<pattern>foto1ú2</pattern>
-<pattern>gastro1h</pattern>
-<pattern>gastro1a2</pattern>
-<pattern>gastro1e2</pattern>
-<pattern>gastro1i2</pattern>
-<pattern>gastro1o2</pattern>
-<pattern>gastro1u2</pattern>
-<pattern>gastro1á2</pattern>
-<pattern>gastro1é2</pattern>
-<pattern>gastro1í2</pattern>
-<pattern>gastro1ó2</pattern>
-<pattern>gastro1ú2</pattern>
-<pattern>geo1h</pattern>
-<pattern>geo1a2</pattern>
-<pattern>geo1e2</pattern>
-<pattern>geo1i2</pattern>
-<pattern>geo1o2</pattern>
-<pattern>geo1u2</pattern>
-<pattern>geo1á2</pattern>
-<pattern>geo1é2</pattern>
-<pattern>geo1í2</pattern>
-<pattern>geo1ó2</pattern>
-<pattern>geo1ú2</pattern>
-<pattern>gluco1h</pattern>
-<pattern>gluco1a2</pattern>
-<pattern>gluco1e2</pattern>
-<pattern>gluco1i2</pattern>
-<pattern>gluco1o2</pattern>
-<pattern>gluco1u2</pattern>
-<pattern>gluco1á2</pattern>
-<pattern>gluco1é2</pattern>
-<pattern>gluco1í2</pattern>
-<pattern>gluco1ó2</pattern>
-<pattern>gluco1ú2</pattern>
-<pattern>hecto1h</pattern>
-<pattern>hecto1a2</pattern>
-<pattern>hecto1e2</pattern>
-<pattern>hecto1i2</pattern>
-<pattern>hecto1o2</pattern>
-<pattern>hecto1u2</pattern>
-<pattern>hecto1á2</pattern>
-<pattern>hecto1é2</pattern>
-<pattern>hecto1í2</pattern>
-<pattern>hecto1ó2</pattern>
-<pattern>hecto1ú2</pattern>
-<pattern>helio1h</pattern>
-<pattern>helio1a2</pattern>
-<pattern>helio1e2</pattern>
-<pattern>helio1i2</pattern>
-<pattern>helio1o2</pattern>
-<pattern>helio1u2</pattern>
-<pattern>helio1á2</pattern>
-<pattern>helio1é2</pattern>
-<pattern>helio1í2</pattern>
-<pattern>helio1ó2</pattern>
-<pattern>helio1ú2</pattern>
-<pattern>hemato1h</pattern>
-<pattern>hemato1a2</pattern>
-<pattern>hemato1e2</pattern>
-<pattern>hemato1i2</pattern>
-<pattern>hemato1o2</pattern>
-<pattern>hemato1u2</pattern>
-<pattern>hemato1á2</pattern>
-<pattern>hemato1é2</pattern>
-<pattern>hemato1í2</pattern>
-<pattern>hemato1ó2</pattern>
-<pattern>hemato1ú2</pattern>
-<pattern>hemi1h</pattern>
-<pattern>hemi1a2</pattern>
-<pattern>hemi1e2</pattern>
-<pattern>hemi1i2</pattern>
-<pattern>hemi1o2</pattern>
-<pattern>hemi1u2</pattern>
-<pattern>hemi1á2</pattern>
-<pattern>hemi1é2</pattern>
-<pattern>hemi1í2</pattern>
-<pattern>hemi1ó2</pattern>
-<pattern>hemi1ú2</pattern>
-<pattern>hemo1h</pattern>
-<pattern>hemo1a2</pattern>
-<pattern>hemo1e2</pattern>
-<pattern>hemo1i2</pattern>
-<pattern>hemo1o2</pattern>
-<pattern>hemo1u2</pattern>
-<pattern>hemo1á2</pattern>
-<pattern>hemo1é2</pattern>
-<pattern>hemo1í2</pattern>
-<pattern>hemo1ó2</pattern>
-<pattern>hemo1ú2</pattern>
-<pattern>2al </pattern>
-<pattern>2ales </pattern>
-<pattern>hexa1h</pattern>
-<pattern>hexa1a2</pattern>
-<pattern>hexa1e2</pattern>
-<pattern>hexa1i2</pattern>
-<pattern>hexa1o2</pattern>
-<pattern>hexa1u2</pattern>
-<pattern>hexa1á2</pattern>
-<pattern>hexa1é2</pattern>
-<pattern>hexa1í2</pattern>
-<pattern>hexa1ó2</pattern>
-<pattern>hexa1ú2</pattern>
-<pattern>hidro1h</pattern>
-<pattern>hidro1a2</pattern>
-<pattern>hidro1e2</pattern>
-<pattern>hidro1i2</pattern>
-<pattern>hidro1o2</pattern>
-<pattern>hidro1u2</pattern>
-<pattern>hidro1á2</pattern>
-<pattern>hidro1é2</pattern>
-<pattern>hidro1í2</pattern>
-<pattern>hidro1ó2</pattern>
-<pattern>hidro1ú2</pattern>
-<pattern>hipe2r3r</pattern>
-<pattern>hipe2r1a2</pattern>
-<pattern>hipe2r1e2</pattern>
-<pattern>hipe2r1i2</pattern>
-<pattern>hipe2r1o2</pattern>
-<pattern>hipe2r1u2</pattern>
-<pattern>hipe2r1á2</pattern>
-<pattern>hipe2r1é2</pattern>
-<pattern>hipe2r1í2</pattern>
-<pattern>hipe2r1ó2</pattern>
-<pattern>hipe2r1ú2</pattern>
-<pattern>pe3r4e3mia</pattern>
-<pattern>histo1h</pattern>
-<pattern>histo1a2</pattern>
-<pattern>histo1e2</pattern>
-<pattern>histo1i2</pattern>
-<pattern>histo1o2</pattern>
-<pattern>histo1u2</pattern>
-<pattern>histo1á2</pattern>
-<pattern>histo1é2</pattern>
-<pattern>histo1í2</pattern>
-<pattern>histo1ó2</pattern>
-<pattern>histo1ú2</pattern>
-<pattern>homo1h</pattern>
-<pattern>homo1a2</pattern>
-<pattern>homo1e2</pattern>
-<pattern>homo1i2</pattern>
-<pattern>homo1o2</pattern>
-<pattern>homo1u2</pattern>
-<pattern>homo1á2</pattern>
-<pattern>homo1é2</pattern>
-<pattern>homo1í2</pattern>
-<pattern>homo1ó2</pattern>
-<pattern>homo1ú2</pattern>
-<pattern>icono1h</pattern>
-<pattern>icono1a2</pattern>
-<pattern>icono1e2</pattern>
-<pattern>icono1i2</pattern>
-<pattern>icono1o2</pattern>
-<pattern>icono1u2</pattern>
-<pattern>icono1á2</pattern>
-<pattern>icono1é2</pattern>
-<pattern>icono1í2</pattern>
-<pattern>icono1ó2</pattern>
-<pattern>icono1ú2</pattern>
-<pattern> i2n2a2</pattern>
-<pattern> i2n2e2</pattern>
-<pattern> i2n2i2</pattern>
-<pattern> i2n2o2</pattern>
-<pattern> i2n2u2</pattern>
-<pattern> i2n2á2</pattern>
-<pattern> i2n2é2</pattern>
-<pattern> i2n2í2</pattern>
-<pattern> i2n2ó2</pattern>
-<pattern> i2n2ú2</pattern>
-<pattern> in3abord</pattern>
-<pattern> in3abarc</pattern>
-<pattern> in3acent</pattern>
-<pattern> in3aguant</pattern>
-<pattern> in3adapt</pattern>
-<pattern> ina3movib</pattern>
-<pattern> in3analiz</pattern>
-<pattern> ina3nic</pattern>
-<pattern> in3anim</pattern>
-<pattern> iná3nim</pattern>
-<pattern> in3apel</pattern>
-<pattern> in3aplic</pattern>
-<pattern> in3aprens</pattern>
-<pattern> in3apreci</pattern>
-<pattern> in3arrug</pattern>
-<pattern> in3asist</pattern>
-<pattern> iné3dit</pattern>
-<pattern> in3efic</pattern>
-<pattern> in3efici</pattern>
-<pattern> in3eludi</pattern>
-<pattern> ine3narr</pattern>
-<pattern>ini3cia</pattern>
-<pattern>iní3cia</pattern>
-<pattern>ini3ciá</pattern>
-<pattern>ini3cie</pattern>
-<pattern> rei3na</pattern>
-<pattern>re3ini3cia</pattern>
-<pattern>re3iní3cia</pattern>
-<pattern>re3ini3ciá</pattern>
-<pattern>re3ini3cie</pattern>
-<pattern> ini3cuo</pattern>
-<pattern> ini3cua</pattern>
-<pattern> ino3cuo</pattern>
-<pattern> ino3cua</pattern>
-<pattern> ino3cula</pattern>
-<pattern> ino3culá</pattern>
-<pattern> ino3cule</pattern>
-<pattern> inú3til</pattern>
-<pattern> inu3tiliz</pattern>
-<pattern>infra1h</pattern>
-<pattern>infra1a2</pattern>
-<pattern>infra1e2</pattern>
-<pattern>infra1i2</pattern>
-<pattern>infra1o2</pattern>
-<pattern>infra1u2</pattern>
-<pattern>infra1á2</pattern>
-<pattern>infra1é2</pattern>
-<pattern>infra1í2</pattern>
-<pattern>infra1ó2</pattern>
-<pattern>infra1ú2</pattern>
-<pattern> inte2r3r</pattern>
-<pattern> inte2r1a2</pattern>
-<pattern> inte2r1e2</pattern>
-<pattern> inte2r1i2</pattern>
-<pattern> inte2r1o2</pattern>
-<pattern> inte2r1u2</pattern>
-<pattern> inte2r1á2</pattern>
-<pattern> inte2r1é2</pattern>
-<pattern> inte2r1í2</pattern>
-<pattern> inte2r1ó2</pattern>
-<pattern> inte2r1ú2</pattern>
-<pattern> in3ter2e3sa</pattern>
-<pattern> in3ter2e3se</pattern>
-<pattern> in3ter2e3so</pattern>
-<pattern> in3ter2e3sá</pattern>
-<pattern> in3ter2e3sé</pattern>
-<pattern> in3ter2e3só</pattern>
-<pattern> de3s4in3ter2e3sa</pattern>
-<pattern> de3s4in3ter2e3se</pattern>
-<pattern> de3s4in3ter2e3so</pattern>
-<pattern> de3s4in3ter2e3sá</pattern>
-<pattern> de3s4in3ter2e3sé</pattern>
-<pattern> de3s4in3ter2e3só</pattern>
-<pattern>3te3ri3n</pattern>
-<pattern>4te4r5i4nsu</pattern>
-<pattern> in3te3r4rog</pattern>
-<pattern> in3te3r4rupc</pattern>
-<pattern> in3te3r4rupt</pattern>
-<pattern> in3te3r4rump</pattern>
-<pattern>intra1h</pattern>
-<pattern>intra1a2</pattern>
-<pattern>intra1e2</pattern>
-<pattern>intra1i2</pattern>
-<pattern>intra1o2</pattern>
-<pattern>intra1u2</pattern>
-<pattern>intra1á2</pattern>
-<pattern>intra1é2</pattern>
-<pattern>intra1í2</pattern>
-<pattern>intra1ó2</pattern>
-<pattern>intra1ú2</pattern>
-<pattern>iso1h</pattern>
-<pattern>iso1a2</pattern>
-<pattern>iso1e2</pattern>
-<pattern>iso1i2</pattern>
-<pattern>iso1o2</pattern>
-<pattern>iso1u2</pattern>
-<pattern>iso1á2</pattern>
-<pattern>iso1é2</pattern>
-<pattern>iso1í2</pattern>
-<pattern>iso1ó2</pattern>
-<pattern>iso1ú2</pattern>
-<pattern>kilo1h</pattern>
-<pattern>kilo1a2</pattern>
-<pattern>kilo1e2</pattern>
-<pattern>kilo1i2</pattern>
-<pattern>kilo1o2</pattern>
-<pattern>kilo1u2</pattern>
-<pattern>kilo1á2</pattern>
-<pattern>kilo1é2</pattern>
-<pattern>kilo1í2</pattern>
-<pattern>kilo1ó2</pattern>
-<pattern>kilo1ú2</pattern>
-<pattern>macro1h</pattern>
-<pattern>macro1a2</pattern>
-<pattern>macro1e2</pattern>
-<pattern>macro1i2</pattern>
-<pattern>macro1o2</pattern>
-<pattern>macro1u2</pattern>
-<pattern>macro1á2</pattern>
-<pattern>macro1é2</pattern>
-<pattern>macro1í2</pattern>
-<pattern>macro1ó2</pattern>
-<pattern>macro1ú2</pattern>
-<pattern>mal2</pattern>
-<pattern>ma4l3h</pattern>
-<pattern> ma4l3e4du</pattern>
-<pattern>mal3b</pattern>
-<pattern>mal3c</pattern>
-<pattern>mal3d</pattern>
-<pattern>mal3f</pattern>
-<pattern>mal3g</pattern>
-<pattern>mal3m</pattern>
-<pattern>mal3p</pattern>
-<pattern>mal3q</pattern>
-<pattern>mal3s</pattern>
-<pattern>mal3t</pattern>
-<pattern>mal3v</pattern>
-<pattern>bien2</pattern>
-<pattern>bien3h</pattern>
-<pattern>bien3v</pattern>
-<pattern>bien3q</pattern>
-<pattern>bien3m</pattern>
-<pattern>bien3t</pattern>
-<pattern>b4ien3do </pattern>
-<pattern> su3b4ien</pattern>
-<pattern>b4ien3das </pattern>
-<pattern>maxi1h</pattern>
-<pattern>maxi1a2</pattern>
-<pattern>maxi1e2</pattern>
-<pattern>maxi1i2</pattern>
-<pattern>maxi1o2</pattern>
-<pattern>maxi1u2</pattern>
-<pattern>maxi1á2</pattern>
-<pattern>maxi1é2</pattern>
-<pattern>maxi1í2</pattern>
-<pattern>maxi1ó2</pattern>
-<pattern>maxi1ú2</pattern>
-<pattern>megalo1h</pattern>
-<pattern>megalo1a2</pattern>
-<pattern>megalo1e2</pattern>
-<pattern>megalo1i2</pattern>
-<pattern>megalo1o2</pattern>
-<pattern>megalo1u2</pattern>
-<pattern>megalo1á2</pattern>
-<pattern>megalo1é2</pattern>
-<pattern>megalo1í2</pattern>
-<pattern>megalo1ó2</pattern>
-<pattern>megalo1ú2</pattern>
-<pattern>mega1h</pattern>
-<pattern>mega1a2</pattern>
-<pattern>mega1e2</pattern>
-<pattern>mega1i2</pattern>
-<pattern>mega1o2</pattern>
-<pattern>mega1u2</pattern>
-<pattern>mega1á2</pattern>
-<pattern>mega1é2</pattern>
-<pattern>mega1í2</pattern>
-<pattern>mega1ó2</pattern>
-<pattern>mega1ú2</pattern>
-<pattern>melano1h</pattern>
-<pattern>melano1a2</pattern>
-<pattern>melano1e2</pattern>
-<pattern>melano1i2</pattern>
-<pattern>melano1o2</pattern>
-<pattern>melano1u2</pattern>
-<pattern>melano1á2</pattern>
-<pattern>melano1é2</pattern>
-<pattern>melano1í2</pattern>
-<pattern>melano1ó2</pattern>
-<pattern>melano1ú2</pattern>
-<pattern>micro1h</pattern>
-<pattern>micro1a2</pattern>
-<pattern>micro1e2</pattern>
-<pattern>micro1i2</pattern>
-<pattern>micro1o2</pattern>
-<pattern>micro1u2</pattern>
-<pattern>micro1á2</pattern>
-<pattern>micro1é2</pattern>
-<pattern>micro1í2</pattern>
-<pattern>micro1ó2</pattern>
-<pattern>micro1ú2</pattern>
-<pattern>mili1h</pattern>
-<pattern>mili1a2</pattern>
-<pattern>mili1e2</pattern>
-<pattern>mili1i2</pattern>
-<pattern>mili1o2</pattern>
-<pattern>mili1u2</pattern>
-<pattern>mili1á2</pattern>
-<pattern>mili1é2</pattern>
-<pattern>mili1í2</pattern>
-<pattern>mili1ó2</pattern>
-<pattern>mili1ú2</pattern>
-<pattern>familia3ri</pattern>
-<pattern>ia5res </pattern>
-<pattern>amili6a</pattern>
-<pattern>a3rio</pattern>
-<pattern>li5área</pattern>
-<pattern>mini1h</pattern>
-<pattern>mini1a2</pattern>
-<pattern>mini1e2</pattern>
-<pattern>mini1i2</pattern>
-<pattern>mini1o2</pattern>
-<pattern>mini1u2</pattern>
-<pattern>mini1á2</pattern>
-<pattern>mini1é2</pattern>
-<pattern>mini1í2</pattern>
-<pattern>mini1ó2</pattern>
-<pattern>mini1ú2</pattern>
-<pattern>2os </pattern>
-<pattern>2o3so </pattern>
-<pattern>2o3sos </pattern>
-<pattern>2o3sa </pattern>
-<pattern>2o3sas </pattern>
-<pattern>2o3samente </pattern>
-<pattern>mini4a5tur</pattern>
-<pattern>multi1h</pattern>
-<pattern>multi1a2</pattern>
-<pattern>multi1e2</pattern>
-<pattern>multi1i2</pattern>
-<pattern>multi1o2</pattern>
-<pattern>multi1u2</pattern>
-<pattern>multi1á2</pattern>
-<pattern>multi1é2</pattern>
-<pattern>multi1í2</pattern>
-<pattern>multi1ó2</pattern>
-<pattern>multi1ú2</pattern>
-<pattern>miria1h</pattern>
-<pattern>miria1a2</pattern>
-<pattern>miria1e2</pattern>
-<pattern>miria1i2</pattern>
-<pattern>miria1o2</pattern>
-<pattern>miria1u2</pattern>
-<pattern>miria1á2</pattern>
-<pattern>miria1é2</pattern>
-<pattern>miria1í2</pattern>
-<pattern>miria1ó2</pattern>
-<pattern>miria1ú2</pattern>
-<pattern>mono1h</pattern>
-<pattern>mono1a2</pattern>
-<pattern>mono1e2</pattern>
-<pattern>mono1i2</pattern>
-<pattern>mono1o2</pattern>
-<pattern>mono1u2</pattern>
-<pattern>mono1á2</pattern>
-<pattern>mono1é2</pattern>
-<pattern>mono1í2</pattern>
-<pattern>mono1ó2</pattern>
-<pattern>mono1ú2</pattern>
-<pattern>2i3co </pattern>
-<pattern>2i3cos </pattern>
-<pattern>2i3ca </pattern>
-<pattern>2i3cas </pattern>
-<pattern>namo1h</pattern>
-<pattern>namo1a2</pattern>
-<pattern>namo1e2</pattern>
-<pattern>namo1i2</pattern>
-<pattern>namo1o2</pattern>
-<pattern>namo1u2</pattern>
-<pattern>namo1á2</pattern>
-<pattern>namo1é2</pattern>
-<pattern>namo1í2</pattern>
-<pattern>namo1ó2</pattern>
-<pattern>namo1ú2</pattern>
-<pattern>necro1h</pattern>
-<pattern>necro1a2</pattern>
-<pattern>necro1e2</pattern>
-<pattern>necro1i2</pattern>
-<pattern>necro1o2</pattern>
-<pattern>necro1u2</pattern>
-<pattern>necro1á2</pattern>
-<pattern>necro1é2</pattern>
-<pattern>necro1í2</pattern>
-<pattern>necro1ó2</pattern>
-<pattern>necro1ú2</pattern>
-<pattern>neo1h</pattern>
-<pattern>neo1a2</pattern>
-<pattern>neo1e2</pattern>
-<pattern>neo1i2</pattern>
-<pattern>neo1o2</pattern>
-<pattern>neo1u2</pattern>
-<pattern>neo1á2</pattern>
-<pattern>neo1é2</pattern>
-<pattern>neo1í2</pattern>
-<pattern>neo1ó2</pattern>
-<pattern>neo1ú2</pattern>
-<pattern>neto1h</pattern>
-<pattern>neto1a2</pattern>
-<pattern>neto1e2</pattern>
-<pattern>neto1i2</pattern>
-<pattern>neto1o2</pattern>
-<pattern>neto1u2</pattern>
-<pattern>neto1á2</pattern>
-<pattern>neto1é2</pattern>
-<pattern>neto1í2</pattern>
-<pattern>neto1ó2</pattern>
-<pattern>neto1ú2</pattern>
-<pattern>norte1h</pattern>
-<pattern>norte1a2</pattern>
-<pattern>norte1e2</pattern>
-<pattern>norte1i2</pattern>
-<pattern>norte1o2</pattern>
-<pattern>norte1u2</pattern>
-<pattern>norte1á2</pattern>
-<pattern>norte1é2</pattern>
-<pattern>norte1í2</pattern>
-<pattern>norte1ó2</pattern>
-<pattern>norte1ú2</pattern>
-<pattern>octo1h</pattern>
-<pattern>octo1a2</pattern>
-<pattern>octo1e2</pattern>
-<pattern>octo1i2</pattern>
-<pattern>octo1o2</pattern>
-<pattern>octo1u2</pattern>
-<pattern>octo1á2</pattern>
-<pattern>octo1é2</pattern>
-<pattern>octo1í2</pattern>
-<pattern>octo1ó2</pattern>
-<pattern>octo1ú2</pattern>
-<pattern>octa1h</pattern>
-<pattern>octa1a2</pattern>
-<pattern>octa1e2</pattern>
-<pattern>octa1i2</pattern>
-<pattern>octa1o2</pattern>
-<pattern>octa1u2</pattern>
-<pattern>octa1á2</pattern>
-<pattern>octa1é2</pattern>
-<pattern>octa1í2</pattern>
-<pattern>octa1ó2</pattern>
-<pattern>octa1ú2</pattern>
-<pattern>oligo1h</pattern>
-<pattern>oligo1a2</pattern>
-<pattern>oligo1e2</pattern>
-<pattern>oligo1i2</pattern>
-<pattern>oligo1o2</pattern>
-<pattern>oligo1u2</pattern>
-<pattern>oligo1á2</pattern>
-<pattern>oligo1é2</pattern>
-<pattern>oligo1í2</pattern>
-<pattern>oligo1ó2</pattern>
-<pattern>oligo1ú2</pattern>
-<pattern>omni1h</pattern>
-<pattern>omni1a2</pattern>
-<pattern>omni1e2</pattern>
-<pattern>omni1i2</pattern>
-<pattern>omni1o2</pattern>
-<pattern>omni1u2</pattern>
-<pattern>omni1á2</pattern>
-<pattern>omni1é2</pattern>
-<pattern>omni1í2</pattern>
-<pattern>omni1ó2</pattern>
-<pattern>omni1ú2</pattern>
-<pattern>i2o </pattern>
-<pattern>i2os </pattern>
-<pattern>paleo1h</pattern>
-<pattern>paleo1a2</pattern>
-<pattern>paleo1e2</pattern>
-<pattern>paleo1i2</pattern>
-<pattern>paleo1o2</pattern>
-<pattern>paleo1u2</pattern>
-<pattern>paleo1á2</pattern>
-<pattern>paleo1é2</pattern>
-<pattern>paleo1í2</pattern>
-<pattern>paleo1ó2</pattern>
-<pattern>paleo1ú2</pattern>
-<pattern>para1h</pattern>
-<pattern>para1a2</pattern>
-<pattern>para1e2</pattern>
-<pattern>para1i2</pattern>
-<pattern>para1o2</pattern>
-<pattern>para1u2</pattern>
-<pattern>para1á2</pattern>
-<pattern>para1é2</pattern>
-<pattern>para1í2</pattern>
-<pattern>para1ó2</pattern>
-<pattern>para1ú2</pattern>
-<pattern>para2is </pattern>
-<pattern>aí5so </pattern>
-<pattern>aí5sos </pattern>
-<pattern>penta1h</pattern>
-<pattern>penta1a2</pattern>
-<pattern>penta1e2</pattern>
-<pattern>penta1i2</pattern>
-<pattern>penta1o2</pattern>
-<pattern>penta1u2</pattern>
-<pattern>penta1á2</pattern>
-<pattern>penta1é2</pattern>
-<pattern>penta1í2</pattern>
-<pattern>penta1ó2</pattern>
-<pattern>penta1ú2</pattern>
-<pattern>piezo1h</pattern>
-<pattern>piezo1a2</pattern>
-<pattern>piezo1e2</pattern>
-<pattern>piezo1i2</pattern>
-<pattern>piezo1o2</pattern>
-<pattern>piezo1u2</pattern>
-<pattern>piezo1á2</pattern>
-<pattern>piezo1é2</pattern>
-<pattern>piezo1í2</pattern>
-<pattern>piezo1ó2</pattern>
-<pattern>piezo1ú2</pattern>
-<pattern>pluri1h</pattern>
-<pattern>pluri1a2</pattern>
-<pattern>pluri1e2</pattern>
-<pattern>pluri1i2</pattern>
-<pattern>pluri1o2</pattern>
-<pattern>pluri1u2</pattern>
-<pattern>pluri1á2</pattern>
-<pattern>pluri1é2</pattern>
-<pattern>pluri1í2</pattern>
-<pattern>pluri1ó2</pattern>
-<pattern>pluri1ú2</pattern>
-<pattern>poli1h</pattern>
-<pattern>poli1a2</pattern>
-<pattern>poli1e2</pattern>
-<pattern>poli1i2</pattern>
-<pattern>poli1o2</pattern>
-<pattern>poli1u2</pattern>
-<pattern>poli1á2</pattern>
-<pattern>poli1é2</pattern>
-<pattern>poli1í2</pattern>
-<pattern>poli1ó2</pattern>
-<pattern>poli1ú2</pattern>
-<pattern>poli4u3r</pattern>
-<pattern>poli4o5mie</pattern>
-<pattern>poli4arq</pattern>
-<pattern>poli4árq</pattern>
-<pattern>poli4éste</pattern>
-<pattern>poli4andr</pattern>
-<pattern>poli4antea</pattern>
-<pattern>expoli4</pattern>
-<pattern> pos2t2a2</pattern>
-<pattern> pos2t2e2</pattern>
-<pattern> pos2t2i2</pattern>
-<pattern> pos2t2o2</pattern>
-<pattern> pos2t2u2</pattern>
-<pattern> pos2t2á2</pattern>
-<pattern> pos2t2é2</pattern>
-<pattern> pos2t2í2</pattern>
-<pattern> pos2t2ó2</pattern>
-<pattern> pos2t2ú2</pattern>
-<pattern> pos3tin</pattern>
-<pattern> pos3tín</pattern>
-<pattern>pos3ta </pattern>
-<pattern>pos3tas </pattern>
-<pattern>s3te </pattern>
-<pattern>s3tes </pattern>
-<pattern>s3tal </pattern>
-<pattern>s3ta3les </pattern>
-<pattern>s3ti3lla </pattern>
-<pattern>s3ti3llas </pattern>
-<pattern>s3ti3llón </pattern>
-<pattern>s3ti3llones </pattern>
-<pattern> pos3tó3ni</pattern>
-<pattern> pos3terg</pattern>
-<pattern> pos3te3ri</pattern>
-<pattern> pos3ti3go</pattern>
-<pattern> pos3ti3la</pattern>
-<pattern> pos3ti3ne</pattern>
-<pattern> pos3ti3za</pattern>
-<pattern> pos3ti3zo</pattern>
-<pattern> pos3tu3ra</pattern>
-<pattern>s3tor </pattern>
-<pattern>s3tora </pattern>
-<pattern>s3toras </pattern>
-<pattern>s3tores </pattern>
-<pattern> pos3tu3la</pattern>
-<pattern> pos3tu3lá</pattern>
-<pattern> pos3tu3le</pattern>
-<pattern> pos3tu3lé</pattern>
-<pattern> post3elec</pattern>
-<pattern> post3impr</pattern>
-<pattern> post3ind</pattern>
-<pattern> post3ope</pattern>
-<pattern> post3rev</pattern>
-<pattern> pre2a2</pattern>
-<pattern> pre2e2</pattern>
-<pattern> pre2i2</pattern>
-<pattern> pre2o2</pattern>
-<pattern> pre2u2</pattern>
-<pattern> pre2h2</pattern>
-<pattern> pre2á2</pattern>
-<pattern> pre2é2</pattern>
-<pattern> pre2í2</pattern>
-<pattern> pre2ó2</pattern>
-<pattern> pre2ú2</pattern>
-<pattern>pre3elij</pattern>
-<pattern>pre3elig</pattern>
-<pattern>pre3exis</pattern>
-<pattern>pre3emin</pattern>
-<pattern>preo3cup</pattern>
-<pattern>preo2cúp</pattern>
-<pattern>pre3olí</pattern>
-<pattern>pre3opin</pattern>
-<pattern> pro2a2</pattern>
-<pattern> pro2e2</pattern>
-<pattern> pro2i2</pattern>
-<pattern> pro2o2</pattern>
-<pattern> pro2u2</pattern>
-<pattern> pro2h2</pattern>
-<pattern> pro2á2</pattern>
-<pattern> pro2é2</pattern>
-<pattern> pro2í2</pattern>
-<pattern> pro2ó2</pattern>
-<pattern> pro2ú2</pattern>
-<pattern>proto1h</pattern>
-<pattern>proto1a2</pattern>
-<pattern>proto1e2</pattern>
-<pattern>proto1i2</pattern>
-<pattern>proto1o2</pattern>
-<pattern>proto1u2</pattern>
-<pattern>proto1á2</pattern>
-<pattern>proto1é2</pattern>
-<pattern>proto1í2</pattern>
-<pattern>proto1ó2</pattern>
-<pattern>proto1ú2</pattern>
-<pattern>radio1h</pattern>
-<pattern>radio1a2</pattern>
-<pattern>radio1e2</pattern>
-<pattern>radio1i2</pattern>
-<pattern>radio1o2</pattern>
-<pattern>radio1u2</pattern>
-<pattern>radio1á2</pattern>
-<pattern>radio1é2</pattern>
-<pattern>radio1í2</pattern>
-<pattern>radio1ó2</pattern>
-<pattern>radio1ú2</pattern>
-<pattern>ranco1h</pattern>
-<pattern>ranco1a2</pattern>
-<pattern>ranco1e2</pattern>
-<pattern>ranco1i2</pattern>
-<pattern>ranco1o2</pattern>
-<pattern>ranco1u2</pattern>
-<pattern>ranco1á2</pattern>
-<pattern>ranco1é2</pattern>
-<pattern>ranco1í2</pattern>
-<pattern>ranco1ó2</pattern>
-<pattern>ranco1ú2</pattern>
-<pattern> re2a2</pattern>
-<pattern> re3e4</pattern>
-<pattern> re2i2</pattern>
-<pattern> re2o2</pattern>
-<pattern> re2u2</pattern>
-<pattern> re2á2</pattern>
-<pattern> re2é2</pattern>
-<pattern> re2í2</pattern>
-<pattern> re2ó2</pattern>
-<pattern> re2ú2</pattern>
-<pattern>ea3cio </pattern>
-<pattern>ea3cios </pattern>
-<pattern>ea3cia </pattern>
-<pattern>ea3cias </pattern>
-<pattern> re3abr</pattern>
-<pattern> re3ábr</pattern>
-<pattern> re3afirm</pattern>
-<pattern> re3afírm</pattern>
-<pattern> re3ajust</pattern>
-<pattern> rea3júst</pattern>
-<pattern> rea3liza</pattern>
-<pattern> rea3lizá</pattern>
-<pattern> rea3líza</pattern>
-<pattern> re3alim</pattern>
-<pattern> rea3lism</pattern>
-<pattern> rea3list</pattern>
-<pattern> re3anim</pattern>
-<pattern> re3aním</pattern>
-<pattern> re3aparec</pattern>
-<pattern> re3ubica</pattern>
-<pattern> re3ubíca</pattern>
-<pattern> reu3mati</pattern>
-<pattern> reu3máti</pattern>
-<pattern> re3unir</pattern>
-<pattern> re3unír</pattern>
-<pattern> re3usar</pattern>
-<pattern> re3usár</pattern>
-<pattern> re3utiliz</pattern>
-<pattern> re3utilíz</pattern>
-<pattern>rmano1h</pattern>
-<pattern>rmano1a2</pattern>
-<pattern>rmano1e2</pattern>
-<pattern>rmano1i2</pattern>
-<pattern>rmano1o2</pattern>
-<pattern>rmano1u2</pattern>
-<pattern>rmano1á2</pattern>
-<pattern>rmano1é2</pattern>
-<pattern>rmano1í2</pattern>
-<pattern>rmano1ó2</pattern>
-<pattern>rmano1ú2</pattern>
-<pattern>retro1h</pattern>
-<pattern>retro1a2</pattern>
-<pattern>retro1e2</pattern>
-<pattern>retro1i2</pattern>
-<pattern>retro1o2</pattern>
-<pattern>retro1u2</pattern>
-<pattern>retro1á2</pattern>
-<pattern>retro1é2</pattern>
-<pattern>retro1í2</pattern>
-<pattern>retro1ó2</pattern>
-<pattern>retro1ú2</pattern>
-<pattern>romo1h</pattern>
-<pattern>romo1a2</pattern>
-<pattern>romo1e2</pattern>
-<pattern>romo1i2</pattern>
-<pattern>romo1o2</pattern>
-<pattern>romo1u2</pattern>
-<pattern>romo1á2</pattern>
-<pattern>romo1é2</pattern>
-<pattern>romo1í2</pattern>
-<pattern>romo1ó2</pattern>
-<pattern>romo1ú2</pattern>
-<pattern>sobre1h</pattern>
-<pattern>sobre1a2</pattern>
-<pattern>sobre1e2</pattern>
-<pattern>sobre1i2</pattern>
-<pattern>sobre1o2</pattern>
-<pattern>sobre1u2</pattern>
-<pattern>sobre1á2</pattern>
-<pattern>sobre1é2</pattern>
-<pattern>sobre1í2</pattern>
-<pattern>sobre1ó2</pattern>
-<pattern>sobre1ú2</pattern>
-<pattern>semi1h</pattern>
-<pattern>semi1a2</pattern>
-<pattern>semi1e2</pattern>
-<pattern>semi1i2</pattern>
-<pattern>semi1o2</pattern>
-<pattern>semi1u2</pattern>
-<pattern>semi1á2</pattern>
-<pattern>semi1é2</pattern>
-<pattern>semi1í2</pattern>
-<pattern>semi1ó2</pattern>
-<pattern>semi1ú2</pattern>
-<pattern>i2a </pattern>
-<pattern>i2as </pattern>
-<pattern>2ótic</pattern>
-<pattern>emi2o2</pattern>
-<pattern>seudo1h</pattern>
-<pattern>seudo1a2</pattern>
-<pattern>seudo1e2</pattern>
-<pattern>seudo1i2</pattern>
-<pattern>seudo1o2</pattern>
-<pattern>seudo1u2</pattern>
-<pattern>seudo1á2</pattern>
-<pattern>seudo1é2</pattern>
-<pattern>seudo1í2</pattern>
-<pattern>seudo1ó2</pattern>
-<pattern>seudo1ú2</pattern>
-<pattern>o2os </pattern>
-<pattern> so3a4s</pattern>
-<pattern>socio1h</pattern>
-<pattern>socio1a2</pattern>
-<pattern>socio1e2</pattern>
-<pattern>socio1i2</pattern>
-<pattern>socio1o2</pattern>
-<pattern>socio1u2</pattern>
-<pattern>socio1á2</pattern>
-<pattern>socio1é2</pattern>
-<pattern>socio1í2</pattern>
-<pattern>socio1ó2</pattern>
-<pattern>socio1ú2</pattern>
-<pattern>a3rio </pattern>
-<pattern>a3rios </pattern>
-<pattern>3logía</pattern>
-<pattern>4ón </pattern>
-<pattern>4ones </pattern>
-<pattern>4i4er </pattern>
-<pattern>4o2ico </pattern>
-<pattern>4o2icos </pattern>
-<pattern>4o2ica </pattern>
-<pattern>4o2icas </pattern>
-<pattern> su2b2a2</pattern>
-<pattern> su2b2e2</pattern>
-<pattern> su2b2i2</pattern>
-<pattern> su2b2o2</pattern>
-<pattern> su2b2u2</pattern>
-<pattern> su2b2á2</pattern>
-<pattern> su2b2é2</pattern>
-<pattern> su2b2í2</pattern>
-<pattern> su2b2ó2</pattern>
-<pattern> su2b2ú2</pattern>
-<pattern> sub2i3ll</pattern>
-<pattern> sub2i3mien</pattern>
-<pattern> sub3índ</pattern>
-<pattern> sub3ími</pattern>
-<pattern> su4b3ray</pattern>
-<pattern> sub3aflue</pattern>
-<pattern> sub3arr</pattern>
-<pattern> sub3enten</pattern>
-<pattern> sub3estim</pattern>
-<pattern> sub3estím</pattern>
-<pattern> sub3ofici</pattern>
-<pattern> sub3urba</pattern>
-<pattern> sub3alter</pattern>
-<pattern> sub3insp</pattern>
-<pattern> su3bién</pattern>
-<pattern> su3bir</pattern>
-<pattern> su3bam</pattern>
-<pattern> su3bordin</pattern>
-<pattern> su3bordín</pattern>
-<pattern> sub3acuá</pattern>
-<pattern> sub3espe</pattern>
-<pattern> sub3esta</pattern>
-<pattern> su3burbi</pattern>
-<pattern> su4b5rein</pattern>
-<pattern>supe2r3r</pattern>
-<pattern>supe2r1a2</pattern>
-<pattern>supe2r1e2</pattern>
-<pattern>supe2r1i2</pattern>
-<pattern>supe2r1o2</pattern>
-<pattern>supe2r1u2</pattern>
-<pattern>supe2r1á2</pattern>
-<pattern>supe2r1é2</pattern>
-<pattern>supe2r1í2</pattern>
-<pattern>supe2r1ó2</pattern>
-<pattern>supe2r1ú2</pattern>
-<pattern>supe3r4a4r</pattern>
-<pattern>supe3r4á4r</pattern>
-<pattern>supe3r4á3vit </pattern>
-<pattern>supe3r4á3vits </pattern>
-<pattern>4a3ción </pattern>
-<pattern>4a3ciones </pattern>
-<pattern>4e3rior </pattern>
-<pattern>4e3riores </pattern>
-<pattern>4e3riora </pattern>
-<pattern>4e3rioras </pattern>
-<pattern>4e3riormente </pattern>
-<pattern>4e3rioridad </pattern>
-<pattern>4e3rioridades </pattern>
-<pattern>4e3ra3ble </pattern>
-<pattern>4e3ra3bles </pattern>
-<pattern>4e3ra3blemente </pattern>
-<pattern>pe5r4ante</pattern>
-<pattern>perpon5d6r</pattern>
-<pattern>supra1h</pattern>
-<pattern>supra1a2</pattern>
-<pattern>supra1e2</pattern>
-<pattern>supra1i2</pattern>
-<pattern>supra1o2</pattern>
-<pattern>supra1u2</pattern>
-<pattern>supra1á2</pattern>
-<pattern>supra1é2</pattern>
-<pattern>supra1í2</pattern>
-<pattern>supra1ó2</pattern>
-<pattern>supra1ú2</pattern>
-<pattern>sup6ra</pattern>
-<pattern>talmo1h</pattern>
-<pattern>talmo1a2</pattern>
-<pattern>talmo1e2</pattern>
-<pattern>talmo1i2</pattern>
-<pattern>talmo1o2</pattern>
-<pattern>talmo1u2</pattern>
-<pattern>talmo1á2</pattern>
-<pattern>talmo1é2</pattern>
-<pattern>talmo1í2</pattern>
-<pattern>talmo1ó2</pattern>
-<pattern>talmo1ú2</pattern>
-<pattern>tele1h</pattern>
-<pattern>tele1a2</pattern>
-<pattern>tele1e2</pattern>
-<pattern>tele1i2</pattern>
-<pattern>tele1o2</pattern>
-<pattern>tele1u2</pattern>
-<pattern>tele1á2</pattern>
-<pattern>tele1é2</pattern>
-<pattern>tele1í2</pattern>
-<pattern>tele1ó2</pattern>
-<pattern>tele1ú2</pattern>
-<pattern>4ósteo </pattern>
-<pattern>4ósteos </pattern>
-<pattern>termo1h</pattern>
-<pattern>termo1a2</pattern>
-<pattern>termo1e2</pattern>
-<pattern>termo1i2</pattern>
-<pattern>termo1o2</pattern>
-<pattern>termo1u2</pattern>
-<pattern>termo1á2</pattern>
-<pattern>termo1é2</pattern>
-<pattern>termo1í2</pattern>
-<pattern>termo1ó2</pattern>
-<pattern>termo1ú2</pattern>
-<pattern>tetra1h</pattern>
-<pattern>tetra1a2</pattern>
-<pattern>tetra1e2</pattern>
-<pattern>tetra1i2</pattern>
-<pattern>tetra1o2</pattern>
-<pattern>tetra1u2</pattern>
-<pattern>tetra1á2</pattern>
-<pattern>tetra1é2</pattern>
-<pattern>tetra1í2</pattern>
-<pattern>tetra1ó2</pattern>
-<pattern>tetra1ú2</pattern>
-<pattern>topo1h</pattern>
-<pattern>topo1a2</pattern>
-<pattern>topo1e2</pattern>
-<pattern>topo1i2</pattern>
-<pattern>topo1o2</pattern>
-<pattern>topo1u2</pattern>
-<pattern>topo1á2</pattern>
-<pattern>topo1é2</pattern>
-<pattern>topo1í2</pattern>
-<pattern>topo1ó2</pattern>
-<pattern>topo1ú2</pattern>
-<pattern>tropo1h</pattern>
-<pattern>tropo1a2</pattern>
-<pattern>tropo1e2</pattern>
-<pattern>tropo1i2</pattern>
-<pattern>tropo1o2</pattern>
-<pattern>tropo1u2</pattern>
-<pattern>tropo1á2</pattern>
-<pattern>tropo1é2</pattern>
-<pattern>tropo1í2</pattern>
-<pattern>tropo1ó2</pattern>
-<pattern>tropo1ú2</pattern>
-<pattern>poi3de </pattern>
-<pattern>poi3des </pattern>
-<pattern>ultra1h</pattern>
-<pattern>ultra1a2</pattern>
-<pattern>ultra1e2</pattern>
-<pattern>ultra1i2</pattern>
-<pattern>ultra1o2</pattern>
-<pattern>ultra1u2</pattern>
-<pattern>ultra1á2</pattern>
-<pattern>ultra1é2</pattern>
-<pattern>ultra1í2</pattern>
-<pattern>ultra1ó2</pattern>
-<pattern>ultra1ú2</pattern>
-<pattern>xeno1h</pattern>
-<pattern>xeno1a2</pattern>
-<pattern>xeno1e2</pattern>
-<pattern>xeno1i2</pattern>
-<pattern>xeno1o2</pattern>
-<pattern>xeno1u2</pattern>
-<pattern>xeno1á2</pattern>
-<pattern>xeno1é2</pattern>
-<pattern>xeno1í2</pattern>
-<pattern>xeno1ó2</pattern>
-<pattern>xeno1ú2</pattern>
-<pattern>inter4és</pattern>
-<pattern>inter4esar</pattern>
-<pattern>inter4in</pattern>
-<pattern>inter4ino</pattern>
-<pattern>inter4ior</pattern>
-<pattern>mili4ar</pattern>
-<pattern>mili4ario</pattern>
-<pattern>para4íso</pattern>
-<pattern>para4ulata</pattern>
-<pattern>super4able</pattern>
-<pattern>super4ación</pattern>
-<pattern>super4ior</pattern>
-<pattern>tran4sacc</pattern>
-<pattern>trans4ar</pattern>
-<pattern>trans4eúnte</pattern>
-<pattern>trans4iber</pattern>
-<pattern>trans4ición</pattern>
-<pattern>trans4ido</pattern>
-<pattern>trans4igen</pattern>
-<pattern>trans4igir</pattern>
-<pattern>trans4istor</pattern>
-<pattern>trans4itab</pattern>
-<pattern>trans4it</pattern>
-<pattern>trans4itorio</pattern>
-<pattern>trans4ubsta</pattern>
-<pattern>ultra4ísmo</pattern>
-<pattern>wa3s4h</pattern>
-<pattern> bi1anual</pattern>
-<pattern> bi1aur</pattern>
-<pattern> bien1and</pattern>
-<pattern> bien1apa</pattern>
-<pattern> bien1ave</pattern>
-<pattern> bien1est</pattern>
-<pattern> bien1int</pattern>
-<pattern> bi1ox</pattern>
-<pattern> bi1ó2x</pattern>
-<pattern> bi1un</pattern>
-<pattern> en1aceit</pattern>
-<pattern> en1aciy</pattern>
-<pattern> en1aguach</pattern>
-<pattern> en1aguaz</pattern>
-<pattern> en1anch</pattern>
-<pattern> en1apa</pattern>
-<pattern> en1arb</pattern>
-<pattern> en1art</pattern>
-<pattern> en2artr</pattern>
-<pattern> en1ej</pattern>
-<pattern> hepta1e</pattern>
-<pattern> intra1o</pattern>
-<pattern> intra1u</pattern>
-<pattern> mal1acon</pattern>
-<pattern> mal1acos</pattern>
-<pattern> mala1e</pattern>
-<pattern> mal1andant</pattern>
-<pattern> mal1andanz</pattern>
-<pattern> mal1est</pattern>
-<pattern> mal1int</pattern>
-<pattern> pa4n1a4meri</pattern>
-<pattern> pa4n1europ</pattern>
-<pattern> pa4n1afri</pattern>
-<pattern> pa4n1ópti</pattern>
-<pattern>3p2sic</pattern>
-<pattern>3p2siq</pattern>
-<pattern> re3a2eg</pattern>
-<pattern> re3a2q</pattern>
-<pattern> re3a2z</pattern>
-<pattern> re3a2grup</pattern>
-<pattern> re3i2m</pattern>
-<pattern> re3inc</pattern>
-<pattern> re3ing</pattern>
-<pattern> re3ins</pattern>
-<pattern> re3int</pattern>
-<pattern> re3o2b</pattern>
-<pattern> re1oc</pattern>
-<pattern> re1oj</pattern>
-<pattern> re3orga</pattern>
-<pattern> re1unt</pattern>
-<pattern> retro1a</pattern>
-<pattern> su2d1a2fr</pattern>
-<pattern> su2d1a2me</pattern>
-<pattern> su2d1est</pattern>
-<pattern>su4d3oes</pattern>
-<pattern> sur1a2me</pattern>
-<pattern> sur1est</pattern>
-<pattern> sur1oes</pattern>
-<pattern> tele1imp</pattern>
-<pattern> tele1obj</pattern>
-<pattern> tra2s1a</pattern>
-<pattern> tra2s1o</pattern>
-<pattern> tra2s2oñ</pattern>
-<pattern> tran2s1alp</pattern>
-<pattern> tran2s1and</pattern>
-<pattern> tran2s1atl</pattern>
-<pattern> tran2s1oce</pattern>
-<pattern> tran2s1ur</pattern>
-<pattern> tri1ó2x</pattern>
-</HyphenationDescription>
+  <pattern>1b</pattern>
+  <pattern>4b </pattern>
+  <pattern> b2</pattern>
+  <pattern>2bb</pattern>
+  <pattern>2bc</pattern>
+  <pattern>2bd</pattern>
+  <pattern>2bf</pattern>
+  <pattern>2bg</pattern>
+  <pattern>2b1h</pattern>
+  <pattern>2bj</pattern>
+  <pattern>2bk</pattern>
+  <pattern>2bm</pattern>
+  <pattern>2bn</pattern>
+  <pattern>2bp</pattern>
+  <pattern>2bq</pattern>
+  <pattern>2bs</pattern>
+  <pattern>2bt</pattern>
+  <pattern>2bv</pattern>
+  <pattern>2bw</pattern>
+  <pattern>2bx</pattern>
+  <pattern>2by</pattern>
+  <pattern>2bz</pattern>
+  <pattern>1c</pattern>
+  <pattern>4c </pattern>
+  <pattern> c2</pattern>
+  <pattern>2cb</pattern>
+  <pattern>2cc</pattern>
+  <pattern>2cd</pattern>
+  <pattern>2cf</pattern>
+  <pattern>2cg</pattern>
+  <pattern>2cj</pattern>
+  <pattern>2ck</pattern>
+  <pattern>2cm</pattern>
+  <pattern>2cn</pattern>
+  <pattern>2cp</pattern>
+  <pattern>2cq</pattern>
+  <pattern>2cs</pattern>
+  <pattern>2ct</pattern>
+  <pattern>2cv</pattern>
+  <pattern>2cw</pattern>
+  <pattern>2cx</pattern>
+  <pattern>2cy</pattern>
+  <pattern>2cz</pattern>
+  <pattern>1d</pattern>
+  <pattern>4d </pattern>
+  <pattern> d2</pattern>
+  <pattern>2db</pattern>
+  <pattern>2dc</pattern>
+  <pattern>2dd</pattern>
+  <pattern>2df</pattern>
+  <pattern>2dg</pattern>
+  <pattern>2d1h</pattern>
+  <pattern>2dj</pattern>
+  <pattern>2dk</pattern>
+  <pattern>2dl</pattern>
+  <pattern>2dm</pattern>
+  <pattern>2dn</pattern>
+  <pattern>2dp</pattern>
+  <pattern>2dq</pattern>
+  <pattern>2ds</pattern>
+  <pattern>2dt</pattern>
+  <pattern>2dv</pattern>
+  <pattern>2dw</pattern>
+  <pattern>2dx</pattern>
+  <pattern>2dy</pattern>
+  <pattern>2dz</pattern>
+  <pattern>1f</pattern>
+  <pattern>4f </pattern>
+  <pattern> f2</pattern>
+  <pattern>2fb</pattern>
+  <pattern>2fc</pattern>
+  <pattern>2fd</pattern>
+  <pattern>2ff</pattern>
+  <pattern>2fg</pattern>
+  <pattern>2f1h</pattern>
+  <pattern>2fj</pattern>
+  <pattern>2fk</pattern>
+  <pattern>2fm</pattern>
+  <pattern>2fn</pattern>
+  <pattern>2fp</pattern>
+  <pattern>2fq</pattern>
+  <pattern>2fs</pattern>
+  <pattern>2ft</pattern>
+  <pattern>2fv</pattern>
+  <pattern>2fw</pattern>
+  <pattern>2fx</pattern>
+  <pattern>2fy</pattern>
+  <pattern>2fz</pattern>
+  <pattern>1g</pattern>
+  <pattern>4g </pattern>
+  <pattern> g2</pattern>
+  <pattern>2gb</pattern>
+  <pattern>2gc</pattern>
+  <pattern>2gd</pattern>
+  <pattern>2gf</pattern>
+  <pattern>2gg</pattern>
+  <pattern>2g1h</pattern>
+  <pattern>2gj</pattern>
+  <pattern>2gk</pattern>
+  <pattern>2gm</pattern>
+  <pattern>2gn</pattern>
+  <pattern>2gp</pattern>
+  <pattern>2gq</pattern>
+  <pattern>2gs</pattern>
+  <pattern>2gt</pattern>
+  <pattern>2gv</pattern>
+  <pattern>2gw</pattern>
+  <pattern>2gx</pattern>
+  <pattern>2gy</pattern>
+  <pattern>2gz</pattern>
+  <pattern>4h </pattern>
+  <pattern>2hb</pattern>
+  <pattern>2hc</pattern>
+  <pattern>2hd</pattern>
+  <pattern>2hf</pattern>
+  <pattern>2hg</pattern>
+  <pattern>2h1h</pattern>
+  <pattern>2hj</pattern>
+  <pattern>2hk</pattern>
+  <pattern>2hl</pattern>
+  <pattern>2hm</pattern>
+  <pattern>2hn</pattern>
+  <pattern>2hp</pattern>
+  <pattern>2hq</pattern>
+  <pattern>2hr</pattern>
+  <pattern>2hs</pattern>
+  <pattern>2ht</pattern>
+  <pattern>2hv</pattern>
+  <pattern>2hw</pattern>
+  <pattern>2hx</pattern>
+  <pattern>2hy</pattern>
+  <pattern>2hz</pattern>
+  <pattern>1j</pattern>
+  <pattern>4j </pattern>
+  <pattern> j2</pattern>
+  <pattern>2jb</pattern>
+  <pattern>2jc</pattern>
+  <pattern>2jd</pattern>
+  <pattern>2jf</pattern>
+  <pattern>2jg</pattern>
+  <pattern>2j1h</pattern>
+  <pattern>2jj</pattern>
+  <pattern>2jk</pattern>
+  <pattern>2jl</pattern>
+  <pattern>2jm</pattern>
+  <pattern>2jn</pattern>
+  <pattern>2jp</pattern>
+  <pattern>2jq</pattern>
+  <pattern>2jr</pattern>
+  <pattern>2js</pattern>
+  <pattern>2jt</pattern>
+  <pattern>2jv</pattern>
+  <pattern>2jw</pattern>
+  <pattern>2jx</pattern>
+  <pattern>2jy</pattern>
+  <pattern>2jz</pattern>
+  <pattern>1k</pattern>
+  <pattern>4k </pattern>
+  <pattern> k2</pattern>
+  <pattern>2kb</pattern>
+  <pattern>2kc</pattern>
+  <pattern>2kd</pattern>
+  <pattern>2kf</pattern>
+  <pattern>2kg</pattern>
+  <pattern>2k1h</pattern>
+  <pattern>2kj</pattern>
+  <pattern>2kk</pattern>
+  <pattern>2km</pattern>
+  <pattern>2kn</pattern>
+  <pattern>2kp</pattern>
+  <pattern>2kq</pattern>
+  <pattern>2ks</pattern>
+  <pattern>2kt</pattern>
+  <pattern>2kv</pattern>
+  <pattern>2kw</pattern>
+  <pattern>2kx</pattern>
+  <pattern>2ky</pattern>
+  <pattern>2kz</pattern>
+  <pattern>1l</pattern>
+  <pattern>4l </pattern>
+  <pattern> l2</pattern>
+  <pattern>2lb</pattern>
+  <pattern>2lc</pattern>
+  <pattern>2ld</pattern>
+  <pattern>2lf</pattern>
+  <pattern>2lg</pattern>
+  <pattern>2l1h</pattern>
+  <pattern>2lj</pattern>
+  <pattern>2lk</pattern>
+  <pattern>2lm</pattern>
+  <pattern>2ln</pattern>
+  <pattern>2lp</pattern>
+  <pattern>2lq</pattern>
+  <pattern>2lr</pattern>
+  <pattern>2ls</pattern>
+  <pattern>2lt</pattern>
+  <pattern>2lv</pattern>
+  <pattern>2lw</pattern>
+  <pattern>2lx</pattern>
+  <pattern>2ly</pattern>
+  <pattern>2lz</pattern>
+  <pattern>1m</pattern>
+  <pattern>4m </pattern>
+  <pattern> m2</pattern>
+  <pattern>2mb</pattern>
+  <pattern>2mc</pattern>
+  <pattern>2md</pattern>
+  <pattern>2mf</pattern>
+  <pattern>2mg</pattern>
+  <pattern>2m1h</pattern>
+  <pattern>2mj</pattern>
+  <pattern>2mk</pattern>
+  <pattern>2ml</pattern>
+  <pattern>2mm</pattern>
+  <pattern>2mn</pattern>
+  <pattern>2mp</pattern>
+  <pattern>2mq</pattern>
+  <pattern>2mr</pattern>
+  <pattern>2ms</pattern>
+  <pattern>2mt</pattern>
+  <pattern>2mv</pattern>
+  <pattern>2mw</pattern>
+  <pattern>2mx</pattern>
+  <pattern>2my</pattern>
+  <pattern>2mz</pattern>
+  <pattern>1n</pattern>
+  <pattern>4n </pattern>
+  <pattern> n2</pattern>
+  <pattern>2nb</pattern>
+  <pattern>2nc</pattern>
+  <pattern>2nd</pattern>
+  <pattern>2nf</pattern>
+  <pattern>2ng</pattern>
+  <pattern>2n1h</pattern>
+  <pattern>2nj</pattern>
+  <pattern>2nk</pattern>
+  <pattern>2nl</pattern>
+  <pattern>2nm</pattern>
+  <pattern>2nn</pattern>
+  <pattern>2np</pattern>
+  <pattern>2nq</pattern>
+  <pattern>2nr</pattern>
+  <pattern>2ns</pattern>
+  <pattern>2nt</pattern>
+  <pattern>2nv</pattern>
+  <pattern>2nw</pattern>
+  <pattern>2nx</pattern>
+  <pattern>2ny</pattern>
+  <pattern>2nz</pattern>
+  <pattern>1p</pattern>
+  <pattern>4p </pattern>
+  <pattern> p2</pattern>
+  <pattern>2pb</pattern>
+  <pattern>2pc</pattern>
+  <pattern>2pd</pattern>
+  <pattern>2pf</pattern>
+  <pattern>2pg</pattern>
+  <pattern>2p1h</pattern>
+  <pattern>2pj</pattern>
+  <pattern>2pk</pattern>
+  <pattern>2pm</pattern>
+  <pattern>2pn</pattern>
+  <pattern>2pp</pattern>
+  <pattern>2pq</pattern>
+  <pattern>2ps</pattern>
+  <pattern>2pt</pattern>
+  <pattern>2pv</pattern>
+  <pattern>2pw</pattern>
+  <pattern>2px</pattern>
+  <pattern>2py</pattern>
+  <pattern>2pz</pattern>
+  <pattern>1q</pattern>
+  <pattern>4q </pattern>
+  <pattern> q2</pattern>
+  <pattern>2qb</pattern>
+  <pattern>2qc</pattern>
+  <pattern>2qd</pattern>
+  <pattern>2qf</pattern>
+  <pattern>2qg</pattern>
+  <pattern>2q1h</pattern>
+  <pattern>2qj</pattern>
+  <pattern>2qk</pattern>
+  <pattern>2ql</pattern>
+  <pattern>2qm</pattern>
+  <pattern>2qn</pattern>
+  <pattern>2qp</pattern>
+  <pattern>2qq</pattern>
+  <pattern>2qr</pattern>
+  <pattern>2qs</pattern>
+  <pattern>2qt</pattern>
+  <pattern>2qv</pattern>
+  <pattern>2qw</pattern>
+  <pattern>2qx</pattern>
+  <pattern>2qy</pattern>
+  <pattern>2qz</pattern>
+  <pattern>1r</pattern>
+  <pattern>4r </pattern>
+  <pattern> r2</pattern>
+  <pattern>2rb</pattern>
+  <pattern>2rc</pattern>
+  <pattern>2rd</pattern>
+  <pattern>2rf</pattern>
+  <pattern>2rg</pattern>
+  <pattern>2r1h</pattern>
+  <pattern>2rj</pattern>
+  <pattern>2rk</pattern>
+  <pattern>2rl</pattern>
+  <pattern>2rm</pattern>
+  <pattern>2rn</pattern>
+  <pattern>2rp</pattern>
+  <pattern>2rq</pattern>
+  <pattern>2rs</pattern>
+  <pattern>2rt</pattern>
+  <pattern>2rv</pattern>
+  <pattern>2rw</pattern>
+  <pattern>2rx</pattern>
+  <pattern>2ry</pattern>
+  <pattern>2rz</pattern>
+  <pattern>1s</pattern>
+  <pattern>4s </pattern>
+  <pattern> s2</pattern>
+  <pattern>2sb</pattern>
+  <pattern>2sc</pattern>
+  <pattern>2sd</pattern>
+  <pattern>2sf</pattern>
+  <pattern>2sg</pattern>
+  <pattern>2s1h</pattern>
+  <pattern>2sj</pattern>
+  <pattern>2sk</pattern>
+  <pattern>2sl</pattern>
+  <pattern>2sm</pattern>
+  <pattern>2sn</pattern>
+  <pattern>2sp</pattern>
+  <pattern>2sq</pattern>
+  <pattern>2sr</pattern>
+  <pattern>2ss</pattern>
+  <pattern>2st</pattern>
+  <pattern>2sv</pattern>
+  <pattern>2sw</pattern>
+  <pattern>2sx</pattern>
+  <pattern>2sy</pattern>
+  <pattern>2sz</pattern>
+  <pattern>1t</pattern>
+  <pattern>4t </pattern>
+  <pattern> t2</pattern>
+  <pattern>2tb</pattern>
+  <pattern>2tc</pattern>
+  <pattern>2td</pattern>
+  <pattern>2tf</pattern>
+  <pattern>2tg</pattern>
+  <pattern>2t1h</pattern>
+  <pattern>2tj</pattern>
+  <pattern>2tk</pattern>
+  <pattern>2tm</pattern>
+  <pattern>2tn</pattern>
+  <pattern>2tp</pattern>
+  <pattern>2tq</pattern>
+  <pattern>2tt</pattern>
+  <pattern>2tv</pattern>
+  <pattern>2tw</pattern>
+  <pattern>2ty</pattern>
+  <pattern>1v</pattern>
+  <pattern>4v </pattern>
+  <pattern> v2</pattern>
+  <pattern>2vb</pattern>
+  <pattern>2vc</pattern>
+  <pattern>2vd</pattern>
+  <pattern>2vf</pattern>
+  <pattern>2vg</pattern>
+  <pattern>2v1h</pattern>
+  <pattern>2vj</pattern>
+  <pattern>2vk</pattern>
+  <pattern>2vm</pattern>
+  <pattern>2vn</pattern>
+  <pattern>2vp</pattern>
+  <pattern>2vq</pattern>
+  <pattern>2vs</pattern>
+  <pattern>2vt</pattern>
+  <pattern>2vv</pattern>
+  <pattern>2vw</pattern>
+  <pattern>2vx</pattern>
+  <pattern>2vy</pattern>
+  <pattern>2vz</pattern>
+  <pattern>1w</pattern>
+  <pattern>4w </pattern>
+  <pattern> w2</pattern>
+  <pattern>2wb</pattern>
+  <pattern>2wc</pattern>
+  <pattern>2wd</pattern>
+  <pattern>2wf</pattern>
+  <pattern>2wg</pattern>
+  <pattern>2w1h</pattern>
+  <pattern>2wj</pattern>
+  <pattern>2wk</pattern>
+  <pattern>2wl</pattern>
+  <pattern>2wm</pattern>
+  <pattern>2wn</pattern>
+  <pattern>2wp</pattern>
+  <pattern>2wq</pattern>
+  <pattern>2wr</pattern>
+  <pattern>2ws</pattern>
+  <pattern>2wt</pattern>
+  <pattern>2wv</pattern>
+  <pattern>2ww</pattern>
+  <pattern>2wx</pattern>
+  <pattern>2wy</pattern>
+  <pattern>2wz</pattern>
+  <pattern>1x</pattern>
+  <pattern>4x </pattern>
+  <pattern> x2</pattern>
+  <pattern>2xb</pattern>
+  <pattern>2xc</pattern>
+  <pattern>2xd</pattern>
+  <pattern>2xf</pattern>
+  <pattern>2xg</pattern>
+  <pattern>2x1h</pattern>
+  <pattern>2xj</pattern>
+  <pattern>2xk</pattern>
+  <pattern>2xl</pattern>
+  <pattern>2xm</pattern>
+  <pattern>2xn</pattern>
+  <pattern>2xp</pattern>
+  <pattern>2xq</pattern>
+  <pattern>2xr</pattern>
+  <pattern>2xs</pattern>
+  <pattern>2xt</pattern>
+  <pattern>2xv</pattern>
+  <pattern>2xw</pattern>
+  <pattern>2xx</pattern>
+  <pattern>2xy</pattern>
+  <pattern>2xz</pattern>
+  <pattern>1y</pattern>
+  <pattern>4y </pattern>
+  <pattern> y2</pattern>
+  <pattern>2yb</pattern>
+  <pattern>2yc</pattern>
+  <pattern>2yd</pattern>
+  <pattern>2yf</pattern>
+  <pattern>2yg</pattern>
+  <pattern>2y1h</pattern>
+  <pattern>2yj</pattern>
+  <pattern>2yk</pattern>
+  <pattern>2yl</pattern>
+  <pattern>2ym</pattern>
+  <pattern>2yn</pattern>
+  <pattern>2yp</pattern>
+  <pattern>2yq</pattern>
+  <pattern>2yr</pattern>
+  <pattern>2ys</pattern>
+  <pattern>2yt</pattern>
+  <pattern>2yv</pattern>
+  <pattern>2yw</pattern>
+  <pattern>2yx</pattern>
+  <pattern>2yy</pattern>
+  <pattern>2yz</pattern>
+  <pattern>1z</pattern>
+  <pattern>4z </pattern>
+  <pattern> z2</pattern>
+  <pattern>2zb</pattern>
+  <pattern>2zc</pattern>
+  <pattern>2zd</pattern>
+  <pattern>2zf</pattern>
+  <pattern>2zg</pattern>
+  <pattern>2z1h</pattern>
+  <pattern>2zj</pattern>
+  <pattern>2zk</pattern>
+  <pattern>2zl</pattern>
+  <pattern>2zm</pattern>
+  <pattern>2zn</pattern>
+  <pattern>2zp</pattern>
+  <pattern>2zq</pattern>
+  <pattern>2zr</pattern>
+  <pattern>2zs</pattern>
+  <pattern>2zt</pattern>
+  <pattern>2zv</pattern>
+  <pattern>2zw</pattern>
+  <pattern>2zx</pattern>
+  <pattern>2zy</pattern>
+  <pattern>2zz</pattern>
+  <pattern>1ñ</pattern>
+  <pattern>4ñ </pattern>
+  <pattern>c4h</pattern>
+  <pattern>4ch </pattern>
+  <pattern>2chb</pattern>
+  <pattern>2chc</pattern>
+  <pattern>2chd</pattern>
+  <pattern>2chf</pattern>
+  <pattern>2chg</pattern>
+  <pattern>2chh</pattern>
+  <pattern>2chj</pattern>
+  <pattern>2chk</pattern>
+  <pattern>ch2l</pattern>
+  <pattern>2chm</pattern>
+  <pattern>2chn</pattern>
+  <pattern>2chp</pattern>
+  <pattern>2chq</pattern>
+  <pattern>ch2r</pattern>
+  <pattern>2chs</pattern>
+  <pattern>2cht</pattern>
+  <pattern>2chv</pattern>
+  <pattern>2chw</pattern>
+  <pattern>2chx</pattern>
+  <pattern>2chy</pattern>
+  <pattern>2chz</pattern>
+  <pattern>l4l</pattern>
+  <pattern>4ll </pattern>
+  <pattern>2llb</pattern>
+  <pattern>2llc</pattern>
+  <pattern>2lld</pattern>
+  <pattern>2llf</pattern>
+  <pattern>2llg</pattern>
+  <pattern>2llh</pattern>
+  <pattern>2llj</pattern>
+  <pattern>2llk</pattern>
+  <pattern>2lll</pattern>
+  <pattern>2llm</pattern>
+  <pattern>2lln</pattern>
+  <pattern>2llp</pattern>
+  <pattern>2llq</pattern>
+  <pattern>2llr</pattern>
+  <pattern>2lls</pattern>
+  <pattern>2llt</pattern>
+  <pattern>2llv</pattern>
+  <pattern>2llw</pattern>
+  <pattern>2llx</pattern>
+  <pattern>2lly</pattern>
+  <pattern>2llz</pattern>
+  <pattern>b2l</pattern>
+  <pattern>4bl </pattern>
+  <pattern>2bl2b</pattern>
+  <pattern>2bl2c</pattern>
+  <pattern>2bl2d</pattern>
+  <pattern>2bl2f</pattern>
+  <pattern>2bl2g</pattern>
+  <pattern>2bl2h</pattern>
+  <pattern>2bl2j</pattern>
+  <pattern>2bl2k</pattern>
+  <pattern>2bl2l</pattern>
+  <pattern>2bl2m</pattern>
+  <pattern>2bl2n</pattern>
+  <pattern>2bl2p</pattern>
+  <pattern>2bl2q</pattern>
+  <pattern>2bl2r</pattern>
+  <pattern>2bl2s</pattern>
+  <pattern>2bl2t</pattern>
+  <pattern>2bl2v</pattern>
+  <pattern>2bl2w</pattern>
+  <pattern>2bl2x</pattern>
+  <pattern>2bl2y</pattern>
+  <pattern>2bl2z</pattern>
+  <pattern>c2l</pattern>
+  <pattern>4cl </pattern>
+  <pattern>2cl2b</pattern>
+  <pattern>2cl2c</pattern>
+  <pattern>2cl2d</pattern>
+  <pattern>2cl2f</pattern>
+  <pattern>2cl2g</pattern>
+  <pattern>2cl2h</pattern>
+  <pattern>2cl2j</pattern>
+  <pattern>2cl2k</pattern>
+  <pattern>2cl2l</pattern>
+  <pattern>2cl2m</pattern>
+  <pattern>2cl2n</pattern>
+  <pattern>2cl2p</pattern>
+  <pattern>2cl2q</pattern>
+  <pattern>2cl2r</pattern>
+  <pattern>2cl2s</pattern>
+  <pattern>2cl2t</pattern>
+  <pattern>2cl2v</pattern>
+  <pattern>2cl2w</pattern>
+  <pattern>2cl2x</pattern>
+  <pattern>2cl2y</pattern>
+  <pattern>2cl2z</pattern>
+  <pattern>f2l</pattern>
+  <pattern>4fl </pattern>
+  <pattern>2fl2b</pattern>
+  <pattern>2fl2c</pattern>
+  <pattern>2fl2d</pattern>
+  <pattern>2fl2f</pattern>
+  <pattern>2fl2g</pattern>
+  <pattern>2fl2h</pattern>
+  <pattern>2fl2j</pattern>
+  <pattern>2fl2k</pattern>
+  <pattern>2fl2l</pattern>
+  <pattern>2fl2m</pattern>
+  <pattern>2fl2n</pattern>
+  <pattern>2fl2p</pattern>
+  <pattern>2fl2q</pattern>
+  <pattern>2fl2r</pattern>
+  <pattern>2fl2s</pattern>
+  <pattern>2fl2t</pattern>
+  <pattern>2fl2v</pattern>
+  <pattern>2fl2w</pattern>
+  <pattern>2fl2x</pattern>
+  <pattern>2fl2y</pattern>
+  <pattern>2fl2z</pattern>
+  <pattern>g2l</pattern>
+  <pattern>4gl </pattern>
+  <pattern>2gl2b</pattern>
+  <pattern>2gl2c</pattern>
+  <pattern>2gl2d</pattern>
+  <pattern>2gl2f</pattern>
+  <pattern>2gl2g</pattern>
+  <pattern>2gl2h</pattern>
+  <pattern>2gl2j</pattern>
+  <pattern>2gl2k</pattern>
+  <pattern>2gl2l</pattern>
+  <pattern>2gl2m</pattern>
+  <pattern>2gl2n</pattern>
+  <pattern>2gl2p</pattern>
+  <pattern>2gl2q</pattern>
+  <pattern>2gl2r</pattern>
+  <pattern>2gl2s</pattern>
+  <pattern>2gl2t</pattern>
+  <pattern>2gl2v</pattern>
+  <pattern>2gl2w</pattern>
+  <pattern>2gl2x</pattern>
+  <pattern>2gl2y</pattern>
+  <pattern>2gl2z</pattern>
+  <pattern>k2l</pattern>
+  <pattern>4kl </pattern>
+  <pattern>2kl2b</pattern>
+  <pattern>2kl2c</pattern>
+  <pattern>2kl2d</pattern>
+  <pattern>2kl2f</pattern>
+  <pattern>2kl2g</pattern>
+  <pattern>2kl2h</pattern>
+  <pattern>2kl2j</pattern>
+  <pattern>2kl2k</pattern>
+  <pattern>2kl2l</pattern>
+  <pattern>2kl2m</pattern>
+  <pattern>2kl2n</pattern>
+  <pattern>2kl2p</pattern>
+  <pattern>2kl2q</pattern>
+  <pattern>2kl2r</pattern>
+  <pattern>2kl2s</pattern>
+  <pattern>2kl2t</pattern>
+  <pattern>2kl2v</pattern>
+  <pattern>2kl2w</pattern>
+  <pattern>2kl2x</pattern>
+  <pattern>2kl2y</pattern>
+  <pattern>2kl2z</pattern>
+  <pattern>p2l</pattern>
+  <pattern>4pl </pattern>
+  <pattern>2pl2b</pattern>
+  <pattern>2pl2c</pattern>
+  <pattern>2pl2d</pattern>
+  <pattern>2pl2f</pattern>
+  <pattern>2pl2g</pattern>
+  <pattern>2pl2h</pattern>
+  <pattern>2pl2j</pattern>
+  <pattern>2pl2k</pattern>
+  <pattern>2pl2l</pattern>
+  <pattern>2pl2m</pattern>
+  <pattern>2pl2n</pattern>
+  <pattern>2pl2p</pattern>
+  <pattern>2pl2q</pattern>
+  <pattern>2pl2r</pattern>
+  <pattern>2pl2s</pattern>
+  <pattern>2pl2t</pattern>
+  <pattern>2pl2v</pattern>
+  <pattern>2pl2w</pattern>
+  <pattern>2pl2x</pattern>
+  <pattern>2pl2y</pattern>
+  <pattern>2pl2z</pattern>
+  <pattern>v2l</pattern>
+  <pattern>4vl </pattern>
+  <pattern>2vl2b</pattern>
+  <pattern>2vl2c</pattern>
+  <pattern>2vl2d</pattern>
+  <pattern>2vl2f</pattern>
+  <pattern>2vl2g</pattern>
+  <pattern>2vl2h</pattern>
+  <pattern>2vl2j</pattern>
+  <pattern>2vl2k</pattern>
+  <pattern>2vl2l</pattern>
+  <pattern>2vl2m</pattern>
+  <pattern>2vl2n</pattern>
+  <pattern>2vl2p</pattern>
+  <pattern>2vl2q</pattern>
+  <pattern>2vl2r</pattern>
+  <pattern>2vl2s</pattern>
+  <pattern>2vl2t</pattern>
+  <pattern>2vl2v</pattern>
+  <pattern>2vl2w</pattern>
+  <pattern>2vl2x</pattern>
+  <pattern>2vl2y</pattern>
+  <pattern>2vl2z</pattern>
+  <pattern>b2r</pattern>
+  <pattern>4br </pattern>
+  <pattern>2br2b</pattern>
+  <pattern>2br2c</pattern>
+  <pattern>2br2d</pattern>
+  <pattern>2br2f</pattern>
+  <pattern>2br2g</pattern>
+  <pattern>2br2h</pattern>
+  <pattern>2br2j</pattern>
+  <pattern>2br2k</pattern>
+  <pattern>2br2l</pattern>
+  <pattern>2br2m</pattern>
+  <pattern>2br2n</pattern>
+  <pattern>2br2p</pattern>
+  <pattern>2br2q</pattern>
+  <pattern>2br2r</pattern>
+  <pattern>2br2s</pattern>
+  <pattern>2br2t</pattern>
+  <pattern>2br2v</pattern>
+  <pattern>2br2w</pattern>
+  <pattern>2br2x</pattern>
+  <pattern>2br2y</pattern>
+  <pattern>2br2z</pattern>
+  <pattern>c2r</pattern>
+  <pattern>4cr </pattern>
+  <pattern>2cr2b</pattern>
+  <pattern>2cr2c</pattern>
+  <pattern>2cr2d</pattern>
+  <pattern>2cr2f</pattern>
+  <pattern>2cr2g</pattern>
+  <pattern>2cr2h</pattern>
+  <pattern>2cr2j</pattern>
+  <pattern>2cr2k</pattern>
+  <pattern>2cr2l</pattern>
+  <pattern>2cr2m</pattern>
+  <pattern>2cr2n</pattern>
+  <pattern>2cr2p</pattern>
+  <pattern>2cr2q</pattern>
+  <pattern>2cr2r</pattern>
+  <pattern>2cr2s</pattern>
+  <pattern>2cr2t</pattern>
+  <pattern>2cr2v</pattern>
+  <pattern>2cr2w</pattern>
+  <pattern>2cr2x</pattern>
+  <pattern>2cr2y</pattern>
+  <pattern>2cr2z</pattern>
+  <pattern>d2r</pattern>
+  <pattern>4dr </pattern>
+  <pattern>2dr2b</pattern>
+  <pattern>2dr2c</pattern>
+  <pattern>2dr2d</pattern>
+  <pattern>2dr2f</pattern>
+  <pattern>2dr2g</pattern>
+  <pattern>2dr2h</pattern>
+  <pattern>2dr2j</pattern>
+  <pattern>2dr2k</pattern>
+  <pattern>2dr2l</pattern>
+  <pattern>2dr2m</pattern>
+  <pattern>2dr2n</pattern>
+  <pattern>2dr2p</pattern>
+  <pattern>2dr2q</pattern>
+  <pattern>2dr2r</pattern>
+  <pattern>2dr2s</pattern>
+  <pattern>2dr2t</pattern>
+  <pattern>2dr2v</pattern>
+  <pattern>2dr2w</pattern>
+  <pattern>2dr2x</pattern>
+  <pattern>2dr2y</pattern>
+  <pattern>2dr2z</pattern>
+  <pattern>f2r</pattern>
+  <pattern>4fr </pattern>
+  <pattern>2fr2b</pattern>
+  <pattern>2fr2c</pattern>
+  <pattern>2fr2d</pattern>
+  <pattern>2fr2f</pattern>
+  <pattern>2fr2g</pattern>
+  <pattern>2fr2h</pattern>
+  <pattern>2fr2j</pattern>
+  <pattern>2fr2k</pattern>
+  <pattern>2fr2l</pattern>
+  <pattern>2fr2m</pattern>
+  <pattern>2fr2n</pattern>
+  <pattern>2fr2p</pattern>
+  <pattern>2fr2q</pattern>
+  <pattern>2fr2r</pattern>
+  <pattern>2fr2s</pattern>
+  <pattern>2fr2t</pattern>
+  <pattern>2fr2v</pattern>
+  <pattern>2fr2w</pattern>
+  <pattern>2fr2x</pattern>
+  <pattern>2fr2y</pattern>
+  <pattern>2fr2z</pattern>
+  <pattern>g2r</pattern>
+  <pattern>4gr </pattern>
+  <pattern>2gr2b</pattern>
+  <pattern>2gr2c</pattern>
+  <pattern>2gr2d</pattern>
+  <pattern>2gr2f</pattern>
+  <pattern>2gr2g</pattern>
+  <pattern>2gr2h</pattern>
+  <pattern>2gr2j</pattern>
+  <pattern>2gr2k</pattern>
+  <pattern>2gr2l</pattern>
+  <pattern>2gr2m</pattern>
+  <pattern>2gr2n</pattern>
+  <pattern>2gr2p</pattern>
+  <pattern>2gr2q</pattern>
+  <pattern>2gr2r</pattern>
+  <pattern>2gr2s</pattern>
+  <pattern>2gr2t</pattern>
+  <pattern>2gr2v</pattern>
+  <pattern>2gr2w</pattern>
+  <pattern>2gr2x</pattern>
+  <pattern>2gr2y</pattern>
+  <pattern>2gr2z</pattern>
+  <pattern>k2r</pattern>
+  <pattern>4kr </pattern>
+  <pattern>2kr2b</pattern>
+  <pattern>2kr2c</pattern>
+  <pattern>2kr2d</pattern>
+  <pattern>2kr2f</pattern>
+  <pattern>2kr2g</pattern>
+  <pattern>2kr2h</pattern>
+  <pattern>2kr2j</pattern>
+  <pattern>2kr2k</pattern>
+  <pattern>2kr2l</pattern>
+  <pattern>2kr2m</pattern>
+  <pattern>2kr2n</pattern>
+  <pattern>2kr2p</pattern>
+  <pattern>2kr2q</pattern>
+  <pattern>2kr2r</pattern>
+  <pattern>2kr2s</pattern>
+  <pattern>2kr2t</pattern>
+  <pattern>2kr2v</pattern>
+  <pattern>2kr2w</pattern>
+  <pattern>2kr2x</pattern>
+  <pattern>2kr2y</pattern>
+  <pattern>2kr2z</pattern>
+  <pattern>p2r</pattern>
+  <pattern>4pr </pattern>
+  <pattern>2pr2b</pattern>
+  <pattern>2pr2c</pattern>
+  <pattern>2pr2d</pattern>
+  <pattern>2pr2f</pattern>
+  <pattern>2pr2g</pattern>
+  <pattern>2pr2h</pattern>
+  <pattern>2pr2j</pattern>
+  <pattern>2pr2k</pattern>
+  <pattern>2pr2l</pattern>
+  <pattern>2pr2m</pattern>
+  <pattern>2pr2n</pattern>
+  <pattern>2pr2p</pattern>
+  <pattern>2pr2q</pattern>
+  <pattern>2pr2r</pattern>
+  <pattern>2pr2s</pattern>
+  <pattern>2pr2t</pattern>
+  <pattern>2pr2v</pattern>
+  <pattern>2pr2w</pattern>
+  <pattern>2pr2x</pattern>
+  <pattern>2pr2y</pattern>
+  <pattern>2pr2z</pattern>
+  <pattern>r2r</pattern>
+  <pattern>4rr </pattern>
+  <pattern>2rr2b</pattern>
+  <pattern>2rr2c</pattern>
+  <pattern>2rr2d</pattern>
+  <pattern>2rr2f</pattern>
+  <pattern>2rr2g</pattern>
+  <pattern>2rr2h</pattern>
+  <pattern>2rr2j</pattern>
+  <pattern>2rr2k</pattern>
+  <pattern>2rr2l</pattern>
+  <pattern>2rr2m</pattern>
+  <pattern>2rr2n</pattern>
+  <pattern>2rr2p</pattern>
+  <pattern>2rr2q</pattern>
+  <pattern>2rr2r</pattern>
+  <pattern>2rr2s</pattern>
+  <pattern>2rr2t</pattern>
+  <pattern>2rr2v</pattern>
+  <pattern>2rr2w</pattern>
+  <pattern>2rr2x</pattern>
+  <pattern>2rr2y</pattern>
+  <pattern>2rr2z</pattern>
+  <pattern>t2r</pattern>
+  <pattern>4tr </pattern>
+  <pattern>2tr2b</pattern>
+  <pattern>2tr2c</pattern>
+  <pattern>2tr2d</pattern>
+  <pattern>2tr2f</pattern>
+  <pattern>2tr2g</pattern>
+  <pattern>2tr2h</pattern>
+  <pattern>2tr2j</pattern>
+  <pattern>2tr2k</pattern>
+  <pattern>2tr2l</pattern>
+  <pattern>2tr2m</pattern>
+  <pattern>2tr2n</pattern>
+  <pattern>2tr2p</pattern>
+  <pattern>2tr2q</pattern>
+  <pattern>2tr2r</pattern>
+  <pattern>2tr2s</pattern>
+  <pattern>2tr2t</pattern>
+  <pattern>2tr2v</pattern>
+  <pattern>2tr2w</pattern>
+  <pattern>2tr2x</pattern>
+  <pattern>2tr2y</pattern>
+  <pattern>2tr2z</pattern>
+  <pattern>v2r</pattern>
+  <pattern>4vr </pattern>
+  <pattern>2vr2b</pattern>
+  <pattern>2vr2c</pattern>
+  <pattern>2vr2d</pattern>
+  <pattern>2vr2f</pattern>
+  <pattern>2vr2g</pattern>
+  <pattern>2vr2h</pattern>
+  <pattern>2vr2j</pattern>
+  <pattern>2vr2k</pattern>
+  <pattern>2vr2l</pattern>
+  <pattern>2vr2m</pattern>
+  <pattern>2vr2n</pattern>
+  <pattern>2vr2p</pattern>
+  <pattern>2vr2q</pattern>
+  <pattern>2vr2r</pattern>
+  <pattern>2vr2s</pattern>
+  <pattern>2vr2t</pattern>
+  <pattern>2vr2v</pattern>
+  <pattern>2vr2w</pattern>
+  <pattern>2vr2x</pattern>
+  <pattern>2vr2y</pattern>
+  <pattern>2vr2z</pattern>
+  <pattern>2b3p2t</pattern>
+  <pattern>2c3p2t</pattern>
+  <pattern>2d3p2t</pattern>
+  <pattern>2l3p2t</pattern>
+  <pattern>2m3p2t</pattern>
+  <pattern>2n3p2t</pattern>
+  <pattern>2r3p2t</pattern>
+  <pattern>2s3p2t</pattern>
+  <pattern>2t3p2t</pattern>
+  <pattern>2x3p2t</pattern>
+  <pattern>2y3p2t</pattern>
+  <pattern>4pt </pattern>
+  <pattern>2b3c2t</pattern>
+  <pattern>2c3c2t</pattern>
+  <pattern>2d3c2t</pattern>
+  <pattern>2l3c2t</pattern>
+  <pattern>2m3c2t</pattern>
+  <pattern>2n3c2t</pattern>
+  <pattern>2r3c2t</pattern>
+  <pattern>2s3c2t</pattern>
+  <pattern>2t3c2t</pattern>
+  <pattern>2x3c2t</pattern>
+  <pattern>2y3c2t</pattern>
+  <pattern>4ct </pattern>
+  <pattern>2b3c2n</pattern>
+  <pattern>2c3c2n</pattern>
+  <pattern>2d3c2n</pattern>
+  <pattern>2l3c2n</pattern>
+  <pattern>2m3c2n</pattern>
+  <pattern>2n3c2n</pattern>
+  <pattern>2r3c2n</pattern>
+  <pattern>2s3c2n</pattern>
+  <pattern>2t3c2n</pattern>
+  <pattern>2x3c2n</pattern>
+  <pattern>2y3c2n</pattern>
+  <pattern>4cn </pattern>
+  <pattern>2b3p2s</pattern>
+  <pattern>2c3p2s</pattern>
+  <pattern>2d3p2s</pattern>
+  <pattern>2l3p2s</pattern>
+  <pattern>2m3p2s</pattern>
+  <pattern>2n3p2s</pattern>
+  <pattern>2r3p2s</pattern>
+  <pattern>2s3p2s</pattern>
+  <pattern>2t3p2s</pattern>
+  <pattern>2x3p2s</pattern>
+  <pattern>2y3p2s</pattern>
+  <pattern>4ps </pattern>
+  <pattern>2b3m2n</pattern>
+  <pattern>2c3m2n</pattern>
+  <pattern>2d3m2n</pattern>
+  <pattern>2l3m2n</pattern>
+  <pattern>2m3m2n</pattern>
+  <pattern>2n3m2n</pattern>
+  <pattern>2r3m2n</pattern>
+  <pattern>2s3m2n</pattern>
+  <pattern>2t3m2n</pattern>
+  <pattern>2x3m2n</pattern>
+  <pattern>2y3m2n</pattern>
+  <pattern>4mn </pattern>
+  <pattern>2b3g2n</pattern>
+  <pattern>2c3g2n</pattern>
+  <pattern>2d3g2n</pattern>
+  <pattern>2l3g2n</pattern>
+  <pattern>2m3g2n</pattern>
+  <pattern>2n3g2n</pattern>
+  <pattern>2r3g2n</pattern>
+  <pattern>2s3g2n</pattern>
+  <pattern>2t3g2n</pattern>
+  <pattern>2x3g2n</pattern>
+  <pattern>2y3g2n</pattern>
+  <pattern>4gn </pattern>
+  <pattern>2b3f2t</pattern>
+  <pattern>2c3f2t</pattern>
+  <pattern>2d3f2t</pattern>
+  <pattern>2l3f2t</pattern>
+  <pattern>2m3f2t</pattern>
+  <pattern>2n3f2t</pattern>
+  <pattern>2r3f2t</pattern>
+  <pattern>2s3f2t</pattern>
+  <pattern>2t3f2t</pattern>
+  <pattern>2x3f2t</pattern>
+  <pattern>2y3f2t</pattern>
+  <pattern>4ft </pattern>
+  <pattern>2b3p2n</pattern>
+  <pattern>2c3p2n</pattern>
+  <pattern>2d3p2n</pattern>
+  <pattern>2l3p2n</pattern>
+  <pattern>2m3p2n</pattern>
+  <pattern>2n3p2n</pattern>
+  <pattern>2r3p2n</pattern>
+  <pattern>2s3p2n</pattern>
+  <pattern>2t3p2n</pattern>
+  <pattern>2x3p2n</pattern>
+  <pattern>2y3p2n</pattern>
+  <pattern>4pn </pattern>
+  <pattern>2b3c2z</pattern>
+  <pattern>2c3c2z</pattern>
+  <pattern>2d3c2z</pattern>
+  <pattern>2l3c2z</pattern>
+  <pattern>2m3c2z</pattern>
+  <pattern>2n3c2z</pattern>
+  <pattern>2r3c2z</pattern>
+  <pattern>2s3c2z</pattern>
+  <pattern>2t3c2z</pattern>
+  <pattern>2x3c2z</pattern>
+  <pattern>2y3c2z</pattern>
+  <pattern>4cz </pattern>
+  <pattern>2b3t2z</pattern>
+  <pattern>2c3t2z</pattern>
+  <pattern>2d3t2z</pattern>
+  <pattern>2l3t2z</pattern>
+  <pattern>2m3t2z</pattern>
+  <pattern>2n3t2z</pattern>
+  <pattern>2r3t2z</pattern>
+  <pattern>2s3t2z</pattern>
+  <pattern>2t3t2z</pattern>
+  <pattern>2x3t2z</pattern>
+  <pattern>2y3t2z</pattern>
+  <pattern>4tz </pattern>
+  <pattern>2b3t2s</pattern>
+  <pattern>2c3t2s</pattern>
+  <pattern>2d3t2s</pattern>
+  <pattern>2l3t2s</pattern>
+  <pattern>2m3t2s</pattern>
+  <pattern>2n3t2s</pattern>
+  <pattern>2r3t2s</pattern>
+  <pattern>2s3t2s</pattern>
+  <pattern>2t3t2s</pattern>
+  <pattern>2x3t2s</pattern>
+  <pattern>2y3t2s</pattern>
+  <pattern>4ts </pattern>
+  <pattern>san4c5t</pattern>
+  <pattern>plan4c5t</pattern>
+  <pattern>o1eu2</pattern>
+  <pattern>a1ae2</pattern>
+  <pattern>a1aó2</pattern>
+  <pattern>eo1á2</pattern>
+  <pattern>eo1e2</pattern>
+  <pattern>o1ae2</pattern>
+  <pattern>o1eó2</pattern>
+  <pattern>2no </pattern>
+  <pattern>2t2l</pattern>
+  <pattern>2t2s</pattern>
+  <pattern>2t2x</pattern>
+  <pattern>2t2z</pattern>
+  <pattern>tz3s4ch</pattern>
+  <pattern>4caca4</pattern>
+  <pattern>4cago4</pattern>
+  <pattern>4caga4</pattern>
+  <pattern>4cagas </pattern>
+  <pattern>4teta </pattern>
+  <pattern>4tetas </pattern>
+  <pattern>4puta4</pattern>
+  <pattern>4puto4</pattern>
+  <pattern> hu4mea</pattern>
+  <pattern> hu4meo</pattern>
+  <pattern> he4mee</pattern>
+  <pattern>4meo </pattern>
+  <pattern>4meable </pattern>
+  <pattern>4meables </pattern>
+  <pattern>4pedo4</pattern>
+  <pattern>4culo4</pattern>
+  <pattern>5mente </pattern>
+  <pattern>4i3go </pattern>
+  <pattern>4es </pattern>
+  <pattern>4és</pattern>
+  <pattern>4e </pattern>
+  <pattern>4e3mos </pattern>
+  <pattern>4éis </pattern>
+  <pattern>4en </pattern>
+  <pattern>4ía </pattern>
+  <pattern>4ías </pattern>
+  <pattern>4ía3mos </pattern>
+  <pattern>4íais </pattern>
+  <pattern>4ían </pattern>
+  <pattern>4í </pattern>
+  <pattern>4í4s3te </pattern>
+  <pattern>4í4s3tes </pattern>
+  <pattern>4í3tes </pattern>
+  <pattern>4í3mos </pattern>
+  <pattern>4ís3teis </pattern>
+  <pattern>4e3ré </pattern>
+  <pattern>4e3rás </pattern>
+  <pattern>4e3rés </pattern>
+  <pattern>4e3rís </pattern>
+  <pattern>4e3rá </pattern>
+  <pattern>4e3re3mos </pattern>
+  <pattern>4e3réis </pattern>
+  <pattern>4e3rán </pattern>
+  <pattern>4i3ga </pattern>
+  <pattern>4i3gas </pattern>
+  <pattern>4i3gás </pattern>
+  <pattern>4i3gamos </pattern>
+  <pattern>4i3gáis </pattern>
+  <pattern>4a4i3gan </pattern>
+  <pattern>4e3ría </pattern>
+  <pattern>4e3rías </pattern>
+  <pattern>4e3ríamos </pattern>
+  <pattern>4e3ríais </pattern>
+  <pattern>4e3rían </pattern>
+  <pattern>4i3gá3mosme </pattern>
+  <pattern>4i3gá3mosmele </pattern>
+  <pattern>4i3gá3mosmelo </pattern>
+  <pattern>4i3gá3mos3mela </pattern>
+  <pattern>4i3gá3mosmeles </pattern>
+  <pattern>4i3gá3mosmelos </pattern>
+  <pattern>4i3gá3mos3melas </pattern>
+  <pattern>4i3gá3moste </pattern>
+  <pattern>4i3gá3mostele </pattern>
+  <pattern>4i3gá3mostelo </pattern>
+  <pattern>4i3gá3mos3tela </pattern>
+  <pattern>4i3gá3mosteles </pattern>
+  <pattern>4i3gá3mostelos </pattern>
+  <pattern>4i3gá3mos3telas </pattern>
+  <pattern>4i3gá3mosle </pattern>
+  <pattern>4i3gá3mosla </pattern>
+  <pattern>4i3gá3moslo </pattern>
+  <pattern>4i3gá3mosele </pattern>
+  <pattern>4i3gá3moselo </pattern>
+  <pattern>4i3gá3mosela </pattern>
+  <pattern>4i3gá3moseles </pattern>
+  <pattern>4i3gá3moselos </pattern>
+  <pattern>4i3gá3moselas </pattern>
+  <pattern>4i3gá3monos </pattern>
+  <pattern>4i3gá3monosle </pattern>
+  <pattern>4i3gá3monoslo </pattern>
+  <pattern>4i3gá3monosla </pattern>
+  <pattern>4i3gá3monosles </pattern>
+  <pattern>4i3gá3monoslos </pattern>
+  <pattern>4i3gá3monoslas </pattern>
+  <pattern>4i3gá3moos </pattern>
+  <pattern>4i3gá3moosle </pattern>
+  <pattern>4i3gá3mooslo </pattern>
+  <pattern>4i3gá3moosla </pattern>
+  <pattern>4i3gá3moosles </pattern>
+  <pattern>4i3gá3mooslos </pattern>
+  <pattern>4i3gá3mooslas </pattern>
+  <pattern>4i3gá3mosles </pattern>
+  <pattern>4i3gá3moslas </pattern>
+  <pattern>4i3gá3moslos </pattern>
+  <pattern>4ed </pattern>
+  <pattern>4é </pattern>
+  <pattern>4edme </pattern>
+  <pattern>4édmele </pattern>
+  <pattern>4édmelo </pattern>
+  <pattern>4éd3mela </pattern>
+  <pattern>4édmeles </pattern>
+  <pattern>4édmelos </pattern>
+  <pattern>4éd3melas </pattern>
+  <pattern>4edte </pattern>
+  <pattern>4édtele </pattern>
+  <pattern>4édtelo </pattern>
+  <pattern>4éd3tela </pattern>
+  <pattern>4édteles </pattern>
+  <pattern>4édtelos </pattern>
+  <pattern>4éd3telas </pattern>
+  <pattern>4edle </pattern>
+  <pattern>4eedla </pattern>
+  <pattern>4edlo </pattern>
+  <pattern>4édsele </pattern>
+  <pattern>4édselo </pattern>
+  <pattern>4édsela </pattern>
+  <pattern>4édseles </pattern>
+  <pattern>4édselos </pattern>
+  <pattern>4édselas </pattern>
+  <pattern>4ednos </pattern>
+  <pattern>4édnosle </pattern>
+  <pattern>4édnoslo </pattern>
+  <pattern>4édnosla </pattern>
+  <pattern>4édnosles </pattern>
+  <pattern>4édnoslos </pattern>
+  <pattern>4édnoslas </pattern>
+  <pattern>4eos </pattern>
+  <pattern>4éosle </pattern>
+  <pattern>4éoslo </pattern>
+  <pattern>4éosla </pattern>
+  <pattern>4éosles </pattern>
+  <pattern>4éoslos </pattern>
+  <pattern>4éoslas </pattern>
+  <pattern>4edles </pattern>
+  <pattern>4edlas </pattern>
+  <pattern>4edlos </pattern>
+  <pattern>4er </pattern>
+  <pattern>4erme </pattern>
+  <pattern>4érmele </pattern>
+  <pattern>4érmelo </pattern>
+  <pattern>4ér3mela </pattern>
+  <pattern>4érmeles </pattern>
+  <pattern>4érmelos </pattern>
+  <pattern>4ér3melas </pattern>
+  <pattern>4erte </pattern>
+  <pattern>4értele </pattern>
+  <pattern>4értelo </pattern>
+  <pattern>4ér3tela </pattern>
+  <pattern>4érteles </pattern>
+  <pattern>4értelos </pattern>
+  <pattern>4ér3telas </pattern>
+  <pattern>4erle </pattern>
+  <pattern>4erla </pattern>
+  <pattern>4erlo </pattern>
+  <pattern>4erse </pattern>
+  <pattern>4érsele </pattern>
+  <pattern>4érselo </pattern>
+  <pattern>4érsela </pattern>
+  <pattern>4érseles </pattern>
+  <pattern>4érselos </pattern>
+  <pattern>4érselas </pattern>
+  <pattern>4ernos </pattern>
+  <pattern>4érnosle </pattern>
+  <pattern>4érnoslo </pattern>
+  <pattern>4érnosla </pattern>
+  <pattern>4érnosles </pattern>
+  <pattern>4érnoslos </pattern>
+  <pattern>4érnoslas </pattern>
+  <pattern>4e3ros </pattern>
+  <pattern>4é3rosle </pattern>
+  <pattern>4é3roslo </pattern>
+  <pattern>4é3rosla </pattern>
+  <pattern>4é3rosles </pattern>
+  <pattern>4é3roslos </pattern>
+  <pattern>4é3roslas </pattern>
+  <pattern>4erles </pattern>
+  <pattern>4erlas </pattern>
+  <pattern>4erlos </pattern>
+  <pattern>4í3do </pattern>
+  <pattern>4í3da </pattern>
+  <pattern>4í3dos </pattern>
+  <pattern>4í3das </pattern>
+  <pattern>4o </pattern>
+  <pattern>4as </pattern>
+  <pattern>4a </pattern>
+  <pattern>4ás </pattern>
+  <pattern>4a3mos </pattern>
+  <pattern>4áis </pattern>
+  <pattern>4an </pattern>
+  <pattern>4aste </pattern>
+  <pattern>4astes </pattern>
+  <pattern>4ó </pattern>
+  <pattern>4ates </pattern>
+  <pattern>4asteis </pattern>
+  <pattern>4a3ron </pattern>
+  <pattern>4a3ba </pattern>
+  <pattern>4a3bas </pattern>
+  <pattern>4á3bamos </pattern>
+  <pattern>4a3bais </pattern>
+  <pattern>4a3ban </pattern>
+  <pattern>4a3ría </pattern>
+  <pattern>4a3rías </pattern>
+  <pattern>4a3ríamos </pattern>
+  <pattern>4a3ríais</pattern>
+  <pattern>4a3rían </pattern>
+  <pattern>4a3ré </pattern>
+  <pattern>4a3rás </pattern>
+  <pattern>4a3rés </pattern>
+  <pattern>4a3rís </pattern>
+  <pattern>4a3rá </pattern>
+  <pattern>4a3remos </pattern>
+  <pattern>4a3réis </pattern>
+  <pattern>4a3rán </pattern>
+  <pattern>4a3ra </pattern>
+  <pattern>4a3ras </pattern>
+  <pattern>4á3ramos </pattern>
+  <pattern>4a3rais </pattern>
+  <pattern>4a3ran </pattern>
+  <pattern>4a3re </pattern>
+  <pattern>4a3res </pattern>
+  <pattern>4á3remos </pattern>
+  <pattern>4a3reis </pattern>
+  <pattern>4a3ren </pattern>
+  <pattern>4a3se </pattern>
+  <pattern>4a3ses </pattern>
+  <pattern>4á3semos </pattern>
+  <pattern>4a3seis </pattern>
+  <pattern>4a3sen </pattern>
+  <pattern>4ad </pattern>
+  <pattern>e5r4as </pattern>
+  <pattern>e5r4a3mos </pattern>
+  <pattern>e5r4áis </pattern>
+  <pattern>e5r4an </pattern>
+  <pattern>e5r4aste </pattern>
+  <pattern>e5r4astes </pattern>
+  <pattern>e5r4ates </pattern>
+  <pattern>e5r4asteis </pattern>
+  <pattern>e5r4a3ron </pattern>
+  <pattern>e5r4a3ba </pattern>
+  <pattern>e5r4a3bas </pattern>
+  <pattern>e5r4á3bamos </pattern>
+  <pattern>e5r4a3bais </pattern>
+  <pattern>e5r4a3ban </pattern>
+  <pattern>e5r4a3ría </pattern>
+  <pattern>e5r4a3rías </pattern>
+  <pattern>e5r4a3ríamos </pattern>
+  <pattern>e5r4a3ríais</pattern>
+  <pattern>e5r4a3rían </pattern>
+  <pattern>e5r4a3ré </pattern>
+  <pattern>e5r4a3rás </pattern>
+  <pattern>e5r4a3rés </pattern>
+  <pattern>e5r4a3rís </pattern>
+  <pattern>e5r4a3rá </pattern>
+  <pattern>e5r4a3remos </pattern>
+  <pattern>e5r4a3réis </pattern>
+  <pattern>e5r4a3rán </pattern>
+  <pattern>e5r4a3ra </pattern>
+  <pattern>e5r4a3ras </pattern>
+  <pattern>e5r4á3ramos </pattern>
+  <pattern>e5r4a3rais </pattern>
+  <pattern>e5r4a3ran </pattern>
+  <pattern>e5r4a3re </pattern>
+  <pattern>e5r4a3res </pattern>
+  <pattern>e5r4á3remos </pattern>
+  <pattern>e5r4a3reis </pattern>
+  <pattern>e5r4a3ren </pattern>
+  <pattern>e5r4a3se </pattern>
+  <pattern>e5r4a3ses </pattern>
+  <pattern>e5r4á3semos </pattern>
+  <pattern>e5r4a3seis </pattern>
+  <pattern>e5r4a3sen </pattern>
+  <pattern>e5r4ad </pattern>
+  <pattern>4adme </pattern>
+  <pattern>4ádmele </pattern>
+  <pattern>4ádmelo </pattern>
+  <pattern>4ád3mela </pattern>
+  <pattern>4ádmeles </pattern>
+  <pattern>4ádmelos </pattern>
+  <pattern>4ád3melas </pattern>
+  <pattern>4adte </pattern>
+  <pattern>4ádtele </pattern>
+  <pattern>4ádtelo </pattern>
+  <pattern>4ád3tela </pattern>
+  <pattern>4ádteles </pattern>
+  <pattern>4ádtelos </pattern>
+  <pattern>4ád3telas </pattern>
+  <pattern>4adle </pattern>
+  <pattern>4eadla </pattern>
+  <pattern>4adlo </pattern>
+  <pattern>4ádsele </pattern>
+  <pattern>4ádselo </pattern>
+  <pattern>4ádsela </pattern>
+  <pattern>4ádseles </pattern>
+  <pattern>4ádselos </pattern>
+  <pattern>4ádselas </pattern>
+  <pattern>4adnos </pattern>
+  <pattern>4ádnosle </pattern>
+  <pattern>4ádnoslo </pattern>
+  <pattern>4ádnosla </pattern>
+  <pattern>4ádnosles </pattern>
+  <pattern>4ádnoslos </pattern>
+  <pattern>4ádnoslas </pattern>
+  <pattern>4aos </pattern>
+  <pattern>4áosle </pattern>
+  <pattern>4áoslo </pattern>
+  <pattern>4áosla </pattern>
+  <pattern>4áosles </pattern>
+  <pattern>4áoslos </pattern>
+  <pattern>4áoslas </pattern>
+  <pattern>4adles </pattern>
+  <pattern>4adlas </pattern>
+  <pattern>4adlos </pattern>
+  <pattern>4ar </pattern>
+  <pattern>4a4rme </pattern>
+  <pattern>4á4rmele </pattern>
+  <pattern>4á4rmelo </pattern>
+  <pattern>4á4r3mela </pattern>
+  <pattern>4á4r3meles </pattern>
+  <pattern>4á4r3melos </pattern>
+  <pattern>4á4r3melas </pattern>
+  <pattern>4a4r3te </pattern>
+  <pattern>4á4r3tele </pattern>
+  <pattern>4á4r3telo </pattern>
+  <pattern>4á4r3tela </pattern>
+  <pattern>4á4r3teles </pattern>
+  <pattern>4á4r3telos </pattern>
+  <pattern>4á4r3telas </pattern>
+  <pattern>4a4r3le </pattern>
+  <pattern>4a4r3la </pattern>
+  <pattern>4a4r3lo </pattern>
+  <pattern>4a4r3se </pattern>
+  <pattern>4á4r3sele </pattern>
+  <pattern>4á4r3selo </pattern>
+  <pattern>4á4r3sela </pattern>
+  <pattern>4á4r3seles </pattern>
+  <pattern>4á4r3selos </pattern>
+  <pattern>4á4r3selas </pattern>
+  <pattern>4a4r3nos </pattern>
+  <pattern>4á4r3nosle </pattern>
+  <pattern>4á4r3noslo </pattern>
+  <pattern>4á4r3nosla </pattern>
+  <pattern>4á4r3nosles </pattern>
+  <pattern>4á4r3noslos </pattern>
+  <pattern>4á4r3noslas </pattern>
+  <pattern>4a3ros </pattern>
+  <pattern>4árosle </pattern>
+  <pattern>4ároslo </pattern>
+  <pattern>4árosla </pattern>
+  <pattern>4árosles </pattern>
+  <pattern>4ároslos </pattern>
+  <pattern>4ároslas </pattern>
+  <pattern>4a4r3les </pattern>
+  <pattern>4a4r3las </pattern>
+  <pattern>4a4r3los </pattern>
+  <pattern>4a3do </pattern>
+  <pattern>4a3da </pattern>
+  <pattern>4a3dos </pattern>
+  <pattern>4a3das </pattern>
+  <pattern>e5r4a3do </pattern>
+  <pattern>e5r4a3da </pattern>
+  <pattern>e5r4a3dos </pattern>
+  <pattern>e5r4a3das </pattern>
+  <pattern>4ando</pattern>
+  <pattern>4ándole </pattern>
+  <pattern>4ándolo </pattern>
+  <pattern>4ándola </pattern>
+  <pattern>4ándoles </pattern>
+  <pattern>4ándolos </pattern>
+  <pattern>4ándolas </pattern>
+  <pattern>4ándonos </pattern>
+  <pattern>4ándoos </pattern>
+  <pattern>4ándome </pattern>
+  <pattern>4ándomelo </pattern>
+  <pattern>4ándomela </pattern>
+  <pattern>4ándomele </pattern>
+  <pattern>4ándomelos </pattern>
+  <pattern>4ándomelas </pattern>
+  <pattern>4ándomeles </pattern>
+  <pattern>4ándote </pattern>
+  <pattern>4ándoteme </pattern>
+  <pattern>4ándotelo </pattern>
+  <pattern>4ándotela </pattern>
+  <pattern>4ándotele </pattern>
+  <pattern>4ándotelos </pattern>
+  <pattern>4ándotelas </pattern>
+  <pattern>4ándoteles </pattern>
+  <pattern>4ándotenos </pattern>
+  <pattern>4ándose </pattern>
+  <pattern>4ándoseme </pattern>
+  <pattern>4ándoselo </pattern>
+  <pattern>4ándosela </pattern>
+  <pattern>4ándosele </pattern>
+  <pattern>4ándoselos </pattern>
+  <pattern>4ándoselas </pattern>
+  <pattern>4ándoseles </pattern>
+  <pattern>4ándosenos </pattern>
+  <pattern>4a3dor </pattern>
+  <pattern>4a3dora </pattern>
+  <pattern>4a3dores </pattern>
+  <pattern>4a3doras </pattern>
+  <pattern>e5r4a3dor </pattern>
+  <pattern>e5r4a3dora </pattern>
+  <pattern>e5r4a3dores </pattern>
+  <pattern>e5r4a3doras </pattern>
+  <pattern>acto1h</pattern>
+  <pattern>acto1a2</pattern>
+  <pattern>acto1e2</pattern>
+  <pattern>acto1i2</pattern>
+  <pattern>acto1o2</pattern>
+  <pattern>acto1u2</pattern>
+  <pattern>acto1á2</pattern>
+  <pattern>acto1é2</pattern>
+  <pattern>acto1í2</pattern>
+  <pattern>acto1ó2</pattern>
+  <pattern>acto1ú2</pattern>
+  <pattern>aero1h</pattern>
+  <pattern>aero1a2</pattern>
+  <pattern>aero1e2</pattern>
+  <pattern>aero1i2</pattern>
+  <pattern>aero1o2</pattern>
+  <pattern>aero1u2</pattern>
+  <pattern>aero1á2</pattern>
+  <pattern>aero1é2</pattern>
+  <pattern>aero1í2</pattern>
+  <pattern>aero1ó2</pattern>
+  <pattern>aero1ú2</pattern>
+  <pattern>afro1h</pattern>
+  <pattern>afro1a2</pattern>
+  <pattern>afro1e2</pattern>
+  <pattern>afro1i2</pattern>
+  <pattern>afro1o2</pattern>
+  <pattern>afro1u2</pattern>
+  <pattern>afro1á2</pattern>
+  <pattern>afro1é2</pattern>
+  <pattern>afro1í2</pattern>
+  <pattern>afro1ó2</pattern>
+  <pattern>afro1ú2</pattern>
+  <pattern> a2</pattern>
+  <pattern> an2a2</pattern>
+  <pattern> an2e2</pattern>
+  <pattern> an2i2</pattern>
+  <pattern> an2o2</pattern>
+  <pattern> an2u2</pattern>
+  <pattern> an2á2</pattern>
+  <pattern> an2é2</pattern>
+  <pattern> an2í2</pattern>
+  <pattern> an2ó2</pattern>
+  <pattern> an2ú2 </pattern>
+  <pattern>ana3lí</pattern>
+  <pattern> aná3li</pattern>
+  <pattern> ana3li</pattern>
+  <pattern> an3aero</pattern>
+  <pattern> an3e2pigr</pattern>
+  <pattern> ane3xa</pattern>
+  <pattern> ane3xá</pattern>
+  <pattern> ane3xe</pattern>
+  <pattern> ane3xé</pattern>
+  <pattern> ane3xio</pattern>
+  <pattern> ane3xió</pattern>
+  <pattern> an3h</pattern>
+  <pattern> ani3mad</pattern>
+  <pattern> ani3mád</pattern>
+  <pattern> ani3dar</pattern>
+  <pattern> ani3ll</pattern>
+  <pattern> ani3m</pattern>
+  <pattern> aniña</pattern>
+  <pattern> ani3q</pattern>
+  <pattern> an3i2so</pattern>
+  <pattern> an3i2só</pattern>
+  <pattern> ani3vel</pattern>
+  <pattern> ano5che</pattern>
+  <pattern> ano5din</pattern>
+  <pattern> ano5mal</pattern>
+  <pattern> ano5nad</pattern>
+  <pattern> anó3nim</pattern>
+  <pattern> anó5mal</pattern>
+  <pattern> ano5nim</pattern>
+  <pattern> ano5ta</pattern>
+  <pattern> ano3tá</pattern>
+  <pattern> anua3l</pattern>
+  <pattern> anua4lm</pattern>
+  <pattern> anu3bl</pattern>
+  <pattern> anu3da</pattern>
+  <pattern> anu3l</pattern>
+  <pattern>asu3b2</pattern>
+  <pattern>anfi1h</pattern>
+  <pattern>anfi1a2</pattern>
+  <pattern>anfi1e2</pattern>
+  <pattern>anfi1i2</pattern>
+  <pattern>anfi1o2</pattern>
+  <pattern>anfi1u2</pattern>
+  <pattern>anfi1á2</pattern>
+  <pattern>anfi1é2</pattern>
+  <pattern>anfi1í2</pattern>
+  <pattern>anfi1ó2</pattern>
+  <pattern>anfi1ú2</pattern>
+  <pattern>anglo1h</pattern>
+  <pattern>anglo1a2</pattern>
+  <pattern>anglo1e2</pattern>
+  <pattern>anglo1i2</pattern>
+  <pattern>anglo1o2</pattern>
+  <pattern>anglo1u2</pattern>
+  <pattern>anglo1á2</pattern>
+  <pattern>anglo1é2</pattern>
+  <pattern>anglo1í2</pattern>
+  <pattern>anglo1ó2</pattern>
+  <pattern>anglo1ú2</pattern>
+  <pattern>ante1h</pattern>
+  <pattern>ante1a2</pattern>
+  <pattern>ante1e2</pattern>
+  <pattern>ante1i2</pattern>
+  <pattern>ante1o2</pattern>
+  <pattern>ante1u2</pattern>
+  <pattern>ante1á2</pattern>
+  <pattern>ante1é2</pattern>
+  <pattern>ante1í2</pattern>
+  <pattern>ante1ó2</pattern>
+  <pattern>ante1ú2</pattern>
+  <pattern> ante2o3je</pattern>
+  <pattern>acante2</pattern>
+  <pattern>4ísmo </pattern>
+  <pattern>4ísmos </pattern>
+  <pattern>4ísta </pattern>
+  <pattern>4ístas </pattern>
+  <pattern>4ístico </pattern>
+  <pattern>4ísticos </pattern>
+  <pattern>4ística </pattern>
+  <pattern>4ísticas </pattern>
+  <pattern>pante4o3n</pattern>
+  <pattern> anteo3nes</pattern>
+  <pattern>mante4a</pattern>
+  <pattern>e4a3miento</pattern>
+  <pattern>e4ándo</pattern>
+  <pattern>tras3antea</pattern>
+  <pattern> anti1h</pattern>
+  <pattern> anti1a2</pattern>
+  <pattern> anti1e2</pattern>
+  <pattern> anti1i2</pattern>
+  <pattern> anti1o2</pattern>
+  <pattern> anti1u2</pattern>
+  <pattern> anti1á2</pattern>
+  <pattern> anti1é2</pattern>
+  <pattern> anti1í2</pattern>
+  <pattern> anti1ó2</pattern>
+  <pattern> anti1ú2</pattern>
+  <pattern>ti2o3qu</pattern>
+  <pattern>ti2o3co</pattern>
+  <pattern>archi1h</pattern>
+  <pattern>archi1a2</pattern>
+  <pattern>archi1e2</pattern>
+  <pattern>archi1i2</pattern>
+  <pattern>archi1o2</pattern>
+  <pattern>archi1u2</pattern>
+  <pattern>archi1á2</pattern>
+  <pattern>archi1é2</pattern>
+  <pattern>archi1í2</pattern>
+  <pattern>archi1ó2</pattern>
+  <pattern>archi1ú2</pattern>
+  <pattern>auto1h</pattern>
+  <pattern>auto1a2</pattern>
+  <pattern>auto1e2</pattern>
+  <pattern>auto1i2</pattern>
+  <pattern>auto1o2</pattern>
+  <pattern>auto1u2</pattern>
+  <pattern>auto1á2</pattern>
+  <pattern>auto1é2</pattern>
+  <pattern>auto1í2</pattern>
+  <pattern>auto1ó2</pattern>
+  <pattern>auto1ú2</pattern>
+  <pattern> bi1anual</pattern>
+  <pattern> bi1aur</pattern>
+  <pattern> bi1ox</pattern>
+  <pattern> bi1ó2x</pattern>
+  <pattern> bi1un</pattern>
+  <pattern>biblio1h</pattern>
+  <pattern>biblio1a2</pattern>
+  <pattern>biblio1e2</pattern>
+  <pattern>biblio1i2</pattern>
+  <pattern>biblio1o2</pattern>
+  <pattern>biblio1u2</pattern>
+  <pattern>biblio1á2</pattern>
+  <pattern>biblio1é2</pattern>
+  <pattern>biblio1í2</pattern>
+  <pattern>biblio1ó2</pattern>
+  <pattern>biblio1ú2</pattern>
+  <pattern>bien2</pattern>
+  <pattern>bien3h</pattern>
+  <pattern>bien3v</pattern>
+  <pattern>bien3q</pattern>
+  <pattern>bien3m</pattern>
+  <pattern>bien3t</pattern>
+  <pattern>b4ien3do </pattern>
+  <pattern> su3b4ien</pattern>
+  <pattern>b4ien3das </pattern>
+  <pattern> bie4n3and</pattern>
+  <pattern> bie4n3a4pa</pattern>
+  <pattern> bie4n3a4ve</pattern>
+  <pattern> bie4n3est</pattern>
+  <pattern> bie4n3int</pattern>
+  <pattern> bie4n3o4lie</pattern>
+  <pattern>bio1h</pattern>
+  <pattern>bio1a2</pattern>
+  <pattern>bio1e2</pattern>
+  <pattern>bio1i2</pattern>
+  <pattern>bio1o2</pattern>
+  <pattern>bio1u2</pattern>
+  <pattern>bio1á2</pattern>
+  <pattern>bio1é2</pattern>
+  <pattern>bio1í2</pattern>
+  <pattern>bio1ó2</pattern>
+  <pattern>bio1ú2</pattern>
+  <pattern>bi1u2ní</pattern>
+  <pattern>cardio1h</pattern>
+  <pattern>cardio1a2</pattern>
+  <pattern>cardio1e2</pattern>
+  <pattern>cardio1i2</pattern>
+  <pattern>cardio1o2</pattern>
+  <pattern>cardio1u2</pattern>
+  <pattern>cardio1á2</pattern>
+  <pattern>cardio1é2</pattern>
+  <pattern>cardio1í2</pattern>
+  <pattern>cardio1ó2</pattern>
+  <pattern>cardio1ú2</pattern>
+  <pattern>cefalo1h</pattern>
+  <pattern>cefalo1a2</pattern>
+  <pattern>cefalo1e2</pattern>
+  <pattern>cefalo1i2</pattern>
+  <pattern>cefalo1o2</pattern>
+  <pattern>cefalo1u2</pattern>
+  <pattern>cefalo1á2</pattern>
+  <pattern>cefalo1é2</pattern>
+  <pattern>cefalo1í2</pattern>
+  <pattern>cefalo1ó2</pattern>
+  <pattern>cefalo1ú2</pattern>
+  <pattern>centi1h</pattern>
+  <pattern>centi1a2</pattern>
+  <pattern>centi1e2</pattern>
+  <pattern>centi1i2</pattern>
+  <pattern>centi1o2</pattern>
+  <pattern>centi1u2</pattern>
+  <pattern>centi1á2</pattern>
+  <pattern>centi1é2</pattern>
+  <pattern>centi1í2</pattern>
+  <pattern>centi1ó2</pattern>
+  <pattern>centi1ú2</pattern>
+  <pattern>centi5área</pattern>
+  <pattern>ciclo1h</pattern>
+  <pattern>ciclo1a2</pattern>
+  <pattern>ciclo1e2</pattern>
+  <pattern>ciclo1i2</pattern>
+  <pattern>ciclo1o2</pattern>
+  <pattern>ciclo1u2</pattern>
+  <pattern>ciclo1á2</pattern>
+  <pattern>ciclo1é2</pattern>
+  <pattern>ciclo1í2</pattern>
+  <pattern>ciclo1ó2</pattern>
+  <pattern>ciclo1ú2</pattern>
+  <pattern>o4i3dea </pattern>
+  <pattern>o4i3deas </pattern>
+  <pattern>o4i3dal </pattern>
+  <pattern>o4i3dales </pattern>
+  <pattern>4o2i3de </pattern>
+  <pattern>4o2i3des </pattern>
+  <pattern>4i2dal </pattern>
+  <pattern>4i2dales </pattern>
+  <pattern>4i3deo </pattern>
+  <pattern>4i3deos </pattern>
+  <pattern>cito1h</pattern>
+  <pattern>cito1a2</pattern>
+  <pattern>cito1e2</pattern>
+  <pattern>cito1i2</pattern>
+  <pattern>cito1o2</pattern>
+  <pattern>cito1u2</pattern>
+  <pattern>cito1á2</pattern>
+  <pattern>cito1é2</pattern>
+  <pattern>cito1í2</pattern>
+  <pattern>cito1ó2</pattern>
+  <pattern>cito1ú2</pattern>
+  <pattern>cnico1h</pattern>
+  <pattern>cnico1a2</pattern>
+  <pattern>cnico1e2</pattern>
+  <pattern>cnico1i2</pattern>
+  <pattern>cnico1o2</pattern>
+  <pattern>cnico1u2</pattern>
+  <pattern>cnico1á2</pattern>
+  <pattern>cnico1é2</pattern>
+  <pattern>cnico1í2</pattern>
+  <pattern>cnico1ó2</pattern>
+  <pattern>cnico1ú2</pattern>
+  <pattern> co2a2</pattern>
+  <pattern> co2e2</pattern>
+  <pattern> co2i2</pattern>
+  <pattern> co3o4</pattern>
+  <pattern> co2u2</pattern>
+  <pattern> co2á2</pattern>
+  <pattern> co2é2</pattern>
+  <pattern> co2í2</pattern>
+  <pattern> co2ó2</pattern>
+  <pattern> co2ú2</pattern>
+  <pattern> co3acree</pattern>
+  <pattern> coá3gul</pattern>
+  <pattern> co3agen</pattern>
+  <pattern> coa3gul</pattern>
+  <pattern> coa3lic</pattern>
+  <pattern> co3arrend</pattern>
+  <pattern> co3auto</pattern>
+  <pattern> co3edic</pattern>
+  <pattern> co3edit</pattern>
+  <pattern> co3educ</pattern>
+  <pattern> co3efici</pattern>
+  <pattern> coe3tá</pattern>
+  <pattern> co3exis</pattern>
+  <pattern> co3imput</pattern>
+  <pattern> coi3to</pattern>
+  <pattern> co4o3per</pattern>
+  <pattern> co4o3pér</pattern>
+  <pattern> co4orden</pattern>
+  <pattern> co4ordin</pattern>
+  <pattern> co4ordín</pattern>
+  <pattern> co4opt</pattern>
+  <pattern> co4ópt</pattern>
+  <pattern> co2nurb</pattern>
+  <pattern>cripto1h</pattern>
+  <pattern>cripto1a2</pattern>
+  <pattern>cripto1e2</pattern>
+  <pattern>cripto1i2</pattern>
+  <pattern>cripto1o2</pattern>
+  <pattern>cripto1u2</pattern>
+  <pattern>cripto1á2</pattern>
+  <pattern>cripto1é2</pattern>
+  <pattern>cripto1í2</pattern>
+  <pattern>cripto1ó2</pattern>
+  <pattern>cripto1ú2</pattern>
+  <pattern>crono1h</pattern>
+  <pattern>crono1a2</pattern>
+  <pattern>crono1e2</pattern>
+  <pattern>crono1i2</pattern>
+  <pattern>crono1o2</pattern>
+  <pattern>crono1u2</pattern>
+  <pattern>crono1á2</pattern>
+  <pattern>crono1é2</pattern>
+  <pattern>crono1í2</pattern>
+  <pattern>crono1ó2</pattern>
+  <pattern>crono1ú2</pattern>
+  <pattern>contra1h</pattern>
+  <pattern>contra1a2</pattern>
+  <pattern>contra1e2</pattern>
+  <pattern>contra1i2</pattern>
+  <pattern>contra1o2</pattern>
+  <pattern>contra1u2</pattern>
+  <pattern>contra1á2</pattern>
+  <pattern>contra1é2</pattern>
+  <pattern>contra1í2</pattern>
+  <pattern>contra1ó2</pattern>
+  <pattern>contra1ú2</pattern>
+  <pattern>deca1h</pattern>
+  <pattern>deca1a2</pattern>
+  <pattern>deca1e2</pattern>
+  <pattern>deca1i2</pattern>
+  <pattern>deca1o2</pattern>
+  <pattern>deca1u2</pattern>
+  <pattern>deca1á2</pattern>
+  <pattern>deca1é2</pattern>
+  <pattern>deca1í2</pattern>
+  <pattern>deca1ó2</pattern>
+  <pattern>deca1ú2</pattern>
+  <pattern>4e3dro </pattern>
+  <pattern>4e3dros </pattern>
+  <pattern>4é3drico </pattern>
+  <pattern>4é3dricos </pattern>
+  <pattern>4é3drica </pattern>
+  <pattern>4é3dricas </pattern>
+  <pattern>4í3ble </pattern>
+  <pattern>4í3bles </pattern>
+  <pattern> de2sa2</pattern>
+  <pattern> de2se2</pattern>
+  <pattern> de2si2</pattern>
+  <pattern> de2so2</pattern>
+  <pattern> de2su2</pattern>
+  <pattern> de2sá2</pattern>
+  <pattern> de2sé2</pattern>
+  <pattern> de2sí2</pattern>
+  <pattern> de2só2</pattern>
+  <pattern> de2sú2</pattern>
+  <pattern>deca2i3mient</pattern>
+  <pattern>3sa </pattern>
+  <pattern>3sas </pattern>
+  <pattern>de2s3órde</pattern>
+  <pattern>de2s3orde</pattern>
+  <pattern>de2s3abast</pattern>
+  <pattern>de2s3aboll</pattern>
+  <pattern>de2s3aboto</pattern>
+  <pattern>de2s3abr</pattern>
+  <pattern>des4a3brid</pattern>
+  <pattern>de2s3abroch</pattern>
+  <pattern>de2s3aceit</pattern>
+  <pattern>de2s3aceler</pattern>
+  <pattern>desa3cert</pattern>
+  <pattern>desa3ciert</pattern>
+  <pattern>de2s3acobar</pattern>
+  <pattern>de2s3acomod</pattern>
+  <pattern>de2s3acomp</pattern>
+  <pattern>de2s3acons</pattern>
+  <pattern>de2s3acopl</pattern>
+  <pattern>de2s3acorr</pattern>
+  <pattern>de2s3acostum</pattern>
+  <pattern>de2s3acot</pattern>
+  <pattern>desa3craliz</pattern>
+  <pattern>de2s3acredit</pattern>
+  <pattern>de2s3activ</pattern>
+  <pattern>de2s3acuart</pattern>
+  <pattern>de2s3aderez</pattern>
+  <pattern>de2s3adeud</pattern>
+  <pattern>de2s3adorar</pattern>
+  <pattern>de2s3adormec</pattern>
+  <pattern>de2s3adorn</pattern>
+  <pattern>de2s3advert</pattern>
+  <pattern>de2s3aferr</pattern>
+  <pattern>de2s3afic</pattern>
+  <pattern>de2s3afil</pattern>
+  <pattern>de2s3afin</pattern>
+  <pattern>de2s3afor</pattern>
+  <pattern>de2s3agu</pattern>
+  <pattern>desa3gú</pattern>
+  <pattern>desa3garr</pattern>
+  <pattern>de2s3agraci</pattern>
+  <pattern>de2s3agrad</pattern>
+  <pattern>de2s3agravi</pattern>
+  <pattern>de2s3agreg</pattern>
+  <pattern>de2s3agrup</pattern>
+  <pattern>des4a3guis</pattern>
+  <pattern>de2s3aherr</pattern>
+  <pattern>de2s3ahij</pattern>
+  <pattern>de2s3ajust</pattern>
+  <pattern>de2s3alagar</pattern>
+  <pattern>de2s3alent</pattern>
+  <pattern>de2s3alfom</pattern>
+  <pattern>de2s3alfor</pattern>
+  <pattern>de2s3alien</pattern>
+  <pattern>de2s3a4line</pattern>
+  <pattern>de2s3a4liné</pattern>
+  <pattern>de2s3aliñ</pattern>
+  <pattern>desa3liv</pattern>
+  <pattern>de2s3alm</pattern>
+  <pattern>de2s3almid</pattern>
+  <pattern>de2s3aloj</pattern>
+  <pattern>de2s3alquil</pattern>
+  <pattern>de2s3alter</pattern>
+  <pattern>de2s3alumbr</pattern>
+  <pattern>desa3marr</pattern>
+  <pattern>desa3mobl</pattern>
+  <pattern>de2s3amold</pattern>
+  <pattern>de2s3amort</pattern>
+  <pattern>de2s3amuebl</pattern>
+  <pattern>de2s3ampa</pattern>
+  <pattern>de2s3and</pattern>
+  <pattern>de2s3angel</pattern>
+  <pattern>de3sangr</pattern>
+  <pattern>de2s3anid</pattern>
+  <pattern>de2s3anim</pattern>
+  <pattern>de2s3aním</pattern>
+  <pattern>de2s3anud</pattern>
+  <pattern>desa3pañ</pattern>
+  <pattern>desa3pacib</pattern>
+  <pattern>de2s3apadr</pattern>
+  <pattern>de2s3apare</pattern>
+  <pattern>de2s3aparec</pattern>
+  <pattern>de2s3aparic</pattern>
+  <pattern>de2s3apeg</pattern>
+  <pattern>de2s3apercib</pattern>
+  <pattern>de2s3apes</pattern>
+  <pattern>de2s3aplic</pattern>
+  <pattern>de2s3apolill</pattern>
+  <pattern>de2s3apoy</pattern>
+  <pattern>de2s3aprend</pattern>
+  <pattern>de2s3apret</pattern>
+  <pattern>de2s3apriet</pattern>
+  <pattern>de2s3aprob</pattern>
+  <pattern>de2s3apropi</pattern>
+  <pattern>de2s3aprovech</pattern>
+  <pattern>de2s3arbol</pattern>
+  <pattern>de2s3aren</pattern>
+  <pattern>de2s3arm</pattern>
+  <pattern>des4arme</pattern>
+  <pattern>de2s3arraig</pattern>
+  <pattern>de2s3arregl</pattern>
+  <pattern>de2s3arrend</pattern>
+  <pattern>de2s3arrim</pattern>
+  <pattern>desa3rroll</pattern>
+  <pattern>de2s3arrop</pattern>
+  <pattern>de2s3arrug</pattern>
+  <pattern>de2s3articul</pattern>
+  <pattern>de2s3asent</pattern>
+  <pattern>de2s3asist</pattern>
+  <pattern>de2s3asn</pattern>
+  <pattern>de2s3atenc</pattern>
+  <pattern>de2s3atend</pattern>
+  <pattern>de2s3atiend</pattern>
+  <pattern>de2s3atent</pattern>
+  <pattern>desa3tin</pattern>
+  <pattern>de2s3atorn</pattern>
+  <pattern>de2s3atranc</pattern>
+  <pattern>de2s3autor</pattern>
+  <pattern>de2s3avis</pattern>
+  <pattern>desa3yun</pattern>
+  <pattern>desa3zón</pattern>
+  <pattern>desa3zon</pattern>
+  <pattern>de2s3embal</pattern>
+  <pattern>de2s3embál</pattern>
+  <pattern>de2s3embar</pattern>
+  <pattern>de2s3embár</pattern>
+  <pattern>de2s3embarg</pattern>
+  <pattern>de2s3embols</pattern>
+  <pattern>de2s3emborr</pattern>
+  <pattern>de2s3embosc</pattern>
+  <pattern>de2s3embot</pattern>
+  <pattern>de2s3embrag</pattern>
+  <pattern>de2s3embrág</pattern>
+  <pattern>de2s3embrave</pattern>
+  <pattern>de2s3embráve</pattern>
+  <pattern>de2s3embroll</pattern>
+  <pattern>de2s3embróll</pattern>
+  <pattern>de2s3embruj</pattern>
+  <pattern>de2s3embrúj</pattern>
+  <pattern>de3semej</pattern>
+  <pattern>de2s3empañ</pattern>
+  <pattern>de2s3empáñ</pattern>
+  <pattern>de2s3empac</pattern>
+  <pattern>de2s3empaquet</pattern>
+  <pattern>de2s3empaquét</pattern>
+  <pattern>de2s3emparej</pattern>
+  <pattern>de2s3emparéj</pattern>
+  <pattern>de2s3emparent</pattern>
+  <pattern>de2s3empat</pattern>
+  <pattern>de2s3empé</pattern>
+  <pattern>de2s3empedr</pattern>
+  <pattern>de2s3empeg</pattern>
+  <pattern>de2s3empeor</pattern>
+  <pattern>de2s3emperez</pattern>
+  <pattern>de2s3empern</pattern>
+  <pattern>de2s3emple</pattern>
+  <pattern>de2s3empolv</pattern>
+  <pattern>de2s3empotr</pattern>
+  <pattern>de2s3empoz</pattern>
+  <pattern>de2s3enam</pattern>
+  <pattern>de2s3encab</pattern>
+  <pattern>de2s3encad</pattern>
+  <pattern>de2s3encaj</pattern>
+  <pattern>de2s3encáj</pattern>
+  <pattern>de2s3encall</pattern>
+  <pattern>de2s3encáll</pattern>
+  <pattern>de2s3encam</pattern>
+  <pattern>de3sencant</pattern>
+  <pattern>de2s3encap</pattern>
+  <pattern>de2s3encar</pattern>
+  <pattern>de2s3encár</pattern>
+  <pattern>de2s3ench</pattern>
+  <pattern>de2s3encl</pattern>
+  <pattern>de2s3enco</pattern>
+  <pattern>de2s3encr</pattern>
+  <pattern>de2s3encu</pattern>
+  <pattern>de2s3end</pattern>
+  <pattern>de3senfad</pattern>
+  <pattern>de3senfád</pattern>
+  <pattern>de2s3enfi</pattern>
+  <pattern>de2s3enfo</pattern>
+  <pattern>de2s3enfó</pattern>
+  <pattern>de3senfren</pattern>
+  <pattern>de2s3enfund</pattern>
+  <pattern>de2s3enfur</pattern>
+  <pattern>de3sengañ</pattern>
+  <pattern>de3sengáñ</pattern>
+  <pattern>de2s3enganch</pattern>
+  <pattern>de2s3engar</pattern>
+  <pattern>de2s3engas</pattern>
+  <pattern>de2s3engom</pattern>
+  <pattern>de2s3engoz</pattern>
+  <pattern>de2s3engra</pattern>
+  <pattern>de2s3enhebr</pattern>
+  <pattern>de2s3enj</pattern>
+  <pattern>de2s3enlad</pattern>
+  <pattern>de2s3enlaz</pattern>
+  <pattern>de2s3enlo</pattern>
+  <pattern>de2s3enm</pattern>
+  <pattern>de2s3enr</pattern>
+  <pattern>de2s3ens</pattern>
+  <pattern>de2s3enta</pattern>
+  <pattern>de3sentend</pattern>
+  <pattern>de3sentien</pattern>
+  <pattern>de3sentién</pattern>
+  <pattern>de2s3enter</pattern>
+  <pattern>de2s3entier</pattern>
+  <pattern>de2s3entiér</pattern>
+  <pattern>de2s3ento</pattern>
+  <pattern>de2s3entr</pattern>
+  <pattern>de2s3entu</pattern>
+  <pattern>de2s3envain</pattern>
+  <pattern>de3senvolvim</pattern>
+  <pattern>de3seo</pattern>
+  <pattern>de2s3eq</pattern>
+  <pattern>de3s4erci</pattern>
+  <pattern>de3s4ert</pattern>
+  <pattern>de3s4ért</pattern>
+  <pattern>de2s3espa</pattern>
+  <pattern>de3sesperac</pattern>
+  <pattern>de2s3esperanz</pattern>
+  <pattern>de2s3estabil</pattern>
+  <pattern>de2s3estim</pattern>
+  <pattern>de3sider</pattern>
+  <pattern>de3sidia</pattern>
+  <pattern>de3sidio</pattern>
+  <pattern>de3siert</pattern>
+  <pattern>de3sign</pattern>
+  <pattern>de3sigual</pattern>
+  <pattern>de3silusi</pattern>
+  <pattern>de2s3imagin</pattern>
+  <pattern>de2s3iman</pattern>
+  <pattern>de2s3impon</pattern>
+  <pattern>de2s3impres</pattern>
+  <pattern>de2s3incent</pattern>
+  <pattern>de2s3inclin</pattern>
+  <pattern>de2s3incorp</pattern>
+  <pattern>de2s3incrust</pattern>
+  <pattern>de3sinenc</pattern>
+  <pattern>de3sinfec</pattern>
+  <pattern>de3su3dar</pattern>
+  <pattern>de3su3das</pattern>
+  <pattern>de3su3dan</pattern>
+  <pattern>de2s3inflam</pattern>
+  <pattern>de2s3infl</pattern>
+  <pattern>de2s3inform</pattern>
+  <pattern>de2s3inhib</pattern>
+  <pattern>de2s3insect</pattern>
+  <pattern>de2s3instal</pattern>
+  <pattern>ini3ci</pattern>
+  <pattern>iní3ci</pattern>
+  <pattern>de3s4integr</pattern>
+  <pattern>de3s4inter</pattern>
+  <pattern>de2s3intox</pattern>
+  <pattern>de2s3inver</pattern>
+  <pattern>de3sisten</pattern>
+  <pattern>de3isti</pattern>
+  <pattern>de2s3obedec</pattern>
+  <pattern>de2s3oblig</pattern>
+  <pattern>de2s3obstr</pattern>
+  <pattern>de3socup</pattern>
+  <pattern>de2s3odor</pattern>
+  <pattern>de3solac</pattern>
+  <pattern>de3solad</pattern>
+  <pattern>de3soll</pattern>
+  <pattern>de2s3orej</pattern>
+  <pattern>de2s3orient</pattern>
+  <pattern>de3sortij</pattern>
+  <pattern>de2s3organi</pattern>
+  <pattern>de3suell</pattern>
+  <pattern>de3sonce</pattern>
+  <pattern>de2s3ovi</pattern>
+  <pattern>de2s3oxi</pattern>
+  <pattern>de2s3oye</pattern>
+  <pattern>de2s3oyé</pattern>
+  <pattern>de3s4ubstan</pattern>
+  <pattern>de3s4ustan</pattern>
+  <pattern>de3s4oseg</pattern>
+  <pattern>de2s3ub4ic</pattern>
+  <pattern>de2s3unir</pattern>
+  <pattern>de2s3unier</pattern>
+  <pattern>de2s3unim</pattern>
+  <pattern> diecio2</pattern>
+  <pattern>ecano1h</pattern>
+  <pattern>ecano1a2</pattern>
+  <pattern>ecano1e2</pattern>
+  <pattern>ecano1i2</pattern>
+  <pattern>ecano1o2</pattern>
+  <pattern>ecano1u2</pattern>
+  <pattern>ecano1á2</pattern>
+  <pattern>ecano1é2</pattern>
+  <pattern>ecano1í2</pattern>
+  <pattern>ecano1ó2</pattern>
+  <pattern>ecano1ú2</pattern>
+  <pattern>eco1h</pattern>
+  <pattern>eco1a2</pattern>
+  <pattern>eco1e2</pattern>
+  <pattern>eco1i2</pattern>
+  <pattern>eco1o2</pattern>
+  <pattern>eco1u2</pattern>
+  <pattern>eco1á2</pattern>
+  <pattern>eco1é2</pattern>
+  <pattern>eco1í2</pattern>
+  <pattern>eco1ó2</pattern>
+  <pattern>eco1ú2</pattern>
+  <pattern>ectro1h</pattern>
+  <pattern>ectro1a2</pattern>
+  <pattern>ectro1e2</pattern>
+  <pattern>ectro1i2</pattern>
+  <pattern>ectro1o2</pattern>
+  <pattern>ectro1u2</pattern>
+  <pattern>ectro1á2</pattern>
+  <pattern>ectro1é2</pattern>
+  <pattern>ectro1í2</pattern>
+  <pattern>ectro1ó2</pattern>
+  <pattern>ectro1ú2</pattern>
+  <pattern> e2n2a2</pattern>
+  <pattern> e2n2e2</pattern>
+  <pattern> e2n2i2</pattern>
+  <pattern> e2n2o2</pattern>
+  <pattern> e2n2u2</pattern>
+  <pattern> e2n2á2</pattern>
+  <pattern> e2n2é2</pattern>
+  <pattern> e2n2í2</pattern>
+  <pattern> e2n2ó2</pattern>
+  <pattern> e2n2ú2</pattern>
+  <pattern> ene3mist</pattern>
+  <pattern> ene3míst</pattern>
+  <pattern> eno3jar</pattern>
+  <pattern> enu3mera</pattern>
+  <pattern> enu3merá</pattern>
+  <pattern> enu3mere</pattern>
+  <pattern> en3aceit</pattern>
+  <pattern> en3arb</pattern>
+  <pattern>4emboca</pattern>
+  <pattern>4o3lógico </pattern>
+  <pattern>4o3lógica </pattern>
+  <pattern>4o3lógicos </pattern>
+  <pattern>4o3lógicas </pattern>
+  <pattern>4o3lógicamente </pattern>
+  <pattern>4o3logía </pattern>
+  <pattern>4o3logías </pattern>
+  <pattern>4ó3logo </pattern>
+  <pattern>4ó3loga </pattern>
+  <pattern>4ó3logos </pattern>
+  <pattern>4ó3logas </pattern>
+  <pattern>endo1h</pattern>
+  <pattern>endo1a2</pattern>
+  <pattern>endo1e2</pattern>
+  <pattern>endo1i2</pattern>
+  <pattern>endo1o2</pattern>
+  <pattern>endo1u2</pattern>
+  <pattern>endo1á2</pattern>
+  <pattern>endo1é2</pattern>
+  <pattern>endo1í2</pattern>
+  <pattern>endo1ó2</pattern>
+  <pattern>endo1ú2</pattern>
+  <pattern>ento1h</pattern>
+  <pattern>ento1a2</pattern>
+  <pattern>ento1e2</pattern>
+  <pattern>ento1i2</pattern>
+  <pattern>ento1o2</pattern>
+  <pattern>ento1u2</pattern>
+  <pattern>ento1á2</pattern>
+  <pattern>ento1é2</pattern>
+  <pattern>ento1í2</pattern>
+  <pattern>ento1ó2</pattern>
+  <pattern>ento1ú2</pattern>
+  <pattern>entre1h</pattern>
+  <pattern>entre1a2</pattern>
+  <pattern>entre1e2</pattern>
+  <pattern>entre1i2</pattern>
+  <pattern>entre1o2</pattern>
+  <pattern>entre1u2</pattern>
+  <pattern>entre1á2</pattern>
+  <pattern>entre1é2</pattern>
+  <pattern>entre1í2</pattern>
+  <pattern>entre1ó2</pattern>
+  <pattern>entre1ú2</pattern>
+  <pattern>euco1h</pattern>
+  <pattern>euco1a2</pattern>
+  <pattern>euco1e2</pattern>
+  <pattern>euco1i2</pattern>
+  <pattern>euco1o2</pattern>
+  <pattern>euco1u2</pattern>
+  <pattern>euco1á2</pattern>
+  <pattern>euco1é2</pattern>
+  <pattern>euco1í2</pattern>
+  <pattern>euco1ó2</pattern>
+  <pattern>euco1ú2</pattern>
+  <pattern>euro1h</pattern>
+  <pattern>euro1a2</pattern>
+  <pattern>euro1e2</pattern>
+  <pattern>euro1i2</pattern>
+  <pattern>euro1o2</pattern>
+  <pattern>euro1u2</pattern>
+  <pattern>euro1á2</pattern>
+  <pattern>euro1é2</pattern>
+  <pattern>euro1í2</pattern>
+  <pattern>euro1ó2</pattern>
+  <pattern>euro1ú2</pattern>
+  <pattern> e2x2a2</pattern>
+  <pattern> e2x2e2</pattern>
+  <pattern> e2x2i2</pattern>
+  <pattern> e2x2o2</pattern>
+  <pattern> e2x2u2</pattern>
+  <pattern> e2x2á2</pattern>
+  <pattern> e2x2é2</pattern>
+  <pattern> e2x2í2</pattern>
+  <pattern> e2x2ó2</pattern>
+  <pattern> e2x2ú2</pattern>
+  <pattern>3gono </pattern>
+  <pattern>3gonos </pattern>
+  <pattern>3gonal </pattern>
+  <pattern>3gonales </pattern>
+  <pattern>exá3men</pattern>
+  <pattern>exá3ri</pattern>
+  <pattern>exé3ge</pattern>
+  <pattern>exó3ti</pattern>
+  <pattern>exa3cerb</pattern>
+  <pattern>exa3ger</pattern>
+  <pattern>exa3min</pattern>
+  <pattern>exe3cr</pattern>
+  <pattern>exe3géti</pattern>
+  <pattern>exe3quia</pattern>
+  <pattern>exi3ja</pattern>
+  <pattern>exi3já</pattern>
+  <pattern>exí3ja</pattern>
+  <pattern>exi3ge</pattern>
+  <pattern>exí3ge</pattern>
+  <pattern>exi3gi</pattern>
+  <pattern>exi3gí</pattern>
+  <pattern>exi3jo</pattern>
+  <pattern>exí3jo</pattern>
+  <pattern>3gua </pattern>
+  <pattern>3guas </pattern>
+  <pattern>3guo </pattern>
+  <pattern>3guos </pattern>
+  <pattern>exi3lia</pattern>
+  <pattern>exi3liá</pattern>
+  <pattern>exí3lia</pattern>
+  <pattern>exi3lie</pattern>
+  <pattern>exi3lié</pattern>
+  <pattern>exí3lie</pattern>
+  <pattern>exi3lio</pattern>
+  <pattern>exi3lió</pattern>
+  <pattern>exí3lio</pattern>
+  <pattern>exi3ma</pattern>
+  <pattern>exi3má</pattern>
+  <pattern>exí3ma</pattern>
+  <pattern>exi3mi</pattern>
+  <pattern>exi3mí</pattern>
+  <pattern>exí3mi</pattern>
+  <pattern>exi3me</pattern>
+  <pattern>exi3mé</pattern>
+  <pattern>exí3me</pattern>
+  <pattern>exi3mo</pattern>
+  <pattern>exi3mó</pattern>
+  <pattern>exí3mo</pattern>
+  <pattern>exi3tos</pattern>
+  <pattern>exi3lar</pattern>
+  <pattern>exo3ner</pattern>
+  <pattern>exo3crin</pattern>
+  <pattern>exo3tér</pattern>
+  <pattern>exo3tic</pattern>
+  <pattern>exo3tiq</pattern>
+  <pattern>exo3tism</pattern>
+  <pattern>exo3gami</pattern>
+  <pattern>exo3gámi</pattern>
+  <pattern>exu3ber</pattern>
+  <pattern>exu3dar</pattern>
+  <pattern>exu3dat</pattern>
+  <pattern>exu3dac</pattern>
+  <pattern>extra1h</pattern>
+  <pattern>extra1a2</pattern>
+  <pattern>extra1e2</pattern>
+  <pattern>extra1i2</pattern>
+  <pattern>extra1o2</pattern>
+  <pattern>extra1u2</pattern>
+  <pattern>extra1á2</pattern>
+  <pattern>extra1é2</pattern>
+  <pattern>extra1í2</pattern>
+  <pattern>extra1ó2</pattern>
+  <pattern>extra1ú2</pattern>
+  <pattern>u4teri</pattern>
+  <pattern> cau5t</pattern>
+  <pattern> deu5t</pattern>
+  <pattern>fono1h</pattern>
+  <pattern>fono1a2</pattern>
+  <pattern>fono1e2</pattern>
+  <pattern>fono1i2</pattern>
+  <pattern>fono1o2</pattern>
+  <pattern>fono1u2</pattern>
+  <pattern>fono1á2</pattern>
+  <pattern>fono1é2</pattern>
+  <pattern>fono1í2</pattern>
+  <pattern>fono1ó2</pattern>
+  <pattern>fono1ú2</pattern>
+  <pattern>foto1h</pattern>
+  <pattern>foto1a2</pattern>
+  <pattern>foto1e2</pattern>
+  <pattern>foto1i2</pattern>
+  <pattern>foto1o2</pattern>
+  <pattern>foto1u2</pattern>
+  <pattern>foto1á2</pattern>
+  <pattern>foto1é2</pattern>
+  <pattern>foto1í2</pattern>
+  <pattern>foto1ó2</pattern>
+  <pattern>foto1ú2</pattern>
+  <pattern>gastro1h</pattern>
+  <pattern>gastro1a2</pattern>
+  <pattern>gastro1e2</pattern>
+  <pattern>gastro1i2</pattern>
+  <pattern>gastro1o2</pattern>
+  <pattern>gastro1u2</pattern>
+  <pattern>gastro1á2</pattern>
+  <pattern>gastro1é2</pattern>
+  <pattern>gastro1í2</pattern>
+  <pattern>gastro1ó2</pattern>
+  <pattern>gastro1ú2</pattern>
+  <pattern>geo1h</pattern>
+  <pattern>geo1a2</pattern>
+  <pattern>geo1e2</pattern>
+  <pattern>geo1i2</pattern>
+  <pattern>geo1o2</pattern>
+  <pattern>geo1u2</pattern>
+  <pattern>geo1á2</pattern>
+  <pattern>geo1é2</pattern>
+  <pattern>geo1í2</pattern>
+  <pattern>geo1ó2</pattern>
+  <pattern>geo1ú2</pattern>
+  <pattern>giga1h</pattern>
+  <pattern>giga1a2</pattern>
+  <pattern>giga1e2</pattern>
+  <pattern>giga1i2</pattern>
+  <pattern>giga1o2</pattern>
+  <pattern>giga1u2</pattern>
+  <pattern>giga1á2</pattern>
+  <pattern>giga1é2</pattern>
+  <pattern>giga1í2</pattern>
+  <pattern>giga1ó2</pattern>
+  <pattern>giga1ú2</pattern>
+  <pattern>gluco1h</pattern>
+  <pattern>gluco1a2</pattern>
+  <pattern>gluco1e2</pattern>
+  <pattern>gluco1i2</pattern>
+  <pattern>gluco1o2</pattern>
+  <pattern>gluco1u2</pattern>
+  <pattern>gluco1á2</pattern>
+  <pattern>gluco1é2</pattern>
+  <pattern>gluco1í2</pattern>
+  <pattern>gluco1ó2</pattern>
+  <pattern>gluco1ú2</pattern>
+  <pattern>hecto1h</pattern>
+  <pattern>hecto1a2</pattern>
+  <pattern>hecto1e2</pattern>
+  <pattern>hecto1i2</pattern>
+  <pattern>hecto1o2</pattern>
+  <pattern>hecto1u2</pattern>
+  <pattern>hecto1á2</pattern>
+  <pattern>hecto1é2</pattern>
+  <pattern>hecto1í2</pattern>
+  <pattern>hecto1ó2</pattern>
+  <pattern>hecto1ú2</pattern>
+  <pattern>helio1h</pattern>
+  <pattern>helio1a2</pattern>
+  <pattern>helio1e2</pattern>
+  <pattern>helio1i2</pattern>
+  <pattern>helio1o2</pattern>
+  <pattern>helio1u2</pattern>
+  <pattern>helio1á2</pattern>
+  <pattern>helio1é2</pattern>
+  <pattern>helio1í2</pattern>
+  <pattern>helio1ó2</pattern>
+  <pattern>helio1ú2</pattern>
+  <pattern>hemato1h</pattern>
+  <pattern>hemato1a2</pattern>
+  <pattern>hemato1e2</pattern>
+  <pattern>hemato1i2</pattern>
+  <pattern>hemato1o2</pattern>
+  <pattern>hemato1u2</pattern>
+  <pattern>hemato1á2</pattern>
+  <pattern>hemato1é2</pattern>
+  <pattern>hemato1í2</pattern>
+  <pattern>hemato1ó2</pattern>
+  <pattern>hemato1ú2</pattern>
+  <pattern>hemi1h</pattern>
+  <pattern>hemi1a2</pattern>
+  <pattern>hemi1e2</pattern>
+  <pattern>hemi1i2</pattern>
+  <pattern>hemi1o2</pattern>
+  <pattern>hemi1u2</pattern>
+  <pattern>hemi1á2</pattern>
+  <pattern>hemi1é2</pattern>
+  <pattern>hemi1í2</pattern>
+  <pattern>hemi1ó2</pattern>
+  <pattern>hemi1ú2</pattern>
+  <pattern>hemo1h</pattern>
+  <pattern>hemo1a2</pattern>
+  <pattern>hemo1e2</pattern>
+  <pattern>hemo1i2</pattern>
+  <pattern>hemo1o2</pattern>
+  <pattern>hemo1u2</pattern>
+  <pattern>hemo1á2</pattern>
+  <pattern>hemo1é2</pattern>
+  <pattern>hemo1í2</pattern>
+  <pattern>hemo1ó2</pattern>
+  <pattern>hemo1ú2</pattern>
+  <pattern>2al </pattern>
+  <pattern>2ales </pattern>
+  <pattern> hepta1e</pattern>
+  <pattern>hexa1h</pattern>
+  <pattern>hexa1a2</pattern>
+  <pattern>hexa1e2</pattern>
+  <pattern>hexa1i2</pattern>
+  <pattern>hexa1o2</pattern>
+  <pattern>hexa1u2</pattern>
+  <pattern>hexa1á2</pattern>
+  <pattern>hexa1é2</pattern>
+  <pattern>hexa1í2</pattern>
+  <pattern>hexa1ó2</pattern>
+  <pattern>hexa1ú2</pattern>
+  <pattern>hidro1h</pattern>
+  <pattern>hidro1a2</pattern>
+  <pattern>hidro1e2</pattern>
+  <pattern>hidro1i2</pattern>
+  <pattern>hidro1o2</pattern>
+  <pattern>hidro1u2</pattern>
+  <pattern>hidro1á2</pattern>
+  <pattern>hidro1é2</pattern>
+  <pattern>hidro1í2</pattern>
+  <pattern>hidro1ó2</pattern>
+  <pattern>hidro1ú2</pattern>
+  <pattern>hipe2r3r</pattern>
+  <pattern>hipe2r1a2</pattern>
+  <pattern>hipe2r1e2</pattern>
+  <pattern>hipe2r1i2</pattern>
+  <pattern>hipe2r1o2</pattern>
+  <pattern>hipe2r1u2</pattern>
+  <pattern>hipe2r1á2</pattern>
+  <pattern>hipe2r1é2</pattern>
+  <pattern>hipe2r1í2</pattern>
+  <pattern>hipe2r1ó2</pattern>
+  <pattern>hipe2r1ú2</pattern>
+  <pattern>pe3r4e3mia</pattern>
+  <pattern>hipe3r4i3cíne</pattern>
+  <pattern>hipe3r4o3nimi</pattern>
+  <pattern>hipe3r4o3ními</pattern>
+  <pattern>hipe3r4ó3nimo</pattern>
+  <pattern>hipe3r4o3xia</pattern>
+  <pattern>hipo1h</pattern>
+  <pattern>hipo1a2</pattern>
+  <pattern>hipo1e2</pattern>
+  <pattern>hipo1i2</pattern>
+  <pattern>hipo1o2</pattern>
+  <pattern>hipo1u2</pattern>
+  <pattern>hipo1á2</pattern>
+  <pattern>hipo1é2</pattern>
+  <pattern>hipo1í2</pattern>
+  <pattern>hipo1ó2</pattern>
+  <pattern>hipo1ú2</pattern>
+  <pattern>spano1h</pattern>
+  <pattern>spano1a2</pattern>
+  <pattern>spano1e2</pattern>
+  <pattern>spano1i2</pattern>
+  <pattern>spano1o2</pattern>
+  <pattern>spano1u2</pattern>
+  <pattern>spano1á2</pattern>
+  <pattern>spano1é2</pattern>
+  <pattern>spano1í2</pattern>
+  <pattern>spano1ó2</pattern>
+  <pattern>spano1ú2</pattern>
+  <pattern>histo1h</pattern>
+  <pattern>histo1a2</pattern>
+  <pattern>histo1e2</pattern>
+  <pattern>histo1i2</pattern>
+  <pattern>histo1o2</pattern>
+  <pattern>histo1u2</pattern>
+  <pattern>histo1á2</pattern>
+  <pattern>histo1é2</pattern>
+  <pattern>histo1í2</pattern>
+  <pattern>histo1ó2</pattern>
+  <pattern>histo1ú2</pattern>
+  <pattern>homo1h</pattern>
+  <pattern>homo1a2</pattern>
+  <pattern>homo1e2</pattern>
+  <pattern>homo1i2</pattern>
+  <pattern>homo1o2</pattern>
+  <pattern>homo1u2</pattern>
+  <pattern>homo1á2</pattern>
+  <pattern>homo1é2</pattern>
+  <pattern>homo1í2</pattern>
+  <pattern>homo1ó2</pattern>
+  <pattern>homo1ú2</pattern>
+  <pattern>ibero1h</pattern>
+  <pattern>ibero1a2</pattern>
+  <pattern>ibero1e2</pattern>
+  <pattern>ibero1i2</pattern>
+  <pattern>ibero1o2</pattern>
+  <pattern>ibero1u2</pattern>
+  <pattern>ibero1á2</pattern>
+  <pattern>ibero1é2</pattern>
+  <pattern>ibero1í2</pattern>
+  <pattern>ibero1ó2</pattern>
+  <pattern>ibero1ú2</pattern>
+  <pattern>icono1h</pattern>
+  <pattern>icono1a2</pattern>
+  <pattern>icono1e2</pattern>
+  <pattern>icono1i2</pattern>
+  <pattern>icono1o2</pattern>
+  <pattern>icono1u2</pattern>
+  <pattern>icono1á2</pattern>
+  <pattern>icono1é2</pattern>
+  <pattern>icono1í2</pattern>
+  <pattern>icono1ó2</pattern>
+  <pattern>icono1ú2</pattern>
+  <pattern> i2n2a2</pattern>
+  <pattern> i2n2e2</pattern>
+  <pattern> i2n2i2</pattern>
+  <pattern> i2n2o2</pattern>
+  <pattern> i2n2u2</pattern>
+  <pattern> i2n2á2</pattern>
+  <pattern> i2n2é2</pattern>
+  <pattern> i2n2í2</pattern>
+  <pattern> i2n2ó2</pattern>
+  <pattern> i2n2ú2</pattern>
+  <pattern> in3abord</pattern>
+  <pattern> in3abarc</pattern>
+  <pattern> in3acent</pattern>
+  <pattern> in3aguant</pattern>
+  <pattern> in3adapt</pattern>
+  <pattern> ina3movib</pattern>
+  <pattern> in3analiz</pattern>
+  <pattern> ina3nic</pattern>
+  <pattern> in3anim</pattern>
+  <pattern> iná3nim</pattern>
+  <pattern> in3apel</pattern>
+  <pattern> in3aplic</pattern>
+  <pattern> in3aprens</pattern>
+  <pattern> in3apreci</pattern>
+  <pattern> in3arrug</pattern>
+  <pattern> in3asist</pattern>
+  <pattern> iné3dit</pattern>
+  <pattern> in3efic</pattern>
+  <pattern> in3efici</pattern>
+  <pattern> in3eludi</pattern>
+  <pattern> ine3narr</pattern>
+  <pattern>ini3cia</pattern>
+  <pattern>iní3cia</pattern>
+  <pattern>ini3ciá</pattern>
+  <pattern>ini3cie</pattern>
+  <pattern> rei3na</pattern>
+  <pattern>re3ini3cia</pattern>
+  <pattern>re3iní3cia</pattern>
+  <pattern>re3ini3ciá</pattern>
+  <pattern>re3ini3cie</pattern>
+  <pattern> ini3cuo</pattern>
+  <pattern> ini3cua</pattern>
+  <pattern> ino3cuo</pattern>
+  <pattern> ino3cua</pattern>
+  <pattern> ino3cula</pattern>
+  <pattern> ino3culá</pattern>
+  <pattern> ino3cule</pattern>
+  <pattern> inú3til</pattern>
+  <pattern> inu3tiliz</pattern>
+  <pattern>infra1h</pattern>
+  <pattern>infra1a2</pattern>
+  <pattern>infra1e2</pattern>
+  <pattern>infra1i2</pattern>
+  <pattern>infra1o2</pattern>
+  <pattern>infra1u2</pattern>
+  <pattern>infra1á2</pattern>
+  <pattern>infra1é2</pattern>
+  <pattern>infra1í2</pattern>
+  <pattern>infra1ó2</pattern>
+  <pattern>infra1ú2</pattern>
+  <pattern> inte2r3r</pattern>
+  <pattern> inte2r1a2</pattern>
+  <pattern> inte2r1e2</pattern>
+  <pattern> inte2r1i2</pattern>
+  <pattern> inte2r1o2</pattern>
+  <pattern> inte2r1u2</pattern>
+  <pattern> inte2r1á2</pattern>
+  <pattern> inte2r1é2</pattern>
+  <pattern> inte2r1í2</pattern>
+  <pattern> inte2r1ó2</pattern>
+  <pattern> inte2r1ú2</pattern>
+  <pattern> in3ter2e3sa</pattern>
+  <pattern> in3ter2e3se</pattern>
+  <pattern> in3ter2e3so</pattern>
+  <pattern> in3ter2e3sá</pattern>
+  <pattern> in3ter2e3sé</pattern>
+  <pattern> in3ter2e3só</pattern>
+  <pattern> de3s4in3ter2e3sa</pattern>
+  <pattern> de3s4in3ter2e3se</pattern>
+  <pattern> de3s4in3ter2e3so</pattern>
+  <pattern> de3s4in3ter2e3sá</pattern>
+  <pattern> de3s4in3ter2e3sé</pattern>
+  <pattern> de3s4in3ter2e3só</pattern>
+  <pattern>4n3te3ri3n</pattern>
+  <pattern>4n4te4r5i4nsu</pattern>
+  <pattern> in3te3r4rog</pattern>
+  <pattern> in3te3r4rupc</pattern>
+  <pattern> in3te3r4rupt</pattern>
+  <pattern> in3te3r4rump</pattern>
+  <pattern>inter4és</pattern>
+  <pattern>inte3r4esar</pattern>
+  <pattern>inte4r4i4n4</pattern>
+  <pattern>inter5ins5t</pattern>
+  <pattern>inte5r4regno</pattern>
+  <pattern>inte3r4ior4</pattern>
+  <pattern>4i4ano </pattern>
+  <pattern>4i4ana </pattern>
+  <pattern>4i4anos </pattern>
+  <pattern>4i4anas </pattern>
+  <pattern>intra1h</pattern>
+  <pattern>intra1a2</pattern>
+  <pattern>intra1e2</pattern>
+  <pattern>intra1i2</pattern>
+  <pattern>intra1o2</pattern>
+  <pattern>intra1u2</pattern>
+  <pattern>intra1á2</pattern>
+  <pattern>intra1é2</pattern>
+  <pattern>intra1í2</pattern>
+  <pattern>intra1ó2</pattern>
+  <pattern>intra1ú2</pattern>
+  <pattern>iso1h</pattern>
+  <pattern>iso1a2</pattern>
+  <pattern>iso1e2</pattern>
+  <pattern>iso1i2</pattern>
+  <pattern>iso1o2</pattern>
+  <pattern>iso1u2</pattern>
+  <pattern>iso1á2</pattern>
+  <pattern>iso1é2</pattern>
+  <pattern>iso1í2</pattern>
+  <pattern>iso1ó2</pattern>
+  <pattern>iso1ú2</pattern>
+  <pattern>kilo1h</pattern>
+  <pattern>kilo1a2</pattern>
+  <pattern>kilo1e2</pattern>
+  <pattern>kilo1i2</pattern>
+  <pattern>kilo1o2</pattern>
+  <pattern>kilo1u2</pattern>
+  <pattern>kilo1á2</pattern>
+  <pattern>kilo1é2</pattern>
+  <pattern>kilo1í2</pattern>
+  <pattern>kilo1ó2</pattern>
+  <pattern>kilo1ú2</pattern>
+  <pattern>macro1h</pattern>
+  <pattern>macro1a2</pattern>
+  <pattern>macro1e2</pattern>
+  <pattern>macro1i2</pattern>
+  <pattern>macro1o2</pattern>
+  <pattern>macro1u2</pattern>
+  <pattern>macro1á2</pattern>
+  <pattern>macro1é2</pattern>
+  <pattern>macro1í2</pattern>
+  <pattern>macro1ó2</pattern>
+  <pattern>macro1ú2</pattern>
+  <pattern>mal2</pattern>
+  <pattern>ma4l3h</pattern>
+  <pattern> ma4l3e4du</pattern>
+  <pattern>mal3b</pattern>
+  <pattern>mal3c</pattern>
+  <pattern>mal3d</pattern>
+  <pattern>mal3f</pattern>
+  <pattern>mal3g</pattern>
+  <pattern>mal3m</pattern>
+  <pattern>mal3p</pattern>
+  <pattern>mal3q</pattern>
+  <pattern>mal3s</pattern>
+  <pattern>mal3t</pattern>
+  <pattern>mal3v</pattern>
+  <pattern> mal1acon</pattern>
+  <pattern> mal1acos</pattern>
+  <pattern> mala1e</pattern>
+  <pattern> mal1andant</pattern>
+  <pattern> mal1andanz</pattern>
+  <pattern> mal1est</pattern>
+  <pattern> mal1int</pattern>
+  <pattern>maxi1h</pattern>
+  <pattern>maxi1a2</pattern>
+  <pattern>maxi1e2</pattern>
+  <pattern>maxi1i2</pattern>
+  <pattern>maxi1o2</pattern>
+  <pattern>maxi1u2</pattern>
+  <pattern>maxi1á2</pattern>
+  <pattern>maxi1é2</pattern>
+  <pattern>maxi1í2</pattern>
+  <pattern>maxi1ó2</pattern>
+  <pattern>maxi1ú2</pattern>
+  <pattern>megalo1h</pattern>
+  <pattern>megalo1a2</pattern>
+  <pattern>megalo1e2</pattern>
+  <pattern>megalo1i2</pattern>
+  <pattern>megalo1o2</pattern>
+  <pattern>megalo1u2</pattern>
+  <pattern>megalo1á2</pattern>
+  <pattern>megalo1é2</pattern>
+  <pattern>megalo1í2</pattern>
+  <pattern>megalo1ó2</pattern>
+  <pattern>megalo1ú2</pattern>
+  <pattern>mega1h</pattern>
+  <pattern>mega1a2</pattern>
+  <pattern>mega1e2</pattern>
+  <pattern>mega1i2</pattern>
+  <pattern>mega1o2</pattern>
+  <pattern>mega1u2</pattern>
+  <pattern>mega1á2</pattern>
+  <pattern>mega1é2</pattern>
+  <pattern>mega1í2</pattern>
+  <pattern>mega1ó2</pattern>
+  <pattern>mega1ú2</pattern>
+  <pattern>melano1h</pattern>
+  <pattern>melano1a2</pattern>
+  <pattern>melano1e2</pattern>
+  <pattern>melano1i2</pattern>
+  <pattern>melano1o2</pattern>
+  <pattern>melano1u2</pattern>
+  <pattern>melano1á2</pattern>
+  <pattern>melano1é2</pattern>
+  <pattern>melano1í2</pattern>
+  <pattern>melano1ó2</pattern>
+  <pattern>melano1ú2</pattern>
+  <pattern>micro1h</pattern>
+  <pattern>micro1a2</pattern>
+  <pattern>micro1e2</pattern>
+  <pattern>micro1i2</pattern>
+  <pattern>micro1o2</pattern>
+  <pattern>micro1u2</pattern>
+  <pattern>micro1á2</pattern>
+  <pattern>micro1é2</pattern>
+  <pattern>micro1í2</pattern>
+  <pattern>micro1ó2</pattern>
+  <pattern>micro1ú2</pattern>
+  <pattern> mili1h</pattern>
+  <pattern> mili1a2</pattern>
+  <pattern> mili1e2</pattern>
+  <pattern> mili1i2</pattern>
+  <pattern> mili1o2</pattern>
+  <pattern> mili1u2</pattern>
+  <pattern> mili1á2</pattern>
+  <pattern> mili1é2</pattern>
+  <pattern> mili1í2</pattern>
+  <pattern> mili1ó2</pattern>
+  <pattern> mili1ú2</pattern>
+  <pattern>familia3ri</pattern>
+  <pattern>ia5res </pattern>
+  <pattern>amili6a</pattern>
+  <pattern>a3rio</pattern>
+  <pattern>a3ria</pattern>
+  <pattern>li5área</pattern>
+  <pattern>mili4ar</pattern>
+  <pattern>mini1h</pattern>
+  <pattern>mini1a2</pattern>
+  <pattern>mini1e2</pattern>
+  <pattern>mini1i2</pattern>
+  <pattern>mini1o2</pattern>
+  <pattern>mini1u2</pattern>
+  <pattern>mini1á2</pattern>
+  <pattern>mini1é2</pattern>
+  <pattern>mini1í2</pattern>
+  <pattern>mini1ó2</pattern>
+  <pattern>mini1ú2</pattern>
+  <pattern>2os </pattern>
+  <pattern>2o3so </pattern>
+  <pattern>2o3sos </pattern>
+  <pattern>2o3sa </pattern>
+  <pattern>2o3sas </pattern>
+  <pattern>2o3samente </pattern>
+  <pattern>mini4a5tur</pattern>
+  <pattern>multi1h</pattern>
+  <pattern>multi1a2</pattern>
+  <pattern>multi1e2</pattern>
+  <pattern>multi1i2</pattern>
+  <pattern>multi1o2</pattern>
+  <pattern>multi1u2</pattern>
+  <pattern>multi1á2</pattern>
+  <pattern>multi1é2</pattern>
+  <pattern>multi1í2</pattern>
+  <pattern>multi1ó2</pattern>
+  <pattern>multi1ú2</pattern>
+  <pattern>miria1h</pattern>
+  <pattern>miria1a2</pattern>
+  <pattern>miria1e2</pattern>
+  <pattern>miria1i2</pattern>
+  <pattern>miria1o2</pattern>
+  <pattern>miria1u2</pattern>
+  <pattern>miria1á2</pattern>
+  <pattern>miria1é2</pattern>
+  <pattern>miria1í2</pattern>
+  <pattern>miria1ó2</pattern>
+  <pattern>miria1ú2</pattern>
+  <pattern>mono1h</pattern>
+  <pattern>mono1a2</pattern>
+  <pattern>mono1e2</pattern>
+  <pattern>mono1i2</pattern>
+  <pattern>mono1o2</pattern>
+  <pattern>mono1u2</pattern>
+  <pattern>mono1á2</pattern>
+  <pattern>mono1é2</pattern>
+  <pattern>mono1í2</pattern>
+  <pattern>mono1ó2</pattern>
+  <pattern>mono1ú2</pattern>
+  <pattern>2i3co </pattern>
+  <pattern>2i3cos </pattern>
+  <pattern>2i3ca </pattern>
+  <pattern>2i3cas </pattern>
+  <pattern>namo1h</pattern>
+  <pattern>namo1a2</pattern>
+  <pattern>namo1e2</pattern>
+  <pattern>namo1i2</pattern>
+  <pattern>namo1o2</pattern>
+  <pattern>namo1u2</pattern>
+  <pattern>namo1á2</pattern>
+  <pattern>namo1é2</pattern>
+  <pattern>namo1í2</pattern>
+  <pattern>namo1ó2</pattern>
+  <pattern>namo1ú2</pattern>
+  <pattern>necro1h</pattern>
+  <pattern>necro1a2</pattern>
+  <pattern>necro1e2</pattern>
+  <pattern>necro1i2</pattern>
+  <pattern>necro1o2</pattern>
+  <pattern>necro1u2</pattern>
+  <pattern>necro1á2</pattern>
+  <pattern>necro1é2</pattern>
+  <pattern>necro1í2</pattern>
+  <pattern>necro1ó2</pattern>
+  <pattern>necro1ú2</pattern>
+  <pattern>neo1h</pattern>
+  <pattern>neo1a2</pattern>
+  <pattern>neo1e2</pattern>
+  <pattern>neo1i2</pattern>
+  <pattern>neo1o2</pattern>
+  <pattern>neo1u2</pattern>
+  <pattern>neo1á2</pattern>
+  <pattern>neo1é2</pattern>
+  <pattern>neo1í2</pattern>
+  <pattern>neo1ó2</pattern>
+  <pattern>neo1ú2</pattern>
+  <pattern>3c2neor</pattern>
+  <pattern>neto1h</pattern>
+  <pattern>neto1a2</pattern>
+  <pattern>neto1e2</pattern>
+  <pattern>neto1i2</pattern>
+  <pattern>neto1o2</pattern>
+  <pattern>neto1u2</pattern>
+  <pattern>neto1á2</pattern>
+  <pattern>neto1é2</pattern>
+  <pattern>neto1í2</pattern>
+  <pattern>neto1ó2</pattern>
+  <pattern>neto1ú2</pattern>
+  <pattern>norte1h</pattern>
+  <pattern>norte1a2</pattern>
+  <pattern>norte1e2</pattern>
+  <pattern>norte1i2</pattern>
+  <pattern>norte1o2</pattern>
+  <pattern>norte1u2</pattern>
+  <pattern>norte1á2</pattern>
+  <pattern>norte1é2</pattern>
+  <pattern>norte1í2</pattern>
+  <pattern>norte1ó2</pattern>
+  <pattern>norte1ú2</pattern>
+  <pattern>octo1h</pattern>
+  <pattern>octo1a2</pattern>
+  <pattern>octo1e2</pattern>
+  <pattern>octo1i2</pattern>
+  <pattern>octo1o2</pattern>
+  <pattern>octo1u2</pattern>
+  <pattern>octo1á2</pattern>
+  <pattern>octo1é2</pattern>
+  <pattern>octo1í2</pattern>
+  <pattern>octo1ó2</pattern>
+  <pattern>octo1ú2</pattern>
+  <pattern>octa1h</pattern>
+  <pattern>octa1a2</pattern>
+  <pattern>octa1e2</pattern>
+  <pattern>octa1i2</pattern>
+  <pattern>octa1o2</pattern>
+  <pattern>octa1u2</pattern>
+  <pattern>octa1á2</pattern>
+  <pattern>octa1é2</pattern>
+  <pattern>octa1í2</pattern>
+  <pattern>octa1ó2</pattern>
+  <pattern>octa1ú2</pattern>
+  <pattern>oligo1h</pattern>
+  <pattern>oligo1a2</pattern>
+  <pattern>oligo1e2</pattern>
+  <pattern>oligo1i2</pattern>
+  <pattern>oligo1o2</pattern>
+  <pattern>oligo1u2</pattern>
+  <pattern>oligo1á2</pattern>
+  <pattern>oligo1é2</pattern>
+  <pattern>oligo1í2</pattern>
+  <pattern>oligo1ó2</pattern>
+  <pattern>oligo1ú2</pattern>
+  <pattern>omni1h</pattern>
+  <pattern>omni1a2</pattern>
+  <pattern>omni1e2</pattern>
+  <pattern>omni1i2</pattern>
+  <pattern>omni1o2</pattern>
+  <pattern>omni1u2</pattern>
+  <pattern>omni1á2</pattern>
+  <pattern>omni1é2</pattern>
+  <pattern>omni1í2</pattern>
+  <pattern>omni1ó2</pattern>
+  <pattern>omni1ú2</pattern>
+  <pattern>i2o </pattern>
+  <pattern>i2os </pattern>
+  <pattern>paleo1h</pattern>
+  <pattern>paleo1a2</pattern>
+  <pattern>paleo1e2</pattern>
+  <pattern>paleo1i2</pattern>
+  <pattern>paleo1o2</pattern>
+  <pattern>paleo1u2</pattern>
+  <pattern>paleo1á2</pattern>
+  <pattern>paleo1é2</pattern>
+  <pattern>paleo1í2</pattern>
+  <pattern>paleo1ó2</pattern>
+  <pattern>paleo1ú2</pattern>
+  <pattern> pa4n1a4meri</pattern>
+  <pattern> pa4n1europ</pattern>
+  <pattern> pa4n1afri</pattern>
+  <pattern> pa4n1hisp</pattern>
+  <pattern> pa4n1ópti</pattern>
+  <pattern>para1h</pattern>
+  <pattern>para1a2</pattern>
+  <pattern>para1e2</pattern>
+  <pattern>para1i2</pattern>
+  <pattern>para1o2</pattern>
+  <pattern>para1u2</pattern>
+  <pattern>para1á2</pattern>
+  <pattern>para1é2</pattern>
+  <pattern>para1í2</pattern>
+  <pattern>para1ó2</pattern>
+  <pattern>para1ú2</pattern>
+  <pattern>para2is </pattern>
+  <pattern>aí5so </pattern>
+  <pattern>aí5sos </pattern>
+  <pattern>para4íso</pattern>
+  <pattern>para4ulata</pattern>
+  <pattern>penta1h</pattern>
+  <pattern>penta1a2</pattern>
+  <pattern>penta1e2</pattern>
+  <pattern>penta1i2</pattern>
+  <pattern>penta1o2</pattern>
+  <pattern>penta1u2</pattern>
+  <pattern>penta1á2</pattern>
+  <pattern>penta1é2</pattern>
+  <pattern>penta1í2</pattern>
+  <pattern>penta1ó2</pattern>
+  <pattern>penta1ú2</pattern>
+  <pattern>piezo1h</pattern>
+  <pattern>piezo1a2</pattern>
+  <pattern>piezo1e2</pattern>
+  <pattern>piezo1i2</pattern>
+  <pattern>piezo1o2</pattern>
+  <pattern>piezo1u2</pattern>
+  <pattern>piezo1á2</pattern>
+  <pattern>piezo1é2</pattern>
+  <pattern>piezo1í2</pattern>
+  <pattern>piezo1ó2</pattern>
+  <pattern>piezo1ú2</pattern>
+  <pattern>pluri1h</pattern>
+  <pattern>pluri1a2</pattern>
+  <pattern>pluri1e2</pattern>
+  <pattern>pluri1i2</pattern>
+  <pattern>pluri1o2</pattern>
+  <pattern>pluri1u2</pattern>
+  <pattern>pluri1á2</pattern>
+  <pattern>pluri1é2</pattern>
+  <pattern>pluri1í2</pattern>
+  <pattern>pluri1ó2</pattern>
+  <pattern>pluri1ú2</pattern>
+  <pattern>poli1h</pattern>
+  <pattern>poli1a2</pattern>
+  <pattern>poli1e2</pattern>
+  <pattern>poli1i2</pattern>
+  <pattern>poli1o2</pattern>
+  <pattern>poli1u2</pattern>
+  <pattern>poli1á2</pattern>
+  <pattern>poli1é2</pattern>
+  <pattern>poli1í2</pattern>
+  <pattern>poli1ó2</pattern>
+  <pattern>poli1ú2</pattern>
+  <pattern>poli4u3r</pattern>
+  <pattern>poli4o5mie</pattern>
+  <pattern>poli4arq</pattern>
+  <pattern>poli4árq</pattern>
+  <pattern>poli4éste</pattern>
+  <pattern>poli4andr</pattern>
+  <pattern>poli4antea</pattern>
+  <pattern>poli4arca</pattern>
+  <pattern>expoli4</pattern>
+  <pattern> pos2t2a2</pattern>
+  <pattern> pos2t2e2</pattern>
+  <pattern> pos2t2i2</pattern>
+  <pattern> pos2t2o2</pattern>
+  <pattern> pos2t2u2</pattern>
+  <pattern> pos2t2á2</pattern>
+  <pattern> pos2t2é2</pattern>
+  <pattern> pos2t2í2</pattern>
+  <pattern> pos2t2ó2</pattern>
+  <pattern> pos2t2ú2</pattern>
+  <pattern> pos3tin</pattern>
+  <pattern> pos3tín</pattern>
+  <pattern>pos3ta </pattern>
+  <pattern>pos3tas </pattern>
+  <pattern>s3te </pattern>
+  <pattern>s3tes </pattern>
+  <pattern>s3tal </pattern>
+  <pattern>s3ta3les </pattern>
+  <pattern>s3ti3lla </pattern>
+  <pattern>s3ti3llas </pattern>
+  <pattern>s3ti3llón </pattern>
+  <pattern>s3ti3llones </pattern>
+  <pattern>s3tor </pattern>
+  <pattern>s3tora </pattern>
+  <pattern>s3toras </pattern>
+  <pattern>s3tores </pattern>
+  <pattern> pos3tó3ni</pattern>
+  <pattern> pos3terg</pattern>
+  <pattern> pos3te3ri</pattern>
+  <pattern> pos3ti3go</pattern>
+  <pattern> pos3ti3la</pattern>
+  <pattern> pos3ti3ne</pattern>
+  <pattern> pos3ti3za</pattern>
+  <pattern> pos3ti3zo</pattern>
+  <pattern> pos3tu3ra</pattern>
+  <pattern> pos3tu3la</pattern>
+  <pattern> pos3tu3lá</pattern>
+  <pattern> pos3tu3le</pattern>
+  <pattern> pos3tu3lé</pattern>
+  <pattern> post3elec</pattern>
+  <pattern> post3impr</pattern>
+  <pattern> post3ind</pattern>
+  <pattern> post3ope</pattern>
+  <pattern> pos2t3rev</pattern>
+  <pattern> pos2t3rom</pattern>
+  <pattern> pre2a2</pattern>
+  <pattern> pre2e2</pattern>
+  <pattern> pre2i2</pattern>
+  <pattern> pre2o2</pattern>
+  <pattern> pre2u2</pattern>
+  <pattern> pre2á2</pattern>
+  <pattern> pre2é2</pattern>
+  <pattern> pre2í2</pattern>
+  <pattern> pre2ó2</pattern>
+  <pattern> pre2ú2</pattern>
+  <pattern> pre1h2</pattern>
+  <pattern>pre3elij</pattern>
+  <pattern>pre3elig</pattern>
+  <pattern>pre3exis</pattern>
+  <pattern>pre3emin</pattern>
+  <pattern>preo3cup</pattern>
+  <pattern>preo2cúp</pattern>
+  <pattern>pre3olí</pattern>
+  <pattern>pre3opin</pattern>
+  <pattern> pro2a2</pattern>
+  <pattern> pro2e2</pattern>
+  <pattern> pro2i2</pattern>
+  <pattern> pro2o2</pattern>
+  <pattern> pro2u2</pattern>
+  <pattern> pro2á2</pattern>
+  <pattern> pro2é2</pattern>
+  <pattern> pro2í2</pattern>
+  <pattern> pro2ó2</pattern>
+  <pattern> pro2ú2</pattern>
+  <pattern> pro3abort</pattern>
+  <pattern>proto1h</pattern>
+  <pattern>proto1a2</pattern>
+  <pattern>proto1e2</pattern>
+  <pattern>proto1i2</pattern>
+  <pattern>proto1o2</pattern>
+  <pattern>proto1u2</pattern>
+  <pattern>proto1á2</pattern>
+  <pattern>proto1é2</pattern>
+  <pattern>proto1í2</pattern>
+  <pattern>proto1ó2</pattern>
+  <pattern>proto1ú2</pattern>
+  <pattern>psico1h</pattern>
+  <pattern>psico1a2</pattern>
+  <pattern>psico1e2</pattern>
+  <pattern>psico1i2</pattern>
+  <pattern>psico1o2</pattern>
+  <pattern>psico1u2</pattern>
+  <pattern>psico1á2</pattern>
+  <pattern>psico1é2</pattern>
+  <pattern>psico1í2</pattern>
+  <pattern>psico1ó2</pattern>
+  <pattern>psico1ú2</pattern>
+  <pattern>3p2sic</pattern>
+  <pattern>3p2siq</pattern>
+  <pattern>quete1h</pattern>
+  <pattern>quete1a2</pattern>
+  <pattern>quete1e2</pattern>
+  <pattern>quete1i2</pattern>
+  <pattern>quete1o2</pattern>
+  <pattern>quete1u2</pattern>
+  <pattern>quete1á2</pattern>
+  <pattern>quete1é2</pattern>
+  <pattern>quete1í2</pattern>
+  <pattern>quete1ó2</pattern>
+  <pattern>quete1ú2</pattern>
+  <pattern>radio1h</pattern>
+  <pattern>radio1a2</pattern>
+  <pattern>radio1e2</pattern>
+  <pattern>radio1i2</pattern>
+  <pattern>radio1o2</pattern>
+  <pattern>radio1u2</pattern>
+  <pattern>radio1á2</pattern>
+  <pattern>radio1é2</pattern>
+  <pattern>radio1í2</pattern>
+  <pattern>radio1ó2</pattern>
+  <pattern>radio1ú2</pattern>
+  <pattern>ranco1h</pattern>
+  <pattern>ranco1a2</pattern>
+  <pattern>ranco1e2</pattern>
+  <pattern>ranco1i2</pattern>
+  <pattern>ranco1o2</pattern>
+  <pattern>ranco1u2</pattern>
+  <pattern>ranco1á2</pattern>
+  <pattern>ranco1é2</pattern>
+  <pattern>ranco1í2</pattern>
+  <pattern>ranco1ó2</pattern>
+  <pattern>ranco1ú2</pattern>
+  <pattern> re2a2</pattern>
+  <pattern> re3e4</pattern>
+  <pattern> re2i2</pattern>
+  <pattern> re2o2</pattern>
+  <pattern> re2u2</pattern>
+  <pattern> re2á2</pattern>
+  <pattern> re2é2</pattern>
+  <pattern> re2í2</pattern>
+  <pattern> re2ó2</pattern>
+  <pattern> re2ú2</pattern>
+  <pattern>ea3cio </pattern>
+  <pattern>ea3cios </pattern>
+  <pattern>ea3cia </pattern>
+  <pattern>ea3cias </pattern>
+  <pattern> re3abr</pattern>
+  <pattern> re3ábr</pattern>
+  <pattern> re3afirm</pattern>
+  <pattern> re3afírm</pattern>
+  <pattern> re3ajust</pattern>
+  <pattern> rea3júst</pattern>
+  <pattern> rea3liza</pattern>
+  <pattern> rea3lizá</pattern>
+  <pattern> rea3líza</pattern>
+  <pattern> re3alim</pattern>
+  <pattern> rea3lism</pattern>
+  <pattern> rea3list</pattern>
+  <pattern> re3anim</pattern>
+  <pattern> re3aním</pattern>
+  <pattern> re3aparec</pattern>
+  <pattern> re3ubica</pattern>
+  <pattern> re3ubíca</pattern>
+  <pattern> reu3mati</pattern>
+  <pattern> reu3máti</pattern>
+  <pattern> re3unir</pattern>
+  <pattern> re3unír</pattern>
+  <pattern> re3usar</pattern>
+  <pattern> re3usár</pattern>
+  <pattern> re3utiliz</pattern>
+  <pattern> re3utilíz</pattern>
+  <pattern> re3a2eg</pattern>
+  <pattern> re3a2q</pattern>
+  <pattern> re3a2z</pattern>
+  <pattern> re3a2grup</pattern>
+  <pattern> re3i2m</pattern>
+  <pattern> re3inc</pattern>
+  <pattern> re3ing</pattern>
+  <pattern> re3ins</pattern>
+  <pattern> re3int</pattern>
+  <pattern> re3o2b</pattern>
+  <pattern> re3oc</pattern>
+  <pattern> re3oj</pattern>
+  <pattern> re3orga</pattern>
+  <pattern> re3unt</pattern>
+  <pattern>rmano1h</pattern>
+  <pattern>rmano1a2</pattern>
+  <pattern>rmano1e2</pattern>
+  <pattern>rmano1i2</pattern>
+  <pattern>rmano1o2</pattern>
+  <pattern>rmano1u2</pattern>
+  <pattern>rmano1á2</pattern>
+  <pattern>rmano1é2</pattern>
+  <pattern>rmano1í2</pattern>
+  <pattern>rmano1ó2</pattern>
+  <pattern>rmano1ú2</pattern>
+  <pattern>retro1h</pattern>
+  <pattern>retro1a2</pattern>
+  <pattern>retro1e2</pattern>
+  <pattern>retro1i2</pattern>
+  <pattern>retro1o2</pattern>
+  <pattern>retro1u2</pattern>
+  <pattern>retro1á2</pattern>
+  <pattern>retro1é2</pattern>
+  <pattern>retro1í2</pattern>
+  <pattern>retro1ó2</pattern>
+  <pattern>retro1ú2</pattern>
+  <pattern>romo1h</pattern>
+  <pattern>romo1a2</pattern>
+  <pattern>romo1e2</pattern>
+  <pattern>romo1i2</pattern>
+  <pattern>romo1o2</pattern>
+  <pattern>romo1u2</pattern>
+  <pattern>romo1á2</pattern>
+  <pattern>romo1é2</pattern>
+  <pattern>romo1í2</pattern>
+  <pattern>romo1ó2</pattern>
+  <pattern>romo1ú2</pattern>
+  <pattern>semi1h</pattern>
+  <pattern>semi1a2</pattern>
+  <pattern>semi1e2</pattern>
+  <pattern>semi1i2</pattern>
+  <pattern>semi1o2</pattern>
+  <pattern>semi1u2</pattern>
+  <pattern>semi1á2</pattern>
+  <pattern>semi1é2</pattern>
+  <pattern>semi1í2</pattern>
+  <pattern>semi1ó2</pattern>
+  <pattern>semi1ú2</pattern>
+  <pattern>i2a </pattern>
+  <pattern>i2as </pattern>
+  <pattern>2ótic</pattern>
+  <pattern>emi2o2</pattern>
+  <pattern>2seudo1h</pattern>
+  <pattern>2seudo1a2</pattern>
+  <pattern>2seudo1e2</pattern>
+  <pattern>2seudo1i2</pattern>
+  <pattern>2seudo1o2</pattern>
+  <pattern>2seudo1u2</pattern>
+  <pattern>2seudo1á2</pattern>
+  <pattern>2seudo1é2</pattern>
+  <pattern>2seudo1í2</pattern>
+  <pattern>2seudo1ó2</pattern>
+  <pattern>2seudo1ú2</pattern>
+  <pattern>o2os </pattern>
+  <pattern> so3a4s</pattern>
+  <pattern>sobre1h</pattern>
+  <pattern>sobre1a2</pattern>
+  <pattern>sobre1e2</pattern>
+  <pattern>sobre1i2</pattern>
+  <pattern>sobre1o2</pattern>
+  <pattern>sobre1u2</pattern>
+  <pattern>sobre1á2</pattern>
+  <pattern>sobre1é2</pattern>
+  <pattern>sobre1í2</pattern>
+  <pattern>sobre1ó2</pattern>
+  <pattern>sobre1ú2</pattern>
+  <pattern>socio1h</pattern>
+  <pattern>socio1a2</pattern>
+  <pattern>socio1e2</pattern>
+  <pattern>socio1i2</pattern>
+  <pattern>socio1o2</pattern>
+  <pattern>socio1u2</pattern>
+  <pattern>socio1á2</pattern>
+  <pattern>socio1é2</pattern>
+  <pattern>socio1í2</pattern>
+  <pattern>socio1ó2</pattern>
+  <pattern>socio1ú2</pattern>
+  <pattern>a3rio </pattern>
+  <pattern>a3rios </pattern>
+  <pattern>3logía</pattern>
+  <pattern>4ón </pattern>
+  <pattern>4ones </pattern>
+  <pattern>4i4er </pattern>
+  <pattern>4o2ico </pattern>
+  <pattern>4o2icos </pattern>
+  <pattern>4o2ica </pattern>
+  <pattern>4o2icas </pattern>
+  <pattern> su2b2a2</pattern>
+  <pattern> su2b2e2</pattern>
+  <pattern> su2b2i2</pattern>
+  <pattern> su2b2o2</pattern>
+  <pattern> su2b2u2</pattern>
+  <pattern> su2b2á2</pattern>
+  <pattern> su2b2é2</pattern>
+  <pattern> su2b2í2</pattern>
+  <pattern> su2b2ó2</pattern>
+  <pattern> su2b2ú2</pattern>
+  <pattern> sub2i3ll</pattern>
+  <pattern> sub2i3mien</pattern>
+  <pattern> sub3índ</pattern>
+  <pattern> sub3ími</pattern>
+  <pattern> su4b3ray</pattern>
+  <pattern> sub3aflue</pattern>
+  <pattern> sub3arr</pattern>
+  <pattern> sub3enten</pattern>
+  <pattern> sub3estim</pattern>
+  <pattern> sub3estím</pattern>
+  <pattern> sub3ofici</pattern>
+  <pattern> sub3urba</pattern>
+  <pattern> sub3alter</pattern>
+  <pattern> sub3insp</pattern>
+  <pattern> su3bién</pattern>
+  <pattern> su3bir</pattern>
+  <pattern> su3bam</pattern>
+  <pattern> su3bordin</pattern>
+  <pattern> su3bordín</pattern>
+  <pattern> sub3acuá</pattern>
+  <pattern> sub3espe</pattern>
+  <pattern> sub3esta</pattern>
+  <pattern> su3burbi</pattern>
+  <pattern> su4b5rein</pattern>
+  <pattern> su2d1a2fr</pattern>
+  <pattern> su2d1a2me</pattern>
+  <pattern> su2d1este</pattern>
+  <pattern>su4d3oes</pattern>
+  <pattern> su2r1a2me</pattern>
+  <pattern> su2r1est</pattern>
+  <pattern> su2r1oes</pattern>
+  <pattern>supe2r3r</pattern>
+  <pattern>supe2r1a2</pattern>
+  <pattern>supe2r1e2</pattern>
+  <pattern>supe2r1i2</pattern>
+  <pattern>supe2r1o2</pattern>
+  <pattern>supe2r1u2</pattern>
+  <pattern>supe2r1á2</pattern>
+  <pattern>supe2r1é2</pattern>
+  <pattern>supe2r1í2</pattern>
+  <pattern>supe2r1ó2</pattern>
+  <pattern>supe2r1ú2</pattern>
+  <pattern>ra5ra</pattern>
+  <pattern>ra5rá</pattern>
+  <pattern>ra5re</pattern>
+  <pattern>ra5ré</pattern>
+  <pattern>ra5rí</pattern>
+  <pattern>ra5ro</pattern>
+  <pattern>supe3r4a4r</pattern>
+  <pattern>supe3r4á4r</pattern>
+  <pattern>supe3r4á3vit </pattern>
+  <pattern>supe3r4á3vits </pattern>
+  <pattern>super4ior</pattern>
+  <pattern>4a3ción </pattern>
+  <pattern>4a3ciones </pattern>
+  <pattern>4e3rior </pattern>
+  <pattern>4e3riores </pattern>
+  <pattern>4e3riora </pattern>
+  <pattern>4e3rioras </pattern>
+  <pattern>4e3riormente </pattern>
+  <pattern>4e3rioridad </pattern>
+  <pattern>4e3rioridades </pattern>
+  <pattern>4e3r4a3ble </pattern>
+  <pattern>4e3r4a3bles </pattern>
+  <pattern>4e3r4a3blemente </pattern>
+  <pattern>pe5r4ante</pattern>
+  <pattern>perpon5d6r</pattern>
+  <pattern>supra1h</pattern>
+  <pattern>supra1a2</pattern>
+  <pattern>supra1e2</pattern>
+  <pattern>supra1i2</pattern>
+  <pattern>supra1o2</pattern>
+  <pattern>supra1u2</pattern>
+  <pattern>supra1á2</pattern>
+  <pattern>supra1é2</pattern>
+  <pattern>supra1í2</pattern>
+  <pattern>supra1ó2</pattern>
+  <pattern>supra1ú2</pattern>
+  <pattern>sup6ra</pattern>
+  <pattern>talmo1h</pattern>
+  <pattern>talmo1a2</pattern>
+  <pattern>talmo1e2</pattern>
+  <pattern>talmo1i2</pattern>
+  <pattern>talmo1o2</pattern>
+  <pattern>talmo1u2</pattern>
+  <pattern>talmo1á2</pattern>
+  <pattern>talmo1é2</pattern>
+  <pattern>talmo1í2</pattern>
+  <pattern>talmo1ó2</pattern>
+  <pattern>talmo1ú2</pattern>
+  <pattern>tele1h</pattern>
+  <pattern>tele1a2</pattern>
+  <pattern>tele1e2</pattern>
+  <pattern>tele1i2</pattern>
+  <pattern>tele1o2</pattern>
+  <pattern>tele1u2</pattern>
+  <pattern>tele1á2</pattern>
+  <pattern>tele1é2</pattern>
+  <pattern>tele1í2</pattern>
+  <pattern>tele1ó2</pattern>
+  <pattern>tele1ú2</pattern>
+  <pattern>4ósteo </pattern>
+  <pattern>4ósteos </pattern>
+  <pattern> tele1imp</pattern>
+  <pattern> tele1obj</pattern>
+  <pattern> tele4o3lót</pattern>
+  <pattern>termo1h</pattern>
+  <pattern>termo1a2</pattern>
+  <pattern>termo1e2</pattern>
+  <pattern>termo1i2</pattern>
+  <pattern>termo1o2</pattern>
+  <pattern>termo1u2</pattern>
+  <pattern>termo1á2</pattern>
+  <pattern>termo1é2</pattern>
+  <pattern>termo1í2</pattern>
+  <pattern>termo1ó2</pattern>
+  <pattern>termo1ú2</pattern>
+  <pattern>tetra1h</pattern>
+  <pattern>tetra1a2</pattern>
+  <pattern>tetra1e2</pattern>
+  <pattern>tetra1i2</pattern>
+  <pattern>tetra1o2</pattern>
+  <pattern>tetra1u2</pattern>
+  <pattern>tetra1á2</pattern>
+  <pattern>tetra1é2</pattern>
+  <pattern>tetra1í2</pattern>
+  <pattern>tetra1ó2</pattern>
+  <pattern>tetra1ú2</pattern>
+  <pattern>topo1h</pattern>
+  <pattern>topo1a2</pattern>
+  <pattern>topo1e2</pattern>
+  <pattern>topo1i2</pattern>
+  <pattern>topo1o2</pattern>
+  <pattern>topo1u2</pattern>
+  <pattern>topo1á2</pattern>
+  <pattern>topo1é2</pattern>
+  <pattern>topo1í2</pattern>
+  <pattern>topo1ó2</pattern>
+  <pattern>topo1ú2</pattern>
+  <pattern> tra2sa2</pattern>
+  <pattern> tra2se2</pattern>
+  <pattern> tra2si2</pattern>
+  <pattern> tra2so2</pattern>
+  <pattern> tra2su2</pattern>
+  <pattern> tra2sá2</pattern>
+  <pattern> tra2sé2</pattern>
+  <pattern> tra2sí2</pattern>
+  <pattern> tra2só2</pattern>
+  <pattern> tra2sú2</pattern>
+  <pattern> tra3s2o3ñ</pattern>
+  <pattern>tran2sa2</pattern>
+  <pattern>tran2se2</pattern>
+  <pattern>tran2si2</pattern>
+  <pattern>tran2so2</pattern>
+  <pattern>tran2su2</pattern>
+  <pattern>tran2sá2</pattern>
+  <pattern>tran2sé2</pattern>
+  <pattern>tran2sí2</pattern>
+  <pattern>tran2só2</pattern>
+  <pattern>tran2sú2</pattern>
+  <pattern>tran2s1alp</pattern>
+  <pattern>tran2s1and</pattern>
+  <pattern>tran2s1atl</pattern>
+  <pattern>tran2s1oce</pattern>
+  <pattern>tran2s1ur</pattern>
+  <pattern>tran3sacci</pattern>
+  <pattern>tran3seún</pattern>
+  <pattern>tran3se3xu</pattern>
+  <pattern>tran3si3cion</pattern>
+  <pattern>tran3si3ción</pattern>
+  <pattern>tran3si3gi</pattern>
+  <pattern>tran3si3gí</pattern>
+  <pattern>tran3si3ge</pattern>
+  <pattern>tran3si3ja</pattern>
+  <pattern>tran3si3já</pattern>
+  <pattern>tran3si3jo</pattern>
+  <pattern>tran3sisto</pattern>
+  <pattern>tran3si3ta</pattern>
+  <pattern>tran3si3tá</pattern>
+  <pattern>tran3si3te</pattern>
+  <pattern>tran3si3té</pattern>
+  <pattern>tran3si3to</pattern>
+  <pattern>tran3si3tó</pattern>
+  <pattern>tran3si3tiv</pattern>
+  <pattern>tran3si3tori</pattern>
+  <pattern>tran3subst</pattern>
+  <pattern>tran3sust</pattern>
+  <pattern> tri1ó2x</pattern>
+  <pattern>tropo1h</pattern>
+  <pattern>tropo1a2</pattern>
+  <pattern>tropo1e2</pattern>
+  <pattern>tropo1i2</pattern>
+  <pattern>tropo1o2</pattern>
+  <pattern>tropo1u2</pattern>
+  <pattern>tropo1á2</pattern>
+  <pattern>tropo1é2</pattern>
+  <pattern>tropo1í2</pattern>
+  <pattern>tropo1ó2</pattern>
+  <pattern>tropo1ú2</pattern>
+  <pattern>ultra1h</pattern>
+  <pattern>ultra1a2</pattern>
+  <pattern>ultra1e2</pattern>
+  <pattern>ultra1i2</pattern>
+  <pattern>ultra1o2</pattern>
+  <pattern>ultra1u2</pattern>
+  <pattern>ultra1á2</pattern>
+  <pattern>ultra1é2</pattern>
+  <pattern>ultra1í2</pattern>
+  <pattern>ultra1ó2</pattern>
+  <pattern>ultra1ú2</pattern>
+  <pattern>vice1h</pattern>
+  <pattern>vice1a2</pattern>
+  <pattern>vice1e2</pattern>
+  <pattern>vice1i2</pattern>
+  <pattern>vice1o2</pattern>
+  <pattern>vice1u2</pattern>
+  <pattern>vice1á2</pattern>
+  <pattern>vice1é2</pattern>
+  <pattern>vice1í2</pattern>
+  <pattern>vice1ó2</pattern>
+  <pattern>vice1ú2</pattern>
+  <pattern>video1h</pattern>
+  <pattern>video1a2</pattern>
+  <pattern>video1e2</pattern>
+  <pattern>video1i2</pattern>
+  <pattern>video1o2</pattern>
+  <pattern>video1u2</pattern>
+  <pattern>video1á2</pattern>
+  <pattern>video1é2</pattern>
+  <pattern>video1í2</pattern>
+  <pattern>video1ó2</pattern>
+  <pattern>video1ú2</pattern>
+  <pattern>xeno1h</pattern>
+  <pattern>xeno1a2</pattern>
+  <pattern>xeno1e2</pattern>
+  <pattern>xeno1i2</pattern>
+  <pattern>xeno1o2</pattern>
+  <pattern>xeno1u2</pattern>
+  <pattern>xeno1á2</pattern>
+  <pattern>xeno1é2</pattern>
+  <pattern>xeno1í2</pattern>
+  <pattern>xeno1ó2</pattern>
+  <pattern>xeno1ú2</pattern>
+  <pattern>zoo1h</pattern>
+  <pattern>zoo1a2</pattern>
+  <pattern>zoo1e2</pattern>
+  <pattern>zoo1i2</pattern>
+  <pattern>zoo1o2</pattern>
+  <pattern>zoo1u2</pattern>
+  <pattern>zoo1á2</pattern>
+  <pattern>zoo1é2</pattern>
+  <pattern>zoo1í2</pattern>
+  <pattern>zoo1ó2</pattern>
+  <pattern>zoo1ú2</pattern>
+  <pattern>wa3s4h</pattern>
+  <pattern>3hablante</pattern>
+  <pattern>3habiente</pattern>
+  <pattern>3aficionad</pattern>
+</HyphenationDescription> 

--- a/cr3gui/data/hyph/Spanish.pattern
+++ b/cr3gui/data/hyph/Spanish.pattern
@@ -32,7 +32,7 @@
 -->
 <HyphenationDescription>
 <pattern>1b</pattern>
-<pattern>4b.</pattern>
+<pattern>4b </pattern>
 <pattern>2bb</pattern>
 <pattern>2bc</pattern>
 <pattern>2bd</pattern>
@@ -53,7 +53,7 @@
 <pattern>2by</pattern>
 <pattern>2bz</pattern>
 <pattern>1c</pattern>
-<pattern>4c.</pattern>
+<pattern>4c </pattern>
 <pattern>2cb</pattern>
 <pattern>2cc</pattern>
 <pattern>2cd</pattern>
@@ -73,7 +73,7 @@
 <pattern>2cy</pattern>
 <pattern>2cz</pattern>
 <pattern>1d</pattern>
-<pattern>4d.</pattern>
+<pattern>4d </pattern>
 <pattern>2db</pattern>
 <pattern>2dc</pattern>
 <pattern>2dd</pattern>
@@ -95,7 +95,7 @@
 <pattern>2dy</pattern>
 <pattern>2dz</pattern>
 <pattern>1f</pattern>
-<pattern>4f.</pattern>
+<pattern>4f </pattern>
 <pattern>2fb</pattern>
 <pattern>2fc</pattern>
 <pattern>2fd</pattern>
@@ -116,7 +116,7 @@
 <pattern>2fy</pattern>
 <pattern>2fz</pattern>
 <pattern>1g</pattern>
-<pattern>4g.</pattern>
+<pattern>4g </pattern>
 <pattern>2gb</pattern>
 <pattern>2gc</pattern>
 <pattern>2gd</pattern>
@@ -136,7 +136,7 @@
 <pattern>2gx</pattern>
 <pattern>2gy</pattern>
 <pattern>2gz</pattern>
-<pattern>4h.</pattern>
+<pattern>4h </pattern>
 <pattern>2hb</pattern>
 <pattern>2hc</pattern>
 <pattern>2hd</pattern>
@@ -159,7 +159,7 @@
 <pattern>2hy</pattern>
 <pattern>2hz</pattern>
 <pattern>1j</pattern>
-<pattern>4j.</pattern>
+<pattern>4j </pattern>
 <pattern>2jb</pattern>
 <pattern>2jc</pattern>
 <pattern>2jd</pattern>
@@ -182,7 +182,7 @@
 <pattern>2jy</pattern>
 <pattern>2jz</pattern>
 <pattern>1k</pattern>
-<pattern>4k.</pattern>
+<pattern>4k </pattern>
 <pattern>2kb</pattern>
 <pattern>2kc</pattern>
 <pattern>2kd</pattern>
@@ -203,7 +203,7 @@
 <pattern>2ky</pattern>
 <pattern>2kz</pattern>
 <pattern>1l</pattern>
-<pattern>4l.</pattern>
+<pattern>4l </pattern>
 <pattern>2lb</pattern>
 <pattern>2lc</pattern>
 <pattern>2ld</pattern>
@@ -225,7 +225,7 @@
 <pattern>2ly</pattern>
 <pattern>2lz</pattern>
 <pattern>1m</pattern>
-<pattern>4m.</pattern>
+<pattern>4m </pattern>
 <pattern>2mb</pattern>
 <pattern>2mc</pattern>
 <pattern>2md</pattern>
@@ -248,7 +248,7 @@
 <pattern>2my</pattern>
 <pattern>2mz</pattern>
 <pattern>1n</pattern>
-<pattern>4n.</pattern>
+<pattern>4n </pattern>
 <pattern>2nb</pattern>
 <pattern>2nc</pattern>
 <pattern>2nd</pattern>
@@ -271,7 +271,7 @@
 <pattern>2ny</pattern>
 <pattern>2nz</pattern>
 <pattern>1p</pattern>
-<pattern>4p.</pattern>
+<pattern>4p </pattern>
 <pattern>2pb</pattern>
 <pattern>2pc</pattern>
 <pattern>2pd</pattern>
@@ -292,7 +292,7 @@
 <pattern>2py</pattern>
 <pattern>2pz</pattern>
 <pattern>1q</pattern>
-<pattern>4q.</pattern>
+<pattern>4q </pattern>
 <pattern>2qb</pattern>
 <pattern>2qc</pattern>
 <pattern>2qd</pattern>
@@ -315,7 +315,7 @@
 <pattern>2qy</pattern>
 <pattern>2qz</pattern>
 <pattern>1r</pattern>
-<pattern>4r.</pattern>
+<pattern>4r </pattern>
 <pattern>2rb</pattern>
 <pattern>2rc</pattern>
 <pattern>2rd</pattern>
@@ -337,7 +337,7 @@
 <pattern>2ry</pattern>
 <pattern>2rz</pattern>
 <pattern>1s</pattern>
-<pattern>4s.</pattern>
+<pattern>4s </pattern>
 <pattern>2sb</pattern>
 <pattern>2sc</pattern>
 <pattern>2sd</pattern>
@@ -360,7 +360,7 @@
 <pattern>2sy</pattern>
 <pattern>2sz</pattern>
 <pattern>1t</pattern>
-<pattern>4t.</pattern>
+<pattern>4t </pattern>
 <pattern>2tb</pattern>
 <pattern>2tc</pattern>
 <pattern>2td</pattern>
@@ -381,7 +381,7 @@
 <pattern>2ty</pattern>
 <pattern>2tz</pattern>
 <pattern>1v</pattern>
-<pattern>4v.</pattern>
+<pattern>4v </pattern>
 <pattern>2vb</pattern>
 <pattern>2vc</pattern>
 <pattern>2vd</pattern>
@@ -402,7 +402,7 @@
 <pattern>2vy</pattern>
 <pattern>2vz</pattern>
 <pattern>1w</pattern>
-<pattern>4w.</pattern>
+<pattern>4w </pattern>
 <pattern>2wb</pattern>
 <pattern>2wc</pattern>
 <pattern>2wd</pattern>
@@ -425,7 +425,7 @@
 <pattern>2wy</pattern>
 <pattern>2wz</pattern>
 <pattern>1x</pattern>
-<pattern>4x.</pattern>
+<pattern>4x </pattern>
 <pattern>2xb</pattern>
 <pattern>2xc</pattern>
 <pattern>2xd</pattern>
@@ -448,7 +448,7 @@
 <pattern>2xy</pattern>
 <pattern>2xz</pattern>
 <pattern>1y</pattern>
-<pattern>4y.</pattern>
+<pattern>4y </pattern>
 <pattern>2yb</pattern>
 <pattern>2yc</pattern>
 <pattern>2yd</pattern>
@@ -471,7 +471,7 @@
 <pattern>2yy</pattern>
 <pattern>2yz</pattern>
 <pattern>1z</pattern>
-<pattern>4z.</pattern>
+<pattern>4z </pattern>
 <pattern>2zb</pattern>
 <pattern>2zc</pattern>
 <pattern>2zd</pattern>
@@ -494,9 +494,9 @@
 <pattern>2zy</pattern>
 <pattern>2zz</pattern>
 <pattern>1ñ</pattern>
-<pattern>4ñ.</pattern>
+<pattern>4ñ </pattern>
 <pattern>c4h</pattern>
-<pattern>4ch.</pattern>
+<pattern>4ch </pattern>
 <pattern>2chb</pattern>
 <pattern>2chc</pattern>
 <pattern>2chd</pattern>
@@ -519,7 +519,7 @@
 <pattern>2chy</pattern>
 <pattern>2chz</pattern>
 <pattern>l4l</pattern>
-<pattern>4ll.</pattern>
+<pattern>4ll </pattern>
 <pattern>2llb</pattern>
 <pattern>2llc</pattern>
 <pattern>2lld</pattern>
@@ -542,7 +542,7 @@
 <pattern>2lly</pattern>
 <pattern>2llz</pattern>
 <pattern>b2l</pattern>
-<pattern>4bl.</pattern>
+<pattern>4bl </pattern>
 <pattern>2bl2b</pattern>
 <pattern>2bl2c</pattern>
 <pattern>2bl2d</pattern>
@@ -565,7 +565,7 @@
 <pattern>2bl2y</pattern>
 <pattern>2bl2z</pattern>
 <pattern>c2l</pattern>
-<pattern>4cl.</pattern>
+<pattern>4cl </pattern>
 <pattern>2cl2b</pattern>
 <pattern>2cl2c</pattern>
 <pattern>2cl2d</pattern>
@@ -588,7 +588,7 @@
 <pattern>2cl2y</pattern>
 <pattern>2cl2z</pattern>
 <pattern>f2l</pattern>
-<pattern>4fl.</pattern>
+<pattern>4fl </pattern>
 <pattern>2fl2b</pattern>
 <pattern>2fl2c</pattern>
 <pattern>2fl2d</pattern>
@@ -611,7 +611,7 @@
 <pattern>2fl2y</pattern>
 <pattern>2fl2z</pattern>
 <pattern>g2l</pattern>
-<pattern>4gl.</pattern>
+<pattern>4gl </pattern>
 <pattern>2gl2b</pattern>
 <pattern>2gl2c</pattern>
 <pattern>2gl2d</pattern>
@@ -634,7 +634,7 @@
 <pattern>2gl2y</pattern>
 <pattern>2gl2z</pattern>
 <pattern>k2l</pattern>
-<pattern>4kl.</pattern>
+<pattern>4kl </pattern>
 <pattern>2kl2b</pattern>
 <pattern>2kl2c</pattern>
 <pattern>2kl2d</pattern>
@@ -657,7 +657,7 @@
 <pattern>2kl2y</pattern>
 <pattern>2kl2z</pattern>
 <pattern>p2l</pattern>
-<pattern>4pl.</pattern>
+<pattern>4pl </pattern>
 <pattern>2pl2b</pattern>
 <pattern>2pl2c</pattern>
 <pattern>2pl2d</pattern>
@@ -680,7 +680,7 @@
 <pattern>2pl2y</pattern>
 <pattern>2pl2z</pattern>
 <pattern>v2l</pattern>
-<pattern>4vl.</pattern>
+<pattern>4vl </pattern>
 <pattern>2vl2b</pattern>
 <pattern>2vl2c</pattern>
 <pattern>2vl2d</pattern>
@@ -703,7 +703,7 @@
 <pattern>2vl2y</pattern>
 <pattern>2vl2z</pattern>
 <pattern>b2r</pattern>
-<pattern>4br.</pattern>
+<pattern>4br </pattern>
 <pattern>2br2b</pattern>
 <pattern>2br2c</pattern>
 <pattern>2br2d</pattern>
@@ -726,7 +726,7 @@
 <pattern>2br2y</pattern>
 <pattern>2br2z</pattern>
 <pattern>c2r</pattern>
-<pattern>4cr.</pattern>
+<pattern>4cr </pattern>
 <pattern>2cr2b</pattern>
 <pattern>2cr2c</pattern>
 <pattern>2cr2d</pattern>
@@ -749,7 +749,7 @@
 <pattern>2cr2y</pattern>
 <pattern>2cr2z</pattern>
 <pattern>d2r</pattern>
-<pattern>4dr.</pattern>
+<pattern>4dr </pattern>
 <pattern>2dr2b</pattern>
 <pattern>2dr2c</pattern>
 <pattern>2dr2d</pattern>
@@ -772,7 +772,7 @@
 <pattern>2dr2y</pattern>
 <pattern>2dr2z</pattern>
 <pattern>f2r</pattern>
-<pattern>4fr.</pattern>
+<pattern>4fr </pattern>
 <pattern>2fr2b</pattern>
 <pattern>2fr2c</pattern>
 <pattern>2fr2d</pattern>
@@ -795,7 +795,7 @@
 <pattern>2fr2y</pattern>
 <pattern>2fr2z</pattern>
 <pattern>g2r</pattern>
-<pattern>4gr.</pattern>
+<pattern>4gr </pattern>
 <pattern>2gr2b</pattern>
 <pattern>2gr2c</pattern>
 <pattern>2gr2d</pattern>
@@ -818,7 +818,7 @@
 <pattern>2gr2y</pattern>
 <pattern>2gr2z</pattern>
 <pattern>k2r</pattern>
-<pattern>4kr.</pattern>
+<pattern>4kr </pattern>
 <pattern>2kr2b</pattern>
 <pattern>2kr2c</pattern>
 <pattern>2kr2d</pattern>
@@ -841,7 +841,7 @@
 <pattern>2kr2y</pattern>
 <pattern>2kr2z</pattern>
 <pattern>p2r</pattern>
-<pattern>4pr.</pattern>
+<pattern>4pr </pattern>
 <pattern>2pr2b</pattern>
 <pattern>2pr2c</pattern>
 <pattern>2pr2d</pattern>
@@ -864,7 +864,7 @@
 <pattern>2pr2y</pattern>
 <pattern>2pr2z</pattern>
 <pattern>r2r</pattern>
-<pattern>4rr.</pattern>
+<pattern>4rr </pattern>
 <pattern>2rr2b</pattern>
 <pattern>2rr2c</pattern>
 <pattern>2rr2d</pattern>
@@ -887,7 +887,7 @@
 <pattern>2rr2y</pattern>
 <pattern>2rr2z</pattern>
 <pattern>t2r</pattern>
-<pattern>4tr.</pattern>
+<pattern>4tr </pattern>
 <pattern>2tr2b</pattern>
 <pattern>2tr2c</pattern>
 <pattern>2tr2d</pattern>
@@ -910,7 +910,7 @@
 <pattern>2tr2y</pattern>
 <pattern>2tr2z</pattern>
 <pattern>v2r</pattern>
-<pattern>4vr.</pattern>
+<pattern>4vr </pattern>
 <pattern>2vr2b</pattern>
 <pattern>2vr2c</pattern>
 <pattern>2vr2d</pattern>
@@ -943,7 +943,7 @@
 <pattern>2t3p2t</pattern>
 <pattern>2x3p2t</pattern>
 <pattern>2y3p2t</pattern>
-<pattern>4pt.</pattern>
+<pattern>4pt </pattern>
 <pattern>2b3c2t</pattern>
 <pattern>2c3c2t</pattern>
 <pattern>2d3c2t</pattern>
@@ -955,7 +955,7 @@
 <pattern>2t3c2t</pattern>
 <pattern>2x3c2t</pattern>
 <pattern>2y3c2t</pattern>
-<pattern>4ct.</pattern>
+<pattern>4ct </pattern>
 <pattern>2b3c2n</pattern>
 <pattern>2c3c2n</pattern>
 <pattern>2d3c2n</pattern>
@@ -967,7 +967,7 @@
 <pattern>2t3c2n</pattern>
 <pattern>2x3c2n</pattern>
 <pattern>2y3c2n</pattern>
-<pattern>4cn.</pattern>
+<pattern>4cn </pattern>
 <pattern>2b3p2s</pattern>
 <pattern>2c3p2s</pattern>
 <pattern>2d3p2s</pattern>
@@ -979,7 +979,7 @@
 <pattern>2t3p2s</pattern>
 <pattern>2x3p2s</pattern>
 <pattern>2y3p2s</pattern>
-<pattern>4ps.</pattern>
+<pattern>4ps </pattern>
 <pattern>2b3m2n</pattern>
 <pattern>2c3m2n</pattern>
 <pattern>2d3m2n</pattern>
@@ -991,7 +991,7 @@
 <pattern>2t3m2n</pattern>
 <pattern>2x3m2n</pattern>
 <pattern>2y3m2n</pattern>
-<pattern>4mn.</pattern>
+<pattern>4mn </pattern>
 <pattern>2b3g2n</pattern>
 <pattern>2c3g2n</pattern>
 <pattern>2d3g2n</pattern>
@@ -1003,7 +1003,7 @@
 <pattern>2t3g2n</pattern>
 <pattern>2x3g2n</pattern>
 <pattern>2y3g2n</pattern>
-<pattern>4gn.</pattern>
+<pattern>4gn </pattern>
 <pattern>2b3f2t</pattern>
 <pattern>2c3f2t</pattern>
 <pattern>2d3f2t</pattern>
@@ -1015,7 +1015,7 @@
 <pattern>2t3f2t</pattern>
 <pattern>2x3f2t</pattern>
 <pattern>2y3f2t</pattern>
-<pattern>4ft.</pattern>
+<pattern>4ft </pattern>
 <pattern>2b3p2n</pattern>
 <pattern>2c3p2n</pattern>
 <pattern>2d3p2n</pattern>
@@ -1027,7 +1027,7 @@
 <pattern>2t3p2n</pattern>
 <pattern>2x3p2n</pattern>
 <pattern>2y3p2n</pattern>
-<pattern>4pn.</pattern>
+<pattern>4pn </pattern>
 <pattern>2b3c2z</pattern>
 <pattern>2c3c2z</pattern>
 <pattern>2d3c2z</pattern>
@@ -1039,7 +1039,7 @@
 <pattern>2t3c2z</pattern>
 <pattern>2x3c2z</pattern>
 <pattern>2y3c2z</pattern>
-<pattern>4cz.</pattern>
+<pattern>4cz </pattern>
 <pattern>2b3t2z</pattern>
 <pattern>2c3t2z</pattern>
 <pattern>2d3t2z</pattern>
@@ -1051,7 +1051,7 @@
 <pattern>2t3t2z</pattern>
 <pattern>2x3t2z</pattern>
 <pattern>2y3t2z</pattern>
-<pattern>4tz.</pattern>
+<pattern>4tz </pattern>
 <pattern>2b3t2s</pattern>
 <pattern>2c3t2s</pattern>
 <pattern>2d3t2s</pattern>
@@ -1063,415 +1063,415 @@
 <pattern>2t3t2s</pattern>
 <pattern>2x3t2s</pattern>
 <pattern>2y3t2s</pattern>
-<pattern>4ts.</pattern>
+<pattern>4ts </pattern>
 <pattern>san4c5t</pattern>
 <pattern>plan4c5t</pattern>
-<pattern>2no.</pattern>
+<pattern>2no </pattern>
 <pattern>2t2l</pattern>
 <pattern>4caca4</pattern>
 <pattern>4cago4</pattern>
 <pattern>4caga4</pattern>
-<pattern>4cagas.</pattern>
-<pattern>4teta.</pattern>
-<pattern>4tetas.</pattern>
+<pattern>4cagas </pattern>
+<pattern>4teta </pattern>
+<pattern>4tetas </pattern>
 <pattern>4puta4</pattern>
 <pattern>4puto4</pattern>
-<pattern>.hu4mea</pattern>
-<pattern>.hu4meo</pattern>
-<pattern>.he4mee</pattern>
-<pattern>4meo.</pattern>
-<pattern>4meable.</pattern>
-<pattern>4meables.</pattern>
+<pattern> hu4mea</pattern>
+<pattern> hu4meo</pattern>
+<pattern> he4mee</pattern>
+<pattern>4meo </pattern>
+<pattern>4meable </pattern>
+<pattern>4meables </pattern>
 <pattern>4pedo4</pattern>
 <pattern>4culo4</pattern>
-<pattern>3mente.</pattern>
-<pattern>4i3go.</pattern>
-<pattern>4es.</pattern>
+<pattern>3mente </pattern>
+<pattern>4i3go </pattern>
+<pattern>4es </pattern>
 <pattern>4és</pattern>
-<pattern>4e.</pattern>
-<pattern>4e3mos.</pattern>
-<pattern>4éis.</pattern>
-<pattern>4en.</pattern>
-<pattern>4ía.</pattern>
-<pattern>4ías.</pattern>
-<pattern>4ía3mos.</pattern>
-<pattern>4íais.</pattern>
-<pattern>4ían.</pattern>
-<pattern>4í.</pattern>
-<pattern>4í4s3te.</pattern>
-<pattern>4í4s3tes.</pattern>
-<pattern>4í3tes.</pattern>
-<pattern>4í3mos.</pattern>
-<pattern>4ís3teis.</pattern>
-<pattern>4e3ré.</pattern>
-<pattern>4e3rás.</pattern>
-<pattern>4e3rés.</pattern>
-<pattern>4e3rís.</pattern>
-<pattern>4e3rá.</pattern>
-<pattern>4e3re3mos.</pattern>
-<pattern>4e3réis.</pattern>
-<pattern>4e3rán.</pattern>
-<pattern>4i3ga.</pattern>
-<pattern>4i3gas.</pattern>
-<pattern>4i3gás.</pattern>
-<pattern>4i3gamos.</pattern>
-<pattern>4i3gáis.</pattern>
-<pattern>4a4i3gan.</pattern>
-<pattern>4e3ría.</pattern>
-<pattern>4e3rías.</pattern>
-<pattern>4e3ríamos.</pattern>
-<pattern>4e3ríais.</pattern>
-<pattern>4e3rían.</pattern>
-<pattern>4i3gá3mosme.</pattern>
-<pattern>4i3gá3mosmele.</pattern>
-<pattern>4i3gá3mosmelo.</pattern>
-<pattern>4i3gá3mos3mela.</pattern>
-<pattern>4i3gá3mosmeles.</pattern>
-<pattern>4i3gá3mosmelos.</pattern>
-<pattern>4i3gá3mos3melas.</pattern>
-<pattern>4i3gá3moste.</pattern>
-<pattern>4i3gá3mostele.</pattern>
-<pattern>4i3gá3mostelo.</pattern>
-<pattern>4i3gá3mos3tela.</pattern>
-<pattern>4i3gá3mosteles.</pattern>
-<pattern>4i3gá3mostelos.</pattern>
-<pattern>4i3gá3mos3telas.</pattern>
-<pattern>4i3gá3mosle.</pattern>
-<pattern>4i3gá3mosla.</pattern>
-<pattern>4i3gá3moslo.</pattern>
-<pattern>4i3gá3mosele.</pattern>
-<pattern>4i3gá3moselo.</pattern>
-<pattern>4i3gá3mosela.</pattern>
-<pattern>4i3gá3moseles.</pattern>
-<pattern>4i3gá3moselos.</pattern>
-<pattern>4i3gá3moselas.</pattern>
-<pattern>4i3gá3monos.</pattern>
-<pattern>4i3gá3monosle.</pattern>
-<pattern>4i3gá3monoslo.</pattern>
-<pattern>4i3gá3monosla.</pattern>
-<pattern>4i3gá3monosles.</pattern>
-<pattern>4i3gá3monoslos.</pattern>
-<pattern>4i3gá3monoslas.</pattern>
-<pattern>4i3gá3moos.</pattern>
-<pattern>4i3gá3moosle.</pattern>
-<pattern>4i3gá3mooslo.</pattern>
-<pattern>4i3gá3moosla.</pattern>
-<pattern>4i3gá3moosles.</pattern>
-<pattern>4i3gá3mooslos.</pattern>
-<pattern>4i3gá3mooslas.</pattern>
-<pattern>4i3gá3mosles.</pattern>
-<pattern>4i3gá3moslas.</pattern>
-<pattern>4i3gá3moslos.</pattern>
-<pattern>4ed.</pattern>
-<pattern>4é.</pattern>
-<pattern>4edme.</pattern>
-<pattern>4édmele.</pattern>
-<pattern>4édmelo.</pattern>
-<pattern>4éd3mela.</pattern>
-<pattern>4édmeles.</pattern>
-<pattern>4édmelos.</pattern>
-<pattern>4éd3melas.</pattern>
-<pattern>4edte.</pattern>
-<pattern>4édtele.</pattern>
-<pattern>4édtelo.</pattern>
-<pattern>4éd3tela.</pattern>
-<pattern>4édteles.</pattern>
-<pattern>4édtelos.</pattern>
-<pattern>4éd3telas.</pattern>
-<pattern>4edle.</pattern>
-<pattern>4eedla.</pattern>
-<pattern>4edlo.</pattern>
-<pattern>4édsele.</pattern>
-<pattern>4édselo.</pattern>
-<pattern>4édsela.</pattern>
-<pattern>4édseles.</pattern>
-<pattern>4édselos.</pattern>
-<pattern>4édselas.</pattern>
-<pattern>4ednos.</pattern>
-<pattern>4édnosle.</pattern>
-<pattern>4édnoslo.</pattern>
-<pattern>4édnosla.</pattern>
-<pattern>4édnosles.</pattern>
-<pattern>4édnoslos.</pattern>
-<pattern>4édnoslas.</pattern>
-<pattern>4eos.</pattern>
-<pattern>4éosle.</pattern>
-<pattern>4éoslo.</pattern>
-<pattern>4éosla.</pattern>
-<pattern>4éosles.</pattern>
-<pattern>4éoslos.</pattern>
-<pattern>4éoslas.</pattern>
-<pattern>4edles.</pattern>
-<pattern>4edlas.</pattern>
-<pattern>4edlos.</pattern>
-<pattern>4er.</pattern>
-<pattern>4erme.</pattern>
-<pattern>4érmele.</pattern>
-<pattern>4érmelo.</pattern>
-<pattern>4ér3mela.</pattern>
-<pattern>4érmeles.</pattern>
-<pattern>4érmelos.</pattern>
-<pattern>4ér3melas.</pattern>
-<pattern>4erte.</pattern>
-<pattern>4értele.</pattern>
-<pattern>4értelo.</pattern>
-<pattern>4ér3tela.</pattern>
-<pattern>4érteles.</pattern>
-<pattern>4értelos.</pattern>
-<pattern>4ér3telas.</pattern>
-<pattern>4erle.</pattern>
-<pattern>4erla.</pattern>
-<pattern>4erlo.</pattern>
-<pattern>4erse.</pattern>
-<pattern>4érsele.</pattern>
-<pattern>4érselo.</pattern>
-<pattern>4érsela.</pattern>
-<pattern>4érseles.</pattern>
-<pattern>4érselos.</pattern>
-<pattern>4érselas.</pattern>
-<pattern>4ernos.</pattern>
-<pattern>4érnosle.</pattern>
-<pattern>4érnoslo.</pattern>
-<pattern>4érnosla.</pattern>
-<pattern>4érnosles.</pattern>
-<pattern>4érnoslos.</pattern>
-<pattern>4érnoslas.</pattern>
-<pattern>4e3ros.</pattern>
-<pattern>4é3rosle.</pattern>
-<pattern>4é3roslo.</pattern>
-<pattern>4é3rosla.</pattern>
-<pattern>4é3rosles.</pattern>
-<pattern>4é3roslos.</pattern>
-<pattern>4é3roslas.</pattern>
-<pattern>4erles.</pattern>
-<pattern>4erlas.</pattern>
-<pattern>4erlos.</pattern>
-<pattern>4í3do.</pattern>
-<pattern>4í3da.</pattern>
-<pattern>4í3dos.</pattern>
-<pattern>4í3das.</pattern>
-<pattern>4o.</pattern>
-<pattern>4as.</pattern>
-<pattern>4a.</pattern>
-<pattern>4ás.</pattern>
-<pattern>4a3mos.</pattern>
-<pattern>4áis.</pattern>
-<pattern>4an.</pattern>
-<pattern>4aste.</pattern>
-<pattern>4astes.</pattern>
-<pattern>4ó.</pattern>
-<pattern>4ates.</pattern>
-<pattern>4asteis.</pattern>
-<pattern>4a3ron.</pattern>
-<pattern>4a3ba.</pattern>
-<pattern>4a3bas.</pattern>
-<pattern>4á3bamos.</pattern>
-<pattern>4a3bais.</pattern>
-<pattern>4a3ban.</pattern>
-<pattern>4a3ría.</pattern>
-<pattern>4a3rías.</pattern>
-<pattern>4a3ríamos.</pattern>
+<pattern>4e </pattern>
+<pattern>4e3mos </pattern>
+<pattern>4éis </pattern>
+<pattern>4en </pattern>
+<pattern>4ía </pattern>
+<pattern>4ías </pattern>
+<pattern>4ía3mos </pattern>
+<pattern>4íais </pattern>
+<pattern>4ían </pattern>
+<pattern>4í </pattern>
+<pattern>4í4s3te </pattern>
+<pattern>4í4s3tes </pattern>
+<pattern>4í3tes </pattern>
+<pattern>4í3mos </pattern>
+<pattern>4ís3teis </pattern>
+<pattern>4e3ré </pattern>
+<pattern>4e3rás </pattern>
+<pattern>4e3rés </pattern>
+<pattern>4e3rís </pattern>
+<pattern>4e3rá </pattern>
+<pattern>4e3re3mos </pattern>
+<pattern>4e3réis </pattern>
+<pattern>4e3rán </pattern>
+<pattern>4i3ga </pattern>
+<pattern>4i3gas </pattern>
+<pattern>4i3gás </pattern>
+<pattern>4i3gamos </pattern>
+<pattern>4i3gáis </pattern>
+<pattern>4a4i3gan </pattern>
+<pattern>4e3ría </pattern>
+<pattern>4e3rías </pattern>
+<pattern>4e3ríamos </pattern>
+<pattern>4e3ríais </pattern>
+<pattern>4e3rían </pattern>
+<pattern>4i3gá3mosme </pattern>
+<pattern>4i3gá3mosmele </pattern>
+<pattern>4i3gá3mosmelo </pattern>
+<pattern>4i3gá3mos3mela </pattern>
+<pattern>4i3gá3mosmeles </pattern>
+<pattern>4i3gá3mosmelos </pattern>
+<pattern>4i3gá3mos3melas </pattern>
+<pattern>4i3gá3moste </pattern>
+<pattern>4i3gá3mostele </pattern>
+<pattern>4i3gá3mostelo </pattern>
+<pattern>4i3gá3mos3tela </pattern>
+<pattern>4i3gá3mosteles </pattern>
+<pattern>4i3gá3mostelos </pattern>
+<pattern>4i3gá3mos3telas </pattern>
+<pattern>4i3gá3mosle </pattern>
+<pattern>4i3gá3mosla </pattern>
+<pattern>4i3gá3moslo </pattern>
+<pattern>4i3gá3mosele </pattern>
+<pattern>4i3gá3moselo </pattern>
+<pattern>4i3gá3mosela </pattern>
+<pattern>4i3gá3moseles </pattern>
+<pattern>4i3gá3moselos </pattern>
+<pattern>4i3gá3moselas </pattern>
+<pattern>4i3gá3monos </pattern>
+<pattern>4i3gá3monosle </pattern>
+<pattern>4i3gá3monoslo </pattern>
+<pattern>4i3gá3monosla </pattern>
+<pattern>4i3gá3monosles </pattern>
+<pattern>4i3gá3monoslos </pattern>
+<pattern>4i3gá3monoslas </pattern>
+<pattern>4i3gá3moos </pattern>
+<pattern>4i3gá3moosle </pattern>
+<pattern>4i3gá3mooslo </pattern>
+<pattern>4i3gá3moosla </pattern>
+<pattern>4i3gá3moosles </pattern>
+<pattern>4i3gá3mooslos </pattern>
+<pattern>4i3gá3mooslas </pattern>
+<pattern>4i3gá3mosles </pattern>
+<pattern>4i3gá3moslas </pattern>
+<pattern>4i3gá3moslos </pattern>
+<pattern>4ed </pattern>
+<pattern>4é </pattern>
+<pattern>4edme </pattern>
+<pattern>4édmele </pattern>
+<pattern>4édmelo </pattern>
+<pattern>4éd3mela </pattern>
+<pattern>4édmeles </pattern>
+<pattern>4édmelos </pattern>
+<pattern>4éd3melas </pattern>
+<pattern>4edte </pattern>
+<pattern>4édtele </pattern>
+<pattern>4édtelo </pattern>
+<pattern>4éd3tela </pattern>
+<pattern>4édteles </pattern>
+<pattern>4édtelos </pattern>
+<pattern>4éd3telas </pattern>
+<pattern>4edle </pattern>
+<pattern>4eedla </pattern>
+<pattern>4edlo </pattern>
+<pattern>4édsele </pattern>
+<pattern>4édselo </pattern>
+<pattern>4édsela </pattern>
+<pattern>4édseles </pattern>
+<pattern>4édselos </pattern>
+<pattern>4édselas </pattern>
+<pattern>4ednos </pattern>
+<pattern>4édnosle </pattern>
+<pattern>4édnoslo </pattern>
+<pattern>4édnosla </pattern>
+<pattern>4édnosles </pattern>
+<pattern>4édnoslos </pattern>
+<pattern>4édnoslas </pattern>
+<pattern>4eos </pattern>
+<pattern>4éosle </pattern>
+<pattern>4éoslo </pattern>
+<pattern>4éosla </pattern>
+<pattern>4éosles </pattern>
+<pattern>4éoslos </pattern>
+<pattern>4éoslas </pattern>
+<pattern>4edles </pattern>
+<pattern>4edlas </pattern>
+<pattern>4edlos </pattern>
+<pattern>4er </pattern>
+<pattern>4erme </pattern>
+<pattern>4érmele </pattern>
+<pattern>4érmelo </pattern>
+<pattern>4ér3mela </pattern>
+<pattern>4érmeles </pattern>
+<pattern>4érmelos </pattern>
+<pattern>4ér3melas </pattern>
+<pattern>4erte </pattern>
+<pattern>4értele </pattern>
+<pattern>4értelo </pattern>
+<pattern>4ér3tela </pattern>
+<pattern>4érteles </pattern>
+<pattern>4értelos </pattern>
+<pattern>4ér3telas </pattern>
+<pattern>4erle </pattern>
+<pattern>4erla </pattern>
+<pattern>4erlo </pattern>
+<pattern>4erse </pattern>
+<pattern>4érsele </pattern>
+<pattern>4érselo </pattern>
+<pattern>4érsela </pattern>
+<pattern>4érseles </pattern>
+<pattern>4érselos </pattern>
+<pattern>4érselas </pattern>
+<pattern>4ernos </pattern>
+<pattern>4érnosle </pattern>
+<pattern>4érnoslo </pattern>
+<pattern>4érnosla </pattern>
+<pattern>4érnosles </pattern>
+<pattern>4érnoslos </pattern>
+<pattern>4érnoslas </pattern>
+<pattern>4e3ros </pattern>
+<pattern>4é3rosle </pattern>
+<pattern>4é3roslo </pattern>
+<pattern>4é3rosla </pattern>
+<pattern>4é3rosles </pattern>
+<pattern>4é3roslos </pattern>
+<pattern>4é3roslas </pattern>
+<pattern>4erles </pattern>
+<pattern>4erlas </pattern>
+<pattern>4erlos </pattern>
+<pattern>4í3do </pattern>
+<pattern>4í3da </pattern>
+<pattern>4í3dos </pattern>
+<pattern>4í3das </pattern>
+<pattern>4o </pattern>
+<pattern>4as </pattern>
+<pattern>4a </pattern>
+<pattern>4ás </pattern>
+<pattern>4a3mos </pattern>
+<pattern>4áis </pattern>
+<pattern>4an </pattern>
+<pattern>4aste </pattern>
+<pattern>4astes </pattern>
+<pattern>4ó </pattern>
+<pattern>4ates </pattern>
+<pattern>4asteis </pattern>
+<pattern>4a3ron </pattern>
+<pattern>4a3ba </pattern>
+<pattern>4a3bas </pattern>
+<pattern>4á3bamos </pattern>
+<pattern>4a3bais </pattern>
+<pattern>4a3ban </pattern>
+<pattern>4a3ría </pattern>
+<pattern>4a3rías </pattern>
+<pattern>4a3ríamos </pattern>
 <pattern>4a3ríais</pattern>
-<pattern>4a3rían.</pattern>
-<pattern>4a3ré.</pattern>
-<pattern>4a3rás.</pattern>
-<pattern>4a3rés.</pattern>
-<pattern>4a3rís.</pattern>
-<pattern>4a3rá.</pattern>
-<pattern>4a3remos.</pattern>
-<pattern>4a3réis.</pattern>
-<pattern>4a3rán.</pattern>
-<pattern>4a3ra.</pattern>
-<pattern>4a3ras.</pattern>
-<pattern>4á3ramos.</pattern>
-<pattern>4a3rais.</pattern>
-<pattern>4a3ran.</pattern>
-<pattern>4a3re.</pattern>
-<pattern>4a3res.</pattern>
-<pattern>4á3remos.</pattern>
-<pattern>4a3reis.</pattern>
-<pattern>4a3ren.</pattern>
-<pattern>4a3se.</pattern>
-<pattern>4a3ses.</pattern>
-<pattern>4á3semos.</pattern>
-<pattern>4a3seis.</pattern>
-<pattern>4a3sen.</pattern>
-<pattern>4ad.</pattern>
-<pattern>e5r4as.</pattern>
-<pattern>e5r4a3mos.</pattern>
-<pattern>e5r4áis.</pattern>
-<pattern>e5r4an.</pattern>
-<pattern>e5r4aste.</pattern>
-<pattern>e5r4astes.</pattern>
-<pattern>e5r4ates.</pattern>
-<pattern>e5r4asteis.</pattern>
-<pattern>e5r4a3ron.</pattern>
-<pattern>e5r4a3ba.</pattern>
-<pattern>e5r4a3bas.</pattern>
-<pattern>e5r4á3bamos.</pattern>
-<pattern>e5r4a3bais.</pattern>
-<pattern>e5r4a3ban.</pattern>
-<pattern>e5r4a3ría.</pattern>
-<pattern>e5r4a3rías.</pattern>
-<pattern>e5r4a3ríamos.</pattern>
+<pattern>4a3rían </pattern>
+<pattern>4a3ré </pattern>
+<pattern>4a3rás </pattern>
+<pattern>4a3rés </pattern>
+<pattern>4a3rís </pattern>
+<pattern>4a3rá </pattern>
+<pattern>4a3remos </pattern>
+<pattern>4a3réis </pattern>
+<pattern>4a3rán </pattern>
+<pattern>4a3ra </pattern>
+<pattern>4a3ras </pattern>
+<pattern>4á3ramos </pattern>
+<pattern>4a3rais </pattern>
+<pattern>4a3ran </pattern>
+<pattern>4a3re </pattern>
+<pattern>4a3res </pattern>
+<pattern>4á3remos </pattern>
+<pattern>4a3reis </pattern>
+<pattern>4a3ren </pattern>
+<pattern>4a3se </pattern>
+<pattern>4a3ses </pattern>
+<pattern>4á3semos </pattern>
+<pattern>4a3seis </pattern>
+<pattern>4a3sen </pattern>
+<pattern>4ad </pattern>
+<pattern>e5r4as </pattern>
+<pattern>e5r4a3mos </pattern>
+<pattern>e5r4áis </pattern>
+<pattern>e5r4an </pattern>
+<pattern>e5r4aste </pattern>
+<pattern>e5r4astes </pattern>
+<pattern>e5r4ates </pattern>
+<pattern>e5r4asteis </pattern>
+<pattern>e5r4a3ron </pattern>
+<pattern>e5r4a3ba </pattern>
+<pattern>e5r4a3bas </pattern>
+<pattern>e5r4á3bamos </pattern>
+<pattern>e5r4a3bais </pattern>
+<pattern>e5r4a3ban </pattern>
+<pattern>e5r4a3ría </pattern>
+<pattern>e5r4a3rías </pattern>
+<pattern>e5r4a3ríamos </pattern>
 <pattern>e5r4a3ríais</pattern>
-<pattern>e5r4a3rían.</pattern>
-<pattern>e5r4a3ré.</pattern>
-<pattern>e5r4a3rás.</pattern>
-<pattern>e5r4a3rés.</pattern>
-<pattern>e5r4a3rís.</pattern>
-<pattern>e5r4a3rá.</pattern>
-<pattern>e5r4a3remos.</pattern>
-<pattern>e5r4a3réis.</pattern>
-<pattern>e5r4a3rán.</pattern>
-<pattern>e5r4a3ra.</pattern>
-<pattern>e5r4a3ras.</pattern>
-<pattern>e5r4á3ramos.</pattern>
-<pattern>e5r4a3rais.</pattern>
-<pattern>e5r4a3ran.</pattern>
-<pattern>e5r4a3re.</pattern>
-<pattern>e5r4a3res.</pattern>
-<pattern>e5r4á3remos.</pattern>
-<pattern>e5r4a3reis.</pattern>
-<pattern>e5r4a3ren.</pattern>
-<pattern>e5r4a3se.</pattern>
-<pattern>e5r4a3ses.</pattern>
-<pattern>e5r4á3semos.</pattern>
-<pattern>e5r4a3seis.</pattern>
-<pattern>e5r4a3sen.</pattern>
-<pattern>e5r4ad.</pattern>
-<pattern>4adme.</pattern>
-<pattern>4ádmele.</pattern>
-<pattern>4ádmelo.</pattern>
-<pattern>4ád3mela.</pattern>
-<pattern>4ádmeles.</pattern>
-<pattern>4ádmelos.</pattern>
-<pattern>4ád3melas.</pattern>
-<pattern>4adte.</pattern>
-<pattern>4ádtele.</pattern>
-<pattern>4ádtelo.</pattern>
-<pattern>4ád3tela.</pattern>
-<pattern>4ádteles.</pattern>
-<pattern>4ádtelos.</pattern>
-<pattern>4ád3telas.</pattern>
-<pattern>4adle.</pattern>
-<pattern>4eadla.</pattern>
-<pattern>4adlo.</pattern>
-<pattern>4ádsele.</pattern>
-<pattern>4ádselo.</pattern>
-<pattern>4ádsela.</pattern>
-<pattern>4ádseles.</pattern>
-<pattern>4ádselos.</pattern>
-<pattern>4ádselas.</pattern>
-<pattern>4adnos.</pattern>
-<pattern>4ádnosle.</pattern>
-<pattern>4ádnoslo.</pattern>
-<pattern>4ádnosla.</pattern>
-<pattern>4ádnosles.</pattern>
-<pattern>4ádnoslos.</pattern>
-<pattern>4ádnoslas.</pattern>
-<pattern>4aos.</pattern>
-<pattern>4áosle.</pattern>
-<pattern>4áoslo.</pattern>
-<pattern>4áosla.</pattern>
-<pattern>4áosles.</pattern>
-<pattern>4áoslos.</pattern>
-<pattern>4áoslas.</pattern>
-<pattern>4adles.</pattern>
-<pattern>4adlas.</pattern>
-<pattern>4adlos.</pattern>
-<pattern>4ar.</pattern>
-<pattern>4a4rme.</pattern>
-<pattern>4á4rmele.</pattern>
-<pattern>4á4rmelo.</pattern>
-<pattern>4á4r3mela.</pattern>
-<pattern>4á4r3meles.</pattern>
-<pattern>4á4r3melos.</pattern>
-<pattern>4á4r3melas.</pattern>
-<pattern>4a4r3te.</pattern>
-<pattern>4á4r3tele.</pattern>
-<pattern>4á4r3telo.</pattern>
-<pattern>4á4r3tela.</pattern>
-<pattern>4á4r3teles.</pattern>
-<pattern>4á4r3telos.</pattern>
-<pattern>4á4r3telas.</pattern>
-<pattern>4a4r3le.</pattern>
-<pattern>4a4r3la.</pattern>
-<pattern>4a4r3lo.</pattern>
-<pattern>4a4r3se.</pattern>
-<pattern>4á4r3sele.</pattern>
-<pattern>4á4r3selo.</pattern>
-<pattern>4á4r3sela.</pattern>
-<pattern>4á4r3seles.</pattern>
-<pattern>4á4r3selos.</pattern>
-<pattern>4á4r3selas.</pattern>
-<pattern>4a4r3nos.</pattern>
-<pattern>4á4r3nosle.</pattern>
-<pattern>4á4r3noslo.</pattern>
-<pattern>4á4r3nosla.</pattern>
-<pattern>4á4r3nosles.</pattern>
-<pattern>4á4r3noslos.</pattern>
-<pattern>4á4r3noslas.</pattern>
-<pattern>4a3ros.</pattern>
-<pattern>4árosle.</pattern>
-<pattern>4ároslo.</pattern>
-<pattern>4árosla.</pattern>
-<pattern>4árosles.</pattern>
-<pattern>4ároslos.</pattern>
-<pattern>4ároslas.</pattern>
-<pattern>4a4r3les.</pattern>
-<pattern>4a4r3las.</pattern>
-<pattern>4a4r3los.</pattern>
-<pattern>4a3do.</pattern>
-<pattern>4a3da.</pattern>
-<pattern>4a3dos.</pattern>
-<pattern>4a3das.</pattern>
-<pattern>e5r4a3do.</pattern>
-<pattern>e5r4a3da.</pattern>
-<pattern>e5r4a3dos.</pattern>
-<pattern>e5r4a3das.</pattern>
+<pattern>e5r4a3rían </pattern>
+<pattern>e5r4a3ré </pattern>
+<pattern>e5r4a3rás </pattern>
+<pattern>e5r4a3rés </pattern>
+<pattern>e5r4a3rís </pattern>
+<pattern>e5r4a3rá </pattern>
+<pattern>e5r4a3remos </pattern>
+<pattern>e5r4a3réis </pattern>
+<pattern>e5r4a3rán </pattern>
+<pattern>e5r4a3ra </pattern>
+<pattern>e5r4a3ras </pattern>
+<pattern>e5r4á3ramos </pattern>
+<pattern>e5r4a3rais </pattern>
+<pattern>e5r4a3ran </pattern>
+<pattern>e5r4a3re </pattern>
+<pattern>e5r4a3res </pattern>
+<pattern>e5r4á3remos </pattern>
+<pattern>e5r4a3reis </pattern>
+<pattern>e5r4a3ren </pattern>
+<pattern>e5r4a3se </pattern>
+<pattern>e5r4a3ses </pattern>
+<pattern>e5r4á3semos </pattern>
+<pattern>e5r4a3seis </pattern>
+<pattern>e5r4a3sen </pattern>
+<pattern>e5r4ad </pattern>
+<pattern>4adme </pattern>
+<pattern>4ádmele </pattern>
+<pattern>4ádmelo </pattern>
+<pattern>4ád3mela </pattern>
+<pattern>4ádmeles </pattern>
+<pattern>4ádmelos </pattern>
+<pattern>4ád3melas </pattern>
+<pattern>4adte </pattern>
+<pattern>4ádtele </pattern>
+<pattern>4ádtelo </pattern>
+<pattern>4ád3tela </pattern>
+<pattern>4ádteles </pattern>
+<pattern>4ádtelos </pattern>
+<pattern>4ád3telas </pattern>
+<pattern>4adle </pattern>
+<pattern>4eadla </pattern>
+<pattern>4adlo </pattern>
+<pattern>4ádsele </pattern>
+<pattern>4ádselo </pattern>
+<pattern>4ádsela </pattern>
+<pattern>4ádseles </pattern>
+<pattern>4ádselos </pattern>
+<pattern>4ádselas </pattern>
+<pattern>4adnos </pattern>
+<pattern>4ádnosle </pattern>
+<pattern>4ádnoslo </pattern>
+<pattern>4ádnosla </pattern>
+<pattern>4ádnosles </pattern>
+<pattern>4ádnoslos </pattern>
+<pattern>4ádnoslas </pattern>
+<pattern>4aos </pattern>
+<pattern>4áosle </pattern>
+<pattern>4áoslo </pattern>
+<pattern>4áosla </pattern>
+<pattern>4áosles </pattern>
+<pattern>4áoslos </pattern>
+<pattern>4áoslas </pattern>
+<pattern>4adles </pattern>
+<pattern>4adlas </pattern>
+<pattern>4adlos </pattern>
+<pattern>4ar </pattern>
+<pattern>4a4rme </pattern>
+<pattern>4á4rmele </pattern>
+<pattern>4á4rmelo </pattern>
+<pattern>4á4r3mela </pattern>
+<pattern>4á4r3meles </pattern>
+<pattern>4á4r3melos </pattern>
+<pattern>4á4r3melas </pattern>
+<pattern>4a4r3te </pattern>
+<pattern>4á4r3tele </pattern>
+<pattern>4á4r3telo </pattern>
+<pattern>4á4r3tela </pattern>
+<pattern>4á4r3teles </pattern>
+<pattern>4á4r3telos </pattern>
+<pattern>4á4r3telas </pattern>
+<pattern>4a4r3le </pattern>
+<pattern>4a4r3la </pattern>
+<pattern>4a4r3lo </pattern>
+<pattern>4a4r3se </pattern>
+<pattern>4á4r3sele </pattern>
+<pattern>4á4r3selo </pattern>
+<pattern>4á4r3sela </pattern>
+<pattern>4á4r3seles </pattern>
+<pattern>4á4r3selos </pattern>
+<pattern>4á4r3selas </pattern>
+<pattern>4a4r3nos </pattern>
+<pattern>4á4r3nosle </pattern>
+<pattern>4á4r3noslo </pattern>
+<pattern>4á4r3nosla </pattern>
+<pattern>4á4r3nosles </pattern>
+<pattern>4á4r3noslos </pattern>
+<pattern>4á4r3noslas </pattern>
+<pattern>4a3ros </pattern>
+<pattern>4árosle </pattern>
+<pattern>4ároslo </pattern>
+<pattern>4árosla </pattern>
+<pattern>4árosles </pattern>
+<pattern>4ároslos </pattern>
+<pattern>4ároslas </pattern>
+<pattern>4a4r3les </pattern>
+<pattern>4a4r3las </pattern>
+<pattern>4a4r3los </pattern>
+<pattern>4a3do </pattern>
+<pattern>4a3da </pattern>
+<pattern>4a3dos </pattern>
+<pattern>4a3das </pattern>
+<pattern>e5r4a3do </pattern>
+<pattern>e5r4a3da </pattern>
+<pattern>e5r4a3dos </pattern>
+<pattern>e5r4a3das </pattern>
 <pattern>4ando</pattern>
-<pattern>4ándole.</pattern>
-<pattern>4ándolo.</pattern>
-<pattern>4ándola.</pattern>
-<pattern>4ándoles.</pattern>
-<pattern>4ándolos.</pattern>
-<pattern>4ándolas.</pattern>
-<pattern>4ándonos.</pattern>
-<pattern>4ándoos.</pattern>
-<pattern>4ándome.</pattern>
-<pattern>4ándomelo.</pattern>
-<pattern>4ándomela.</pattern>
-<pattern>4ándomele.</pattern>
-<pattern>4ándomelos.</pattern>
-<pattern>4ándomelas.</pattern>
-<pattern>4ándomeles.</pattern>
-<pattern>4ándote.</pattern>
-<pattern>4ándoteme.</pattern>
-<pattern>4ándotelo.</pattern>
-<pattern>4ándotela.</pattern>
-<pattern>4ándotele.</pattern>
-<pattern>4ándotelos.</pattern>
-<pattern>4ándotelas.</pattern>
-<pattern>4ándoteles.</pattern>
-<pattern>4ándotenos.</pattern>
-<pattern>4ándose.</pattern>
-<pattern>4ándoseme.</pattern>
-<pattern>4ándoselo.</pattern>
-<pattern>4ándosela.</pattern>
-<pattern>4ándosele.</pattern>
-<pattern>4ándoselos.</pattern>
-<pattern>4ándoselas.</pattern>
-<pattern>4ándoseles.</pattern>
-<pattern>4ándosenos.</pattern>
-<pattern>4a3dor.</pattern>
-<pattern>4a3dora.</pattern>
-<pattern>4a3dores.</pattern>
-<pattern>4a3doras.</pattern>
-<pattern>e5r4a3dor.</pattern>
-<pattern>e5r4a3dora.</pattern>
-<pattern>e5r4a3dores.</pattern>
-<pattern>e5r4a3doras.</pattern>
+<pattern>4ándole </pattern>
+<pattern>4ándolo </pattern>
+<pattern>4ándola </pattern>
+<pattern>4ándoles </pattern>
+<pattern>4ándolos </pattern>
+<pattern>4ándolas </pattern>
+<pattern>4ándonos </pattern>
+<pattern>4ándoos </pattern>
+<pattern>4ándome </pattern>
+<pattern>4ándomelo </pattern>
+<pattern>4ándomela </pattern>
+<pattern>4ándomele </pattern>
+<pattern>4ándomelos </pattern>
+<pattern>4ándomelas </pattern>
+<pattern>4ándomeles </pattern>
+<pattern>4ándote </pattern>
+<pattern>4ándoteme </pattern>
+<pattern>4ándotelo </pattern>
+<pattern>4ándotela </pattern>
+<pattern>4ándotele </pattern>
+<pattern>4ándotelos </pattern>
+<pattern>4ándotelas </pattern>
+<pattern>4ándoteles </pattern>
+<pattern>4ándotenos </pattern>
+<pattern>4ándose </pattern>
+<pattern>4ándoseme </pattern>
+<pattern>4ándoselo </pattern>
+<pattern>4ándosela </pattern>
+<pattern>4ándosele </pattern>
+<pattern>4ándoselos </pattern>
+<pattern>4ándoselas </pattern>
+<pattern>4ándoseles </pattern>
+<pattern>4ándosenos </pattern>
+<pattern>4a3dor </pattern>
+<pattern>4a3dora </pattern>
+<pattern>4a3dores </pattern>
+<pattern>4a3doras </pattern>
+<pattern>e5r4a3dor </pattern>
+<pattern>e5r4a3dora </pattern>
+<pattern>e5r4a3dores </pattern>
+<pattern>e5r4a3doras </pattern>
 <pattern>acto1h</pattern>
 <pattern>acto1a2</pattern>
 <pattern>acto1e2</pattern>
@@ -1494,53 +1494,53 @@
 <pattern>afro1í2</pattern>
 <pattern>afro1ó2</pattern>
 <pattern>afro1ú2</pattern>
-<pattern>.a2</pattern>
-<pattern>.an2a2</pattern>
-<pattern>.an2e2</pattern>
-<pattern>.an2i2</pattern>
-<pattern>.an2o2</pattern>
-<pattern>.an2u2</pattern>
-<pattern>.an2á2</pattern>
-<pattern>.an2é2</pattern>
-<pattern>.an2í2</pattern>
-<pattern>.an2ó2</pattern>
-<pattern>.an2ú2.</pattern>
+<pattern> a2</pattern>
+<pattern> an2a2</pattern>
+<pattern> an2e2</pattern>
+<pattern> an2i2</pattern>
+<pattern> an2o2</pattern>
+<pattern> an2u2</pattern>
+<pattern> an2á2</pattern>
+<pattern> an2é2</pattern>
+<pattern> an2í2</pattern>
+<pattern> an2ó2</pattern>
+<pattern> an2ú2 </pattern>
 <pattern>ana3lí</pattern>
-<pattern>.aná3li</pattern>
-<pattern>.ana3li</pattern>
-<pattern>.an3aero</pattern>
-<pattern>.an3e2pigr</pattern>
-<pattern>.ane3xa</pattern>
-<pattern>.ane3xá</pattern>
-<pattern>.ane3xe</pattern>
-<pattern>.ane3xé</pattern>
-<pattern>.ane3xio</pattern>
-<pattern>.ane3xió</pattern>
-<pattern>.an3h</pattern>
-<pattern>.ani3mad</pattern>
-<pattern>.ani3mád</pattern>
-<pattern>.ani3dar</pattern>
-<pattern>.ani3ll</pattern>
-<pattern>.ani3m</pattern>
-<pattern>.aniña</pattern>
-<pattern>.ani3q</pattern>
-<pattern>.an3i2so</pattern>
-<pattern>.an3i2só</pattern>
-<pattern>.ani3vel</pattern>
-<pattern>.ano5che</pattern>
-<pattern>.ano5din</pattern>
-<pattern>.ano5mal</pattern>
-<pattern>.ano5nad</pattern>
-<pattern>.anó3nim</pattern>
-<pattern>.anó5mal</pattern>
-<pattern>.ano5nim</pattern>
-<pattern>.ano5ta</pattern>
-<pattern>.ano3tá</pattern>
-<pattern>.anua3l</pattern>
-<pattern>.anua4lm</pattern>
-<pattern>.anu3bl</pattern>
-<pattern>.anu3da</pattern>
-<pattern>.anu3l</pattern>
+<pattern> aná3li</pattern>
+<pattern> ana3li</pattern>
+<pattern> an3aero</pattern>
+<pattern> an3e2pigr</pattern>
+<pattern> ane3xa</pattern>
+<pattern> ane3xá</pattern>
+<pattern> ane3xe</pattern>
+<pattern> ane3xé</pattern>
+<pattern> ane3xio</pattern>
+<pattern> ane3xió</pattern>
+<pattern> an3h</pattern>
+<pattern> ani3mad</pattern>
+<pattern> ani3mád</pattern>
+<pattern> ani3dar</pattern>
+<pattern> ani3ll</pattern>
+<pattern> ani3m</pattern>
+<pattern> aniña</pattern>
+<pattern> ani3q</pattern>
+<pattern> an3i2so</pattern>
+<pattern> an3i2só</pattern>
+<pattern> ani3vel</pattern>
+<pattern> ano5che</pattern>
+<pattern> ano5din</pattern>
+<pattern> ano5mal</pattern>
+<pattern> ano5nad</pattern>
+<pattern> anó3nim</pattern>
+<pattern> anó5mal</pattern>
+<pattern> ano5nim</pattern>
+<pattern> ano5ta</pattern>
+<pattern> ano3tá</pattern>
+<pattern> anua3l</pattern>
+<pattern> anua4lm</pattern>
+<pattern> anu3bl</pattern>
+<pattern> anu3da</pattern>
+<pattern> anu3l</pattern>
 <pattern>asu3b2</pattern>
 <pattern>aero1h</pattern>
 <pattern>aero1a2</pattern>
@@ -1586,30 +1586,30 @@
 <pattern>ante1í2</pattern>
 <pattern>ante1ó2</pattern>
 <pattern>ante1ú2</pattern>
-<pattern>.ante2o3je</pattern>
+<pattern> ante2o3je</pattern>
 <pattern>acante2</pattern>
-<pattern>4ísmo.</pattern>
-<pattern>4ísmos.</pattern>
-<pattern>4ísta.</pattern>
-<pattern>4ístas.</pattern>
-<pattern>4ístico.</pattern>
-<pattern>4ísticos.</pattern>
-<pattern>4ística.</pattern>
-<pattern>4ísticas.</pattern>
-<pattern>t4eo3nes.</pattern>
+<pattern>4ísmo </pattern>
+<pattern>4ísmos </pattern>
+<pattern>4ísta </pattern>
+<pattern>4ístas </pattern>
+<pattern>4ístico </pattern>
+<pattern>4ísticos </pattern>
+<pattern>4ística </pattern>
+<pattern>4ísticas </pattern>
+<pattern>t4eo3nes </pattern>
 <pattern>mante4a</pattern>
 <pattern>e4a3miento</pattern>
-<pattern>.anti1h</pattern>
-<pattern>.anti1a2</pattern>
-<pattern>.anti1e2</pattern>
-<pattern>.anti1i2</pattern>
-<pattern>.anti1o2</pattern>
-<pattern>.anti1u2</pattern>
-<pattern>.anti1á2</pattern>
-<pattern>.anti1é2</pattern>
-<pattern>.anti1í2</pattern>
-<pattern>.anti1ó2</pattern>
-<pattern>.anti1ú2</pattern>
+<pattern> anti1h</pattern>
+<pattern> anti1a2</pattern>
+<pattern> anti1e2</pattern>
+<pattern> anti1i2</pattern>
+<pattern> anti1o2</pattern>
+<pattern> anti1u2</pattern>
+<pattern> anti1á2</pattern>
+<pattern> anti1é2</pattern>
+<pattern> anti1í2</pattern>
+<pattern> anti1ó2</pattern>
+<pattern> anti1ú2</pattern>
 <pattern>ti2o3qu</pattern>
 <pattern>ti2o3co</pattern>
 <pattern>archi1h</pattern>
@@ -1702,16 +1702,16 @@
 <pattern>ciclo1í2</pattern>
 <pattern>ciclo1ó2</pattern>
 <pattern>ciclo1ú2</pattern>
-<pattern>o4i3dea.</pattern>
-<pattern>o4i3deas.</pattern>
-<pattern>o4i3dal.</pattern>
-<pattern>o4i3dales.</pattern>
-<pattern>4o2i3de.</pattern>
-<pattern>4o2i3des.</pattern>
-<pattern>4i2dal.</pattern>
-<pattern>4i2dales.</pattern>
-<pattern>4i3deo.</pattern>
-<pattern>4i3deos.</pattern>
+<pattern>o4i3dea </pattern>
+<pattern>o4i3deas </pattern>
+<pattern>o4i3dal </pattern>
+<pattern>o4i3dales </pattern>
+<pattern>4o2i3de </pattern>
+<pattern>4o2i3des </pattern>
+<pattern>4i2dal </pattern>
+<pattern>4i2dales </pattern>
+<pattern>4i3deo </pattern>
+<pattern>4i3deos </pattern>
 <pattern>cito1h</pattern>
 <pattern>cito1a2</pattern>
 <pattern>cito1e2</pattern>
@@ -1735,16 +1735,16 @@
 <pattern>cnico1í2</pattern>
 <pattern>cnico1ó2</pattern>
 <pattern>cnico1ú2</pattern>
-<pattern>.co2a2</pattern>
-<pattern>.co2e2</pattern>
-<pattern>.co2i2</pattern>
-<pattern>.co3o4</pattern>
-<pattern>.co2u2</pattern>
-<pattern>.co2á2</pattern>
-<pattern>.co2é2</pattern>
-<pattern>.co2í2</pattern>
-<pattern>.co2ó2</pattern>
-<pattern>.co2ú2</pattern>
+<pattern> co2a2</pattern>
+<pattern> co2e2</pattern>
+<pattern> co2i2</pattern>
+<pattern> co3o4</pattern>
+<pattern> co2u2</pattern>
+<pattern> co2á2</pattern>
+<pattern> co2é2</pattern>
+<pattern> co2í2</pattern>
+<pattern> co2ó2</pattern>
+<pattern> co2ú2</pattern>
 <pattern>co4á3gul</pattern>
 <pattern>co4acci</pattern>
 <pattern>co4acti</pattern>
@@ -1816,26 +1816,26 @@
 <pattern>deca1í2</pattern>
 <pattern>deca1ó2</pattern>
 <pattern>deca1ú2</pattern>
-<pattern>4e3dro.</pattern>
-<pattern>4e3dros.</pattern>
-<pattern>4é3drico.</pattern>
-<pattern>4é3dricos.</pattern>
-<pattern>4é3drica.</pattern>
-<pattern>4é3dricas.</pattern>
-<pattern>.de2sa2</pattern>
-<pattern>.de2se2</pattern>
-<pattern>.de2si2</pattern>
-<pattern>.de2so2</pattern>
-<pattern>.de2su2</pattern>
-<pattern>.de2sá2</pattern>
-<pattern>.de2sé2</pattern>
-<pattern>.de2sí2</pattern>
-<pattern>.de2só2</pattern>
-<pattern>.de2sú2</pattern>
+<pattern>4e3dro </pattern>
+<pattern>4e3dros </pattern>
+<pattern>4é3drico </pattern>
+<pattern>4é3dricos </pattern>
+<pattern>4é3drica </pattern>
+<pattern>4é3dricas </pattern>
+<pattern> de2sa2</pattern>
+<pattern> de2se2</pattern>
+<pattern> de2si2</pattern>
+<pattern> de2so2</pattern>
+<pattern> de2su2</pattern>
+<pattern> de2sá2</pattern>
+<pattern> de2sé2</pattern>
+<pattern> de2sí2</pattern>
+<pattern> de2só2</pattern>
+<pattern> de2sú2</pattern>
 <pattern>deca2i3mient</pattern>
 <pattern>decimo1</pattern>
-<pattern>3sa.</pattern>
-<pattern>3sas.</pattern>
+<pattern>3sa </pattern>
+<pattern>3sas </pattern>
 <pattern>de2s3órde</pattern>
 <pattern>de2s3orde</pattern>
 <pattern>de2s3abast</pattern>
@@ -2119,7 +2119,7 @@
 <pattern>de2s3unir</pattern>
 <pattern>de2s3unier</pattern>
 <pattern>de2s3unim</pattern>
-<pattern>.dieci1o2</pattern>
+<pattern> dieci1o2</pattern>
 <pattern>dodeca1h</pattern>
 <pattern>dodeca1a2</pattern>
 <pattern>dodeca1e2</pattern>
@@ -2164,33 +2164,33 @@
 <pattern>ectro1í2</pattern>
 <pattern>ectro1ó2</pattern>
 <pattern>ectro1ú2</pattern>
-<pattern>.en2a2</pattern>
-<pattern>.en2e2</pattern>
-<pattern>.en2i2</pattern>
-<pattern>.en2o2</pattern>
-<pattern>.en2u2</pattern>
-<pattern>.en2á2</pattern>
-<pattern>.en2é2</pattern>
-<pattern>.en2í2</pattern>
-<pattern>.en2ó2</pattern>
-<pattern>.en2ú2</pattern>
-<pattern>.ene3mist</pattern>
-<pattern>.ene3míst</pattern>
-<pattern>.eno3jar</pattern>
-<pattern>.enu3mera</pattern>
-<pattern>.enu3merá</pattern>
-<pattern>.enu3mere</pattern>
-<pattern>4o3lógico.</pattern>
-<pattern>4o3lógica.</pattern>
-<pattern>4o3lógicos.</pattern>
-<pattern>4o3lógicas.</pattern>
-<pattern>4o3lógicamente.</pattern>
-<pattern>4o3logía.</pattern>
-<pattern>4o3logías.</pattern>
-<pattern>4ó3logo.</pattern>
-<pattern>4ó3loga.</pattern>
-<pattern>4ó3logos.</pattern>
-<pattern>4ó3logas.</pattern>
+<pattern> en2a2</pattern>
+<pattern> en2e2</pattern>
+<pattern> en2i2</pattern>
+<pattern> en2o2</pattern>
+<pattern> en2u2</pattern>
+<pattern> en2á2</pattern>
+<pattern> en2é2</pattern>
+<pattern> en2í2</pattern>
+<pattern> en2ó2</pattern>
+<pattern> en2ú2</pattern>
+<pattern> ene3mist</pattern>
+<pattern> ene3míst</pattern>
+<pattern> eno3jar</pattern>
+<pattern> enu3mera</pattern>
+<pattern> enu3merá</pattern>
+<pattern> enu3mere</pattern>
+<pattern>4o3lógico </pattern>
+<pattern>4o3lógica </pattern>
+<pattern>4o3lógicos </pattern>
+<pattern>4o3lógicas </pattern>
+<pattern>4o3lógicamente </pattern>
+<pattern>4o3logía </pattern>
+<pattern>4o3logías </pattern>
+<pattern>4ó3logo </pattern>
+<pattern>4ó3loga </pattern>
+<pattern>4ó3logos </pattern>
+<pattern>4ó3logas </pattern>
 <pattern>endo1h</pattern>
 <pattern>endo1a2</pattern>
 <pattern>endo1e2</pattern>
@@ -2259,8 +2259,8 @@
 <pattern>extra1ó2</pattern>
 <pattern>extra1ú2</pattern>
 <pattern>u4teri</pattern>
-<pattern>.cau5t</pattern>
-<pattern>.deu5t</pattern>
+<pattern> cau5t</pattern>
+<pattern> deu5t</pattern>
 <pattern>fono1h</pattern>
 <pattern>fono1a2</pattern>
 <pattern>fono1e2</pattern>
@@ -2371,8 +2371,8 @@
 <pattern>hemo1í2</pattern>
 <pattern>hemo1ó2</pattern>
 <pattern>hemo1ú2</pattern>
-<pattern>2al.</pattern>
-<pattern>2ales.</pattern>
+<pattern>2al </pattern>
+<pattern>2ales </pattern>
 <pattern>hexa1h</pattern>
 <pattern>hexa1a2</pattern>
 <pattern>hexa1e2</pattern>
@@ -2440,55 +2440,55 @@
 <pattern>icono1í2</pattern>
 <pattern>icono1ó2</pattern>
 <pattern>icono1ú2</pattern>
-<pattern>.i2n2a2</pattern>
-<pattern>.i2n2e2</pattern>
-<pattern>.i2n2i2</pattern>
-<pattern>.i2n2o2</pattern>
-<pattern>.i2n2u2</pattern>
-<pattern>.i2n2á2</pattern>
-<pattern>.i2n2é2</pattern>
-<pattern>.i2n2í2</pattern>
-<pattern>.i2n2ó2</pattern>
-<pattern>.i2n2ú2</pattern>
-<pattern>.in3abord</pattern>
-<pattern>.in3abarc</pattern>
-<pattern>.in3acent</pattern>
-<pattern>.in3aguant</pattern>
-<pattern>.in3adapt</pattern>
-<pattern>.ina3movib</pattern>
-<pattern>.in3analiz</pattern>
-<pattern>.ina3nic</pattern>
-<pattern>.in3anim</pattern>
-<pattern>.iná3nim</pattern>
-<pattern>.in3apel</pattern>
-<pattern>.in3aplic</pattern>
-<pattern>.in3aprens</pattern>
-<pattern>.in3apreci</pattern>
-<pattern>.in3arrug</pattern>
-<pattern>.in3asist</pattern>
-<pattern>.iné3dit</pattern>
-<pattern>.in3efic</pattern>
-<pattern>.in3efici</pattern>
-<pattern>.in3eludi</pattern>
-<pattern>.ine3narr</pattern>
+<pattern> i2n2a2</pattern>
+<pattern> i2n2e2</pattern>
+<pattern> i2n2i2</pattern>
+<pattern> i2n2o2</pattern>
+<pattern> i2n2u2</pattern>
+<pattern> i2n2á2</pattern>
+<pattern> i2n2é2</pattern>
+<pattern> i2n2í2</pattern>
+<pattern> i2n2ó2</pattern>
+<pattern> i2n2ú2</pattern>
+<pattern> in3abord</pattern>
+<pattern> in3abarc</pattern>
+<pattern> in3acent</pattern>
+<pattern> in3aguant</pattern>
+<pattern> in3adapt</pattern>
+<pattern> ina3movib</pattern>
+<pattern> in3analiz</pattern>
+<pattern> ina3nic</pattern>
+<pattern> in3anim</pattern>
+<pattern> iná3nim</pattern>
+<pattern> in3apel</pattern>
+<pattern> in3aplic</pattern>
+<pattern> in3aprens</pattern>
+<pattern> in3apreci</pattern>
+<pattern> in3arrug</pattern>
+<pattern> in3asist</pattern>
+<pattern> iné3dit</pattern>
+<pattern> in3efic</pattern>
+<pattern> in3efici</pattern>
+<pattern> in3eludi</pattern>
+<pattern> ine3narr</pattern>
 <pattern>ini3cia</pattern>
 <pattern>iní3cia</pattern>
 <pattern>ini3ciá</pattern>
 <pattern>ini3cie</pattern>
-<pattern>.rei3na</pattern>
+<pattern> rei3na</pattern>
 <pattern>re3ini3cia</pattern>
 <pattern>re3iní3cia</pattern>
 <pattern>re3ini3ciá</pattern>
 <pattern>re3ini3cie</pattern>
-<pattern>.ini3cuo</pattern>
-<pattern>.ini3cua</pattern>
-<pattern>.ino3cuo</pattern>
-<pattern>.ino3cua</pattern>
-<pattern>.ino3cula</pattern>
-<pattern>.ino3culá</pattern>
-<pattern>.ino3cule</pattern>
-<pattern>.inú3til</pattern>
-<pattern>.inu3tiliz</pattern>
+<pattern> ini3cuo</pattern>
+<pattern> ini3cua</pattern>
+<pattern> ino3cuo</pattern>
+<pattern> ino3cua</pattern>
+<pattern> ino3cula</pattern>
+<pattern> ino3culá</pattern>
+<pattern> ino3cule</pattern>
+<pattern> inú3til</pattern>
+<pattern> inu3tiliz</pattern>
 <pattern>infra1h</pattern>
 <pattern>infra1a2</pattern>
 <pattern>infra1e2</pattern>
@@ -2500,35 +2500,35 @@
 <pattern>infra1í2</pattern>
 <pattern>infra1ó2</pattern>
 <pattern>infra1ú2</pattern>
-<pattern>.inte2r3r</pattern>
-<pattern>.inte2r1a2</pattern>
-<pattern>.inte2r1e2</pattern>
-<pattern>.inte2r1i2</pattern>
-<pattern>.inte2r1o2</pattern>
-<pattern>.inte2r1u2</pattern>
-<pattern>.inte2r1á2</pattern>
-<pattern>.inte2r1é2</pattern>
-<pattern>.inte2r1í2</pattern>
-<pattern>.inte2r1ó2</pattern>
-<pattern>.inte2r1ú2</pattern>
-<pattern>.in3ter2e3sa</pattern>
-<pattern>.in3ter2e3se</pattern>
-<pattern>.in3ter2e3so</pattern>
-<pattern>.in3ter2e3sá</pattern>
-<pattern>.in3ter2e3sé</pattern>
-<pattern>.in3ter2e3só</pattern>
-<pattern>.de3s4in3ter2e3sa</pattern>
-<pattern>.de3s4in3ter2e3se</pattern>
-<pattern>.de3s4in3ter2e3so</pattern>
-<pattern>.de3s4in3ter2e3sá</pattern>
-<pattern>.de3s4in3ter2e3sé</pattern>
-<pattern>.de3s4in3ter2e3só</pattern>
+<pattern> inte2r3r</pattern>
+<pattern> inte2r1a2</pattern>
+<pattern> inte2r1e2</pattern>
+<pattern> inte2r1i2</pattern>
+<pattern> inte2r1o2</pattern>
+<pattern> inte2r1u2</pattern>
+<pattern> inte2r1á2</pattern>
+<pattern> inte2r1é2</pattern>
+<pattern> inte2r1í2</pattern>
+<pattern> inte2r1ó2</pattern>
+<pattern> inte2r1ú2</pattern>
+<pattern> in3ter2e3sa</pattern>
+<pattern> in3ter2e3se</pattern>
+<pattern> in3ter2e3so</pattern>
+<pattern> in3ter2e3sá</pattern>
+<pattern> in3ter2e3sé</pattern>
+<pattern> in3ter2e3só</pattern>
+<pattern> de3s4in3ter2e3sa</pattern>
+<pattern> de3s4in3ter2e3se</pattern>
+<pattern> de3s4in3ter2e3so</pattern>
+<pattern> de3s4in3ter2e3sá</pattern>
+<pattern> de3s4in3ter2e3sé</pattern>
+<pattern> de3s4in3ter2e3só</pattern>
 <pattern>3te3ri3n</pattern>
 <pattern>4te4r5i4nsu</pattern>
-<pattern>.in3te3r4rog</pattern>
-<pattern>.in3te3r4rupc</pattern>
-<pattern>.in3te3r4rupt</pattern>
-<pattern>.in3te3r4rump</pattern>
+<pattern> in3te3r4rog</pattern>
+<pattern> in3te3r4rupc</pattern>
+<pattern> in3te3r4rupt</pattern>
+<pattern> in3te3r4rump</pattern>
 <pattern>intra1h</pattern>
 <pattern>intra1a2</pattern>
 <pattern>intra1e2</pattern>
@@ -2575,7 +2575,7 @@
 <pattern>macro1ú2</pattern>
 <pattern>mal2</pattern>
 <pattern>ma4l3h</pattern>
-<pattern>.ma4l3e4du</pattern>
+<pattern> ma4l3e4du</pattern>
 <pattern>mal3b</pattern>
 <pattern>mal3c</pattern>
 <pattern>mal3d</pattern>
@@ -2593,9 +2593,9 @@
 <pattern>bien3q</pattern>
 <pattern>bien3m</pattern>
 <pattern>bien3t</pattern>
-<pattern>b4ien3do.</pattern>
-<pattern>.su3b4ien</pattern>
-<pattern>b4ien3das.</pattern>
+<pattern>b4ien3do </pattern>
+<pattern> su3b4ien</pattern>
+<pattern>b4ien3das </pattern>
 <pattern>maxi1h</pattern>
 <pattern>maxi1a2</pattern>
 <pattern>maxi1e2</pattern>
@@ -2663,7 +2663,7 @@
 <pattern>mili1ó2</pattern>
 <pattern>mili1ú2</pattern>
 <pattern>familia3ri</pattern>
-<pattern>ia5res.</pattern>
+<pattern>ia5res </pattern>
 <pattern>amili6a</pattern>
 <pattern>a3rio</pattern>
 <pattern>li5área</pattern>
@@ -2678,12 +2678,12 @@
 <pattern>mini1í2</pattern>
 <pattern>mini1ó2</pattern>
 <pattern>mini1ú2</pattern>
-<pattern>2os.</pattern>
-<pattern>2o3so.</pattern>
-<pattern>2o3sos.</pattern>
-<pattern>2o3sa.</pattern>
-<pattern>2o3sas.</pattern>
-<pattern>2o3samente.</pattern>
+<pattern>2os </pattern>
+<pattern>2o3so </pattern>
+<pattern>2o3sos </pattern>
+<pattern>2o3sa </pattern>
+<pattern>2o3sas </pattern>
+<pattern>2o3samente </pattern>
 <pattern>mini4a5tur</pattern>
 <pattern>multi1h</pattern>
 <pattern>multi1a2</pattern>
@@ -2718,10 +2718,10 @@
 <pattern>mono1í2</pattern>
 <pattern>mono1ó2</pattern>
 <pattern>mono1ú2</pattern>
-<pattern>2i3co.</pattern>
-<pattern>2i3cos.</pattern>
-<pattern>2i3ca.</pattern>
-<pattern>2i3cas.</pattern>
+<pattern>2i3co </pattern>
+<pattern>2i3cos </pattern>
+<pattern>2i3ca </pattern>
+<pattern>2i3cas </pattern>
 <pattern>namo1h</pattern>
 <pattern>namo1a2</pattern>
 <pattern>namo1e2</pattern>
@@ -2821,8 +2821,8 @@
 <pattern>omni1í2</pattern>
 <pattern>omni1ó2</pattern>
 <pattern>omni1ú2</pattern>
-<pattern>i2o.</pattern>
-<pattern>i2os.</pattern>
+<pattern>i2o </pattern>
+<pattern>i2os </pattern>
 <pattern>paleo1h</pattern>
 <pattern>paleo1a2</pattern>
 <pattern>paleo1e2</pattern>
@@ -2845,9 +2845,9 @@
 <pattern>para1í2</pattern>
 <pattern>para1ó2</pattern>
 <pattern>para1ú2</pattern>
-<pattern>para2is.</pattern>
-<pattern>aí5so.</pattern>
-<pattern>aí5sos.</pattern>
+<pattern>para2is </pattern>
+<pattern>aí5so </pattern>
+<pattern>aí5sos </pattern>
 <pattern>penta1h</pattern>
 <pattern>penta1a2</pattern>
 <pattern>penta1e2</pattern>
@@ -2900,61 +2900,61 @@
 <pattern>poli4andr</pattern>
 <pattern>poli4antea</pattern>
 <pattern>expoli4</pattern>
-<pattern>.pos2t2a2</pattern>
-<pattern>.pos2t2e2</pattern>
-<pattern>.pos2t2i2</pattern>
-<pattern>.pos2t2o2</pattern>
-<pattern>.pos2t2u2</pattern>
-<pattern>.pos2t2á2</pattern>
-<pattern>.pos2t2é2</pattern>
-<pattern>.pos2t2í2</pattern>
-<pattern>.pos2t2ó2</pattern>
-<pattern>.pos2t2ú2</pattern>
-<pattern>.pos3tin</pattern>
-<pattern>.pos3tín</pattern>
-<pattern>pos3ta.</pattern>
-<pattern>pos3tas.</pattern>
-<pattern>s3te.</pattern>
-<pattern>s3tes.</pattern>
-<pattern>s3tal.</pattern>
-<pattern>s3ta3les.</pattern>
-<pattern>s3ti3lla.</pattern>
-<pattern>s3ti3llas.</pattern>
-<pattern>s3ti3llón.</pattern>
-<pattern>s3ti3llones.</pattern>
-<pattern>.pos3tó3ni</pattern>
-<pattern>.pos3terg</pattern>
-<pattern>.pos3te3ri</pattern>
-<pattern>.pos3ti3go</pattern>
-<pattern>.pos3ti3la</pattern>
-<pattern>.pos3ti3ne</pattern>
-<pattern>.pos3ti3za</pattern>
-<pattern>.pos3ti3zo</pattern>
-<pattern>.pos3tu3ra</pattern>
-<pattern>s3tor.</pattern>
-<pattern>s3tora.</pattern>
-<pattern>s3toras.</pattern>
-<pattern>s3tores.</pattern>
-<pattern>.pos3tu3la</pattern>
-<pattern>.pos3tu3lá</pattern>
-<pattern>.pos3tu3le</pattern>
-<pattern>.pos3tu3lé</pattern>
-<pattern>.post3elec</pattern>
-<pattern>.post3impr</pattern>
-<pattern>.post3ind</pattern>
-<pattern>.post3ope</pattern>
-<pattern>.post3rev</pattern>
-<pattern>.pre2a2</pattern>
-<pattern>.pre2e2</pattern>
-<pattern>.pre2i2</pattern>
-<pattern>.pre2o2</pattern>
-<pattern>.pre2u2</pattern>
-<pattern>.pre2h2</pattern>
-<pattern>.pre2á2</pattern>
-<pattern>.pre2é2</pattern>
-<pattern>.pre2í2</pattern>
-<pattern>.pre2ó2</pattern>
-<pattern>.pre2ú2</pattern>
+<pattern> pos2t2a2</pattern>
+<pattern> pos2t2e2</pattern>
+<pattern> pos2t2i2</pattern>
+<pattern> pos2t2o2</pattern>
+<pattern> pos2t2u2</pattern>
+<pattern> pos2t2á2</pattern>
+<pattern> pos2t2é2</pattern>
+<pattern> pos2t2í2</pattern>
+<pattern> pos2t2ó2</pattern>
+<pattern> pos2t2ú2</pattern>
+<pattern> pos3tin</pattern>
+<pattern> pos3tín</pattern>
+<pattern>pos3ta </pattern>
+<pattern>pos3tas </pattern>
+<pattern>s3te </pattern>
+<pattern>s3tes </pattern>
+<pattern>s3tal </pattern>
+<pattern>s3ta3les </pattern>
+<pattern>s3ti3lla </pattern>
+<pattern>s3ti3llas </pattern>
+<pattern>s3ti3llón </pattern>
+<pattern>s3ti3llones </pattern>
+<pattern> pos3tó3ni</pattern>
+<pattern> pos3terg</pattern>
+<pattern> pos3te3ri</pattern>
+<pattern> pos3ti3go</pattern>
+<pattern> pos3ti3la</pattern>
+<pattern> pos3ti3ne</pattern>
+<pattern> pos3ti3za</pattern>
+<pattern> pos3ti3zo</pattern>
+<pattern> pos3tu3ra</pattern>
+<pattern>s3tor </pattern>
+<pattern>s3tora </pattern>
+<pattern>s3toras </pattern>
+<pattern>s3tores </pattern>
+<pattern> pos3tu3la</pattern>
+<pattern> pos3tu3lá</pattern>
+<pattern> pos3tu3le</pattern>
+<pattern> pos3tu3lé</pattern>
+<pattern> post3elec</pattern>
+<pattern> post3impr</pattern>
+<pattern> post3ind</pattern>
+<pattern> post3ope</pattern>
+<pattern> post3rev</pattern>
+<pattern> pre2a2</pattern>
+<pattern> pre2e2</pattern>
+<pattern> pre2i2</pattern>
+<pattern> pre2o2</pattern>
+<pattern> pre2u2</pattern>
+<pattern> pre2h2</pattern>
+<pattern> pre2á2</pattern>
+<pattern> pre2é2</pattern>
+<pattern> pre2í2</pattern>
+<pattern> pre2ó2</pattern>
+<pattern> pre2ú2</pattern>
 <pattern>pre3elij</pattern>
 <pattern>pre3elig</pattern>
 <pattern>pre3exis</pattern>
@@ -2963,17 +2963,17 @@
 <pattern>preo2cúp</pattern>
 <pattern>pre3olí</pattern>
 <pattern>pre3opin</pattern>
-<pattern>.pro2a2</pattern>
-<pattern>.pro2e2</pattern>
-<pattern>.pro2i2</pattern>
-<pattern>.pro2o2</pattern>
-<pattern>.pro2u2</pattern>
-<pattern>.pro2h2</pattern>
-<pattern>.pro2á2</pattern>
-<pattern>.pro2é2</pattern>
-<pattern>.pro2í2</pattern>
-<pattern>.pro2ó2</pattern>
-<pattern>.pro2ú2</pattern>
+<pattern> pro2a2</pattern>
+<pattern> pro2e2</pattern>
+<pattern> pro2i2</pattern>
+<pattern> pro2o2</pattern>
+<pattern> pro2u2</pattern>
+<pattern> pro2h2</pattern>
+<pattern> pro2á2</pattern>
+<pattern> pro2é2</pattern>
+<pattern> pro2í2</pattern>
+<pattern> pro2ó2</pattern>
+<pattern> pro2ú2</pattern>
 <pattern>proto1h</pattern>
 <pattern>proto1a2</pattern>
 <pattern>proto1e2</pattern>
@@ -3007,45 +3007,45 @@
 <pattern>ranco1í2</pattern>
 <pattern>ranco1ó2</pattern>
 <pattern>ranco1ú2</pattern>
-<pattern>.re2a2</pattern>
-<pattern>.re3e4</pattern>
-<pattern>.re2i2</pattern>
-<pattern>.re2o2</pattern>
-<pattern>.re2u2</pattern>
-<pattern>.re2á2</pattern>
-<pattern>.re2é2</pattern>
-<pattern>.re2í2</pattern>
-<pattern>.re2ó2</pattern>
-<pattern>.re2ú2</pattern>
-<pattern>ea3cio.</pattern>
-<pattern>ea3cios.</pattern>
-<pattern>ea3cia.</pattern>
-<pattern>ea3cias.</pattern>
-<pattern>.re3abr</pattern>
-<pattern>.re3ábr</pattern>
-<pattern>.re3afirm</pattern>
-<pattern>.re3afírm</pattern>
-<pattern>.re3ajust</pattern>
-<pattern>.rea3júst</pattern>
-<pattern>.rea3liza</pattern>
-<pattern>.rea3lizá</pattern>
-<pattern>.rea3líza</pattern>
-<pattern>.re3alim</pattern>
-<pattern>.rea3lism</pattern>
-<pattern>.rea3list</pattern>
-<pattern>.re3anim</pattern>
-<pattern>.re3aním</pattern>
-<pattern>.re3aparec</pattern>
-<pattern>.re3ubica</pattern>
-<pattern>.re3ubíca</pattern>
-<pattern>.reu3mati</pattern>
-<pattern>.reu3máti</pattern>
-<pattern>.re3unir</pattern>
-<pattern>.re3unír</pattern>
-<pattern>.re3usar</pattern>
-<pattern>.re3usár</pattern>
-<pattern>.re3utiliz</pattern>
-<pattern>.re3utilíz</pattern>
+<pattern> re2a2</pattern>
+<pattern> re3e4</pattern>
+<pattern> re2i2</pattern>
+<pattern> re2o2</pattern>
+<pattern> re2u2</pattern>
+<pattern> re2á2</pattern>
+<pattern> re2é2</pattern>
+<pattern> re2í2</pattern>
+<pattern> re2ó2</pattern>
+<pattern> re2ú2</pattern>
+<pattern>ea3cio </pattern>
+<pattern>ea3cios </pattern>
+<pattern>ea3cia </pattern>
+<pattern>ea3cias </pattern>
+<pattern> re3abr</pattern>
+<pattern> re3ábr</pattern>
+<pattern> re3afirm</pattern>
+<pattern> re3afírm</pattern>
+<pattern> re3ajust</pattern>
+<pattern> rea3júst</pattern>
+<pattern> rea3liza</pattern>
+<pattern> rea3lizá</pattern>
+<pattern> rea3líza</pattern>
+<pattern> re3alim</pattern>
+<pattern> rea3lism</pattern>
+<pattern> rea3list</pattern>
+<pattern> re3anim</pattern>
+<pattern> re3aním</pattern>
+<pattern> re3aparec</pattern>
+<pattern> re3ubica</pattern>
+<pattern> re3ubíca</pattern>
+<pattern> reu3mati</pattern>
+<pattern> reu3máti</pattern>
+<pattern> re3unir</pattern>
+<pattern> re3unír</pattern>
+<pattern> re3usar</pattern>
+<pattern> re3usár</pattern>
+<pattern> re3utiliz</pattern>
+<pattern> re3utilíz</pattern>
 <pattern>rmano1h</pattern>
 <pattern>rmano1a2</pattern>
 <pattern>rmano1e2</pattern>
@@ -3101,8 +3101,8 @@
 <pattern>semi1í2</pattern>
 <pattern>semi1ó2</pattern>
 <pattern>semi1ú2</pattern>
-<pattern>i2a.</pattern>
-<pattern>i2as.</pattern>
+<pattern>i2a </pattern>
+<pattern>i2as </pattern>
 <pattern>2ótic</pattern>
 <pattern>emi2o2</pattern>
 <pattern>seudo1h</pattern>
@@ -3116,8 +3116,8 @@
 <pattern>seudo1í2</pattern>
 <pattern>seudo1ó2</pattern>
 <pattern>seudo1ú2</pattern>
-<pattern>o2os.</pattern>
-<pattern>.so3a4s</pattern>
+<pattern>o2os </pattern>
+<pattern> so3a4s</pattern>
 <pattern>socio1h</pattern>
 <pattern>socio1a2</pattern>
 <pattern>socio1e2</pattern>
@@ -3129,50 +3129,50 @@
 <pattern>socio1í2</pattern>
 <pattern>socio1ó2</pattern>
 <pattern>socio1ú2</pattern>
-<pattern>a3rio.</pattern>
-<pattern>a3rios.</pattern>
+<pattern>a3rio </pattern>
+<pattern>a3rios </pattern>
 <pattern>3logía</pattern>
-<pattern>4ón.</pattern>
-<pattern>4ones.</pattern>
-<pattern>4i4er.</pattern>
-<pattern>4o2ico.</pattern>
-<pattern>4o2icos.</pattern>
-<pattern>4o2ica.</pattern>
-<pattern>4o2icas.</pattern>
-<pattern>.su2b2a2</pattern>
-<pattern>.su2b2e2</pattern>
-<pattern>.su2b2i2</pattern>
-<pattern>.su2b2o2</pattern>
-<pattern>.su2b2u2</pattern>
-<pattern>.su2b2á2</pattern>
-<pattern>.su2b2é2</pattern>
-<pattern>.su2b2í2</pattern>
-<pattern>.su2b2ó2</pattern>
-<pattern>.su2b2ú2</pattern>
-<pattern>.sub2i3ll</pattern>
-<pattern>.sub2i3mien</pattern>
-<pattern>.sub3índ</pattern>
-<pattern>.sub3ími</pattern>
-<pattern>.su4b3ray</pattern>
-<pattern>.sub3aflue</pattern>
-<pattern>.sub3arr</pattern>
-<pattern>.sub3enten</pattern>
-<pattern>.sub3estim</pattern>
-<pattern>.sub3estím</pattern>
-<pattern>.sub3ofici</pattern>
-<pattern>.sub3urba</pattern>
-<pattern>.sub3alter</pattern>
-<pattern>.sub3insp</pattern>
-<pattern>.su3bién</pattern>
-<pattern>.su3bir</pattern>
-<pattern>.su3bam</pattern>
-<pattern>.su3bordin</pattern>
-<pattern>.su3bordín</pattern>
-<pattern>.sub3acuá</pattern>
-<pattern>.sub3espe</pattern>
-<pattern>.sub3esta</pattern>
-<pattern>.su3burbi</pattern>
-<pattern>.su4b5rein</pattern>
+<pattern>4ón </pattern>
+<pattern>4ones </pattern>
+<pattern>4i4er </pattern>
+<pattern>4o2ico </pattern>
+<pattern>4o2icos </pattern>
+<pattern>4o2ica </pattern>
+<pattern>4o2icas </pattern>
+<pattern> su2b2a2</pattern>
+<pattern> su2b2e2</pattern>
+<pattern> su2b2i2</pattern>
+<pattern> su2b2o2</pattern>
+<pattern> su2b2u2</pattern>
+<pattern> su2b2á2</pattern>
+<pattern> su2b2é2</pattern>
+<pattern> su2b2í2</pattern>
+<pattern> su2b2ó2</pattern>
+<pattern> su2b2ú2</pattern>
+<pattern> sub2i3ll</pattern>
+<pattern> sub2i3mien</pattern>
+<pattern> sub3índ</pattern>
+<pattern> sub3ími</pattern>
+<pattern> su4b3ray</pattern>
+<pattern> sub3aflue</pattern>
+<pattern> sub3arr</pattern>
+<pattern> sub3enten</pattern>
+<pattern> sub3estim</pattern>
+<pattern> sub3estím</pattern>
+<pattern> sub3ofici</pattern>
+<pattern> sub3urba</pattern>
+<pattern> sub3alter</pattern>
+<pattern> sub3insp</pattern>
+<pattern> su3bién</pattern>
+<pattern> su3bir</pattern>
+<pattern> su3bam</pattern>
+<pattern> su3bordin</pattern>
+<pattern> su3bordín</pattern>
+<pattern> sub3acuá</pattern>
+<pattern> sub3espe</pattern>
+<pattern> sub3esta</pattern>
+<pattern> su3burbi</pattern>
+<pattern> su4b5rein</pattern>
 <pattern>supe2r3r</pattern>
 <pattern>supe2r1a2</pattern>
 <pattern>supe2r1e2</pattern>
@@ -3186,20 +3186,20 @@
 <pattern>supe2r1ú2</pattern>
 <pattern>supe3r4a4r</pattern>
 <pattern>supe3r4á4r</pattern>
-<pattern>supe3r4á3vit.</pattern>
-<pattern>supe3r4á3vits.</pattern>
-<pattern>4a3ción.</pattern>
-<pattern>4a3ciones.</pattern>
-<pattern>4e3rior.</pattern>
-<pattern>4e3riores.</pattern>
-<pattern>4e3riora.</pattern>
-<pattern>4e3rioras.</pattern>
-<pattern>4e3riormente.</pattern>
-<pattern>4e3rioridad.</pattern>
-<pattern>4e3rioridades.</pattern>
-<pattern>4e3ra3ble.</pattern>
-<pattern>4e3ra3bles.</pattern>
-<pattern>4e3ra3blemente.</pattern>
+<pattern>supe3r4á3vit </pattern>
+<pattern>supe3r4á3vits </pattern>
+<pattern>4a3ción </pattern>
+<pattern>4a3ciones </pattern>
+<pattern>4e3rior </pattern>
+<pattern>4e3riores </pattern>
+<pattern>4e3riora </pattern>
+<pattern>4e3rioras </pattern>
+<pattern>4e3riormente </pattern>
+<pattern>4e3rioridad </pattern>
+<pattern>4e3rioridades </pattern>
+<pattern>4e3ra3ble </pattern>
+<pattern>4e3ra3bles </pattern>
+<pattern>4e3ra3blemente </pattern>
 <pattern>pe5r4ante</pattern>
 <pattern>perpon5d6r</pattern>
 <pattern>supra1h</pattern>
@@ -3236,8 +3236,8 @@
 <pattern>tele1í2</pattern>
 <pattern>tele1ó2</pattern>
 <pattern>tele1ú2</pattern>
-<pattern>4ósteo.</pattern>
-<pattern>4ósteos.</pattern>
+<pattern>4ósteo </pattern>
+<pattern>4ósteos </pattern>
 <pattern>termo1h</pattern>
 <pattern>termo1a2</pattern>
 <pattern>termo1e2</pattern>
@@ -3282,8 +3282,8 @@
 <pattern>tropo1í2</pattern>
 <pattern>tropo1ó2</pattern>
 <pattern>tropo1ú2</pattern>
-<pattern>poi3de.</pattern>
-<pattern>poi3des.</pattern>
+<pattern>poi3de </pattern>
+<pattern>poi3des </pattern>
 <pattern>ultra1h</pattern>
 <pattern>ultra1a2</pattern>
 <pattern>ultra1e2</pattern>
@@ -3333,73 +3333,73 @@
 <pattern>trans4ubsta</pattern>
 <pattern>ultra4ísmo</pattern>
 <pattern>wa3s4h</pattern>
-<pattern>.bi1anual</pattern>
-<pattern>.bi1aur</pattern>
-<pattern>.bien1and</pattern>
-<pattern>.bien1apa</pattern>
-<pattern>.bien1ave</pattern>
-<pattern>.bien1est</pattern>
-<pattern>.bien1int</pattern>
-<pattern>.bi1ox</pattern>
-<pattern>.bi1ó2x</pattern>
-<pattern>.bi1un</pattern>
-<pattern>.en1aceit</pattern>
-<pattern>.en1aciy</pattern>
-<pattern>.en1aguach</pattern>
-<pattern>.en1aguaz</pattern>
-<pattern>.en1anch</pattern>
-<pattern>.en1apa</pattern>
-<pattern>.en1arb</pattern>
-<pattern>.en1art</pattern>
-<pattern>.en2artr</pattern>
-<pattern>.en1ej</pattern>
-<pattern>.hepta1e</pattern>
-<pattern>.intra1o</pattern>
-<pattern>.intra1u</pattern>
-<pattern>.mal1acon</pattern>
-<pattern>.mal1acos</pattern>
-<pattern>.mala1e</pattern>
-<pattern>.mal1andant</pattern>
-<pattern>.mal1andanz</pattern>
-<pattern>.mal1est</pattern>
-<pattern>.mal1int</pattern>
-<pattern>.pa4n1a4meri</pattern>
-<pattern>.pa4n1europ</pattern>
-<pattern>.pa4n1afri</pattern>
-<pattern>.pa4n1ópti</pattern>
+<pattern> bi1anual</pattern>
+<pattern> bi1aur</pattern>
+<pattern> bien1and</pattern>
+<pattern> bien1apa</pattern>
+<pattern> bien1ave</pattern>
+<pattern> bien1est</pattern>
+<pattern> bien1int</pattern>
+<pattern> bi1ox</pattern>
+<pattern> bi1ó2x</pattern>
+<pattern> bi1un</pattern>
+<pattern> en1aceit</pattern>
+<pattern> en1aciy</pattern>
+<pattern> en1aguach</pattern>
+<pattern> en1aguaz</pattern>
+<pattern> en1anch</pattern>
+<pattern> en1apa</pattern>
+<pattern> en1arb</pattern>
+<pattern> en1art</pattern>
+<pattern> en2artr</pattern>
+<pattern> en1ej</pattern>
+<pattern> hepta1e</pattern>
+<pattern> intra1o</pattern>
+<pattern> intra1u</pattern>
+<pattern> mal1acon</pattern>
+<pattern> mal1acos</pattern>
+<pattern> mala1e</pattern>
+<pattern> mal1andant</pattern>
+<pattern> mal1andanz</pattern>
+<pattern> mal1est</pattern>
+<pattern> mal1int</pattern>
+<pattern> pa4n1a4meri</pattern>
+<pattern> pa4n1europ</pattern>
+<pattern> pa4n1afri</pattern>
+<pattern> pa4n1ópti</pattern>
 <pattern>3p2sic</pattern>
 <pattern>3p2siq</pattern>
-<pattern>.re3a2eg</pattern>
-<pattern>.re3a2q</pattern>
-<pattern>.re3a2z</pattern>
-<pattern>.re3a2grup</pattern>
-<pattern>.re3i2m</pattern>
-<pattern>.re3inc</pattern>
-<pattern>.re3ing</pattern>
-<pattern>.re3ins</pattern>
-<pattern>.re3int</pattern>
-<pattern>.re3o2b</pattern>
-<pattern>.re1oc</pattern>
-<pattern>.re1oj</pattern>
-<pattern>.re3orga</pattern>
-<pattern>.re1unt</pattern>
-<pattern>.retro1a</pattern>
-<pattern>.su2d1a2fr</pattern>
-<pattern>.su2d1a2me</pattern>
-<pattern>.su2d1est</pattern>
+<pattern> re3a2eg</pattern>
+<pattern> re3a2q</pattern>
+<pattern> re3a2z</pattern>
+<pattern> re3a2grup</pattern>
+<pattern> re3i2m</pattern>
+<pattern> re3inc</pattern>
+<pattern> re3ing</pattern>
+<pattern> re3ins</pattern>
+<pattern> re3int</pattern>
+<pattern> re3o2b</pattern>
+<pattern> re1oc</pattern>
+<pattern> re1oj</pattern>
+<pattern> re3orga</pattern>
+<pattern> re1unt</pattern>
+<pattern> retro1a</pattern>
+<pattern> su2d1a2fr</pattern>
+<pattern> su2d1a2me</pattern>
+<pattern> su2d1est</pattern>
 <pattern>su4d3oes</pattern>
-<pattern>.sur1a2me</pattern>
-<pattern>.sur1est</pattern>
-<pattern>.sur1oes</pattern>
-<pattern>.tele1imp</pattern>
-<pattern>.tele1obj</pattern>
-<pattern>.tra2s1a</pattern>
-<pattern>.tra2s1o</pattern>
-<pattern>.tra2s2oñ</pattern>
-<pattern>.tran2s1alp</pattern>
-<pattern>.tran2s1and</pattern>
-<pattern>.tran2s1atl</pattern>
-<pattern>.tran2s1oce</pattern>
-<pattern>.tran2s1ur</pattern>
-<pattern>.tri1ó2x</pattern>
+<pattern> sur1a2me</pattern>
+<pattern> sur1est</pattern>
+<pattern> sur1oes</pattern>
+<pattern> tele1imp</pattern>
+<pattern> tele1obj</pattern>
+<pattern> tra2s1a</pattern>
+<pattern> tra2s1o</pattern>
+<pattern> tra2s2oñ</pattern>
+<pattern> tran2s1alp</pattern>
+<pattern> tran2s1and</pattern>
+<pattern> tran2s1atl</pattern>
+<pattern> tran2s1oce</pattern>
+<pattern> tran2s1ur</pattern>
+<pattern> tri1ó2x</pattern>
 </HyphenationDescription>


### PR DESCRIPTION
CRengine doesn't respect the dot(`.`) in the dictionary. Instead of a dot(`.`) we should use space(` `).
After this change hyphenation in Spanish and Dutch should works better.