### PR TITLE
Cache re-use fix, warnings, and tunable

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -246,6 +246,7 @@ protected:
     int _maxUncompressedSize;
     int _chunkSize;
     char _type;       /// type, to show in log
+    bool _maxSizeReachedWarned;
     ldomTextStorageChunk * getChunk( lUInt32 address );
 public:
     /// type
@@ -1967,6 +1968,8 @@ private:
     int _page_height;
     int _page_width;
     bool _rendered;
+    bool _just_rendered_from_cache;
+    bool _toc_from_cache_valid;
     ldomXRangeList _selections;
 #endif
 
@@ -2028,6 +2031,8 @@ public:
 
     /// returns pointer to TOC root node
     LVTocItem * getToc() { return &m_toc; }
+
+    bool isTocFromCacheValid() { return _toc_from_cache_valid; }
 
 #if BUILD_LITE!=1
     /// save document formatting parameters after render
@@ -2402,5 +2407,9 @@ void enableCacheFileContentsValidation(bool enable);
 
 /// pass false to not compress data in cache files
 void compressCachedData(bool enable);
+
+/// increase the 4 hardcoded TEXT_CACHE_UNPACKED_SPACE, ELEM_CACHE_UNPACKED_SPACE,
+// RECT_CACHE_UNPACKED_SPACE and STYLE_CACHE_UNPACKED_SPACE by this factor
+void setStorageMaxUncompressedSizeFactor(float factor);
 
 #endif

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -759,7 +759,10 @@ void dumpSection(ldomNode * elem) {
 LVTocItem * LVDocView::getToc() {
 	if (!m_doc)
 		return NULL;
-	updatePageNumbers(m_doc->getToc());
+        if (!m_doc->isTocFromCacheValid())
+            // Avoid expensive calls to getXPointer() when the toc items' _path
+            // and _page are available and valid when just loaded from cache
+            updatePageNumbers(m_doc->getToc());
 	return m_doc->getToc();
 }
 

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -13,6 +13,7 @@
 
 #include "../include/lvstyles.h"
 
+// #include <stdio.h>
 
 //DEFINE_NULL_REF( css_style_rec_t )
 
@@ -21,9 +22,15 @@ lUInt32 calcHash(font_ref_t & f)
 {
     if ( !f )
         return 14321;
+    // printf("family %u size %u weight %u italic %u kerning %u bitmap %u baseline %u typeface %u = hash %x\n", (lUInt32)f->getFontFamily(), (lUInt32)f->getSize(), (lUInt32)f->getWeight(), (lUInt32)f->getItalic(), (lUInt32)f->getKerning(), (lUInt32)f->getBitmapMode(), (lUInt32)f->getBaseline(), (lUInt32)f->getTypeFace().getHash(), f->_hash);
     if ( f->_hash )
         return f->_hash;
     lUInt32 v = 31;
+    // Commenting the next line may ensure more stable cache (by avoiding
+    // style hash mismatch), as for some undetermined reason, nodes may be
+    // associated to a same font with all other properties identical except
+    // for the _family which may oscillate between 1 (serif) and 2 (sans_serif)
+    // when we increase or decrease font size (even for a same font_size!)
     v = v * 31 + (lUInt32)f->getFontFamily();
     v = v * 31 + (lUInt32)f->getSize();
     v = v * 31 + (lUInt32)f->getWeight();


### PR DESCRIPTION
Now that I know [how to make crengine output some logs](https://github.com/koreader/crengine/pull/99#issuecomment-364692377), I get to see a bit more what happens and when :)

I noticed that, when loading from cache, we almost always got:
```
2018/02/26 12:10:06.6552 WARN checkRenderContext: Style hash doesn't match 9d95bb50!=a7379213
2018/02/26 12:10:06.6552 WARN rendering context is changed - full render required...
```
so the data from the cache was trashed, and a full rendering was done :( (only the DOM tree was kept and XML parsing still avoided).
I tracked it down to changes introduced in #40 and #45 (pinging @frankyifei for info), that the first commit here fix. Commit message:
```
Fix styles cache corruption

When a style is applied to a node with el->setStyle(newstyle), a hash of this
style is calculated and used as a key to access/re-use/retrieve this style.
If we modify such a style after that, we do corrupt the hash/style relation,
which may change some other elements' style.
And it will also prevent the use of the saved style cache when re-opening
a document from its cache, as then the validation of the loaded style hash
against the saved hash fails. A full rendering would then be done, losing
the benefit of the cache.
This fix allows cache to be re-used, and documents with cache to be
re-opened really faster.
```

After that, we get:
`2018/02/26 12:10:55.7263 WARN rendering context is not changed - no render!`
and opening from cache is really fast.

...

Except for some big books ... where I still got:
```
2018/02/26 12:10:06.6552 WARN checkRenderContext: Style hash doesn't match 9d95bb50!=a7379213
2018/02/26 12:10:06.6552 WARN rendering context is changed - full render required...
```
For one big book, I got logged:
```
2018/02/26 14:21:52.7637 WARN *** Document memory usage:
elements:381759,
textNodes:388173,
ptext=(2685040 uncompressed),
ptelems=(5170768 uncompressed)
rects=(1605632 uncompressed),
nodestyles=(1064960 uncompressed),
styles:94,
fonts:17,
renderedNodes:32,
totalNodes:769932(12030Kb),
mutableElements:75(~7Kb)
```
and the `nodestyles=(1064960 uncompressed)` was really near some hardcoded limit in lvtinydom.cpp:
https://github.com/koreader/crengine/blob/f7f08d93838d16da79e875ccea57a2f2d414301f/crengine/src/lvtinydom.cpp#L48-L55
which gives:
```
DOC_BUFFER_SIZE 0xA00000 = 10 MB
TEXT_CACHE_UNPACKED_SPACE = 2.5 MB
ELEM_CACHE_UNPACKED_SPACE = 4.5 MB
RECT_CACHE_UNPACKED_SPACE = 1.5 MB
STYLE_CACHE_UNPACKED_SPACE = 1 MB
```
If I increase `STYLE_CACHE_UNPACKED_SPACE ` from 1 MB to 2 MB, my above document loads from cache without any `Style hash doesn't match ` and we get `rendering context is not changed - no render` !
It happened that this book need to have 1114112B room for styledata slots - and the first of them contained in the first (1114112 - 1064960) = 49152B had a null styledata after the data structure was loaded from cache. I dunno if the problem was at the the time of cache saving, or cache loading... It's really hard to understand this cache structure/packing/unpacking (1), so, rather than trying to fix something there, it's easier to increase these cache sizes so that packing unpacking has less chances to happen.
( (1) it involves the compact() and getChunk() codes that @frankyifei met in https://github.com/koreader/koreader/issues/2386#issuecomment-275914669, and that I also tried to comprehend in the past with no success).

In the same vein, if I increase `TEXT_CACHE_UNPACKED_SPACE` from 2.5 MB to 5 MB, the table rendering bug with @Eduardomb22 's book from https://github.com/koreader/koreader/issues/3623 is solved !

So, this introduces the 2nd commit from this PR:
```
Allow for increasing unpacked cache size (and warn when reached)

Some hardcoded limits about the individual cache types cause
packing/unpacking (compression) of their data. When such limits
are reached (often with big documents) and compression is done, some
bug (at first sight unrelated) may happen, for example:
- styles hash corruption, invalidating re-use of the cache
- text elements compression: some bad rendering of tables

We will now emit warnings when such limits are reached,
so we know these limits may be the cause of some other bugs.
This commit also allows for increasing these hardcoded limits
with a lua setting, so we can quickly see the effects of them
on the bugs.
A warning will also be printed when, when loaded from cache,
some mismatch happen, causing the cache to not be re-used (we
didnt know about this before).

Also avoids rebuilding TOC when just loaded from cache (this was
the only work that was possibly taking some time when loaded
from cache), so loading from cache is not amazingly fast.
```

We'll now see in our crash.log:
```
CRE WARNING: storage for TEXT NODES reached max allowed uncompressed size (2916352 > 2621440)
             consider setting or increasing 'cre_storage_size_factor'
```
or
```
02/27/18-18:38:36 DEBUG CreDocument: set gamma index 15
CRE WARNING: storage for ELEMENTS' STYLE DATA reached max allowed uncompressed size (1163264 > 1048576)
             consider setting or increasing 'cre_storage_size_factor'
02/27/18-18:38:39 DEBUG CreDocument: set hyphenation dictionary French.pattern
02/27/18-18:38:39 DEBUG CreDocument: set visible page count 1
CRE WARNING: cached rendering is invalid (style hash mismatch): doing full rendering
CRE WARNING: storage for ELEMENTS reached max allowed uncompressed size (5203232 > 4718592)
             consider setting or increasing 'cre_storage_size_factor'
CRE WARNING: storage for TEXT NODES reached max allowed uncompressed size (2912144 > 2621440)
             consider setting or increasing 'cre_storage_size_factor'
CRE WARNING: storage for RENDERED RECTS reached max allowed uncompressed size (1736704 > 1572864)
             consider setting or increasing 'cre_storage_size_factor'
02/27/18-18:39:02 DEBUG CreDocument: goto page 6698
```


And we'll be able to add to `settings.reader.lua` and tweak: `cre_storage_size_factor=1.5` or 2 or 3 or 4, to increase these limits, till we see these WARNING disappear, and see if some other bug disappear too.
```lua
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
     cre.initCache(DataStorage:getDataDir() .. "/cache/cr3cache", 1024*1024*32,
-        G_reader_settings:nilOrTrue("cre_compress_cached_data"))
+        G_reader_settings:nilOrTrue("cre_compress_cached_data"),
+        G_reader_settings:readSetting("cre_storage_size_factor"))
 end
```

I don't know yet if these increases have side effects, but we'll see (memory usage went from 104M to 120M when I used cre_storage_size_factor=2 with my big book).

With the small optimisation to TOC, opening big books from cache is now really really fast. The render time from https://github.com/koreader/crengine/pull/97#issue-168301041 that was 28s is now down to 2s (time taken by parsing some bits in the .epub that is done before looking for an existing cache) !

...

I still got some `Style hash doesn't match`, mostly with several of @Eduardomb22 's books, in the following scenario:
- open the book (from cache or not, doesn't matter)
- increase or decrease font size
- close the book
- reopen the book => `Style hash doesn't match`

In this case, it's the font hash cache that is corrupted, because when we change font size, somehow, the font family property of the cached font is changed from serif (1) to sans-serif (2):
```
    family 1 size 16 weight 400 italic 0 kerning 1 bitmap 0 baseline 15 typeface 1990064148 = hash b2424958
    zzz hash fh 0 72: b2424958
    family 1 size 16 weight 400 italic 0 kerning 1 bitmap 0 baseline 15 typeface 1990064148 = hash b2424958
    zzz hash fh 0 72: b2424958
    family 2 size 15 weight 400 italic 0 kerning 1 bitmap 0 baseline 14 typeface 1990064148 = hash e53d3af5
    zzz hash fh 0 72: e53d3af5
    family 2 size 15 weight 400 italic 0 kerning 1 bitmap 0 baseline 14 typeface 1990064148 = hash e53d3af5
    zzz hash fh 0 72: e53d3af5
```
And when it's loading from cache, the 2 vs 1 causes a font hash mismatch, and a full rendering is done...
I can't find out why, so we'll do with it. I let some stuff commented in `src/lvstyles.cpp` in case I get back to that someday.


