### PR TITLE
(epub) decode XML charref in Series metadata

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -813,10 +813,14 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             lString16 content = item->getAttributeValue("content");
             if (name == "cover")
                 coverId = content;
-            else if (name == "calibre:series")
-                m_doc_props->setString(DOC_PROP_SERIES_NAME, content );
-            else if (name == "calibre:series_index")
-                m_doc_props->setString(DOC_PROP_SERIES_NUMBER, content );
+            else if (name == "calibre:series") {
+                PreProcessXmlString(content, 0);
+                m_doc_props->setString(DOC_PROP_SERIES_NAME, content);
+            }
+            else if (name == "calibre:series_index") {
+                PreProcessXmlString(content, 0);
+                m_doc_props->setString(DOC_PROP_SERIES_NUMBER, content);
+            }
         }
 
         // items


### PR DESCRIPTION
Only needed for Series, whose text is put as xml element attributes by calibre (other metadata are all in text elements and are already correctly decoded). (see koreader/koreader#3347)
Sample epub content;opf file:
```
<meta name="calibre:series" content="les &toto; g&ezauts blah &amp; les couleurs"/>
<meta name="calibre:series_index" content="5.5"/>
<meta name="calibre:title_sort" content="Il a vu rouge"/>
<dc:description>&lt;div style="text-align: justify;"&gt;Dans ...&lt;/div&gt;</dc:description>
<dc:title>Il a vu rouge &amp; noir</dc:title>
<dc:subject>Policier</dc:subject>
<dc:subject>Rouge &amp; noir</dc:subject>
```
