### PR TITLE
cre:findText(): fix my coding errors

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6070,7 +6070,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
                 txt.lowercase();
 
             while ( ::findTextRev( txt, offs, pattern ) ) {
-                if ( !words.length() && maxHeight>0 ) {
+                if ( firstFoundTextY==-1 && maxHeight>0 ) {
                     ldomXPointer p( _end.getNode(), offs );
                     int currentTextY = p.toPoint().y;
                     if (maxHeightCheckStartY == -1 || currentTextY <= maxHeightCheckStartY)
@@ -6111,7 +6111,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
                 txt.lowercase();
 
             while ( ::findText( txt, offs, pattern ) ) {
-                if ( !words.length() && maxHeight>0 ) {
+                if ( firstFoundTextY==-1 && maxHeight>0 ) {
                     ldomXPointer p( _start.getNode(), offs );
                     int currentTextY = p.toPoint().y;
                     if (checkMaxFromStart) {


### PR DESCRIPTION
Follow up to #94: findText() was not stopping at maxHeight, and was searching until (and returning results from) end of document.
(We may now accumulate words while not yet setting `firstFoundTextY` - we wait till `maxHeightCheckStartY` reached - so the condition needed to be changed as a condition on _firstFoundTextY not yet set_ instead of _no word found_).