### PR TITLE
Various fixes from upstream (crengine/crengine only)

### DIFF
--- a/cr3qt/src/tocdlg.cpp
+++ b/cr3qt/src/tocdlg.cpp
@@ -17,15 +17,17 @@ class TocItem : public QTreeWidgetItem
                                    )
                 , _item( item )
         {
-            int page = item->getPage();
-            if ( !nearestItem || (page <= currPage && page > nearestPage) ) {
-                nearestItem = this;
-                nearestPage = page;
-            }
+            if (item) {
+                int page = item->getPage();
+                if ( !nearestItem || (page <= currPage && page > nearestPage) ) {
+                    nearestItem = this;
+                    nearestPage = page;
+                }
 
-            setData( 0, Qt::UserRole, QVariant( cr2qt(item->getPath()) ) );
-            for ( int i=0; i<item->getChildCount(); i++ ) {
-                addChild( new TocItem( item->getChild(i), currPage, nearestPage, nearestItem ) );
+                setData( 0, Qt::UserRole, QVariant( cr2qt(item->getPath()) ) );
+                for ( int i=0; i<item->getChildCount(); i++ ) {
+                    addChild( new TocItem( item->getChild(i), currPage, nearestPage, nearestItem ) );
+                }
             }
         }
 };

--- a/crengine/include/lvautoptr.h
+++ b/crengine/include/lvautoptr.h
@@ -5,8 +5,13 @@
 template <class T >
 class LVAutoPtr {
     T * p;
-    LVAutoPtr( const LVAutoPtr & v ) { } // no copy allowed
-    LVAutoPtr & operator = (const LVAutoPtr & v) { return *this; } // no copy
+    LVAutoPtr( const LVAutoPtr & v ) {
+        CR_UNUSED(v);
+    } // no copy allowed
+    LVAutoPtr & operator = (const LVAutoPtr & v) {
+        CR_UNUSED(v);
+        return *this;
+    } // no copy
 public:
     LVAutoPtr()
         : p(NULL)

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -606,7 +606,7 @@ public:
     /// set list of icons to display at left side of header
     void setHeaderIcons( LVRefVec<LVImageSource> icons );
     /// set list of battery icons to display battery state
-    void setBatteryIcons( LVRefVec<LVImageSource> icons );
+    void setBatteryIcons( const LVRefVec<LVImageSource> & icons );
     /// sets page margins
     void setPageMargins( const lvRect & rc );
     /// returns page margins

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -797,6 +797,8 @@ public:
     int scrollPosToDocPos( int scrollpos );
     /// returns position in 1/100 of percents (0..10000)
     int getPosPercent();
+    /// returns position in 1/100 of percents (0..10000)
+    int getPosEndPagePercent();
 
     /// execute command
     int doCommand( LVDocCmd cmd, int param=0 );

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -400,6 +400,8 @@ public:
     virtual ~LVFontManager() { }
     /// returns available typefaces
     virtual void getFaceList( lString16Collection & ) { }
+    /// returns available font files
+    virtual void getFontFileNameList( lString16Collection & ) { }
 
     /// returns first found face from passed list, or return face for font found by family only
     virtual lString8 findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily);

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -65,7 +65,7 @@ private:
     LVFontGlyphCacheItem * head;
     LVFontGlyphCacheItem * tail;
     LVFontGlobalGlyphCache * global_cache;
-    int size;
+    //int size;
 public:
     LVFontLocalGlyphCache( LVFontGlobalGlyphCache * globalCache )
         : head(NULL), tail(NULL), global_cache( globalCache )

--- a/crengine/include/lvptrvec.h
+++ b/crengine/include/lvptrvec.h
@@ -85,7 +85,8 @@ public:
             _count = 0;
             if ( ownItems ) {
                 for (int i=cnt - 1; i>=0; --i)
-                    delete _list[i];
+                    if (_list[i])
+                        delete _list[i];
             }
             free( _list );
         }

--- a/crengine/include/lvref.h
+++ b/crengine/include/lvref.h
@@ -368,11 +368,14 @@ private:
     //========================================
     void Release()
     { 
-        if (--_ptr->_refcount == 0) 
+        if (--_ptr->_refcount == 0)
         {
-            if ( _ptr->_obj )
-                delete (reinterpret_cast<T*>(_ptr->_obj));
-            delete _ptr;
+            if (_ptr != &ref_count_rec_t::null_ref)
+            {
+                if ( _ptr->_obj )
+                    delete (reinterpret_cast<T*>(_ptr->_obj));
+                delete _ptr;
+            }
         }
     }
     //========================================

--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -606,8 +606,8 @@ public:
                 break;
             }
         }
-        int pos = p-fn;
-        if (p>fn)
+        int pos = (int)(p - fn);
+        if (p > fn)
             m_path = m_fname.substr(0, pos);
         m_filename = m_fname.substr(pos, m_fname.length() - pos);
     }

--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -817,12 +817,19 @@ LVContainerRef LVOpenDirectory( const lChar16 * path, const wchar_t * mask = L"*
 LVContainerRef LVOpenDirectory(const lString16& path, const wchar_t * mask = L"*.*" );
 LVContainerRef LVOpenDirectory(const lString8& path, const wchar_t * mask = L"*.*" );
 
+bool LVDirectoryIsEmpty(const lString8& path);
+bool LVDirectoryIsEmpty(const lString16& path);
+
 /// Create directory if not exist
 bool LVCreateDirectory( lString16 path );
 /// delete file, return true if file found and successfully deleted
 bool LVDeleteFile( lString16 filename );
 /// delete file, return true if file found and successfully deleted
 bool LVDeleteFile( lString8 filename );
+/// delete directory, return true if directory is found and successfully deleted
+bool LVDeleteDirectory( lString16 filename );
+/// delete directory, return true if directory is found and successfully deleted
+bool LVDeleteDirectory( lString8 filename );
 /// rename file
 bool LVRenameFile(lString16 oldname, lString16 newname);
 /// rename file

--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -435,7 +435,7 @@ protected:
     }
 
 public:
-    LVNamedStream() : _crc(0), _crcFailed(false), _autosyncLimit(0), _bytesWritten(0) { }
+    LVNamedStream() : m_mode(LVOM_ERROR), _crc(0), _crcFailed(false), _autosyncLimit(0), _bytesWritten(0) { }
     /// set write bytes limit to call flush(true) automatically after writing of each sz bytes
     virtual void setAutoSyncSize(lvsize_t sz) { _autosyncLimit = sz; }
     /// returns stream/container name, may be NULL if unknown

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -654,6 +654,8 @@ public:
     /// trims all unused space at end of string (sets size to length)
     lString16 & pack();
 
+    /// trims non alpha at beginning and end of string
+    lString16 & trimNonAlpha();
     /// trims spaces at beginning and end of string
     lString16 & trim();
     /// trims duplicate space characters inside string and (optionally) at end and beginning of string

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -784,9 +784,9 @@ public:
     lString8Collection()
         : chunks(NULL), count(0), size(0)
     { }
-    lString8Collection(lString8Collection & src)
+    lString8Collection(const lString8Collection & src)
         : chunks(NULL), count(0), size(0)
-    { addAll(src); }
+    { reserve(src.size); addAll(src); }
     lString8Collection(const lString8 & str, const lString8 & delimiter)
         : chunks(NULL), count(0), size(0)
     {
@@ -813,6 +813,13 @@ public:
     lString8 & operator [] (int index)
     {
         return ((lString8 *)chunks)[index];
+    }
+    lString8Collection& operator=(const lString8Collection& other)
+    {
+        clear();
+        reserve(other.size);
+        addAll(other);
+        return *this;
     }
     int length() const { return count; }
     void clear();
@@ -920,7 +927,7 @@ template <int BUFSIZE> class lStringBuf16 {
     lString16 & str;
     lChar16 buf[BUFSIZE];
     int pos;
-	lStringBuf16 & operator = (lStringBuf16 & v)
+	lStringBuf16 & operator = (const lStringBuf16 & v)
 	{
         CR_UNUSED(v);
 		// not available

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -920,6 +920,7 @@ template <int BUFSIZE> class lStringBuf16 {
     int pos;
 	lStringBuf16 & operator = (lStringBuf16 & v)
 	{
+        CR_UNUSED(v);
 		// not available
 		return *this;
 	}

--- a/crengine/include/lvtypes.h
+++ b/crengine/include/lvtypes.h
@@ -344,6 +344,11 @@ public:
         _interval = expirationIntervalMillis;
     }
 
+    CRTimerUtil(const CRTimerUtil & t) {
+        _start = t._start;
+        _interval = t._interval;
+    }
+
     void restart() {
         _start = getSystemTimeMillis();
     }

--- a/crengine/include/lvtypes.h
+++ b/crengine/include/lvtypes.h
@@ -113,6 +113,7 @@ public:
     int width() const { return right - left; }
     /// returns rectangle height
     int height() const { return bottom - top; }
+    int minDimension() { return (right - left < bottom - top) ? right - left : bottom - top; }
     lvPoint size() const { return lvPoint(right-left, bottom - top); }
     void shrink( int delta ) { left+=delta; right-=delta; top+=delta; bottom-=delta; }
     void shrinkBy( const lvRect & rc ) { left+=rc.left; right-=rc.right; top+=rc.top; bottom-=rc.bottom; }
@@ -160,7 +161,7 @@ public:
     }
 
     /// returns true if point is inside this rectangle
-    bool isPointInside ( lvPoint & pt ) const 
+    bool isPointInside ( const lvPoint & pt ) const
     {
         return left<=pt.x && top<=pt.y && right>pt.x && bottom > pt.y;
     }

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -309,7 +309,7 @@ private:
         lUInt32      flags;
         lString16    text;
         cache_item( lString16 & txt )
-            : next(NULL), text(txt)
+            : next(NULL), pos(0), size(0), flags(0), text(txt)
         {
         }
     };

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -1124,7 +1124,7 @@ public:
                 res = _fileList.length()>0;
                 while ( _toc && _toc->getParent() )
                     _toc = _toc->getParent();
-                if ( res && _toc->getChildCount()>0 ) {
+                if ( res && _toc && _toc->getChildCount()>0 ) {
                     lString16 name = _toc->getChild(0)->getName();
                     CRPropRef m_doc_props = _doc->getProps();
                     m_doc_props->setString(DOC_PROP_TITLE, name);

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -438,7 +438,7 @@ class CHMUrlStr {
         const lUInt8 * data = ptr;
         const lUInt8 * maxdata = ptr + size;
         while ( data + 8 < maxdata ) {
-            lUInt32 offset = blockOffset + (data - ptr);
+            lUInt32 offset = (lUInt32)(blockOffset + (data - ptr));
             //lUInt32 urlOffset =
             readInt32(data);
             //lUInt32 frameOffset =
@@ -446,7 +446,7 @@ class CHMUrlStr {
             if ( data < maxdata ) { //urlOffset > offset ) {
                 CHMUrlStrEntry * item = new CHMUrlStrEntry();
                 item->offset = offset;
-                item->url = readString(data, maxdata - data);
+                item->url = readString(data, (int)(maxdata - data));
                 //CRLog::trace("urlstr[offs=%x, url=%s]", item->offset, item->url.c_str());
                 _table.add( item );
             }

--- a/crengine/src/cri18n.cpp
+++ b/crengine/src/cri18n.cpp
@@ -254,8 +254,8 @@ bool CRIniFileTranslator::open(const char * fileName)
             elp++;
         }
         if ( eqpos!=NULL && eqpos>p && *elp!='#' ) {
-            lString8 name( p, eqpos-p );
-            lString8 value( eqpos+1, elp - eqpos - 1);
+            lString8 name( p, (lvsize_t)(eqpos-p) );
+            lString8 value( eqpos+1, (lvsize_t)(elp - eqpos - 1));
             _map.set(name, value);
         }
         for ( p=elp; *elp && *elp!='\r' && *elp!='\n'; elp++)

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -2086,6 +2086,7 @@ void MakeStatsForFile( const char * fname, const char * cp_name, const char * la
    unsigned char * buf = new unsigned char[buf_size];
    fread(buf, 1, buf_size, in);
    short char_stat[256];
+   memset(char_stat, 0, sizeof(short)*256);
    dbl_char_stat_t dbl_char_stat[DBL_CHAR_STAT_SIZE];
    bool skipHtml = hasXmlTags(buf, buf_size);
    MakeCharStat(buf, buf_size, char_stat, skipHtml);

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -1952,7 +1952,7 @@ int strincmp(const unsigned char * buf, const char * pattern, int len)
 
 int strnstr(const unsigned char * buf, int buf_len, const char * pattern)
 {
-    int plen = strlen(pattern);
+    int plen = (int)strlen(pattern);
     for (int i=0; i<=buf_len - plen; i++) {
         if (!strincmp(buf + i, pattern, plen)) {
             return i;
@@ -1963,7 +1963,7 @@ int strnstr(const unsigned char * buf, int buf_len, const char * pattern)
 
 int rstrnstr(const unsigned char * buf, int buf_len, const char * pattern)
 {
-    int plen = strlen(pattern);
+    int plen = (int)strlen(pattern);
     for (int i=buf_len - plen; i>=0; i--) {
         if (!strincmp(buf + i, pattern, plen)) {
             return i;

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -485,7 +485,7 @@ CRFileHistRecord * CRFileHist::savePosition( lString16 fpathname, size_t sz,
     splitFName( fpathname, path, name );
     CRBookmark bmk( ptr );
     //CRLog::trace("Bookmark created");
-    int index = findEntry( name, path, sz );
+    int index = findEntry( name, path, (lvsize_t)sz );
     //CRLog::trace("findEntry exited");
     if ( index>=0 ) {
         makeTop( index );
@@ -499,7 +499,7 @@ CRFileHistRecord * CRFileHist::savePosition( lString16 fpathname, size_t sz,
     rec->setSeries( series );
     rec->setFileName( name );
     rec->setFilePath( path );
-    rec->setFileSize( sz );
+    rec->setFileSize( (lvsize_t)sz );
     rec->setLastPos( &bmk );
     rec->setLastTime( (time_t)time(0) );
 
@@ -513,7 +513,7 @@ ldomXPointer CRFileHist::restorePosition( ldomDocument * doc, lString16 fpathnam
     lString16 name;
     lString16 path;
     splitFName( fpathname, path, name );
-    int index = findEntry( name, path, sz );
+    int index = findEntry( name, path, (lvsize_t)sz );
     if ( index>=0 ) {
         makeTop( index );
         return doc->createXPointer( _records[0]->getLastPos()->getStartPos() );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1554,6 +1554,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 	lvRect oldcr;
 	drawbuf->GetClipRect(&oldcr);
 	lvRect hrc = headerRc;
+    hrc.bottom += 2;
 	drawbuf->SetClipRect(&hrc);
 	bool drawGauge = true;
 	lvRect info = headerRc;
@@ -1584,17 +1585,28 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 //		cl4 = cl1;
 //		//pal[0] = cl1;
 //	}
-        if ( leftPage )
-            drawbuf->FillRect(info.left, gpos - 2, info.right, gpos - 2     + 1, cl1);
+	if ( leftPage )
+		drawbuf->FillRect(info.left, gpos - 2, info.right, gpos - 2 + 1, cl1);
         //drawbuf->FillRect(info.left+percent_pos, gpos-gh, info.right, gpos-gh+1, cl1 ); //cl3
         //      drawbuf->FillRect(info.left + percent_pos, gpos - 2, info.right, gpos - 2
         //                      + 1, cl1); // cl3
 
 	int sbound_index = 0;
 	bool enableMarks = !leftPage && (phi & PGHDR_CHAPTER_MARKS) && sbounds.length()<info.width()/5;
+	int w = GetWidth();
+	int h = GetHeight();
+	if (w > h)
+		w = h;
+	int markh = 3;
+	int markw = 1;
+	if (w > 700) {
+		markh = 7;
+        markw = 2;
+	}
 	for ( int x = info.left; x<info.right; x++ ) {
 		int cl = -1;
 		int sz = 1;
+		int szx = 1;
 		int boundCategory = 0;
 		while ( enableMarks && sbound_index<sbounds.length() ) {
 			int sx = info.left + sbounds[sbound_index] * (info.width() - 1) / 10000;
@@ -1612,20 +1624,20 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 			sz = 1;
 		} else {
             if ( x < info.left + percent_pos ) {
-				sz = 3;
+                sz = 3;
 				if ( boundCategory==0 )
 					cl = cl1;
                 else
                     sz = 0;
             } else {
 				if ( boundCategory!=0 )
-					sz = 3;
+					sz = markh;
 				cl = cl1;
+				szx = markw;
 			}
 		}
         if ( cl!=-1 && sz>0 )
-			drawbuf->FillRect(x, gpos - 2 - sz/2, x+1, gpos - 2
-					+ sz/2 + 1, cl);
+            drawbuf->FillRect(x, gpos - 2 - sz/2, x + szx, gpos - 2 + sz/2 + 1, cl);
 	}
 
 	lString16 text;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -455,7 +455,7 @@ lString8 substituteCssMacros(lString8 src, CRPropRef props) {
             }
             if (!err) {
                 // substitute variable
-                lString8 prop(s + 1, s2 - s - 1);
+                lString8 prop(s + 1, (lvsize_t)(s2 - s - 1));
                 lString16 v;
                 // $styles.stylename.all will merge all properties like styles.stylename.*
                 if (prop.endsWith(".all")) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1457,6 +1457,37 @@ LVArray<int> & LVDocView::getSectionBounds() {
 	return m_section_bounds;
 }
 
+int LVDocView::getPosEndPagePercent() {
+    LVLock lock(getMutex());
+    checkPos();
+    if (getViewMode() == DVM_SCROLL) {
+        int fh = GetFullHeight();
+        int p = GetPos() + m_pageRects[0].height() - m_pageMargins.top - m_pageMargins.bottom - 10;
+        if (fh > 0)
+            return (int) (((lInt64) p * 10000) / fh);
+        else
+            return 0;
+    } else {
+        int fh = m_pages.length();
+        if (fh > 0) {
+            int p = getCurPage() + 1;// + 1;
+            if (getVisiblePageCount() > 1)
+                p++;
+            if (p > fh - 1)
+                p = fh - 1;
+            if (p < 0)
+                p = 0;
+            p = m_pages[p]->start - 10;
+            int fh = GetFullHeight();
+            if (fh > 0)
+                return (int) (((lInt64) p * 10000) / fh);
+            else
+                return 0;
+        } else
+            return 0;
+    }
+}
+
 int LVDocView::getPosPercent() {
 	LVLock lock(getMutex());
 	checkPos();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1555,7 +1555,7 @@ bool LVDocView::setBatteryState(int newState) {
 }
 
 /// set list of battery icons to display battery state
-void LVDocView::setBatteryIcons(LVRefVec<LVImageSource> icons) {
+void LVDocView::setBatteryIcons(const LVRefVec<LVImageSource> & icons) {
 	m_batteryIcons = icons;
 }
 
@@ -3155,6 +3155,7 @@ void LVDocView::setViewMode(LVDocViewMode view_mode, int visiblePageCount) {
 		m_pagesVisible = visiblePageCount;
         m_props->setInt(PROP_LANDSCAPE_PAGES, m_pagesVisible);
     }
+    updateLayout();
     REQUEST_RENDER("setViewMode")
     _posIsSet = false;
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1468,13 +1468,13 @@ int LVDocView::getPosEndPagePercent() {
         else
             return 0;
     } else {
-        int fh = m_pages.length();
-        if (fh > 0) {
+        int pc = m_pages.length();
+        if (pc > 0) {
             int p = getCurPage() + 1;// + 1;
             if (getVisiblePageCount() > 1)
                 p++;
-            if (p > fh - 1)
-                p = fh - 1;
+            if (p > pc - 1)
+                p = pc - 1;
             if (p < 0)
                 p = 0;
             p = m_pages[p]->start - 10;
@@ -2415,29 +2415,31 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
 		// PAGES mode
 		if (pageIndex < 0 || pageIndex >= m_pages.length())
 			pageIndex = getCurPage();
-		LVRendPageInfo * page = m_pages[pageIndex];
-		if (page->type != PAGE_TYPE_NORMAL)
-			return res;
-		ldomXPointer start = m_doc->createXPointer(lvPoint(0, page->start));
-		//ldomXPointer end = m_doc->createXPointer( lvPoint( m_dx+m_dy, page->start + page->height - 1 ) );
-		// On some pages (eg: that ends with some padding between an
-		// image on this page, and some text on next page), there may
-		// be some area which is rendered "final" without any content,
-		// thus holding no node. We would then get a null 'end' here.
-		// But we can get a xpointer by looking a few pixels back the
-		// height of page.
-		// (This does not seem to happen at start, nor on either side
-		// in scroll mode)
-		// ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start + page->height), 1);
-		ldomXPointer end;
-		for (int height=page->height; height>0; height--) {
-			end = m_doc->createXPointer(lvPoint(0, page->start + height), 1);
-			if (!end.isNull())
-				break; // we found our end of page xpointer
+		if (pageIndex >= 0 && pageIndex < m_pages.length()) {
+			LVRendPageInfo * page = m_pages[pageIndex];
+			if (page->type != PAGE_TYPE_NORMAL)
+				return res;
+			ldomXPointer start = m_doc->createXPointer(lvPoint(0, page->start));
+			//ldomXPointer end = m_doc->createXPointer( lvPoint( m_dx+m_dy, page->start + page->height - 1 ) );
+			// On some pages (eg: that ends with some padding between an
+			// image on this page, and some text on next page), there may
+			// be some area which is rendered "final" without any content,
+			// thus holding no node. We would then get a null 'end' here.
+			// But we can get a xpointer by looking a few pixels back the
+			// height of page.
+			// (This does not seem to happen at start, nor on either side
+			// in scroll mode)
+			// ldomXPointer end = m_doc->createXPointer(lvPoint(0, page->start + page->height), 1);
+			ldomXPointer end;
+			for (int height=page->height; height>0; height--) {
+				end = m_doc->createXPointer(lvPoint(0, page->start + height), 1);
+				if (!end.isNull())
+					break; // we found our end of page xpointer
+			}
+			if (start.isNull() || end.isNull())
+				return res;
+			res = LVRef<ldomXRange> (new ldomXRange(start, end));
 		}
-		if (start.isNull() || end.isNull())
-			return res;
-		res = LVRef<ldomXRange> (new ldomXRange(start, end));
 	}
 	return res;
 }
@@ -2477,7 +2479,8 @@ int LVDocView::getCurrentPageImageCount()
 
     };
     ImageCounter cnt;
-    range->forEach(&cnt);
+    if (!range.isNull())
+        range->forEach(&cnt);
     return cnt.get();
 }
 
@@ -2487,7 +2490,8 @@ lString16 LVDocView::getPageText(bool, int pageIndex) {
     CHECK_RENDER("getPageText()")
 	lString16 txt;
 	LVRef < ldomXRange > range = getPageDocumentRange(pageIndex);
-	txt = range->getRangeText();
+	if (!range.isNull())
+		txt = range->getRangeText();
 	return txt;
 }
 
@@ -4505,10 +4509,11 @@ ldomXPointer LVDocView::getCurrentPageMiddleParagraph() {
 		int pageIndex = getCurPage();
 		if (pageIndex < 0 || pageIndex >= m_pages.length())
 			pageIndex = getCurPage();
-		LVRendPageInfo * page = m_pages[pageIndex];
-		if (page->type == PAGE_TYPE_NORMAL)
-			ptr = m_doc->createXPointer(lvPoint(0, page->start + page->height
-					/ 2));
+		if (pageIndex >= 0 && pageIndex < m_pages.length()) {
+			LVRendPageInfo *page = m_pages[pageIndex];
+			if (page->type == PAGE_TYPE_NORMAL)
+				ptr = m_doc->createXPointer(lvPoint(0, page->start + page->height / 2));
+		}
 	}
 	if (ptr.isNull())
 		return ptr;
@@ -5452,6 +5457,10 @@ int LVDocView::onSelectionCommand( int cmd, int param )
 {
     CHECK_RENDER("onSelectionCommand()")
     LVRef<ldomXRange> pageRange = getPageDocumentRange();
+    if (pageRange.isNull()) {
+        clearSelection();
+        return 0;
+    }
     ldomXPointerEx pos( getBookmark() );
     ldomXRangeList & sel = getDocument()->getSelections();
     ldomXRange currSel;

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -66,13 +66,15 @@ static lUInt8 rgbToGrayMask( lUInt32 color, int bpp )
         color &= 3;
         color |= (color << 2) | (color << 4) | (color << 6);
         break;
-    default:
-    //case DRAW_BUF_3_BPP: // 8 colors
-    //case DRAW_BUF_4_BPP: // 16 colors
-    //case DRAW_BUF_8_BPP: // 256 colors
+    case DRAW_BUF_3_BPP: // 8 colors
+    case DRAW_BUF_4_BPP: // 16 colors
+    case DRAW_BUF_8_BPP: // 256 colors
         // return 8 bit as is
         color = rgbToGray(color);
         color &= ((1<<bpp)-1)<<(8-bpp);
+        return (lUInt8)color;
+    default:
+        color = rgbToGray(color);
         return (lUInt8)color;
     }
     return (lUInt8)color;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -259,7 +259,7 @@ int LVFont::getVisualAligmentWidth()
 {
     FONT_GUARD
     if ( _visual_alignment_width==-1 ) {
-        lChar16 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';', L'，', L'。', L'！', 0 };
+        lChar16 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';', (lChar16)L'，', (lChar16)L'。', (lChar16)L'！', 0 };
         int maxw = 0;
         for ( int i=0; chars[i]; i++ ) {
             int w = getCharWidth( chars[i] );

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -485,6 +485,18 @@ public:
         }
         list.sort();
     }
+    virtual void getFontFileNameList(lString16Collection &list)
+    {
+        list.clear();
+        for ( int i=0; i<_registered_list.length(); i++ ) {
+            if (_registered_list[i]->getDef()->getDocumentId() == -1) {
+                lString16 name = Utf8ToUnicode(_registered_list[i]->getDef()->getName());
+                if (!list.contains(name))
+                    list.add(name);
+            }
+        }
+        list.sort();
+    }
     virtual void clearFallbackFonts()
     {
         LVPtrVector< LVFontCacheItem > * fonts = getInstances();
@@ -2679,8 +2691,14 @@ public:
         _cache.getFaceList( list );
     }
 
-	bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)
+    /// returns registered font files
+    virtual void getFontFileNameList( lString16Collection & list )
+    {
+        FONT_MAN_GUARD
+        _cache.getFontFileNameList(list);
+    }
 
+	bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)
 {
     FONT_MAN_GUARD
     lString8 fontname=lString8("\0");
@@ -3375,6 +3393,12 @@ public:
         }
         return res;
     }
+    /// returns registered font files
+    virtual void getFontFileNameList( lString16Collection & list )
+    {
+        FONT_MAN_GUARD
+        _cache.getFontFileNameList(list);
+    }
     virtual bool Init( lString8 path )
     {
         _path = path;
@@ -3532,6 +3556,12 @@ public:
     virtual void getFaceList( lString16Collection & list )
     {
         _cache.getFaceList(list);
+    }
+    /// returns registered font files
+    virtual void getFontFileNameList( lString16Collection & list )
+    {
+        FONT_MAN_GUARD
+        _cache.getFontFileNameList(list);
     }
 };
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -3617,6 +3617,8 @@ bool ShutdownFontManager()
 
 int LVFontDef::CalcDuplicateMatch( const LVFontDef & def ) const
 {
+    if (def._documentId != -1 && _documentId != def._documentId)
+        return false;
     bool size_match = (_size==-1 || def._size==-1) ? true
         : (def._size == _size);
     bool weight_match = (_weight==-1 || def._weight==-1) ? true

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -3036,6 +3036,11 @@ public:
             );
         }
     #endif
+			if ( face ) {
+				FT_Done_Face( face );
+				face = NULL;
+			}
+
             if ( _cache.findDuplicate( &def ) ) {
                 CRLog::trace("font definition is duplicate");
                 return false;
@@ -3048,11 +3053,6 @@ public:
                     _cache.update( &newDef, LVFontRef(NULL) );
             }
             res = true;
-
-            if ( face ) {
-                FT_Done_Face( face );
-                face = NULL;
-            }
 
             if ( index>=num_faces-1 )
                 break;
@@ -3232,7 +3232,13 @@ public:
             );
         }
     #endif
-            if ( _cache.findDuplicate( &def ) ) {
+
+			if ( face ) {
+				FT_Done_Face( face );
+				face = NULL;
+			}
+
+			if ( _cache.findDuplicate( &def ) ) {
                 CRLog::trace("font definition is duplicate");
                 return false;
             }
@@ -3244,11 +3250,6 @@ public:
                     _cache.update( &newDef, LVFontRef(NULL) );
             }
             res = true;
-
-            if ( face ) {
-                FT_Done_Face( face );
-                face = NULL;
-            }
 
             if ( index>=num_faces-1 )
                 break;

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -524,6 +524,7 @@ static void lvpng_error_func (png_structp png, png_const_charp msg)
 
 static void lvpng_warning_func (png_structp png, png_const_charp msg)
 {
+    CR_UNUSED(png);
     CRLog::warn("libpng: %s", msg);
 }
 
@@ -532,7 +533,7 @@ static void lvpng_read_func(png_structp png, png_bytep buf, png_size_t len)
     LVNodeImageSource * obj = (LVNodeImageSource *) png_get_io_ptr(png);
     LVStream * stream = obj->GetSourceStream();
     lvsize_t bytesRead = 0;
-    if ( stream->Read( buf, len, &bytesRead )!=LVERR_OK || bytesRead!=(lvsize_t)len )
+    if ( stream->Read( buf, (int)len, &bytesRead )!=LVERR_OK || bytesRead!=len )
         longjmp(png_jmpbuf(png), 1);
 }
 
@@ -1184,7 +1185,7 @@ int LVGifImageSource::DecodeFromBuffer(unsigned char *buf, int buf_size, LVImage
             {
                 LVGifFrame * pFrame = new LVGifFrame(this);
                 int cbRead = 0;
-                if (pFrame->DecodeFromBuffer(p, buf_size - (p - buf), cbRead) ) {
+                if (pFrame->DecodeFromBuffer(p, (int)(buf_size - (p - buf)), cbRead) ) {
                     found = true;
                     pFrame->Draw( callback );
                 }
@@ -1199,7 +1200,7 @@ int LVGifImageSource::DecodeFromBuffer(unsigned char *buf, int buf_size, LVImage
                     m_transparent_color = p[6];
                     defined_transparent_color = true;
                 }
-                res = skipGifExtension(p, buf_size - (p - buf));
+                res = skipGifExtension(p, (int)buf_size - (p - buf));
             }
             break;
         case ';': // terminate record
@@ -1537,7 +1538,7 @@ int LVGifFrame::DecodeFromBuffer( unsigned char * buf, int buf_size, int &bytes_
 
     // test raster stream size
     int i;
-    int rest_buf_size = buf_size - (p-buf);
+    int rest_buf_size = (int)(buf_size - (p-buf));
     for (i=0; i<rest_buf_size && p[i]; ) {
         // next block
         int block_size = p[i];
@@ -1549,7 +1550,7 @@ int LVGifFrame::DecodeFromBuffer( unsigned char * buf, int buf_size, int &bytes_
         return 0; // error
 
     // set read bytes count
-    bytes_read = (p-buf) + i;
+    bytes_read = (int)((p-buf) + i);
 
     // create stream buffer
     stream_buffer = new unsigned char[stream_buffer_size+3];

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -518,14 +518,13 @@ public:
 
 static void lvpng_error_func (png_structp png, png_const_charp msg)
 {
-    //fprintf(stderr, "png error: %s\n", msg);
+    CRLog::error("libpng: %s", msg);
     longjmp(png_jmpbuf(png), 1);
 }
 
 static void lvpng_warning_func (png_structp png, png_const_charp msg)
 {
-    //fprintf(stderr, "png warning: %s\n", msg);
-    //longjmp(png_jmpbuf(png), 1);
+    CRLog::warn("libpng: %s", msg);
 }
 
 static void lvpng_read_func(png_structp png, png_bytep buf, png_size_t len)

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -192,29 +192,30 @@ CR9PatchInfo * LVImageSource::DetectNinePatch()
 	_ninePatch = new CR9PatchInfo();
 	CRNinePatchDecoder decoder(GetWidth(), GetHeight(), _ninePatch);
 	Decode(&decoder);
-	if (!(_ninePatch->frame.left > 0 && _ninePatch->frame.top > 0
+	if (_ninePatch->frame.left > 0 && _ninePatch->frame.top > 0
 			&& _ninePatch->frame.left < _ninePatch->frame.right
-			&& _ninePatch->frame.top < _ninePatch->frame.bottom)) {
+			&& _ninePatch->frame.top < _ninePatch->frame.bottom) {
+		// remove 1 pixel frame
+		_ninePatch->padding.left--;
+		_ninePatch->padding.top--;
+		_ninePatch->padding.right = GetWidth() - _ninePatch->padding.right - 1;
+		_ninePatch->padding.bottom = GetHeight() - _ninePatch->padding.bottom - 1;
+		fixNegative(_ninePatch->padding.left);
+		fixNegative(_ninePatch->padding.top);
+		fixNegative(_ninePatch->padding.right);
+		fixNegative(_ninePatch->padding.bottom);
+		_ninePatch->frame.left--;
+		_ninePatch->frame.top--;
+		_ninePatch->frame.right = GetWidth() - _ninePatch->frame.right - 1;
+		_ninePatch->frame.bottom = GetHeight() - _ninePatch->frame.bottom - 1;
+		fixNegative(_ninePatch->frame.left);
+		fixNegative(_ninePatch->frame.top);
+		fixNegative(_ninePatch->frame.right);
+		fixNegative(_ninePatch->frame.bottom);
+	} else {
 		delete _ninePatch;
 		_ninePatch = NULL;
 	}
-	// remove 1 pixel frame
-	_ninePatch->padding.left--;
-	_ninePatch->padding.top--;
-	_ninePatch->padding.right = GetWidth() - _ninePatch->padding.right - 1;
-	_ninePatch->padding.bottom = GetHeight() - _ninePatch->padding.bottom - 1;
-	fixNegative(_ninePatch->padding.left);
-	fixNegative(_ninePatch->padding.top);
-	fixNegative(_ninePatch->padding.right);
-	fixNegative(_ninePatch->padding.bottom);
-	_ninePatch->frame.left--;
-	_ninePatch->frame.top--;
-	_ninePatch->frame.right = GetWidth() - _ninePatch->frame.right - 1;
-	_ninePatch->frame.bottom = GetHeight() - _ninePatch->frame.bottom - 1;
-	fixNegative(_ninePatch->frame.left);
-	fixNegative(_ninePatch->frame.top);
-	fixNegative(_ninePatch->frame.right);
-	fixNegative(_ninePatch->frame.bottom);
 	return _ninePatch;
 }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2995,9 +2995,9 @@ void convertLengthToPx( css_length_t & val, int base_px, int base_em )
 }
 */
 
-inline void spreadParent( css_length_t & val, css_length_t & parent_val )
+inline void spreadParent( css_length_t & val, css_length_t & parent_val, bool inherited=true )
 {
-    if ( val.type == css_val_inherited )
+    if ( val.type == css_val_inherited || (val.type == css_val_unspecified && inherited))
         val = parent_val;
 }
 
@@ -3235,7 +3235,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     spreadParent( pstyle->letter_spacing, parent_style->letter_spacing );
     spreadParent( pstyle->line_height, parent_style->line_height );
     spreadParent( pstyle->color, parent_style->color );
-    spreadParent( pstyle->background_color, parent_style->background_color );
+    spreadParent( pstyle->background_color, parent_style->background_color, false );
 
     // set calculated style
     //enode->getDocument()->cacheStyle( style );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1099,7 +1099,7 @@ void SplitLines( const lString16 & str, lString16Collection & lines )
     while ( *start=='\r' || *start=='\n' )
         start++;
     if ( s > start )
-        lines.add( lString16( start, s-start ) );
+        lines.add( lString16( start, (lvsize_t)(s-start) ) );
 }
 
 // Returns the marker for a list item node. If txform is supplied render the marker, too.

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -159,7 +159,7 @@ void LVNamedStream::SetName(const lChar16 * name)
         if (p[-1] == '/' || p[-1]=='\\')
             break;
     }
-    int pos = p-fn;
+    int pos = (int)(p - fn);
     if (p>fn)
         m_path = m_fname.substr(0, pos);
     m_filename = m_fname.substr(pos, m_fname.length() - pos);
@@ -1003,6 +1003,7 @@ public:
     /// flushes unsaved data from buffers to file, with optional flush of OS buffers
     virtual lverror_t Flush( bool sync )
     {
+        CR_UNUSED(sync);
 #ifdef _WIN32
         if ( m_hFile==INVALID_HANDLE_VALUE || !FlushFileBuffers( m_hFile ) )
             return LVERR_FAIL;
@@ -1045,7 +1046,7 @@ public:
             m_pos += dwBytesRead;
 	        return LVERR_OK;
         } else {
-			DWORD err = GetLastError();
+            //DWORD err = GetLastError();
 			if (nBytesRead)
 				*nBytesRead = 0;
             return LVERR_FAIL;
@@ -2187,7 +2188,7 @@ private:
     {
         if (m_zstream.avail_in < ARC_INBUF_SIZE / 4 && m_inbytesleft > 0)
         {
-            int inpos = m_zstream.next_in ? (m_zstream.next_in - m_inbuf) : 0;
+            int inpos = (int)(m_zstream.next_in ? (m_zstream.next_in - m_inbuf) : 0);
             if ( inpos > ARC_INBUF_SIZE/2 )
             {
                 // move rest of data to beginning of buffer
@@ -2254,7 +2255,7 @@ private:
     // returns count of available decoded bytes in buffer
     inline int getAvailBytes()
     {
-        return m_zstream.next_out - m_outbuf - m_decodedpos;
+        return (int)(m_zstream.next_out - m_outbuf - m_decodedpos);
     }
     /// decode next portion of data, returns number of decoded bytes available, -1 if error
     int decodeNext()
@@ -2270,7 +2271,7 @@ private:
         if (m_decodedpos > ARC_OUTBUF_SIZE/2 || (m_zstream.avail_out < ARC_OUTBUF_SIZE / 4 && m_outbytesleft > 0) )
         {
 
-            int outpos = m_zstream.next_out - m_outbuf;
+            int outpos = (int)(m_zstream.next_out - m_outbuf);
             if ( m_decodedpos > ARC_OUTBUF_SIZE/2 || outpos > ARC_OUTBUF_SIZE*2/4 || m_zstream.avail_out==0 || m_inbytesleft==0 )
             {
                 // move rest of data to beginning of buffer

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -4037,12 +4037,14 @@ class LVBlockWriteStream : public LVNamedStream
             , size( block_size ), next(NULL)
         {
             buf = (lUInt8*)malloc( size );
-            if ( !buf ) {
+            if ( buf ) {
+                memset(buf, 0, size);
+    //            modified_start = 0;
+    //            modified_end = size;
+            }
+            else {
                 CRLog::error("buffer allocation failed");
             }
-            memset(buf, 0, size);
-//            modified_start = 0;
-//            modified_end = size;
         }
         ~Block()
         {
@@ -4229,6 +4231,7 @@ class LVBlockWriteStream : public LVNamedStream
         CRLog::trace("creating block %x", (int)p->block_start);
 #endif
         if ( readBlock( p )!=LVERR_OK ) {
+            delete p;
             return LVERR_FAIL;
         }
 #if TRACE_BLOCK_WRITE_STREAM

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -3476,8 +3476,7 @@ public:
     virtual lverror_t Read( void * buf, lvsize_t count, lvsize_t * nBytesRead )
     {
         // TODO
-        if ( nBytesRead )
-            *nBytesRead = 0;
+        lvsize_t bytesRead = 0;
         lUInt8 * dst = (lUInt8*) buf;
         while (count) {
             int bytesLeft = _decodedLen - (int)(_pos - _decodedStart);
@@ -3485,10 +3484,15 @@ public:
                 SetPos(_pos);
                 bytesLeft = _decodedLen - (int)(_pos - _decodedStart);
                 if ( bytesLeft==0 && _pos==_decodedStart+_decodedLen) {
-                    return *nBytesRead ? LVERR_OK : LVERR_EOF;
+                    if (nBytesRead)
+                        *nBytesRead = bytesRead;
+                    return bytesRead ? LVERR_OK : LVERR_EOF;
                 }
-                if ( bytesLeft<=0 || bytesLeft>_decodedLen )
+                if ( bytesLeft<=0 || bytesLeft>_decodedLen ) {
+                    if (nBytesRead)
+                        *nBytesRead = bytesRead;
                     return LVERR_FAIL;
+                }
             }
             lUInt8 * src = _decoded + (_pos - _decodedStart);
             unsigned n = count;
@@ -3499,10 +3503,11 @@ public:
             }
             count -= n;
             bytesLeft -= n;
-            if ( nBytesRead )
-                *nBytesRead += n;
+            bytesRead += n;
             _pos += n;
         }
+        if (nBytesRead)
+            *nBytesRead = bytesRead;
         return LVERR_OK;
     }
 

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -3176,6 +3176,16 @@ lvsize_t LVPumpStream( LVStream * out, LVStream * in )
     return totalBytesRead;
 }
 
+bool LVDirectoryIsEmpty(const lString8& path) {
+    return LVDirectoryIsEmpty(Utf8ToUnicode(path));
+}
+
+bool LVDirectoryIsEmpty(const lString16& path) {
+    LVContainerRef dir = LVOpenDirectory(path);
+    if (dir.isNull())
+        return false;
+    return dir->GetObjectCount() == 0;
+}
 
 LVContainerRef LVOpenDirectory(const lString16& path, const wchar_t * mask) {
 	return LVOpenDirectory(path.c_str(), mask);
@@ -3982,6 +3992,22 @@ bool LVRenameFile(lString8 oldname, lString8 newname) {
 /// delete file, return true if file found and successfully deleted
 bool LVDeleteFile( lString8 filename ) {
     return LVDeleteFile(Utf8ToUnicode(filename));
+}
+
+/// delete directory, return true if directory is found and successfully deleted
+bool LVDeleteDirectory( lString16 filename ) {
+#ifdef _WIN32
+    return RemoveDirectoryW( filename.c_str() ) ? true : false;
+#else
+    if ( unlink( UnicodeToUtf8( filename ).c_str() ) )
+        return false;
+    return true;
+#endif
+}
+
+/// delete directory, return true if directory is found and successfully deleted
+bool LVDeleteDirectory( lString8 filename ) {
+    return LVDeleteDirectory(Utf8ToUnicode(filename));
 }
 
 #define TRACE_BLOCK_WRITE_STREAM 0

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1052,6 +1052,49 @@ lString16 & lString16::pack()
     return *this;
 }
 
+bool isAlNum(lChar16 ch) {
+    lUInt16 props = lGetCharProps(ch);
+    return (props & (CH_PROP_ALPHA | CH_PROP_DIGIT)) != 0;
+}
+
+/// trims non alpha at beginning and end of string
+lString16 & lString16::trimNonAlpha()
+{
+    int firstns;
+    for (firstns = 0; firstns<pchunk->len &&
+        !isAlNum(pchunk->buf16[firstns]); ++firstns)
+        ;
+    if (firstns >= pchunk->len)
+    {
+        clear();
+        return *this;
+    }
+    int lastns;
+    for (lastns = pchunk->len-1; lastns>0 &&
+        !isAlNum(pchunk->buf16[lastns]); --lastns)
+        ;
+    int newlen = lastns-firstns+1;
+    if (newlen == pchunk->len)
+        return *this;
+    if (pchunk->nref == 1)
+    {
+        if (firstns>0)
+            lStr_memcpy( pchunk->buf16, pchunk->buf16+firstns, newlen );
+        pchunk->buf16[newlen] = 0;
+        pchunk->len = newlen;
+    }
+    else
+    {
+        lstring_chunk_t * poldchunk = pchunk;
+        release();
+        alloc( newlen );
+        _lStr_memcpy( pchunk->buf16, poldchunk->buf16+firstns, newlen );
+        pchunk->buf16[newlen] = 0;
+        pchunk->len = newlen;
+    }
+    return *this;
+}
+
 lString16 & lString16::trim()
 {
     //

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1304,13 +1304,14 @@ int lString16Collection::add( const lString16 & str )
 }
 void lString16Collection::clear()
 {
-    for (int i=0; i<count; i++)
-    {
-        ((lString16 *)chunks)[i].release();
-    }
-    if (chunks)
+    if (chunks) {
+        for (int i=0; i<count; i++)
+        {
+            ((lString16 *)chunks)[i].release();
+        }
         free(chunks);
-    chunks = NULL;
+        chunks = NULL;
+    }
     count = 0;
     size = 0;
 }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -2358,7 +2358,7 @@ lString8 & lString8::trim()
             (pchunk->buf8[lastns]==' ' || pchunk->buf8[lastns]=='\t');
             --lastns)
         ;
-    int newlen = lastns-firstns+1;
+    int newlen = (int)(lastns - firstns + 1);
     if (newlen == pchunk->len)
         return *this;
     if (pchunk->nref == 1)
@@ -2734,7 +2734,7 @@ int TrimDoubleSpaces(lChar16 * buf, int len,  bool allowStartSpace, bool allowEn
             state = 2;
         }
     }
-    return pdst - buf;
+    return (int)(pdst - buf);
 }
 
 lString16 & lString16::trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens )
@@ -3023,8 +3023,8 @@ void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen)
             s++;
         }
     }
-    srclen = s - src;
-    dstlen = p - dst;
+    srclen = (int)(s - src);
+    dstlen = (int)(p - dst);
 }
 
 lString16 Utf8ToUnicode( const char * s ) {
@@ -4570,7 +4570,7 @@ bool lString8::startsWith( const char * substring ) const
 {
     if (!substring || !substring[0])
         return true;
-    int len = strlen(substring);
+    int len = (int)strlen(substring);
     if (length() < len)
         return false;
     const lChar8 * s1 = c_str();
@@ -4602,7 +4602,7 @@ bool lString8::endsWith( const lChar8 * substring ) const
 {
 	if ( !substring || !*substring )
 		return true;
-    int len = strlen(substring);
+    int len = (int)strlen(substring);
     if ( length() < len )
         return false;
     const lChar8 * s1 = c_str() + (length()-len);

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -2849,26 +2849,10 @@ int Utf8CharCount( const lChar8 * str )
                 break;
             if ( !(*str++) )
                 break;
-        } else if ( (ch & 0xFC) == 0xF8 ) {
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
         } else {
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
-            if ( !(*str++) )
-                break;
+            // In Unicode standard maximum length of UTF-8 sequence is 4 byte!
+            // invalid first byte in UTF-8 sequence, just leave as is
+            ;
         }
         count++;
     }
@@ -2890,10 +2874,9 @@ int Utf8CharCount( const lChar8 * str, int len )
             str+=2;
         } else if ( (ch & 0xF8) == 0xF0 ) {
             str+=3;
-        } else if ( (ch & 0xFC) == 0xF8 ) {
-            str+=4;
         } else {
-            str+=5;
+            // invalid first byte of UTF-8 sequence, just leave as is
+            ;
         }
         if (str > endp)
             break;
@@ -2911,9 +2894,9 @@ inline int charUtf8ByteCount(int ch) {
         return 3;
     if (!(ch & ~0x1FFFFF))
         return 4;
-    if (!(ch & ~0x3FFFFFF))
-        return 5;
-    return 6;
+    // In Unicode Standard codepoint must be in range U+0000..U+10FFFF
+    // return invalid codepoint as one byte
+    return 1;
 }
 
 int Utf8ByteCount(const lChar16 * str)
@@ -2967,21 +2950,10 @@ static void DecodeUtf8(const char * s,  lChar16 * p, int len)
                 | CONT_BYTE(1,6)
                 | CONT_BYTE(2,0);
             s += 3;
-        } else if ( (ch & 0xFC) == 0xF8 ) {
-            *p++ = ((ch & 0x03) << 24)
-                | CONT_BYTE(0,18)
-                | CONT_BYTE(1,12)
-                | CONT_BYTE(2,6)
-                | CONT_BYTE(3,0);
-            s += 4;
         } else {
-            *p++ = ((ch & 0x01) << 30)
-                | CONT_BYTE(0,24)
-                | CONT_BYTE(1,18)
-                | CONT_BYTE(2,12)
-                | CONT_BYTE(3,6)
-                | CONT_BYTE(4,0);
-            s += 5;
+            // Invalid first byte in UTF-8 sequence
+            // Pass with mask 0x7F, to resolve exception around env->NewStringUTF()
+            *p++ = (char) (ch & 0x7F);
         }
     }
 }
@@ -3032,33 +3004,12 @@ void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen)
                     | CONT_BYTE(3,0);
                 s += 4;
             }
-        } else if ( (ch & 0xFC) == 0xF8 ) {
-            if (s + 5 > ends)
-                break;
-            if (IS_FOLLOWING(1) && IS_FOLLOWING(2) && IS_FOLLOWING(3) &&
-                IS_FOLLOWING(4)) {
-                matched = true;
-                *p++ = ((ch & 0x03) << 24)
-                    | CONT_BYTE(1,18)
-                    | CONT_BYTE(2,12)
-                    | CONT_BYTE(3,6)
-                    | CONT_BYTE(4,0);
-                s += 5;
-            }
         } else {
-            if (s + 6 > ends)
-                break;
-            if (IS_FOLLOWING(1) && IS_FOLLOWING(2) && IS_FOLLOWING(3) &&
-                IS_FOLLOWING(4) && IS_FOLLOWING(5)) {
-                matched = true;
-                *p++ = ((ch & 0x01) << 30)
-                    | CONT_BYTE(1,24)
-                    | CONT_BYTE(2,18)
-                    | CONT_BYTE(3,12)
-                    | CONT_BYTE(4,6)
-                    | CONT_BYTE(5,0);
-                s += 6;
-            }
+            // Invalid first byte in UTF-8 sequence
+            // Pass with mask 0x7F, to resolve exception around env->NewStringUTF()
+            *p++ = (char) (ch & 0x7F);
+            s++;
+            matched = true; // just to avoid next if
         }
 
         // unexpected character
@@ -3126,19 +3077,10 @@ lString8 UnicodeToUtf8(const lChar16 * s, int count)
                 *buf++ = ( (lUInt8) ( ((ch >> 12) & 0x3F) | 0x80 ) );
                 *buf++ = ( (lUInt8) ( ((ch >> 6) & 0x3F) | 0x80 ) );
                 *buf++ = ( (lUInt8) ( ((ch ) & 0x3F) | 0x80 ) );
-            } else if (!(ch & ~0x3FFFFFF)) {
-                *buf++ = ( (lUInt8) ( ((ch >> 24) & 0x03) | 0xF8 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 18) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 12) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 6) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch ) & 0x3F) | 0x80 ) );
             } else {
-                *buf++ = ( (lUInt8) ( ((ch >> 30) & 0x01) | 0xFC ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 24) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 18) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 12) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch >> 6) & 0x3F) | 0x80 ) );
-                *buf++ = ( (lUInt8) ( ((ch ) & 0x3F) | 0x80 ) );
+                // invalid codepoint
+                // In Unicode Standard codepoint must be in range U+0000 .. U+10FFFF
+                *buf++ = '?';
             }
         }
     }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -995,16 +995,37 @@ bool CacheFile::write( lUInt16 type, lUInt16 dataIndex, const lUInt8 * buf, int 
         block = allocBlock( type, dataIndex, size );
     }
     if ( !block )
+    {
+#if DOC_DATA_COMPRESSION_LEVEL!=0
+        if ( compress ) {
+            free( (void*)buf );
+        }
+#endif
         return false;
+    }
     if ( (int)_stream->SetPos( block->_blockFilePos )!=block->_blockFilePos )
+    {
+#if DOC_DATA_COMPRESSION_LEVEL!=0
+        if ( compress ) {
+            free( (void*)buf );
+        }
+#endif
         return false;
+    }
     // assert: size == block->_dataSize
     // actual writing of data
     block->_dataSize = size;
     lvsize_t bytesWritten = 0;
     _stream->Write(buf, size, &bytesWritten );
     if ( (int)bytesWritten!=size )
+    {
+#if DOC_DATA_COMPRESSION_LEVEL!=0
+        if ( compress ) {
+            free( (void*)buf );
+        }
+#endif
         return false;
+    }
 #if CACHE_FILE_WRITE_BLOCK_PADDING==1
     int paddingSize = block->_blockSize - size; //roundSector( size ) - size
     if ( paddingSize ) {
@@ -1614,6 +1635,7 @@ bool tinyNodeCollection::openCacheFile()
 
     if ( !ldomDocCache::enabled() ) {
         CRLog::error("Cannot open cached document: cache dir is not initialized");
+        delete f;
         return false;
     }
 
@@ -1663,6 +1685,7 @@ bool tinyNodeCollection::createCacheFile()
 
     if ( !ldomDocCache::enabled() ) {
         CRLog::error("Cannot swap: cache dir is not initialized");
+        delete f;
         return false;
     }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1133,8 +1133,7 @@ bool CacheFile::create( LVStreamRef stream )
     }
 
     _size = _sectorSize;
-    LVAutoPtr<lUInt8> sector0( new lUInt8[_sectorSize] );
-    memset(sector0.get(), 0, _sectorSize);
+    LVArray<lUInt8> sector0(_sectorSize, 0);
     lvsize_t bytesWritten = 0;
     _stream->Write(sector0.get(), _sectorSize, &bytesWritten );
     if ( (int)bytesWritten!=_sectorSize ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6778,13 +6778,27 @@ bool ldomXPointerEx::prevVisibleText( bool thisBlockOnly )
 // TODO: implement better behavior
 inline bool IsUnicodeSpace( lChar16 ch )
 {
-    return ch==' ';
+    //return ch==' ';
+    switch ((unsigned short)ch) {
+        case 0x0020:        // SPACE
+        case 0x00A0:        // NO-BREAK SPACE
+        case 0x2000:        // EN QUAD
+        case 0x2001:        // EM QUAD
+        case 0x2002:        // EN SPACE
+        case 0x2003:        // EM SPACE
+        case 0x2004:        // THREE-PER-EM SPACE
+        case 0x2005:        // FOUR-PER-EM SPACE
+        case 0x202F:        // NARROW NO-BREAK SPACE
+        case 0x3000:        // IDEOGRAPHIC SPACE
+            return true;
+    }
+    return false;
 }
 
 // TODO: implement better behavior
 inline bool IsUnicodeSpaceOrNull( lChar16 ch )
 {
-    return ch==0 || ch==' ';
+    return ch==0 || IsUnicodeSpace(ch);
 }
 
 // Note:
@@ -6927,6 +6941,7 @@ bool ldomXPointerEx::nextVisibleWordStart( bool thisBlockOnly )
                 if ( !nextVisibleText(thisBlockOnly) )
                     return false;
                 _data->setOffset( 0 );
+                moved = true;
             }
         }
         // skip spaces
@@ -7150,6 +7165,8 @@ bool ldomXPointerEx::isSentenceStart()
             break;
         }
     }
+#if 0
+    // At this implementation it's a wrong to check previous node
     if ( !prevNonSpace ) {
         ldomXPointerEx pos(*this);
         while ( !prevNonSpace && pos.prevVisibleText(true) ) {
@@ -7161,6 +7178,18 @@ bool ldomXPointerEx::isSentenceStart()
                     break;
                 }
             }
+        }
+    }
+#endif
+
+    // skip separated separator.
+    if (1 == textLen) {
+        switch (currCh) {
+            case '.':
+            case '?':
+            case '!':
+            case L'\x2026': // horizontal ellypsis
+                return false;
         }
     }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -62,7 +62,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.16k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.17k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x000A
 

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -201,7 +201,7 @@ lChar16 LVTextFileBase::ReadRtfChar( int, const lChar16 * conv_table )
         m_buf_pos+=2;
         if ( digit1>=0 && digit2>=0 ) {
             ch = ( (lChar8)((digit1 << 4) | digit2) );
-            if ( ch&0x80 )
+            if ( ch&0x80 && conv_table )
                 return conv_table[ch&0x7F];
             else
                 return ch;
@@ -210,7 +210,7 @@ lChar16 LVTextFileBase::ReadRtfChar( int, const lChar16 * conv_table )
         }
     } else {
         if ( ch>=' ' ) {
-            if ( ch&0x80 )
+            if ( ch&0x80 && conv_table )
                 return conv_table[ch&0x7F];
             else
                 return ch;
@@ -873,7 +873,10 @@ int LVTextFileBase::ReadTextBytes( lvpos_t pos, int bytesToRead, lChar16 * buf, 
             int enc_id = (flags & TXTFLG_ENCODING_MASK) >> TXTFLG_ENCODING_SHIFT;
             if ( enc_id >= ce_8bit_cp ) {
                 conv_table = (lChar16 *)GetCharsetByte2UnicodeTableById( enc_id );
-                enc_type = ce_8bit_cp;
+                if (conv_table)
+                    enc_type = ce_8bit_cp;
+                else
+                    enc_type = (char_encoding_type)enc_id;
             } else {
                 conv_table = NULL;
                 enc_type = (char_encoding_type)enc_id;
@@ -3458,13 +3461,15 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
     lChar16 nch = 0;
     lChar16 lch = 0;
     lChar16 nsp = 0;
-    bool pre = (flags & TXTFLG_PRE);
+    bool pre = (flags & TXTFLG_PRE) != 0;
     bool pre_para_splitting = (flags & TXTFLG_PRE_PARA_SPLITTING)!=0;
     if ( pre_para_splitting )
         pre = false;
-    //CRLog::trace("before: '%s' %s", LCSTR(s), pre ? "pre ":" ");
+    //CRLog::trace("before: '%s' %s, len=%d", LCSTR(str), pre ? "pre ":" ", len);
     int j = 0;
     for (int i=0; i<len; ++i ) {
+        if (j >= len)
+            break;
         lChar16 ch = str[i];
         if (pre) {
             if (ch == '\r') {
@@ -3506,13 +3511,18 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
             else if (state==1 && ((ch>='a' && ch<='z') || (ch>='A' && ch<='Z')) ) {
                 int k;
                 lChar16 entname[16];
-                for ( k=i; str[k] && str[k]!=';'  && str[k]!=' ' && k-i<16; k++ )
-                    entname[k-i] = str[k];
-                entname[k-i] = 0;
+                for ( k = 0; k < 16; k++ ) {
+                    entname[k] = str[k + i];
+                    if (!entname[k] || entname[k]==';' || entname[k]==' ')
+                        break;
+                }
+                if (16 == k)
+                    k--;
+                entname[k] = 0;
                 int n;
                 lChar16 code = 0;
                 // TODO: optimize search
-                if ( str[k]==';' || str[k]==' ' ) {
+                if ( str[i+k]==';' || str[i+k]==' ' ) {
                     for ( n=0; def_entity_table[n].name; n++ ) {
                         if ( !lStr_cmp( def_entity_table[n].name, entname ) ) {
                             code = def_entity_table[n].code;
@@ -3521,7 +3531,7 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
                     }
                 }
                 if ( code ) {
-                    i=k;
+                    i+=k;
                     state = 0;
                     if ( enc_table && code<256 && code>=128 )
                         code = enc_table[code - 128];
@@ -3529,8 +3539,10 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
                     nsp = 0;
                 } else {
                     // include & and rest of entity into output string
-                    str[j++] = '&';
-                    str[j++] = str[i];
+                    if (j < len - 1) {
+                        str[j++] = '&';
+                        str[j++] = str[i];
+                    }
                     state = 0;
                 }
 

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -100,7 +100,7 @@ void LVFileParserBase::updateProgress()
     m_progressUpdateCounter = (m_progressUpdateCounter + 1) & PROGRESS_UPDATE_RATE_MASK;
     if ( m_progressUpdateCounter!=0 )
         return; // to speed up checks
-    time_t t = (time_t)time((time_t)0);
+    time_t t = (time_t)time(NULL);
     if ( m_lastProgressTime==0 ) {
         m_lastProgressTime = t;
         return;

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -332,7 +332,7 @@ bool CRPropAccessor::parseColor(lString16 value, lUInt32 & result) {
 /// get color (#xxxxxx) property by name, returns false if not found
 bool CRPropAccessor::getColor( const char * propName, lUInt32 &result ) const
 {
-    int n = 0;
+    //int n = 0;
     lString16 value;
     if ( !getString( propName, value ) ) {
         //CRLog::debug("%s is not found", propName);
@@ -596,8 +596,8 @@ bool CRPropAccessor::loadFromStream( LVStream * stream )
             elp++;
         }
         if ( eqpos!=NULL && eqpos>p && *elp!='#' ) {
-            lString8 name( p, eqpos-p );
-            lString8 value( eqpos+1, elp - eqpos - 1);
+            lString8 name( p, (int)(eqpos - p) );
+            lString8 value( eqpos+1, (int)(elp - eqpos - 1));
             setString( name.c_str(), Utf8ToUnicode(removeBackslashChars(value)) );
         }
         for ( p=elp; *elp && *elp!='\r' && *elp!='\n'; elp++)

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -561,7 +561,7 @@ bool LVRtfParser::Parse()
                 p++;
                 OnControlWord( cwname, PARAM_VALUE_NONE, asteriskFlag );
             }
-            m_buf_pos += p - (m_buf + m_buf_pos);
+            m_buf_pos += (int)(p - (m_buf + m_buf_pos));
         } else {
             //lChar16 txtch = 0;
             if ( ch=='\\' ) {
@@ -588,7 +588,7 @@ bool LVRtfParser::Parse()
             }
             //=======================================================
             //=======================================================
-            m_buf_pos += p - (m_buf + m_buf_pos);
+            m_buf_pos += (int)(p - (m_buf + m_buf_pos));
         }
     }
     m_callback->OnStop();

--- a/crengine/src/wordfmt.cpp
+++ b/crengine/src/wordfmt.cpp
@@ -23,7 +23,7 @@
 #if (defined(_WIN32) && !defined(MINGW))
 extern "C" {
 	int strcasecmp(const char *s1, const char *s2) {
-		return stricmp(s1,s2);
+        return _stricmp(s1,s2);
 	}
 //char	*optarg = NULL;
 //	int	optind = 0;
@@ -286,7 +286,7 @@ vSubstring2Diagram(diagram_type *pDiag,
     UCHAR ucFontColor, USHORT usFontstyle, drawfile_fontref tFontRef,
     USHORT usFontSize, USHORT usMaxFontSize)
 {
-    lString16 s( szString, tStringLength);
+    lString16 s( szString, (int)tStringLength);
 #ifdef _LINUX
     TRACE("antiword::vSubstring2Diagram(%s)", LCSTR(s));
 #else
@@ -631,7 +631,7 @@ bReadBytes(UCHAR *aucBytes, size_t tMemb, ULONG ulOffset, FILE *pFile)
             return FALSE;
         }
         lvsize_t bytesRead=0;
-        if ( stream->Read(aucBytes, tMemb*sizeof(UCHAR), &bytesRead)!=LVERR_OK || bytesRead!=tMemb ) {
+        if ( stream->Read(aucBytes, tMemb*sizeof(UCHAR), &bytesRead)!=LVERR_OK || bytesRead != (lvsize_t)tMemb ) {
             return FALSE;
         }
     } else {
@@ -682,8 +682,8 @@ bTranslateImage(diagram_type *pDiag, FILE *pFile, BOOL bMinimalInformation,
     case imagetype_is_jpeg:
     case imagetype_is_png:
         {
-            lUInt32 offset = ulFileOffsetImage + pImg->tPosition;
-            lUInt32 len = pImg->tLength - pImg->tPosition;
+            lUInt32 offset = (lUInt32)(ulFileOffsetImage + pImg->tPosition);
+            lUInt32 len = lUInt32(pImg->tLength - pImg->tPosition);
 
             if (!bSetDataOffset(pFile, offset)) {
                 return FALSE;

--- a/thirdparty/antiword/antiword.h
+++ b/thirdparty/antiword/antiword.h
@@ -141,8 +141,8 @@
 /* Macros */
 #define STREQ(x,y)	(*(x) == *(y) && strcmp(x,y) == 0)
 #define STRNEQ(x,y,n)	(*(x) == *(y) && strncmp(x,y,n) == 0)
-#if defined(__dos) || defined(__EMX__)
-#define STRCEQ(x,y)	(stricmp(x,y) == 0)
+#if defined(__dos) || defined(__EMX__) || defined(_WIN32)
+#define STRCEQ(x,y)	(_stricmp(x,y) == 0)
 #else
 #define STRCEQ(x,y)	(strcasecmp(x,y) == 0)
 #endif /* __dos or __EMX__ */

--- a/thirdparty/antiword/blocklist.c
+++ b/thirdparty/antiword/blocklist.c
@@ -533,16 +533,16 @@ usGetNextByte(FILE *pFile, readinfo_type *pInfoCurrent, list_mem_type *pAnchor,
 		pInfoCurrent->tByteNext = 0;
 	}
 	if (pulFileOffset != NULL) {
-		*pulFileOffset =
+        *pulFileOffset = (ULONG)(
 			pInfoCurrent->pBlockCurrent->tInfo.ulFileOffset +
 			pInfoCurrent->ulBlockOffset +
-			pInfoCurrent->tByteNext;
+            pInfoCurrent->tByteNext);
 	}
 	if (pulCharPos != NULL) {
-		*pulCharPos =
+        *pulCharPos = (ULONG)(
 			pInfoCurrent->pBlockCurrent->tInfo.ulCharPos +
 			pInfoCurrent->ulBlockOffset +
-			pInfoCurrent->tByteNext;
+            pInfoCurrent->tByteNext);
 	}
 	if (pusPropMod != NULL) {
 		*pusPropMod = pInfoCurrent->pBlockCurrent->tInfo.usPropMod;

--- a/thirdparty/antiword/datalist.c
+++ b/thirdparty/antiword/datalist.c
@@ -119,7 +119,7 @@ bAdd2DataBlockList(const data_block_type *pDataBlock)
 ULONG
 ulGetDataOffset(FILE *pFile)
 {
-	return pBlockCurrent->tInfo.ulFileOffset + ulBlockOffset + tByteNext;
+    return (ULONG)(pBlockCurrent->tInfo.ulFileOffset + ulBlockOffset + tByteNext);
 } /* end of ulGetDataOffset */
 
 /*

--- a/thirdparty/antiword/fonts_u.c
+++ b/thirdparty/antiword/fonts_u.c
@@ -242,7 +242,7 @@ lComputeStringWidth(const char *szString, size_t tStringLength,
 
 	if (eEncoding == encoding_cyrillic) {
 		/* FIXME: until the character tables are available */
-		return (tStringLength * 600L * (long)usFontSize + 1) / 2;
+        return (long)((tStringLength * 600L * (long)usFontSize + 1) / 2);
 	}
 
 	DBG_DEC_C(eEncoding != encoding_latin_1 &&

--- a/thirdparty/antiword/misc.c
+++ b/thirdparty/antiword/misc.c
@@ -234,7 +234,7 @@ bReadBuffer(FILE *pFile, ULONG ulStartBlock,
 			}
 		}
 		if (ulOffset >= (ULONG)tBlockSize) {
-			ulOffset -= tBlockSize;
+            ulOffset -= (long)tBlockSize;
 			continue;
 		}
 		ulBegin = ulDepotOffset(ulIndex, tBlockSize) + ulOffset;

--- a/thirdparty/antiword/out2window.c
+++ b/thirdparty/antiword/out2window.c
@@ -288,9 +288,9 @@ vJustify2Window(diagram_type *pDiag, output_type *pAnchor,
 		pTmp->szStorage = xfree(pTmp->szStorage);
 		pTmp->szStorage = szStorage;
 		pTmp->tStorageSize = pTmp->tNextFree + (size_t)lToAdd + 1;
-		pTmp->lStringWidth +=
+        pTmp->lStringWidth += (long)(
 			(pcNew - szStorage - (long)pTmp->tNextFree) *
-			lSpaceWidth;
+            lSpaceWidth);
 		fail(pcNew < szStorage);
 		pTmp->tNextFree = (size_t)(pcNew - szStorage);
 		fail(pTmp->tNextFree != strlen(pTmp->szStorage));
@@ -359,7 +359,7 @@ tStyle2Window(char *szLine, size_t tLineSize, const style_block_type *pStyle,
 	for (tIndex = 0; tIndex <= tStyleIndex; tIndex++) {
 		if (tIndex == tStyleIndex ||
 		    (bNeedPrevLvl && tIndex < tStyleIndex)) {
-			if (pcTxt - szLine >= tLineSize - 25) {
+            if ((long)(pcTxt - szLine) >= (long)(tLineSize - 25)) {
 				/* Prevent a possible buffer overflow */
 				DBG_DEC(pcTxt - szLine);
 				DBG_DEC(tLineSize - 25);

--- a/thirdparty/antiword/pdf.c
+++ b/thirdparty/antiword/pdf.c
@@ -943,7 +943,7 @@ vAddFontsPDF(diagram_type *pDiag)
 
 	/* Twelve of the standard type 1 fonts */
 	for (tIndex = 0; tIndex < 12; tIndex++) {
-		vSetLocation(5 + tIndex);
+        vSetLocation((int)(5 + tIndex));
 		vFPprintf(pOutFile, "%u 0 obj\n", 5 + tIndex);
 		vFPprintf(pOutFile, "<<\n");
 		vFPprintf(pOutFile, "/Type /Font\n");

--- a/thirdparty/antiword/prop8.c
+++ b/thirdparty/antiword/prop8.c
@@ -805,7 +805,7 @@ vGet8LstInfo(FILE *pFile, const pps_info_type *pPPS,
 	}
 
 	/* LVLF (List leVeL on File) */
-	ulBeginLvlfInfo = ulBeginLstfInfo + tLstfInfoLen;
+    ulBeginLvlfInfo = (ULONG)(ulBeginLstfInfo + tLstfInfoLen);
 	DBG_HEX(ulBeginLvlfInfo);
 
 	aucXString = NULL;
@@ -865,8 +865,8 @@ vGet8LstInfo(FILE *pFile, const pps_info_type *pPPS,
 					sGetLeftIndent(aucPapx, tPapxLen);
 				aucPapx = xfree(aucPapx);
 			}
-			ulStart += tPapxLen;
-			ucChpxLen = ucGetByte(24, aucLvlfInfo);
+            ulStart += (ULONG)tPapxLen;
+            ucChpxLen = ucGetByte(24, aucLvlfInfo);
 			ulStart += (ULONG)ucChpxLen;
 			/* Read the length of the XString */
 			if (!bReadBuffer(pFile, pPPS->tTable.ulSB,
@@ -922,7 +922,7 @@ vGet8LstInfo(FILE *pFile, const pps_info_type *pPPS,
 					usIstd,
 					ucListLevel,
 					&tList);
-			ulStart += tXstLen;
+            ulStart += (ULONG)tXstLen;
 			aucXString = xfree(aucXString);
 		}
 	}

--- a/thirdparty/antiword/stylesheet.c
+++ b/thirdparty/antiword/stylesheet.c
@@ -536,7 +536,7 @@ vGet6Stylesheet(FILE *pFile, ULONG ulStartBlock,
 					NO_DBG_DEC(pStyle->usIstdNext);
 					vGet6StyleInfo(0,
 						aucBuffer + tOffset + tPos + 4,
-						tUpxLen - 2, pStyle);
+                        (int)(tUpxLen - 2), pStyle);
 					NO_DBG_DEC(pStyle->sLeftIndent);
 					NO_DBG_DEC(pStyle->sRightIndent);
 					NO_DBG_HEX(pStyle->ucAlignment);
@@ -739,7 +739,7 @@ vGet8Stylesheet(FILE *pFile, const pps_info_type *pPPS,
 					NO_DBG_DEC(pStyle->usIstdNext);
 					vGet8StyleInfo(0,
 						aucBuffer + tOffset + tPos + 4,
-						tUpxLen - 2, pStyle);
+                        (int)(tUpxLen - 2), pStyle);
 					NO_DBG_DEC(pStyle->sLeftIndent);
 					NO_DBG_DEC(pStyle->sRightIndent);
 					NO_DBG_HEX(pStyle->ucAlignment);

--- a/thirdparty/chmlib/src/chm_lib.c
+++ b/thirdparty/chmlib/src/chm_lib.c
@@ -73,8 +73,8 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #else
-#define strcasecmp stricmp
-#define strncasecmp strnicmp
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #endif
 #else
 /* basic Linux system includes */
@@ -169,7 +169,7 @@ typedef unsigned long long      UInt64;
 
 /* x86-64 */
 /* Note that these may be appropriate for other 64-bit machines. */
-#elif __x86_64__ || __ia64__
+#elif __x86_64__ || __ia64__ || __aarch64__
 typedef unsigned char           UChar;
 typedef short                   Int16;
 typedef unsigned short          UInt16;
@@ -1423,7 +1423,7 @@ static Int64 _chm_decompress_block(struct chmFile *h,
     /* let the caching system pull its weight! */
     if (block - blockAlign <= h->lzx_last_block  &&
         block              >= h->lzx_last_block)
-        blockAlign = (block - h->lzx_last_block);
+        blockAlign = (UInt32)(block - h->lzx_last_block);
 
     /* check if we need previous blocks */
     if (blockAlign != 0)
@@ -1431,7 +1431,7 @@ static Int64 _chm_decompress_block(struct chmFile *h,
         /* fetch all required previous blocks since last reset */
         for (i = blockAlign; i > 0; i--)
         {
-            UInt32 curBlockIdx = block - i;
+            UInt32 curBlockIdx = (UInt32)(block - i);
 
             /* check if we most recently decompressed the previous block */
             if (h->lzx_last_block != curBlockIdx)
@@ -1461,7 +1461,7 @@ static Int64 _chm_decompress_block(struct chmFile *h,
 #endif
                 if (!_chm_get_cmpblock_bounds(h, curBlockIdx, &cmpStart, &cmpLen) ||
                     cmpLen < 0                                                    ||
-                    cmpLen > h->reset_table.block_len + 6144                      ||
+                    cmpLen > (int)(h->reset_table.block_len + 6144)               ||
                     _chm_fetch_bytes(h, cbuffer, cmpStart, cmpLen) != cmpLen      ||
                     LZXdecompress(h->lzx_state, cbuffer, lbuffer, (int)cmpLen,
                                   (int)h->reset_table.block_len) != DECR_OK)
@@ -1803,7 +1803,7 @@ int chm_enumerate_dir(struct chmFile *h,
     /* initialize pathname state */
     strncpy(prefixRectified, prefix, CHM_MAX_PATHLEN);
     prefixRectified[CHM_MAX_PATHLEN] = '\0';
-    prefixLen = strlen(prefixRectified);
+    prefixLen = (int)strlen(prefixRectified);
     if (prefixLen != 0)
     {
         if (prefixRectified[prefixLen-1] != '/')
@@ -1881,7 +1881,7 @@ int chm_enumerate_dir(struct chmFile *h,
             }
             strncpy(lastPath, ui.path, CHM_MAX_PATHLEN);
             lastPath[CHM_MAX_PATHLEN] = '\0';
-            lastPathLen = strlen(lastPath);
+            lastPathLen = (int)strlen(lastPath);
 
             /* get the length of the path */
             ui_path_len = strlen(ui.path)-1;

--- a/thirdparty/libjpeg/jmemmgr.c
+++ b/thirdparty/libjpeg/jmemmgr.c
@@ -303,7 +303,7 @@ alloc_small (j_common_ptr cinfo, int pool_id, size_t sizeofobject)
       if (slop < MIN_SLOP)	/* give up when it gets real small */
 	out_of_memory(cinfo, 2); /* jpeg_get_small failed */
     }
-    mem->total_space_allocated += min_request + slop;
+    mem->total_space_allocated += (int)(min_request + slop);
     /* Success, initialize the new pool header and add to end of list */
     hdr_ptr->hdr.next = NULL;
     hdr_ptr->hdr.bytes_used = 0;
@@ -363,7 +363,7 @@ alloc_large (j_common_ptr cinfo, int pool_id, size_t sizeofobject)
 					    SIZEOF(large_pool_hdr));
   if (hdr_ptr == NULL)
     out_of_memory(cinfo, 4);	/* jpeg_get_large failed */
-  mem->total_space_allocated += sizeofobject + SIZEOF(large_pool_hdr);
+  mem->total_space_allocated += (int)(sizeofobject + SIZEOF(large_pool_hdr));
 
   /* Success, initialize the new pool header and add to list */
   hdr_ptr->hdr.next = mem->large_list[pool_id];
@@ -973,7 +973,7 @@ free_pool (j_common_ptr cinfo, int pool_id)
 		  lhdr_ptr->hdr.bytes_left +
 		  SIZEOF(large_pool_hdr);
     jpeg_free_large(cinfo, (void FAR *) lhdr_ptr, space_freed);
-    mem->total_space_allocated -= space_freed;
+    mem->total_space_allocated -= (int)space_freed;
     lhdr_ptr = next_lhdr_ptr;
   }
 
@@ -987,7 +987,7 @@ free_pool (j_common_ptr cinfo, int pool_id)
 		  shdr_ptr->hdr.bytes_left +
 		  SIZEOF(small_pool_hdr);
     jpeg_free_small(cinfo, (void *) shdr_ptr, space_freed);
-    mem->total_space_allocated -= space_freed;
+    mem->total_space_allocated -= (int)space_freed;
     shdr_ptr = next_shdr_ptr;
   }
 }

--- a/thirdparty/libjpeg/jmorecfg.h
+++ b/thirdparty/libjpeg/jmorecfg.h
@@ -209,10 +209,12 @@ typedef unsigned int JDIMENSION;
  * explicit coding is needed; see uses of the NEED_FAR_POINTERS symbol.
  */
 
+#ifndef FAR
 #ifdef NEED_FAR_POINTERS
 #define FAR  far
 #else
 #define FAR
+#endif
 #endif
 
 


### PR DESCRIPTION
Went thru all upstream commits since when we diverged (fbc7e4f2 Fri Feb 21 14:10:20 2014), involving the `crengine/crengine` subtree (with bits involving `crengine/thirdparty`, nothing interesting in `crengine/cr3gui`).

Commits considered (I have discarded a few that were too remote to what we do, or too diverging, or other ways of doing what we have already done - I didn't wrote down which - and those that were made by us first and contributed upstream):
```
OK CONFLICT FIXED 9c84869b Fixed UTF-8 encoding/decoding according Unicode Standard.
OK 8b289e38 Fixed regression in commit ced047b1 Sequences like '&nbsp;', '&amp;' and other not performed as should.
OK ced047b1 Fixed stack corruption on broken files: index out of range in PreProcessXmlString() in lvxml.cpp. Added few safety checks in lvxml.cpp.
OK 0e8f032c Resolved null pointer dereferences in lvdocview.cpp. On some small files app crashed.
OK 35853044 Fixed potential segfaults and memory leaks (thanks to clang-analyzer).
already done by one below e7f80dfb Updated desktop (Qt5) version fot HarfBuzz kerning, but not tested yet!
already done e54d409c Fix segfault while scrolling
already done: 01befed1 Fix Segmentation fault in the Release build
OK 4a729372 Fix build with GCC 7.3.x
OK 7ce3fb0b Fixes/improvements to pull request #2.
OK 035ddd0d crengine: call updateLayout when switching view modes
OK a4ef1538 fixes
OK c4040040 Fixed bug in TTS: after some tags text skipped.
OK 986d1907 Fixed potential memory leak.
OK (chunks done differently)  018c4d81 Fixed some potencially bugs (by a static analyzer): common realloc mistate, etc...
OK fb3cd275 Fixed potencially memory leaks and potencially memory corruptions.
OK 73df78f5 page end percent fix
OK 0a86db6f end page percent fix
OK 2c61a3ca end page percent
OK (small fix only) 9b8ece63 fix rendering after loading from cache
OK c3c4490e trim non-alpha
OK 96ce9c02 string trim by alpha
OK 7832a205 more file operations
OK 82c894a7 chapter marks for big screens
OK 62c8a408 fixes
OK 78c32390 lvRect improvements
OK 0c5d5921 fix 64bit build warnings
OK 4f2f0a3f fix some 64bit warnings
OK 190b29f8 Do not abort on libpng warnings.
OK f55d6328 Log libpng warnings and errors.
OK 67b44bb9 Fixed inheritance handling of letter-spacing, line-height, color css properties
already done: d9842c71 fix formatting of spaces
OK 9a954a13 merge patch #22 Embedded fonts are ignored sometimes - by macnuts
OK bea4188f merge patch #23 - FT_Done_Face not always called - by macnuts
```
(those marked `already done` were done by @Frenzie or me some months ago).

I cherry-picked them, fixed conflicts, re-ordered and squashed the related ones, and gave them more meaningful titles, keeping original authors and dates.

For the bits of code I know, I checked they don't do harm. For those I don't know, I trust upstream. They are bits that we don't use, but well, let's have them in case we need them.
Tested for a few hours on my device.
I hope this won't break anything or cause strange glitches and cause us future headaches.

Commits considered but not included:
Related to build on android and OSX that I can't judge:
```
0766fdaa enable mutexes for android builds
aa7ad4ce fix android / x86 build on Android 4.1.2
2510332d stacktrace on android
81b84557 OSX build fixes
```
Related to margins, but margins are fine for us, so I'd rather not mess with them:
```
86072b55 page margins fixes
06972921 page settings API improvements
28811c4d fix page margins settings
```
All others up to today not listed are either revert of our originally merged CJK/visualAlignment stuff, merge commits, or just bumps of crengine versions.