### PR TITLE
Avoid uneeded re-rendering on load when with full status bar

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2515,12 +2515,6 @@ void LVDocView::setRenderProps(int dx, int dy) {
 	updateLayout();
 	m_showCover = !getCoverPageImage().isNull();
 
-	if (dx == 0)
-		dx = m_pageRects[0].width() - m_pageMargins.left - m_pageMargins.right;
-	if (dy == 0)
-		dy = m_pageRects[0].height() - m_pageMargins.top - m_pageMargins.bottom
-				- getPageHeaderHeight();
-
 	lString8 fontName = lString8(DEFAULT_FONT_NAME);
 	m_font_size = scaleFontSizeForDPI(m_requested_font_size);
 	gRootFontSize = m_font_size; // stored as global (for 'rem' css unit)
@@ -2531,6 +2525,12 @@ void LVDocView::setRenderProps(int dx, int dy) {
 			DEFAULT_FONT_FAMILY, m_statusFontFace);
 	if (!m_font || !m_infoFont)
 		return;
+
+	if (dx == 0)
+		dx = m_pageRects[0].width() - m_pageMargins.left - m_pageMargins.right;
+	if (dy == 0)
+		dy = m_pageRects[0].height() - m_pageMargins.top - m_pageMargins.bottom
+				- getPageHeaderHeight();
 
     updateDocStyleSheet();
 


### PR DESCRIPTION
People that uses the full status bar may get on document load:
`CRE: document loaded, but styles re-init needed (possible epub with embedded fonts)`

`getPageHeaderHeight()` was called before `m_infoFont` was set to its definitive value. So, the second time it is called, we may get a different value, which causes a difference in page height, so a hash mismatch, and so a re-rendering.
Just move the `dy` computation AFTER `m_infoFont` is set to its correct and definitive value, and avoid any mismatch.
(Minor, does not need an immediate bump - just PRing that so I don't forget it.)