### PR TITLE
Fix and extend support of vertical-align, and other rendering fixes

### DIFF
--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -29,7 +29,7 @@ int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing 
 /// converts style to text formatting API flags
 int styleToTextFmtFlags( const css_style_ref_t & style, int oldflags );
 /// renders block as single text formatter object
-void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags, int ident, int line_h );
+void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags, int ident, int line_h, int valign_dy=0 );
 /// renders block which contains subblocks
 int renderBlockElement( LVRendPageContext & context, ldomNode * node, int x, int y, int width );
 /// renders table element

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -96,7 +96,7 @@ typedef struct css_style_rec_tag {
     css_text_align_t     text_align_last;
     css_text_decoration_t text_decoration;
     css_text_transform_t text_transform;
-    css_vertical_align_t vertical_align;
+    css_length_t         vertical_align;
     css_font_family_t    font_family;
     lString8             font_name;
     css_length_t         font_size;
@@ -139,7 +139,7 @@ typedef struct css_style_rec_tag {
     , text_align_last(css_ta_inherit)
     , text_decoration (css_td_inherit)
     , text_transform (css_tt_inherit)
-    , vertical_align(css_va_inherit)
+    , vertical_align(css_val_unspecified, css_va_baseline)
     , font_family(css_ff_inherit)
     , font_size(css_val_inherited, 0)
     , font_style(css_fs_inherit)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3058,9 +3058,9 @@ void convertLengthToPx( css_length_t & val, int base_px, int base_em )
 }
 */
 
-inline void spreadParent( css_length_t & val, css_length_t & parent_val, bool inherited=true )
+inline void spreadParent( css_length_t & val, css_length_t & parent_val, bool unspecified_is_inherited=true )
 {
-    if ( val.type == css_val_inherited || (val.type == css_val_unspecified && inherited))
+    if ( val.type == css_val_inherited || (val.type == css_val_unspecified && unspecified_is_inherited) )
         val = parent_val;
 }
 
@@ -3296,9 +3296,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     }
     // line_height
     spreadParent( pstyle->letter_spacing, parent_style->letter_spacing );
-    spreadParent( pstyle->line_height, parent_style->line_height );
+    spreadParent( pstyle->line_height, parent_style->line_height, false ); // css_val_unspecified is a valid unit
     spreadParent( pstyle->color, parent_style->color );
-    spreadParent( pstyle->background_color, parent_style->background_color, false );
+    spreadParent( pstyle->background_color, parent_style->background_color, false ); // css_val_unspecified means no bg color
 
     // set calculated style
     //enode->getDocument()->cacheStyle( style );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -745,10 +745,12 @@ public:
                 if ( i==y ) {
                     //upper left corner of cell
 
+                    // If last cell of a row and border_collapse: increase cell width (whether final or block)
+                    if (border_collapse&&j==rows[i]->cells.length()-1) cell->width+=measureBorder(cell->elem,1);
+
                     RenderRectAccessor fmt( cell->elem );
                     if ( cell->elem->getRendMethod()==erm_final ) {
                         LFormattedTextRef txform;
-                        if (border_collapse&&j==rows[i]->cells.length()-1) cell->width+=measureBorder(cell->elem,1);
                         int h = cell->elem->renderFinalBlock( txform, &fmt, cell->width - cell->padding_left - cell->padding_right-delta-bsp_h*(100+100/n)/100);
                         cell->height = h + cell->padding_top + cell->padding_bottom+measureBorder(cell->elem,0)+measureBorder(cell->elem,2);
                         fmt.setY( posy +table_padding_top+bsp_v); //cell->padding_top ); //cell->row->y - cell->row->y );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1003,7 +1003,31 @@ bool LVCssDeclaration::parse( const char * &decl )
                 n = parse_name( decl, css_lsp_names, -1 );
                 break;
             case cssd_vertical_align:
-                n = parse_name( decl, css_va_names, -1 );
+                {
+                    css_length_t len;
+                    int n1 = parse_name( decl, css_va_names, -1 );
+                    if (n1 != -1) {
+                        len.type = css_val_unspecified;
+                        len.value = n1;
+                        buf<<(lUInt32) (prop_code | parse_important(decl));
+                        buf<<(lUInt32) len.type;
+                        buf<<(lUInt32) len.value;
+                    }
+                    else {
+                        bool negative = false;
+                        if ( *decl == '-' ) {
+                            decl++;
+                            negative = true;
+                        }
+                        if ( parse_number_value( decl, len ) ) {
+                            if ( negative )
+                                len.value = -len.value;
+                            buf<<(lUInt32) (prop_code | parse_important(decl));
+                            buf<<(lUInt32) len.type;
+                            buf<<(lUInt32) len.value;
+                        }
+                    }
+                }
                 break;
             case cssd_font_family:
                 {
@@ -1856,7 +1880,7 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             style->Apply( (css_page_break_t) *p++, &style->page_break_inside, imp_bit_page_break_inside, is_important );
             break;
         case cssd_vertical_align:
-            style->Apply( (css_vertical_align_t) *p++, &style->vertical_align, imp_bit_vertical_align, is_important );
+            style->Apply( read_length(p), &style->vertical_align, imp_bit_vertical_align, is_important );
             break;
         case cssd_font_family:
             style->Apply( (css_font_family_t) *p++, &style->font_family, imp_bit_font_family, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -56,7 +56,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.letter_spacing.pack()) * 31
          + (lUInt32)rec.list_style_position) * 31
          + (lUInt32)(rec.page_break_before | (rec.page_break_after<<4) | (rec.page_break_inside<<8))) * 31
-         + (lUInt32)rec.vertical_align) * 31
+         + (lUInt32)rec.vertical_align.pack()) * 31
          + (lUInt32)rec.font_size.type) * 31
          + (lUInt32)rec.font_size.value) * 31
          + (lUInt32)rec.font_style) * 31
@@ -297,7 +297,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(text_align_last);   //    css_text_align_t     text_align_last;
     ST_PUT_ENUM(text_decoration);   //    css_text_decoration_t text_decoration;
     ST_PUT_ENUM(text_transform);    //    css_text_transform_t text_transform;
-    ST_PUT_ENUM(vertical_align);    //    css_vertical_align_t vertical_align;
+    ST_PUT_LEN(vertical_align);     //    css_length_t         vertical_align;
     ST_PUT_ENUM(font_family);       //    css_font_family_t    font_family;
     buf << font_name;               //    lString8             font_name;
     ST_PUT_LEN(font_size);          //    css_length_t         font_size;
@@ -348,7 +348,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_text_align_t, text_align_last);         //    css_text_align_t     text_align_last;
     ST_GET_ENUM(css_text_decoration_t, text_decoration);    //    css_text_decoration_t text_decoration;
     ST_GET_ENUM(css_text_transform_t, text_transform);      //    css_text_transform_t text_transform;
-    ST_GET_ENUM(css_vertical_align_t, vertical_align);      //    css_vertical_align_t vertical_align;
+    ST_GET_LEN(vertical_align);                             //    css_length_t         vertical_align;
     ST_GET_ENUM(css_font_family_t, font_family);            //    css_font_family_t    font_family;
     buf >> font_name;                                       //    lString8             font_name;
     ST_GET_LEN(font_size);                                  //    css_length_t         font_size;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -419,6 +419,7 @@ public:
                 m_srcs[pos] = src;
                 m_charindex[pos] = OBJECT_CHAR_INDEX; //0xFFFF;
                 last_non_space_pos = pos;
+                prev_was_space = false;
                 pos++;
             } else {
                 int len = src->t.len;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -902,6 +902,12 @@ public:
         }
 
         src_text_fragment_t * lastSrc = m_srcs[start];
+        // Ignore space at start of line (this rarely happens, as line
+        // splitting discards the space on which a split is made - but it
+        // can happen in other rare wrap cases like lastDeprecatedWrap)
+        if ( (m_flags[start] & LCHAR_IS_SPACE) && !(lastSrc->flags & LTEXT_FLAG_PREFORMATTED) ) {
+            start++;
+        }
         int wstart = start;
         bool lastIsSpace = false;
         bool lastWord = false;
@@ -1388,6 +1394,8 @@ public:
                         lastNormalWrap = i;
                     // We could use lastDeprecatedWrap, but it then get too much real chances to be used:
                     // else lastDeprecatedWrap = i;
+                    // Note that a wrap can happen AFTER a '-' (that has CH_PROP_AVOID_WRAP_AFTER)
+                    // when lastDeprecatedWrap is prefered below.
                 }
                 else if ( i==m_length-1 )
                     lastNormalWrap = i;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.17k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x000C
+#define FORMATTING_VERSION_ID 0x000D
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -3693,7 +3693,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->page_break_inside = css_pb_auto;
     s->list_style_type = css_lst_disc;
     s->list_style_position = css_lsp_outside;
-    s->vertical_align = css_va_baseline;
+    s->vertical_align.type = css_val_unspecified;
+    s->vertical_align.value = css_va_baseline;
     s->font_family = def_font->getFontFamily();
     s->font_size.type = css_val_screen_px; // we use this type, as we got the real font size from FontManager
     s->font_size.value = def_font->getSize();
@@ -13340,7 +13341,8 @@ void runBasicTinyDomUnitTests()
         style1->page_break_before = css_pb_auto;
         style1->page_break_after = css_pb_auto;
         style1->page_break_inside = css_pb_auto;
-        style1->vertical_align = css_va_baseline;
+        style1->vertical_align.type = css_val_unspecified;
+        style1->vertical_align.value = css_va_baseline;
         style1->font_family = css_ff_sans_serif;
         style1->font_size.type = css_val_px;
         style1->font_size.value = 24 << 8;
@@ -13368,7 +13370,8 @@ void runBasicTinyDomUnitTests()
         style2->page_break_before = css_pb_auto;
         style2->page_break_after = css_pb_auto;
         style2->page_break_inside = css_pb_auto;
-        style2->vertical_align = css_va_baseline;
+        style2->vertical_align.type = css_val_unspecified;
+        style2->vertical_align.value = css_va_baseline;
         style2->font_family = css_ff_sans_serif;
         style2->font_size.type = css_val_px;
         style2->font_size.value = 24 << 8;
@@ -13396,7 +13399,8 @@ void runBasicTinyDomUnitTests()
         style3->page_break_before = css_pb_auto;
         style3->page_break_after = css_pb_auto;
         style3->page_break_inside = css_pb_auto;
-        style3->vertical_align = css_va_baseline;
+        style3->vertical_align.type = css_val_unspecified;
+        style3->vertical_align.value = css_va_baseline;
         style3->font_family = css_ff_sans_serif;
         style3->font_size.type = css_val_px;
         style3->font_size.value = 24 << 8;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3545,13 +3545,13 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     *stream << "\n";
             }
         }
-        if ( isInitialNode && cssFiles.length()==0 && WNEFLAG(GET_CSS_FILES) ) {
+        if ( isInitialNode && cssFiles.length()==0 && WNEFLAG(GET_CSS_FILES) && !node->isRoot() ) {
             // We have gathered CSS files as we walked the DOM, which we usually
             // do from the root node if we want CSS files.
             // In case we started from an inner node, and we are requested for
             // CSS files - but we have none - walk the DOM back to gather them.
             ldomNode *pnode = node->getParentNode();
-            for ( ; !pnode->isRoot(); pnode = pnode->getParentNode() ) {
+            for ( ; pnode && !pnode->isNull() && !pnode->isRoot(); pnode = pnode->getParentNode() ) {
                 if ( pnode->getNodeId() == el_DocFragment || pnode->getNodeId() == el_body ) {
                     // The CSS file in StyleSheet="" attribute was the first one seen by
                     // crengine, so add it first to cssFiles


### PR DESCRIPTION
Details in the individual commit messages.

2nd commit fix line-height inheritance when no unit (eg: `line-height: 1.2`) which will suprise people like me who like things condensed, but those people will then just have to use more often the `Ignore publisher line heights` style tweak.
4th commit fixes https://github.com/koreader/koreader/issues/3629#issuecomment-430383477 and other occasional spaces at start of line.

The 6th commit is the main one, and implements full and correct support for `vertical-align:` for text and images (but not for table cells). Previously discussed at https://github.com/koreader/crengine/pull/142#issuecomment-427599008.
This will need a lightening of footnotes detection (any vertical align drift will be a footnote, even if small) in base/cre.cpp.

Useful links:
https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align (not inherited)
https://www.w3.org/TR/CSS2/visudet.html#line-height
https://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align (really excellent)
https://meyerweb.com/eric/css/inline-format.html
https://christopheraue.net/design/vertical-align
http://typedrawers.com/discussion/1399/determining-ex-em-and-en (and x-height)

Some screenshots with [test-vertical-align.zip](https://github.com/koreader/crengine/files/2545919/test-vertical-align.zip)

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965367-b0012e00-e046-11e8-9987-586ce0e9d1a7.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965404-3d448280-e047-11e8-812a-d9cd31b1c6cb.png)</kbd>
Firefox:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965472-1cc8f800-e048-11e8-8126-350aff6b6e12.png)</kbd>

Before / After / Firefox:
(The ² and 8x are non vertical aligned sup and sub chars, just to see how the font consider where its sup and sub position should be)
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965380-d2934700-e046-11e8-8f5a-c658bc8e6ef8.png)</kbd> - <kbd>![image](https://user-images.githubusercontent.com/24273478/47965411-4d5c6200-e047-11e8-9d7d-905b4668efb9.png)</kbd> - <kbd>![image](https://user-images.githubusercontent.com/24273478/47965480-2ce0d780-e048-11e8-96af-46719c3d8ebc.png)</kbd>

Before / After / Firefox:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965388-f6568d00-e046-11e8-9c6a-b8a13afc87d5.png)</kbd><kbd>![image](https://user-images.githubusercontent.com/24273478/47965446-c065d880-e047-11e8-8694-4a63c3628744.png)</kbd><kbd>![image](https://user-images.githubusercontent.com/24273478/47965489-4aae3c80-e048-11e8-86e1-480f4984b715.png)</kbd>

Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965398-12f2c500-e047-11e8-9c0d-46e2eb7150b8.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965423-83014b00-e047-11e8-8db6-9c322aed9c83.png)</kbd>
Firefox:
<kbd>![image](https://user-images.githubusercontent.com/24273478/47965509-7af5db00-e048-11e8-8b0e-fd61bd6c9884.png)</kbd>
(Was hesitant to fix this last one, as I thought I prefered the Before :) but I'm finally OK with After. That is the thing about "strut" that the specs mention. Also, there is no way to get the Before with the use of some style tweaks...)

