### PR TITLE
Fix getPageDocumentRange() on some pages

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2356,8 +2356,21 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
 			return res;
 		ldomXPointer start = m_doc->createXPointer(lvPoint(0, page->start));
 		//ldomXPointer end = m_doc->createXPointer( lvPoint( m_dx+m_dy, page->start + page->height - 1 ) );
-		ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start
-                                + page->height), 1);
+		// On some pages (eg: that ends with some padding between an
+		// image on this page, and some text on next page), there may
+		// be some area which is rendered "final" without any content,
+		// thus holding no node. We would then get a null 'end' here.
+		// But we can get a xpointer by looking a few pixels back the
+		// height of page.
+		// (This does not seem to happen at start, nor on either side
+		// in scroll mode)
+		// ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start + page->height), 1);
+		ldomXPointer end;
+		for (int i=0; i<page->height; i++) {
+			end = m_doc->createXPointer(lvPoint(0, page->start + page->height - i), 1);
+			if (!end.isNull())
+				break; // we found our end of page xpointer
+		}
 		if (start.isNull() || end.isNull())
 			return res;
 		res = LVRef<ldomXRange> (new ldomXRange(start, end));

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2366,8 +2366,8 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
 		// in scroll mode)
 		// ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start + page->height), 1);
 		ldomXPointer end;
-		for (int i=0; i<page->height; i++) {
-			end = m_doc->createXPointer(lvPoint(0, page->start + page->height - i), 1);
+		for (int height=page->height; height>0; height--) {
+			end = m_doc->createXPointer(lvPoint(0, page->start + height), 1);
 			if (!end.isNull())
 				break; // we found our end of page xpointer
 		}


### PR DESCRIPTION
On some pages (eg: that ends with some padding between an image on this page, and some text on next page), there may be some area which is rendered "final" without any content, thus holding no node. We would then get no xpointer for end of page (and features that use it would fail, ie: word selection, `getCurrentPageLinks()`, `getPageText()`).
But we can get a xpointer by looking a few pixels back the height of page.

For example, on this page (showing next page just below), swipe to follow nearest link would fail (while there are footnotes links):

<kbd>![page1](https://user-images.githubusercontent.com/24273478/37020527-568d1878-211c-11e8-936b-49678485f5c2.png)</kbd>

<kbd>![page2](https://user-images.githubusercontent.com/24273478/37020529-59364108-211c-11e8-8da6-63c1f196431d.png)</kbd>

At the bottom of the first page, there is some area, between the red and blue lines, that does not hold any node, so no xpointer would be found there (dunno if this happen only because there are the left and right borders to draw):

<kbd>![details2](https://user-images.githubusercontent.com/24273478/37020533-5b904e3a-211c-11e8-8397-77433ffefc47.png)</kbd>

On my wikipedia saved as epub documents, the xpointer is found 3 pixels above (probably dependant of the layout options / font size).

Some debugging logs:
```
pageIndex: 17
pageStart: 9067, height: 566
[Looking for start xpointer]
rc: top/bottom/left/right: 8713 / 9234 / 1 / 581
pt.x -1 - pt.y 354 - finalNode->getRendMethod: 2
txtform...
txtform->GetLineCount: 22
  l: 0
  l: 1
  l: 2
  l: 3
  l: 4
  l: 5
  l: 6
  l: 7
  l: 8
  l: 9
  l: 10
  l: 11
  l: 12
  l: 13
  l: 14
  l: 15
    w: 0
start: /body/DocFragment/body/div/p[16]/text()[10].165   [FOUND]

[Looking for end xpointer]
rc: top/bottom/left/right: 9633 / 9633 / 55 / 527
pt.x -55 - pt.y 0 - finalNode->getRendMethod: 2
txtform...
txtform->GetLineCount: 0
ldomDocument::createXPointer: eof [NOT FOUND]

  fixing y: -1
rc: top/bottom/left/right: 9633 / 9633 / 55 / 527
pt.x -55 - pt.y -1 - finalNode->getRendMethod: 2
txtform...
txtform->GetLineCount: 0
ldomDocument::createXPointer: eof [NOT FOUND]

  fixing y: -2
rc: top/bottom/left/right: 9633 / 9633 / 55 / 527
pt.x -55 - pt.y -2 - finalNode->getRendMethod: 2
txtform...
txtform->GetLineCount: 0
ldomDocument::createXPointer: eof [NOT FOUND]

  fixing y: -3
rc: top/bottom/left/right: 9359 / 9631 / 53 / 529
pt.x -53 - pt.y 271 - finalNode->getRendMethod: 2
txtform...
txtform->GetLineCount: 1
  l: 0
    w: 0
end: /body/DocFragment/body/div/div[15]/div/img.0 [FOUND]
```
