### PR TITLE
Support 'width:' css style on some block elements

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1662,6 +1662,59 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
             x += margin_left;
         y += margin_top;
 
+        // Support style 'width:' attribute, for selected elements only
+        css_length_t style_width = enode->getStyle()->width;
+        if (style_width.type != css_val_unspecified) {
+            // printf("style_width.type: %d (%d)\n", style_width.value, style_width.type);
+
+            bool apply_style_width = false;
+            bool style_width_pct_em_only = true; // only apply if width is in '%' or in 'em'
+            int  style_width_alignment = 0; // 0: left aligned / 1: centered / 2: right aligned
+            // Uncomment for testing alternate defaults:
+            // apply_style_width = true;        // apply width to all elements (except table elements)
+            // apply_style_width = false;       // never apply any width (as previously)
+            // style_width_pct_em_only = false; // accept any kind of unit
+
+            if (enode->getNodeId() == el_hr) { // <HR>
+                apply_style_width = true;
+                style_width_alignment = 1; // <hr> are auto-centered
+                style_width_pct_em_only = false; // width for <hr> is safe, whether px or %
+            }
+            if (enode->getStyle()->display >= css_d_table ) {
+                // table elements are managed elsewhere: we'd rather not mess with the table
+                // layout algorithm by applying styles width here (even if this algorithm
+                // is not perfect, it looks like applying width here does not make it better).
+                apply_style_width = false;
+            }
+
+            /* If alignment would depend on parent style (I thought a children <div> would be
+             * aligned according to parent <div style="text-align: right">, but it does not.
+                ldomNode * parent = enode->getParentNode();
+                css_text_align_t align = parent->getStyle()->text_align;
+                if (align == css_ta_center) style_width_alignment = 1;
+                if (align == css_ta_right) style_width_alignment = 2;
+            */
+
+            if (apply_style_width && style_width_pct_em_only) {
+                if (style_width.type != css_val_percent && style_width.type != css_val_em) {
+                    apply_style_width = false;
+                }
+            }
+            if (apply_style_width) {
+                int style_width_px = lengthToPx( style_width, width, em );
+                if (style_width_px && style_width_px < width) { // ignore if greater than our given width
+                    // printf("style_width: %dps at ~y=%d\n", style_width_px, y);
+                    if (style_width_alignment == 1) { // centered
+                        x += (width - style_width_px)/2;
+                    }
+                    else if (style_width_alignment == 2) { // right aligned
+                        x += (width - style_width_px);
+                    }
+                    width = style_width_px;
+                }
+            }
+        }
+
         bool flgSplit = false;
         width -= margin_left + margin_right;
         int h = 0;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1662,17 +1662,21 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
             x += margin_left;
         y += margin_top;
 
-        // Support style 'width:' attribute, for selected elements only
+        // Support style 'width:' attribute, for specific elements only: solely <HR> for now.
+        // As crengine does not support many fancy display: styles, and each HTML block
+        // elements is rendered as a crengine blockElement (an independant full width slice,
+        // with possibly some margin/padding/indentation/border, of the document height),
+        // we don't want to waste reading width with blank areas (as we are not sure
+        // the content producer intended them because of crengine limitations).
         css_length_t style_width = enode->getStyle()->width;
         if (style_width.type != css_val_unspecified) {
             // printf("style_width.type: %d (%d)\n", style_width.value, style_width.type);
 
-            bool apply_style_width = false;
+            bool apply_style_width = false; // Don't apply width by default
             bool style_width_pct_em_only = true; // only apply if width is in '%' or in 'em'
             int  style_width_alignment = 0; // 0: left aligned / 1: centered / 2: right aligned
             // Uncomment for testing alternate defaults:
             // apply_style_width = true;        // apply width to all elements (except table elements)
-            // apply_style_width = false;       // never apply any width (as previously)
             // style_width_pct_em_only = false; // accept any kind of unit
 
             if (enode->getNodeId() == el_hr) { // <HR>
@@ -1680,21 +1684,13 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                 style_width_alignment = 1; // <hr> are auto-centered
                 style_width_pct_em_only = false; // width for <hr> is safe, whether px or %
             }
-            if (enode->getStyle()->display >= css_d_table ) {
+
+            if (apply_style_width && enode->getStyle()->display >= css_d_table ) {
                 // table elements are managed elsewhere: we'd rather not mess with the table
                 // layout algorithm by applying styles width here (even if this algorithm
                 // is not perfect, it looks like applying width here does not make it better).
                 apply_style_width = false;
             }
-
-            /* If alignment would depend on parent style (I thought a children <div> would be
-             * aligned according to parent <div style="text-align: right">, but it does not.
-                ldomNode * parent = enode->getParentNode();
-                css_text_align_t align = parent->getStyle()->text_align;
-                if (align == css_ta_center) style_width_alignment = 1;
-                if (align == css_ta_right) style_width_alignment = 2;
-            */
-
             if (apply_style_width && style_width_pct_em_only) {
                 if (style_width.type != css_val_percent && style_width.type != css_val_em) {
                     apply_style_width = false;


### PR DESCRIPTION
`<HR>` only for now.
I let in code for generic support on all or some elements, and/or to support them only if value is in '%' or 'em' units which make the width relative to current block width. But it's safer to not support them on other elements, for wider and better readability.

Mentionned in https://github.com/koreader/koreader/issues/2842.
The only place `width:` is currently supported by crengine is for images.

For crengine, `<hr>` is just a dummy block element (which happens to be empty the way it is used by authors), to which our epub.css or html.css add some borders.
So, to support `width`, we just have to support them for all block elements.

Which I did, it was easy. And we now support `width:`!
Except that it's most often preferable to NOT support `width:` :)

95% of the EPUBs (non Wikipedia) I tested have no elements with `width`. Those who have some often have them in the presentationnal first few pages, for layout of the editor & co.

But all the Wikipedia EPUB have some widths:
[One width: 80%](https://github.com/koreader/koreader/blob/3f92525ec79a5df09912af24d90f011be6103261/frontend/ui/wikipedia.lua#L943) I let in by error (as it was never used by crengine) in the stylesheet.css, and that I should remove. If width were supported on div, this would shift thumbnails dotted images to the left, and old Saved EPUB would be ugly.
Also, many EPUBs have some `width: 226px` to center text below thumbnails images. If supported, the thumbnails images would be ugly with a many-lines small-width captions. These would be hard to remove while saving as EPUB.
And some places where 2 consecutive `<div style='width: 50%'>` with lists to be displayed side by side: if we'd support these, they will be displayed one below the other by crengine, with a unneeded 50% shrink...

So, finally, the less risky options is to just support width: for `<HR>` :)
(I guess that's why it wasn't supported, given how easy it was to add support for it).

I let in some comments. I can clean that a bit if we agree we don't have to support more, or let them in and add a generic comment about why we don't.

Sample file for testing: [test-width.html.txt](https://github.com/koreader/crengine/files/1923703/test-width.html.txt)
<kbd>![image](https://user-images.githubusercontent.com/24273478/38928747-73f4eb2e-430a-11e8-9cc4-39811c731f6b.png)</kbd>
