### PR TITLE
Speedup loading EPUB metadata

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -842,6 +842,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 m_doc_props->setString(DOC_PROP_SERIES_NUMBER, content);
             }
         }
+        if (metadataOnly && coverId.empty())
+            return true; // no cover to look for, no need for more work
 
         // items
         for ( int i=1; i<50000; i++ ) {
@@ -865,6 +867,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                             m_doc_props->setString(DOC_PROP_COVER_FILE, coverFileName);
                         }
                     }
+                    if (metadataOnly)
+                        return true; // coverId found, no need for more work
                 }
                 EpubItem * epubItem = new EpubItem;
                 epubItem->href = href;


### PR DESCRIPTION
Speedup loading EPUB metadata by returning early when no cover to find, or as soon as we find the cover: we don't need to look at all the other items. Followup to #123.
