### PR TITLE
corrected epub.css

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -103,7 +103,7 @@ big { font-size: 130%; }
    display: block; 
    white-space: pre; 
    text-align: left; 
-   font-family: "Courier New", "Courier", monospace; 
+   font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", monospace;
    margin-top: 0.5em; 
    margin-bottom: 0.5em; 
   /* background-color: #BFBFBF; */ 


### PR DESCRIPTION
addded  font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", monospace; in for code, pre.

https://github.com/koreader/koreader/issues/3974 for context.