### PR TITLE
Toggable alternative rendering method for list items

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -25,8 +25,8 @@ enum css_display_t {
     css_d_inherit,
     css_d_inline,
     css_d_block,
-    css_d_list_item, 
-    css_d_list_item_block,
+    css_d_list_item,        // display: list-item
+    css_d_list_item_block,  // display: -cr-list-item-block
     css_d_run_in, 
     css_d_compact, 
     css_d_marker, 

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -26,6 +26,7 @@ enum css_display_t {
     css_d_inline,
     css_d_block,
     css_d_list_item, 
+    css_d_list_item_block,
     css_d_run_in, 
     css_d_compact, 
     css_d_marker, 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -595,6 +595,7 @@ static const char * css_d_names[] =
     "inline",
     "block",
     "list-item", 
+    "list-item-block", // non-standard, for alternative rendering of list items
     "run-in", 
     "compact", 
     "marker", 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -595,7 +595,7 @@ static const char * css_d_names[] =
     "inline",
     "block",
     "list-item", 
-    "list-item-block", // non-standard, for alternative rendering of list items
+    "-cr-list-item-block", // non-standard, for alternative rendering of list items
     "run-in", 
     "compact", 
     "marker", 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -594,8 +594,8 @@ static const char * css_d_names[] =
     "inherit",
     "inline",
     "block",
-    "list-item", 
-    "-cr-list-item-block", // non-standard, for alternative rendering of list items
+    "list-item",           // crengine rendering of list items as final : css_d_list_item
+    "-cr-list-item-block", // non-standard, for alternative rendering of list items : css_d_list_item_block
     "run-in", 
     "compact", 
     "marker", 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -36,7 +36,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.10k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.11k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0004
 
@@ -3764,6 +3764,7 @@ static bool isBlockNode( ldomNode * node )
     {
     case css_d_block:
     case css_d_list_item:
+    case css_d_list_item_block:
     case css_d_table:
     case css_d_table_row:
     case css_d_inline_table:
@@ -4120,6 +4121,7 @@ void ldomNode::initNodeRendMethod()
             switch ( d )
             {
             case css_d_block:
+            case css_d_list_item_block:
             case css_d_inline:
             case css_d_run_in:
                 setRendMethod( erm_final );
@@ -7460,6 +7462,7 @@ public:
         case css_d_inherit:
         case css_d_block:
         case css_d_list_item:
+        case css_d_list_item_block:
         case css_d_compact:
         case css_d_marker:
         case css_d_table:


### PR DESCRIPTION
Adds support for a new non-standard css `display:` value: `-cr-list-item-block` which renders list items as block instead of final.
Based on original work from @bbgordon, see https://github.com/koreader/koreader/issues/2107#issuecomment-375799779.

I started from @bbgordon code (there's still some of his code as-is), but ended up doing things a bit differently:
- we keep the original list-item rendering code (rendering method `erm_list_item`), so it's still the default
- this PR should have no impact, unless we add to styles (standard css or via a style tweak):
`li {display: -cr-list-item-block; }`
(the new added code is always wrapped in stuff like  `if ( enode->getStyle()->display == css_d_list_item_block )`)
- no new rendering method (no `erm_list_item_block`): list items are managed by the classic `erm_block` method
- no negative margins, no change to lvtextfm.cpp, even if I think there are negative values that are stored in the `lInt16` slots... but that would be another thing
- no DOM node manipulations (no insertChild or removeChild that @bbgordon used to insert the marker in the final node when `list-style-position: inside`)

It looks like highlights made on the original rendering method are still there when switching to the new one (but it may be too early to be sure of that :)
It may be that long list items (now rendered as a block) can be pushed on a new page, because of #119.

So, for testing this, we'll need a user style tweak (or we'll add a official Style tweak) with:
`li {display: -cr-list-item-block; }`
We could add to that if needed stuff like 
`li > p:first-child { text-indent: 0; }`

When switching between these 2 display:, one may need to restart koreader and delete the cache file (as display inline/block adds some autoBox elements to the DOM, the DOM needs to be rebuild).
I'll push another PR to try to detect that and propose to the user to reload the document.

If we ever decide to make this the default, we should just update:
- use `css_d_list_item_block` instead of `css_d_list_item` in
https://github.com/koreader/crengine/blob/e144c9080e4e202c159e097bf192a969eb36371a/crengine/include/fb2def.h#L63

- change this:
https://github.com/koreader/crengine/blob/e144c9080e4e202c159e097bf192a969eb36371a/crengine/src/lvstsheet.cpp#L596-L598
to: 
```c
    "block",
    "list-item-old-inline-rendering", 
    "list-item", // so style: list-item gets to be css_d_list_item_block
    "run-in", 
```

With current list-item rendering code:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40267787-3809c654-5b63-11e8-9485-a41ca1807791.png)</kbd>

With this alternate list-item rendering code:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40267800-5a19d4d2-5b63-11e8-9225-57cdf7538f7b.png)</kbd>

With some Wikipedia TOC:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40267834-dcff8806-5b63-11e8-8d43-d9da319b91b4.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/40267854-2c792ec8-5b64-11e8-8595-6c913f15b1c3.png)</kbd>
