### PR TITLE
Allow for more than 65535 different attribute values

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -62,7 +62,7 @@
 
 #define LXML_NS_NONE 0       ///< no namespace specified
 #define LXML_NS_ANY  0xFFFF  ///< any namespace can be specified
-#define LXML_ATTR_VALUE_NONE  0xFFFF  ///< attribute not found
+#define LXML_ATTR_VALUE_NONE  0xFFFFFFFF  ///< attribute not found
 
 #define DOC_STRING_HASH_SIZE  256
 #define RESERVED_DOC_SPACE    4096
@@ -959,21 +959,21 @@ public:
     lUInt16 getAttrNameIndex( const lChar8 * name );
 
     /// helper: returns attribute value
-    inline const lString16 & getAttrValue( lUInt16 index ) const
+    inline const lString16 & getAttrValue( lUInt32 index ) const
     {
         return _attrValueTable[index];
     }
 
     /// helper: returns attribute value index
-    inline lUInt16 getAttrValueIndex( const lChar16 * value )
+    inline lUInt32 getAttrValueIndex( const lChar16 * value )
     {
-        return (lUInt16)_attrValueTable.add( value );
+        return (lUInt32)_attrValueTable.add( value );
     }
 
-    /// helper: returns attribute value index, 0xffff if not found
-    inline lUInt16 findAttrValueIndex( const lChar16 * value )
+    /// helper: returns attribute value index, 0xffffffff if not found
+    inline lUInt32 findAttrValueIndex( const lChar16 * value )
     {
-        return (lUInt16)_attrValueTable.find( value );
+        return (lUInt32)_attrValueTable.find( value );
     }
 
     /// Get element name by id
@@ -1048,10 +1048,10 @@ public:
     }
 #endif
 
-    void onAttributeSet( lUInt16 attrId, lUInt16 valueId, ldomNode * node );
+    void onAttributeSet( lUInt16 attrId, lUInt32 valueId, ldomNode * node );
 
     /// get element by id attribute value code
-    inline ldomNode * getNodeById( lUInt16 attrValueId )
+    inline ldomNode * getNodeById( lUInt32 attrValueId )
     {
         return getTinyNode( _idNodeMap.get( attrValueId ) );
     }
@@ -1059,7 +1059,7 @@ public:
     /// get element by id attribute value
     inline ldomNode * getElementById( const lChar16 * id )
     {
-        lUInt16 attrValueId = getAttrValueIndex( id );
+        lUInt32 attrValueId = getAttrValueIndex( id );
         ldomNode * node = getNodeById( attrValueId );
         return node;
     }
@@ -1114,7 +1114,7 @@ protected:
     lUInt16       _nextUnknownAttrId;    // Next Id for unknown attribute
     lUInt16       _nextUnknownNsId;      // Next Id for unknown namespace
     lString16HashedCollection _attrValueTable;
-    LVHashTable<lUInt16,lInt32> _idNodeMap; // id to data index map
+    LVHashTable<lUInt32,lInt32> _idNodeMap; // id to data index map
     LVHashTable<lString16,LVImageSourceRef> _urlImageMap; // url to image source map
     lUInt16 _idAttrId; // Id for "id" attribute name
     lUInt16 _nameAttrId; // Id for "name" attribute name
@@ -1139,12 +1139,12 @@ struct lxmlAttribute
     //
     lUInt16 nsid;
     lUInt16 id;
-    lUInt16 index;
+    lUInt32 index;
     inline bool compare( lUInt16 nsId, lUInt16 attrId )
     {
         return (nsId == nsid || nsId == LXML_NS_ANY) && (id == attrId);
     }
-    inline void setData( lUInt16 nsId, lUInt16 attrId, lUInt16 valueIndex )
+    inline void setData( lUInt16 nsId, lUInt16 attrId, lUInt32 valueIndex )
     {
         nsid = nsId;
         id = attrId;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2811,7 +2811,7 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 		return false; // only internal links supported (started with #)
 	}
 	link = link.substr(1, link.length() - 1);
-	lUInt16 id = m_doc->getAttrValueIndex(link.c_str());
+	lUInt32 id = m_doc->getAttrValueIndex(link.c_str());
 	ldomNode * dest = m_doc->getNodeById(id);
 	if (!dest)
 		return false;


### PR DESCRIPTION
Fix TOC and links with books with many footnotes, links and backlinks.
Attributes values (just like element names and attribute names) are strings stored in a table, and later referenced only by an integer value that points to this table entry.
These integer values were stored in a `lUInt16` slot, limiting their number to 0-65535. When going above this limit, it started again at 0, overriding previous references, which messed attribute string retrieval (eg: 2nd book attribute was then mapped to the value set by the 65537th attribute).
So, id= and href= were wrong, impacting TOC entries and links.
We now store them in a `lUint32` slot, allowing for a lot more different attribute values.

This fixes TOC and links on a french Bible (TOB), where every of the 30 000 verses are like:
```html
 <a id='Luke_v13.4' href='#Luke_c13'>13.4</a>
```
with additional inter-verses links and links to glossary entries.
So, the 65535 limit was easily reached (it needs more than 90 000 slots).

Memory usage and cachefile sizes increase only by a small bit:
Before:
```
Opening big book load 24s+render 21s=153M
Page turn and back: 157M
Opening small book: 166M
Re-opening big book 3s=139M
Restarting koreader on this big book: 3s 109/112M
Final cache size for big/small book: 18 269 184 / 191 488
```

After:
```
Opening big book load 24s+render 21s=154M
Page turn and back: 158M
Opening small book: 167M
Re-opening big book 3s=143M
Restarting koreader on this big book: 3s 111/114M
Final cache size for big/small book: 18 551 808 / 192 512
```

I thought the compiler would have helped me a lot more with changing these types, but it did not.
Many segfaults till I found all the stuff needed change, and it works now on all kind of links I checked, with no crash. I'm not 100% sure I addressed every stuff, but well...
We can merge/bump this independantly in a few days.