### PR TITLE
text formatting: fix collapsing spaces and newlines

### DIFF
--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -222,7 +222,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
 #define LCHAR_IS_EOL               16 ///< flag: this char is CR or LF
 #define LCHAR_IS_OBJECT            32 ///< flag: this char is object or image
 #define LCHAR_MANDATORY_NEWLINE    64 ///< flag: this char must start with new line
-#define LCHAR_IS_LEADING_SPACE    128 ///< flag: this char is a space at start of non-pre paragraph (and can be stripped)
+#define LCHAR_IS_COLLAPSED_SPACE  128 ///< flag: this char is a space that should not be displayed
 
 /** \brief returns true if character is unicode space 
     \param code is character

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1407,6 +1407,19 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         //***********************************
         baseflags = f; // to allow blocks in one level with inlines
         if ( enode->getNodeId()==el_br ) {
+            if (baseflags & LTEXT_FLAG_NEWLINE) {
+                // We meet a <BR/>, but no text node were met before (or it
+                // would have cleared the newline flag).
+                // Output a single space so that a blank line can be made,
+                // as wanted by a <BR/>.
+                // (This makes consecutive and stuck <br><br><br> work)
+                LVFont * font = enode->getFont().get();
+                txform->AddSourceLine( L" ", 1, 0, 0, font, baseflags | LTEXT_FLAG_OWNTEXT, line_h);
+                // baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
+                // No need to clear the flag, as we set it just below
+                // (any LTEXT_ALIGN_* set implies LTEXT_FLAG_NEWLINE)
+
+            }
             // use the same alignment
             //baseflags |= LTEXT_ALIGN_LEFT;
             switch (style->text_align) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.16k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0007
+#define FORMATTING_VERSION_ID 0x0008
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
Attempt to conform better to https://www.w3.org/TR/css-text-3/ mainly in the way we handle collapsing spaces. When in doubt, try to display as Firefox does.
Details as comments in the code. Added more comments about how I understood lvtextfm works.
(Some specifics to CJK are mentionned, and some sample code commented out - will have to be continued by a CJK dev if that feels necessary.)

This reverts the recent "fix leading spaces issues" commit #204, while still fixing these leading spaces issues in a more generic way, leading spaces being considered collapsed spaces.

Also fix missing new line when standalone `<br/>` stuck together (`<br/><br/>`) (and stuck `\n\n` in pre-paragraphs). Don't display the last such newline at the end of rendered block, as most browser's don't.

I must say that I've never noticed in casual reading any issue that this fixes that needed fixing :) May be some missed `<BR>`, but I didn't know then that there should be some - and non-collapsed spaces can be hardly noticable when reading with a small font, and the variable spacing that crengine uses for text justification.
It's just while making sample test html that I noticed there are issues, so let's fix them. Hope I haven't broken anything, and I hope that the collapsed newlines we had won't feel like it was a feature that I killed :)

Sample HTML test file: [test-simple-text6.html.txt](https://github.com/koreader/crengine/files/2241555/test-simple-text6.html.txt)

Rendered by Firefox:
<kbd>
![image](https://user-images.githubusercontent.com/24273478/43403223-d0a5c6ee-9414-11e8-80b2-14b5d8324e63.png)
![image](https://user-images.githubusercontent.com/24273478/43403265-e7ec4daa-9414-11e8-8de4-f85c6295c698.png)
</kbd>

Previously renderered by koreader (in yellow, the differences from Firefox - non yellow text is just to be sure, or stuff that was initially fine but became broken while doing this that I had to unbreak):
<kbd>
![image](https://user-images.githubusercontent.com/24273478/43403638-db2ccbf2-9415-11e8-8a51-8bc3b0a33e1d.png)
![image](https://user-images.githubusercontent.com/24273478/43403691-0a406606-9416-11e8-9448-1a15aeaca69e.png)
</kbd>

Rendered now by koreader with this PR:
<kbd>
![image](https://user-images.githubusercontent.com/24273478/43403315-13552eee-9415-11e8-88c2-ca561a4d6049.png)
![image](https://user-images.githubusercontent.com/24273478/43403342-1f48d67e-9415-11e8-8151-b9566dbb133c.png)
</kbd>
