### PR TITLE
Stylesheets: implement CSS selectors specificity

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -110,9 +110,10 @@ class LVCssSelectorRule
     lUInt16 _attrid;
     LVCssSelectorRule * _next;
     lString16 _value;
+    lUInt32 _weight; // weight to add to LVCssSelector specificity
 public:
     LVCssSelectorRule(LVCssSelectorRuleType type)
-    : _type(type), _id(0), _attrid(0), _next(NULL)
+    : _type(type), _id(0), _attrid(0), _next(NULL), _weight(0)
     { }
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
@@ -123,6 +124,7 @@ public:
     /// check condition for node
     bool check( const ldomNode * & node );
     lUInt32 getHash();
+    lUInt32 getWeight();
 };
 
 /** \brief simple CSS selector

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -110,10 +110,9 @@ class LVCssSelectorRule
     lUInt16 _attrid;
     LVCssSelectorRule * _next;
     lString16 _value;
-    lUInt32 _weight; // weight to add to LVCssSelector specificity
 public:
     LVCssSelectorRule(LVCssSelectorRuleType type)
-    : _type(type), _id(0), _attrid(0), _next(NULL), _weight(0)
+    : _type(type), _id(0), _attrid(0), _next(NULL)
     { }
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1972,25 +1972,24 @@ lUInt32 LVCssSelectorRule::getWeight() {
 
     // declaration from a style="" attribute (a) are always applied last,
     // and don't have a selector here.
-    switch (_type)
-    {
-    case cssrt_id:            // E#id
-        return 1 << 16;
-        break;
-    case cssrt_attrset:       // E[foo]
-    case cssrt_attreq:        // E[foo="value"]
-    case cssrt_attrhas:       // E[foo~="value"]
-    case cssrt_attrstarts:    // E[foo|="value"]
-    case cssrt_class:         // E.class
-        return 1 << 8;
-        break;
-    case cssrt_parent:        // E > F
-    case cssrt_ancessor:      // E F
-    case cssrt_predecessor:   // E + F
-        return 1;
-        break;
-    case cssrt_universal:     // *
-        return 0;
+    switch (_type) {
+        case cssrt_id:            // E#id
+            return 1 << 16;
+            break;
+        case cssrt_attrset:       // E[foo]
+        case cssrt_attreq:        // E[foo="value"]
+        case cssrt_attrhas:       // E[foo~="value"]
+        case cssrt_attrstarts:    // E[foo|="value"]
+        case cssrt_class:         // E.class
+            return 1 << 8;
+            break;
+        case cssrt_parent:        // E > F
+        case cssrt_ancessor:      // E F
+        case cssrt_predecessor:   // E + F
+            return 1;
+            break;
+        case cssrt_universal:     // *
+            return 0;
     }
     return 0;
 }
@@ -2480,6 +2479,7 @@ lUInt32 LVCssSelector::getHash()
         hash = hash * 31 + ruleHash;
     }
     hash = hash * 31 + nextHash;
+    hash = hash * 31 + _specificity;
     if (!_decl.isNull())
         hash = hash * 31 + _decl->getHash();
     return hash;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1946,6 +1946,55 @@ static bool parse_ident( const char * &str, char * ident )
     return true;
 }
 
+lUInt32 LVCssSelectorRule::getWeight() {
+    /* Each LVCssSelectorRule will add its own weight to
+       its LVCssSelector container specifity.
+
+    Following https://www.w3.org/TR/CSS2/cascade.html#specificity
+
+    A selector's specificity is calculated as follows:
+
+    - count 1 if the declaration is from is a 'style' attribute rather
+    than a rule with a selector, 0 otherwise (= a) (In HTML, values
+    of an element's "style" attribute are style sheet rules. These
+    rules have no selectors, so a=1, b=0, c=0, and d=0.)
+    - count the number of ID attributes in the selector (= b) => 1 << 16
+    - count the number of other attributes and pseudo-classes in the
+    selector (= c) => 1 << 8
+    - count the number of element names and pseudo-elements in the
+    selector (= d) => 1
+
+    The specificity is based only on the form of the selector. In
+    particular, a selector of the form "[id=p33]" is counted as an
+    attribute selector (a=0, b=0, c=1, d=0), even if the id attribute is
+    defined as an "ID" in the source document's DTD.
+    */
+
+    // declaration from a style="" attribute (a) are always applied last,
+    // and don't have a selector here.
+    switch (_type)
+    {
+    case cssrt_id:            // E#id
+        return 1 << 16;
+        break;
+    case cssrt_attrset:       // E[foo]
+    case cssrt_attreq:        // E[foo="value"]
+    case cssrt_attrhas:       // E[foo~="value"]
+    case cssrt_attrstarts:    // E[foo|="value"]
+    case cssrt_class:         // E.class
+        return 1 << 8;
+        break;
+    case cssrt_parent:        // E > F
+    case cssrt_ancessor:      // E F
+    case cssrt_predecessor:   // E + F
+        return 1;
+        break;
+    case cssrt_universal:     // *
+        return 0;
+    }
+    return 0;
+}
+
 bool LVCssSelectorRule::check( const ldomNode * & node )
 {
     if (node->isNull() || node->isRoot())
@@ -2269,6 +2318,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
                 return false;
             insertRuleStart( rule ); //insertRuleAfterStart
             //insertRuleAfterStart( rule ); //insertRuleAfterStart
+            _specificity += rule->getWeight();
 
             /*
             if ( _id!=0 ) {
@@ -2290,6 +2340,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
             LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_parent);
             rule->setId(_id);
             insertRuleStart( rule );
+            _specificity += rule->getWeight();
             _id=0;
             continue;
         }
@@ -2299,6 +2350,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
             LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_predecessor);
             rule->setId(_id);
             insertRuleStart( rule );
+            _specificity += rule->getWeight();
             _id=0;
             continue;
         }
@@ -2307,6 +2359,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
             LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_ancessor);
             rule->setId(_id);
             insertRuleStart( rule );
+            _specificity += rule->getWeight();
             _id=0;
             continue;
         }


### PR DESCRIPTION
There was already some code to process selectors by ascending order of specificity, but LVCssSelector._specificity was always 0.
We now add to it some weight depending of the kind of each LVCssSelectorRule it may include.
See https://github.com/koreader/crengine/issues/167#issuecomment-385236850

I haven't tested that much nor looked much at the selector order navigation, I just added these simple rules and the 2 test cases in https://github.com/koreader/koreader/issues/2841 seem ok:

Before => after

<kbd>![image](https://user-images.githubusercontent.com/24273478/39490586-9ea695c8-4d89-11e8-9057-714e1a018d5f.png)</kbd> => <kbd>![image](https://user-images.githubusercontent.com/24273478/39490385-fbb2848a-4d88-11e8-9fb4-78c757d120c8.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/39490629-c0607396-4d89-11e8-83b1-c25f43ff027b.png)</kbd>
=>
<kbd>![image](https://user-images.githubusercontent.com/24273478/39490364-eff027b0-4d88-11e8-8670-a8bcbcf69dae.png)</kbd>