### PR TITLE
.html documents: use css defined in <head><style>

### DIFF
--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -191,6 +191,7 @@ XS_ATTR( title )
 XS_ATTR( subtitle )
 XS_ATTR( suptitle )
 XS_ATTR( start )
+XS_ATTR( StyleSheetText )
 
 XS_END_ATTRS
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2244,6 +2244,8 @@ protected:
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
+    bool _inHeadStyle;
+    lString16 _headStyleText;
     virtual void AutoClose( lUInt16 tag_id, bool open );
     virtual void ElementCloseHandler( ldomNode * elem );
     virtual void appendStyle( const lChar16 * style );


### PR DESCRIPTION
It was not implemented for plain .html files, but was for .epub.
We use the same kind of trick (store the css content into an attribute of the <body> element) as done for .epub (except that for epub, it's stored as a children element, which I couldn't do for some reason - having it as an attribute has the benefit it's not displayed when `Clear all external styles`).

`ldomDocumentWriterFilter` is only used to parse HTML (and PDF, CHM), and allows for autoclosing tags. EPUB use a more strick one `ldomDocumentWriter`, that I didn't touch (but I used the same kind of trick that was done in it for DocFragment head styles and styles link).

Should allow us to test more easily html snippets, and no more to have to embed them into an epub.

Such as the one from https://github.com/koreader/crengine/issues/140 , which used to display (with crengine, when properly renamed to `.html` :) as:
<kbd>![before](https://user-images.githubusercontent.com/24273478/39141083-edf7f608-4726-11e8-9977-af20fc0a9f69.png)</kbd>

It would display now as:
<kbd>![after](https://user-images.githubusercontent.com/24273478/39141086-f0dac6ca-4726-11e8-9060-a8eb8ad2ce2b.png)</kbd>
