### PR TITLE
Fix a few CSS selector issues

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -94,6 +94,7 @@ enum LVCssSelectorRuleType
     cssrt_parent,        // E > F
     cssrt_ancessor,      // E F
     cssrt_predecessor,   // E + F
+    cssrt_predsibling,   // E ~ F
     cssrt_attrset,       // E[foo]
     cssrt_attreq,        // E[foo="value"]
     cssrt_attrhas,       // E[foo~="value"]


### PR DESCRIPTION
Fix _some_ of the issues reported in #176.
- fix standalone #ID (was working only as ELEM#ID)
- fix non-lowercase element name (elements are internally lowercased, so we should lowercase there too to expect any match)
- fix E+F selector, that should ignore immediate preceding text nodes, and consider the first met element node
- adds E~F selector (like E+F, but *any* instead of "immediate" precedessor is considered for a match)