### PR TITLE
Fix Avoid reparsing from previous PR

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -493,7 +493,8 @@ void LVDocView::setStyleSheet(lString8 css_text) {
 }
 
 void LVDocView::updateDocStyleSheet() {
-    if (!m_stylesheetNeedsUpdate)
+    // Don't skip this when document is not yet rendered (or is being re-rendered)
+    if (m_is_rendered && !m_stylesheetNeedsUpdate)
         return;
     CRPropRef p = m_props->getSubProps("styles.");
     m_doc->setStyleSheet(substituteCssMacros(m_stylesheet, p).c_str(), true);


### PR DESCRIPTION
Followup to #218 : we need to delay this avoiding until the document is rendered at least once, otherwise, we may get again some "CRE WARNING: cached rendering is invalid" (that the 2nd part of #218 was supposed to finally eradicate :| )