### PR TITLE
text formatting: fix leading spaces issues

### DIFF
--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -222,6 +222,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
 #define LCHAR_IS_EOL               16 ///< flag: this char is CR or LF
 #define LCHAR_IS_OBJECT            32 ///< flag: this char is object or image
 #define LCHAR_MANDATORY_NEWLINE    64 ///< flag: this char must start with new line
+#define LCHAR_IS_LEADING_SPACE    128 ///< flag: this char is a space at start of non-pre paragraph (and can be stripped)
 
 /** \brief returns true if character is unicode space 
     \param code is character

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1419,6 +1419,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else {
             }
             */
+            /* removal of leading spaces is now managed directly by lvtextfm
             //int offs = 0;
             if ( txform->GetSrcCount()==0 && style->white_space!=css_ws_pre ) {
                 // clear leading spaces for first text of paragraph
@@ -1430,10 +1431,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //offs = i;
                 }
             }
-            if ( txt.length()>0 )
+            */
+            if ( txt.length()>0 ) {
                 txform->AddSourceLine( txt.c_str(), txt.length(), cl, bgcl, font, baseflags | tflags,
                     line_h, ident, enode, 0, letter_spacing );
-            baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
+                baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
+            }
         }
     }
     else


### PR DESCRIPTION
This should fix the issue
- described by @frankyifei in https://github.com/koreader/koreader/issues/2021#issuecomment-219996796
- met alongside https://github.com/koreader/crengine/pull/172
- explained in https://github.com/koreader/koreader/pull/3934#issuecomment-387114056
- reported in https://github.com/koreader/koreader/issues/1283 and https://github.com/koreader/koreader/issues/2067.

With:
```html
    <p>
        Some text<br/>
        More text
    </p>
```
Before > after
<kbd>![image](https://user-images.githubusercontent.com/24273478/41142486-22665e82-6af6-11e8-95e2-216000ea54d8.png)</kbd> > <kbd>![image](https://user-images.githubusercontent.com/24273478/41142506-335f8074-6af6-11e8-9c9a-df5baa9de94e.png)</kbd>

The newlines being considered like a space, and the XML parser replacing multiple spaces with a single space, we would end up with each of these text nodes beginning with a space.
- The space after the `<P>` would be stripped by some hack in lvrend.cpp (now removed), which would cause any highlight on that line to be shifted (because the text is no more sync'ed with the node content).
- The space after the `<BR/>` would not be dealt with by the lvrend.cpp hack (so, highlights on that line would be ok), but would be rendered and cause some unwanted indentation of all lines following a `<BR/>`.

This fix both cases by having the text formatting code deal with leading spaces, keeping text and node link in sync.
Previously made highlights looks like they are still valid and now rendered correctly, which is a relief!
(I had many previous attempts at fixing this, in lvtinydom.cpp getRect, in lvrend.cpp, elsewhere in lvtextfm.cpp, none working perfectly without side effects. As I got more familiar with lvtextfm.cpp, this looks like the clearest, simplest and most obvious solution, and it works perfectly on all my sample cases.)

More complex sample:
<kbd>![image](https://user-images.githubusercontent.com/24273478/41142789-41c997fc-6af7-11e8-8d83-a2c2672291dc.png)</kbd> > <kbd>![image](https://user-images.githubusercontent.com/24273478/41142803-4f0672be-6af7-11e8-8786-105deb2542e2.png)</kbd>
