### PR TITLE
Fix cache decompression bug that would invalidate cache

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13,7 +13,7 @@
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.02k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.03k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0003
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2602,26 +2602,38 @@ bool ldomPack( const lUInt8 * buf, int bufsize, lUInt8 * &dstbuf, lUInt32 & dsts
         return false;
     z.avail_in = bufsize;
     z.next_in = (unsigned char *)buf;
-    z.avail_out = PACK_BUF_SIZE;
-    z.next_out = tmp;
-    ret = deflate( &z, Z_FINISH );
-    int have = PACK_BUF_SIZE - z.avail_out;
-    deflateEnd(&z);
-    if ( ret!=Z_STREAM_END || have==0 || have>=PACK_BUF_SIZE || z.avail_in!=0 ) {
-        // some error occured while packing, leave unpacked
-        //setpacked( buf, bufsize );
-        return false;
+    int compressed_size = 0;
+    lUInt8 *compressed_buf = NULL;
+    while (true) {
+        z.avail_out = PACK_BUF_SIZE;
+        z.next_out = tmp;
+        ret = deflate( &z, Z_FINISH );
+        if (ret == Z_STREAM_ERROR) { // some error occured while packing
+            deflateEnd(&z);
+            if (compressed_buf)
+                free(compressed_buf);
+            // printf("deflate() error: %d (%d > %d)\n", ret, bufsize, compressed_size);
+            return false;
+        }
+        int have = PACK_BUF_SIZE - z.avail_out;
+        compressed_buf = (lUInt8 *)realloc(compressed_buf, compressed_size + have);
+        memcpy(compressed_buf + compressed_size, tmp, have );
+        compressed_size += have;
+        if (z.avail_out != 0) // buffer not fully filled = deflate is done
+            break;
+        // printf("deflate() additional call needed (%d > %d)\n", bufsize, compressed_size);
     }
-    dstsize = have;
-    dstbuf = (lUInt8 *)malloc(have);
-    memcpy( dstbuf, tmp, have );
+    deflateEnd(&z);
+    dstsize = compressed_size;
+    dstbuf = compressed_buf;
+    // printf("deflate() done: %d > %d\n", bufsize, compressed_size);
     return true;
 }
 
 /// unpack data from _compbuf to _buf
 bool ldomUnpack( const lUInt8 * compbuf, int compsize, lUInt8 * &dstbuf, lUInt32 & dstsize  )
 {
-    lUInt8 tmp[UNPACK_BUF_SIZE]; // 64K buffer for compressed data
+    lUInt8 tmp[UNPACK_BUF_SIZE]; // 256K buffer for uncompressed data
     int ret;
     z_stream z;
     memset( &z, 0, sizeof(z) );
@@ -2633,18 +2645,32 @@ bool ldomUnpack( const lUInt8 * compbuf, int compsize, lUInt8 * &dstbuf, lUInt32
         return false;
     z.avail_in = compsize;
     z.next_in = (unsigned char *)compbuf;
-    z.avail_out = UNPACK_BUF_SIZE;
-    z.next_out = tmp;
-    ret = inflate( &z, Z_FINISH );
-    int have = UNPACK_BUF_SIZE - z.avail_out;
-    inflateEnd(&z);
-    if ( ret!=Z_STREAM_END || have==0 || have>=UNPACK_BUF_SIZE || z.avail_in!=0 ) {
-        // some error occured while unpacking
-        return false;
+    int uncompressed_size = 0;
+    lUInt8 *uncompressed_buf = NULL;
+    while (true) {
+        z.avail_out = UNPACK_BUF_SIZE;
+        z.next_out = tmp;
+        ret = inflate( &z, Z_SYNC_FLUSH );
+        if (ret != Z_OK && ret != Z_STREAM_END) { // some error occured while unpacking
+            inflateEnd(&z);
+            if (uncompressed_buf)
+                free(uncompressed_buf);
+            // printf("inflate() error: %d (%d > %d)\n", ret, compsize, uncompressed_size);
+            return false;
+        }
+        int have = UNPACK_BUF_SIZE - z.avail_out;
+        uncompressed_buf = (lUInt8 *)realloc(uncompressed_buf, uncompressed_size + have);
+        memcpy(uncompressed_buf + uncompressed_size, tmp, have );
+        uncompressed_size += have;
+        if (ret == Z_STREAM_END) {
+            break;
+        }
+        // printf("inflate() additional call needed (%d > %d)\n", compsize, uncompressed_size);
     }
-    dstsize = have;
-    dstbuf = (lUInt8 *)malloc(have);
-    memcpy( dstbuf, tmp, have );
+    inflateEnd(&z);
+    dstsize = uncompressed_size;
+    dstbuf = uncompressed_buf;
+    // printf("inflate() done %d > %d\n", compsize, uncompressed_size);
     return true;
 }
 


### PR DESCRIPTION
Fix https://github.com/koreader/crengine/pull/102#issuecomment-369920620

If some compressed chunk would once uncompressed be > 256KB (`UNPACK_BUF_SIZE = 0x40000`), it would not fit in the buffer and cache loading would be abandoned, causing a full reloading and rendering.
Fixed this by having in ldomUnpack a loop so we can call inflate() as many times as it is necessary to get the full chunk.

With  @Eduardomb22 's problematic book:
```
[saving]
[...]
deflate() done: 462 > 329
deflate() done: 419564 > 63895
deflate() done: 13164 > 5994
[...]
[loading]
inflate() done 329 > 462
inflate() additional call needed (63895 > 262144) [this would have cause failure to unpack]
inflate() done 63895 > 419564   [but now we can complete  it]
inflate() done 5994 > 13164
[...]
```

Also added this loop in ldomPack so big chunks that, once compressed, would not fit in a 64KB (`PACK_BUF_SIZE = 0x10000`) buffer (in which case, they were stored in cache uncompressed), do fit now. This may reduce the size of cache files (but they now takes a bit of extra time to be opened...)

With my big book (previous cache size was 22MB, and now 18MB with this fix):
```
[saving]
[...]
deflate() done: 16384 > 1329
deflate() done: 16384 > 1358
deflate() done: 16384 > 1386
deflate() done: 16384 > 1403
deflate() done: 16384 > 647
deflate() done: 380 > 17
deflate() done: 969 > 618
deflate() additional call needed (5141795 > 65536)  [this would have cause failure to pack]
deflate() additional call needed (5141795 > 131072) [so it would have been saved uncompressed]
deflate() additional call needed (5141795 > 196608) [taking 5MB instead of]
deflate() additional call needed (5141795 > 262144) [the 811KB we get now below]
deflate() additional call needed (5141795 > 327680)
deflate() additional call needed (5141795 > 393216)
deflate() additional call needed (5141795 > 458752)
deflate() additional call needed (5141795 > 524288)
deflate() additional call needed (5141795 > 589824)
deflate() additional call needed (5141795 > 655360)
deflate() additional call needed (5141795 > 720896)
deflate() additional call needed (5141795 > 786432)
deflate() done: 5141795 > 811396
deflate() done: 96819 > 51699
deflate() done: 16384 > 3726
deflate() done: 16384 > 3633
deflate() done: 16384 > 3633
deflate() done: 16384 > 3632
deflate() done: 16384 > 3630
[...]
[loading]
inflate() done 618 > 969
inflate() additional call needed (811396 > 262144)
inflate() additional call needed (811396 > 524288)
inflate() additional call needed (811396 > 786432)
inflate() additional call needed (811396 > 1048576)
inflate() additional call needed (811396 > 1310720)
inflate() additional call needed (811396 > 1572864)
inflate() additional call needed (811396 > 1835008)
inflate() additional call needed (811396 > 2097152)
inflate() additional call needed (811396 > 2359296)
inflate() additional call needed (811396 > 2621440)
inflate() additional call needed (811396 > 2883584)
inflate() additional call needed (811396 > 3145728)
inflate() additional call needed (811396 > 3407872)
inflate() additional call needed (811396 > 3670016)
inflate() additional call needed (811396 > 3932160)
inflate() additional call needed (811396 > 4194304)
inflate() additional call needed (811396 > 4456448)
inflate() additional call needed (811396 > 4718592)
inflate() additional call needed (811396 > 4980736)
inflate() done 811396 > 5141795
inflate() done 51699 > 96819
inflate() done 14 > 8
inflate() done 20 > 12
inflate() done 3726 > 16384
inflate() done 3633 > 16384
inflate() done 3633 > 16384
inflate() done 3632 > 16384
inflate() done 3630 > 16384
[...]
```

Writing this for reference, because it always annoys me that **de**flate does **not** do **de**compression:
- `ldomPack()` uses zlib's `deflate()` to do compression.
- `ldomUnpack()` uses zlib's `inflate()` to do decompression.

We could have just double UNPACK_BUF_SIZE to solve the problem with the single book that exhibit it , but well, better have it right.
https://github.com/koreader/crengine/blob/9cc32c831c3518eb7da7cd84f5a75646e354cebd/crengine/src/lvtinydom.cpp#L85-L86

(Note that I'm not really at ease with C, and, although it compiles and works :) I'm not fully confident. And I'm not sure this is the most proper way (using `realloc()`) to multi-append some fix buffer content to a new buffer which we should give back as a pointer..).