### PR TITLE
(epub) Return Series Number as string

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -816,7 +816,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             else if (name == "calibre:series")
                 m_doc_props->setString(DOC_PROP_SERIES_NAME, content );
             else if (name == "calibre:series_index")
-                m_doc_props->setInt(DOC_PROP_SERIES_NUMBER, content.atoi() );
+                m_doc_props->setString(DOC_PROP_SERIES_NUMBER, content );
         }
 
         // items


### PR DESCRIPTION
Series number is stored internally as string, but there was a unnecessary integer conversion. This allows koreader to get `The super serie #2.5` (see https://github.com/koreader/koreader/issues/3347)
This is just for epub.
There is another part of code that may do it for fb2 (?), but as it's a bit more complicated and I have no fb2 to test with, I prefer not to touch it.
https://github.com/koreader/crengine/blob/8eefe54e40e4c3f56392e7d8ee2fe43848d53256/crengine/src/lvtinydom.cpp#L5629-L5640