### PR TITLE
Avoid rewriting cache file when no change were made

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -390,6 +390,7 @@ protected:
     /// final block cache
     CVRendBlockCache _renderedBlockCache;
     CacheFile * _cacheFile;
+    bool _cacheFileStale;
     bool _mapped;
     bool _maperror;
     int  _mapSavingStage;
@@ -460,7 +461,7 @@ public:
     }
 
     /// add named BLOB data to document
-    bool addBlob(lString16 name, const lUInt8 * data, int size) { return _blobCache.addBlob(data, size, name); }
+    bool addBlob(lString16 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
     /// get BLOB by name
     LVStreamRef getBlob(lString16 name) { return _blobCache.getBlob(name); }
 
@@ -516,6 +517,8 @@ public:
     /// returns doc properties collection
     void setProps( CRPropRef props ) { _docProps = props; }
 
+    /// set cache file stale flag
+    void setCacheFileStale( bool stale ) { _cacheFileStale = stale; }
 
     /// minimize memory consumption
     void compact();

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -4330,7 +4330,7 @@ void CRLog::info( const char * msg, ... )
         return;
     va_list args;
     va_start( args, msg );
-    CRLOG->log( "WARN", msg, args );
+    CRLOG->log( "INFO", msg, args );
     va_end(args);
 }
 


### PR DESCRIPTION
Even when loaded from cache, and no change made in rendering (layout, styles, fonts), the cache was mostly rewritten when closing the document, introducting a long pause (>10 seconds) when leaving a big document.
This PR prevents this: cache will be rewritten only when rendering has been changed (or when some other obscure parts of the code decide to write themselves stuff to cache).
(There is another flag named `dirty` that is set when writes have started, and unset when all are done - I named this one `stale` to avoid confusion.)

Note that the bug with font family described at bottom of https://github.com/koreader/crengine/pull/100#issue-171740521 is still there: with some books, after changing renderings, and so updating cache (before or after this PR), on next opening, this cache would be considered invalid, and a new rendering is then done on load (which is itself written to cache again on close - and this new one is then valid for the next openings).