### PR TITLE
Optimize tinyNodeCollection::calcStyleHash()

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -397,6 +397,7 @@ protected:
     img_scaling_options_t _imgScalingOptions;
     int  _minSpaceCondensingPercent;
 
+    lUInt32 _nodeStyleHash;
 
     int calcFinalBlocks();
     void dropStyles();


### PR DESCRIPTION
(As noticed in https://github.com/koreader/koreader/pull/3740)
`tinyNodeCollection::calcStyleHash()` is called on each rendering (at each page turn) to check nodes have not changed, so that previous rendering info can still be used.
It was looping thru all the nodes to compute some hash (each styles hash themselves are hopefully cached), which is really expensive (30% of page render time on a small book, 95% on a big book).
As nodes and their styles/fonts can only change at some occasions, it is best to use a cache for this computed value, that we reset only on such occasions.
I'm quite certain nodes do not change except when we do an explicit re-rendering when some other stuff is changed (noticed by some of the other hashes change: default font, stylesheet...)  so we would even have no need to set `_nodeStyleHash = 0` as `ldomDocument::updateRenderContext()` would provoke a full re-rendering. But I added the `_nodeStyleHash = 0;` to all TinyNodeCollections methods that may modify the hash, just to have things proper.

Simple page turn before:
```
03/16/18-19:18:02 DEBUG goto relative screen: 1 , in mode:  page
03/16/18-19:18:02 DEBUG CreDocument: goto page 48
2018/03/16 19:18:02.4487 TRACE LVDocView:Resize(600x610)
2018/03/16 19:18:02.4488 TRACE Size is not changed: 600x610
2018/03/16 19:18:02.4494 DEBUG Render(width=582, height=578, fontSize=19, currentFontSize=19, 0 char width=12)
2018/03/16 19:18:02.4494 WARN Render is called for width 582, pageHeight=578, fontFace=Bitter, docFlags=15
2018/03/16 19:18:02.4495 TRACE initializing default style...

2018/03/16 19:18:02.4495 DEBUG calcStyleHash start
2018/03/16 19:18:02.4495 DEBUG   CALCULATING _nodeStyleHash
2018/03/16 19:18:02.5023 WARN Calculating style hash...  elemCount=382430, globalHash=4e94c012, docFlags=0000000f, nodeStyleHash=310750e9

2018/03/16 19:18:02.5024 DEBUG calcStyleHash done
2018/03/16 19:18:02.5024 WARN rendering context is not changed - no render!
2018/03/16 19:18:02.5052 WARN 9784 rendered pages found
2018/03/16 19:18:02.5052 DEBUG LVFontCache::gc() : 19 fonts still used, 0 fonts dropped
2018/03/16 19:18:02.5053 DEBUG Updating selections...
2018/03/16 19:18:02.5053 TRACE updateSelections() : selection count = 0
2018/03/16 19:18:02.5053 DEBUG Render is finished
2018/03/16 19:18:02.5083 DEBUG Loaded font ./fonts/noto/NotoSansCJK-Regular.ttf [0]: faceName=Noto Sans CJK SC,
03/16/18-19:18:02 DEBUG refresh on physical rectangle -1 -1 602 612
```
after:
```
03/16/18-19:07:20 DEBUG goto relative screen: 1 , in mode:  page
03/16/18-19:07:20 DEBUG CreDocument: goto page 48
2018/03/16 19:07:20.9390 TRACE LVDocView:Resize(600x610)
2018/03/16 19:07:20.9390 TRACE Size is not changed: 600x610
2018/03/16 19:07:20.9397 DEBUG Render(width=582, height=578, fontSize=19, currentFontSize=19, 0 char width=12)
2018/03/16 19:07:20.9398 WARN Render is called for width 582, pageHeight=578, fontFace=Bitter, docFlags=15
2018/03/16 19:07:20.9398 TRACE initializing default style...

2018/03/16 19:07:20.9398 DEBUG calcStyleHash start
2018/03/16 19:07:20.9398 DEBUG   using saved _nodeStyleHash
2018/03/16 19:07:20.9399 WARN Calculating style hash...  elemCount=382430, globalHash=4e94c012, docFlags=0000000f, nodeStyleHash=310750e9
2018/03/16 19:07:20.9399 DEBUG calcStyleHash done

2018/03/16 19:07:20.9399 WARN rendering context is not changed - no render!
2018/03/16 19:07:20.9452 WARN 9784 rendered pages found
2018/03/16 19:07:20.9452 DEBUG LVFontCache::gc() : 23 fonts still used, 0 fonts dropped
2018/03/16 19:07:20.9452 DEBUG Updating selections...
2018/03/16 19:07:20.9453 TRACE updateSelections() : selection count = 0
2018/03/16 19:07:20.9453 DEBUG Render is finished
03/16/18-19:07:20 DEBUG refresh on physical rectangle -1 -1 602 612
```
It is only 50ms gain on the emulator, but it's probably ~500ms on a device, which is enough to give a feeling of a small boost (and more page turns per battery % :)
