### PR TITLE
Allow building an alternative TOC from document headings

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1917,8 +1917,12 @@ public:
     }
     void clear() { _children.clear(); }
     // root node constructor
-    LVTocItem( ldomDocument * doc ) : _parent(NULL), _doc(doc), _level(0), _index(0) { }
+    LVTocItem( ldomDocument * doc ) : _parent(NULL), _doc(doc), _level(0), _index(0), _page(0) { }
     ~LVTocItem() { clear(); }
+
+    /// For use on the root toc item only (_page, otherwise unused, can be used to store this flag)
+    void setAlternativeTocFlag() { if (_level==0) _page = 1; }
+    bool hasAlternativeTocFlag() { return _level==0 && _page==1; }
 };
 
 
@@ -2063,6 +2067,9 @@ public:
 
     /// returns pointer to TOC root node
     LVTocItem * getToc() { return &m_toc; }
+    /// build alternative TOC from document heading elements (H1 to H6)
+    void buildAlternativeToc();
+    bool isTocAlternativeToc() { return m_toc.hasAlternativeTocFlag(); }
 
     bool isTocFromCacheValid() { return _toc_from_cache_valid; }
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -863,7 +863,9 @@ void LVDocView::updatePageNumbers(LVTocItem * item) {
 	} else {
 		//CRLog::error("Page position is not found for path %s", LCSTR(item->getPath()) );
 		// unknown position
-		item->_page = -1;
+                // Don't update _page of root toc item, as it carries the alternative TOC flag
+                if (item->_level > 0)
+                    item->_page = -1;
 		item->_percent = -1;
 	}
 	for (int i = 0; i < item->getChildCount(); i++) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11987,7 +11987,48 @@ bool LVTocItem::deserialize( ldomDocument * doc, SerialBuf & buf )
 //}
 
 
+static void makeTocFromHeadings( ldomNode * node )
+{
+    int level = 0;
+    // el_h1 .. el_h6 are consecutive and ordered in include/fb2def.h
+    if ( node->getNodeId() < el_h1 || node->getNodeId() > el_h6 )
+        return;
+    level = node->getNodeId() - el_h1 + 1;
+    lString16 title = node->getText(' ');
+    ldomXPointer xp = ldomXPointer(node, 0);
+    LVTocItem * root = node->getDocument()->getToc();
+    LVTocItem * parent = root;
+    // Find adequate parent, or create intermediates
+    int plevel = 1;
+    while (plevel < level) {
+        int nbc = parent->getChildCount();
+        if (nbc) { // use the latest children
+            parent = parent->getChild(nbc-1);
+        }
+        else {
+            // If we'd like to stick it to the last parent found, even if
+            // of wrong level, just do: break;
+            // But it is cleaner to create intermediate(s)
+            parent = parent->addChild(L"", xp, lString16::empty_str);
+        }
+        plevel++;
+    }
+    LVTocItem * tocItem = parent->addChild(title, xp, lString16::empty_str);
+}
 
+void ldomDocument::buildAlternativeToc()
+{
+    m_toc.clear();
+    getRootNode()->recurseElements(makeTocFromHeadings);
+    // m_toc.setAlternativeTocFlag() use the root toc item _page property
+    // (never used for the root node) to store the fact this is an
+    // alternatve TOC. This info can then be serialized to cache and
+    // retrieved without any additional work or space overhead.
+    m_toc.setAlternativeTocFlag();
+    // cache file will have to be updated with the alt TOC
+    setCacheFileStale(true);
+    _toc_from_cache_valid = false; // to force update of page numbers
+}
 
 
 #if 0 && defined(_DEBUG)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12016,11 +12016,24 @@ static void makeTocFromHeadings( ldomNode * node )
     LVTocItem * tocItem = parent->addChild(title, xp, lString16::empty_str);
 }
 
+static void makeTocFromDocFragments( ldomNode * node )
+{
+    if ( node->getNodeId() != el_DocFragment )
+        return;
+    // No title, and only level 1 with DocFragments
+    ldomXPointer xp = ldomXPointer(node, 0);
+    LVTocItem * root = node->getDocument()->getToc();
+    LVTocItem * tocItem = root->addChild(L"", xp, lString16::empty_str);
+}
+
 void ldomDocument::buildAlternativeToc()
 {
     m_toc.clear();
     getRootNode()->recurseElements(makeTocFromHeadings);
-    // m_toc.setAlternativeTocFlag() use the root toc item _page property
+    // If no heading found, fall back to gathering DocFraments
+    if ( !m_toc.getChildCount() )
+        getRootNode()->recurseElements(makeTocFromDocFragments);
+    // m_toc.setAlternativeTocFlag() uses the root toc item _page property
     // (never used for the root node) to store the fact this is an
     // alternatve TOC. This info can then be serialized to cache and
     // retrieved without any additional work or space overhead.


### PR DESCRIPTION
Allow building an alternative TOC from document headings.
This only adds methods so that can be checked and triggered from lua side.
(Getting back the original TOC will need the cache to be invalidated and the book reloaded)

For now, I'll have that be toggable with long-press on the `Table of content` menu item.

It should allow us to got from empty or minimal TOC (I sometimes got some with only 1 or 2 items) like:
<kbd>![toc_no_toc](https://user-images.githubusercontent.com/24273478/41274774-eafb00ac-6e1e-11e8-8e2e-07b3c5451ae1.png)</kbd>

<kbd>![footer_no_toc](https://user-images.githubusercontent.com/24273478/41274810-105c1444-6e1f-11e8-9bbe-2bcf3545f4d8.png)</kbd>


to:
<kbd>![toc_alt_toc](https://user-images.githubusercontent.com/24273478/41274783-f1f5f286-6e1e-11e8-8c62-6bf19e55346f.png)</kbd>

<kbd>![footer_alt_toc](https://user-images.githubusercontent.com/24273478/41274814-12fc8530-6e1f-11e8-8a8b-8238787b8a44.png)</kbd>