### PR TITLE
Fix two highlight issues

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2250,7 +2250,7 @@ bool LVDocView::windowToDocPoint(lvPoint & pt) {
 	return false;
 }
 
-/// converts point from documsnt to window coordinates, returns true if success
+/// converts point from document to window coordinates, returns true if success
 bool LVDocView::docToWindowPoint(lvPoint & pt) {
 	LVLock lock(getMutex());
     CHECK_RENDER("docToWindowPoint()")
@@ -2273,6 +2273,12 @@ bool LVDocView::docToWindowPoint(lvPoint & pt) {
                 }
                 if (index >= 0) {
                     int x = pt.x + m_pageRects[index].left + m_pageMargins.left;
+                    // We shouldn't get x ouside page width as we never crop on the
+                    // width: if we do (if bug somewhere else), force it to be at the
+                    // far right (this helps not discarding some highlights rects)
+                    if (x >= m_pageRects[index].right - m_pageMargins.right) {
+                        x = m_pageRects[index].right - m_pageMargins.right - 1;
+                    }
                     if (x < m_pageRects[index].right - m_pageMargins.right) {
                         pt.x = x;
                         pt.y = pt.y + getPageHeaderHeight() + m_pageMargins.top - m_pages[page + index]->start;


### PR DESCRIPTION
Only use char properties to detect word boundaries for hyphenation.
In all other places, mostly in lvtinydom.cpp, we use the isWordSeparator functions to detect word boundaries. One place was still not using it, and this caused some highlights inconsistencies (the `some text` in the screenshots below).
(Fix some char properties errors, even if they are now no more used).

Fix ldomXPointer::getRect(extended=true) to return the width of the char pointed to, instead of the width of the word containing that char. The notion of what a word is can in some cases be different, and that was causing displaced highlights on some hyphenated words (eg: with french words "l'empe-reur", the part before hyphenation being considered either as one word for rendering, or as 2 words when walking words to get boxes to highlight - see https://github.com/koreader/koreader/issues/1252#issuecomment-403270465).
Will need one line commented out in base/cre.cpp:
```c
@@ blah blah @@ static int getWordBoxesFromPositions(lua_State *L) {
        } else {  // word is hyphenated
                ldomWord word = words[i];
                int y = -1;
                for (int j=word.getStart(); j < word.getEnd(); j++) {
                        if (ldomXPointer(word.getNode(), j).getRectEx(charRect)) {
                                if (!docToWindowRect(tv, charRect)) continue;
                                if (y == -1) y = charRect.top;
-                               if (j != word.getStart() && y == charRect.top) continue;
+                               // charRect is now the width of each individual char.
+                               // Previously, ldomXPointer::getRectEx() was returning its
+                               // own word->width, so getting it only from the first call
+                               // looked like it was fine. But our "word"s come from
+                               // lStr_findWordBounds(), unlike the ones ldomXPointer::getRectEx()
+                               // uses that come from lvtextfm.cpp which splits on spaces only.
+                               // We would then get shifted highlights with some texts
+                               // (e.g. with french text "l'empereur" word->t.start starts
+                               // at 'l' while here our word may start at 'e'mpereur)
+                               // was: if (j != word.getStart() && y == charRect.top) continue;
+                               // Keep extending lineRect with each individual charRect we met.
+                               // When charRect.left < lastx, we are on next line and lineRect
+                               // is ready to be pushed.
                                y = charRect.top;
                                if (charRect.left < lastx) {
                                        lua_pushLineRect(L, lineRect.left, lineRect.top,
                                                                                lineRect.right, lineRect.bottom, lcount++);
                                        lua_newtable(L); // new line box
                                        lineRect.clear();
                                }
                                lineRect.extend(charRect);
                                lastx = charRect.left;
                        }
                }
        }
```
Before:
<kbd>![highlight_before](https://user-images.githubusercontent.com/24273478/43365477-c4cf13da-932d-11e8-8000-fcad3d68759c.png)</kbd>
(On each of the last lines, the 2 words `some text` were selected and highlighted)

After:
<kbd>![highlight_after](https://user-images.githubusercontent.com/24273478/43365479-c95b8d16-932d-11e8-948e-0bed077e919d.png)</kbd>

(There is still a small issue with real punctuation, being not part of words, being stripped out of end of highlighted boxes - but that's more tedious to fix).