### PR TITLE
CSS: add support for some pseudo-classes

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -88,6 +88,36 @@ public:
 
 typedef LVRef<LVCssDeclaration> LVCssDeclRef;
 
+// See https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
+enum LVCssSelectorPseudoClass
+{
+    csspc_first_child,      // :first-child
+    csspc_first_of_type,    // :first-of-type
+    csspc_last_child,       // :last-child
+    csspc_last_of_type,     // :last-of-type
+    csspc_nth_child,        // :nth-child(even), :nth-child(3n+4)
+    csspc_nth_of_type,      // :nth-of-type()
+    csspc_nth_last_child,   // :nth-last-child()
+    csspc_nth_last_of_type, // :nth-last-of-type()
+    csspc_only_child,       // :only-child
+    csspc_only_of_type,     // :only-of-type
+};
+
+static const char * css_pseudo_classes[] =
+{
+    "first-child",
+    "first-of-type",
+    "last-child",
+    "last-of-type",
+    "nth-child",
+    "nth-of-type",
+    "nth-last-child",
+    "nth-last-of-type",
+    "only-child",
+    "only-of-type",
+    NULL
+};
+
 enum LVCssSelectorRuleType
 {
     cssrt_universal,     // *
@@ -100,7 +130,8 @@ enum LVCssSelectorRuleType
     cssrt_attrhas,       // E[foo~="value"]
     cssrt_attrstarts,    // E[foo|="value"]
     cssrt_id,            // E#id
-    cssrt_class          // E.class
+    cssrt_class,         // E.class
+    cssrt_pseudoclass    // E:pseudo-class, E:pseudo-class(value)
 };
 
 class LVCssSelectorRule

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8314,7 +8314,7 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
 void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 flags )
 {
     if (_inHeadStyle) {
-        _headStyleText << lString16(text);
+        _headStyleText << lString16(text, len);
         _inHeadStyle = false;
         return;
     }


### PR DESCRIPTION
Supports:
```
    :first-child
    :first-of-type
    :last-child
    :last-of-type
    :only-child
    :only-of-type
```
and, with only `odd` or `even` as parameter:
```
    :nth-child(even)
    :nth-of-type(odd)
    :nth-last-child()
    :nth-last-of-type()
```
Details about pseudo-classes at https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes

Also:
- fix parent selector to match when element-less (eg: ".pcls > DIV")
- ancessor selector would not match anything when element-less (eg: ".pcls DIV"): when element-less, it becomes non deterministic, and would need to takes multiple paths thru each parent to check for a match). It is now tweaked to at least match parent (so it behaves as ".pcls > DIV")
- fix html document HEAD STYLE parsing which could gather extraneous characters

Fix failure with css3-modsel-170d.epub in #176 .

css3-modsel-32.epub still fails, because of the ancessor selector (which leads me to discovering the parent/ancessor element-less selector problem above).
It contains `.t1 td:first-child`, and there is an intermediate `tr` between `table class=t1` and the `td`.
It would work with `.t1 tr td:first-child` or `.t1 > * > td:first-child`
