### PR TITLE
Keep previous fallback font if new fallback font fails

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1849,11 +1849,14 @@ public:
     virtual bool SetFallbackFontFace( lString8 face ) {
         FONT_MAN_GUARD
         if ( face!=_fallbackFontFace ) {
-            _cache.clearFallbackFonts();
             CRLog::trace("Looking for fallback font %s", face.c_str());
             LVFontCacheItem * item = _cache.findFallback( face, -1 );
-            if ( !item )
+            if ( !item ) {
                 face.clear();
+                // Don't reset previous fallback if this one is not found/valid
+                return false;
+            }
+            _cache.clearFallbackFonts();
             _fallbackFontFace = face;
         }
         return !_fallbackFontFace.empty();


### PR DESCRIPTION
Avoid some infinite loop somewhere (couldn't track where) when no fallback font is defined.
Droid Sans Mono is such a font that is not accepted as a fallback (couldn't see why...).
Closes https://github.com/koreader/koreader/issues/3152

edit: for reference, as this may happen again in other contexts:
One thing that gets visited by this infinite loop is:
https://github.com/koreader/crengine/blob/e2dc17c4721f52077932b1948a44022e403ed759/crengine/src/lvfntman.cpp#L970-L980
It should return the replacement char in the original font, but it returns false when this replacement char is not found either in the original font. So there must be somewhere some place that does not like getting `false` and loop...
An option to fix this would be, instead of returning false, if the def_char is not found, try at a last resort to return the glyph for a space  `glyph_index = getCharIndex( code, L' ' );` . There must be a space in all fonts made in history :)
