### PR TITLE
Adds support for dpi-based css units (px/in/cm/mm/pt/pc)

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -158,20 +158,24 @@ enum css_list_style_position_t {
     css_lsp_outside
 };
 
-/// css length value types
+/// css length value types, see:
+//  https://developer.mozilla.org/en-US/docs/Web/CSS/length
+//  https://www.w3.org/Style/Examples/007/units.en.html
 enum css_value_type_t {
     css_val_inherited,
     css_val_unspecified,
-    css_val_px,
-    css_val_em,
-    css_val_ex,
-    css_val_in, // 2.54 cm
-    css_val_cm,
-    css_val_mm,
-    css_val_pt, // 1/72 in
-    css_val_pc, // 12 pt
+    css_val_px,  // css px (1 css px = 1 screen px at 96 DPI)
+    css_val_em,  // relative to font size of the current element
+    css_val_ex,  // 1ex =~ 0.5em in many fonts (https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+    css_val_rem, // 'root em', relative to font-size of the root element (typically <html>)
+    css_val_in,  // 2.54 cm   1in = 96 css px
+    css_val_cm,  //        2.54cm = 96 css px
+    css_val_mm,  //        25.4mm = 96 css px
+    css_val_pt,  // 1/72 in  72pt = 96 css px
+    css_val_pc,  // 12 pt     6pc = 96 css px
     css_val_percent,
-    css_val_color
+    css_val_color,
+    css_val_screen_px  // screen px, for already scaled values
 };
 
 /// css border style values
@@ -229,16 +233,17 @@ enum css_border_collapse_value_t{
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value
-    int         value;      ///< value (*256 for all types except % and px)
+    int         value;      ///< value: *256 for all types (to allow for fractional px and %), except css_val_screen_px
+                            // allow for values -/+ 524288.0 (32bits -8 for fraction -4 for pack -1 for sign)
     css_length_tag()
-        : type (css_val_px), value (0)
+        : type (css_val_screen_px), value (0)
     {
     }
     css_length_tag( int px_value )
-        : type (css_val_px), value (px_value)
+        : type (css_val_screen_px), value (px_value)
     {
     }
-    css_length_tag(css_value_type_t n_type, int n_value)
+    css_length_tag(css_value_type_t n_type, int n_value) // expects caller to do << 8
         : type(n_type), value(n_value)
     {
     }

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -258,7 +258,8 @@ private:
     ldomXPointer _posBookmark; // bookmark for current position
 
     int m_battery_state;
-    int m_font_size;
+    int m_requested_font_size;
+    int m_font_size; // = m_requested_font_size, possibly scaled according to DPI
     int m_status_font_size;
     int m_def_interline_space;
     LVArray<int> m_font_sizes;
@@ -809,6 +810,10 @@ public:
     void ZoomFont( int delta );
     /// retrieves current base font size
     int  getFontSize() { return m_font_size; }
+    /// retrieves requested font size (before scaling for DPI)
+    int  getRequestedFontSize() { return m_requested_font_size; }
+    /// scale font size according to gRenderDPI
+    int scaleFontSizeForDPI( int fontSize );
     /// sets new base font size
     void setFontSize( int newSize );
     /// retrieves current status bar font size

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -60,6 +60,10 @@
 
 #define PROP_FILE_PROPS_FONT_SIZE    "cr3.file.props.font.size"
 
+// default is 96 (1 css px = 1 screen px)
+// use 0 for old crengine behaviour (no support for absolute units and 1css px = 1 screen px)
+#define PROP_RENDER_DPI                 "crengine.render.dpi"
+#define PROP_RENDER_SCALE_FONT_WITH_DPI "crengine.render.scale.font.with.dpi"
 
 #define PROP_CACHE_VALIDATION_ENABLED  "crengine.cache.validation.enabled"
 #define PROP_MIN_FILE_SIZE_TO_CACHE  "crengine.cache.filesize.min"

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -49,6 +49,15 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 /// get global document font style embolden mode
 int LVRendGetFontEmbolden();
 
-#endif
 int measureBorder(ldomNode *enode,int border);
 int lengthToPx( css_length_t val, int base_px, int base_em );
+int scaleForRenderDPI( int value );
+
+#define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px
+#define DEF_RENDER_DPI 96
+#define DEF_RENDER_SCALE_FONT_WITH_DPI 0
+extern int gRenderDPI;
+extern bool gRenderScaleFontWithDPI;
+extern int gRootFontSize;;
+
+#endif

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -328,12 +328,12 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
         // Approximate the (usually uneven) gaps between named sizes.
         if ( substr_icompare( "smaller", str ) ) {
             value.type = css_val_percent;
-            value.value = 80;
+            value.value = 80 << 8;
             return true;
         }
         else if ( substr_icompare( "larger", str ) ) {
             value.type = css_val_percent;
-            value.value = 125;
+            value.value = 125 << 8;
             return true;
         }
     }
@@ -368,6 +368,8 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
         value.type = css_val_pt;
     else if ( substr_icompare( "ex", str ) )
         value.type = css_val_ex;
+    else if ( substr_icompare( "rem", str ) )
+        value.type = css_val_rem;
     else if ( substr_icompare( "px", str ) )
         value.type = css_val_px;
     else if ( substr_icompare( "in", str ) )
@@ -382,12 +384,10 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
         value.type = css_val_percent;
     else if (n == 0 && frac == 0)
         value.type = css_val_px;
-    else
-        return false;
-    if ( value.type == css_val_px || value.type == css_val_percent )
-        value.value = n;                               // normal
-    else
-        value.value = n * 256 + 256 * frac / frac_div; // *256
+    // allow unspecified unit (for line-height)
+    // else
+    //    return false;
+    value.value = n * 256 + 256 * frac / frac_div; // *256
     return true;
 }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -259,6 +259,10 @@ void LFormattedText::AddSourceObject(
     lInt16 width = (lUInt16)img->GetWidth();
     lInt16 height = (lUInt16)img->GetHeight();
 
+    // Scale image native size according to gRenderDPI
+    width = scaleForRenderDPI(width);
+    height = scaleForRenderDPI(height);
+
     css_style_ref_t style = node->getStyle();
     int w = 0, h = 0;
     int em = node->getFont()->getSize();
@@ -266,7 +270,7 @@ void LFormattedText::AddSourceObject(
     if ((nodename.lowercase().compare("sub")==0
                 || nodename.lowercase().compare("sup")==0)
             && (style->font_size.type==css_val_percent)) {
-        em = em*100/style->font_size.value;
+        em = em * 100 * 256 / style->font_size.value ; // value is %*256
     }
     w = lengthToPx(style->width, 100, em);
     h = lengthToPx(style->height, 100, em);
@@ -275,13 +279,13 @@ void LFormattedText::AddSourceObject(
 
     if ( w*h==0 ) {
         if ( w==0 ) {
-            if ( h==0 ) {
+            if ( h==0 ) { // use image native size
                 h = height;
                 w = width;
-            } else {
+            } else { // use style height, keep aspect ratio
                 w = width*h/height;
             }
-        } else if ( h==0 ) {
+        } else if ( h==0 ) { // use style width, keep aspect ratio
             h = w*height/width;
             if (h == 0) h = height;
         }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.15k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0006
+#define FORMATTING_VERSION_ID 0x0007
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -362,6 +362,8 @@ lUInt32 calcGlobalSettingsHash(int documentId)
     hash = hash * 31 + HyphMan::getLeftHyphenMin();
     hash = hash * 31 + HyphMan::getRightHyphenMin();
     hash = hash * 31 + HyphMan::getTrustSoftHyphens();
+    hash = hash * 31 + gRenderDPI;
+    hash = hash * 31 + gRootFontSize;
     return hash;
 }
 
@@ -3302,7 +3304,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->list_style_position = css_lsp_outside;
     s->vertical_align = css_va_baseline;
     s->font_family = def_font->getFontFamily();
-    s->font_size.type = css_val_px;
+    s->font_size.type = css_val_screen_px; // we use this type, as we got the real font size from FontManager
     s->font_size.value = def_font->getSize();
     s->font_name = def_font->getTypeFace();
     s->font_weight = css_fw_400;
@@ -3310,7 +3312,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->text_indent.type = css_val_px;
     s->text_indent.value = 0;
     s->line_height.type = css_val_percent;
-    s->line_height.value = def_interline_space;
+    s->line_height.value = def_interline_space << 8;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();
     if ( _last_docflags != getDocFlags() ) {
@@ -12294,14 +12296,14 @@ void runBasicTinyDomUnitTests()
         style1->vertical_align = css_va_baseline;
         style1->font_family = css_ff_sans_serif;
         style1->font_size.type = css_val_px;
-        style1->font_size.value = 24;
+        style1->font_size.value = 24 << 8;
         style1->font_name = cs8("Arial");
         style1->font_weight = css_fw_400;
         style1->font_style = css_fs_normal;
         style1->text_indent.type = css_val_px;
         style1->text_indent.value = 0;
         style1->line_height.type = css_val_percent;
-        style1->line_height.value = 100;
+        style1->line_height.value = 100 << 8;
 
         css_style_ref_t style2;
         style2 = css_style_ref_t( new css_style_rec_t );
@@ -12321,14 +12323,14 @@ void runBasicTinyDomUnitTests()
         style2->vertical_align = css_va_baseline;
         style2->font_family = css_ff_sans_serif;
         style2->font_size.type = css_val_px;
-        style2->font_size.value = 24;
+        style2->font_size.value = 24 << 8;
         style2->font_name = cs8("Arial");
         style2->font_weight = css_fw_400;
         style2->font_style = css_fs_normal;
         style2->text_indent.type = css_val_px;
         style2->text_indent.value = 0;
         style2->line_height.type = css_val_percent;
-        style2->line_height.value = 100;
+        style2->line_height.value = 100 << 8;
 
         css_style_ref_t style3;
         style3 = css_style_ref_t( new css_style_rec_t );
@@ -12348,14 +12350,14 @@ void runBasicTinyDomUnitTests()
         style3->vertical_align = css_va_baseline;
         style3->font_family = css_ff_sans_serif;
         style3->font_size.type = css_val_px;
-        style3->font_size.value = 24;
+        style3->font_size.value = 24 << 8;
         style3->font_name = cs8("Arial");
         style3->font_weight = css_fw_400;
         style3->font_style = css_fs_normal;
         style3->text_indent.type = css_val_px;
         style3->text_indent.value = 0;
         style3->line_height.type = css_val_percent;
-        style3->line_height.value = 100;
+        style3->line_height.value = 100 << 8;
 
         el1->setStyle(style1);
         css_style_ref_t s1 = el1->getStyle();


### PR DESCRIPTION
Follow up to #161.

Add or fix support of 'px', 'in', 'cm', 'mm', 'pt' and 'pc' css units.
They are all scaled according to the global crengine setting `PROP_RENDER_DPI`/`gRenderDPI `with a default value of `96`. This setting will be toggable from a set of values from a KOReader bottom config panel, and is independant from the KOReader/device internal screen_dpi setting. This will acts like a Zoom option (but not affecting the selected default font size, except for elements with a font size set with a css absolute unit).
(I don't think we should use the device DPI, using 300 DPI on my GloHD makes everything too large for my liking, and cause some surprise with many text epubs that uses stuff like `MsoNormal {text-indent: 0.5pt}`)

<kbd>![image](https://user-images.githubusercontent.com/24273478/42104251-2b2d5b24-7bcc-11e8-8534-3970513af891.png)</kbd>
(I'm not really sure in which panel this should go.)

With `PROP_RENDER_DPI=0`, we get the original crengine behaviour (nearly no support for dpi-based units).
With `PROP_RENDER_DPI=96`, 1 css px = 1 screen px, and allows to get the original crengine behaviour with the 'px' unit.
With any other value `PROP_RENDER_DPI=N`, all absolute units (px, cm, ...) are scaled by `N/96`, so DPI=300 makes things 3 times larger, DPI=48 2 times smaller.
(A `border-width: 1in`, on my 300 DPI GloHD, with `PROP_RENDER_DPI=300`, measures to 2.50 cm, nearly the expected 2.54cm).

Images are scaled too according to this DPI setting (because the values in `<img style="width: 242px; height:121px">` are scaled, images without these will be scaled too for coherency in this idea of Zoom option).

An other global crengine setting `PROP_RENDER_SCALE_FONT_WITH_DPI `(default value: 0/false) allows for scaling the main font size too when we scale DPI. (Implemented just to see how it would work, but it's best to not use it, and have font size and Zoom/DPI changeable independantly).

Change internal representation of the css value for all css types to have all them *256, to allow for fractional original values.
Added internal css type `css_val_screen_px` for already scaled values, like font sizes.

Also add support for the `rem` css unit (related to the root font size).

Also fix border-width: with % units, where border would be drawn, but the content would not be shifted by the border size and could be overwritten by the border.

Sample file for testing: [test-css-abs-units.html.txt](https://github.com/koreader/crengine/files/2150164/test-css-abs-units.html.txt)
Frontend patch for the toggable: [renderDPI4f.diff.txt](https://github.com/koreader/crengine/files/2150165/renderDPI4f.diff.txt)

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104204-049309dc-7bcc-11e8-94eb-dc55614e1775.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104217-0d6a38aa-7bcc-11e8-8505-0ee296e1c6ef.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104229-17018c9c-7bcc-11e8-8246-5da57dccc66e.png)</kbd>

After with DPI=96:
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104445-dceab6d6-7bcc-11e8-942d-abbc700ec97b.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104458-e4772a88-7bcc-11e8-9e3a-2505df04e269.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104467-ebd147be-7bcc-11e8-9e46-7e025ead624c.png)</kbd>

After with DPI=212:
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104503-16bdcfba-7bcd-11e8-9300-82885250a11c.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104513-1cccdc3e-7bcd-11e8-8bac-4524e04a11a2.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104520-2318b306-7bcd-11e8-9e71-1f7522ed6af6.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/42104530-2cb09d98-7bcd-11e8-9b04-21a7bbe5cac4.png)</kbd>

edit: it was a lot of work and testing, just to have support for them - but for a low practical usage (mostly only useful to scale images, mainly sometimes useful in Wikipedia EPUB).
