### PR TITLE
Fix a few edge-case rendering issues

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4006,7 +4006,11 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex )
 #if BUILD_LITE!=1
 static void resetRendMethodToInline( ldomNode * node )
 {
-    node->setRendMethod(erm_inline);
+    // we shouldn't reset to inline (visible) if display: none
+    // (using node->getRendMethod() != erm_invisible seems too greedy and may
+    // hide other nodes)
+    if (node->getStyle()->display != css_d_none)
+        node->setRendMethod(erm_inline);
 }
 
 static void resetRendMethodToInvisible( ldomNode * node )


### PR DESCRIPTION
- resetRendMethodToInline() is used to make inline all nodes that are children of an inline element (which in itself looks like wrong, but that's how crengine works, and fixing that would be another thing). But it shouldn't reset to inline child nodes that are 'display:none' as that would make them visible.

- list item marker with list-style-position:ouside : don't account for the marker height on the first child only, as if this first child is display:none, that would make an empty line with the marker. Instead, account for it on the whole children block.

The little arrow at the start of item on the 1st image are in a `class='noprint'`. If we'd like to use `.noprint {display: none}`, we would get what's on the 2nd image. With this fix, we get what's on the 3rd:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40837336-7d2df282-659a-11e8-91b6-2cf1f2b2bafa.png)</kbd><kbd>![image](https://user-images.githubusercontent.com/24273478/40837374-939a9480-659a-11e8-80d5-92bb364333d2.png)</kbd><kbd>![image](https://user-images.githubusercontent.com/24273478/40837823-08cf5d5c-659c-11e8-852c-aa104851df8d.png)</kbd>

(Unfortunately, the Wikipedia pages are so messy and different in styles from one page to the other, that on some pages, this arrow is in a class=noprint, but not on some other pages, and on some others pages, there are valuable links in such class=noprint... Also, these arrows that link back to the text may be useful on our readers, even if I like how it looks without).

- fix some alignment/new-line issue when the first child of a final block has some empty text or is an image (this is a more generic fix than #58 by @frankyifei and replaces it; I checked with the sample from https://github.com/koreader/koreader/issues/2070 that this issue stays fixed)

<kbd>![image](https://user-images.githubusercontent.com/24273478/40837503-f14b470a-659a-11e8-8b50-65c5ad1b79e3.png)</kbd> => <kbd>![image](https://user-images.githubusercontent.com/24273478/40837747-c52ab786-659b-11e8-9202-55a7aca91a4e.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/40838179-52fdd7d6-659d-11e8-9c96-2915a2c6ab90.png)</kbd>=><kbd>![image](https://user-images.githubusercontent.com/24273478/40838453-91101754-659e-11e8-9761-c7fbfafc4c94.png)</kbd>

The `baseflags &= ~LTEXT_FLAG_NEWLINE` stuff is still very unclear to me.
LTEXT_FLAG_NEWLINE shares the 3 lower bits with the LTEXT_ALIGN_LEFT/RIGHT/CENTER/WIDTH, and serves sometimes as a mask to get them, and when there are `&= ~LTEXT_FLAG_NEWLINE`, I'm not sure if it's not just to clear the LTEXT_ALIGN_* flags.
https://github.com/koreader/crengine/blob/d30046ef8beba54a6d88533f5ee06e3b85362eef/crengine/include/lvtextfm.h#L28-L42
Also, I haven't found (yet?) a single place where this LTEXT_FLAG_NEWLINE is set :| and it must be...