### PR TITLE
Fix rare segfault with text formatting code

### DIFF
--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -829,6 +829,8 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth )
 {
     lUInt16 chprops[WORD_LENGTH];
+    if ( len > WORD_LENGTH-2 )
+        len = WORD_LENGTH - 2;
     lStr_getCharProps( str, len, chprops );
     int start, end, i, j;
     #define MIN_WORD_LEN_TO_HYPHEN 2

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -350,7 +350,7 @@ public:
         // The code in this file will fill these buffers with m_length items, so
         // from index [0] to [m_length-1], and read them back.
         // Willingly or not (bug?), this code may also access the buffer one slot
-        // further [m_length], and we need to set this slot to zero to avoid
+        // further at [m_length], and we need to set this slot to zero to avoid
         // a segfault. So, we need to reserve this additional slot when
         // allocating dynamic buffers, or checking if the static buffers can be
         // used.
@@ -386,11 +386,11 @@ public:
             m_widths = m_static_widths;
             m_staticBufs = true;
         }
-        memset( m_flags, 0, sizeof(lUInt8)*m_length ); // starts with all flags set to zero
+        memset( m_flags, 0, sizeof(lUInt8)*m_length ); // start with all flags set to zero
         pos = 0;
 
         // We set to zero the additional slot that the code may peek at (with
-        // the checks against m_length we did, we know this slow is allocated).
+        // the checks against m_length we did, we know this slot is allocated).
         // (This can be removed if we find this was a bug and can fix it)
         m_flags[m_length] = 0;
         m_text[m_length] = 0;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -361,8 +361,9 @@ public:
 
 #define STATIC_BUFS_SIZE 8192
 #define ITEMS_RESERVED 16
-        if ( !m_staticBufs || m_length > STATIC_BUFS_SIZE-1 ) {
-            if ( m_length > m_size-1 ) {
+        // "m_length+1" to keep room for the additional slot to be zero'ed
+        if ( !m_staticBufs || m_length+1 > STATIC_BUFS_SIZE ) {
+            if ( m_length+1 > m_size ) {
                 // realloc
                 m_size = m_length+ITEMS_RESERVED;
                 m_text = cr_realloc(m_staticBufs ? NULL : m_text, m_size);


### PR DESCRIPTION
(follow up to https://github.com/koreader/koreader/pull/3993#issuecomment-394197067)
Very rare, but happened systematically on a specific page of a specific book.
There's probably a bug elsewhere that makes some code go look further than `m_length` and cause a segfault. `memset()`'ing all buffers on their full allocated size to 0 seems to avoid these occasional segfaults. But just setting zero to the slot just after `[0..m_length-1]` seems enough (and is less expensive than full memset).

I did first disable the use of static buffers, and it didn't crash anymore.
I then went on with memseting to zero the whole m_size/STATIC_BUFS_SIZE, and it didnt crash.
I then went on with memseting to zero only `[0..m_length-1]`, and it crashed.
I then went on with memseting to zero only `[0..m_length]`, and it didnt crash.
I then went on with memseting to zero only `[m_length]`, and it didnt crash.
I noticed a small (5%-10%) performance penalty when the full memsets were used, so I stick with the single slot zero'ing which is enough to solve my crash case.
To remember in case we meet some other similar crash.

The crash was when going to a page (top of the page shown in the screenshots below).
When going forward to this page, we'd get:
<kbd>![image](https://user-images.githubusercontent.com/24273478/41036999-3b336596-6992-11e8-9600-2ef3eb0f38d9.png)</kbd>
After going forward, and going back to this page, we would get either a segfault (4/5 rate), or the page shown as (1/5 rate):
<kbd>![image](https://user-images.githubusercontent.com/24273478/41037088-7af7ebde-6992-11e8-9a60-b1e950616ca2.png)</kbd>
Notice how the 5th line is changed, with spaces added to push the small pencil image on next line...
This PR also fixes this, and make the page always shown as on the first screenshot.

