### PR TITLE
cre:findText(): fix some coding errors

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1653,7 +1653,7 @@ public:
     ldomNode * getNearestCommonParent();
 
     /// searches for specified text inside range
-    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, bool checkMaxFromStart = false );
+    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1, bool checkMaxFromStart = false );
 };
 
 class ldomMarkedText
@@ -2113,7 +2113,7 @@ public:
     /// get rendered block cache object
     CVRendBlockCache & getRendBlockCache() { return _renderedBlockCache; }
 
-    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight );
+    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1 );
 #endif
 };
 


### PR DESCRIPTION
See details in https://github.com/koreader/koreader/pull/3656 and https://github.com/koreader/koreader-base/pull/595.

Fix a few coding errors (probably from original author when copy'and'pasting the forward section into a reverse section, and forgetting to replace/update a few things - and some > vs >=), which would result in:
- reverse search: `<span>1234stuff56789012345</span>` : `stuff` was not found because reverse lookup stopped at text[5] (5 being the length of `stuff`)
- reverse search: `<span>stuff123456789012345</span>` : `stuff` was not found because reverse lookup stopped at text[1] (once previous was fixed)
- forward search: `<span>123456789012345stuff</span>` : `stuff` was not found because forward lookup stopped at text[-1]

Also, in reverse code, a `_start` (that should be `_end`) caused that only the first node (so, the last in prev page) was searched for for pattern. All the nodes before it still on displayed page were not highlighted.

Also add an optional parameter `maxHeightCheckStartY` to `findText()`, so it starts accounting for `maxHeight` only when a result whose Y is above/below that value (depend on search direction).
It will allow cre.cpp to find an occurence in current page, but if no occurence on the next 2 pages, to still continue search for pattern in the next pages, so we do not stay stuck on the current page.