### PR TITLE
Add getHRef(a_xpointer) methods

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1325,6 +1325,8 @@ public:
     }
     /// returns href attribute of <A> element, null string if not found
     lString16 getHRef();
+    /// returns href attribute of <A> element, plus xpointer of <A> element itself
+    lString16 getHRef(ldomXPointer & a_xpointer);
 	/// create a copy of pointer data
 	ldomXPointer * clone()
 	{
@@ -1641,6 +1643,8 @@ public:
     void getRangeWords( LVArray<ldomWord> & list );
     /// returns href attribute of <A> element, null string if not found
     lString16 getHRef();
+    /// returns href attribute of <A> element, plus xpointer of <A> element itself
+    lString16 getHRef(ldomXPointer & a_xpointer);
     /// sets range to nearest word bounds, returns true if success
     static bool getWordRange( ldomXRange & range, ldomXPointer & p );
     /// run callback for each node in range

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7548,8 +7548,8 @@ lString16 ldomXRange::getRangeText( lChar16 blockDelimiter, int maxTextLen )
     return callback.getText();
 }
 
-/// returns href attribute of <A> element, null string if not found
-lString16 ldomXPointer::getHRef()
+/// returns href attribute of <A> element, plus xpointer of <A> element itself
+lString16 ldomXPointer::getHRef(ldomXPointer & a_xpointer)
 {
     if ( isNull() )
         return lString16::empty_str;
@@ -7560,12 +7560,28 @@ lString16 ldomXPointer::getHRef()
         node = node->getParentNode();
     if ( !node )
         return lString16::empty_str;
+    a_xpointer.setNode(node);
+    a_xpointer.setOffset(0);
     lString16 ref = node->getAttributeValue( LXML_NS_ANY, attr_href );
     if (!ref.empty() && ref[0] != '#')
         ref = DecodeHTMLUrlString(ref);
     return ref;
 }
 
+/// returns href attribute of <A> element, null string if not found
+lString16 ldomXPointer::getHRef()
+{
+    ldomXPointer unused_a_xpointer;
+    return getHRef(unused_a_xpointer);
+}
+
+/// returns href attribute of <A> element, plus xpointer of <A> element itself
+lString16 ldomXRange::getHRef(ldomXPointer & a_xpointer)
+{
+    if ( isNull() )
+        return lString16::empty_str;
+    return _start.getHRef(a_xpointer);
+}
 
 /// returns href attribute of <A> element, null string if not found
 lString16 ldomXRange::getHRef()


### PR DESCRIPTION
To get the accurate xpointer to the `<A>` elements in cre.cpp's getLinkFromPosition() and getPageLinks().

I need more precise xpointers for https://github.com/koreader/koreader-base/pull/597.
Because of some bugs in crengine I can't pinpoint (yet), it happens, mostly in the same complex epub (some wikipedia) that are already messed up (tables missing), that the xpointer returned (by https://github.com/koreader/koreader-base/pull/597, but also by the methods this PR adds) is wrong, and points to some other elements (some other `<a>` only?) in the same `<p>`. I don't want to use it as it may be on previous page, and would make things worse.
These new methods will allow verifying the quality of the a_xpointer, simply by getting its position and calling getHRef again on it: if the a_xpointer is the same, it is valid. If not, it is wrong.