### PR TITLE
Make the <style> element hidden by default

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -26,6 +26,7 @@ poem { margin-top: 1em; margin-bottom: 1em; text-indent: 0px }
 text-author { font-weight: bold; font-style: italic; margin-left: 5%}
 epigraph { margin-left: 15%; margin-right: 1em; text-align: left; text-indent: 1em; font-style: italic; margin-top: 15px; margin-bottom: 25px }
 cite { display: block; font-style: italic; margin-left: 5%; margin-right: 5%; text-align: justify; margin-top: 20px; margin-bottom: 20px }
+style { display: inline; }
 
 title p, subtitle p, h1 p, h2 p, h3 p, h4 p, h5 p, h6 p { 
 	text-align: center; 

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -29,8 +29,10 @@
 //=====================================================
 XS_BEGIN_TAGS
 
+// Internal element for block rendering
 XS_TAG1T( autoBoxing )
 
+// Mix of HTML / FB2 elements
 XS_TAG2( xml, "?xml" )
 XS_TAG2( xml_stylesheet, "?xml-stylesheet" )
 XS_TAG1( FictionBook )
@@ -52,7 +54,7 @@ XS_TAG1D( form, true, css_d_none, css_ws_normal )
 XS_TAG1D( binary, true, css_d_none, css_ws_normal )
 XS_TAG2T( text_author, "text-author" )
 
-//epub
+// Classic HTML / EPUB elements
 XS_TAG1T( div )
 XS_TAG1( svg )
 XS_TAG1( dl )
@@ -83,7 +85,7 @@ XS_TAG1I( i )
 XS_TAG1I( strikethrough )
 XS_TAG1I( sub )
 XS_TAG1I( sup )
-XS_TAG1I( style )
+XS_TAG1D( style, true, css_d_none, css_ws_normal )
 XS_TAG1I( strong )
 XS_TAG1I( emphasis )
 XS_TAG1D( code, true, css_d_inline, css_ws_pre )
@@ -106,7 +108,8 @@ XS_TAG1D( tfoot, false, css_d_table_footer_group, css_ws_normal )
 XS_TAG1D( th, true, css_d_table_cell, css_ws_normal )
 XS_TAG1D( td, true, css_d_table_cell, css_ws_normal )
 
-XS_TAG1I( cite )
+// The following are FB2 block elements
+XS_TAG1I( cite ) // conflict between HTML (inline) and FB2 (block): default here to inline (fb2.css puts it back to block)
 XS_TAG1T( v )
 XS_TAG1( stanza )
 XS_TAG1( epigraph )
@@ -147,6 +150,7 @@ XS_TAG1T( isbn )
 XS_TAG1T( nickname )
 XS_TAG1T( keywords )
 
+// Internal element for EPUB, containing each individual HTML file
 XS_TAG1( DocFragment )
 
 XS_END_TAGS

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2879,6 +2879,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             if (enode->getNodeId() == el_li) {
                 pstyle->display = css_d_list_item; // otherwise correctly set to css_d_list_item_block
             }
+            if (enode->getNodeId() == el_style) {
+                pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)
+            }
         }
     }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -32,7 +32,8 @@
 //
 // 20180524: changed default rendering of:
 //   <li> (and css 'display:list-item') from css_d_list_item to css_d_list_item_block
-//   <cite> from css_d_block to css_d_inline
+//   <cite> from css_d_block to css_d_inline (inline in HTML, block in FB2, ensured by fb2.css)
+//   <style> from css_d_inline to css_d_none (invisible in HTML)
 // Changed also the default display: value for base elements (and so
 // for unknown elements) from css_d_inherit to css_d_inline, and disable
 // inheritance for the display: property, as per specs.


### PR DESCRIPTION
Hide `<style>` content when `<style>` appears in the `<body>`, see https://github.com/koreader/crengine/pull/191#issuecomment-391742834.
Again, it was `display: inline`, and could then be part of the process of autoBoxing and DOM change.
So, previous behaviour is ensured when `gDOMVersionRequested < 20180524` (I re-used the yesterday version as no nightly was made since).