### PR TITLE
Fix possible segfault with style vertical-align

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -777,7 +777,7 @@ public:
                     if ( vertical_align )  {                         //if (vertical_align && node->getAttributeValue("","class")=="duokan-footnote") // apply to duokan-footnote
                         ldomNode *node=(ldomNode*)para->object;
                         LVFont *font=(LVFont*)para->t.font;
-                        if (!node->getText().empty()) {
+                        if (!node->isNull() && !node->getText().empty()) {
                             if ( vertical_align == LTEXT_VALIGN_SUB ) {
                                 int fh=font->getHeight();
                                 word->y +=  fh*0.3333;


### PR DESCRIPTION
Happened when changing style (epub>html or epub>clear all) on a Wikipedia article (Statistics.EN.epub) that has, in its section `Find more about Statistics at Wikipedia's `, 7 times:

`<li style="min-height: 31px;"><span style="display: inline-block; width: 31px; line-height: 31px; vertical-align: middle; text-align: center;"><img src="images/img00011.png" style="width: 27px; height: 27px" alt=""/></span><span style="display: inline-block; margin-left: 4px; width: 182px; vertical-align: middle;"><a href="https://en.wiktionary.org/wiki/Special:Search/Statistics" class="extiw" title="wikt:Special:Search/Statistics">Definitions</a> from Wiktionary</span></li>`

(the few other Wikipedia epubs I looked at don't have any vertical-align).

Haven't investigated at all what this code (coming from #13) does and if it still does what it aimed at after this (logical) fix, but it displays the same, and it doesn't segfault anymore.