### PR TITLE
 Fix page-mode rendering of tables with tall rows 

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -700,8 +700,15 @@ public:
                         fmt.setWidth( cell->width); //  - cell->padding_left - cell->padding_right
                         fmt.setHeight( cell->height); // - cell->padding_top - cell->padding_bottom
                     } else if ( cell->elem->getRendMethod()!=erm_invisible ) {
+                        // We must use a different context (used by rendering
+                        // functions to record, with context.AddLine(), each
+                        // rendered block's height, to be used for splitting
+                        // blocks among pages, for page-mode display), so that
+                        // sub-renderings (of cells' content) do not add to our
+                        // main context. Their heights will already be accounted
+                        // in their row's height (added to main context below).
                         LVRendPageContext emptycontext( NULL, context.getPageHeight() );
-                        int h = renderBlockElement( context, cell->elem, posx, posy, cell->width-cell->padding_left-cell->padding_right );
+                        int h = renderBlockElement( emptycontext, cell->elem, posx, posy, cell->width-cell->padding_left-cell->padding_right );
                         cell->height = h;
                         fmt.setY( posy ); //cell->row->y - cell->row->y );
                         fmt.setX( cell->col->x+posx );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13,7 +13,7 @@
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.04k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.05k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0003
 


### PR DESCRIPTION
Fix bug reported at https://github.com/koreader/crengine/pull/102#issuecomment-371266353

Any tall row (row height higher than page height) in a table could mess the rendering of the few first rows.
(Because of a typo in lvrend.cpp: the `emptycontext` was created for that purpose, but the author just forgot to use it on the next line).

Also, such tall row content would be truncated to the page height and the overflowed content would
simply not be displayed. So, added `SplitLineIfOverflowPage()` to deal with such rows.

[Sample file for testing](https://github.com/koreader/crengine/files/1794781/Direito_tables_test.epub.zip) before/after, made out from the chapter in question from @Eduardomb22 's book, plus some added tests with (randomly found) tall images.
Thsi PR just fix the page mode rendering, so no part of the content (as displayed in scroll mode) is lost when in page mode (the choice of where to split rows on pages, or image size scaling in table or page, may sometime feel like it could be better, but that's not the object of this PR :)