### PR TITLE
Various: fix CJK highlight, page links; adds getHtml(), getSegmentsRects()

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -767,6 +767,10 @@ public:
     /// export to WOL format
     bool exportWolFile( LVStream * stream, bool flgGray, int levels );
 
+    /// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
+    /// path relative to document directory for non-container documents like HTML)
+    LVStreamRef getDocumentFileStream( lString16 filePath );
+
     /// draws page to image buffer
     void drawPageTo( LVDrawBuf * drawBuf, LVRendPageInfo & page, lvRect * pageRect, int pageCount, int basePage);
     /// draws coverpage to image buffer

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1263,6 +1263,8 @@ public:
 #if BUILD_LITE!=1
     /// return parent final node, if found
     ldomNode * getFinalNode() const;
+    /// return true is this node is a final node
+    bool isFinalNode() const;
 #endif
     /// returns offset within node
 	inline int getOffset() const { return _data->getOffset(); }
@@ -1530,6 +1532,13 @@ public:
     void recurseElements( void (*pFun)( ldomXPointerEx & node ) );
     /// calls specified function recursively for all nodes of DOM tree
     void recurseNodes( void (*pFun)( ldomXPointerEx & node ) );
+
+    /// move to next sibling or parent's next sibling
+    bool nextOuterElement();
+    /// move to (end of) last and deepest child node descendant of current node
+    bool lastInnerNode( bool toTextEnd=false );
+    /// move to (end of) last and deepest child text node descendant of current node
+    bool lastInnerTextNode( bool toTextEnd=false );
 };
 
 class ldomXRange;
@@ -1622,7 +1631,7 @@ public:
     /// create intersection of two ranges
     ldomXRange( const ldomXRange & v1,  const ldomXRange & v2 );
     /// copy constructor of full node range
-    ldomXRange( ldomNode * p );
+    ldomXRange( ldomNode * p, bool fitEndToLastInnerChild=false );
     /// copy assignment
     ldomXRange & operator = ( const ldomXRange & v )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1369,6 +1369,11 @@ public:
     inline bool isElement() const { return !isNull() && getNode()->isElement(); }
     /// returns true if current node is element
     inline bool isText() const { return !isNull() && getNode()->isText(); }
+    /// returns HTML (serialized from the DOM, may be different from the source HTML)
+    lString8 getHtml( lString16Collection & cssFiles, int wflags=0 );
+    lString8 getHtml( int wflags=0 ) {
+        lString16Collection cssFiles; return getHtml(cssFiles, wflags);
+    };
 };
 
 #define MAX_DOM_LEVEL 64
@@ -1697,6 +1702,11 @@ public:
 #endif
     /// returns nearest common element for start and end points
     ldomNode * getNearestCommonParent();
+    /// returns HTML (serialized from the DOM, may be different from the source HTML)
+    lString8 getHtml( lString16Collection & cssFiles, int wflags=0, bool fromRootNode=false );
+    lString8 getHtml( int wflags=0, bool fromRootNode=false ) {
+        lString16Collection cssFiles; return getHtml(cssFiles, wflags, fromRootNode);
+    };
 
     /// searches for specified text inside range
     bool findText( lString16 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1, bool checkMaxFromStart = false );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1698,7 +1698,13 @@ public:
     void forEach( ldomNodeCallback * callback );
 #if BUILD_LITE!=1
     /// returns rectangle (in doc coordinates) for range. Returns true if found.
-    bool getRectEx( lvRect & rect );
+    bool getRectEx( lvRect & rect, bool & isSingleLine );
+    bool getRectEx( lvRect & rect ) {
+        bool isSingleLine; return getRectEx(rect, isSingleLine);
+    };
+    // returns multiple segments rects (one for each text line)
+    // that the ldomXRange spans on the page.
+    void getSegmentRects( LVArray<lvRect> & rects );
 #endif
     /// returns nearest common element for start and end points
     ldomNode * getNearestCommonParent();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -886,6 +886,20 @@ void LVDocView::updatePageNumbers(LVTocItem * item) {
 	}
 }
 
+/// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
+/// path relative to document directory for non-container documents like HTML)
+LVStreamRef LVDocView::getDocumentFileStream( lString16 filePath ) {
+    if ( !filePath.empty() ) {
+        LVContainerRef cont = m_doc->getContainer();
+        if ( cont.isNull() ) // no real container
+            cont = m_container; // consider document directory as the container
+        LVStreamRef stream = cont->OpenStream(filePath.c_str(), LVOM_READ);
+        // if failure, a NULL stream is returned
+        return stream;
+    }
+    return LVStreamRef(); // not found: return NULL ref
+}
+
 /// returns cover page image stream, if any
 LVStreamRef LVDocView::getCoverPageImageStream() {
     lString16 fileName;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -329,8 +329,45 @@ static bool parse_number_value( const char * & str, css_length_t & value, bool i
         return true;
     }
     if ( is_font_size ) {
+        // Absolute-size keywords, based on the default font size (which is medium)
+        // Factors as suggested in https://drafts.csswg.org/css-fonts-3/#absolute-size-value
+        if ( substr_icompare( "medium", str ) ) {
+            value.type = css_val_rem;
+            value.value = 256;
+            return true;
+        }
+        else if ( substr_icompare( "small", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 8/9);
+            return true;
+        }
+        else if ( substr_icompare( "x-small", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 3/4);
+            return true;
+        }
+        else if ( substr_icompare( "xx-small", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 3/5);
+            return true;
+        }
+        else if ( substr_icompare( "large", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 6/5);
+            return true;
+        }
+        else if ( substr_icompare( "x-large", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 3/2);
+            return true;
+        }
+        else if ( substr_icompare( "xx-large", str ) ) {
+            value.type = css_val_rem;
+            value.value = (int)(256 * 2);
+            return true;
+        }
         // Approximate the (usually uneven) gaps between named sizes.
-        if ( substr_icompare( "smaller", str ) ) {
+        else if ( substr_icompare( "smaller", str ) ) {
             value.type = css_val_percent;
             value.value = 80 << 8;
             return true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.17k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x000A
+#define FORMATTING_VERSION_ID 0x000B
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6985,13 +6985,13 @@ bool ldomXPointerEx::thisVisibleWordEnd(bool thisBlockOnly)
     if ( _data->getOffset() >= textLen )
         return false;
     // skip spaces
-    while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
+    while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
         _data->addOffset(1);
         //moved = true;
     }
     // skip non-spaces
     while ( _data->getOffset()<textLen ) {
-        if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
+        if ( IsWordSeparator(text[ _data->getOffset() ]) )
             break;
         moved = true;
         _data->addOffset(1);


### PR DESCRIPTION
Will be needed by upcoming PRs in frontend code and base/cre.cpp.
I'll bump it all at once, as it felt quite hard to split all that into individual single-topic cre>base>frontend bumps.
There will probably be some warnings with my C++ code from the clang checks done in base...

Details in the individual commit messages.

Some screenshots about what's fixed and what to expect:

Some single highlight of some CJK/mixed text before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/46607655-02ac0080-cb02-11e8-89e5-1613182db65d.png)</kbd>
The 2nd commit will fix the non-highlighted char on the right, the `ldomXRange::getSegmentRects()` addition will allow a more proper highlighting of non-word chars on the page edges:
<kbd>![image](https://user-images.githubusercontent.com/24273478/46607881-e5c3fd00-cb02-11e8-87f5-91b8f534405c.png)</kbd>

With some french text (brackets on the left, punctuation on the right), before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/46607757-6d5d3c00-cb02-11e8-8435-c8b943c5b8f4.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/46607824-aa293300-cb02-11e8-8633-1fbf65a78036.png)</kbd>
(This does not fix punctuation, quotes or parens at start or end of selected text not being included in the highlight.)

The `::getHtml()` and various flags will allow having 2 kind of display when viewing some text selection HTML:
<kbd>![image](https://user-images.githubusercontent.com/24273478/46608284-88c94680-cb04-11e8-9f5e-a3d4da77c12d.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/46608290-9252ae80-cb04-11e8-9d6b-2169657411ae.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/46608307-a0083400-cb04-11e8-89fd-d904fea00064.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/46608189-2cfebd80-cb04-11e8-92f7-fd994ea2cbe6.png)</kbd>

Other stuff will be used for footnotes popup, some screenshots in https://github.com/koreader/koreader/issues/3054#issuecomment-427501944.

Discussion about font-size absolute keyword in https://github.com/koreader/crengine/pull/142#issuecomment-427630601.

