### PR TITLE
lvtextfm.cpp: simple changes from upstream

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -898,7 +898,7 @@ public:
                         int lastc = m_text[endp];
                         int wAlign = font->getVisualAligmentWidth();
                         word->width += wAlign/2;
-                        while ( (lastc==' ') && endp>0 ) { // || lastc=='\r' || lastc=='\n'
+                        while ( (m_flags[endp] & LCHAR_IS_SPACE) && endp>0 ) { // || lastc=='\r' || lastc=='\n'
                             word->width -= m_widths[endp] - m_widths[endp-1];
                             endp--;
                             lastc = m_text[endp];
@@ -987,11 +987,11 @@ public:
     }
 
     int getMaxCondensedSpaceTruncation(int pos) {
-        if (pos<0 || pos>m_length || m_text[pos]!=' ')
+        if (pos<0 || pos>=m_length || !(m_flags[pos] & LCHAR_IS_SPACE))
             return 0;
         if (m_pbuffer->min_space_condensing_percent==100)
             return 0;
-        int w = (m_widths[pos] - m_widths[pos-1]);
+        int w = (m_widths[pos] - (pos > 0 ? m_widths[pos-1] : 0));
         int dw = w * (100 - m_pbuffer->min_space_condensing_percent) / 100;
         if ( dw>0 ) {
             // typographic rule: don't use spaces narrower than 1/4 of font size
@@ -1117,13 +1117,17 @@ public:
                     lastMandatoryWrap = i;
                     break;
                 }
+                // Note: upstream has added in:
+                //   https://github.com/buggins/coolreader/commit/e2a1cf3306b6b083467d77d99dad751dc3aa07d9
+                // to the next if:
+                //  || lGetCharProps(m_text[i]) == 0
                 if ((flags & LCHAR_ALLOW_WRAP_AFTER) || i==m_length-1 || isCJKIdeograph(m_text[i]))
                     lastNormalWrap = i;
                 else if ( flags & LCHAR_DEPRECATED_WRAP_AFTER )
                     lastDeprecatedWrap = i;
                 else if ( flags & LCHAR_ALLOW_HYPH_WRAP_AFTER )
                     lastHyphWrap = i;
-                if (m_pbuffer->min_space_condensing_percent!=100 && i<m_length-1 && m_text[i]==' ' && (i==m_length-1 || m_text[i+1]!=' ')) {
+                if (m_pbuffer->min_space_condensing_percent!=100 && i<m_length-1 && (m_flags[i] & LCHAR_IS_SPACE) && (i==m_length-1 || !(m_flags[i + 1] & LCHAR_IS_SPACE))) {
                     int dw = getMaxCondensedSpaceTruncation(i);
                     if ( dw>0 )
                         spaceReduceWidth += dw;


### PR DESCRIPTION
Mostly some saner bound checking, and the use of `flags&LCHAR_IS_SPACE` instead of `char==' '`.
That's mostly what has changed upstream for lvtextfm.cpp (except some revert of the CJK stuff that we added and that was initially merged upstream, that we should obviously keep).

I have no test case that would show these changes fix anything, but they look safe and sane, so rather merge them in case they fix stuff. (and I don't have to wonder if this commit upstream would solve that problem I see).

Sources (for reference, we diverged `Fri Feb 21 14:10:20 2014`):
https://github.com/buggins/coolreader/commits/master/crengine/src/lvtextfm.cpp commit history

https://github.com/buggins/coolreader/commit/e2a1cf3306b6b083467d77d99dad751dc3aa07d9 some changed that I just added as a comment, as it feels it may be unsafe (we added some CJK stuff there)

https://github.com/buggins/coolreader/commit/2415a1bec733d3d01d94d26519e75162d59fe015 2 fixes to bound checking (the other stuff has been later reverted, and partially re-applied by the commit below)

https://github.com/buggins/coolreader/commit/d9842c71f6870604c231dfc02519d4bf27942ebc 3 changes to use flag comparison instead of char space comparison (may fix something when non regular spaces are used, dunno).
