### PR TITLE
Fix decoding of URL with percent-encoding chars

### DIFF
--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -4978,34 +4978,34 @@ static int decodeHex( lChar16 ch )
     return -1;
 }
 
-static lChar16 decodeHTMLChar( const lChar16 * s )
+static lChar8 decodeHTMLChar( const lChar16 * s )
 {
     if (s[0] == '%') {
         int d1 = decodeHex( s[1] );
         if (d1 >= 0) {
             int d2 = decodeHex( s[2] );
             if (d2 >= 0) {
-                return (lChar16)(d1*16 + d2);
+                return (lChar8)(d1*16 + d2);
             }
         }
     }
     return 0;
 }
 
-/// decodes path like "file%20name" to "file name"
+/// decodes path like "file%20name%C3%A7" to "file nameç"
 lString16 DecodeHTMLUrlString( lString16 s )
 {
     const lChar16 * str = s.c_str();
     for ( int i=0; str[i]; i++ ) {
         if ( str[i]=='%'  ) {
-            lChar16 ch = decodeHTMLChar( str + i );
+            lChar8 ch = decodeHTMLChar( str + i );
             if ( ch==0 ) {
                 continue;
             }
             // HTML encoded char found
-            lString16 res;
+            lString8 res;
             res.reserve(s.length());
-            res.append(str, i);
+            res.append(UnicodeToUtf8(str, i));
             res.append(1, ch);
             i+=3;
 
@@ -5014,16 +5014,16 @@ lString16 DecodeHTMLUrlString( lString16 s )
                 if ( str[i]=='%'  ) {
                     ch = decodeHTMLChar( str + i );
                     if ( ch==0 ) {
-                        res.append(1, str[i]);
+                        res.append(1, (lChar8)str[i]);
                         continue;
                     }
                     res.append(1, ch);
                     i+=2;
                 } else {
-                    res.append(1, str[i]);
+                    res.append(1, (lChar8)str[i]);
                 }
             }
-            return res;
+            return Utf8ToUnicode(res);
         }
     }
     return s;


### PR DESCRIPTION
Which should nowadays be UTF8 bytes, each percent encoded. See https://en.wikipedia.org/wiki/Percent-encoding#Current_standard

Previously, each percent encoded char was assumed to be a unicode code point, which made it works with some latin1 chars percent encoded (those in https://www.fileformat.info/info/unicode/block/latin_supplement/list.htm) - but must have failed with chars from other charsets.

crengine uses mostly lString16 for its internal string representations. I'm not even sure if these are UTF16, or just hold unicode codepoints (so, limited to < 65535), or if these are the same up to some point.

This will allow me to remove the workaround in https://github.com/koreader/koreader/blob/afb07a8ca7b21e77cb19b7992444a0436aa87bf5/frontend/ui/wikipedia.lua#L1074-L1100
It should also show more readable urls when clicking on some external link.

----
Unrelated question:
For some wikipedia article, we may get from wikipedia api:
```json
        ["title"] = "François Ier (roi de France)",
        ["displaytitle"] = "François <abbr class=\"abbr\" title=\"premier\">I<sup>er</sup></abbr> (roi de France)",
or
        ["title"] = "Bouchard Père & Fils",
        ["displaytitle"] = "Bouchard Père & Fils",
```
for https://fr.wikipedia.org/wiki/Fran%C3%A7ois_Ier_(roi_de_France) and https://fr.wikipedia.org/wiki/Bouchard_P%C3%A8re_%26_Fils
I currently put them as is in the wikipedia EPUB parts (OEBPS/content.opf, OEBPS/toc.ncx, OEBPS/content.html). But these unencoded `&` (which I guess make all that invalid XML or HTML) make them not being displayed by crengine, neither in the HTML nor in the TOC, so we are shown "Bouchard Père Fils"...

What's the best way to go about that ?:
- encode all `&` as `&amp;` while making the EPUB parts (which seem strange, as there are possibly HTML tags, so I should just deal with `&amp;` and not bother with the usual buddys `&gt;` and `&lt;` - but that's probably the easiest way).
- make crengine supports non-entity `&` (but what to do with something like `they met at Jack&John; and went away` ?), which would need us to mess with https://github.com/koreader/crengine/blob/925bae617252aa036ea875700dbec46661796f47/crengine/src/lvxml.cpp#L3485-L3545 (we are in the `// error: return to normal mode` section when this happen).


