### PR TITLE
Allow for quicker loading when ony interested in metadata

### DIFF
--- a/crengine/include/epubfmt.h
+++ b/crengine/include/epubfmt.h
@@ -6,7 +6,7 @@
 
 
 bool DetectEpubFormat( LVStreamRef stream );
-bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback );
+bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback, bool metadataOnly = false );
 lString16 EpubGetRootFilePath( LVContainerRef m_arc );
 LVStreamRef GetEpubCoverpage(LVContainerRef arc);
 

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -850,11 +850,11 @@ public:
     /// clear view
     void Clear();
     /// load document from file
-    bool LoadDocument( const char * fname );
+    bool LoadDocument( const char * fname, bool metadataOnly = false );
     /// load document from file
-    bool LoadDocument( const lChar16 * fname );
+    bool LoadDocument( const lChar16 * fname, bool metadataOnly = false );
     /// load document from stream
-    bool LoadDocument( LVStreamRef stream );
+    bool LoadDocument( LVStreamRef stream, bool metadataOnly = false );
 
     /// save last file position
     void savePosition();

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -703,7 +703,7 @@ public:
     }
 };
 
-bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback )
+bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback, bool metadataOnly )
 {
     LVContainerRef arc = LVOpenArchieve( stream );
     if ( arc.isNull() )
@@ -921,6 +921,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     if ( spineItems.length()==0 )
         return false;
 
+    if (metadataOnly)
+        return true; // no need for more work
 
 #if BUILD_LITE!=1
     if ( m_doc->openFromCache(formatCallback) ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3427,7 +3427,7 @@ static void FileToArcProps(CRPropRef props) {
 }
 
 /// load document from file
-bool LVDocView::LoadDocument(const lChar16 * fname) {
+bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 	if (!fname || !fname[0])
 		return false;
 
@@ -3477,7 +3477,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname) {
 		m_doc_props->setString(DOC_PROP_FILE_NAME, arcItemPathName);
         m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 		// loading document
-		if (LoadDocument(stream)) {
+		if (LoadDocument(stream, metadataOnly)) {
 			m_filename = lString16(fname);
 			m_stream.Clear();
 			return true;
@@ -3523,7 +3523,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname) {
 			(int) stream->GetSize()));
     m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
-	if (LoadDocument(stream)) {
+	if (LoadDocument(stream, metadataOnly)) {
 		m_filename = lString16(fname);
 		m_stream.Clear();
 
@@ -3675,7 +3675,7 @@ void LVDocView::createDefaultDocument(lString16 title, lString16 message) {
 }
 
 /// load document from stream
-bool LVDocView::LoadDocument(LVStreamRef stream) {
+bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 
 
 	m_swapDone = false;
@@ -3749,7 +3749,7 @@ bool LVDocView::LoadDocument(LVStreamRef stream) {
 			if ( m_callback )
                 m_callback->OnLoadFileFormatDetected(doc_format_epub);
             updateDocStyleSheet();
-            bool res = ImportEpubDocument( m_stream, m_doc, m_callback, this );
+            bool res = ImportEpubDocument( m_stream, m_doc, m_callback, this, metadataOnly );
 			if ( !res ) {
 				setDocFormat( doc_format_none );
                 createDefaultDocument( cs16("ERROR: Error reading EPUB format"), cs16("Cannot open document") );
@@ -4385,10 +4385,10 @@ void LVDocView::swapToCache() {
     m_swapDone = true;
 }
 
-bool LVDocView::LoadDocument(const char * fname) {
+bool LVDocView::LoadDocument(const char * fname, bool metadataOnly) {
 	if (!fname || !fname[0])
 		return false;
-	return LoadDocument(LocalToUnicode(lString8(fname)).c_str());
+	return LoadDocument(LocalToUnicode(lString8(fname)).c_str(), metadataOnly);
 }
 
 /// returns XPointer to middle paragraph of current page


### PR DESCRIPTION
This adds an optional parameter to `LoadDocument()`, that will be used only by coverbrowser plugin for metadata and cover extraction (so extracting metadata from a big book can take 3s instead of 120s).
It will return early when metadata are obtained, and avoid the full document loading (XML parsing, DOM tree building).
Only implemented for EPUB for now (HTML needs XML parsing, and I don't really know much about the other formats).
Will need small mods to `cre.cpp` and `credocument.lua` to pass up this parameter.