### PR TITLE
Update French.pattern

### DIFF
--- a/cr3gui/data/hyph/French.pattern
+++ b/cr3gui/data/hyph/French.pattern
@@ -1883,4 +1883,11 @@
 <pattern> con5</pattern>
 <pattern> cul5</pattern>
 -->
+<!-- rules to take care of some exceptions introduced by right 1 
+but needed by crengine no quote pattern -->
+<pattern>d2s </pattern>
+<pattern>f2s </pattern>
+<pattern>g2s </pattern>
+<pattern>m2s </pattern>
+<pattern>n2x </pattern>
 </HyphenationDescription>


### PR DESCRIPTION
Added 5 rules to take care of some exceptions introduced by right min 1, but needed by crengine no-quote and no-hyphen patterns.

Added the rules saying "do not cut there when it's the end of the word" : 
 
`<pattern>d2s </pattern>`
`<pattern>f2s </pattern>`
`<pattern>g2s </pattern>`
`<pattern>m2s </pattern>`
`<pattern>n2x </pattern>`
