### PR TITLE
Fix updating fallback font

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -255,7 +255,7 @@ public:
     virtual int getKerningOffset(lChar16 ch1, lChar16 ch2, lChar16 def_char) { CR_UNUSED3(ch1,ch2,def_char); return 0; }
 
     /// set fallback font for this font
-    void setFallbackFont( LVProtectedFastRef<LVFont> font ) { CR_UNUSED(font); }
+    virtual void setFallbackFont( LVProtectedFastRef<LVFont> font ) { CR_UNUSED(font); }
     /// get fallback font for this font
     LVFont * getFallbackFont() { return NULL; }
 };

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -479,8 +479,13 @@ public:
     }
     virtual void clearFallbackFonts()
     {
+        LVPtrVector< LVFontCacheItem > * fonts = getInstances();
+        for ( int i=0; i<fonts->length(); i++ ) {
+            fonts->get(i)->getFont()->setFallbackFont(LVFontRef());
+        }
         for ( int i=0; i<_registered_list.length(); i++ ) {
-            _registered_list[i]->getFont()->setFallbackFont(LVFontRef());
+            if (!_registered_list[i]->getFont().isNull())
+                _registered_list[i]->getFont()->setFallbackFont(LVFontRef());
         }
     }
     LVFontCache( )
@@ -779,9 +784,11 @@ public:
 
     // fallback font support
     /// set fallback font for this font
-    void setFallbackFont( LVFontRef font ) {
+    virtual void setFallbackFont( LVFontRef font ) {
         _fallbackFont = font;
         _fallbackFontIsSet = !font.isNull();
+        _glyph_cache.clear();
+        _wcache.clear();
     }
 
     /// get fallback font for this font

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -36,7 +36,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.09k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.10k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0004
 


### PR DESCRIPTION
The fact that LVFont:setFallbackFont() wasn't 'virtual' made clearFallbackFonts() always use this no-op one. Now, it will use the extended LVFreeTypeFace:setFallbackFont() one, which will allow us to update the fallback font in real time, without the need for a restart.