### PR TITLE
Avoid page break between a node and its borders

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2489,6 +2489,14 @@ void LVDocView::Render(int dx, int dy, LVRendPageList * pages) {
                 m_font, m_def_interline_space, m_props);
 
 #if 0
+                // For debugging lvpagesplitter.cpp (small books)
+                for (int i=0; i<m_pages.length(); i++) {
+                    printf("%4d:   %7d .. %-7d [%d]\n", i, m_pages[i]->start, m_pages[i]->start+m_pages[i]->height, m_pages[i]->height);
+                }
+#endif
+
+#if 0
+                // For debugging lvpagesplitter.cpp (larger books)
 		FILE * f = fopen("pagelist.log", "wt");
 		if (f) {
 			for (int i=0; i<m_pages.length(); i++)

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -152,6 +152,9 @@ public:
     {
     }
 
+    // The final list of pages can be listed by changing some '#if 0' to '#if 1'
+    // in lvdocview.cpp LVDocView::Render()
+
     unsigned CalcSplitFlag( int flg1, int flg2 )
     {
         if (flg1==RN_SPLIT_AVOID || flg2==RN_SPLIT_AVOID)
@@ -251,11 +254,10 @@ public:
             pageend = last;
         }
         if (slice_start != line->getStart()) {
-            // We did cut slices: we need to make a virtual 'line' with the
-            // last slice, and as it fits on a page, use it at start of next
-            // page, to possibly have other lines added after it on this page.
-            next = new LVRendLineInfo(slice_start, line->getEnd(), line->flags);
-            pagestart = next;
+            // We did cut slices: we made a virtual 'line' with the last slice,
+            // and as it fits on a page, use it at start of next page, to
+            // possibly have other lines added after it on this page.
+            StartPage(last);
         }
     }
     void AddLine( LVRendLineInfo * line )

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -271,10 +271,26 @@ public:
             unsigned flgSplit = CalcSplitFlag( last->getSplitAfter(), line->getSplitBefore() );
             //bool flgFit = currentHeight( next ? next : line ) <= page_h;
             bool flgFit = currentHeight( line ) <= page_h;
+
+            if (!flgFit && flgSplit==RN_SPLIT_AVOID && pageend && next) {
+                // This new line doesn't fit, but split should be avoided between
+                // last and this line - and we have a previous line where a split
+                // is allowed (pageend and next were reset on StartPage(),
+                // and were only updated below when flgSplit==RN_SPLIT_AUTO)
+                // Let AddToList() use current pagestart and pageend,
+                // and StartPage on 'next'.
+                AddToList();
+                StartPage(next);
+                // Recompute flgFit (if it still doesn't fit, it will be
+                // splitted below)
+                flgFit = currentHeight( line ) <= page_h;
+            }
+
             if (!flgFit)
             {
-            // doesn't fit
-            // split
+            // Doesn't fit, but split is allowed (or mandatory) between
+            // last and this line - or we don't have a previous line
+            // where split is allowed: split between last and this line
 //                if ( !next || !pageend) {
                     next = line;
                     pageend = last;


### PR DESCRIPTION
Properly add the RN_SPLIT_AFTER_AVOID and RN_SPLIT_BEFORE_AVOID to the AddLine() calls for the padding lines when these contain a border, so no page break can happen in between them.

Also fix page splitting algorithm to properly ensure these AVOID flags.
Upstream had some commits and reverts that may be were a try at fixing that: https://github.com/koreader/crengine/commit/8471d00c2afcc2953e3408b6988a830a0f654798  https://github.com/koreader/crengine/commit/1e08c37c3cb7a732ad12b41d3ee6d357c551651b  https://github.com/koreader/crengine/commit/64fadbbbe9aa82803c2ba1b386e9d3c5bfac1e74

Pining @frankyifei for having a quick look at the lvrend.cpp changes (as you added these padding/border management).

Before:
<kbd>![border_before1](https://user-images.githubusercontent.com/24273478/41290404-14284006-6e4d-11e8-9e4a-dce9f2d99827.png)</kbd>
<kbd>![border_before2](https://user-images.githubusercontent.com/24273478/41290409-15f62182-6e4d-11e8-8551-d35f8412810c.png)</kbd>

After:
<kbd>![border_after1](https://user-images.githubusercontent.com/24273478/41290415-19e036fc-6e4d-11e8-88b1-1fe9b5b60fbd.png)</kbd>
<kbd>![border_after2](https://user-images.githubusercontent.com/24273478/41290420-1bc58df0-6e4d-11e8-901b-4d7f623f97c6.png)</kbd>

(With some additional page-break css declaration to the wikipedia stylesheet, I'll be able to further avoid a page break in these thumbnails between the image and its caption.)