### PR TITLE
Fix crash on following empty links

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4653,8 +4653,12 @@ void LVDocView::getCurrentPageLinks(ldomXRangeList & list) {
 						if (_list[i]->getStart().getNode() == elem)
 							return true; // don't add, duplicate found!
 					}
-					ldomNode * node = elem->getChildNode(0);
-					if ( node ) _list.add(new ldomXRange(node));
+					// We ignore <a/> and <a></a> with no content, as we
+					// can't make a ldomXRange out of them
+					if (elem->hasChildren()) {
+						ldomNode * node = elem->getChildNode(0);
+						if ( node ) _list.add(new ldomXRange(node));
+					}
 				}
 				return true;
 			}


### PR DESCRIPTION
`getCurrentPageLinks()` (used when swipe to follow links is enabled) returns ldomXRange objects for links' content, that we can't build on empty links.
edit: `elem->getChildNode(0);` expects to have children, and it returns something (a node, widh id 32, so may be the root node) even when there is no child, which `if (node)` let pass - so it requires calling `hasChildren()` before calling `getChildNode()`.

Solves the crash reported in https://github.com/koreader/koreader/issues/3731.
For this book, it was caused by empty calibre tags with id for page changes (ala kepub I guess):
```html
The next census, compiled <a epub:type="pagebreak" id="page12" class="calibre1"></a>in 2011 and published at the end of 2012
```
If it had content, we would get in KOReader (on this page, which has another valid footnote link):
```
a_xp: /body/DocFragment[6]/body/section/p[5]/sup/a/text().0
a_xp: /body/DocFragment[6]/body/section/p[6]/a/text().0
03/09/18-11:47:24 WARN  {
    [1] = {
        ["end_x"] = 179,
        ["a_xpointer"] = "/body/DocFragment[6]/body/section/p[5]/sup/a.0",
        ["end_y"] = 299,
        ["start_x"] = 172,
        ["section"] = "#_doc_fragment_24_ c02-f1",
        ["start_y"] = 299
    },
    [2] = {
        ["end_x"] = 250,
        ["a_xpointer"] = "/body/DocFragment[6]/body/section/p[6]/a.0",
        ["end_y"] = 367,
        ["start_x"] = 232,
        ["uri"] = "",
        ["start_y"] = 367
    }
}
```
This empty link has no `href=` attribute, so it would get empty `uri` (external link) or `section` (internal link) key, and would be discarded in the _follow page link_ candidates.
Could be a problem on empty links that have a `href=`, but as we wouldn't see them anyway on the page, it's fine (and would prevent following an invisible link when swiping left, expecting to go to next page).
