### PR TITLE
ldomXPointer::toPoint(): add optional use_getRectEx param

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1314,9 +1314,10 @@ public:
 #if BUILD_LITE!=1
     /// returns caret rectangle for pointer inside formatted document
     bool getRect(lvRect & rect) const;
+    /// returns caret rectangle for pointer inside formatted document considering paddings and borders
     bool getRectEx(lvRect & rect) const;
     /// returns coordinates of pointer inside formatted document
-    lvPoint toPoint() const;
+    lvPoint toPoint( bool use_getRectEx=false ) const;
 #endif
     /// converts to string
 	lString16 toString();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5038,11 +5038,17 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
 }
 
 /// returns coordinates of pointer inside formatted document
-lvPoint ldomXPointer::toPoint() const
+lvPoint ldomXPointer::toPoint(bool use_getRectEx) const
 {
     lvRect rc;
-    if ( !getRect( rc ) )
-        return lvPoint(-1, -1);
+    if (use_getRectEx) {
+        if ( !getRectEx( rc ) )
+            return lvPoint(-1, -1);
+    }
+    else {
+        if ( !getRect( rc ) )
+            return lvPoint(-1, -1);
+    }
     return rc.topLeft();
 }
 


### PR DESCRIPTION
Using `getRectEx()` instead of `getRect()` in some cases gives more accurate coordinates.
To be used in cre.cpp `getPosFromXPointer()` to get a more accurate y:
```c
--- a/cre.cpp
+++ b/cre.cpp
@@ -540,7 +540,7 @@ static int getPosFromXPointer(lua_State *L) {
        int pos = 0;
        ldomXPointer xp = doc->dom_doc->createXPointer(lString16(xpointer_str));

-       lvPoint pt = xp.toPoint();
+       lvPoint pt = xp.toPoint(true); // use_getRectEx, for better accuracy
        if (pt.y > 0) {
                pos = pt.y;
        }
```

Always using it in` ldomXPointer::toPoint()` has some side effects, like highlights being drawn a bit shifted outside words.

getRectEx() was introduced in #51 and #52  (it could have been made simpler by just passing an optional parameter to the existing getRect()).

Always using it in `getPosFromXPointer()` looks like it shouldn't hurt, but in case it does, we could have it also have it as an optional parameter that would be used only in:
https://github.com/koreader/koreader/blob/d601eabc4ad516f07266e6a809c3322b8b83933c/frontend/apps/reader/modules/readerlink.lua#L157-L160
That code often fails in tables, and no marker is shown when back when clicking on footnotes in tables. I also have sometimes (mostly on kobo, none on the emulator with the same document!) for some books without tables: `WARN not coherent a_xpointer `, so hopefully, this will fix them too.
Can be checked with the epub from #156, taping one the the following footnotes, or swiping to follow link:
<kbd>![image](https://user-images.githubusercontent.com/24273478/39095293-5ddc2b2c-463e-11e8-86ee-020c482b77b0.png)</kbd>
