### PR TITLE
hyphenation: allow for setting min left/right fragment length

### DIFF
--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -86,25 +86,25 @@ class AlgoHyph;
 /// hyphenation manager
 class HyphMan
 {
-	friend class HyphDictionary;
-	friend class TexHyph;
-	friend class AlgoHyph;
+    friend class HyphDictionary;
+    friend class TexHyph;
+    friend class AlgoHyph;
     static HyphMethod * _method;
-	static HyphDictionary * _selectedDictionary;
-	static HyphDictionaryList * _dictList;
-        static int _LeftHyphenMin;
-        static int _RightHyphenMin;
+    static HyphDictionary * _selectedDictionary;
+    static HyphDictionaryList * _dictList;
+    static int _LeftHyphenMin;
+    static int _RightHyphenMin;
 public:
-	static void uninit();
+    static void uninit();
     static bool activateDictionaryFromStream( LVStreamRef stream );
-	static HyphDictionaryList * getDictList() { return _dictList; }
+    static HyphDictionaryList * getDictList() { return _dictList; }
     static bool activateDictionary( lString16 id ) { return _dictList->activate(id); }
     static bool initDictionaries(lString16 dir, bool clear = true);
-	static HyphDictionary * getSelectedDictionary() { return _selectedDictionary; }
-	static int getLeftHyphenMin() { return _LeftHyphenMin; }
-	static int getRightHyphenMin() { return _RightHyphenMin; }
-	static bool setLeftHyphenMin( int left_hyphen_min );
-	static bool setRightHyphenMin( int right_hyphen_min );
+    static HyphDictionary * getSelectedDictionary() { return _selectedDictionary; }
+    static int getLeftHyphenMin() { return _LeftHyphenMin; }
+    static int getRightHyphenMin() { return _RightHyphenMin; }
+    static bool setLeftHyphenMin( int left_hyphen_min );
+    static bool setRightHyphenMin( int right_hyphen_min );
 
     HyphMan();
     ~HyphMan();

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -80,14 +80,20 @@ public:
 
 class HyphDictionary;
 class HyphDictionaryList;
+class TexHyph;
+class AlgoHyph;
 
 /// hyphenation manager
 class HyphMan
 {
 	friend class HyphDictionary;
+	friend class TexHyph;
+	friend class AlgoHyph;
     static HyphMethod * _method;
 	static HyphDictionary * _selectedDictionary;
 	static HyphDictionaryList * _dictList;
+        static int _LeftHyphenMin;
+        static int _RightHyphenMin;
 public:
 	static void uninit();
     static bool activateDictionaryFromStream( LVStreamRef stream );
@@ -95,6 +101,10 @@ public:
     static bool activateDictionary( lString16 id ) { return _dictList->activate(id); }
     static bool initDictionaries(lString16 dir, bool clear = true);
 	static HyphDictionary * getSelectedDictionary() { return _selectedDictionary; }
+	static int getLeftHyphenMin() { return _LeftHyphenMin; }
+	static int getRightHyphenMin() { return _RightHyphenMin; }
+	static bool setLeftHyphenMin( int left_hyphen_min );
+	static bool setRightHyphenMin( int right_hyphen_min );
 
     HyphMan();
     ~HyphMan();

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -47,6 +47,8 @@
 #define PROP_SHOW_BATTERY_PERCENT    "window.status.battery.percent"
 #define PROP_FONT_KERNING_ENABLED    "font.kerning.enabled"
 #define PROP_LANDSCAPE_PAGES         "window.landscape.pages"
+#define PROP_HYPHENATION_LEFT_HYPHEN_MIN "crengine.hyphenation.left.hyphen.min"
+#define PROP_HYPHENATION_RIGHT_HYPHEN_MIN "crengine.hyphenation.right.hyphen.min"
 #define PROP_HYPHENATION_DICT        "crengine.hyphenation.directory"
 #define PROP_HYPHENATION_DICT_VALUE_NONE "@none"
 #define PROP_HYPHENATION_DICT_VALUE_ALGORITHM "@algorithm"

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -50,6 +50,12 @@
 
 #endif
 
+// min value supported by algorithms is 2 (max is arbitrary 10)
+#define HYPH_MIN_HYPHEN_MIN 2
+#define HYPH_MAX_HYPHEN_MIN 10
+
+int HyphMan::_LeftHyphenMin = HYPH_MIN_HYPHEN_MIN;
+int HyphMan::_RightHyphenMin = HYPH_MIN_HYPHEN_MIN;
 
 HyphDictionary * HyphMan::_selectedDictionary = NULL;
 
@@ -174,6 +180,22 @@ bool HyphMan::initDictionaries(lString16 dir, bool clear)
 		_dictList->activate( lString16(HYPH_DICT_ID_ALGORITHM) );
 		return false;
 	}
+}
+
+bool HyphMan::setLeftHyphenMin( int left_hyphen_min ) {
+    if (left_hyphen_min >= HYPH_MIN_HYPHEN_MIN && left_hyphen_min <= HYPH_MAX_HYPHEN_MIN) {
+        HyphMan::_LeftHyphenMin = left_hyphen_min;
+        return true;
+    }
+    return false;
+}
+
+bool HyphMan::setRightHyphenMin( int right_hyphen_min ) {
+    if (right_hyphen_min >= HYPH_MIN_HYPHEN_MIN && right_hyphen_min <= HYPH_MAX_HYPHEN_MIN) {
+        HyphMan::_RightHyphenMin = right_hyphen_min;
+        return true;
+    }
+    return false;
 }
 
 bool HyphDictionary::activate()
@@ -790,6 +812,10 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     bool res = false;
     int p=0;
     for ( p=len-3; p>=1; p-- ) {
+        if (p < HyphMan::_LeftHyphenMin - 1)
+            continue;
+        if (p > len - HyphMan::_RightHyphenMin - 1)
+            continue;
         // hyphenate
         //00010030100
         int nw = widths[p]+hyphCharWidth;
@@ -820,6 +846,10 @@ bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8
         // now look over word, placing hyphens
         if ( end-start > MIN_WORD_LEN_TO_HYPHEN ) { // word must be long enough
             for (i=start;i<end-MIN_WORD_LEN_TO_HYPHEN;++i) {
+                if (i-start < HyphMan::_LeftHyphenMin - 1)
+                    continue;
+                if (end-i < HyphMan::_RightHyphenMin + 1)
+                    continue;
                 if ( widths[i] > maxWidth )
                     break;
                 if ( chprops[i] & CH_PROP_VOWEL ) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5887,6 +5887,18 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                     REQUEST_RENDER("propsApply hyphenation dict")
                 }
             }
+        } else if (name == PROP_HYPHENATION_LEFT_HYPHEN_MIN) {
+            int leftHyphenMin = props->getIntDef(PROP_HYPHENATION_LEFT_HYPHEN_MIN, 2);
+            if (HyphMan::getLeftHyphenMin() != leftHyphenMin) {
+                HyphMan::setLeftHyphenMin(leftHyphenMin);
+                REQUEST_RENDER("propsApply hyphenation left_hyphen_min")
+            }
+        } else if (name == PROP_HYPHENATION_RIGHT_HYPHEN_MIN) {
+            int rightHyphenMin = props->getIntDef(PROP_HYPHENATION_RIGHT_HYPHEN_MIN, 2);
+            if (HyphMan::getRightHyphenMin() != rightHyphenMin) {
+                HyphMan::setRightHyphenMin(rightHyphenMin);
+                REQUEST_RENDER("propsApply hyphenation right_hyphen_min")
+            }
 #endif
         } else if (name == PROP_INTERLINE_SPACE) {
             int interlineSpace = props->getIntDef(PROP_INTERLINE_SPACE,

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -310,6 +310,8 @@ lUInt32 calcGlobalSettingsHash(int documentId)
     if ( gFlgFloatingPunctuationEnabled )
         hash = hash * 75 + 1761;
     hash = hash * 31 + (HyphMan::getSelectedDictionary()!=NULL ? HyphMan::getSelectedDictionary()->getHash() : 123 );
+    hash = hash * 31 + HyphMan::getLeftHyphenMin();
+    hash = hash * 31 + HyphMan::getRightHyphenMin();
     return hash;
 }
 


### PR DESCRIPTION
When hyphenating a word, the existing algorithms enforce a minimal length of 2 for each word fragments on left or right side.
This allows for increasing these minimal sizes, as requested in https://github.com/koreader/koreader/issues/3848.
These new numbers need to be included in the globalHash computation so the document can be re-rendered when they are updated.

See discussion about where to do that in hyphman.cpp and tests at https://github.com/koreader/koreader/issues/3848#issuecomment-381647179 and followups.

I'll PR the frontend code to use that in the evening.