### PR TITLE
Compute nodeStyleDisplayHash and adds isBuiltDomStale()

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -102,6 +102,8 @@ extern int gDOMVersionRequested;
 
 #define DEF_MIN_SPACE_CONDENSING_PERCENT 50
 
+#define NODE_DISPLAY_STYLE_HASH_UNITIALIZED 0xFFFFFFFF
+
 //#if BUILD_LITE!=1
 /// final block cache
 typedef LVRef<LFormattedText> LFormattedTextRef;
@@ -396,6 +398,7 @@ protected:
     CVRendBlockCache _renderedBlockCache;
     CacheFile * _cacheFile;
     bool _cacheFileStale;
+    bool _cacheFileLeaveAsDirty;
     bool _mapped;
     bool _maperror;
     int  _mapSavingStage;
@@ -404,6 +407,8 @@ protected:
     int  _minSpaceCondensingPercent;
 
     lUInt32 _nodeStyleHash;
+    lUInt32 _nodeDisplayStyleHash;
+    lUInt32 _nodeDisplayStyleHashInitial;
 
     int calcFinalBlocks();
     void dropStyles();
@@ -524,6 +529,17 @@ public:
 
     /// set cache file stale flag
     void setCacheFileStale( bool stale ) { _cacheFileStale = stale; }
+
+    /// is built (and cached) DOM possibly invalid (can happen when some nodes have changed display style)
+    bool isBuiltDomStale() {
+        return _nodeDisplayStyleHashInitial != NODE_DISPLAY_STYLE_HASH_UNITIALIZED &&
+                _nodeDisplayStyleHash != _nodeDisplayStyleHashInitial;
+    }
+
+    /// if a cache file is in use
+    bool hasCacheFile() { return _cacheFile != NULL; }
+    /// set cache file as dirty, so it's not re-used on next load
+    void invalidateCacheFile() { _cacheFileLeaveAsDirty = true; };
 
     /// minimize memory consumption
     void compact();
@@ -1105,10 +1121,12 @@ protected:
         lUInt32 render_docflags;
         lUInt32 render_style_hash;
         lUInt32 stylesheet_hash;
+        lUInt32 node_displaystyle_hash;
         bool serialize( SerialBuf & buf );
         bool deserialize( SerialBuf & buf );
         DocFileHeader()
-            : render_dx(0), render_dy(0), render_docflags(0), render_style_hash(0), stylesheet_hash(0)
+            : render_dx(0), render_dy(0), render_docflags(0), render_style_hash(0), stylesheet_hash(0),
+                node_displaystyle_hash(NODE_DISPLAY_STYLE_HASH_UNITIALIZED)
         {
         }
     };


### PR DESCRIPTION
On each stylesheet change, a nodeStyleDisplayHash will be computed from all the nodes "display:" values. It should allow us to detect that the DOM may not be coherent with the styles, because:
- the DOM may get some added autoBoxing nodes as children of "display: block" nodes
- these autoBoxing nodes are never removed, so they stay there when a node style change from "display: block" to "display: inline", which won't make the rendering fully inline
- when cache is re-used, the DOM can't change, and no autoBoxing will be added when a node style change from "display: inline" to "display: block"
This may cause some rendering issues, and the only solution is to reload the document (with the need to prevent cache re-use for documents with an existing cache).

These checks will be done from the lua side, with the help of the new functions isBuiltDomStale(), hasCacheFile() and invalidateCacheFile().

The aim is to add this into ReaderRolling:
```lua
@@ -179,6 +180,25 @@ end
 -- we cannot do it in onSaveSettings() because getLastPercent() uses self.ui.document
 function ReaderRolling:onCloseDocument()
     self.ui.doc_settings:saveSetting("percent_finished", self:getLastPercent())
+    -- also checks if DOM is coherent with styles, and invalidate
+    -- cache if not, so a new DOM is build on next opening
+    if self.ui.document:isBuiltDomStale() then
+        if self.ui.document:hasCacheFile() then
+            logger.dbg("cre DOM may not be in sync with styles, invalidating cache file for a full reload at next opening")
+            self.ui.document:invalidateCacheFile()
+        end
+    end
+end
+
+function ReaderRolling:onCheckDomStyleCoherence()
+    if self.ui.document:isBuiltDomStale() then
+        UIManager:show(ConfirmBox:new{
+            text = _("Styles have changed in such a way that fully reloading the document may be needed for a correct rendering.\nDo you want to reload the document?"),
+            ok_callback = function()
+                self.ui:reloadDocument()
+            end,
+        })
+    end
 end
@@ -566,6 +586,9 @@ function ReaderRolling:updatePos() -- called on style/layout change
         self.view.footer:updateFooter()
     end
     UIManager:setDirty(self.view.dialog, "partial")
+    UIManager:scheduleIn(0.1, function ()
+        self:onCheckDomStyleCoherence()
+    end)
 end
```
which should show when it's the case:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40272152-86a1c488-5ba9-11e8-81e5-32aa8095b9dd.png)</kbd>

This PR is fully info gathering code, and shouldn't cause any change as long as the lua frontend code does not use it. I had while testing some kind of loop with this message, that I hope I have fixed. But I'll be more confident to push the frontend code if I can test it for a few hours on a device, before making everybody use it.
So, if that looks fine, I'd like to bump this (and proxy functions in base) into next nightly.

Examples of bad rendering when switching list-item modes (from historical inline to new block rendering):
From historical inline (fine):
<kbd>![old_fine](https://user-images.githubusercontent.com/24273478/40272189-0f4620cc-5baa-11e8-86a3-de21ace64056.png)</kbd>
to new block rendering of list-items (ugly):
<kbd>![old_to_block](https://user-images.githubusercontent.com/24273478/40272191-10a93ef4-5baa-11e8-8d0f-817f7f59098f.png)</kbd>
New block rendering after clearing cache and reloading:
<kbd>![block_fine](https://user-images.githubusercontent.com/24273478/40272196-3029dee6-5baa-11e8-89c8-e01a39780252.png)</kbd>
Then toggling back to inline rendering of list-items
<kbd>![block_to_old](https://user-images.githubusercontent.com/24273478/40272199-415841d0-5baa-11e8-8604-f3de0cf1923b.png)</kbd>
Clear cache and reload, and you get back the correct _historical inline (fine)_ above.