### PR TITLE
Fix max image height, hide <epub:case> in <epub:switch>

### DIFF
--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -123,6 +123,10 @@ XS_TAG1I( strong )
 XS_TAG1I( sub )
 XS_TAG1I( sup )
 
+// EPUB3 elements (in ns_epub - otherwise set to inline like any unknown element)
+XS_TAG1I( switch )  // <epub:switch>
+XS_TAG1I( case )    // <epub:case required-namespace="...">
+XS_TAG1I( default ) // <epub:default>
 
 // FB2 elements
 XS_TAG1( FictionBook )
@@ -227,6 +231,7 @@ XS_NS( xsi )
 XS_NS( xmlns )
 XS_NS( xlink )
 XS_NS( xs )
+XS_NS( epub )
 
 XS_END_NS
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -884,6 +884,8 @@ public:
     lString16 getObjectImageRefName();
     /// returns object image stream
     LVStreamRef getObjectImageStream();
+    /// returns the sum of this node and its parents' top and bottom margins, borders and paddings
+    int getSurroundingAddedHeight();
     /// formats final block
     int renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor * fmt, int width );
     /// formats final block again after change, returns true if size of block is changed

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4048,6 +4048,21 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
 
+    if (enode->getNodeNsId() == ns_epub) {
+        if (enode->getNodeId() == el_case) { // <epub:case required-namespace="...">
+            // As we don't support any specific namespace (like MathML, SVG...), just
+            // hide <epub:case> content - it must be followed by a <epub:default>
+            // section with usually regular content like some image.
+            ldomNode * parent = enode->getParentNode();
+            if (parent && parent->getNodeNsId() == ns_epub && parent->getNodeId() == el_switch) {
+                // (We can't here check parent's other children for the presence of one
+                // el_default, as we can be called while XML is being parsed and the DOM
+                // built and siblings not yet there, so just trust there is an el_default.)
+                pstyle->display = css_d_none;
+            }
+        }
+    }
+
     // not used (could be used for 'rem', but we have it in gRootFontSize)
     // int baseFontSize = enode->getDocument()->getDefaultFont()->getSize();
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -62,7 +62,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.18k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.19k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x000D
 


### PR DESCRIPTION
#### Fix max image height to prevent spurious page breaks

Images are enforced a max height, which was the page height.
To prevent any uneeded page break before or after a big image (originally or scaled by CSS), we should additionally take into account the image container margins/borders/padding, and the space below added by the recently enforced strut (Some details in https://github.com/koreader/koreader/pull/4378#issuecomment-444771941)
Could happen with a cover page set like:
`<div><p style="margin-top: 20px"><img src="" style="height: 100%"/></p></div>`

(Before https://github.com/koreader/crengine/commit/08adb23425350ff02ace9cec3280d68e9f0d75bb, a first page bigger than page-height was simply truncated, and the bottom part just lost. https://github.com/koreader/crengine/commit/08adb23425350ff02ace9cec3280d68e9f0d75bb fixed that, but then, cover pages may be splitted into multiple pages. This commit fixes that by ensuring the whole image and surrounding space fit in page-height.)

#### Hide `<epub:case>` in `<epub:switch>`, show only `<epub:default>`

This EPUB3 feature provides alternative content for engines that support their namespace. Details in https://github.com/koreader/koreader/issues/4381#issuecomment-444995517, [specs](http://www.idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-epub-case).
As we don't currently support any, just set them to `display:none` so that only the `<epub:default>` content is shown (usually, an image).
The curious person (who will now possibly not know there is a `<epub:switch>` with a hidden `<epub:case>`) will be able to toggle that alternate content with a style tweak:
<kbd>![image](https://user-images.githubusercontent.com/24273478/49689489-3ddaa800-fb22-11e8-9eaa-60d07d2fc9fa.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/49689516-81cdad00-fb22-11e8-92d2-20fca11f989e.png)</kbd>


