### PR TITLE
Speedup loading from cache EPUB with many files

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8903,10 +8903,9 @@ lUInt32 tinyNodeCollection::calcStyleHash()
         // Re-use saved _nodeStyleHash if it has not been invalidated,
         // as the following loop can be expensive
         res = _nodeStyleHash;
-        CRLog::debug("  using saved _nodeStyleHash");
+        CRLog::debug("  using saved _nodeStyleHash %x", res);
     }
     else {
-        CRLog::debug("  CALCULATING _nodeStyleHash");
         for ( int i=0; i<count; i++ ) {
             int offs = i*TNC_PART_LEN;
             int sz = TNC_PART_LEN;
@@ -8932,6 +8931,7 @@ lUInt32 tinyNodeCollection::calcStyleHash()
                 }
             }
         }
+        CRLog::debug("  COMPUTED _nodeStyleHash %x", res);
         _nodeStyleHash = res;
     }
     CRLog::info("Calculating style hash...  elemCount=%d, globalHash=%08x, docFlags=%08x, nodeStyleHash=%08x", _elemCount, globalHash, docFlags, res);

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -901,6 +901,7 @@ bool CRPropAccessor::deserialize( SerialBuf & buf )
             return false;
         buf >> val;
         setString( nm.c_str(), val );
+        // CRLog::debug("  deserialized prop %s: %s", nm.c_str(), UnicodeToLocal(val).c_str());
     }
     buf.checkCRC( buf.pos() - pos );
     return !buf.error();


### PR DESCRIPTION
I have some EPUB with > 3000 individual HTML files, that take 10 seconds to open from cache on my device, 3 seconds on the emulator. With this, it opens in 1 second on the emulator, so I expect 3-4 seconds on the device.

Before:
```
2018/03/18 09:23:28.8143 DEBUG Parsing opf
2018/03/18 09:23:28.8477 DEBUG Using font mangling key abcde...

(we will be avoiding this, that is not needed when loading from cache)
2018/03/18 09:23:28.8478 DEBUG opf: reading items
2018/03/18 09:23:28.8478 WARN EPUB coverpage file: cover.jpeg
2018/03/18 09:23:28.8482 WARN EPUB coverpage image is correct: 562 x 853
2018/03/18 09:23:29.6267 DEBUG opf: reading items done.
2018/03/18 09:23:29.6268 DEBUG opf: reading spine
2018/03/18 09:23:30.4992 DEBUG opf: reading spine done
2018/03/18 09:23:30.5000 DEBUG opf: closed

2018/03/18 09:23:30.5000 DEBUG Trying loading from cache
2018/03/18 09:23:30.5002 WARN ldomDocument::openCacheFile() - looking for cache file
2018/03/18 09:23:30.5003 WARN ldomDocument::openCacheFile() - cache file found, trying to read index
2018/03/18 09:23:30.5014 WARN Started validation of cache file contents
2018/03/18 09:23:30.5317 WARN Finished validation of cache file contents -- successful
2018/03/18 09:23:30.5318 WARN ldomDocument::openCacheFile() - index read successfully
2018/03/18 09:23:30.5318 TRACE ldomDocument::loadCacheFileContent()
2018/03/18 09:23:30.5326 TRACE ldomDocument::loadCacheFileContent() - ID data
2018/03/18 09:23:31.2224 TRACE ldomDocument::loadCacheFileContent() - page data
2018/03/18 09:23:31.2261 WARN 9784 pages read from cache file
2018/03/18 09:23:31.2261 TRACE ldomDocument::loadCacheFileContent() - embedded font data
2018/03/18 09:23:31.2274 TRACE ldomDocument::loadCacheFileContent() - node data
2018/03/18 09:23:31.3931 TRACE ldomDocument::loadCacheFileContent() - element storage
2018/03/18 09:23:31.3934 TRACE ldomDocument::loadCacheFileContent() - text storage
2018/03/18 09:23:31.3936 TRACE ldomDocument::loadCacheFileContent() - rect storage
2018/03/18 09:23:31.3937 TRACE ldomDocument::loadCacheFileContent() - node style storage
2018/03/18 09:23:31.3938 TRACE ldomDocument::loadCacheFileContent() - TOC
2018/03/18 09:23:31.3947 TRACE Setting style data: 15422 bytes
2018/03/18 09:23:31.3948 TRACE ldomDocument::loadCacheFileContent() - using loaded styles
2018/03/18 09:23:31.4578 TRACE ldomDocument::loadCacheFileContent() - completed successfully
2018/03/18 09:23:31.4579 DEBUG Loaded from cache
03/18/18-09:23:31 DEBUG CreDocument: set hyphenation dictionary French.pattern
```

After:
```
2018/03/18 09:26:31.4933 DEBUG Parsing opf
2018/03/18 09:26:31.5256 DEBUG Using font mangling key abcde...
2018/03/18 09:26:31.5257 DEBUG Trying loading from cache
2018/03/18 09:26:31.5257 WARN ldomDocument::openCacheFile() - looking for cache file
2018/03/18 09:26:31.5258 WARN ldomDocument::openCacheFile() - cache file found, trying to read index
2018/03/18 09:26:31.5272 WARN Started validation of cache file contents
2018/03/18 09:26:31.5567 WARN Finished validation of cache file contents -- successful
2018/03/18 09:26:31.5567 WARN ldomDocument::openCacheFile() - index read successfully
2018/03/18 09:26:31.5568 TRACE ldomDocument::loadCacheFileContent()
2018/03/18 09:26:31.5569 DEBUG   deserialized prop doc.cover.file: cover.jpeg
2018/03/18 09:26:31.5570 DEBUG   deserialized prop doc.file.crc32: 0xABCDEF12
2018/03/18 09:26:31.5570 DEBUG   deserialized prop doc.file.format: EPUB
2018/03/18 09:26:31.5570 DEBUG   deserialized prop doc.file.format.id: 4
2018/03/18 09:26:31.5570 DEBUG   deserialized prop doc.file.name: blah.epub
2018/03/18 09:26:31.5571 DEBUG   deserialized prop doc.file.path: /koreader_stuff/test/
2018/03/18 09:26:31.5571 DEBUG   deserialized prop doc.file.size: 7654412
2018/03/18 09:26:31.5571 DEBUG   deserialized prop doc.keywords: Blah
2018/03/18 09:26:31.5571 DEBUG   deserialized prop doc.language: fr
2018/03/18 09:26:31.5571 DEBUG   deserialized prop doc.title: Blah 2018
2018/03/18 09:26:31.5576 TRACE ldomDocument::loadCacheFileContent() - ID data
2018/03/18 09:26:32.2429 TRACE ldomDocument::loadCacheFileContent() - page data
2018/03/18 09:26:32.2466 WARN 9784 pages read from cache file
2018/03/18 09:26:32.2466 TRACE ldomDocument::loadCacheFileContent() - embedded font data
2018/03/18 09:26:32.2479 TRACE ldomDocument::loadCacheFileContent() - node data
2018/03/18 09:26:32.4136 TRACE ldomDocument::loadCacheFileContent() - element storage
2018/03/18 09:26:32.4139 TRACE ldomDocument::loadCacheFileContent() - text storage
2018/03/18 09:26:32.4141 TRACE ldomDocument::loadCacheFileContent() - rect storage
2018/03/18 09:26:32.4141 TRACE ldomDocument::loadCacheFileContent() - node style storage
2018/03/18 09:26:32.4142 TRACE ldomDocument::loadCacheFileContent() - TOC
2018/03/18 09:26:32.4152 TRACE Setting style data: 15422 bytes
2018/03/18 09:26:32.4152 TRACE ldomDocument::loadCacheFileContent() - using loaded styles
2018/03/18 09:26:32.4786 TRACE ldomDocument::loadCacheFileContent() - completed successfully
2018/03/18 09:26:32.4787 DEBUG Loaded from cache
03/18/18-09:26:32 DEBUG CreDocument: set hyphenation dictionary French.pattern
```

The `openFromCache()` could have been made even earlier, but there's the font mangling key that needs to be caught, and it is not saved in cache.
Although I can't test it, dunno if it ever worked. With the book from https://github.com/koreader/koreader/issues/2959#issuecomment-373655248 , we get:
```
2018/03/18 10:18:50.3802 DEBUG Using font mangling key urn:uuid:102760a2-d225-4088-ac0b-b7d2d064ac2a
2018/03/18 10:18:50.3802 DEBUG Trying loading from cache
2018/03/18 10:18:50.3844 TRACE ldomDocument::loadCacheFileContent() - embedded font data
2018/03/18 10:18:50.3845 DEBUG RegisterDocumentFont(documentId=10, path=fonts/00001.ttf)
2018/03/18 10:18:50.4030 ERROR FT_New_Memory_Face returned error 2
2018/03/18 10:18:50.4031 DEBUG RegisterDocumentFont(documentId=10, path=fonts/00002.ttf)
2018/03/18 10:18:50.4212 ERROR FT_New_Memory_Face returned error 2
```
But we already got that with a one month old crengine when not loading from cache:
```
2018/03/18 10:24:49.3984 DEBUG EPUB: 19 documents merged
2018/03/18 10:24:49.3984 DEBUG RegisterDocumentFont(documentId=3, path=fonts/00001.ttf)
2018/03/18 10:24:49.4187 ERROR FT_New_Memory_Face returned error 2
2018/03/18 10:24:49.4190 DEBUG RegisterDocumentFont(documentId=3, path=fonts/00002.ttf)
2018/03/18 10:24:49.4385 ERROR FT_New_Memory_Face returned error 2
```
