### PR TITLE
Supports <ol start=N> and <li value=N> attributes

### DIFF
--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -190,6 +190,7 @@ XS_ATTR( StyleSheet )
 XS_ATTR( title )
 XS_ATTR( subtitle )
 XS_ATTR( suptitle )
+XS_ATTR( start )
 
 XS_END_ATTRS
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11033,6 +11033,8 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             ldomNode * parent = getParentNode();
             counterValue = 0;
             // See if parent has a 'start' attribute that overrides this 0
+            // https://www.w3.org/TR/html5/grouping-content.html#the-ol-element
+            // "The start attribute, if present, must be a valid integer giving the ordinal value of the first list item."
             lString16 value = parent->getAttributeValue(attr_start);
             if ( !value.empty() ) {
                 int ivalue;
@@ -11058,6 +11060,8 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                 }
                 // See if it has a 'value' attribute that overrides
                 // the incremented value
+                // https://www.w3.org/TR/html5/grouping-content.html#the-li-element
+                // "The value attribute, if present, must be a valid integer giving the ordinal value of the list item.
                 lString16 value = child->getAttributeValue(attr_value);
                 if ( !value.empty() ) {
                         int ivalue;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11032,6 +11032,13 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             // calculate counter
             ldomNode * parent = getParentNode();
             counterValue = 0;
+            // See if parent has a 'start' attribute that overrides this 0
+            lString16 value = parent->getAttributeValue(attr_start);
+            if ( !value.empty() ) {
+                int ivalue;
+                if (value.atoi(ivalue))
+                    counterValue = ivalue - 1;
+            }
             for (int i = 0; i < parent->getChildCount(); i++) {
                 ldomNode * child = parent->getChildNode(i);
                 css_style_ref_t cs = child->getStyle();
@@ -11049,6 +11056,14 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                     // do nothing
                     ;
                 }
+                // See if it has a 'value' attribute that overrides
+                // the incremented value
+                lString16 value = child->getAttributeValue(attr_value);
+                if ( !value.empty() ) {
+                        int ivalue;
+                        if (value.atoi(ivalue))
+                        counterValue = ivalue;
+                }
                 if ( child==this )
                     break;
             }
@@ -11058,7 +11073,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
         static const char * lower_roman[] = {"i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix",
                                              "x", "xi", "xii", "xiii", "xiv", "xv", "xvi", "xvii", "xviii", "xix",
                                          "xx", "xxi", "xxii", "xxiii"};
-        if (counterValue > 0) {
+        if (counterValue > 0 || st == css_lst_decimal) {
             switch (st) {
             case css_lst_decimal:
                 marker = lString16::itoa(counterValue);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13,7 +13,7 @@
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.06k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.07k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0003
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11058,10 +11058,9 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                     // do nothing
                     ;
                 }
-                // See if it has a 'value' attribute that overrides
-                // the incremented value
+                // See if it has a 'value' attribute that overrides the incremented value
                 // https://www.w3.org/TR/html5/grouping-content.html#the-li-element
-                // "The value attribute, if present, must be a valid integer giving the ordinal value of the list item.
+                // "The value attribute, if present, must be a valid integer giving the ordinal value of the list item."
                 lString16 value = child->getAttributeValue(attr_value);
                 if ( !value.empty() ) {
                         int ivalue;


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/3782
This adds support for `<ol start=N>` and `<li value=N>` attributes, and allows zero and negative values for decimal numbering.
This HTML (texts truncated) snippet:
```html
<ol class="list_">
        <li value="2" class="block_18">(arts. 10 e 927, Â§1Âº) Para a formaÃ§Ã£o do precedente, somente podem ser usados argumentos submetidos ao contraditÃ³rio. <i class="calibre5">(Grupo: Prec
</ol>
        <p class="block_17">Â| </p>
<ol class="list_">
        <li value="3" class="block_18"></li>
        <li value="3b" class="block_18"></li>
        <li value="0" class="block_18"></li>
        <li class="block_18"></li>
        <li value="-27" class="block_18"></li>
        <li class="block_18"></li>
        <li value="9" class="block_18"></li>
        <li class="block_18"></li>
</ol>
<p class="block_19">Â| </p>
<ol class="list_" start="0">
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
</ol>
<ol class="list_" start="-2">
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
</ol>
<ol class="list_" start="42">
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
</ol>
<ol style="list-style-type: lower-alpha" start="5">
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
        <li class="block_18">(art. 69, Â§ 1Âº) A carta arbitral</li>
</ol>
```
gives this:
<kbd>![li_numbering](https://user-images.githubusercontent.com/24273478/37707020-cf1c7716-2d01-11e8-9187-4267f3eaf688.png)</kbd>

Added support for zero, as otherwise, this list item had no left padding, and would stick out of the others.

It's a bit unclear whether this part of the code is called for each list item (it seems so, given the above results), as in https://github.com/koreader/crengine/blob/11d6ae013f95ff511de1df4c3ba418aee3db999c/crengine/src/lvrend.cpp#L1125-L1162
it looks like it reuses the previous counterValue and give it to the function we fixed, which should bypass what we added if non-zero (= already defined).