### PR TITLE
Fix border being drawn in spite of 'border-width: 0'

### DIFF
--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -158,6 +158,12 @@ typedef struct css_style_rec_tag {
     , border_style_bottom(css_border_none)
     , border_style_right(css_border_none)
     , border_style_left(css_border_none)
+    , border_width{
+        css_length_t(css_val_unspecified, 0),
+        css_length_t(css_val_unspecified, 0),
+        css_length_t(css_val_unspecified, 0),
+        css_length_t(css_val_unspecified, 0)
+        }
     , background_repeat(css_background_r_none)
     , background_attachment(css_background_a_none)
     , background_position(css_background_p_none)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1649,7 +1649,7 @@ int measureBorder(ldomNode *enode,int border) {
                 css_length_t bw = enode->getStyle()->border_width[0];
                 if (bw.value == 0 && bw.type > css_val_unspecified) return 0; // explicit value of 0: no border
                 int topBorderwidth = lengthToPx(bw, width, em);
-                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : DEFAULT_BORDER_WIDTH; // default value if no width specified
+                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : DEFAULT_BORDER_WIDTH;
                 return topBorderwidth;}
             else if (border==1){
                 bool hasrightBorder = (enode->getStyle()->border_style_right >= css_border_solid &&

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1635,6 +1635,9 @@ void getPageBreakStyle( ldomNode * el, css_page_break_t &before, css_page_break_
     }
 }
 
+// Default border width in screen px when border requested but no width specified
+#define DEFAULT_BORDER_WIDTH 2
+
 //measure border width, 0 for top,1 for right,2 for bottom,3 for left
 int measureBorder(ldomNode *enode,int border) {
         int em = enode->getFont()->getSize();
@@ -1646,7 +1649,7 @@ int measureBorder(ldomNode *enode,int border) {
                 css_length_t bw = enode->getStyle()->border_width[0];
                 if (bw.value == 0 && bw.type > css_val_unspecified) return 0; // explicit value of 0: no border
                 int topBorderwidth = lengthToPx(bw, width, em);
-                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : 2; // default value of 2px if not specified
+                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : DEFAULT_BORDER_WIDTH; // default value if no width specified
                 return topBorderwidth;}
             else if (border==1){
                 bool hasrightBorder = (enode->getStyle()->border_style_right >= css_border_solid &&
@@ -1655,7 +1658,7 @@ int measureBorder(ldomNode *enode,int border) {
                 css_length_t bw = enode->getStyle()->border_width[1];
                 if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
                 int rightBorderwidth = lengthToPx(bw, width, em);
-                rightBorderwidth = rightBorderwidth != 0 ? rightBorderwidth : 2;
+                rightBorderwidth = rightBorderwidth != 0 ? rightBorderwidth : DEFAULT_BORDER_WIDTH;
                 return rightBorderwidth;}
             else if (border ==2){
                 bool hasbottomBorder = (enode->getStyle()->border_style_bottom >= css_border_solid &&
@@ -1664,7 +1667,7 @@ int measureBorder(ldomNode *enode,int border) {
                 css_length_t bw = enode->getStyle()->border_width[2];
                 if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
                 int bottomBorderwidth = lengthToPx(bw, width, em);
-                bottomBorderwidth = bottomBorderwidth != 0 ? bottomBorderwidth : 2;
+                bottomBorderwidth = bottomBorderwidth != 0 ? bottomBorderwidth : DEFAULT_BORDER_WIDTH;
                 return bottomBorderwidth;}
             else if (border==3){
                 bool hasleftBorder = (enode->getStyle()->border_style_left >= css_border_solid &&
@@ -1673,7 +1676,7 @@ int measureBorder(ldomNode *enode,int border) {
                 css_length_t bw = enode->getStyle()->border_width[3];
                 if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
                 int leftBorderwidth = lengthToPx(bw, width, em);
-                leftBorderwidth = leftBorderwidth != 0 ? leftBorderwidth : 2;
+                leftBorderwidth = leftBorderwidth != 0 ? leftBorderwidth : DEFAULT_BORDER_WIDTH;
                 return leftBorderwidth;}
            else return 0;
         }
@@ -2086,13 +2089,13 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
         int em = enode->getFont()->getSize();
         int width = fmt.getWidth();
         int topBorderwidth = lengthToPx(enode->getStyle()->border_width[0],width,em);
-        topBorderwidth=topBorderwidth!=0?topBorderwidth:2;
+        topBorderwidth = topBorderwidth!=0 ? topBorderwidth : DEFAULT_BORDER_WIDTH;
         int rightBorderwidth = lengthToPx(enode->getStyle()->border_width[1],width,em);
-        rightBorderwidth=rightBorderwidth!=0?rightBorderwidth:2;
+        rightBorderwidth = rightBorderwidth!=0 ? rightBorderwidth : DEFAULT_BORDER_WIDTH;
         int bottomBorderwidth = lengthToPx(enode->getStyle()->border_width[2],width,em);
-        bottomBorderwidth=bottomBorderwidth!=0?bottomBorderwidth:2;
+        bottomBorderwidth = bottomBorderwidth!=0 ? bottomBorderwidth : DEFAULT_BORDER_WIDTH;
         int leftBorderwidth = lengthToPx(enode->getStyle()->border_width[3],width,em);
-        leftBorderwidth=leftBorderwidth!=0?leftBorderwidth:2;
+        leftBorderwidth = leftBorderwidth!=0 ? leftBorderwidth : DEFAULT_BORDER_WIDTH;
         int tbw=topBorderwidth,rbw=rightBorderwidth,bbw=bottomBorderwidth,lbw=leftBorderwidth;
         if (hastopBorder) {
             int dot=1,interval=0;//default style

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1642,30 +1642,38 @@ int measureBorder(ldomNode *enode,int border) {
         if (border==0){
                 bool hastopBorder = (enode->getStyle()->border_style_top >= css_border_solid &&
                                      enode->getStyle()->border_style_top <= css_border_outset);
-                int topBorderwidth = lengthToPx(enode->getStyle()->border_width[0], width, em);
-                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : 2;
-                topBorderwidth = hastopBorder?topBorderwidth:0;
+                if (!hastopBorder) return 0;
+                css_length_t bw = enode->getStyle()->border_width[0];
+                if (bw.value == 0 && bw.type > css_val_unspecified) return 0; // explicit value of 0: no border
+                int topBorderwidth = lengthToPx(bw, width, em);
+                topBorderwidth = topBorderwidth != 0 ? topBorderwidth : 2; // default value of 2px if not specified
                 return topBorderwidth;}
             else if (border==1){
                 bool hasrightBorder = (enode->getStyle()->border_style_right >= css_border_solid &&
                                        enode->getStyle()->border_style_right <= css_border_outset);
-                int rightBorderwidth = lengthToPx(enode->getStyle()->border_width[1], width, em);
+                if (!hasrightBorder) return 0;
+                css_length_t bw = enode->getStyle()->border_width[1];
+                if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
+                int rightBorderwidth = lengthToPx(bw, width, em);
                 rightBorderwidth = rightBorderwidth != 0 ? rightBorderwidth : 2;
-                rightBorderwidth = hasrightBorder?rightBorderwidth:0;
                 return rightBorderwidth;}
             else if (border ==2){
                 bool hasbottomBorder = (enode->getStyle()->border_style_bottom >= css_border_solid &&
                                         enode->getStyle()->border_style_bottom <= css_border_outset);
-                int bottomBorderwidth = lengthToPx(enode->getStyle()->border_width[2], width, em);
+                if (!hasbottomBorder) return 0;
+                css_length_t bw = enode->getStyle()->border_width[2];
+                if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
+                int bottomBorderwidth = lengthToPx(bw, width, em);
                 bottomBorderwidth = bottomBorderwidth != 0 ? bottomBorderwidth : 2;
-                bottomBorderwidth = hasbottomBorder?bottomBorderwidth:0;
                 return bottomBorderwidth;}
             else if (border==3){
                 bool hasleftBorder = (enode->getStyle()->border_style_left >= css_border_solid &&
                                       enode->getStyle()->border_style_left <= css_border_outset);
-                int leftBorderwidth = lengthToPx(enode->getStyle()->border_width[3], width, em);
+                if (!hasleftBorder) return 0;
+                css_length_t bw = enode->getStyle()->border_width[3];
+                if (bw.value == 0 && bw.type > css_val_unspecified) return 0;
+                int leftBorderwidth = lengthToPx(bw, width, em);
                 leftBorderwidth = leftBorderwidth != 0 ? leftBorderwidth : 2;
-                leftBorderwidth = hasleftBorder?leftBorderwidth:0;
                 return leftBorderwidth;}
            else return 0;
         }
@@ -2060,6 +2068,17 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
     bool hasrightBorder = (enode->getStyle()->border_style_right >=css_border_solid&&enode->getStyle()->border_style_right<=css_border_outset);
     bool hasbottomBorder = (enode->getStyle()->border_style_bottom >=css_border_solid&&enode->getStyle()->border_style_bottom<=css_border_outset);
     bool hasleftBorder = (enode->getStyle()->border_style_left >=css_border_solid&&enode->getStyle()->border_style_left<=css_border_outset);
+
+    // check for explicit 'border-width: 0' which means no border
+    css_length_t bw;
+    bw = enode->getStyle()->border_width[0];
+    hastopBorder = hastopBorder & !(bw.value == 0 && bw.type > css_val_unspecified);
+    bw = enode->getStyle()->border_width[1];
+    hasrightBorder = hasrightBorder & !(bw.value == 0 && bw.type > css_val_unspecified);
+    bw = enode->getStyle()->border_width[2];
+    hasbottomBorder = hasbottomBorder & !(bw.value == 0 && bw.type > css_val_unspecified);
+    bw = enode->getStyle()->border_width[3];
+    hasleftBorder = hasleftBorder & !(bw.value == 0 && bw.type > css_val_unspecified);
 
     if (hasbottomBorder or hasleftBorder or hasrightBorder or hastopBorder) {
         lUInt32 shadecolor=0x555555;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4011,6 +4011,8 @@ static void resetRendMethodToInline( ldomNode * node )
     // hide other nodes)
     if (node->getStyle()->display != css_d_none)
         node->setRendMethod(erm_inline);
+    if (gDOMVersionRequested < 20180528) // do that in all cases
+        node->setRendMethod(erm_inline);
 }
 
 static void resetRendMethodToInvisible( ldomNode * node )


### PR DESCRIPTION
A border was drawn because it should when no width is specified.
We should distinguish between styles (css_val_unspecified, 0) and (css_val_px, 0) (or some other css unit, including no-unit), which means an explicite border-width: 0 has been set via styles and no border should be drawn.
Details in https://github.com/koreader/crengine/pull/16#issuecomment-393894913

Context for the various use of `bw.type > css_val_unspecified`:
https://github.com/koreader/crengine/blob/a2f4e37be34f488ca22a978cd3e7c27e8ee05e2e/crengine/include/cssdef.h#L161-L175