### PR TITLE
CSS: adds support for the 'text-transform:' property

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -84,6 +84,16 @@ enum css_text_decoration_t {
     css_td_blink = 5
 };
 
+/// text-transform property values
+enum css_text_transform_t {
+    css_tt_inherit = 0,
+    css_tt_none = 1,
+    css_tt_uppercase = 2,
+    css_tt_lowercase = 3,
+    css_tt_capitalize = 4,
+    css_tt_full_width = 5
+};
+
 /// hyphenate property values
 enum css_hyphenate_t {
     css_hyph_inherit = 0,
@@ -230,6 +240,7 @@ enum css_border_collapse_value_t{
     css_border_c_inherit,
     css_border_c_none
 };
+
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -28,14 +28,20 @@
 #define UNICODE_NB_HYPHEN   0x2011
 #define UNICODE_CJK_IDEOGRAPHS_BEGIN 0x3041
 #define UNICODE_CJK_IDEOGRAPHS_END 0x02CEAF
+#define UNICODE_CJK_IDEOGRAPHIC_SPACE 0x3000
 #define UNICODE_CJK_PUNCTUATION_BEGIN 0x3000
 #define UNICODE_CJK_PUNCTUATION_END 0x303F
 #define UNICODE_GENERAL_PUNCTUATION_BEGIN 0x2000
 #define UNICODE_GENERAL_PUNCTUATION_END 0x206F
 #define UNICODE_ZERO_WIDTH_NO_BREAK_SPACE 0xfeff
+// These may be wrong as this block contain katakana and hangul
+// letters, as well as ascii full-width chars:
 #define UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_BEGIN 0xFF01
 #define UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_END 0xFFEE
 
+#define UNICODE_ASCII_FULL_WIDTH_BEGIN 0xFF01
+#define UNICODE_ASCII_FULL_WIDTH_END 0xFF5E
+#define UNICODE_ASCII_FULL_WIDTH_OFFSET 0xFEE0 // substract or add to convert to/from ASCII
 
 
 /// strlen for lChar16
@@ -76,6 +82,10 @@ int    lStr_cmp(const lChar8 * str1, const lChar8 * str2);
 void lStr_uppercase( lChar16 * str, int len );
 /// convert string to lowercase
 void lStr_lowercase( lChar16 * str, int len );
+/// convert string to be capitalized
+void lStr_capitalize( lChar16 * str, int len );
+/// convert string to use full width chars
+void lStr_fullWidthChars( lChar16 * str, int len );
 /// calculates CRC32 for buffer contents
 lUInt32 lStr_crc32( lUInt32 prevValue, const void * buf, int size );
 
@@ -109,6 +119,8 @@ void lStr_getCharProps( const lChar16 * str, int sz, lUInt16 * props );
 lUInt16 lGetCharProps( lChar16 ch );
 /// find alpha sequence bounds
 void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int & end );
+// is char a word separator
+bool lStr_isWordSeparator( lChar16 ch );
 
 
 // must be power of 2
@@ -524,6 +536,10 @@ public:
     lString16 & uppercase();
     /// make string lowercase
     lString16 & lowercase();
+    /// make string capitalized
+    lString16 & capitalize();
+    /// make string use full width chars
+    lString16 & fullWidthChars();
     /// compare with another string
     int compare(const lString16& str) const { return lStr_cmp(pchunk->buf16, str.pchunk->buf16); }
     /// compare subrange with another string

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -29,52 +29,53 @@ enum css_style_rec_important_bit {
     imp_bit_text_align            = 1ULL << 2,
     imp_bit_text_align_last       = 1ULL << 3,
     imp_bit_text_decoration       = 1ULL << 4,
-    imp_bit_vertical_align        = 1ULL << 5,
-    imp_bit_font_family           = 1ULL << 6,
-    imp_bit_font_name             = 1ULL << 7,
-    imp_bit_font_size             = 1ULL << 8,
-    imp_bit_font_style            = 1ULL << 9,
-    imp_bit_font_weight           = 1ULL << 10,
-    imp_bit_text_indent           = 1ULL << 11,
-    imp_bit_line_height           = 1ULL << 12,
-    imp_bit_width                 = 1ULL << 13,
-    imp_bit_height                = 1ULL << 14,
-    imp_bit_margin_left           = 1ULL << 15,
-    imp_bit_margin_right          = 1ULL << 16,
-    imp_bit_margin_top            = 1ULL << 17,
-    imp_bit_margin_bottom         = 1ULL << 18,
-    imp_bit_padding_left          = 1ULL << 19,
-    imp_bit_padding_right         = 1ULL << 20,
-    imp_bit_padding_top           = 1ULL << 21,
-    imp_bit_padding_bottom        = 1ULL << 22,
-    imp_bit_color                 = 1ULL << 23,
-    imp_bit_background_color      = 1ULL << 24,
-    imp_bit_letter_spacing        = 1ULL << 25,
-    imp_bit_page_break_before     = 1ULL << 26,
-    imp_bit_page_break_after      = 1ULL << 27,
-    imp_bit_page_break_inside     = 1ULL << 28,
-    imp_bit_hyphenate             = 1ULL << 29,
-    imp_bit_list_style_type       = 1ULL << 30,
-    imp_bit_list_style_position   = 1ULL << 31,
-    imp_bit_border_style_top      = 1ULL << 32,
-    imp_bit_border_style_bottom   = 1ULL << 33,
-    imp_bit_border_style_right    = 1ULL << 34,
-    imp_bit_border_style_left     = 1ULL << 35,
-    imp_bit_border_width_top      = 1ULL << 36,
-    imp_bit_border_width_right    = 1ULL << 37,
-    imp_bit_border_width_bottom   = 1ULL << 38,
-    imp_bit_border_width_left     = 1ULL << 39,
-    imp_bit_border_color_top      = 1ULL << 40,
-    imp_bit_border_color_right    = 1ULL << 41,
-    imp_bit_border_color_bottom   = 1ULL << 42,
-    imp_bit_border_color_left     = 1ULL << 43,
-    imp_bit_background_image      = 1ULL << 44,
-    imp_bit_background_repeat     = 1ULL << 45,
-    imp_bit_background_attachment = 1ULL << 46,
-    imp_bit_background_position   = 1ULL << 47,
-    imp_bit_border_collapse       = 1ULL << 48,
-    imp_bit_border_spacing_h      = 1ULL << 49,
-    imp_bit_border_spacing_v      = 1ULL << 50
+    imp_bit_text_transform        = 1ULL << 5,
+    imp_bit_vertical_align        = 1ULL << 6,
+    imp_bit_font_family           = 1ULL << 7,
+    imp_bit_font_name             = 1ULL << 8,
+    imp_bit_font_size             = 1ULL << 9,
+    imp_bit_font_style            = 1ULL << 10,
+    imp_bit_font_weight           = 1ULL << 11,
+    imp_bit_text_indent           = 1ULL << 12,
+    imp_bit_line_height           = 1ULL << 13,
+    imp_bit_width                 = 1ULL << 14,
+    imp_bit_height                = 1ULL << 15,
+    imp_bit_margin_left           = 1ULL << 16,
+    imp_bit_margin_right          = 1ULL << 17,
+    imp_bit_margin_top            = 1ULL << 18,
+    imp_bit_margin_bottom         = 1ULL << 19,
+    imp_bit_padding_left          = 1ULL << 20,
+    imp_bit_padding_right         = 1ULL << 21,
+    imp_bit_padding_top           = 1ULL << 22,
+    imp_bit_padding_bottom        = 1ULL << 23,
+    imp_bit_color                 = 1ULL << 24,
+    imp_bit_background_color      = 1ULL << 25,
+    imp_bit_letter_spacing        = 1ULL << 26,
+    imp_bit_page_break_before     = 1ULL << 27,
+    imp_bit_page_break_after      = 1ULL << 28,
+    imp_bit_page_break_inside     = 1ULL << 29,
+    imp_bit_hyphenate             = 1ULL << 30,
+    imp_bit_list_style_type       = 1ULL << 31,
+    imp_bit_list_style_position   = 1ULL << 32,
+    imp_bit_border_style_top      = 1ULL << 33,
+    imp_bit_border_style_bottom   = 1ULL << 34,
+    imp_bit_border_style_right    = 1ULL << 35,
+    imp_bit_border_style_left     = 1ULL << 36,
+    imp_bit_border_width_top      = 1ULL << 37,
+    imp_bit_border_width_right    = 1ULL << 38,
+    imp_bit_border_width_bottom   = 1ULL << 39,
+    imp_bit_border_width_left     = 1ULL << 40,
+    imp_bit_border_color_top      = 1ULL << 41,
+    imp_bit_border_color_right    = 1ULL << 42,
+    imp_bit_border_color_bottom   = 1ULL << 43,
+    imp_bit_border_color_left     = 1ULL << 44,
+    imp_bit_background_image      = 1ULL << 45,
+    imp_bit_background_repeat     = 1ULL << 46,
+    imp_bit_background_attachment = 1ULL << 47,
+    imp_bit_background_position   = 1ULL << 48,
+    imp_bit_border_collapse       = 1ULL << 49,
+    imp_bit_border_spacing_h      = 1ULL << 50,
+    imp_bit_border_spacing_v      = 1ULL << 51
 };
 
 /**
@@ -86,14 +87,15 @@ typedef struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
     lUInt64              important; // bitmap for !important (used only by LVCssDeclaration)
-                                    // we have currently below 51 css properties
-                                    // lvstsheet knows about 66, which are mapped to these 51
+                                    // we have currently below 52 css properties
+                                    // lvstsheet knows about 67, which are mapped to these 52
                                     // update bits above if you add new properties below
     css_display_t        display;
     css_white_space_t    white_space;
     css_text_align_t     text_align;
     css_text_align_t     text_align_last;
     css_text_decoration_t text_decoration;
+    css_text_transform_t text_transform;
     css_vertical_align_t vertical_align;
     css_font_family_t    font_family;
     lString8             font_name;
@@ -136,6 +138,7 @@ typedef struct css_style_rec_tag {
     , text_align(css_ta_inherit)
     , text_align_last(css_ta_inherit)
     , text_decoration (css_td_inherit)
+    , text_transform (css_tt_inherit)
     , vertical_align(css_va_inherit)
     , font_family(css_ff_inherit)
     , font_size(css_val_inherited, 0)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1571,6 +1571,7 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->text_align = source->text_align ;
     dest->text_align_last = source->text_align_last ;
     dest->text_decoration = source->text_decoration ;
+    dest->text_transform = source->text_transform ;
     dest->list_style_type = source->list_style_type ;
     dest->list_style_position = source->list_style_position ;
     dest->hyphenate = source->hyphenate ;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1464,6 +1464,24 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         lInt32(bgcl))
                     bgcl=0xFFFFFFFF;
 
+            switch (style->text_transform) {
+            case css_tt_uppercase:
+                txt.uppercase();
+                break;
+            case css_tt_lowercase:
+                txt.lowercase();
+                break;
+            case css_tt_capitalize:
+                txt.capitalize();
+                break;
+            case css_tt_full_width:
+                // txt.fullWidthChars(); // disabled for now (may change CJK rendering)
+                break;
+            case css_tt_none:
+            case css_tt_inherit:
+                break;
+            }
+
             lInt8 letter_spacing;
             // % is not supported for letter_spacing by Firefox, but crengine
             // did support it, by relating it to font size, so let's use em
@@ -3074,6 +3092,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( white_space, css_ws_inherit );
     UPDATE_STYLE_FIELD( text_align, css_ta_inherit );
     UPDATE_STYLE_FIELD( text_decoration, css_td_inherit );
+    UPDATE_STYLE_FIELD( text_transform, css_tt_inherit );
     UPDATE_STYLE_FIELD( hyphenate, css_hyph_inherit );
     UPDATE_STYLE_FIELD( list_style_type, css_lst_inherit );
     UPDATE_STYLE_FIELD( list_style_position, css_lsp_inherit );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -31,6 +31,7 @@ enum css_decl_code {
     cssd_text_align,
     cssd_text_align_last,
     cssd_text_decoration,
+    cssd_text_transform,
     cssd_hyphenate, // hyphenate
     cssd_hyphenate2, // -webkit-hyphens
     cssd_hyphenate3, // adobe-hyphenate
@@ -103,6 +104,7 @@ static const char * css_decl_name[] = {
     "text-align",
     "text-align-last",
     "text-decoration",
+    "text-transform",
     "hyphenate",
     "-webkit-hyphens",
     "adobe-hyphenate",
@@ -659,6 +661,17 @@ static const char * css_td_names[] =
     NULL
 };
 
+static const char * css_tt_names[] =
+{
+    "inherit",
+    "none",
+    "uppercase",
+    "lowercase",
+    "capitalize",
+    "full-width",
+    NULL
+};
+
 static const char * css_hyph_names[] = 
 {
     "inherit",
@@ -909,6 +922,9 @@ bool LVCssDeclaration::parse( const char * &decl )
                 break;
             case cssd_text_decoration:
                 n = parse_name( decl, css_td_names, -1 );
+                break;
+            case cssd_text_transform:
+                n = parse_name( decl, css_tt_names, -1 );
                 break;
             case cssd_hyphenate:
             case cssd_hyphenate2:
@@ -1767,6 +1783,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_text_decoration:
             style->Apply( (css_text_decoration_t) *p++, &style->text_decoration, imp_bit_text_decoration, is_important );
+            break;
+        case cssd_text_transform:
+            style->Apply( (css_text_transform_t) *p++, &style->text_transform, imp_bit_text_transform, is_important );
             break;
         case cssd_hyphenate:
             style->Apply( (css_hyphenate_t) *p++, &style->hyphenate, imp_bit_hyphenate, is_important );
@@ -2837,6 +2856,10 @@ bool LVProcessStyleSheetImport( const char * &str, lString8 & import_file )
             return false;
         p++;
     }
+    // Remove trailing ';' at end of "@import url(..);"
+    skip_spaces( p );
+    if ( *p==';' )
+        p++;
     if ( import_file.empty() )
         return false;
     str = p;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -41,7 +41,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((
            (lUInt32)(rec.important>>32)) * 31
          + (lUInt32)(rec.important&0xFFFFFFFFULL)) * 31
          + (lUInt32)rec.display * 31
@@ -49,6 +49,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.text_align) * 31
          + (lUInt32)rec.text_align_last) * 31
          + (lUInt32)rec.text_decoration) * 31
+         + (lUInt32)rec.text_transform) * 31
          + (lUInt32)rec.hyphenate) * 31
          + (lUInt32)rec.list_style_type) * 31
          + (lUInt32)rec.letter_spacing.pack()) * 31
@@ -106,6 +107,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.text_align == r2.text_align &&
            r1.text_align_last == r2.text_align_last &&
            r1.text_decoration == r2.text_decoration &&
+           r1.text_transform == r2.text_transform &&
            r1.list_style_type == r2.list_style_type &&
            r1.list_style_position == r2.list_style_position &&
            r1.hyphenate == r2.hyphenate &&
@@ -293,6 +295,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(text_align);        //    css_text_align_t     text_align;
     ST_PUT_ENUM(text_align_last);   //    css_text_align_t     text_align_last;
     ST_PUT_ENUM(text_decoration);   //    css_text_decoration_t text_decoration;
+    ST_PUT_ENUM(text_transform);    //    css_text_transform_t text_transform;
     ST_PUT_ENUM(vertical_align);    //    css_vertical_align_t vertical_align;
     ST_PUT_ENUM(font_family);       //    css_font_family_t    font_family;
     buf << font_name;               //    lString8             font_name;
@@ -343,6 +346,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_text_align_t, text_align);              //    css_text_align_t     text_align;
     ST_GET_ENUM(css_text_align_t, text_align_last);         //    css_text_align_t     text_align_last;
     ST_GET_ENUM(css_text_decoration_t, text_decoration);    //    css_text_decoration_t text_decoration;
+    ST_GET_ENUM(css_text_transform_t, text_transform);      //    css_text_transform_t text_transform;
     ST_GET_ENUM(css_vertical_align_t, vertical_align);      //    css_vertical_align_t vertical_align;
     ST_GET_ENUM(css_font_family_t, font_family);            //    css_font_family_t    font_family;
     buf >> font_name;                                       //    lString8             font_name;


### PR DESCRIPTION
(as wished in https://github.com/koreader/koreader/issues/3432#issuecomment-406062300 )

Only `uppercase`, `lowercase` and `capitalize`.
https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
http://www.fileformat.info/info/unicode/block/halfwidth_and_fullwidth_forms/list.htm
Some code for `full-width` is there but not used, and would need additional changes to lvfnt/lvfntman/hyphman/lvtextfm, This may change CJK rendering, so it will need some CJK user or developer to confirm and followup.
Details: supporting full-width (original or text-transform'ed) ascii text would need to handle these as ASCII chars, and the IDEOGRAPHIC_SPACE (0x3000) as a space in word splitting and hyphenation: that would make it candidate to width change for justification, and it would lose it's fixed width as most CJK chars share I guess. So, using full-width chars to have english chars aligned with CJK chars forming a grid, you would need the CJK space to be handled like a variable width space, killing the grid. Or just have these full-width chars stay CJK and english words being cut at any place.
I have no idea if that would be an improvement or a disaster :) so I let it out (the most consertive would be to handled these chars as CJK, but I don't want to see my english text being cut anywhere for wrapping).
Here's a patch to apply after this PR/commit to have that kind of support for full-width, if anyone is insterested in following up on that (pinging @frankyifei @chrox just in case they are):
[textTransform_support_for_full-width.diff.txt](https://github.com/koreader/crengine/files/2216187/textTransform_support_for_full-width.diff.txt)

With embedded styles (adding colors and text-transform) disabled, showing the original text:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43036139-8f9acd04-8cfb-11e8-9077-0667d5f0f293.png)</kbd>
With this PR and embedded styles on:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43036141-9dc00566-8cfb-11e8-96eb-e42506289587.png)</kbd>

Here's how it would look with my full-width support patch and algo-hyphenation
<kbd>![image](https://user-images.githubusercontent.com/24273478/43036210-44c055f4-8cfd-11e8-99a0-ad172e670c74.png)</kbd>
Same with english US hyphenation:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43036264-5ec1312a-8cfe-11e8-8616-41c5a9d932a6.png)</kbd>
(among my fonts, only `Noto Sans CJK` seems to have these full-width chars...).

This is how it looks in Firefox:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43036194-f87151d0-8cfc-11e8-9b3c-c38e8a50e963.png)</kbd>
(strangely, the full-width `i` or `r` does not look like having the same width as the others - may be I misunderstood what this full-width is aimed at :)


Unrelated: also fix handling of @import url(...); as forgetting to strip the trailing ';' would result in failure in parsing the remaining of the stylesheet.

