### PR TITLE
epub.css: remove div { margin: 1px; }

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -39,9 +39,6 @@ h4 { font-size: 120%; }
 h5 { font-size: 110%; }
 
 /* Block elements */
-div {
-    margin: 1px;
-}
 p {
     text-align: justify;
     text-indent: 1.2em;


### PR DESCRIPTION
This looks unneeded, and may cause unwanted page break (eg: when big image in a DIV, scaled down to fit 100% of screen height, this added 1px may add a blank page before or after the image).
See https://github.com/koreader/koreader/pull/3992#issuecomment-394071949