### PR TITLE
Try to please clang: avoid compiler errors

### DIFF
--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -158,12 +158,12 @@ typedef struct css_style_rec_tag {
     , border_style_bottom(css_border_none)
     , border_style_right(css_border_none)
     , border_style_left(css_border_none)
-    , border_width{
+    , border_width({
         css_length_t(css_val_unspecified, 0),
         css_length_t(css_val_unspecified, 0),
         css_length_t(css_val_unspecified, 0),
         css_length_t(css_val_unspecified, 0)
-        }
+        })
     , background_repeat(css_background_r_none)
     , background_attachment(css_background_a_none)
     , background_position(css_background_p_none)


### PR DESCRIPTION
Attempt at fixing:
```
/home/travis/build/koreader/koreader-base/thirdparty/kpvcrlib/crengine/crengine/include/lvstyles.h:167:5: error: expected member name or ';' after declaration specifiers
    , background_repeat(css_background_r_none)
    ^
/home/travis/build/koreader/koreader-base/thirdparty/kpvcrlib/crengine/crengine/include/lvstyles.h:161:19: error: expected '('
    , border_width{
                  ^
/home/travis/build/koreader/koreader-base/thirdparty/kpvcrlib/crengine/crengine/include/lvstyles.h:165:45: error: expected ';' after expression
        css_length_t(css_val_unspecified, 0)
                                            ^
                                            ;
```
even if I'm not sure that's the right or most efficient way of initializing that array of `css_length_t border_width[4]`