### PR TITLE
Allow setting a bias to fonts for them to be prefered in CalcMatch algorithm

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -316,7 +316,7 @@ public:
     /// garbage collector frees unused fonts
     virtual void gc() = 0;
     /// returns most similar font
-    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId = -1) = 0;
+    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId = -1, bool useBias=false) = 0;
     /// set fallback font face (returns true if specified font is found)
     virtual bool SetFallbackFontFace( lString8 face ) { CR_UNUSED(face); return false; }
     /// get fallback font face (returns empty string if no fallback font is set)
@@ -375,6 +375,8 @@ public:
 
     virtual bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic){ return false;}
 
+    /// set as preferred font with the given bias to add in CalcMatch algorithm
+    virtual bool SetAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias=true ) { CR_UNUSED(face); return false; }
 };
 
 class LVBaseFont : public LVFont

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -308,6 +308,7 @@ private:
     // for document font: _documentId, _buf, _name
     int               _documentId;
     LVByteArrayRef    _buf;
+    int               _bias;
 public:
     LVFontDef(const lString8 & name, int size, int weight, int italic, css_font_family_t family, const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
     : _size(size)
@@ -319,6 +320,7 @@ public:
     , _index(index)
     , _documentId(documentId)
     , _buf(buf)
+    , _bias(0)
     {
     }
     LVFontDef(const LVFontDef & def)
@@ -331,6 +333,7 @@ public:
     , _index(def._index)
     , _documentId(def._documentId)
     , _buf(def._buf)
+    , _bias(def._bias)
     {
     }
 
@@ -374,11 +377,22 @@ public:
     void setBuf(LVByteArrayRef buf) { _buf = buf; }
     ~LVFontDef() {}
     /// calculates difference between two fonts
-    int CalcMatch( const LVFontDef & def ) const;
+    int CalcMatch( const LVFontDef & def, bool useBias ) const;
     /// difference between fonts for duplicates search
     int CalcDuplicateMatch( const LVFontDef & def ) const;
     /// calc match for fallback font search
     int CalcFallbackMatch( lString8 face, int size ) const;
+
+    bool setBiasIfNameMatch( lString8 facename, int bias, bool clearIfNot=true ) {
+        if (_typeface.compare(facename) == 0) {
+            _bias = bias;
+            return true;
+        }
+        if (clearIfNot) {
+            _bias = 0; // reset bias for other fonts
+        }
+        return false;
+    }
 };
 
 /// font cache item
@@ -408,8 +422,9 @@ public:
     void removeDocumentFonts(int documentId);
     int  length() { return _registered_list.length(); }
     void addInstance( const LVFontDef * def, LVFontRef ref );
+    bool setAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias );
     LVPtrVector< LVFontCacheItem > * getInstances() { return &_instance_list; }
-    LVFontCacheItem * find( const LVFontDef * def );
+    LVFontCacheItem * find( const LVFontDef * def, bool useBias=false );
     LVFontCacheItem * findFallback( lString8 face, int size );
     LVFontCacheItem * findDuplicate( const LVFontDef * def );
     LVFontCacheItem * findDocumentFontDuplicate(int documentId, lString8 name);
@@ -1859,6 +1874,13 @@ public:
         return !_fallbackFontFace.empty();
     }
 
+    /// set as preferred font with the given bias to add in CalcMatch algorithm
+    virtual bool SetAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias ) {
+        FONT_MAN_GUARD
+        return _cache.setAsPreferredFontWithBias(face, bias, clearOthersBias);
+    }
+
+
     /// get fallback font face (returns empty string if no fallback font is set)
     virtual lString8 GetFallbackFontFace() { return _fallbackFontFace; }
 
@@ -2325,7 +2347,7 @@ public:
             return false;
         }
 }
-    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId)
+    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId, bool useBias=false)
     {
         FONT_MAN_GUARD
     #if (DEBUG_FONT_MAN==1)
@@ -2353,7 +2375,7 @@ public:
                 weight>400?"bold":"",
                 italic?"italic":"" );
     #endif
-        LVFontCacheItem * item = _cache.find( &def );
+        LVFontCacheItem * item = _cache.find( &def, useBias );
     #if (DEBUG_FONT_MAN==1)
         if ( item && _log ) { //_log &&
             fprintf(_log, "   found item: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s, weightDelta=%d) FontRef=%d\n",
@@ -2366,6 +2388,7 @@ public:
         bool italicize = false;
 
         LVFontDef newDef(*item->getDef());
+        // printf("  got %s\n", newDef.getTypeFace().c_str());
 
         if (!item->getFont().isNull())
         {
@@ -3159,7 +3182,7 @@ int LVFontDef::CalcDuplicateMatch( const LVFontDef & def ) const
     return size_match && weight_match && italic_match && family_match && typeface_match;
 }
 
-int LVFontDef::CalcMatch( const LVFontDef & def ) const
+int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
 {
     if (_documentId != -1 && _documentId != def._documentId)
         return 0;
@@ -3179,12 +3202,17 @@ int LVFontDef::CalcMatch( const LVFontDef & def ) const
         ? 256
         : ( (_family==css_ff_monospace)==(def._family==css_ff_monospace) ? 64 : 0 );
     int typeface_match = (_typeface == def._typeface) ? 256 : 0;
-    return
+    int bias = useBias ? _bias : 0;
+    int score = bias
         + (size_match     * 100)
         + (weight_match   * 5)
         + (italic_match   * 5)
         + (family_match   * 100)
         + (typeface_match * 1000);
+//    printf("### %s (%d) vs %s (%d): size=%d weight=%d italic=%d family=%d typeface=%d bias=%d => %d\n",
+//        _typeface.c_str(), _family, def._typeface.c_str(), def._family,
+//        size_match, weight_match, italic_match, family_match, typeface_match, _bias, score);
+    return score;
 }
 
 int LVFontDef::CalcFallbackMatch( lString8 face, int size ) const
@@ -3402,7 +3430,7 @@ LVFontCacheItem * LVFontCache::findFallback( lString8 face, int size )
     return _registered_list[best_index];
 }
 
-LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef )
+LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef, bool useBias )
 {
     int best_index = -1;
     int best_match = -1;
@@ -3420,7 +3448,7 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef )
             def.setTypeFace(lString8::empty_str);
         for (i=0; i<_instance_list.length(); i++)
         {
-            int match = _instance_list[i]->_def.CalcMatch( def );
+            int match = _instance_list[i]->_def.CalcMatch( def, useBias );
             if (match > best_instance_match)
             {
                 best_instance_match = match;
@@ -3429,7 +3457,7 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef )
         }
         for (i=0; i<_registered_list.length(); i++)
         {
-            int match = _registered_list[i]->_def.CalcMatch( def );
+            int match = _registered_list[i]->_def.CalcMatch( def, useBias );
             if (match > best_match)
             {
                 best_match = match;
@@ -3442,6 +3470,23 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef )
     if (best_instance_match >= best_match)
         return _instance_list[best_instance_index];
     return _registered_list[best_index];
+}
+
+bool LVFontCache::setAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias )
+{
+    bool found = false;
+    int i;
+    for (i=0; i<_instance_list.length(); i++)
+    {
+        if (_instance_list[i]->_def.setBiasIfNameMatch( face, bias, clearOthersBias ))
+            found = true;
+    }
+    for (i=0; i<_registered_list.length(); i++)
+    {
+        if (_registered_list[i]->_def.setBiasIfNameMatch( face, bias, clearOthersBias ))
+            found = true;
+    }
+    return found;
 }
 
 void LVFontCache::addInstance( const LVFontDef * def, LVFontRef ref )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -912,13 +912,14 @@ LVFontRef getFont(css_style_rec_t * style, int documentId)
     fw += rend_font_embolden;
     if ( fw>900 )
         fw = 900;
+    // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());
     LVFontRef fnt = fontMan->GetFont(
         sz,
         fw,
         style->font_style==css_fs_italic,
         style->font_family,
         lString8(style->font_name.c_str()),
-        documentId);
+        documentId, true); // useBias=true, so that our preferred font gets used
     //fnt = LVCreateFontTransform( fnt, LVFONT_TRANSFORM_EMBOLDEN );
     return fnt;
 }


### PR DESCRIPTION
Will be used from koreader's lua side to make the default font used when renderer request a font when dealing with the `font-family` css style: `serif`, `sans-serif`... or font not found (and so, when Embedded Fonts are disabled).
Without that, the first default font set will always be used: if an other default font is set, it is used only for text that has no font-family style.
This should fix the behaviour described at https://github.com/koreader/koreader/pull/3149#issuecomment-326002177.

Details:
when rendering styles, when meeting a "font-family:" style, the renderer calls `GetFont()` with characteristics from the style stack (italic, size, weigth...) to get the font to use.
This `GetFont()` loops thru all the available fonts, compute a score number about how well that font matches the requested characteristics, and the one with the highest score is returned.
When getting no font typeface name (ie: when font-family: serif / sans-serif, or a font name that is not there if Embedded Fonts are disabled), most of the fonts will get the same score, and the first one will be returned.
So, when in a koreader session, changing multiple times the default font, the current value would not be seen on such texts with font-family, while it would be seen on standard text.
This can be verified with this sample file: [test_css_font_family.html.txt](https://github.com/koreader/crengine/files/1269922/test_css_font_family.html.txt) : the 1st line and the 4 following should have the same new default font.

We can change this behaviour by giving a (new) bias properties to our new default font, and using this bias in the score computation.
(I would have used the word _weight_ instead of _bias_, but _weight_ already has a meaning for fonts :) so I introduced the word _bias_)

This should be followed by a proxy fonction in cre.cpp, and should be used from document/credocument.lua this way:

```lua
function CreDocument:setFontFace(new_font_face)
    if new_font_face then
        logger.dbg("CreDocument: set font face", new_font_face)
        self._document:setStringProperty("font.face.default", new_font_face)

        -- The following makes FontManager prefers this font in its
        -- match algorithm, with the bias given (applies
        -- only to rendering of elements with css font-family)
        -- see: lvfntman.cpp LVFontDef::CalcMatch() for the calculation.
        -- It will compute a bias/weight for each font, and add:
        -- ignorable, because any font will get them :
        --   + 25600 if sizes matches
        --   +  1280 if weights matches
        --   +  1280 if italic matches
        -- interesting:
        --   + 25600 if standard font family matches (static const char * css_ff_names[] =
        --     "inherit", "serif", "sans-serif", "cursive", "fantasy", "monospace")
        --     (note that crengine registers all fonts as "sans-serif", except if
        --     their name is "Times" or "Times New Roman")
        --   +  6400 if they don't and none are monospace (ie:serif vs sans-serif, prefer
        --           a sans-serif to a monospace if looking for a serif)
        --   +256000 if font names match
        -- So, here, we can use:
        --      +1: uses existing real font-family, but use our font for
        --          font-family: serif, sans-serif, and fonts not found
        --  +25601: uses existing real font-family, but use
        --          our font even for font-family: monospace
        -- +256001: prefer our font to any existing font-family
        self._document:setAsPreferredFontWithBias(new_font_face, 1)
    end
end
```

We should then be able to tweak this algorithm from koreader's side only.
This patch should have no effect as long as no `self._document:setAsPreferredFontWithBias()` is made, so if problems arise, we can just comment that on koreader's side.
