### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/crengine/include/lvmemman.h
+++ b/crengine/include/lvmemman.h
@@ -38,7 +38,7 @@ inline void crFatalError() { crFatalError( -1, "Unknown fatal error" ); }
 void crSetFatalErrorHandler( lv_FatalErrorHandler_t * handler );
 
 /// typed realloc with result check (size is counted in T), fatal error if failed
-template <typename T> T * cr_realloc( T * ptr, size_t newSize ) {
+template <typename T> inline T * cr_realloc( T * ptr, size_t newSize ) {
     T * newptr = reinterpret_cast<T*>(realloc(ptr, sizeof(T)*newSize));
     if ( newptr )
         return newptr;

--- a/crengine/include/lvptrvec.h
+++ b/crengine/include/lvptrvec.h
@@ -49,7 +49,7 @@ public:
     {
         if ( size > _size )
         {
-            _list = (T**)realloc( _list, size * sizeof( T* ));
+            _list = cr_realloc( _list, size );
             for (int i=_size; i<size; i++)
                 _list[i] = NULL;
             _size = size;
@@ -284,7 +284,7 @@ public:
                 free( rows[i] );
             numrows = nrows;
         } else if (nrows>numrows) {
-            rows = (_Ty**) realloc( rows, sizeof(_Ty)*nrows );
+            rows = cr_realloc( rows, nrows );
             for (int i=numrows; i<nrows; i++) {
                 rows[i] = (_Ty*)malloc( sizeof(_Ty*) * ncols );
                 for (int j=0; j<numcols; j++)
@@ -294,7 +294,7 @@ public:
         }
         if (ncols>numcols) {
             for (int i=0; i<numrows; i++) {
-                rows[i] = (_Ty*)realloc( rows[i], sizeof(_Ty) * ncols );
+                rows[i] = cr_realloc( rows[i], ncols );
                 for (int j=numcols; j<ncols; j++)
                     rows[i][j]=fill_elem;
             }

--- a/crengine/include/lvptrvec.h
+++ b/crengine/include/lvptrvec.h
@@ -219,7 +219,7 @@ public:
     {
         if ( empty() )
             return NULL;
-        return remove( 0 );
+        return remove( (int)0 );
     }
     /// stack-like interface: push item to stack
     void push( T * item )

--- a/crengine/include/lvref.h
+++ b/crengine/include/lvref.h
@@ -382,7 +382,7 @@ public:
 	LVRef & clone()
 	{
 		if ( isNull() )
-			return LVRef();
+			return LVRef(NULL);
 		return LVRef( new T( *_ptr ) );
 	}
 

--- a/crengine/include/lvrefcache.h
+++ b/crengine/include/lvrefcache.h
@@ -15,6 +15,7 @@
 #if !defined(__LV_REF_CACHE_H_INCLUDED__)
 #define __LV_REF_CACHE_H_INCLUDED__
 
+#include "lvmemman.h"
 #include "lvref.h"
 #include "lvarray.h"
 
@@ -152,7 +153,7 @@ private:
                 indexsize = size/2;
             else
                 indexsize *= 2;
-            index = (LVRefCacheIndexRec*)realloc( index, sizeof(LVRefCacheIndexRec)*indexsize );
+            index = cr_realloc( index, indexsize );
             for ( int i=nextindex+1; i<indexsize; i++ ) {
                 index[i].item = NULL;
                 index[i].refcount = 0;
@@ -332,7 +333,7 @@ public:
         indexsize = list.length();
         nextindex = indexsize > 0 ? indexsize-1 : 0;
         if ( indexsize ) {
-            index = (LVRefCacheIndexRec*)realloc( index, sizeof(LVRefCacheIndexRec)*indexsize );
+            index = cr_realloc( index, indexsize );
             index[0].item = NULL;
             index[0].refcount=0;
             for ( int i=1; i<indexsize; i++ ) {

--- a/crengine/src/lstridmap.cpp
+++ b/crengine/src/lstridmap.cpp
@@ -11,6 +11,7 @@
 
 *******************************************************/
 
+#include "../include/lvmemman.h"
 #include "../include/lstridmap.h"
 #include "../include/dtddef.h"
 #include "../include/lvtinydom.h"
@@ -265,8 +266,8 @@ void LDOMNameIdMap::AddItem( LDOMNameIdMapItem * item )
     {
         // reallocate storage
         lUInt16 newsize = item->id+16;
-        m_by_id = (LDOMNameIdMapItem **)realloc( m_by_id, sizeof(LDOMNameIdMapItem *)*newsize );
-        m_by_name = (LDOMNameIdMapItem **)realloc( m_by_name, sizeof(LDOMNameIdMapItem *)*newsize );
+        m_by_id = cr_realloc( m_by_id, newsize );
+        m_by_name = cr_realloc( m_by_name, newsize );
         for (lUInt16 i = m_size; i<newsize; i++)
         {
             m_by_id[i] = NULL;

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1045,7 +1045,7 @@ lString16 & lString16::pack()
         }
         else
         {
-            pchunk->buf16 = (lChar16 *) realloc( pchunk->buf16, sizeof(lChar16)*(pchunk->len+1) );
+            pchunk->buf16 = cr_realloc( pchunk->buf16, pchunk->len+1 );
             pchunk->size = pchunk->len;
         }
     }
@@ -1222,7 +1222,7 @@ void lString16Collection::reserve(int space)
     if ( count + space > size )
     {
         size = count + space + 64;
-        chunks = (lstring16_chunk_t * *)realloc( chunks, sizeof(lstring16_chunk_t *) * size );
+        chunks = cr_realloc( chunks, size );
     }
 }
 
@@ -1343,7 +1343,7 @@ void lString8Collection::reserve(int space)
     if ( count + space > size )
     {
         size = count + space + 64;
-        chunks = (lstring8_chunk_t * *)realloc( chunks, sizeof(lstring8_chunk_t *) * size );
+        chunks = cr_realloc( chunks, size );
     }
 }
 
@@ -2330,7 +2330,7 @@ lString8 & lString8::pack()
         }
         else
         {
-            pchunk->buf8 = (lChar8 *) realloc( pchunk->buf8, sizeof(lChar8)*(pchunk->len+1) );
+            pchunk->buf8 = cr_realloc( pchunk->buf8, pchunk->len+1 );
             pchunk->size = pchunk->len;
         }
     }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -82,7 +82,7 @@ formatted_word_t * lvtextAddFormattedWord( formatted_line_t * pline )
     if ( pline->word_count >= size)
     {
         size += FRM_ALLOC_SIZE;
-        pline->words = (formatted_word_t*)realloc( pline->words, sizeof(formatted_word_t)*(size) );
+        pline->words = cr_realloc( pline->words, size );
     }
     return &pline->words[ pline->word_count++ ];
 }
@@ -93,7 +93,7 @@ formatted_line_t * lvtextAddFormattedLine( formatted_text_fragment_t * pbuffer )
     if (pbuffer->frmlinecount >= size)
     {
         size += FRM_ALLOC_SIZE;
-        pbuffer->frmlines = (formatted_line_t**)realloc( pbuffer->frmlines, sizeof(formatted_line_t*)*(size) );
+        pbuffer->frmlines = cr_realloc( pbuffer->frmlines, size );
     }
     return (pbuffer->frmlines[ pbuffer->frmlinecount++ ] = lvtextAllocFormattedLine());
 }
@@ -104,7 +104,7 @@ formatted_line_t * lvtextAddFormattedLineCopy( formatted_text_fragment_t * pbuff
     if ( pbuffer->frmlinecount >= size)
     {
         size += FRM_ALLOC_SIZE;
-        pbuffer->frmlines = (formatted_line_t**)realloc( pbuffer->frmlines, sizeof(formatted_line_t*)*(size) );
+        pbuffer->frmlines = cr_realloc( pbuffer->frmlines, size );
     }
     return (pbuffer->frmlines[ pbuffer->frmlinecount++ ] = lvtextAllocFormattedLineCopy(words, words_count));
 }
@@ -170,7 +170,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
     if ( pbuffer->srctextlen >= srctextsize)
     {
         srctextsize += FRM_ALLOC_SIZE;
-        pbuffer->srctext = (src_text_fragment_t*)realloc( pbuffer->srctext, sizeof(src_text_fragment_t)*(srctextsize) );
+        pbuffer->srctext = cr_realloc( pbuffer->srctext, srctextsize );
     }
     src_text_fragment_t * pline = &pbuffer->srctext[ pbuffer->srctextlen++ ];
     pline->t.font = font;
@@ -220,7 +220,7 @@ void lvtextAddSourceObject(
     if ( pbuffer->srctextlen >= srctextsize)
     {
         srctextsize += FRM_ALLOC_SIZE;
-        pbuffer->srctext = (src_text_fragment_t*)realloc( pbuffer->srctext, sizeof(src_text_fragment_t)*(srctextsize) );
+        pbuffer->srctext = cr_realloc( pbuffer->srctext, srctextsize );
     }
     src_text_fragment_t * pline = &pbuffer->srctext[ pbuffer->srctextlen++ ];
     pline->index = (lUInt16)(pbuffer->srctextlen-1);
@@ -351,11 +351,11 @@ public:
             if ( m_length+ITEMS_RESERVED>m_size ) {
                 // realloc
                 m_size = m_length+ITEMS_RESERVED;
-                m_text = (lChar16*)realloc(m_staticBufs ? NULL : m_text, sizeof(lChar16)*m_size);
-                m_flags = (lUInt8*)realloc(m_staticBufs ? NULL : m_flags, sizeof(lUInt8)*m_size);
-                m_charindex = (lUInt16*)realloc(m_staticBufs ? NULL : m_charindex, sizeof(lUInt16)*m_size);
-                m_srcs = (src_text_fragment_t **)realloc(m_staticBufs ? NULL : m_srcs, sizeof(src_text_fragment_t *)*m_size);
-                m_widths = (int*)realloc(m_staticBufs ? NULL : m_widths, sizeof(int)*m_size);
+                m_text = cr_realloc(m_staticBufs ? NULL : m_text, m_size);
+                m_flags = cr_realloc(m_staticBufs ? NULL : m_flags, m_size);
+                m_charindex = cr_realloc(m_staticBufs ? NULL : m_charindex, m_size);
+                m_srcs = cr_realloc(m_staticBufs ? NULL : m_srcs, m_size);
+                m_widths = cr_realloc(m_staticBufs ? NULL : m_widths, m_size);
             }
             m_staticBufs = false;
         } else {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2616,7 +2616,7 @@ bool ldomPack( const lUInt8 * buf, int bufsize, lUInt8 * &dstbuf, lUInt32 & dsts
             return false;
         }
         int have = PACK_BUF_SIZE - z.avail_out;
-        compressed_buf = (lUInt8 *)realloc(compressed_buf, compressed_size + have);
+        compressed_buf = cr_realloc(compressed_buf, compressed_size + have);
         memcpy(compressed_buf + compressed_size, tmp, have );
         compressed_size += have;
         if (z.avail_out != 0) // buffer not fully filled = deflate is done
@@ -2659,7 +2659,7 @@ bool ldomUnpack( const lUInt8 * compbuf, int compsize, lUInt8 * &dstbuf, lUInt32
             return false;
         }
         int have = UNPACK_BUF_SIZE - z.avail_out;
-        uncompressed_buf = (lUInt8 *)realloc(uncompressed_buf, uncompressed_size + have);
+        uncompressed_buf = cr_realloc(uncompressed_buf, uncompressed_size + have);
         memcpy(uncompressed_buf + uncompressed_size, tmp, have );
         uncompressed_size += have;
         if (ret == Z_STREAM_END) {

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -674,6 +674,7 @@ public:
         lUInt32 fsize = stream->GetSize();
         PDBHdr hdr;
         PDBRecordEntry entry;
+        memset(&hdr, 0, sizeof(hdr)); // avoid cppcheck warning
         if ( !hdr.read(stream) )
             return false;
         if ( hdr.recordCount==0 )
@@ -715,6 +716,7 @@ public:
             if ( _records[0].size<sizeof(EReaderHeader) )
                 return false;
             EReaderHeader preamble;
+            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream) )
                 return false; // invalid preamble


### PR DESCRIPTION
Attempt at fixing warnings from #106. Just to see what cppcheck says.
Don't merge yet: it compiles, it seems to work, and my C skills warning still applies :) and there is at least one which I doubt:

This one has 2 `*` more at start than in the `sizeof()`
```c
-            rows = (_Ty**) realloc( rows, sizeof(_Ty)*nrows );
+            rows = cr_realloc( rows, nrows );
```

All the others have one `*` more at start than in the `sizeof()`
```c
-            _list = (T**)realloc( _list, size * sizeof( T* ));
+            _list = cr_realloc( _list, size );
```

Added a `inline` to this cr_realloc , so I don't have to worry about performance impacts (libcrengine grows by 1 KB only, so it's negligeable).