### PR TITLE
Avoid stylesheet reparsing, fix some cache mismatch

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -59,12 +59,10 @@ center {
 ul {
     list-style-type: disc;
     margin-left: 1em;
-    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><ul>) */
 }
 ol {
     list-style-type: decimal;
     margin-left: 1em;
-    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><ol>) */
 }
 li {
     display: list-item;
@@ -88,7 +86,6 @@ dd {
 table {
     font-size: 80%;
     margin: 3px;
-    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><table>) */
 }
 td, th {
     text-indent: 0;

--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -59,10 +59,12 @@ center {
 ul {
     list-style-type: disc;
     margin-left: 1em;
+    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><ul>) */
 }
 ol {
     list-style-type: decimal;
     margin-left: 1em;
+    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><ol>) */
 }
 li {
     display: list-item;
@@ -86,6 +88,7 @@ dd {
 table {
     font-size: 80%;
     margin: 3px;
+    text-align: justify; /* don't inherit, do like body (fix ugly centering when <center><table>) */
 }
 td, th {
     text-indent: 0;

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -294,6 +294,7 @@ private:
     LVImageSourceRef m_backgroundImage;
     LVRef<LVColorDrawBuf> m_backgroundImageScaled;
     bool m_backgroundTiled;
+    bool m_stylesheetNeedsUpdate;;
     int m_highlightBookmarks;
     LVPtrVector<LVBookMarkPercentInfo> m_bookmarksPercents;
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -149,6 +149,7 @@ LVDocView::LVDocView(int bitsPerPixel) :
 			 */
 			, m_stream(NULL), m_doc(NULL), m_stylesheet(def_stylesheet),
             m_backgroundTiled(true),
+            m_stylesheetNeedsUpdate(true),
             m_highlightBookmarks(1),
 			m_pageMargins(DEFAULT_PAGE_MARGIN,
 					DEFAULT_PAGE_MARGIN / 2 /*+ INFO_FONT_SIZE + 4 */,
@@ -488,11 +489,15 @@ void LVDocView::setStyleSheet(lString8 css_text) {
     REQUEST_RENDER("setStyleSheet")
 
     m_stylesheet = css_text;
+    m_stylesheetNeedsUpdate = true;
 }
 
 void LVDocView::updateDocStyleSheet() {
+    if (!m_stylesheetNeedsUpdate)
+        return;
     CRPropRef p = m_props->getSubProps("styles.");
     m_doc->setStyleSheet(substituteCssMacros(m_stylesheet, p).c_str(), true);
+    m_stylesheetNeedsUpdate = false;
 }
 
 void LVDocView::Clear() {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2500,6 +2500,12 @@ public:
 
         //printf("going to load font file %s\n", fname.c_str());
         bool loaded = false;
+        // Use the family of the font we found in the cache (it may be different
+        // from the requested family).
+        // Assigning the requested familly to this new font could be wrong, and
+        // may cause a style or font mismatch when loading from cache, forcing a
+        // full re-rendering).
+        family = item->getDef()->getFamily();
         if (item->getDef()->getBuf().isNull())
             loaded = font->loadFromFile( pathname.c_str(), item->getDef()->getIndex(), size, family, isBitmapModeForSize(size), italicize );
         else

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -22,15 +22,9 @@ lUInt32 calcHash(font_ref_t & f)
 {
     if ( !f )
         return 14321;
-    // printf("family %u size %u weight %u italic %u kerning %u bitmap %u baseline %u typeface %u = hash %x\n", (lUInt32)f->getFontFamily(), (lUInt32)f->getSize(), (lUInt32)f->getWeight(), (lUInt32)f->getItalic(), (lUInt32)f->getKerning(), (lUInt32)f->getBitmapMode(), (lUInt32)f->getBaseline(), (lUInt32)f->getTypeFace().getHash(), f->_hash);
     if ( f->_hash )
         return f->_hash;
     lUInt32 v = 31;
-    // Commenting the next line may ensure more stable cache (by avoiding
-    // style hash mismatch), as for some undetermined reason, nodes may be
-    // associated to a same font with all other properties identical except
-    // for the _family which may oscillate between 1 (serif) and 2 (sans_serif)
-    // when we increase or decrease font size (even for a same font_size!)
     v = v * 31 + (lUInt32)f->getFontFamily();
     v = v * 31 + (lUInt32)f->getSize();
     v = v * 31 + (lUInt32)f->getWeight();


### PR DESCRIPTION
Don't re-parse stylesheets on each rendering (page turn, menu opening, widget opening or closing...) when not needed. Should save a few 10ms on each document painting on a device.
(Shouldn't really be noticable, but that will avoid me suspecting crengine when looking at slowness in refreshes.)

Fix the last remaining `CRE WARNING: cached rendering is invalid (style/stylesheet hash mismatch): doing full rendering` that could happen on loading a document from cache if we had change font size on previous session, mostly when a document has `body {font-family: serif}`.
(That's the one I couldn't fixed mentionned at end of https://github.com/koreader/crengine/pull/100#issue-171740521).

~~epub.css: don't inherit text-align for TABLE, OL, UL, mostly for when they are contained in a `<CENTER>`.
For TABLE, because it's the behaviour of current browsers.
For OL and UL: because crengine rendering limitation would always put the bullet/number on the far left of the 100% width of text, moving them far away from their text if that text is small and centered.
This was described (with screenshots) in https://github.com/koreader/crengine/pull/196#issuecomment-393861885.
I can remove that and make it a Style tweak if you think it's not the right thing to do by default.~~
^ Keeping that for another PR, as I got another idea for OL & UL.