### PR TITLE
Allow toggling cache data compression at run time

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2400,4 +2400,7 @@ void runTinyDomUnitTests();
 /// pass true to enable CRC check for
 void enableCacheFileContentsValidation(bool enable);
 
+/// pass true to not compress data in cache file
+void doNotCompressCachedData(bool enable);
+
 #endif

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2400,7 +2400,7 @@ void runTinyDomUnitTests();
 /// pass true to enable CRC check for
 void enableCacheFileContentsValidation(bool enable);
 
-/// pass true to not compress data in cache file
-void doNotCompressCachedData(bool enable);
+/// pass false to not compress data in cache files
+void compressCachedData(bool enable);
 
 #endif

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -20,7 +20,7 @@
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
 // Note: keep this above 1, toggling between compression and no-compression
-// can be done at run time by calling doNotCompressCachedData(bool)
+// can be done at run time by calling compressCachedData(false)
 #define DOC_DATA_COMPRESSION_LEVEL 1 // 0, 1, 3 (0=no compression)
 #endif
 
@@ -98,17 +98,13 @@
 #define FONT_HASH_TABLE_SIZE      256
 
 
-static const char CACHE_FILE_MAGIC[] = "CoolReader 3 Cache"
+static const char COMPRESSED_CACHE_FILE_MAGIC[] = "CoolReader 3 Cache"
                                        " File v" CACHE_FILE_FORMAT_VERSION ": "
                                        "c0"
-#if DOC_DATA_COMPRESSION_LEVEL==0
-                                       "m0"
-#else
                                        "m1"
-#endif
                                         "\n";
 
-static const char CACHE_FILE_WITH_UNCOMPRESSED_DATA_MAGIC[] = "CoolReader 3 Cache"
+static const char UNCOMPRESSED_CACHE_FILE_MAGIC[] = "CoolReader 3 Cache"
                                        " File v" CACHE_FILE_FORMAT_VERSION ": "
                                        "c0"
                                        "m0"
@@ -159,9 +155,11 @@ enum CacheFileBlockType {
 #define USE_PERSISTENT_TEXT 1
 
 
-static bool _doNotCompressCachedData = false;
-void doNotCompressCachedData(bool enable) {
-	_doNotCompressCachedData = enable;
+// default is to compress to use smaller cache files (but slower rendering
+// and page turns with big documents)
+static bool _compressCachedData = true;
+void compressCachedData(bool enable) {
+	_compressCachedData = enable;
 }
 
 static bool _enableCacheFileContentsValidation = (bool)ENABLE_CACHE_FILE_CONTENTS_VALIDATION;
@@ -376,7 +374,7 @@ struct SimpleCacheFileHeader
     lUInt32 _dirty;
     SimpleCacheFileHeader( lUInt32 dirtyFlag ) {
         memset( _magic, 0, sizeof(_magic));
-        memcpy( _magic, _doNotCompressCachedData ? CACHE_FILE_WITH_UNCOMPRESSED_DATA_MAGIC : CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE );
+        memcpy( _magic, _compressCachedData ? COMPRESSED_CACHE_FILE_MAGIC : UNCOMPRESSED_CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE );
         _dirty = dirtyFlag;
     }
 };
@@ -388,7 +386,7 @@ struct CacheFileHeader : public SimpleCacheFileHeader
     // duplicate of one of index records which contains
     bool validate()
     {
-        if (memcmp(_magic, _doNotCompressCachedData ? CACHE_FILE_WITH_UNCOMPRESSED_DATA_MAGIC : CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE) != 0) {
+        if (memcmp(_magic, _compressCachedData ? COMPRESSED_CACHE_FILE_MAGIC : UNCOMPRESSED_CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE) != 0) {
             CRLog::error("CacheFileHeader::validate: magic doesn't match");
             return false;
         }
@@ -899,10 +897,7 @@ bool CacheFile::write( lUInt16 type, lUInt16 dataIndex, const lUInt8 * buf, int 
 
     lUInt32 uncompressedSize = 0;
     lUInt64 newpackedhash = newhash;
-#if DOC_DATA_COMPRESSION_LEVEL==0
-    compress = false;
-#else
-    if (_doNotCompressCachedData)
+    if (!_compressCachedData)
         compress = false;
     if ( compress ) {
         lUInt8 * dstbuf = NULL;
@@ -919,7 +914,6 @@ bool CacheFile::write( lUInt16 type, lUInt16 dataIndex, const lUInt8 * buf, int 
 #endif
         }
     }
-#endif
 
     CacheFileItem * block = NULL;
     if ( existingblock && existingblock->_dataSize>=size ) {
@@ -967,11 +961,9 @@ bool CacheFile::write( lUInt16 type, lUInt16 dataIndex, const lUInt8 * buf, int 
     block->_packedHash = newpackedhash;
     block->_uncompressedSize = uncompressedSize;
 
-#if DOC_DATA_COMPRESSION_LEVEL!=0
     if ( compress ) {
         free( (void*)buf );
     }
-#endif
     _indexChanged = true;
 
     //CRLog::error("CacheFile::write: block %d:%d (pos %ds, size %ds) is written (crc=%08x)", type, dataIndex, (int)block->_blockFilePos/_sectorSize, (int)(size+_sectorSize-1)/_sectorSize, block->_dataCRC);
@@ -2589,7 +2581,7 @@ bool ldomPack( const lUInt8 * buf, int bufsize, lUInt8 * &dstbuf, lUInt32 & dsts
     z.zalloc = Z_NULL;
     z.zfree = Z_NULL;
     z.opaque = Z_NULL;
-    ret = deflateInit( &z, _doNotCompressCachedData ? 0 : DOC_DATA_COMPRESSION_LEVEL );
+    ret = deflateInit( &z, DOC_DATA_COMPRESSION_LEVEL );
     if ( ret != Z_OK )
         return false;
     z.avail_in = bufsize;


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/3261#issuecomment-348710821 for why not compressing data saved in cache can be a good thing (speedup of many things, but uses more disk space).

It had to be specified at compile time with:
https://github.com/koreader/crengine/blob/6e37d80dd638211c35e7ed9892e476aaacc5a9a1/crengine/src/lvtinydom.cpp#L20-L23
but we will now be able to have the same effect as it being 0 by calling at run time, from cre.cpp: `compressCachedData(false)`.

Some updated numbers (with the same book as in https://github.com/koreader/koreader/issues/3261#issuecomment-348710821 - dunno why I get worse times today, may be I had a non-debug emulator build at the time...)

compression| cache before | load time | render time | close time | page change time| resulting cache size
---- | ---------------- | -------------------------- | ---------------- | ---------------- | ---------------- | ----------------
yes | no cache yet | 25 s | 47 s | 20 s | 1.5 s | 22 Mb
yes | existing cache | 2 s | 60 s | 1 s | 1.5 s | 22 Mb
no | no cache yet | 23 s | 28 s | 3 s | 1 s | 62 Mb
no | existing cache | 2 s | 28 s | 1 s | 1 s | 62 Mb

I did not really measure the "page change time", but one gets the feeling of it being really more responsive when no compression.
KOReader mem usage is nearly the same after startup and a few page changes at around 130M.

(I checked that, before this PR patch, and after, the above results for compression=yes are the same, so the added checks for `_compressCachedData` are negligeable).
As the magic headers are different, crengine deals itself with cleaning and rebuilding a cache file. Of course, we better not change it when a book is currently opened, but we can set it at start time.

Will be followed by this patch to cre.cpp:
```c
 static int initCache(lua_State *L) {
     const char *cache_path = luaL_checkstring(L, 1);
     int cache_size = luaL_checkint(L, 2);
+    bool compress_cached_data = true;
+    if (lua_isboolean(L, 3)) {
+        compress_cached_data = lua_toboolean(L, 3);
+    }
+
+    // Setting this to false uses more disk space for cache,
+    // but speed up rendering and page turns quite a bit
+    compressCachedData(compress_cached_data);

     ldomDocCache::init(lString16(cache_path), cache_size);

    return 0;
}
```
Then, we can simply use in credocument.lua:
```lua
function CreDocument:cacheInit()
    -- remove legacy cr3cache directory
    if lfs.attributes("./cr3cache", "mode") == "directory" then
        os.execute("rm -r ./cr3cache")
    end
-    cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32)
+    cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32, G_reader_settings:nilOrTrue("cre_compress_cached_data"))
end
```
So those interested can test how it does on our devices by adding to their settings.reader.lua:
`["cre_compress_cached_data"] = false,`

