### PR TITLE
Better fix: don't ignore page breaks on empty nodes

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2021,19 +2021,14 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
 
 
                     // recurse all sub-blocks for blocks
-                    int pb_flag;
                     int y = padding_top;
                     int cnt = enode->getChildCount();
                     lvRect r;
                     enode->getAbsRect(r);
-                    pb_flag = pagebreakhelper(enode,width);
                     if (margin_top>0)
-                        context.AddLine(r.top-margin_top, r.top, pb_flag);
+                        context.AddLine(r.top-margin_top, r.top, pagebreakhelper(enode,width));
                     if (padding_top>0)
-                        context.AddLine(r.top, r.top+padding_top, pb_flag|padding_top_split_flag);
-                    if (margin_top==0 && padding_top==0 && pb_flag)
-                        // If no margin or padding to carry pb_flag, add an empty line
-                        context.AddLine(r.top, r.top, pb_flag);
+                        context.AddLine(r.top, r.top+padding_top, pagebreakhelper(enode,width)|padding_top_split_flag);
 
                     // List item marker rendering when css_d_list_item_block
                     int list_marker_padding = 0; // set to non-zero when list-style-position = outside
@@ -2098,9 +2093,19 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     if ( y < st_y )
                         y = st_y;
                     fmt.setHeight( y + padding_bottom ); //+ margin_top + margin_bottom ); //???
+
+                    if (margin_top==0 && padding_top==0) {
+                        // If no margin or padding that would have carried the page break above, and
+                        // if this page break was not consumed (it is reset to css_pb_auto when used)
+                        // by any child node and is still there, add an empty line to carry it
+                        int pb_flag = pagebreakhelper(enode,width);
+                        if (pb_flag)
+                            context.AddLine(r.top, r.top, pb_flag);
+                    }
+
                     lvRect rect;
                     enode->getAbsRect(rect);
-                    pb_flag = CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER;
+                    int pb_flag = CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER;
                     if(padding_bottom>0)
                         context.AddLine(y+rect.top, y+rect.top+padding_bottom, (margin_bottom>0?RN_SPLIT_AFTER_AUTO:pb_flag)|padding_bottom_split_flag);
                     if(margin_bottom>0)


### PR DESCRIPTION
Previous fix (in #233) was wrong, and was adding too many wrong page breaks (noticed by unit tests in https://github.com/koreader/koreader/pull/4217).
This reverts some bits from it, and fix that hopefully the right way.

Note that this fix (to solve https://github.com/koreader/koreader/issues/4207) may still add some new page breaks (and blank pages) that might be bothering (to me at least :) or feel uneeded. But in my tests, they look like they obey HTML and CSS.
For example if one HTML file in an epub (so, making a DocFragment, which generates a page-break by itself) contains:
```html
<body>
  <div></div>
  <h3>some title</h3>
```
Previously, the empty div that would have carried the page-break (from DocFragment) was ignored, and the DocFragment page-break was lost, but the one implied by the H3 (we have in epub.css a page-break before H1 H2 and H3) was rendered.
Now, both will be rendered and generate a blank page.

This happened before with some EPUBs for some other reason, and we have a Style Tweak to avoid that (`Avoid blank page on chapter start`). So, I guess those like me who don't like blank page will have to use that tweak more often.

The diff from before the previous fix looks like this:
```diff
@@ -1979,9 +2026,9 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     lvRect r;
                     enode->getAbsRect(r);
                     if (margin_top>0)
-                        context.AddLine(r.top - margin_top, r.top, pagebreakhelper(enode,width));
+                        context.AddLine(r.top-margin_top, r.top, pagebreakhelper(enode,width));
                     if (padding_top>0)
-                        context.AddLine(r.top,r.top+padding_top,pagebreakhelper(enode,width)|padding_top_split_flag);
+                        context.AddLine(r.top, r.top+padding_top, pagebreakhelper(enode,width)|padding_top_split_flag);

                     // List item marker rendering when css_d_list_item_block
                     int list_marker_padding = 0; // set to non-zero when list-style-position = outside
@@ -2046,12 +2093,26 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                     if ( y < st_y )
                         y = st_y;
                     fmt.setHeight( y + padding_bottom ); //+ margin_top + margin_bottom ); //???
+
+                    if (margin_top==0 && padding_top==0) {
+                        // If no margin or padding that would have carried the page break above, and
+                        // if this page break was not consumed (it is reset to css_pb_auto when used)
+                        // by any child node and is still there, add an empty line to carry it
+                        int pb_flag = pagebreakhelper(enode,width);
+                        if (pb_flag)
+                            context.AddLine(r.top, r.top, pb_flag);
+                    }
+
                     lvRect rect;
                     enode->getAbsRect(rect);
+                    int pb_flag = CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER;
                     if(padding_bottom>0)
-                        context.AddLine(y+rect.top,y+rect.top+padding_bottom,(margin_bottom>0?RN_SPLIT_AFTER_AUTO:CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER)|padding_bottom_split_flag);
+                        context.AddLine(y+rect.top, y+rect.top+padding_bottom, (margin_bottom>0?RN_SPLIT_AFTER_AUTO:pb_flag)|padding_bottom_split_flag);
                     if(margin_bottom>0)
-                        context.AddLine(y+rect.top+padding_bottom,y+rect.top+padding_bottom+margin_bottom,CssPageBreak2Flags(getPageBreakAfter(enode))<<RN_SPLIT_AFTER);
+                        context.AddLine(y+rect.top+padding_bottom, y+rect.top+padding_bottom+margin_bottom, pb_flag);
+                    if (margin_bottom==0 && padding_bottom==0 && pb_flag)
+                        // If no margin or padding to carry pb_flag, add an empty line
+                        context.AddLine(y+rect.top, y+rect.top, pb_flag);
                     if ( isFootNoteBody )
                         context.leaveFootNote();
                     return y + margin_top + margin_bottom + padding_bottom; // return block height

```