### PR TITLE
[fix] crengine/src/lvxml.cpp: add all empty HTML elements

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -3948,6 +3948,7 @@ static const char * AC_DL[] = {"dl", "dt", "p", NULL};
 static const char * AC_DT[] = {"dt", "dt", "dd", "p", NULL};
 static const char * AC_BR[] = {"br", NULL};
 static const char * AC_HR[] = {"hr", NULL};
+static const char * AC_WBR[] = {"wbr", NULL};
 static const char * AC_PARAM[] = {"param", "param", NULL};
 static const char * AC_IMG[]= {"img", NULL};
 static const char * AC_TD[] = {"td", "td", "th", NULL};
@@ -3961,6 +3962,13 @@ static const char * AC_TBODY[] = {"tbody", "tr", "thead", "tfoot", "tbody", NULL
 static const char * AC_OPTION[] = {"option", "option", NULL};
 static const char * AC_PRE[] = {"pre", "pre", NULL};
 static const char * AC_INPUT[] = {"input", NULL};
+static const char * AC_AREA[] = {"area", NULL};
+static const char * AC_BASE[] = {"base", NULL};
+static const char * AC_EMBED[] = {"embed", NULL};
+static const char * AC_LINK[] = {"link", NULL};
+static const char * AC_META[] = {"meta", NULL};
+static const char * AC_SOURCE[] = {"source", NULL};
+static const char * AC_TRACK[] = {"track", NULL};
 const char * *
 HTML_AUTOCLOSE_TABLE[] = {
     AC_INPUT,
@@ -3979,8 +3987,16 @@ HTML_AUTOCLOSE_TABLE[] = {
     AC_COL,
     AC_BR,
     AC_HR,
+    AC_WBR,
     AC_PARAM,
     AC_IMG,
+    AC_AREA,
+    AC_BASE,
+    AC_EMBED,
+    AC_LINK,
+    AC_META,
+    AC_SOURCE,
+    AC_TRACK,
     AC_DIV,
     AC_THEAD,
     AC_TFOOT,


### PR DESCRIPTION
Fixes https://github.com/koreader/crengine/issues/165#issuecomment-386542218

The HTML was parsed like this instead of properly auto-closing empty elements like `LINK` and `META`.

```xml
<?xml version="1.0"?>
<html>
  <head>
    <title>CSS Test: Simple ID selectors specificity over attribute selectors</title>
    <link rel="author" title="Microsoft" href="http://www.microsoft.com/">
      <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors">
        <meta name="flags" content="">
          <meta name="assert" content="ID selectors trump attribute selectors in specificity.">
            <style type="text/css"> div#div1 { color: green; } div[id=div1] { color: red; } </style>
          </meta>
        </meta>
      </link>
    </link>
  </head>
  <body>
    <p>Test passes if the "Filler Text" below is green.</p>
    <div id="div1">Filler Text</div>
  </body>
</html>
```

The full list:

https://developer.mozilla.org/en-US/docs/Glossary/empty_element

* `<area>`
* `<base>`
* `<br>`
* `<col>`
* `<embed>`
* `<hr>`
* `<img>`
* `<input>`
* `<link>`
* `<meta>`
* `<param>`
* `<source>`
* `<track>`
* `<wbr>`