### PR TITLE
Proper handling of <BR> tags in .html documents

### DIFF
--- a/cr3gui/data/chm.css
+++ b/cr3gui/data/chm.css
@@ -205,6 +205,8 @@ hr {
    margin-bottom: 0.5em 
    }
 
+br + br { margin-top: 1em; }
+
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/dict.css
+++ b/cr3gui/data/dict.css
@@ -15,6 +15,8 @@ title {
    margin-bottom: 1em 
    }
 
+br + br { margin-top: 1em; }
+
 emphasis, i { font-style: italic }
 
 strong, b { font-weight: bold }

--- a/cr3gui/data/doc.css
+++ b/cr3gui/data/doc.css
@@ -205,6 +205,8 @@ hr {
    margin-bottom: 0.5em 
    }
 
+br + br { margin-top: 1em; }
+
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -53,6 +53,8 @@ p { text-align: justify; text-indent: 1.2em; margin-top:0em; margin-bottom: 0em 
 
 hr { height: 2px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em }
 
+br + br { margin-top: 1em; }
+
 sub { vertical-align: sub; font-size: 70% }
 sup { vertical-align: super; font-size: 70% }
 sup img{display:inline}

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -6,6 +6,8 @@ empty-line { height: 1em }
 
 hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em; /* 2px */ }
 
+br + br { margin-top: 1em; }
+
 a { display: inline; text-decoration: underline; }
 a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 

--- a/cr3gui/data/htm.css
+++ b/cr3gui/data/htm.css
@@ -207,6 +207,8 @@ hr {
    margin-bottom: 0.5em 
    }
 
+br + br { margin-top: 1em; }
+
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/rtf.css
+++ b/cr3gui/data/rtf.css
@@ -207,6 +207,8 @@ hr {
    margin-bottom: 0.5em 
    }
 
+br + br { margin-top: 1em; }
+
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/txt.css
+++ b/cr3gui/data/txt.css
@@ -207,6 +207,8 @@ hr {
    margin-bottom: 0.5em 
    }
 
+br + br { margin-top: 1em; }
+
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -72,7 +72,7 @@ XS_TAG1T( blockquote )
 XS_TAG1I( em )
 XS_TAG1I( q )
 XS_TAG1I( span )
-XS_TAG1I( br )
+XS_TAG1( br )
 
 XS_TAG1D( title, true, css_d_block, css_ws_normal )
 

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -80,4 +80,6 @@
 #define PROP_IMG_SCALING_ZOOMOUT_BLOCK_MODE "crengine.image.scaling.zoomout.block.mode"
 #define PROP_IMG_SCALING_ZOOMOUT_BLOCK_SCALE "crengine.image.scaling.zoomout.block.scale"
 
+#define PROP_DOM_VERSION             "crengine.dom.version"
+
 #endif // LVDOCVIEWPROPS_H

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -40,6 +40,11 @@
 #include "props.h"
 #include "bookformats.h"
 
+// Allows for requesting older DOM building code (including bugs NOT fixed)
+extern const int gDOMVersionCurrent;
+extern int gDOMVersionRequested;
+
+
 #define LXML_NO_DATA       0 ///< to mark data storage record as empty
 #define LXML_ELEMENT_NODE  1 ///< element node
 #define LXML_TEXT_NODE     2 ///< text node

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5681,6 +5681,8 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 
     for (int i=0; def_style_macros[i*2]; i++)
         props->setStringDef(def_style_macros[i * 2], def_style_macros[i * 2 + 1]);
+
+    props->setIntDef(PROP_DOM_VERSION, gDOMVersionCurrent);
 }
 
 #define H_MARGIN 8
@@ -5948,6 +5950,8 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_PAGE_VIEW_MODE) {
             bool value = props->getBoolDef(PROP_CACHE_VALIDATION_ENABLED, true);
             enableCacheFileContentsValidation(value);
+        } else if (name == PROP_DOM_VERSION) {
+            gDOMVersionRequested = props->getIntDef(PROP_DOM_VERSION, gDOMVersionCurrent);
         } else {
 
             // unknown property, adding to list of unknown properties

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1195,7 +1195,7 @@ int LVGifImageSource::DecodeFromBuffer(unsigned char *buf, int buf_size, LVImage
             break;
         case '!': // extension record
             {
-                if (p[1]==0xf9 && (p[3]&1!=0))
+                if ( p[1]==0xf9 && ( (p[3]&1)!=0 ) )
                 {
                     m_transparent_color = p[6];
                     defined_transparent_color = true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11,6 +11,29 @@
 
 *******************************************************/
 
+
+/// Change this in case of incompatible changes in XML parsing or DOM
+// building that could result in XPATHs being different than previously
+// (this could make saved bookmarks and highlights, made with a previous
+// version, not found in the DOM built with a newer version.
+// Users of this library can request the old behaviour by setting
+// gDOMVersionRequested to an older version to request the old (possibly
+// buggy) behaviour.
+#define DOM_VERSION_CURRENT 20180503
+
+// Changes:
+// 20100101 to 20180502: historical version
+//
+// 20180503: fixed <BR> that were previously converted to <P> because
+// of a fix for "bad LIB.RU books" being applied in any case. This
+// could prevent the style of the container to be applied on HTML
+// sub-parts after a <BR>, or the style of <P> (with text-indent) to
+// be applied after a <BR>.
+
+extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
+int gDOMVersionRequested     = DOM_VERSION_CURRENT;
+
+
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.09k"
@@ -8077,7 +8100,10 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         _inHeadStyle = true;
     }
 
-    if ( _libRuDocumentDetected ) {
+    // Fixed 20180503: this was done previously in any case, but now only
+    // if _libRuDocumentDetected. We still allow the old behaviour if
+    // requested to keep previously recorded XPATHs valid.
+    if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
         // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
         if ((tagname[0] == 'b' && tagname[1] == 'r' && tagname[2] == 0)
             || (tagname[0] == 'd' && tagname[1] == 'd' && tagname[2] == 0)) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13,7 +13,7 @@
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.08k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.09k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0004
 
@@ -8077,14 +8077,16 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         _inHeadStyle = true;
     }
 
-    // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
-    if ((tagname[0] == 'b' && tagname[1] == 'r' && tagname[2] == 0)
-        || (tagname[0] == 'd' && tagname[1] == 'd' && tagname[2] == 0)) {
-        // substitute to P
-        tagname = L"p";
-        _libRuParagraphStart = true; // to trim leading &nbsp;
-    } else {
-        _libRuParagraphStart = false;
+    if ( _libRuDocumentDetected ) {
+        // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
+        if ((tagname[0] == 'b' && tagname[1] == 'r' && tagname[2] == 0)
+            || (tagname[0] == 'd' && tagname[1] == 'd' && tagname[2] == 0)) {
+            // substitute to P
+            tagname = L"p";
+            _libRuParagraphStart = true; // to trim leading &nbsp;
+        } else {
+            _libRuParagraphStart = false;
+        }
     }
 
     lUInt16 id = _document->getElementNameIndex(tagname);


### PR DESCRIPTION
`<BR>` were always being converted to `<P>` because of "Patch for bad LIB.RU books" that was being applied everytime.
So, it was losing the style of the container for text after a `<br>`
With this HTML:
```html
<html>
<head>
<style>
p { color: red; text-indent: 1.2em;}
</style>
</head>
<body>

This is some text.<br/>
This is some text.<br/>
This is some text.<br/>
This is some text.<br/>This is some text.<br/>This is some text.<br/>This is some text.<br/>
This is some text.

<hr/>

<p class=thisisaP style="color: blue">
This is some text.<br/>
This is some text.<br/>
This is some text.
</p>

<hr/>

<div class=thisisaDIV style="color: green">
This is some text.<br/>
This is some text.<br/>
This is some text.
</div>

<hr/>

<div class=thisisaDIV style="color: green">
This is some text.<br/>
This is some text.<br/>
This is some text.
</div>

<hr/>

<pre class=thisisaPRE style="color: teal">


          This is some text.<br/>
This is some text.<br/>

</pre>


</body>
</html>
```


<kbd>![before](https://user-images.githubusercontent.com/24273478/39563823-f9bd220a-4eb1-11e8-97f0-9080381e661f.png)</kbd> => <kbd>![after](https://user-images.githubusercontent.com/24273478/39563827-fcc47dfe-4eb1-11e8-8415-0bffa3cf1cc9.png)</kbd>

There is still a problem with leading space/newline not being stripped out, but I can't figure out (yet) where to fix that (lvtextfm.cpp probably).
So, may be don't merge this yet... watching the screenshots I just made, the wrong behaviour seems less intriguing that the fixed one :| 

Also fix unrelated clang warning (the only serious one I found in travis output), in code from https://github.com/koreader/crengine/commit/d0854294e
```
src/lvimg.cpp:1198:40: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]
                if (p[1]==0xf9 && (p[3]&1!=0))
                                       ^~~~~
src/lvimg.cpp:1198:40: note: place parentheses around the '!=' expression to silence this warning
                if (p[1]==0xf9 && (p[3]&1!=0))
                                       ^
                                        (   )
src/lvimg.cpp:1198:40: note: place parentheses around the & expression to evaluate it first
                if (p[1]==0xf9 && (p[3]&1!=0))
                                       ^
                                   (     )
```
