### PR TITLE
 Fix CSS class check, and segfault on ignored starting space

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2267,15 +2267,19 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             //CRLog::trace("attr_class: %s %s", LCSTR(val), LCSTR(_value) );
             /*As I have eliminated leading and ending spaces in the attribute value, any space in
              *val means there are more than one classes */
-            int pos = val.pos(_value);
-            if (val.pos(" ") != -1 && pos != -1) {
-                int len = _value.length();
-                if (pos + len == val.length() || //in the end
-                    val.at(pos + len) == L' ')      //in the beginning or in the middle
-                    return true;
-                else
-                    return false;
-        }
+            if (val.pos(" ") != -1) {
+                lString16 value_w_space_after = _value + " ";
+                if (val.pos(value_w_space_after) == 0)
+                    return true; // at start
+                lString16 value_w_space_before = " " + _value;
+                int pos = val.pos(value_w_space_before);
+                if (pos != -1 && pos + value_w_space_before.length() == val.length())
+                    return true; // at end
+                lString16 value_w_spaces_before_after = " " + _value + " ";
+                if (val.pos(value_w_spaces_before_after) != -1)
+                    return true; // in between
+                return false;
+            }
             return val == _value;
         }
         break;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -917,7 +917,13 @@ public:
         // splitting discards the space on which a split is made - but it
         // can happen in other rare wrap cases like lastDeprecatedWrap)
         if ( (m_flags[start] & LCHAR_IS_SPACE) && !(lastSrc->flags & LTEXT_FLAG_PREFORMATTED) ) {
-            start++;
+            // But do it only if we're going to stay in same text node (if not
+            // the space may have some reason - there's sometimes a no-break-space
+            // before an image)
+            if (start < end-1 && m_srcs[start+1] == m_srcs[start]) {
+                start++;
+                lastSrc = m_srcs[start];
+            }
         }
         int wstart = start;
         bool lastIsSpace = false;


### PR DESCRIPTION
First commit fix CSS class name match when multi class names (originally from #72).
With 
```html
<style>
.zabc { color: orange }
.abcz { color: red }
.abc { text-decoration: underline }
</style>
<h1>multi classes matching</h1>
<div>
<span class="abc">underline</span>
<span class="zabc">none</span>
<span class="abcz">none</span>
<span class="abc vvv">underline</span>
<span class="zabc vvv ">none</span>
<span class="abcz vvv">none</span>
<span class="uuu abc">underline</span>
<span class="uuu zabc ">none</span>
<span class="uuu abcz">none</span>
<span class="uuu abc vvv">underline</span>
<span class="uuu zabc vvv ">none</span>
<span class="uuu abcz vvv">none</span>
<br/>
</div>
```
Before (some orange `none` shouldn't be underline):
<kbd>![bad](https://user-images.githubusercontent.com/24273478/48304271-55207880-e517-11e8-8e16-2afd5eaf82cf.png)</kbd>
After:
<kbd>![good](https://user-images.githubusercontent.com/24273478/48304273-56ea3c00-e517-11e8-8952-fcd02bf0bf9c.png)</kbd>

Second commit fix https://github.com/koreader/koreader/issues/4322, which was caused by https://github.com/koreader/crengine/commit/5699fc2713adcf52e2c584bf7403463687519493 (from #240).
The cause was this nobrspace before the image:
<kbd>![segfault](https://user-images.githubusercontent.com/24273478/48304299-be07f080-e517-11e8-8ee1-9e9ab96b1533.png)</kbd>
Because `lastSrc = m_srcs[start];` was missing and it wasn't updated (which was fine when we stay in the same text node), I guess it was trying to make a word (so get the element `font->getHeight()`) on an element that was skipped or with an empty text.

Also prevent skipping the above space when it's the last thing before another elements, as it may have some purpose (I don't see which in the HTML above... but I assume that if the publisher put one, it was for a reason). My previous test cases for fixing this starting space still work after this.