### PR TITLE
hyphenation: change hyphen_min minimal value from 2 to 1

### DIFF
--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -29,6 +29,11 @@ public:
 #define WORD_LENGTH   64
 #define MAX_REAL_WORD 24
 
+// min value supported by algorithms is 1 (max is arbitrary 10)
+// value enforced by algorithm previously was 2, so it's the default
+#define HYPH_DEFAULT_HYPHEN_MIN 2
+#define HYPH_MIN_HYPHEN_MIN 1
+#define HYPH_MAX_HYPHEN_MIN 10
 
 enum HyphDictType
 {

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -80,8 +80,7 @@ public:
 	bool activate( lString16 id );
 };
 
-#define DEF_HYPHENATION_DICT "Russian_EnUS_hyphen_(Alan).pdb"
-#define DEF_HYPHENATION_DICT2 "ru.pattern"
+#define DEF_HYPHENATION_DICT "English_US_hyphen_(Alan).pdb"
 
 class HyphDictionary;
 class HyphDictionaryList;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -50,12 +50,8 @@
 
 #endif
 
-// min value supported by algorithms is 2 (max is arbitrary 10)
-#define HYPH_MIN_HYPHEN_MIN 2
-#define HYPH_MAX_HYPHEN_MIN 10
-
-int HyphMan::_LeftHyphenMin = HYPH_MIN_HYPHEN_MIN;
-int HyphMan::_RightHyphenMin = HYPH_MIN_HYPHEN_MIN;
+int HyphMan::_LeftHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
+int HyphMan::_RightHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 
 HyphDictionary * HyphMan::_selectedDictionary = NULL;
 
@@ -811,7 +807,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 
     bool res = false;
     int p=0;
-    for ( p=len-3; p>=1; p-- ) {
+    for ( p=len-2; p>=0; p-- ) {
         if (p < HyphMan::_LeftHyphenMin - 1)
             continue;
         if (p > len - HyphMan::_RightHyphenMin - 1)

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -169,7 +169,6 @@ bool HyphMan::initDictionaries(lString16 dir, bool clear)
         _dictList = new HyphDictionaryList();
     if (_dictList->open(dir, clear)) {
 		if ( !_dictList->activate( lString16(DEF_HYPHENATION_DICT) ) )
-	    	if ( !_dictList->activate( lString16(DEF_HYPHENATION_DICT2) ) )
     			_dictList->activate( lString16(HYPH_DICT_ID_ALGORITHM) );
 		return true;
 	} else {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5888,13 +5888,13 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 }
             }
         } else if (name == PROP_HYPHENATION_LEFT_HYPHEN_MIN) {
-            int leftHyphenMin = props->getIntDef(PROP_HYPHENATION_LEFT_HYPHEN_MIN, 2);
+            int leftHyphenMin = props->getIntDef(PROP_HYPHENATION_LEFT_HYPHEN_MIN, HYPH_DEFAULT_HYPHEN_MIN);
             if (HyphMan::getLeftHyphenMin() != leftHyphenMin) {
                 HyphMan::setLeftHyphenMin(leftHyphenMin);
                 REQUEST_RENDER("propsApply hyphenation left_hyphen_min")
             }
         } else if (name == PROP_HYPHENATION_RIGHT_HYPHEN_MIN) {
-            int rightHyphenMin = props->getIntDef(PROP_HYPHENATION_RIGHT_HYPHEN_MIN, 2);
+            int rightHyphenMin = props->getIntDef(PROP_HYPHENATION_RIGHT_HYPHEN_MIN, HYPH_DEFAULT_HYPHEN_MIN);
             if (HyphMan::getRightHyphenMin() != rightHyphenMin) {
                 HyphMan::setRightHyphenMin(rightHyphenMin);
                 REQUEST_RENDER("propsApply hyphenation right_hyphen_min")


### PR DESCRIPTION
Followup to #151, as it seems it works fine with a minimal value of 1.
See https://github.com/koreader/koreader/issues/3848#issuecomment-382291410 for why it can matter with French.

No adaptation seemed needed in AlgoHyph, but I couldn't make it show me a hyphenation happening at 1.
Also move the #define for these values into the header file, so we can use them in lvdocview.cpp