### PR TITLE
html head styles: fix styles not being applied

### DIFF
--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -59,7 +59,8 @@ HyphDictionaryList * HyphMan::_dictList = NULL;
 
 // MAX_PATTERN_SIZE is actually the max size of a word (pattern stripped
 // from all the numbers that give the quality of a split after previous char)
-#define MAX_PATTERN_SIZE  16
+// (35 is needed for German.pattern)
+#define MAX_PATTERN_SIZE  35
 #define PATTERN_HASH_SIZE 16384
 class TexPattern;
 class TexHyph : public HyphMethod

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8116,6 +8116,11 @@ void ldomDocumentWriterFilter::OnTagBody()
         OnText(_headStyleText.c_str(), _headStyleText.length(), 0);
         OnTagClose(L"", L"stylesheet");
         CRLog::trace("added BODY>stylesheet child element with HEAD>STYLE content");
+        // We add the head style content to current stylesheet, just like it is done for
+        // EPUB in ldomDocumentWriter::OnTagClose(). This is just to change the
+        // stylesheet hash, so that a new rendering is triggered (it will parse again the
+        // stylesheets, and will take into account the one we just set in this element).
+        _document->parseStyleSheet(lString16(), _headStyleText);
         _headStyleText.clear();
     }
 }


### PR DESCRIPTION
~~- `<STYLE>` after non-self-closing `<META>` or `<LINK>` wasn't parsed.~~ done correctly by next PR by @Frenzie (thanks!)

On loading a head style, a re-rendering was not explicitely requested (but may have been done because of other re-rendering reasons like setting a hyphenation dict).
Closes #165

Also: Hyphenation: increase MAX_PATTERN_SIZE from 16 to 35 . See https://github.com/koreader/crengine/pull/150#issuecomment-386612527
