### PR TITLE
Various fixes related to styles handling on load

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -888,7 +888,7 @@ public:
     void setRenderProps( int dx, int dy );
 
     /// Constructor
-    LVDocView( int bitsPerPixel=-1 );
+    LVDocView( int bitsPerPixel=-1, bool noDefaultDocument=false );
     /// Destructor
     virtual ~LVDocView();
 };

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2223,6 +2223,9 @@ protected:
     lUInt16 _stopTagId;
     //============================
     lUInt32 _flags;
+    bool _inHeadStyle;
+    lString16 _headStyleText;
+    lString16Collection _stylesheetLinks;
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
 public:
     /// returns flags
@@ -2276,8 +2279,6 @@ protected:
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
-    bool _inHeadStyle;
-    lString16 _headStyleText;
     virtual void AutoClose( lUInt16 tag_id, bool open );
     virtual void ElementCloseHandler( ldomNode * elem );
     virtual void appendStyle( const lChar16 * style );


### PR DESCRIPTION
3 commits for various fixes related to styles handling on load

### Allow creating no default document on load

When opening a document, there was always a default document loaded ("Welcome to CoolReader").
This allows for bypassing this (noDefaultDocument=true will be passed by cre.cpp).
```c
--- a/cre.cpp
+++ b/cre.cpp
@@ -334,7 +334,7 @@ static int newDocView(lua_State *L) {
        luaL_getmetatable(L, "credocument");
        lua_setmetatable(L, -2);

-       doc->text_view = new LVDocView();
+       doc->text_view = new LVDocView(-1, true); // bitsPerPixel=-1, noDefaultDocument=true
        //doc->text_view->setBackgroundColor(0xFFFFFF);
        //doc->text_view->setTextColor(0x000000);
        //doc->text_view->doCommand(DCMD_SET_DOC_FONTS, 1);
```

The performance improvement is negligeable, but these ghost documents interfered with debugging crengine, so things will get cleaner from now on.
(This was easier to do that I expected, with only a few conditionals to add to ensure no segfault when no document - that's quite dependant on how koreader uses crengine, and the things it does before loading the final document.)

### Rework styles loading, avoid nodes styles re-init in somes cases

Styles loading (from `<HEAD><STYLES>` and `<HEAD><LINK REL="stylesheet">`) were done in different and inconsistent ways, resulting in some of them not being applied, or not being stored in the DOM and
cache, so not re-applied on re-rendering (eg: embedded styles off then back on) or on re-loading from cache.
Fixed by mostly doing in the XHTML and HTML writers/parsers what is done almost correctly in the EPUB parser.

Mostly noticable with HTML documents (I didn't do that very well in #159 and #174), where linked stylesheets were not stored in the cache.
Before, big HTML, first load:
<kbd>![before_html_big_first_load](https://user-images.githubusercontent.com/24273478/43990365-7cd76676-9d5b-11e8-8cd2-146ae6cc19c9.png)</kbd>
Before, same big HTML, when re-rendered after loading from cache:
<kbd>![before_html_big_from_cache_rerendered](https://user-images.githubusercontent.com/24273478/43990410-e659f226-9d5b-11e8-914e-95bff769c0fe.png)</kbd>
Before, nearly the same HTML (smaller, no cache), when loaded with Embedded styles off, and enabling embedded styles after load:
<kbd>![before_html_small_load_emb_styles_off](https://user-images.githubusercontent.com/24273478/43990519-b69eb6ba-9d5c-11e8-9a5d-edeaa20b95c3.png)</kbd>

After, same big HTML, expected rendering stays the same no matter what (first load/load from cache, toggling embedded styles off/on, initial loading with embedded styles off, then cached, then reloading and then enabling embedded styles):
<kbd>![after_html_big_from_cache_rerendered](https://user-images.githubusercontent.com/24273478/43990401-cece2488-9d5b-11e8-87b9-1b755633e289.png)</kbd>

It was mostly fine with EPUBs, except that it worked because of some stylesheets push()/pop() not done correctly, that triggered a full styles re-init when an EPUB has a single HTML with either `<HEAD>`
or a secondary linked css file. This fixes that case, and avoid the full styles re-init on such books, providing up to a 25% speed up in loading time.
(This full styles re-init still happens and is necessary when an EPUB contains embedded fonts. Added a printf() so we'll know that, and know when we may still have a bug with this.)

Background: while loading a document, styles are applied to nodes during that loading phase (this is necessary mostly because of "white-space: pre", so the right method to read text nodes content
is used), so it has not to be done again in the following render phase (it is still re-done when we later change some rendering settings).
Before rendering, checkRenderContext ensures everything is coherent with various hashes, and it ought to be coherent on first load. Failing the push()/pop() resulted in the original external stylesheet being no more the same as originally, and this was noted by some hash check, triggerring an unnecessary full node styles re-init.

Timings with some big EPUBs I use for benchmarking (last timings in https://github.com/koreader/crengine/pull/163#issuecomment-384439539):
Before: loading time: 14s - rendering time: 11s
After: loading time: 14s - rendering time: 5s
On kobo, that same book loaded previously in 85s, now in 60s (it loaded in 240s 6 months ago :)

### Fix support of style "white-space: pre"

`"white-space: pre"` in stylesheets were processed correctly, but had no effect because it was applied too late (after the text nodes has been loaded with a non-pre XML reading method, so white spaces and newlines were no more there).
(It worked only on real `<PRE>` tags, because they have hardcoded `"white-space: pre"` in fb2def.h.)
Also accounts for `"white-space: pre"` changes in the `nodeDisplayStyleHash`, so we can let the user know that reloading is needed for a correct rendering.

<kbd>![image](https://user-images.githubusercontent.com/24273478/43990554-efb73580-9d5c-11e8-9ea7-408d0d4b89df.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/43990557-f68656a2-9d5c-11e8-803a-e35fb74161b3.png)</kbd>
