### PR TITLE
Fix handling of soft-hyphens

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -12,7 +12,7 @@ for entry in "$search_dir"/*; do
     fi
 done
 
-file_list_jq=$(jq -r '.[].filename' "$search_dir/languages.json" | grep -v '@none' | grep -v '@algorithm')
+file_list_jq=$(jq -r '.[].filename' "$search_dir/languages.json" | grep -v '@none' | grep -v '@algorithm' | grep -v '@softhyphens')
 
 if [ ! "$file_list" = "$file_list_jq" ]; then
     echo "Warning, json should reflect hyphenation patterns. Diff:"

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ cr3gui/data/manual/
 cr3gui/data/cr3.css
 cr3gui/data/cr3.ini
 cr3gui/data/dict/
-cr3gui/data/dict_ext/
+cr3gui/data/dict_ext
 thirdparty

--- a/cr3gui/data/hyph/languages.json
+++ b/cr3gui/data/hyph/languages.json
@@ -10,6 +10,11 @@
         "language": "-"
     },
     {
+        "name": "Soft-hyphens only",
+        "filename": "@softhyphens",
+        "language": "-"
+    },
+    {
         "name": "Bulgarian",
         "filename": "Bulgarian.pattern",
         "language": "bg",

--- a/cr3gui/data/hyph/languages.json
+++ b/cr3gui/data/hyph/languages.json
@@ -5,13 +5,14 @@
         "language": "-"
     },
     {
-        "name": "Algorithm",
-        "filename": "@algorithm",
-        "language": "-"
-    },
-    {
         "name": "Soft-hyphens only",
         "filename": "@softhyphens",
+        "language": "-",
+        "separator": true
+    },
+    {
+        "name": "Algorithm",
+        "filename": "@algorithm",
         "language": "-"
     },
     {

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -35,6 +35,9 @@ public:
 #define HYPH_MIN_HYPHEN_MIN 1
 #define HYPH_MAX_HYPHEN_MIN 10
 
+// Don't trust soft-hyphens when using dict or algo methods
+#define HYPH_DEFAULT_TRUST_SOFT_HYPHENS 0
+
 enum HyphDictType
 {
 	HDT_NONE,      // disable hyphenation
@@ -102,6 +105,7 @@ class HyphMan
     static HyphDictionaryList * _dictList;
     static int _LeftHyphenMin;
     static int _RightHyphenMin;
+    static int _TrustSoftHyphens;
 public:
     static void uninit();
     static bool activateDictionaryFromStream( LVStreamRef stream );
@@ -113,6 +117,8 @@ public:
     static int getRightHyphenMin() { return _RightHyphenMin; }
     static bool setLeftHyphenMin( int left_hyphen_min );
     static bool setRightHyphenMin( int right_hyphen_min );
+    static int getTrustSoftHyphens() { return _TrustSoftHyphens; }
+    static bool setTrustSoftHyphens( int trust_soft_hyphen );
 
     HyphMan();
     ~HyphMan();

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -39,6 +39,7 @@ enum HyphDictType
 {
 	HDT_NONE,      // disable hyphenation
 	HDT_ALGORITHM, // universal
+	HDT_SOFTHYPHENS, // from soft hyphens in text
 	HDT_DICT_ALAN, // tex/alreader
     HDT_DICT_TEX   // tex/fbreader
 };
@@ -63,6 +64,7 @@ public:
 
 #define HYPH_DICT_ID_NONE L"@none"
 #define HYPH_DICT_ID_ALGORITHM L"@algorithm"
+#define HYPH_DICT_ID_SOFTHYPHENS L"@softhyphens"
 #define HYPH_DICT_ID_DICTIONARY L"@dictionary"
 
 
@@ -86,6 +88,7 @@ class HyphDictionary;
 class HyphDictionaryList;
 class TexHyph;
 class AlgoHyph;
+class SoftHyphensHyph;
 
 /// hyphenation manager
 class HyphMan
@@ -93,6 +96,7 @@ class HyphMan
     friend class HyphDictionary;
     friend class TexHyph;
     friend class AlgoHyph;
+    friend class SoftHyphensHyph;
     static HyphMethod * _method;
     static HyphDictionary * _selectedDictionary;
     static HyphDictionaryList * _dictList;

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -49,6 +49,7 @@
 #define PROP_LANDSCAPE_PAGES         "window.landscape.pages"
 #define PROP_HYPHENATION_LEFT_HYPHEN_MIN "crengine.hyphenation.left.hyphen.min"
 #define PROP_HYPHENATION_RIGHT_HYPHEN_MIN "crengine.hyphenation.right.hyphen.min"
+#define PROP_HYPHENATION_TRUST_SOFT_HYPHENS "crengine.hyphenation.trust.soft.hyphens"
 #define PROP_HYPHENATION_DICT        "crengine.hyphenation.directory"
 #define PROP_HYPHENATION_DICT_VALUE_NONE "@none"
 #define PROP_HYPHENATION_DICT_VALUE_ALGORITHM "@algorithm"

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -998,6 +998,9 @@ void limitStringSize(lString16 & str, int maxSize);
 
 int TrimDoubleSpaces(lChar16 * buf, int len,  bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens);
 
+/// remove soft-hyphens from string
+lString16 removeSoftHyphens( lString16 s );
+
 
 #define LCSTR(x) (UnicodeToUtf8(x).c_str())
 bool splitIntegerList( lString16 s, lString16 delim, int & value1, int & value2 );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1769,7 +1769,7 @@ public:
     ldomWordEx( ldomWord & word )
         :  _word(word), _mark(word), _range(word)
     {
-        _text = _word.getText();
+        _text = removeSoftHyphens( _word.getText() );
     }
     ldomWord & getWord() { return _word; }
     ldomXRange & getRange() { return _range; }

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -52,6 +52,7 @@
 
 int HyphMan::_LeftHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_RightHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
+int HyphMan::_TrustSoftHyphens = HYPH_DEFAULT_TRUST_SOFT_HYPHENS;
 
 HyphDictionary * HyphMan::_selectedDictionary = NULL;
 
@@ -202,6 +203,11 @@ bool HyphMan::setRightHyphenMin( int right_hyphen_min ) {
     return false;
 }
 
+bool HyphMan::setTrustSoftHyphens( int trust_soft_hyphens ) {
+    HyphMan::_TrustSoftHyphens = trust_soft_hyphens;
+    return true;
+}
+
 bool HyphDictionary::activate()
 {
     if (HyphMan::_selectedDictionary == this)
@@ -350,11 +356,11 @@ HyphMan::~HyphMan()
 {
 }
 
-// Used by SoftHyphensHyph::hyphenate(), but also as a first step
-// by TexHyph::hyphenate() and AlgoHyph::hyphenate() too: if
-// soft hyphens found in provided word, trust and use them; don't
-// do the regular patterns and algorithm matching (mostly because
-// making these ignore and skip soft-hyphens looks quite hard).
+// Used by SoftHyphensHyph::hyphenate(), but also possibly (when
+// TrustSoftHyphens is true) as a first step by TexHyph::hyphenate()
+// and AlgoHyph::hyphenate(): if soft hyphens are found in the
+// provided word, trust and use them; don't do the regular patterns
+// and algorithm matching.
 static bool softhyphens_hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth )
 {
     bool soft_hyphens_found = false;
@@ -800,30 +806,47 @@ bool TexHyph::match( const lChar16 * str, char * mask )
 
 bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth )
 {
-    if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth) )
-        return true;
+    if ( HyphMan::_TrustSoftHyphens ) {
+        if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth) )
+            return true;
+    }
     if ( len<=3 )
         return false;
     if ( len>=WORD_LENGTH )
         len = WORD_LENGTH - 2;
     lChar16 word[WORD_LENGTH+4];
     char mask[WORD_LENGTH+4];
+
+    // Make word from str, with soft-hyphens stripped out.
+    // Prepend and append a space so patterns can match word boundaries.
+    int wlen;
     word[0] = ' ';
-    lStr_memcpy( word+1, str, len );
-    lStr_lowercase(word+1, len);
-    word[len+1] = ' ';
-    word[len+2] = 0;
-    word[len+3] = 0;
-    word[len+4] = 0;
+    int w = 1;
+    for ( int i=0; i<len; i++ ) {
+        if ( str[i] != UNICODE_SOFT_HYPHEN_CODE ) {
+            word[w++] = str[i];
+        }
+    }
+    wlen = w-1;
+    word[w++] = ' ';
+    word[w++] = 0;
+    word[w++] = 0;
+    word[w++] = 0;
+    if ( wlen<=3 )
+        return false;
+    lStr_lowercase(word+1, wlen);
+    // printf("word:%s => #%s# (%d => %d)\n", LCSTR(lString16(str, len)), LCSTR(lString16(word)), len, wlen);
 
 #if DUMP_HYPHENATION_WORDS==1
     CRLog::trace("word to hyphenate: '%s'", LCSTR(lString16(word)));
 #endif
 
-    memset( mask, '0', len+3 );
-    mask[len+3] = 0;
+    // Find matches from dict patterns, at any position in word.
+    // Places where hyphenation is allowed are put into 'mask'.
+    memset( mask, '0', wlen+3 );
+    mask[wlen+3] = 0;
     bool found = false;
-    for ( int i=0; i<len; i++ ) {
+    for ( int i=0; i<wlen; i++ ) {
         found = match( word + i, mask + i ) || found;
     }
     if ( !found )
@@ -833,10 +856,12 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     lString16 buf;
     lString16 buf2;
     bool boundFound = false;
-    for ( int i=0; i<len; i++ ) {
+    for ( int i=0; i<wlen; i++ ) {
         buf << word[i+1];
         buf2 << word[i+1];
         buf2 << (lChar16)mask[i+2];
+        // This maxWidth check may be wrong here (in the dump only) because
+        // of a +1 shift and possible more shifts due to soft-hyphens.
         int nw = widths[i]+hyphCharWidth;
         if ( (mask[i+2]&1) ) {
             buf << (lChar16)'-';
@@ -853,22 +878,30 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     CRLog::trace("Hyphenate: %s  %s", LCSTR(buf), LCSTR(buf2) );
 #endif
 
+    // Moves allowed hyphenation positions from 'mask' to the provided 'flags',
+    // taking soft-hyphen shifts into account
+    int soft_hyphens_skipped = 0;
     bool res = false;
-    int p=0;
-    for ( p=len-2; p>=0; p-- ) {
-        if (p < HyphMan::_LeftHyphenMin - 1)
+    for ( int p=0 ; p<=len-2; p++ ) {
+        // printf(" char %c\n", str[p]);
+        if ( str[p] == UNICODE_SOFT_HYPHEN_CODE ) {
+            soft_hyphens_skipped++;
+            continue;
+        }
+        if (p-soft_hyphens_skipped < HyphMan::_LeftHyphenMin - 1)
             continue;
         if (p > len - HyphMan::_RightHyphenMin - 1)
             continue;
         // hyphenate
         //00010030100
         int nw = widths[p]+hyphCharWidth;
-        if ( (mask[p+2]&1) && nw <= maxWidth ) {
-            //if ( checkHyphenRules( word+1, len, p ) ) {
-            //widths[p] += hyphCharWidth; // don't add hyph width
+        // printf(" word %c\n", word[p+1-soft_hyphens_skipped]);
+        // p+2 because: +1 because word has a space prepended, and +1 because
+        // mask[] holds the flag for char n on slot n+1
+        if ( (mask[p+2-soft_hyphens_skipped]&1) && nw <= maxWidth ) {
             flags[p] |= LCHAR_ALLOW_HYPH_WRAP_AFTER;
+            // printf(" allowed after %c\n", str[p]);
             res = true;
-            //}
         }
     }
     return res;
@@ -876,8 +909,10 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 
 bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth )
 {
-    if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth) )
-        return true;
+    if ( HyphMan::_TrustSoftHyphens ) {
+        if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth) )
+            return true;
+    }
     lUInt16 chprops[WORD_LENGTH];
     if ( len > WORD_LENGTH-2 )
         len = WORD_LENGTH - 2;
@@ -903,10 +938,20 @@ bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8
                 if ( chprops[i] & CH_PROP_VOWEL ) {
                     for ( j=i+1; j<end; ++j ) {
                         if ( chprops[j] & CH_PROP_VOWEL ) {
-                            if ( (chprops[i+1] & CH_PROP_CONSONANT) && (chprops[i+2] & CH_PROP_CONSONANT) )
-                                ++i;
-                            else if ( (chprops[i+1] & CH_PROP_CONSONANT) && ( chprops[i+2] & CH_PROP_ALPHA_SIGN ) )
-                                i += 2;
+                            int next = i+1;
+                            while ( (chprops[next] & CH_PROP_HYPHEN) && next<end-MIN_WORD_LEN_TO_HYPHEN) {
+                                // printf("next++\n");
+                                next++;
+                            }
+                            int next2 = next+1;
+                            while ( (chprops[next2] & CH_PROP_HYPHEN) && next2<end-MIN_WORD_LEN_TO_HYPHEN) {
+                                // printf("next2++\n");
+                                next2++;
+                            }
+                            if ( (chprops[next] & CH_PROP_CONSONANT) && (chprops[next2] & CH_PROP_CONSONANT) )
+                                i = next;
+                            else if ( (chprops[next] & CH_PROP_CONSONANT) && ( chprops[next2] & CH_PROP_ALPHA_SIGN ) )
+                                i = next2;
                             if ( i-start>=1 && end-i>2 ) {
                                 // insert hyphenation mark
                                 lUInt16 nw = widths[i] + hyphCharWidth;
@@ -916,8 +961,13 @@ bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8
                                     const char * dblSequences[] = {
                                         "sh", "th", "ph", "ch", NULL
                                     };
+                                    next = i+1;
+                                    while ( (chprops[next] & CH_PROP_HYPHEN) && next<end-MIN_WORD_LEN_TO_HYPHEN) {
+                                        // printf("next3++\n");
+                                        next++;
+                                    }
                                     for (int k=0; dblSequences[k]; k++)
-                                        if (str[i]==dblSequences[k][0] && str[i+1]==dblSequences[k][1]) {
+                                        if (str[i]==dblSequences[k][0] && str[next]==dblSequences[k][1]) {
                                             disabled = true;
                                             break;
                                         }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5930,6 +5930,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 HyphMan::setRightHyphenMin(rightHyphenMin);
                 REQUEST_RENDER("propsApply hyphenation right_hyphen_min")
             }
+        } else if (name == PROP_HYPHENATION_TRUST_SOFT_HYPHENS) {
+            int trustSoftHyphens = props->getIntDef(PROP_HYPHENATION_TRUST_SOFT_HYPHENS, HYPH_DEFAULT_TRUST_SOFT_HYPHENS);
+            if (HyphMan::getTrustSoftHyphens() != trustSoftHyphens) {
+                HyphMan::setTrustSoftHyphens(trustSoftHyphens);
+                REQUEST_RENDER("propsApply hyphenation trust_soft_hyphens")
+            }
 #endif
         } else if (name == PROP_INTERLINE_SPACE) {
             int interlineSpace = props->getIntDef(PROP_INTERLINE_SPACE,

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -361,6 +361,7 @@ lUInt32 calcGlobalSettingsHash(int documentId)
     hash = hash * 31 + (HyphMan::getSelectedDictionary()!=NULL ? HyphMan::getSelectedDictionary()->getHash() : 123 );
     hash = hash * 31 + HyphMan::getLeftHyphenMin();
     hash = hash * 31 + HyphMan::getRightHyphenMin();
+    hash = hash * 31 + HyphMan::getTrustSoftHyphens();
     return hash;
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.15k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0005
+#define FORMATTING_VERSION_ID 0x0006
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -5992,7 +5992,7 @@ bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool rever
     return range.findText( pattern, caseInsensitive, reverse, words, maxCount, maxHeight, maxHeightCheckStartY );
 }
 
-static bool findText( const lString16 & str, int & pos, const lString16 & pattern )
+static bool findText( const lString16 & str, int & pos, int & endpos, const lString16 & pattern )
 {
     int len = pattern.length();
     if ( pos < 0 || pos + len > (int)str.length() )
@@ -6002,21 +6002,27 @@ static bool findText( const lString16 & str, int & pos, const lString16 & patter
     int nlen = str.length() - pos - len;
     for ( int j=0; j<=nlen; j++ ) {
         bool matched = true;
+        int nsofthyphens = 0; // There can be soft-hyphen in str, but not in pattern
         for ( int i=0; i<len; i++ ) {
-            if ( s1[i] != s2[i] ) {
+            while ( i+nsofthyphens < nlen && s1[i+nsofthyphens] == UNICODE_SOFT_HYPHEN_CODE ) {
+                nsofthyphens += 1;
+            }
+            if ( s1[i+nsofthyphens] != s2[i] ) {
                 matched = false;
                 break;
             }
         }
-        if ( matched )
+        if ( matched ) {
+            endpos = pos + len + nsofthyphens;
             return true;
+        }
         s1++;
         pos++;
     }
     return false;
 }
 
-static bool findTextRev( const lString16 & str, int & pos, const lString16 & pattern )
+static bool findTextRev( const lString16 & str, int & pos, int & endpos, const lString16 & pattern )
 {
     int len = pattern.length();
     if ( pos+len>(int)str.length() )
@@ -6028,14 +6034,20 @@ static bool findTextRev( const lString16 & str, int & pos, const lString16 & pat
     int nlen = pos;
     for ( int j=nlen; j>=0; j-- ) {
         bool matched = true;
+        int nsofthyphens = 0; // There can be soft-hyphen in str, but not in pattern
         for ( int i=0; i<len; i++ ) {
-            if ( s1[i] != s2[i] ) {
+            while ( i+nsofthyphens < nlen && s1[i+nsofthyphens] == UNICODE_SOFT_HYPHEN_CODE ) {
+                nsofthyphens += 1;
+            }
+            if ( s1[i+nsofthyphens] != s2[i] ) {
                 matched = false;
                 break;
             }
         }
-        if ( matched )
+        if ( matched ) {
+            endpos = pos + len + nsofthyphens;
             return true;
+        }
         s1--;
         pos--;
     }
@@ -6062,6 +6074,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
 
             lString16 txt = _end.getNode()->getText();
             int offs = _end.getOffset();
+            int endpos;
 
             if ( firstFoundTextY!=-1 && maxHeight>0 ) {
                 ldomXPointer p( _end.getNode(), offs );
@@ -6073,14 +6086,14 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
             if ( caseInsensitive )
                 txt.lowercase();
 
-            while ( ::findTextRev( txt, offs, pattern ) ) {
+            while ( ::findTextRev( txt, offs, endpos, pattern ) ) {
                 if ( firstFoundTextY==-1 && maxHeight>0 ) {
                     ldomXPointer p( _end.getNode(), offs );
                     int currentTextY = p.toPoint().y;
                     if (maxHeightCheckStartY == -1 || currentTextY <= maxHeightCheckStartY)
                         firstFoundTextY = currentTextY;
                 }
-                words.add( ldomWord(_end.getNode(), offs, offs + pattern.length() ) );
+                words.add( ldomWord(_end.getNode(), offs, endpos ) );
                 offs--;
             }
             if ( !_end.prevVisibleText() )
@@ -6101,6 +6114,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
 		}
         while ( !isNull() ) {
             int offs = _start.getOffset();
+            int endpos;
 
             if ( firstFoundTextY!=-1 && maxHeight>0 ) {
                 ldomXPointer p( _start.getNode(), offs );
@@ -6114,7 +6128,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
             if ( caseInsensitive )
                 txt.lowercase();
 
-            while ( ::findText( txt, offs, pattern ) ) {
+            while ( ::findText( txt, offs, endpos, pattern ) ) {
                 if ( firstFoundTextY==-1 && maxHeight>0 ) {
                     ldomXPointer p( _start.getNode(), offs );
                     int currentTextY = p.toPoint().y;
@@ -6126,7 +6140,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
                             firstFoundTextY = currentTextY;
                     }
                 }
-                words.add( ldomWord(_start.getNode(), offs, offs + pattern.length() ) );
+                words.add( ldomWord(_start.getNode(), offs, endpos ) );
                 offs++;
             }
             if ( !_start.nextVisibleText() )
@@ -6587,6 +6601,7 @@ inline bool IsWordSeparator( lChar16 ch )
     if (ch >= 0x61 && ch <= 0x7A) return false; // lowercase ascii letters
     if (ch >= 0x41 && ch <= 0x5A) return false; // uppercase ascii letters
     if (ch >= 0x30 && ch <= 0x39) return false; // digits
+    if (ch == 0xAD ) return false; // soft-hyphen, considered now as part of word
     // All other below 0xC0 are word separators:
     //   < 0x30 space, !"#$%&'()*+,-./
     //   < 0x41 :;<=>?@
@@ -7219,7 +7234,7 @@ public:
         for ( int i=nodeRange->getStart().getOffset(); i <= len; i++ ) {
             // int alpha = lGetCharProps(text[i]) & CH_PROP_ALPHA;
             // Also allow digits (years, page numbers) to be considered words
-            int alpha = lGetCharProps(text[i]) & (CH_PROP_ALPHA|CH_PROP_DIGIT);
+            int alpha = lGetCharProps(text[i]) & (CH_PROP_ALPHA|CH_PROP_DIGIT|CH_PROP_HYPHEN);
             if (alpha && beginOfWord<0 ) {
                 beginOfWord = i;
             }
@@ -7583,7 +7598,7 @@ lString16 ldomXRange::getRangeText( lChar16 blockDelimiter, int maxTextLen )
 {
     ldomTextCollector callback( blockDelimiter, maxTextLen );
     forEach( &callback );
-    return callback.getText();
+    return removeSoftHyphens( callback.getText() );
 }
 
 /// returns href attribute of <A> element, plus xpointer of <A> element itself
@@ -11994,7 +12009,7 @@ static void makeTocFromHeadings( ldomNode * node )
     if ( node->getNodeId() < el_h1 || node->getNodeId() > el_h6 )
         return;
     level = node->getNodeId() - el_h1 + 1;
-    lString16 title = node->getText(' ');
+    lString16 title = removeSoftHyphens( node->getText(' ') );
     ldomXPointer xp = ldomXPointer(node, 0);
     LVTocItem * root = node->getDocument()->getToc();
     LVTocItem * parent = root;


### PR DESCRIPTION
Implement method **C** described in https://github.com/koreader/koreader/issues/3431#issuecomment-397534353 :
Don't consider soft-hyphens as word separator anymore: now, they are just like a zero-width alpha character, and are never drawned (this should fix any spacing/rendering glitch by getting rid of some dubious edge cases handling).
Only the hyphenation methods will use them to decide where that word is breakable, and only that added hyphen will be drawn.

Remove soft-hyphens only at library boundaries:
- when returning selected text when holding on word or text, for the methods used by cre.cpp:
  - when creating ldomWordEx, for ldomWordEx.getText(), for cre.cpp getWordFromPosition()
  - ldomXRange::getRangeText(), for cre.cpp getTextFromPositions()
- when searching user provided text (without soft-hyphens): skip soft-hyphens when doing text comparison, for cre.cpp findText()
- when making alternative TOC from text headings

(It might be that I have forgotten other stuff where that would be needed, testing will tell.)

Adds a new hyphenation method "Soft-hyphens only", mostly for testing and knowing if the book is heavily soft-hyphenated.
The hyphenation method "None" will now work correctly, and allow to not hyphenate on soft-hyphens anymore.

Other hyphenation methods (language based or algorithmic) will first check if there are soft-hyphens in the word they are asked to hyphenate, and if there are, trust these and skip their regular method.
I wrote in https://github.com/koreader/koreader/issues/3431#issuecomment-397534353 : _have only the hyphenation algorithms deal with them when they are given a word to hyphenate: a) if any soft hyphen in the word, either ignore them and use existing algorithm, or b) give up algorithm and just say split is allowed where the soft-hyphen are_
I went with b) , but this is mostly a technical skill decision: having these TeX pattern code handle word with soft-hyphen would need to get rid of them, get the flags, and then shift the flags obtained at each position when there was a soft-hyphen so it aligns back again on the word with soft-hyphen... feels hard and risky to me :)
b) would be good with text with only occasional soft-hyphens, like the author would have added them to foreign/exotic words.
But b) won't allow to workaround badly soft-hyphenated texts by using a language based hyphenation: only None will allow to get rid of the bad soft-hyphenation, so not allowing for any hyphenation.

(tagged as [wip] as I'll be off tomorrow for a week, so I won't be able to test/make any fix - but I'll go with a custom build with this, so I can check for some time it has no side effect on books without soft-hyphens - @robert00s : please test if you can with books with tons of soft-hyphens :)