### PR TITLE
Fix rendering issue when line ends with an image

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4765,10 +4765,10 @@ void LVDocView::getCurrentPageLinks(ldomXRangeList & list) {
 		// search for links
 		class LinkKeeper: public ldomNodeCallback {
 			ldomXRangeList &_list;
-			bool check_first_text_node_parents_done = false;
+			bool check_first_text_node_parents_done;
 		public:
-			LinkKeeper(ldomXRangeList & list) :
-				_list(list) {
+			LinkKeeper(ldomXRangeList & list) : _list(list) {
+				check_first_text_node_parents_done = false;
 			}
 			/// called for each found text fragment in range
 			virtual void onText(ldomXRange * r) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -310,6 +310,7 @@ public:
                 //CRLog::trace("LookupElem[%d] (%s, %d) %d", i, LCSTR(item->getNodeName()), state, (int)item->getRendMethod() );
                 switch ( rendMethod ) {
                 case erm_invisible:  // invisible: don't render
+                case erm_killed:     // no room to render element
                     // do nothing: invisible
                     break;
                 case erm_table:      // table element: render as table

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1441,15 +1441,16 @@ public:
                     break;
                 }
                 bool grabbedExceedingSpace = false;
-                if ( x + m_widths[i]-w0 > maxWidth + spaceReduceWidth - firstCharMargin)
+                if ( x + m_widths[i]-w0 > maxWidth + spaceReduceWidth - firstCharMargin) {
                     // It's possible the char at i is a space whose width exceeds maxWidth,
                     // but it should be a candidate for lastNormalWrap (otherwise, the
                     // previous word will be hyphenated and we will get spaces widen for
                     // text justification)
-                    if ( flags & LCHAR_ALLOW_WRAP_AFTER ) // don't break yet
+                    if ( (flags & LCHAR_ALLOW_WRAP_AFTER) && !(flags & LCHAR_IS_OBJECT) ) // don't break yet
                         grabbedExceedingSpace = true;
                     else
                         break;
+                }
                 // Note: upstream has added in:
                 //   https://github.com/buggins/coolreader/commit/e2a1cf3306b6b083467d77d99dad751dc3aa07d9
                 // to the next if:


### PR DESCRIPTION
Fix rendering degradation noticed in https://github.com/koreader/crengine/pull/243#issuecomment-445024150 and introduced by 6eb2b447 in lvtextfm.cpp:
an image is also LCHAR_ALLOW_WRAP_AFTER, so ignore LCHAR_IS_OBJECT in the added check.
Also fix 3 unrelated compiler warnings (moved from #244 to this PR as one overlaps with this fix).