### PR TITLE
Crash with fatal error when max nodes limit reached

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1836,6 +1836,8 @@ ldomNode * tinyNodeCollection::allocTinyNode( int type )
         } else {
             // create new item
             _elemCount++;
+            if (_elemCount >= (TNC_PART_COUNT << TNC_PART_SHIFT))
+                crFatalError(1003, "allocTinyNode: can't create any more element nodes (hard limit)");
             ldomNode * part = _elemList[_elemCount >> TNC_PART_SHIFT];
             if ( !part ) {
                 part = (ldomNode*)malloc( sizeof(ldomNode) * TNC_PART_LEN );
@@ -1858,6 +1860,8 @@ ldomNode * tinyNodeCollection::allocTinyNode( int type )
         } else {
             // create new item
             _textCount++;
+            if (_textCount >= (TNC_PART_COUNT << TNC_PART_SHIFT))
+                crFatalError(1003, "allocTinyNode: can't create any more text nodes (hard limit)");
             ldomNode * part = _textList[_textCount >> TNC_PART_SHIFT];
             if ( !part ) {
                 part = (ldomNode*)malloc( sizeof(ldomNode) * TNC_PART_LEN );


### PR DESCRIPTION
Crash with fatal error when max nodes limit reached instead of segfault (to ease discriminating bugs).
```
t:1048574
t:1048575
t:1048576
FATAL ERROR #1003: allocTinyNode: can't create any more text nodes (hard limit)
```

Copied from https://github.com/koreader/koreader/issues/3459#issuecomment-371751375 :
Some book crashes with a segfault, when it reaches the point when there are 1024 * 1024 = 1048576 text nodes.
There is a hardcoded limit of the number of 1024-nodes slots, which is 1024:
https://github.com/koreader/crengine/blob/052637f1f4ca831fd03aafab89df8358d8ca0f49/crengine/include/lvtinydom.h#L364-L378
I thought we could just increase it to 2048, but it segfaults elsewhere.

There are some other design choices (good for limiting resources usage) that limits this to 1024:
https://github.com/koreader/crengine/blob/052637f1f4ca831fd03aafab89df8358d8ca0f49/crengine/include/lvtinydom.h#L575-L578
`dataIndex`, which is the `incremented_id << 4`, then fails to be stored in 24 bits slots when it reaches 1048576:
```
(1024*1024) << 4 = 16777216
2**24 = 16777216
```
Increasing this 24 bit slot, or any other trick, would probably be too much work and too risky for a change. I think this will stay a limitation.
