### PR TITLE
Fix some compile warnings (from upstream)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(MSVC)
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   # Update if necessary
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -std=c++11 -fPIC -Wno-misleading-indentation")
 endif()
 
 if (NOT DEFINED GUI)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -705,7 +705,7 @@ public:
     void destroy();
 
     /// returns true for invalid/deleted node ot NULL this pointer
-    inline bool isNull() const { return this == NULL || _handle._dataIndex==0; }
+    inline bool isNull() const { return _handle._dataIndex==0; }
     /// returns true if node is stored in persistent storage
     inline bool isPersistent() const { return (_handle._dataIndex&2)!=0; }
     /// returns data index of node's registration in document data storage
@@ -1197,6 +1197,7 @@ class ldomDocument;
 class ldomXPointer
 {
 protected:
+	friend class ldomXPointerEx;
 	struct XPointerData {
 	protected:
 		ldomDocument * _doc;
@@ -1205,7 +1206,7 @@ protected:
 		int _refCount;
 	public:
 		inline void addRef() { _refCount++; }
-		inline void release() { if ( (--_refCount)==0 ) delete this; }
+		inline int decRef() { return --_refCount; }
 		// create empty
 		XPointerData() : _doc(NULL), _dataIndex(0), _offset(0), _refCount(1) { }
 		// create instance
@@ -1243,6 +1244,7 @@ protected:
         inline void addOffset( int offset ) { _offset+=offset; }
         ~XPointerData() { }
 	};
+	XPointerData * _data;
 	/// node pointer
     //ldomNode * _node;
 	/// offset within node for pointer, -1 for xpath
@@ -1253,9 +1255,13 @@ protected:
 	{
 	}
 public:
-	XPointerData * _data;
     /// clear pointer (make null)
-    void clear() { *this = ldomXPointer(); }
+    void clear()
+    {
+        if (_data->decRef() == 0)
+            delete _data;
+        _data = new XPointerData();
+    }
     /// return document
 	inline ldomDocument * getDocument() { return _data->getDocument(); }
     /// returns node pointer
@@ -1278,7 +1284,11 @@ public:
 	{
 	}
 	/// remove reference
-	~ldomXPointer() { _data->release(); }
+	~ldomXPointer()
+	{
+		if (_data->decRef() == 0)
+			delete _data;
+	}
     /// copy constructor
 	ldomXPointer( const ldomXPointer& v )
 		: _data(v._data)
@@ -1290,10 +1300,11 @@ public:
 	{
 		if ( _data==v._data )
 			return *this;
-		_data->release();
+		if (_data->decRef() == 0)
+			delete _data;
 		_data = v._data;
 		_data->addRef();
-        return *this;
+		return *this;
 	}
     /// constructor
     ldomXPointer( ldomNode * node, int offset )
@@ -1311,7 +1322,7 @@ public:
     /// returns true for NULL pointer
 	bool isNull() const
 	{
-        return !this || !_data || _data->isNull();
+        return !_data || _data->isNull();
 	}
     /// returns true if object is pointer
 	bool isPointer() const
@@ -1420,7 +1431,8 @@ public:
     {
 		if ( _data==v._data )
 			return *this;
-		_data->release();
+		if (_data->decRef() == 0)
+			delete _data;
 		_data = new XPointerData( *v._data );
         initIndex();
         return *this;
@@ -1430,7 +1442,8 @@ public:
     {
 		if ( _data==v._data )
 			return *this;
-		_data->release();
+		if (_data->decRef() == 0)
+			delete _data;
 		_data = new XPointerData( *v._data );
         _level = v._level;
         for ( int i=0; i<_level; i++ )

--- a/crengine/src/crgui.cpp
+++ b/crengine/src/crgui.cpp
@@ -471,7 +471,7 @@ void CRGUIWindowManager::showWaitIcon( lString16 filename, int progressPercent )
 /// draws icon at center of screen, with optional progress gauge
 void CRGUIWindowManager::showProgress( lString16 filename, int progressPercent )
 {
-    time_t t = (time_t)time((time_t)0);
+    time_t t = (time_t)time((time_t*)0);
     if ( t<_lastProgressUpdate+PROGRESS_UPDATE_INTERVAL || progressPercent==_lastProgressPercent )
         return;
     showWaitIcon( filename, progressPercent );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -932,7 +932,10 @@ LVStreamRef LVDocView::getCoverPageImageStream() {
 	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
 			el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
-	ldomNode * cover_el = m_doc->getRootNode()->findChildElement(path);
+	ldomNode * rootNode = m_doc->getRootNode();
+	ldomNode * cover_el = 0;
+	if (rootNode)
+		cover_el = rootNode->findChildElement(path);
 	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
 
 	if (cover_el) {
@@ -956,7 +959,10 @@ LVImageSourceRef LVDocView::getCoverPageImage() {
 	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
 			el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
-	ldomNode * cover_el = m_doc->getRootNode()->findChildElement(path);
+	ldomNode * cover_el = 0;
+	ldomNode * rootNode = m_doc->getRootNode();
+	if (rootNode)
+		cover_el = rootNode->findChildElement(path);
 	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
 
 	if (cover_el) {
@@ -2375,7 +2381,9 @@ LVImageSourceRef LVDocView::getImageByPoint(lvPoint pt) {
     if (ptr.isNull())
         return res;
     //CRLog::debug("node: %s", LCSTR(ptr.toString()));
-    res = ptr.getNode()->getObjectImageSource();
+    ldomNode* node = ptr.getNode();
+    if (node)
+        res = node->getObjectImageSource();
     if (!res.isNull())
         CRLog::debug("getImageByPoint(%d, %d) : found image %d x %d", pt.x, pt.y, res->GetWidth(), res->GetHeight());
     return res;
@@ -4371,7 +4379,10 @@ bool LVDocView::ParseDocument() {
 
 		if (m_doc_format == doc_format_html) {
 			static lUInt16 path[] = { el_html, el_head, el_title, 0 };
-			ldomNode * el = m_doc->getRootNode()->findChildElement(path);
+			ldomNode * el = NULL;
+			ldomNode * rootNode = m_doc->getRootNode();
+			if (rootNode)
+				el = rootNode->findChildElement(path);
 			if (el != NULL) {
                 lString16 s = el->getText(L' ', 1024);
 				if (!s.empty()) {

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -733,6 +733,8 @@ lUInt32 LVGrayDrawBuf::GetPixel( int x, int y )
 
 void LVGrayDrawBuf::Clear( lUInt32 color )
 {
+    if (!_data)
+        return;
     color = rgbToGrayMask( color, _bpp );
 #if (GRAY_INVERSE==1)
     color ^= 0xFF;

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -2938,7 +2938,7 @@ public:
 	}
 	virtual lverror_t Write( const void * buf, lvsize_t count, lvsize_t * nBytesWritten )
 	{
-		if (!m_pBuffer || m_mode==LVOM_READ )
+		if (!m_pBuffer || !buf || m_mode==LVOM_READ )
 			return LVERR_FAIL;
 		SetBufSize( m_pos+count ); // check buf size
 		int bytes_avail = (int)(m_bufsize-m_pos);

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2173,7 +2173,7 @@ lUInt32 LVCssSelectorRule::getWeight() {
 
 bool LVCssSelectorRule::check( const ldomNode * & node )
 {
-    if (node->isNull() || node->isRoot())
+    if (!node || node->isNull() || node->isRoot())
         return false;
     // For most checks, while navigating nodes, we must ignore sibling text nodes.
     // We also ignore <autoBoxing> (crengine internal block element, inserted
@@ -2190,7 +2190,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             node = node->getParentNode();
             while (node && !node->isNull() && node->getNodeId() == el_autoBoxing)
                 node = node->getParentNode();
-            if (node->isNull())
+            if (!node || node->isNull())
                 return false;
             // If _id=0, we are the parent and we match
             if (!_id || node->getNodeId() == _id)
@@ -2205,9 +2205,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             {
                 node = node->getParentNode();
 		// prevent segfault due to undefined memory address on Ubuntu 17.10 (due to gcc 7.2.0?)
-                if (!node)
-                    return false;
-                if (node->isNull())
+                if (!node || node->isNull())
                     return false;
                 if (node->getNodeId() == el_autoBoxing)
                     continue;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -260,6 +260,10 @@ void LFormattedText::AddSourceObject(
      )
 {
     ldomNode * node = (ldomNode*)object;
+    if (!node || node->isNull()) {
+        TR("LFormattedText::AddSourceObject(): node is NULL!");
+        return;
+    }
     LVImageSourceRef img = node->getObjectImageSource();
     if ( img.isNull() )
         img = LVCreateDummyImageSource( node, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
@@ -1895,13 +1899,15 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 {
                     srcline = &m_pbuffer->srctext[word->src_text_index];
                     ldomNode * node = (ldomNode *) srcline->object;
-                    LVImageSourceRef img = node->getObjectImageSource();
-                    if ( img.isNull() )
-                        img = LVCreateDummyImageSource( node, word->width, word->o.height );
-                    int xx = x + frmline->x + word->x;
-                    int yy = line_y + frmline->baseline - word->o.height + word->y;
-                    buf->Draw( img, xx, yy, word->width, word->o.height );
-                    //buf->FillRect( xx, yy, xx+word->width, yy+word->height, 1 );
+                    if (node) {
+                        LVImageSourceRef img = node->getObjectImageSource();
+                        if ( img.isNull() )
+                            img = LVCreateDummyImageSource( node, word->width, word->o.height );
+                        int xx = x + frmline->x + word->x;
+                        int yy = line_y + frmline->baseline - word->o.height + word->y;
+                        buf->Draw( img, xx, yy, word->width, word->o.height );
+                        //buf->FillRect( xx, yy, xx+word->width, yy+word->height, 1 );
+                    }
                 }
                 else
                 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2682,7 +2682,7 @@ void ldomTextStorageChunk::modified()
 void ldomTextStorageChunk::freeNode( int offset )
 {
     offset <<= 4;
-    if ( offset>=0 && offset<(int)_bufpos ) {
+    if ( _buf && offset>=0 && offset<(int)_bufpos ) {
         TextDataStorageItem * item = (TextDataStorageItem *)(_buf+offset);
         if ( (item->type==LXML_TEXT_NODE || item->type==LXML_ELEMENT_NODE) && item->dataIndex ) {
             item->type = LXML_NO_DATA;
@@ -2696,7 +2696,7 @@ void ldomTextStorageChunk::freeNode( int offset )
 lString8 ldomTextStorageChunk::getText( int offset )
 {
     offset <<= 4;
-    if ( offset>=0 && offset<(int)_bufpos ) {
+    if ( _buf && offset>=0 && offset<(int)_bufpos ) {
         TextDataStorageItem * item = (TextDataStorageItem *)(_buf+offset);
         return item->getText8();
     }
@@ -6027,7 +6027,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended) const
 ldomXPointer ldomDocument::createXPointer( ldomNode * baseNode, const lString16 & xPointerStr )
 {
     //CRLog::trace( "ldomDocument::createXPointer(%s)", UnicodeToUtf8(xPointerStr).c_str() );
-    if ( xPointerStr.empty() )
+    if ( xPointerStr.empty() || !baseNode )
         return ldomXPointer();
     const lChar16 * str = xPointerStr.c_str();
     int index = -1;
@@ -12482,7 +12482,7 @@ ldomNode * ldomNode::findChildElement( lUInt16 nsid, lUInt16 id, int index )
 ldomNode * ldomNode::findChildElement( lUInt16 idPath[] )
 {
     ASSERT_NODE_NOT_NULL;
-    if ( !this || !isElement() )
+    if ( !isElement() )
         return NULL;
     ldomNode * elem = this;
     for ( int i=0; idPath[i]; i++ ) {
@@ -12689,7 +12689,7 @@ public:
 /// returns object image ref name
 lString16 ldomNode::getObjectImageRefName()
 {
-    if ( !this || !isElement() )
+    if (!isElement())
         return lString16::empty_str;
     //printf("ldomElement::getObjectImageSource() ... ");
     const css_elem_def_props_t * et = getDocument()->getElementTypePtr(getNodeId());

--- a/thirdparty/antiword/fail.c
+++ b/thirdparty/antiword/fail.c
@@ -11,7 +11,7 @@
 
 #if !defined(NDEBUG)
 void
-__fail(char *szExpression, char *szFilename, int iLineNumber)
+__fail(const char *szExpression, const char *szFilename, int iLineNumber)
 {
 	if (szExpression == NULL || szFilename == NULL) {
 		werr(1, "Internal error: no expression");

--- a/thirdparty/antiword/fail.h
+++ b/thirdparty/antiword/fail.h
@@ -17,6 +17,6 @@
 #define fail(e)	((e) ? __fail(#e, __FILE__, __LINE__) : (void)0)
 #endif /* NDEBUG */
 
-extern void	__fail(char *, char *, int);
+extern void	__fail(const char *, const char *, int);
 
 #endif /* __fail_h */


### PR DESCRIPTION
Includes most of the first commit mentionned in #242.
~~Also fixed some other compiler warning introduced by my recent changes.~~ moved into #245

Still to be tested by me on my device, just pushing this to see its effect on CI output. edit: looks OK.

No real idea if we should keep or not the addition to gcc flags: `-std=c++11 -fPIC -Wno-misleading-indentation`. Pinging @NiLuJe for opinion.
(I don't think we have any misleading indentation warning - may be that was for some other part of coolreader code like cr3qt - so, we could probably remove it)