### PR TITLE
Stylesheets: fix parsing of 'inherit' property value

### DIFF
--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -146,7 +146,7 @@ typedef struct css_style_rec_tag {
     , height(css_val_unspecified, 0)
     , color(css_val_inherited, 0)
     , background_color(css_val_unspecified, 0)
-    , letter_spacing(css_val_unspecified, 0)
+    , letter_spacing(css_val_inherited, 0)
     , page_break_before(css_pb_auto)
     , page_break_after(css_pb_auto)
     , page_break_inside(css_pb_auto)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -302,7 +302,7 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
     value.type = css_val_unspecified;
     skip_spaces( str );
     // Here and below: named values and unit case should not matter
-    if ( substr_icompare( "inherited", str ) )
+    if ( substr_icompare( "inherit", str ) )
     {
         value.type = css_val_inherited;
         value.value = 0;
@@ -541,7 +541,7 @@ bool parse_color_value( const char * & str, css_length_t & value )
 {
     value.type = css_val_unspecified;
     skip_spaces( str );
-    if ( substr_compare( "inherited", str ) )
+    if ( substr_compare( "inherit", str ) )
     {
         value.type = css_val_inherited;
         value.value = 0;


### PR DESCRIPTION
It was correct for enum values, but not for length values.
Also fix default value for `letter_spacing` to be `inherit`.

See https://github.com/koreader/koreader/issues/1430#issuecomment-385656723.

Should allow fixing some annoying books with:
```css
body { margin: 0 0 0 0 !important; }
* { line-height: inherit !important ;}
```
