### PR TITLE
ldomNode::elementFromPoint(): also check for x coordinate

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10825,6 +10825,22 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
             return this;
         return NULL;
     }
+    if (!direction && pt.x != 0) {
+        // We shouldn't do the following if we are given a direction
+        // (full text search) as we may get locked on some page.
+        // We also don't need to do it if pt.x=0, which is often used
+        // to get current page top or range xpointers.
+        // We are given a x>0 when tap/hold to highlight text or find
+        // a link, and checking x vs fmt.x and width allows for doing
+        // that correctly in 2nd+ table cells.
+        // (No need to check if ( pt.x < fmt.getX() ): we probably
+        // meet the multiple elements that can be formatted on a same
+        // line in the order they appear as children of their parent,
+        // we can simply just ignore those who end before our pt.x)
+        if ( pt.x >= fmt.getX() + fmt.getWidth() ) {
+            return NULL;
+        }
+    }
     if ( enode->getRendMethod() == erm_final || enode->getRendMethod() == erm_list_item ) {
         return this;
     }


### PR DESCRIPTION
This allows getting links and highlighting text in table cells.
Previously, it worked only on the first cell of a row, and highlighting was incoherent when done in secondary cells.

Noticable on Wikipedia EPUBs where we have at start and at end of article often huge tables full of links, where links were simply not working. Also allows following footnotes in these tables.
Highlighting also works now in table cells, with some possible strange results when crossing cells (but it's still better than previously).. I guess it may still not work very well with some strange combinations of colspan & rowspan.