### PR TITLE
Upstream fix for MOBI format detection

### DIFF
--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -748,6 +748,9 @@ public:
         } else if (_format==MOBI ) {
             if ( _records[0].size<sizeof(MobiPreamble) )
                 return false;
+            if (!validateContent)
+                contentFormat = doc_format_pdb;
+
             MobiPreamble preamble;
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream, _mobiExtraDataFlags) )


### PR DESCRIPTION
Cancels out 077e88650ffea1a7cf26fb43120cd66191570068

Upstream commit hash is a712fa235cfb257410d7113fd5e6932acb1bc1b5