### PR TITLE
Fix some CSS case sensitivity issues

### DIFF
--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -2540,6 +2540,15 @@ void LVColorDrawBuf::DrawOnTop( LVDrawBuf * buf, int x, int y)
                         dst++;
                         src++;
                     }
+                } else if (bpp == 16) {
+                    lUInt16 * dst = ((lUInt16 *)buf->GetScanLine(y + yy)) + x;
+                    for (int xx=0; xx < _dx; xx++) {
+                        if (x + xx >= clip.left && x + xx < clip.right) {
+                            if(src!=0) *dst = rgb888to565(*src);
+                        }
+                        dst++;
+                        src++;
+                    }
                 } else if (bpp == 32) {
                     lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y + yy)) + x;
                     for (int xx = 0; xx < _dx; xx++) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2362,15 +2362,18 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
     if (!style->background_image.empty()) {
         lString16 filename = lString16(style->background_image.c_str());
         {//url("path") to path
-            if (filename.lowercase().startsWith("url")) filename = filename.substr(3);
+            if (lString16(filename).lowercase().startsWith("url")) filename = filename.substr(3);
             filename.trim();
-            if (filename.lowercase().startsWith("(")) filename = filename.substr(1);
-            if (filename.lowercase().endsWith(")")) filename = filename.substr(0, filename.length() - 1);
+            if (filename.startsWith("(")) filename = filename.substr(1);
+            if (filename.endsWith(")")) filename = filename.substr(0, filename.length() - 1);
             filename.trim();
-            if (filename.lowercase().startsWith("\"")) filename = filename.substr(1);
-            if (filename.lowercase().endsWith("\"")) filename = filename.substr(0, filename.length() - 1);
+            if (filename.startsWith("\"")) filename = filename.substr(1);
+            if (filename.endsWith("\"")) filename = filename.substr(0, filename.length() - 1);
             filename.trim();
-            if (filename.lowercase().startsWith("../")) filename = filename.substr(3);
+            // This is probably wrong: we should have resolved the path at
+            // stylesheet parsing time (but the current code does not).
+            // Here, all files relative path information is no more accessible.
+            if (filename.startsWith("../")) filename = filename.substr(3);
         }
         LVImageSourceRef img = enode->getParentNode()->getDocument()->getObjectImageSource(filename);
         if (!img.isNull()) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -245,7 +245,7 @@ static css_decl_code parse_property_name( const char * & res )
     const char * str = res;
     for (int i=1; css_decl_name[i]; i++)
     {
-        if (substr_compare( css_decl_name[i], str ))
+        if (substr_icompare( css_decl_name[i], str )) // css property case should not matter (eg: "Font-Weight:")
         {
             // found!
             skip_spaces(str);
@@ -266,7 +266,7 @@ static int parse_name( const char * & str, const char * * names, int def_value )
 {
     for (int i=0; names[i]; i++)
     {
-        if (substr_compare( names[i], str ))
+        if (substr_icompare( names[i], str )) // css named value case should not matter (eg: "BOLD")
         {
             // found!
             return i;
@@ -288,7 +288,8 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
 {
     value.type = css_val_unspecified;
     skip_spaces( str );
-    if ( substr_compare( "inherited", str ) )
+    // Here and below: named values and unit case should not matter
+    if ( substr_icompare( "inherited", str ) )
     {
         value.type = css_val_inherited;
         value.value = 0;
@@ -296,12 +297,12 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
     }
     if ( is_font_size ) {
         // Approximate the (usually uneven) gaps between named sizes.
-        if ( substr_compare( "smaller", str ) ) {
+        if ( substr_icompare( "smaller", str ) ) {
             value.type = css_val_percent;
             value.value = 80;
             return true;
         }
-        else if ( substr_compare( "larger", str ) ) {
+        else if ( substr_icompare( "larger", str ) ) {
             value.type = css_val_percent;
             value.value = 125;
             return true;
@@ -332,23 +333,23 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
             str++;
         }
     }
-    if ( substr_compare( "em", str ) )
+    if ( substr_icompare( "em", str ) )
         value.type = css_val_em;
-    else if ( substr_compare( "pt", str ) )
+    else if ( substr_icompare( "pt", str ) )
         value.type = css_val_pt;
-    else if ( substr_compare( "ex", str ) )
+    else if ( substr_icompare( "ex", str ) )
         value.type = css_val_ex;
-    else if ( substr_compare( "px", str ) )
+    else if ( substr_icompare( "px", str ) )
         value.type = css_val_px;
-    else if ( substr_compare( "in", str ) )
+    else if ( substr_icompare( "in", str ) )
         value.type = css_val_in;
-    else if ( substr_compare( "cm", str ) )
+    else if ( substr_icompare( "cm", str ) )
         value.type = css_val_cm;
-    else if ( substr_compare( "mm", str ) )
+    else if ( substr_icompare( "mm", str ) )
         value.type = css_val_mm;
-    else if ( substr_compare( "pc", str ) )
+    else if ( substr_icompare( "pc", str ) )
         value.type = css_val_pc;
-    else if ( substr_compare( "%", str ) )
+    else if ( substr_icompare( "%", str ) )
         value.type = css_val_percent;
     else if (n == 0 && frac == 0)
         value.type = css_val_px;
@@ -2015,7 +2016,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         // todo
         {
             lString16 val = node->getAttributeValue(attr_class);
-            val.lowercase();
+            // val.lowercase(); // className should be case sensitive
 //            if ( val.length() != _value.length() )
 //                return false;
             //CRLog::trace("attr_class: %s %s", LCSTR(val), LCSTR(_value) );
@@ -2114,7 +2115,7 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         skip_spaces( str );
         LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_class);
         lString16 s( attrvalue );
-        s.lowercase();
+        // s.lowercase(); // className should be case sensitive
         rule->setAttr(attr_class, s);
         return rule;
     } else if ( *str=='#' ) {


### PR DESCRIPTION
- Case should not matter when parsing CSS declaration properties ("`Font-Weight`"), named values ("`Bold`"), named length ("`LARGER`"), and length units ("`10PX`").
- Case should matter when matching class names ("`<div class="bottomBorder"` should not use CSS defined as "div.bottomborder").
- Fix color rendering of background image (the conversion of internal images from 32bpp to the final 16bpp was simply not implemented).
- Fix existing unwanted lowercasing of background image file reference (`url("BackgrounImage.jpeg")` was lowercased in the process of parsing it.

See discussion in #140. Closes #140.

There is still an existing issue with resolution of relative image path there that could fail (couldn't find a quick fix for this), and some other existing strange issue when no-repeat is used (as in the After screenshot before, that looked the same before, with a lowercase filename and fullpath).

Sample file for testing that kind of stuff: 

[test-css-nocase.epub.zip](https://github.com/koreader/crengine/files/1946521/test-css-nocase.epub.zip)

Before:
<kbd>![before](https://user-images.githubusercontent.com/24273478/39239730-171e9e18-4882-11e8-83a5-935bc50135c7.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/39239755-2aece5b2-4882-11e8-906a-2663a9988678.png)</kbd>

