### PR TITLE
Revert parts of recent BR handling fixes

### DIFF
--- a/cr3gui/data/chm.css
+++ b/cr3gui/data/chm.css
@@ -205,8 +205,6 @@ hr {
    margin-bottom: 0.5em 
    }
 
-br + br { margin-top: 1em; }
-
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/dict.css
+++ b/cr3gui/data/dict.css
@@ -15,8 +15,6 @@ title {
    margin-bottom: 1em 
    }
 
-br + br { margin-top: 1em; }
-
 emphasis, i { font-style: italic }
 
 strong, b { font-weight: bold }

--- a/cr3gui/data/doc.css
+++ b/cr3gui/data/doc.css
@@ -205,8 +205,6 @@ hr {
    margin-bottom: 0.5em 
    }
 
-br + br { margin-top: 1em; }
-
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -53,8 +53,6 @@ p { text-align: justify; text-indent: 1.2em; margin-top:0em; margin-bottom: 0em 
 
 hr { height: 2px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em }
 
-br + br { margin-top: 1em; }
-
 sub { vertical-align: sub; font-size: 70% }
 sup { vertical-align: super; font-size: 70% }
 sup img{display:inline}

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -6,8 +6,6 @@ empty-line { height: 1em }
 
 hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em; /* 2px */ }
 
-br + br { margin-top: 1em; }
-
 a { display: inline; text-decoration: underline; }
 a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 

--- a/cr3gui/data/htm.css
+++ b/cr3gui/data/htm.css
@@ -207,8 +207,6 @@ hr {
    margin-bottom: 0.5em 
    }
 
-br + br { margin-top: 1em; }
-
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/rtf.css
+++ b/cr3gui/data/rtf.css
@@ -207,8 +207,6 @@ hr {
    margin-bottom: 0.5em 
    }
 
-br + br { margin-top: 1em; }
-
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/cr3gui/data/txt.css
+++ b/cr3gui/data/txt.css
@@ -207,8 +207,6 @@ hr {
    margin-bottom: 0.5em 
    }
 
-br + br { margin-top: 1em; }
-
 a { 
    display:inline; 
    text-decoration: underline;  

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -72,7 +72,7 @@ XS_TAG1T( blockquote )
 XS_TAG1I( em )
 XS_TAG1I( q )
 XS_TAG1I( span )
-XS_TAG1( br )
+XS_TAG1I( br )
 
 XS_TAG1D( title, true, css_d_block, css_ws_normal )
 


### PR DESCRIPTION
Make BR a inline element again (being a block element fixed the leading space, but make xpointers invalid and highlights shifted).
Remove BR + BR CSS, which was just wrong, but didn't show up till we fixed E + F selector.

Reverts part of #172.
Discussed in and after https://github.com/koreader/koreader/pull/3934#issuecomment-386996718
