### PR TITLE
HTML: fix parsing of non-lowercase stylesheet link tags

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4524,8 +4524,8 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         // link node
         if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
              _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             _currNode->getElement()->getAttributeValue("rel") == "stylesheet" &&
-             _currNode->getElement()->getAttributeValue("type") == "text/css" ) {
+             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
             lString16 href = _currNode->getElement()->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
@@ -7839,10 +7839,10 @@ void ldomDocumentFragmentWriter::OnAttribute( const lChar16 * nsname, const lCha
         }
     } else {
         if ( styleDetectionState ) {
-            if ( !lStr_cmp(attrname, "rel") && !lStr_cmp(attrvalue, "stylesheet") )
+            if ( !lStr_cmp(attrname, "rel") && lString16(attrvalue).lowercase() == L"stylesheet" )
                 styleDetectionState |= 2;
             else if ( !lStr_cmp(attrname, "type") ) {
-                if ( !lStr_cmp(attrvalue, "text/css") )
+                if ( lString16(attrvalue).lowercase() == L"text/css")
                     styleDetectionState |= 4;
                 else
                     styleDetectionState = 0;  // text/css type supported only
@@ -8158,13 +8158,14 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     //CRLog::trace("OnAttribute(%s, %s)", LCSTR(lString16(attrname)), LCSTR(lString16(attrvalue)));
 
     if ( !lStr_cmp(attrname, "align") ) {
-        if ( !lStr_cmp(attrvalue, "justify") )
+        lString16 align = lString16(attrvalue).lowercase();
+        if ( align == L"justify")
             appendStyle( L"text-align: justify" );
-        else if ( !lStr_cmp(attrvalue, "left") )
+        else if ( align == L"left")
             appendStyle( L"text-align: left" );
-        else if ( !lStr_cmp(attrvalue, "right") )
+        else if ( align == L"right")
             appendStyle( L"text-align: right" );
-        else if ( !lStr_cmp(attrvalue, "center") )
+        else if ( align == L"center")
             appendStyle( L"text-align: center" );
        return;
     }
@@ -8199,8 +8200,8 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         // link node
         if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
              _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             _currNode->getElement()->getAttributeValue("rel") == "stylesheet" &&
-             _currNode->getElement()->getAttributeValue("type") == "text/css" ) {
+             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
             lString16 href = _currNode->getElement()->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));


### PR DESCRIPTION
The few attributes of which we compare the value to predefined strings were not lowercased. So, the following would be ignored:

```html
    <link href="some.css" rel="styleSHEET" type="TEXT/css"/>
    <div align=CENTER>align center</div>
    <DIV Align=Right>align right</div>
```

(The tagname and attrname comparisons are ok, as they are internally lowercased. Only the attrvalue isn't, and shouldn't be, except when comparing to expected fixed values that can be in mixed case.)

Fix the issue with styles not applied on a specific book reported at https://www.mobileread.com/forums/showthread.php?t=309717.
The books html contains:

```html
  <head>
    <link href="springer_epub.css" type="text/css" rel="styleSheet"/>
  </head>
```
