### PR TITLE
Fix some re rendering issues (mostly with tables)

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -680,21 +680,6 @@ public:
         // calc individual cells dimensions
         for (i=0; i<rows.length(); i++) {
             CCRTableRow * row = rows[i];
-
-            // reset row's Y that was set in previous drawing (and the other X/W/H
-            // while we're at it, although they seem to not be reused for rendering).
-            // Not reseting row Y would mess the splitting of table elements among
-            // different pages in DVM_PAGES view mode, even making some table elements
-            // disappear.
-            // (Their Y would be added to their child TD's Y by ldomNode::getAbsRect(),
-            // which goes thru all parents to add their Y to the considered node Y).
-            RenderRectAccessor rowfmt( row->elem );
-            rowfmt.setX( 0 );
-            rowfmt.setWidth( 0 );
-            rowfmt.setY( 0 );
-            rowfmt.setHeight( 0 );
-            rowfmt.push();
-
             for (j=0; j<rows[i]->cells.length(); j++) {
                 CCRTableCell * cell = rows[i]->cells[j];
                 //int x = cell->col->index;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -680,6 +680,21 @@ public:
         // calc individual cells dimensions
         for (i=0; i<rows.length(); i++) {
             CCRTableRow * row = rows[i];
+
+            // reset row's Y that was set in previous drawing (and the other X/W/H
+            // while we're at it, although they seem to not be reused for rendering).
+            // Not reseting row Y would mess the splitting of table elements among
+            // different pages in DVM_PAGES view mode, even making some table elements
+            // disappear.
+            // (Their Y would be added to their child TD's Y by ldomNode::getAbsRect(),
+            // which goes thru all parents to add their Y to the considered node Y).
+            RenderRectAccessor rowfmt( row->elem );
+            rowfmt.setX( 0 );
+            rowfmt.setWidth( 0 );
+            rowfmt.setY( 0 );
+            rowfmt.setHeight( 0 );
+            rowfmt.push();
+
             for (j=0; j<rows[i]->cells.length(); j++) {
                 CCRTableCell * cell = rows[i]->cells[j];
                 //int x = cell->col->index;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13,7 +13,7 @@
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.01k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.02k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0003
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10516,9 +10516,9 @@ void ldomNode::recurseElementsDeepFirst( void (*pFun)( ldomNode * node ) )
 static void updateRendMethod( ldomNode * node )
 {
     node->initNodeRendMethod();
-    // Also clean up node previous positionnings (they were set while in
+    // Also clean up node previous positionings (they were set while in
     // a previous page drawing phase), that could otherwise have negative
-    // impact on the coming rendering (noticable with table elements).
+    // impact on the coming rendering (noticeable with table elements).
     RenderRectAccessor fmt( node );
     fmt.setX(0);
     fmt.setWidth(0);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10516,6 +10516,15 @@ void ldomNode::recurseElementsDeepFirst( void (*pFun)( ldomNode * node ) )
 static void updateRendMethod( ldomNode * node )
 {
     node->initNodeRendMethod();
+    // Also clean up node previous positionnings (they were set while in
+    // a previous page drawing phase), that could otherwise have negative
+    // impact on the coming rendering (noticable with table elements).
+    RenderRectAccessor fmt( node );
+    fmt.setX(0);
+    fmt.setWidth(0);
+    fmt.setY(0);
+    fmt.setHeight(0);
+    fmt.push();
 }
 
 /// init render method for the whole subtree


### PR DESCRIPTION
I had been trying to figure out this bug every other month, and I'm glad I finally found a so small fix :)

It was quite noticable on Wikipedia articles saved as epub, that often have a multi-pages table (biography elements, numbers, various factual infos) at start of book.
It would display all fine on first opening, but when you change some layout option, or font sizes (or just toggle `Embedded fonts`, which should have zero impact on the rendering), the table would be messed up, with some big parts of it missing, and the number of pages would have decreased !
Also, it you then switch from `page` mode to `scroll` mode, it's all fine in scroll mode! and bad again when you switch back to `page` mode. (I also initially thought it was a problem with cache, but it was not).

It was that some part of the rendering process, which decides which y0->y1 (from the whole document 0->height) should fit on each page-mode page, got corrupted.
We would get (diff from initial rendering / second rendering) for a 6 pages book:
```diff
 page         y0    y1      page_height
    0:         0 .. 558     [558]
    1:       558 .. 1125    [567]
-   2:      1125 .. 1689    [564]
-   3:      1689 .. 2254    [565]
-   4:      2254 .. 2820    [566]
-   5:      2820 .. 3097    [277]
+   2:      1125 .. 1546    [421]
+   3:      2165 .. 2728    [563]      (where did 1546 > 2165 go ?!)
+   4:      2728 .. 3097    [369]
```
So, some part of the (totally correct) document height would not be part of any page!
Scroll mode does not rely on this page splitting, and just cut slices of the whole document height according to scroll position.

It turned out that, in the positionning of table elements, some Y of the `<tr>`s, that were 0 on the first rendering, but were no more 0 on the second rendering, were wrongly added to the rendering positionning calculations.
This function (which is totally correct) does indeed add the parent `<tr>`, `<table>` ... to a `<td>` vertical positionning:
https://github.com/koreader/crengine/blob/9cc32c831c3518eb7da7cd84f5a75646e354cebd/crengine/src/lvtinydom.cpp#L10456-L10461
I first fixed it by just ignoring `<tr>` nodes there (as they are a kind of virtual element), but that was just a hack. So let's not touch it.

The `<tr>` Y were indeed set in the drawing phase that followed the first rendering (which was correct). Then, next renderings were using these Y, and pushing all table elements down, making them overflow. For some reason (not really clear to me), that would make the following text move up, and override the vertical part where the table should be (so, less number of pages in the book).

First commit was my first clean attempt at fixing this.

I then thought: why should just `<tr>` have this problem? Would be best to do it to all nodes.
So, the second commit of this PR remove the first, and do it in a generic way to all elements: this `updateRendMethod()` is called by `initNodeRendMethodRecursive()`, which is called only when cleaning things before a new rendering (it looks expensive, but it is really not).

And with this second commit (not with the first), the problem described by @Eduardomb22  in https://github.com/koreader/koreader/issues/3623#issuecomment-359240654 with his book (table in §15.8.1.3 would have their cells all messed up when you change fonts size, layout, or just font hinting) is solved !

So, I guess this generic fix is the right thing to do.
(We can squash these 2 commits, I made them two for reference and illustrative purpose only.)

