### PR TITLE
[fix] crengine/src/lvfntman.cpp: improve letter_spacing limit

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -55,6 +55,7 @@
 #endif
 
 #define MAX_LINE_CHARS 2048
+#define MAX_LETTER_SPACING MAX_LINE_CHARS/2
 
 
 //DEFINE_NULL_REF( LVFont )
@@ -1086,8 +1087,13 @@ public:
 #if (ALLOW_KERNING==1)
         int use_kerning = _allowKerning && FT_HAS_KERNING( _face );
 #endif
-        if ( letter_spacing<0 || letter_spacing>50 )
+        if ( letter_spacing < 0 )
+        {
             letter_spacing = 0;
+        } else if ( letter_spacing > MAX_LETTER_SPACING )
+        {
+            letter_spacing = MAX_LETTER_SPACING;
+        }
 
         //int i;
 
@@ -1197,7 +1203,7 @@ public:
                         text, len,
                         widths,
                         flags,
-                        2048, // max_width,
+                        MAX_LINE_CHARS,
                         L' ',  // def_char
                         0
                      );
@@ -1356,8 +1362,13 @@ public:
         FONT_GUARD
         if ( len <= 0 || _face==NULL )
             return;
-        if ( letter_spacing<0 || letter_spacing>50 )
+        if ( letter_spacing < 0 )
+        {
             letter_spacing = 0;
+        } else if ( letter_spacing > MAX_LETTER_SPACING )
+        {
+            letter_spacing = MAX_LETTER_SPACING;
+        }
         lvRect clip;
         buf->GetClipRect( &clip );
         updateTransform();
@@ -1580,7 +1591,7 @@ public:
                         text, len,
                         widths,
                         flags,
-                        2048, // max_width,
+                        MAX_LINE_CHARS,
                         L' ',  // def_char
                         0
                      );
@@ -1743,8 +1754,13 @@ public:
     {
         if ( len <= 0 )
             return;
-        if ( letter_spacing<0 || letter_spacing>50 )
+        if ( letter_spacing < 0 )
+        {
             letter_spacing = 0;
+        } else if ( letter_spacing > MAX_LETTER_SPACING )
+        {
+            letter_spacing = MAX_LETTER_SPACING;
+        }
         lvRect clip;
         buf->GetClipRect( &clip );
         if ( y + _height < clip.top || y >= clip.bottom )
@@ -3364,7 +3380,7 @@ lUInt32 LBitmapFont::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    2048, // max_width,
+                    MAX_LINE_CHARS,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -3753,7 +3769,7 @@ lUInt32 LVWin32DrawFont::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    2048, // max_width,
+                    MAX_LINE_CHARS,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -3772,7 +3788,7 @@ lUInt16 LVWin32DrawFont::measureText(
                     int max_width,
                     lChar16 def_char,
                     int letter_spacing,
-					bool allow_hyphenation
+                    bool allow_hyphenation
                  )
 {
     if (_hfont==NULL)
@@ -4112,7 +4128,7 @@ lUInt32 LVWin32Font::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    2048, // max_width,
+                    MAX_LINE_CHARS,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -55,7 +55,8 @@
 #endif
 
 #define MAX_LINE_CHARS 2048
-#define MAX_LETTER_SPACING MAX_LINE_CHARS/2
+#define MAX_LINE_WIDTH 2048
+#define MAX_LETTER_SPACING MAX_LINE_WIDTH/2
 
 
 //DEFINE_NULL_REF( LVFont )
@@ -1203,7 +1204,7 @@ public:
                         text, len,
                         widths,
                         flags,
-                        MAX_LINE_CHARS,
+                        MAX_LINE_WIDTH,
                         L' ',  // def_char
                         0
                      );
@@ -1591,7 +1592,7 @@ public:
                         text, len,
                         widths,
                         flags,
-                        MAX_LINE_CHARS,
+                        MAX_LINE_WIDTH,
                         L' ',  // def_char
                         0
                      );
@@ -3380,7 +3381,7 @@ lUInt32 LBitmapFont::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    MAX_LINE_CHARS,
+                    MAX_LINE_WIDTH,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -3769,7 +3770,7 @@ lUInt32 LVWin32DrawFont::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    MAX_LINE_CHARS,
+                    MAX_LINE_WIDTH,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -4128,7 +4129,7 @@ lUInt32 LVWin32Font::getTextWidth( const lChar16 * text, int len )
                     text, len,
                     widths,
                     flags,
-                    MAX_LINE_CHARS,
+                    MAX_LINE_WIDTH,
                     L' '  // def_char
                  );
     if ( res>0 && res<MAX_LINE_CHARS )


### PR DESCRIPTION
The way a limit works is by setting the value to the limit if you
surpass it, not by setting `0` if you go beyond the limit.

Also upped the value to something more sensible as well as
made it more sensibly tweakable in the future.

As a testcase, just stick some large value in letter-spacing.

```html
<!DOCTYPE html>
<html>
<body>
<div style="letter-spacing:500px">
asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf asdfasfasdf
</div>
</body>
</html>
```

See https://github.com/koreader/koreader/issues/1430#issuecomment-385753941 for discussion.