### PR TITLE
Fix table & lists when in centered/right aligned container

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -87,6 +87,9 @@ table {
     font-size: 80%;
     margin: 3px;
 }
+table table { /* stop imbricated tables from getting smaller */
+    font-size: 100%;
+}
 td, th {
     text-indent: 0;
     padding: 3px;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3042,7 +3042,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     }
 
     // Firefox resets text-align: to 'left' for table (eg: <center><table>
-    // doesnn't have its cells' content centered, not even justified if body
+    // doesn't have its cells' content centered, not even justified if body
     // has "text-align: justify"), while crengine would make them centered.
     // So, we dont wan't table to starts with css_ta_inherit. We could use
     // css_ta_left (as Firefox), but it's best in our context to use the

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3041,6 +3041,25 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
 
+    // Firefox resets text-align: to 'left' for table (eg: <center><table>
+    // doesnn't have its cells' content centered, not even justified if body
+    // has "text-align: justify"), while crengine would make them centered.
+    // So, we dont wan't table to starts with css_ta_inherit. We could use
+    // css_ta_left (as Firefox), but it's best in our context to use the
+    // value set to the (or current DocFragment's) BODY node, which starts
+    // with css_ta_left but may be set to css_ta_justify by our epub.css.
+    if (enode->getNodeId() == el_table) {
+        // To do as Firefox:
+        // pstyle->text_align = css_ta_left;
+        // But we'd rather use the BODY value:
+        ldomNode * body = enode->getParentNode();
+        while ( body != NULL && body->getNodeId()!=el_body )
+            body = body->getParentNode();
+        if ( body ) {
+            pstyle->text_align = body->getStyle()->text_align;
+        }
+    }
+
     // not used (could be used for 'rem', but we have it in gRootFontSize)
     // int baseFontSize = enode->getDocument()->getDefaultFont()->getSize();
 
@@ -3204,23 +3223,6 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     spreadParent( pstyle->line_height, parent_style->line_height );
     spreadParent( pstyle->color, parent_style->color );
     spreadParent( pstyle->background_color, parent_style->background_color );
-
-    // Firefox resets text-align: to 'left' for table (eg: <center><table>
-    // doesnn't have its cells' content centered, not even justified if body
-    // has "text-align: justify"), while crengine would make them centered.
-    // We'd rather do the same as Firefox.
-    if (enode->getNodeId() == el_table) {
-        pstyle->text_align = css_ta_left;
-        /*
-        // If we'd rather use the same text-align set for <body>
-        ldomNode * body = enode->getParentNode();
-        while ( body != NULL && body->getNodeId()!=el_body )
-            body = body->getParentNode();
-        if ( body ) {
-            pstyle->text_align = body->getStyle()->text_align;
-        }
-        */
-    }
 
     // set calculated style
     //enode->getDocument()->cacheStyle( style );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -311,7 +311,7 @@ public:
                         colindex++;
                     }
                     break;
-                case erm_list_item:
+                case erm_list_item:     // no more used (obsolete rendering method)
                 case erm_block:         // render as block element (render as containing other elements)
                 case erm_final:         // final element: render the whole it's content as single render block
                 case erm_mixed:         // block and inline elements are mixed: autobox inline portions of nodes; TODO
@@ -1241,7 +1241,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
         }
 
-        if ( rm==erm_list_item ) {
+        if ( rm==erm_list_item ) { // no more used (obsolete rendering method)
             // put item number/marker to list
             lString16 marker;
             int marker_width = 0;
@@ -1283,7 +1283,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
         // List item marker rendering when css_d_list_item_block and list-style-position = inside:
         // render the marker if any, and continue rendering text on same line
-        if ( style->display == css_d_list_item_block && style->list_style_position == css_lsp_inside ) {
+        // Rendering hack: we do that too when list-style-position = outside AND text-align "right"
+        // or "center", as this will draw the marker at the near left of the text (otherwise,
+        // the marker would be drawn on the far left of the whole available width, which is ugly.
+        if ( style->display == css_d_list_item_block && ( style->list_style_position == css_lsp_inside ||
+                (style->list_style_position == css_lsp_outside &&
+                    (style->text_align == css_ta_center || style->text_align == css_ta_right)) ) ) {
             // list_item_block rendered as final (containing only text and inline elements)
             int marker_width;
             lString16 marker = renderListItemMarker( enode, marker_width, txform, line_h, flags );
@@ -1975,11 +1980,14 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                         int list_marker_width;
                         lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 16, 0);
                         list_marker_height = txform->Format( (lUInt16)(width - list_marker_width), (lUInt16)enode->getDocument()->getPageHeight() );
-                        if ( enode->getStyle()->list_style_position == css_lsp_outside )
+                        if ( enode->getStyle()->list_style_position == css_lsp_outside &&
+                            enode->getStyle()->text_align != css_ta_center && enode->getStyle()->text_align != css_ta_right) {
                             // When list_style_position = outside, we have to shift the whole block
                             // to the right and reduce the available width, which is done
                             // below when calling renderBlockElement() for each child
+                            // Rendering hack: we treat it just as "inside" when text-align "right" or "center"
                             list_marker_padding = list_marker_width;
+                        }
                         else {
                             // When list_style_position = inside, we need to let renderFinalBlock()
                             // know there is a marker to prepend when rendering the first of our
@@ -2036,14 +2044,16 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     return y + margin_top + margin_bottom + padding_bottom; // return block height
                 }
                 break;
-            case erm_list_item:
+            case erm_list_item: // no more used (obsolete rendering method)
             case erm_final:
             case erm_table_cell:
                 {
 
                     if ( enode->getStyle()->display == css_d_list_item_block ) {
                         // list_item_block rendered as final (containing only text and inline elements)
-                        if ( enode->getStyle()->list_style_position == css_lsp_outside ) {
+                        // Rendering hack: not when text-align "right" or "center", as we treat it just as "inside"
+                        if ( enode->getStyle()->list_style_position == css_lsp_outside &&
+                            enode->getStyle()->text_align != css_ta_center && enode->getStyle()->text_align != css_ta_right) {
                             // When list_style_position = outside, we have to shift the final block
                             // to the right and reduce its width
                             int list_marker_width;
@@ -2802,9 +2812,11 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
 
                 // List item marker drawing when css_d_list_item_block and list-style-position = outside
                 // and list_item_block rendered as block (containing text and block elements)
+                // Rendering hack: not when text-align "right" or "center", as we treat it just as "inside"
                 // (if list-style-position = inside, drawing is managed by renderFinalBlock())
                 if ( enode->getStyle()->display == css_d_list_item_block &&
-                        enode->getStyle()->list_style_position == css_lsp_outside ) {
+                        enode->getStyle()->list_style_position == css_lsp_outside &&
+                            enode->getStyle()->text_align != css_ta_center && enode->getStyle()->text_align != css_ta_right) {
                     // We already adjusted all children blocks' left-padding and width in renderBlockElement(),
                     // we just need to draw the marker in the space we made
                     LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
@@ -2846,16 +2858,18 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                  DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
             	}
             break;
-        case erm_list_item:
+        case erm_list_item: // no more used (obsolete rendering method)
         case erm_final:
         case erm_table_caption:
             {
 
                 // List item marker drawing when css_d_list_item_block and list-style-position = outside
                 // and list_item_block rendered as final (containing only text and inline elements)
+                // Rendering hack: not when text-align "right" or "center", as we treat it just as "inside"
                 // (if list-style-position = inside, drawing is managed by renderFinalBlock())
                 if ( enode->getStyle()->display == css_d_list_item_block &&
-                        enode->getStyle()->list_style_position == css_lsp_outside ) {
+                        enode->getStyle()->list_style_position == css_lsp_outside &&
+                            enode->getStyle()->text_align != css_ta_center && enode->getStyle()->text_align != css_ta_right) {
                     // We already adjusted our block X and width in renderBlockElement(),
                     // we just need to draw the marker in the space we made on the left of
                     // this node.
@@ -3190,6 +3204,23 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     spreadParent( pstyle->line_height, parent_style->line_height );
     spreadParent( pstyle->color, parent_style->color );
     spreadParent( pstyle->background_color, parent_style->background_color );
+
+    // Firefox resets text-align: to 'left' for table (eg: <center><table>
+    // doesnn't have its cells' content centered, not even justified if body
+    // has "text-align: justify"), while crengine would make them centered.
+    // We'd rather do the same as Firefox.
+    if (enode->getNodeId() == el_table) {
+        pstyle->text_align = css_ta_left;
+        /*
+        // If we'd rather use the same text-align set for <body>
+        ldomNode * body = enode->getParentNode();
+        while ( body != NULL && body->getNodeId()!=el_body )
+            body = body->getParentNode();
+        if ( body ) {
+            pstyle->text_align = body->getStyle()->text_align;
+        }
+        */
+    }
 
     // set calculated style
     //enode->getDocument()->cacheStyle( style );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4192,7 +4192,7 @@ void ldomNode::initNodeRendMethod()
         recurseElements( resetRendMethodToInline );
         setRendMethod(erm_runin);
     } else if ( d==css_d_list_item ) {
-        // list item
+        // list item (no more used, obsolete rendering method)
         setRendMethod(erm_list_item);
     } else if (d == css_d_table) {
         // table
@@ -6938,7 +6938,7 @@ ldomNode * ldomXPointerEx::getThisBlockNode()
         case erm_block:
         case erm_final:
         case erm_mixed:
-        case erm_list_item:
+        case erm_list_item: // no more used (obsolete rendering method)
         case erm_table:
         case erm_table_row_group:
         case erm_table_row:


### PR DESCRIPTION
Previously discussed in https://github.com/koreader/crengine/pull/196#issuecomment-393861885 and #218.

- For list items with with "list-style-position: outside" (default and most common) and "text-align: center" or "right", draw them just like "list-style-position: inside" is rendered, as this will draw the marker at the near left of the text (previously, the marker was drawn on the far left of the whole available width, which was ugly).

- Firefox resets text-align: to 'left' for table (eg: `<center><table>` doesnn't have its cells' content centered, not even justified if body has "text-align: justify"), while crengine would make them centered. We'd rather do the same as Firefox.
edit: but a bit different than Firefox: we use the BODY text-align value. Why? I had initially written this:
> (I checked on some books that put lots of text in tables that the publisher usually specify the cells text alignment, left for small table, justify for longer text. When not specified, we could have used justify, or try to fetch and use the alignement of BODY - but it feels somehow safer to use left: for tables with small texts in cells, like in Wikipedia EPUBs, it's less ugly with left than justify that stretches words and make long empty spaces in little cells.)
Thinking again after trying to find samples for screenshots: our rendering for "left" is a bit strange, as it puts hyphen just like if justified, but when left-aligned, the hyphen is no more stuck to the right margin... Using "justify" could then be prettier, and make sense as we're a book reader and decided for justify for BODY...
**So: left, or fetch the alignment of BODY (which will be justify, unless overriden by publisher or some Style tweak) ?**
If we were to fix "left" (in another PR): should hyphenation just be disabled when text is left-aligned - or different than "justify" ?
edit: looks like hyphenation can happen on left-aligned, and it behave as crengine does https://www.creativebloq.com/web-design/how-alignment-and-hyphenation-improve-your-texts-impact-71516015 (I still find that a bit ugly, may be cause I'm too much used to justified text in koreader and paper books, and browsers don't hyphenate).

So, when using our epub.css, we'll have table starting with `text-align: justify` , and that can be overriden by any stylesheet. If one selects Style tweak > Left align most texts, BODY and TABLE will start with "left" (but TABLE will still follow the publisher styles if he set any).

Some test file, rendered by Firefox:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044367-cd3bf512-8da4-11e8-9479-b1a8f078510e.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044371-e3236c8e-8da4-11e8-9d5f-1eb71cbfcbba.png)</kbd>

Before this PR, rendered by crengine.
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044357-ab8d370a-8da4-11e8-8f8a-c28a2b42c222.png)</kbd>

After this PR, rendered by crengine:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044387-2cd30ed4-8da5-11e8-892a-ab039683a328.png)</kbd>

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/40840030-4718ff10-65a5-11e8-8c44-d0e3814232df.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044396-5b25628c-8da5-11e8-9391-f23b0afe1860.png)</kbd>

~~Before~~ Table justified (because our body is justified by epub.css):
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044428-0249b69e-8da6-11e8-80c9-b4a142f824c2.png)</kbd>
~~After:~~ Table left aligned
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044458-8414ac6a-8da6-11e8-841b-da49cee0f883.png)</kbd>

~~Before~~ Table justified (because our body is justified by epub.css):
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044597-4b7a88c2-8da9-11e8-8187-6848b7f55bc0.png)</kbd>
~~After:~~ Table left aligned
<kbd>![image](https://user-images.githubusercontent.com/24273478/43044592-32ee65e4-8da9-11e8-9cd0-c322dd0f10d9.png)</kbd>
