### PR TITLE
Tables rendering: tweak column widths algorithm

### DIFF
--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -241,9 +241,9 @@ class LVRendLineInfo {
     friend struct PageSplitState;
     LVFootNoteList * links; // 4 bytes
     int start;              // 4 bytes
-    lInt16 height;          // 2 bytes
+    int height;             // 4 bytes (we may get extra tall lines with tables TR)
 public:
-    lInt16 flags;           // 2 bytes
+    lUInt16 flags;          // 2 bytes
     int getSplitBefore() const { return (flags>>RN_SPLIT_BEFORE)&7; }
     int getSplitAfter() const { return (flags>>RN_SPLIT_AFTER)&7; }
 /*
@@ -273,7 +273,7 @@ public:
 
     LVRendLineInfo() : links(NULL), start(-1), height(0), flags(0) { }
     LVRendLineInfo( int line_start, int line_end, lUInt16 line_flags )
-    : links(NULL), start(line_start), height((lUInt16)(line_end-line_start)), flags(line_flags)
+    : links(NULL), start(line_start), height(line_end-line_start), flags(line_flags)
     {
     }
     LVFootNoteList * getLinks() { return links; }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.19k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x000D
+#define FORMATTING_VERSION_ID 0x000E
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
#### Tables rendering: tweak column widths algorithm 

By using the mean of the cells's max_content_width instead of the max, so that a single large cell among many smaller cells doesn't request all the width for this column (which would give less to others, which could make them use more height). This should help getting more reasonable heights across all rows.
May help avoiding some less optimal column width choices as noticed with CJK in https://github.com/koreader/crengine/pull/243#issuecomment-443756622 and with symbol fonts in https://github.com/koreader/crengine/pull/243#issuecomment-445265737

There are some cases when this change make things worse, but I think there are more cases where it make things better, and it makes these far better than it makes the others worse with my test samples.

Before:
<kbd>![test_before](https://user-images.githubusercontent.com/24273478/50044818-b7761700-0089-11e9-88e8-0cdc9526f64e.png)</kbd>
After:
<kbd>![test_after](https://user-images.githubusercontent.com/24273478/50044820-ba710780-0089-11e9-9cb7-bf6e50825424.png)</kbd>
(The portuguese words list 2 symbols now on the same line actually may not happen with bigger font sizes.)

Before:
<kbd>![key1_before](https://user-images.githubusercontent.com/24273478/50044823-c2c94280-0089-11e9-8e4f-f14e9e185abd.png)</kbd>
After:
<kbd>![key1_after](https://user-images.githubusercontent.com/24273478/50044826-c5c43300-0089-11e9-9e77-8e8f894f44e0.png)</kbd>



#### Page splitting: fix possible missing blocks again 
Fix signed integer overflow that could make a huge table row (h > 32768 px) disappear from pages view.

Before (with a big font size with [China.EN.epub](https://en.wikipedia.org/wiki/China) which has a huge single table at its end):
```
PS: ========= ADDING PAGE 473: 254036 > 254583 h=547
PS:           new current page 254583>254623 h=40
PS: Adding line 254623>254663 h=40, flags=<0|0>   to current page 254583>254623 h=40
PS:   fit, split allowed
PS: Adding line 254663>254703 h=40, flags=<0|0>   to current page 254583>254663 h=80
PS:   fit, split allowed
PS: Adding line 254703>254743 h=40, flags=<0|0>   to current page 254583>254703 h=120
PS:   fit, split allowed
PS: Adding line 254743>254746 h=3, flags=<0|0>   to current page 254583>254743 h=160
PS:   fit, split allowed
PS: Adding line 254746>254749 h=3, flags=<0|0>   to current page 254583>254746 h=163
PS:   fit, split allowed
PS: Adding line 254749>254749 h=0, flags=<1|1>   to current page 254583>254749 h=166
PS:   fit, split to avoid
PS: Adding line 254749>254825 h=76, flags=<1|1>   to current page 254583>254749 h=166
PS:   fit, split to avoid
PS: Adding line 254825>234161 h=-20664, flags=<1|1>   to current page 254583>254825 h=242
PS:   fit, split to avoid
PS: Adding line 299697>299697 h=0, flags=<1|1>   to current page 254583>234161 h=-20422
PS:   does not fit but split avoid
PS: ========= ADDING PAGE 474: 254583 > 254746 h=163
PS:           new current page 254746>234161 h=-20585        <=== negative height, huge table row lost
PS:   does not fit but split can't be avoided
PS: ========= ADDING PAGE 475: 254746 > 234161 h=-20585
PS:           new current page 299697>299697 h=0
PS: Adding line 299697>299700 h=3, flags=<1|0>   to current page 299697>299697 h=0
PS:   fit, split to avoid
PS: Adding line 299700>299703 h=3, flags=<0|0>   to current page 299697>299700 h=3
PS:   fit, split allowed
PS: Adding line 299703>299743 h=40, flags=<0|0>   to current page 299697>299703 h=6
PS:   fit, split allowed
PS: Adding line 299743>299746 h=3, flags=<0|0>   to current page 299697>299743 h=46
PS:   fit, split allowed
PS: Adding line 299746>299749 h=3, flags=<0|0>   to current page 299697>299746 h=49
PS:   fit, split allowed
PS: Adding line 299749>299749 h=0, flags=<1|1>   to current page 299697>299749 h=52
PS:   fit, split to avoid
PS: Adding line 299749>299966 h=217, flags=<1|1>   to current page 299697>299749 h=52
PS:   fit, split to avoid
PS: Adding line 299966>299966 h=0, flags=<1|1>   to current page 299697>299966 h=269
PS:   fit, split to avoid
PS: Adding line 299966>299969 h=3, flags=<1|0>   to current page 299697>299966 h=269
PS:   fit, split to avoid
PS: Adding line 299969>299972 h=3, flags=<0|0>   to current page 299697>299969 h=272
PS:   fit, split allowed
PS: Adding line 0>0 h=0, flags=<2|0>   to current page 299697>299972 h=275
PS:   BACKWARD, IGNORED
PS: ========= ADDING PAGE 476: 299697 > 299972 h=275
```
After:
```
PS: ========= ADDING PAGE 473: 254036 > 254583 h=547
PS:           new current page 254583>254623 h=40
PS: Adding line 254623>254663 h=40, flags=<0|0>   to current page 254583>254623 h=40
PS:   fit, split allowed
PS: Adding line 254663>254703 h=40, flags=<0|0>   to current page 254583>254663 h=80
PS:   fit, split allowed
PS: Adding line 254703>254743 h=40, flags=<0|0>   to current page 254583>254703 h=120
PS:   fit, split allowed
PS: Adding line 254743>254746 h=3, flags=<0|0>   to current page 254583>254743 h=160
PS:   fit, split allowed
PS: Adding line 254746>254749 h=3, flags=<0|0>   to current page 254583>254746 h=163
PS:   fit, split allowed
PS: Adding line 254749>254749 h=0, flags=<1|1>   to current page 254583>254749 h=166
PS:   fit, split to avoid
PS: Adding line 254749>254825 h=76, flags=<1|1>   to current page 254583>254749 h=166
PS:   fit, split to avoid
PS: Adding line 254825>299697 h=44872, flags=<1|1>   to current page 254583>254825 h=242
PS:   does not fit but split avoid
PS: ========= ADDING PAGE 474: 254583 > 254746 h=163
PS:           new current page 254746>254825 h=79
PS:   does not fit but split can't be avoided
PS: ========= ADDING PAGE 475: 254746 > 254825 h=79
PS:           new current page 254825>299697 h=44872      <== = positive height, huge table row splitted into pages
PS:     line overflows page: 44872 > 578
PS: ==== SPLITTED AS PAGE 476: 254825 > 255403 h=578
PS: ==== SPLITTED AS PAGE 477: 255403 > 255981 h=578
PS: ==== SPLITTED AS PAGE 478: 255981 > 256559 h=578
PS: ==== SPLITTED AS PAGE 479: 256559 > 257137 h=578
PS: ==== SPLITTED AS PAGE 480: 257137 > 257715 h=578
PS: ==== SPLITTED AS PAGE 481: 257715 > 258293 h=578
PS: ==== SPLITTED AS PAGE 482: 258293 > 258871 h=578
PS: ==== SPLITTED AS PAGE 483: 258871 > 259449 h=578
PS: ==== SPLITTED AS PAGE 484: 259449 > 260027 h=578
PS: ==== SPLITTED AS PAGE 485: 260027 > 260605 h=578
PS: ==== SPLITTED AS PAGE 486: 260605 > 261183 h=578
PS: ==== SPLITTED AS PAGE 487: 261183 > 261761 h=578
PS: ==== SPLITTED AS PAGE 488: 261761 > 262339 h=578
PS: ==== SPLITTED AS PAGE 489: 262339 > 262917 h=578
PS: ==== SPLITTED AS PAGE 490: 262917 > 263495 h=578
PS: ==== SPLITTED AS PAGE 491: 263495 > 264073 h=578
[...]
PS: ==== SPLITTED AS PAGE 548: 296441 > 297019 h=578
PS: ==== SPLITTED AS PAGE 549: 297019 > 297597 h=578
PS: ==== SPLITTED AS PAGE 550: 297597 > 298175 h=578
PS: ==== SPLITTED AS PAGE 551: 298175 > 298753 h=578
PS: ==== SPLITTED AS PAGE 552: 298753 > 299331 h=578
PS:           new current page 299331>299697 h=366
PS: Adding line 299697>299697 h=0, flags=<1|1>   to current page 299331>299697 h=366
PS:   fit, split to avoid
PS: Adding line 299697>299700 h=3, flags=<1|0>   to current page 299331>299697 h=366
PS:   fit, split to avoid
PS: Adding line 299700>299703 h=3, flags=<0|0>   to current page 299331>299700 h=369
PS:   fit, split allowed
PS: Adding line 299703>299743 h=40, flags=<0|0>   to current page 299331>299703 h=372
PS:   fit, split allowed
PS: Adding line 299743>299746 h=3, flags=<0|0>   to current page 299331>299743 h=412
PS:   fit, split allowed
PS: Adding line 299746>299749 h=3, flags=<0|0>   to current page 299331>299746 h=415
PS:   fit, split allowed
PS: Adding line 299749>299749 h=0, flags=<1|1>   to current page 299331>299749 h=418
PS:   fit, split to avoid
PS: Adding line 299749>299966 h=217, flags=<1|1>   to current page 299331>299749 h=418
PS:   does not fit but split avoid
PS: ========= ADDING PAGE 553: 299331 > 299746 h=415
PS:           new current page 299746>299749 h=3
PS:   fit, split to avoid
PS: Adding line 299966>299966 h=0, flags=<1|1>   to current page 299746>299966 h=220
PS:   fit, split to avoid
PS: Adding line 299966>299969 h=3, flags=<1|0>   to current page 299746>299966 h=220
PS:   fit, split to avoid
PS: Adding line 299969>299972 h=3, flags=<0|0>   to current page 299746>299969 h=223
PS:   fit, split allowed
PS: Adding line 0>0 h=0, flags=<2|0>   to current page 299746>299972 h=226
PS:   BACKWARD, IGNORED
PS: ========= ADDING PAGE 554: 299746 > 299972 h=226
```


