### PR TITLE
Tweak table columns widths algorithm. Fix some ignored page-breaks

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1974,14 +1974,19 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
 
 
                     // recurse all sub-blocks for blocks
+                    int pb_flag;
                     int y = padding_top;
                     int cnt = enode->getChildCount();
                     lvRect r;
                     enode->getAbsRect(r);
+                    pb_flag = pagebreakhelper(enode,width);
                     if (margin_top>0)
-                        context.AddLine(r.top - margin_top, r.top, pagebreakhelper(enode,width));
+                        context.AddLine(r.top-margin_top, r.top, pb_flag);
                     if (padding_top>0)
-                        context.AddLine(r.top,r.top+padding_top,pagebreakhelper(enode,width)|padding_top_split_flag);
+                        context.AddLine(r.top, r.top+padding_top, pb_flag|padding_top_split_flag);
+                    if (margin_top==0 && padding_top==0 && pb_flag)
+                        // If no margin or padding to carry pb_flag, add an empty line
+                        context.AddLine(r.top, r.top, pb_flag);
 
                     // List item marker rendering when css_d_list_item_block
                     int list_marker_padding = 0; // set to non-zero when list-style-position = outside
@@ -2048,10 +2053,14 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     fmt.setHeight( y + padding_bottom ); //+ margin_top + margin_bottom ); //???
                     lvRect rect;
                     enode->getAbsRect(rect);
+                    pb_flag = CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER;
                     if(padding_bottom>0)
-                        context.AddLine(y+rect.top,y+rect.top+padding_bottom,(margin_bottom>0?RN_SPLIT_AFTER_AUTO:CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER)|padding_bottom_split_flag);
+                        context.AddLine(y+rect.top, y+rect.top+padding_bottom, (margin_bottom>0?RN_SPLIT_AFTER_AUTO:pb_flag)|padding_bottom_split_flag);
                     if(margin_bottom>0)
-                        context.AddLine(y+rect.top+padding_bottom,y+rect.top+padding_bottom+margin_bottom,CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
+                        context.AddLine(y+rect.top+padding_bottom, y+rect.top+padding_bottom+margin_bottom, pb_flag);
+                    if (margin_bottom==0 && padding_bottom==0 && pb_flag)
+                        // If no margin or padding to carry pb_flag, add an empty line
+                        context.AddLine(y+rect.top, y+rect.top, pb_flag);
                     if ( isFootNoteBody )
                         context.leaveFootNote();
                     return y + margin_top + margin_bottom + padding_bottom; // return block height


### PR DESCRIPTION
### Fix: don't ignore page breaks on empty nodes
See https://github.com/koreader/koreader/issues/4207#issuecomment-419668415

### Tweak table columns widths algorithm

See https://github.com/koreader/koreader/issues/4197
Changed a few rules:

Previously, on tables where columns have no width= specified:
- width was distributed between columns according to each longest   cells plain text size (so, if a column contains only cells with 10 chars, and another column contains one cell with 990 chars, the former would get a width of 1/100th of the table width, which could cause various display gliches when trying to render the 10 chars on a very small width)
- a minimal width of 8px was ensured
- it was further reduced to the length of its longest plain text if it happens to be smaller
- the width recovered from this last reduction was evenly distributed to all columns (so, the shortened columns could become wider again)

Now:
- still split according to each longest plain text size, but ensure a minimum width of half of what it would be if all no-width cells were splitted equally (so, with the above example, the small column would be 1/4th instead of 1/100th)
- a minimal width of 1.2em is ensured
- still reduce it to the length of its longest plain text if is is smaller
- the width recovered from this last reduction is distributed only to all columns that were not reduced

The 1.2em and _half of what it would be if all no-width cells were splitted equally_  are a bit arbitrary choices, but that's what looked the nicest with my test cases.
This is still not perfect (mainly because the longest plain text size may not always be a good indicator of the content width, as it does not take into account padding and other styles, and font variations in the cell content), but it seems to avoid the most obvious glitches under various font sizes.

#### Before

![image](https://user-images.githubusercontent.com/24273478/45309938-3c9ade80-b525-11e8-9b6c-5331150af2c3.png)

![image](https://user-images.githubusercontent.com/24273478/45309964-4c1a2780-b525-11e8-924f-4eb56b1d334a.png)
or, with a smaller font size:
![image](https://user-images.githubusercontent.com/24273478/45309989-5f2cf780-b525-11e8-9812-84511f8b0b51.png)

![image](https://user-images.githubusercontent.com/24273478/45310026-779d1200-b525-11e8-837f-f0fd8fd2a262.png)

![image](https://user-images.githubusercontent.com/24273478/45310039-8257a700-b525-11e8-968b-a60c6b26bbee.png)

![image](https://user-images.githubusercontent.com/24273478/45310077-9bf8ee80-b525-11e8-9289-f8d3eefbcc71.png)

#### After

![image](https://user-images.githubusercontent.com/24273478/45310239-0ad64780-b526-11e8-9586-c65be921a80e.png)

![image](https://user-images.githubusercontent.com/24273478/45310276-1cb7ea80-b526-11e8-858f-476dd95a8a32.png)
or, with a smaller font size:
![image](https://user-images.githubusercontent.com/24273478/45310292-27727f80-b526-11e8-9232-427cd81d88ca.png)

![image](https://user-images.githubusercontent.com/24273478/45310330-36593200-b526-11e8-8ea7-349f80165503.png)

![image](https://user-images.githubusercontent.com/24273478/45310400-656fa380-b526-11e8-82ee-5537ece3b3ec.png)

![image](https://user-images.githubusercontent.com/24273478/45310421-702a3880-b526-11e8-8700-7ed55f235a55.png)
