### PR TITLE
Adds support for a private CSS property "-cr-hint:"

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -245,6 +245,25 @@ enum css_generic_value_t {
     css_generic_auto = -1 // for (css_val_unspecified, css_value_auto), for "margin: auto"
 };
 
+// Non standard property for providing hints to crengine via style tweaks
+// (see src/lvstsheet.cpp css_cr_hint_names[]= for explanations)
+enum css_cr_hint_t {
+    css_cr_hint_inherit,
+    css_cr_hint_none,
+    css_cr_hint_noteref,
+    css_cr_hint_noteref_ignore,
+    css_cr_hint_footnote,
+    css_cr_hint_footnote_ignore,
+    css_cr_hint_footnote_inpage,
+    css_cr_hint_toc_level1,
+    css_cr_hint_toc_level2,
+    css_cr_hint_toc_level3,
+    css_cr_hint_toc_level4,
+    css_cr_hint_toc_level5,
+    css_cr_hint_toc_level6,
+    css_cr_hint_toc_ignore
+};
+
 /// css length value
 typedef struct css_length_tag {
     css_value_type_t type;  ///< type of value

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -67,6 +67,6 @@ int scaleForRenderDPI( int value );
 #define DEF_RENDER_SCALE_FONT_WITH_DPI 0
 extern int gRenderDPI;
 extern bool gRenderScaleFontWithDPI;
-extern int gRootFontSize;;
+extern int gRootFontSize;
 
 #endif

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -75,7 +75,8 @@ enum css_style_rec_important_bit {
     imp_bit_background_position   = 1ULL << 48,
     imp_bit_border_collapse       = 1ULL << 49,
     imp_bit_border_spacing_h      = 1ULL << 50,
-    imp_bit_border_spacing_v      = 1ULL << 51
+    imp_bit_border_spacing_v      = 1ULL << 51,
+    imp_bit_cr_hint               = 1ULL << 52
 };
 
 /**
@@ -87,8 +88,8 @@ typedef struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
     lUInt64              important; // bitmap for !important (used only by LVCssDeclaration)
-                                    // we have currently below 52 css properties
-                                    // lvstsheet knows about 67, which are mapped to these 52
+                                    // we have currently below 53 css properties
+                                    // lvstsheet knows about 68, which are mapped to these 52
                                     // update bits above if you add new properties below
     css_display_t        display;
     css_white_space_t    white_space;
@@ -129,6 +130,7 @@ typedef struct css_style_rec_tag {
     css_background_position_value_t background_position;
     css_border_collapse_value_t border_collapse;
     css_length_t border_spacing[2];//first horizontal and the second vertical spacing
+    css_cr_hint_t          cr_hint;
     css_style_rec_tag()
     : refCount(0)
     , hash(0)
@@ -165,6 +167,7 @@ typedef struct css_style_rec_tag {
     , background_attachment(css_background_a_none)
     , background_position(css_background_p_none)
     , border_collapse(css_border_seperate)
+    , cr_hint(css_cr_hint_none)
     {
         // css_length_t fields are initialized by css_length_tag()
         // to (css_val_screen_px, 0)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -771,6 +771,9 @@ public:
     /// returns true if element node has attribute with specified name id
     inline bool hasAttribute( lUInt16 id ) const  { return hasAttribute( LXML_NS_ANY, id ); }
 
+    /// returns attribute value by attribute name id, looking at children if needed
+    const lString16 & getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const;
+    const lString16 & getFirstInnerAttributeValue( lUInt16 id ) const { return getFirstInnerAttributeValue( LXML_NS_ANY, id ); };
 
     /// returns element type structure pointer if it was set in document for this element name
     const css_elem_def_props_t * getElementTypePtr();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4577,7 +4577,20 @@ ldomXPointer LVDocView::getBookmark() {
 					ptr = m_doc->createXPointer(lvPoint(0, page->start));
 			}
 		} else {
-			ptr = m_doc->createXPointer(lvPoint(0, _pos));
+			// ptr = m_doc->createXPointer(lvPoint(0, _pos));
+			// In scroll mode, the y position may not resolve to any xpointer
+			// (because of margins, empty elements...)
+			// When inside an image (top of page being the middle of an image),
+			// we get the top of the image, and when restoring this position,
+			// we'll have the top of the image at the top of the page, so
+			// scrolling a bit up.
+			// Let's do the same in that case: get the previous text node
+			// position
+			for (int y = _pos; y >= 0; y--) {
+				ptr = m_doc->createXPointer(lvPoint(0, y));
+				if (!ptr.isNull())
+					break;
+			}
 		}
 	}
 	return ptr;

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -126,7 +126,10 @@ void LVRendPageContext::AddLine( int starty, int endy, int flags )
     }
 }
 
-#define FOOTNOTE_MARGIN 12
+// We use 1.0rem (1x root font size) as the footnote margin (vertical margin
+// between text and first foornote)
+#define FOOTNOTE_MARGIN_REM 1
+extern int gRootFontSize;
 
 // helper class
 struct PageSplitState {
@@ -255,7 +258,7 @@ public:
             h += line->getEnd() - pagestart->getStart();
         int footh = 0 /*currentFootnoteHeight()*/ + footheight;
         if ( footh )
-            h += FOOTNOTE_MARGIN + footh;
+            h += FOOTNOTE_MARGIN_REM*gRootFontSize + footh;
         return h;
     }
     void SplitLineIfOverflowPage( LVRendLineInfo * line )
@@ -485,7 +488,7 @@ public:
     {
         int dh = line->getEnd()
             - (footstart ? footstart->getStart() : line->getStart())
-            + (footheight==0?FOOTNOTE_MARGIN:0);
+            + (footheight==0 ? FOOTNOTE_MARGIN_REM*gRootFontSize : 0);
         int h = currentHeight(NULL); //next
         #ifdef DEBUG_FOOTNOTES
             CRLog::trace("Add footnote line %d  footheight=%d  h=%d  dh=%d  page_h=%d",

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2491,6 +2491,7 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->border_collapse=source->border_collapse;
     dest->border_spacing[0]=source->border_spacing[0];
     dest->border_spacing[1]=source->border_spacing[1];
+    dest->cr_hint = source->cr_hint;
 }
 
 css_page_break_t getPageBreakBefore( ldomNode * el ) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -95,6 +95,7 @@ enum css_decl_code {
     cssd_border_collapse,
     cssd_border_spacing,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
+    cssd_cr_hint,
     cssd_stop
 };
 
@@ -169,6 +170,7 @@ static const char * css_decl_name[] = {
     "border-collapse",
     "border-spacing",
     "-cr-ignore-if-dom-version-greater-or-equal",
+    "-cr-hint",
     NULL
 };
 
@@ -926,6 +928,27 @@ static const char * css_bc_names[]={
         NULL
 };
 
+// -cr-hint names (non standard property for providing hints to crengine via style tweaks)
+static const char * css_cr_hint_names[]={
+        "inherit",
+        "none",
+                            // For footnote popup detection:
+        "noteref",          // link is to a footnote
+        "noteref-ignore",   // link is not to a footnote (even if everything else indicates it is)
+        "footnote",         // block is a footnote (must be a full footnote block container)
+        "footnote-ignore",  // block is not a footnote (even if everything else indicates it is)
+        "footnote-inpage",  // block is a footnote (must be a full footnote block container), and to be
+                            // displayed at the bottom of all pages that contain a link to it.
+        "toc-level1",       // to be considered as TOC item of level N when building alternate TOC
+        "toc-level2",
+        "toc-level3",
+        "toc-level4",
+        "toc-level5",
+        "toc-level6",
+        "toc-ignore",       // ignore these H1...H6 when building alternate TOC
+        NULL
+};
+
 bool LVCssDeclaration::parse( const char * &decl )
 {
     SerialBuf buf(512, true);
@@ -962,6 +985,10 @@ bool LVCssDeclaration::parse( const char * &decl )
                         return false;
                     }
                 }
+                break;
+            // non standard property for providing hints via style tweaks
+            case cssd_cr_hint:
+                n = parse_name( decl, css_cr_hint_names, -1 );
                 break;
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
@@ -2087,6 +2114,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_border_collapse:
             style->Apply( (css_border_collapse_value_t) *p++, &style->border_collapse, imp_bit_border_collapse, is_important );
+            break;
+        case cssd_cr_hint:
+            style->Apply( (css_cr_hint_t) *p++, &style->cr_hint, imp_bit_cr_hint, is_important );
             break;
         case cssd_stop:
             return;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -42,10 +42,10 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((
            (lUInt32)(rec.important>>32)) * 31
          + (lUInt32)(rec.important&0xFFFFFFFFULL)) * 31
-         + (lUInt32)rec.display * 31
+         + (lUInt32)rec.display) * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
          + (lUInt32)rec.text_align_last) * 31
@@ -94,6 +94,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.border_collapse)*31
          + (lUInt32)rec.border_spacing[0].pack())*31
          + (lUInt32)rec.border_spacing[1].pack())*31
+         + (lUInt32)rec.cr_hint) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash());
     return rec.hash;
@@ -151,7 +152,8 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.background_position==r2.background_position&&
            r1.border_collapse==r2.border_collapse&&
            r1.border_spacing[0]==r2.border_spacing[0]&&
-           r1.border_spacing[1]==r2.border_spacing[1];
+           r1.border_spacing[1]==r2.border_spacing[1]&&
+           r1.cr_hint==r2.cr_hint;
 }
 
 
@@ -331,6 +333,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(border_collapse);
     ST_PUT_LEN(border_spacing[0]);
     ST_PUT_LEN(border_spacing[1]);
+    ST_PUT_ENUM(cr_hint);
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -382,6 +385,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_border_collapse_value_t ,border_collapse);
     ST_GET_LEN(border_spacing[0]);
     ST_GET_LEN(border_spacing[1]);
+    ST_GET_ENUM(css_cr_hint_t, cr_hint);
     lUInt32 hash = 0;
     buf >> hash;
     // printf("imp: %llx oldhash: %lx ", important, hash);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6000,7 +6000,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended) const
                 }
             }
         }
-        return false;
+        // return false;
+        // Not found, which is possible with a final node with only empty
+        // elements. This final node has a rect, so use it.
+        rect = rc;
+        return true;
     } else {
         // no base final node, using blocks
         //lvRect rc;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11466,6 +11466,42 @@ void ldomNode::setAttributeValue( lUInt16 nsid, lUInt16 id, const lChar16 * valu
         getDocument()->onAttributeSet( id, valueIndex, this );
 }
 
+/// returns attribute value by attribute name id, looking at children if needed
+const lString16 & ldomNode::getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const
+{
+    ASSERT_NODE_NOT_NULL;
+    if (hasAttribute(nsid, id))
+        return getAttributeValue(nsid, id);
+    ldomNode * n = (ldomNode *) this;
+    if (n->isElement() && n->getChildCount() > 0) {
+        int nextChildIndex = 0;
+        n = n->getChildNode(nextChildIndex);
+        while (true) {
+            // Check only the first time we met a node (nextChildIndex == 0)
+            // and not when we get back to it from a child to process next sibling
+            if (nextChildIndex == 0) {
+                if (n->isElement() && n->hasAttribute(nsid, id))
+                    return n->getAttributeValue(nsid, id);
+            }
+            // Process next child
+            if (n->isElement() && nextChildIndex < n->getChildCount()) {
+                n = n->getChildNode(nextChildIndex);
+                nextChildIndex = 0;
+                continue;
+            }
+            // No more child, get back to parent and have it process our sibling
+            nextChildIndex = n->getNodeIndex() + 1;
+            n = n->getParentNode();
+            if (!n) // back to root node
+                break;
+            if (n == this && nextChildIndex >= n->getChildCount())
+                // back to this node, and done with its children
+                break;
+        }
+    }
+    return lString16::empty_str;
+}
+
 /// returns element type structure pointer if it was set in document for this element name
 const css_elem_def_props_t * ldomNode::getElementTypePtr()
 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.19k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x000E
+#define FORMATTING_VERSION_ID 0x000F
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -3728,6 +3728,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->text_indent.value = 0;
     s->line_height.type = css_val_percent;
     s->line_height.value = def_interline_space << 8;
+    s->cr_hint = css_cr_hint_none;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();
     if ( _last_docflags != getDocFlags() ) {
@@ -13479,6 +13480,7 @@ void runBasicTinyDomUnitTests()
         style1->text_indent.value = 0;
         style1->line_height.type = css_val_percent;
         style1->line_height.value = 100 << 8;
+        style1->cr_hint = css_cr_hint_none;
 
         css_style_ref_t style2;
         style2 = css_style_ref_t( new css_style_rec_t );
@@ -13508,6 +13510,7 @@ void runBasicTinyDomUnitTests()
         style2->text_indent.value = 0;
         style2->line_height.type = css_val_percent;
         style2->line_height.value = 100 << 8;
+        style2->cr_hint = css_cr_hint_none;
 
         css_style_ref_t style3;
         style3 = css_style_ref_t( new css_style_rec_t );
@@ -13537,6 +13540,7 @@ void runBasicTinyDomUnitTests()
         style3->text_indent.value = 0;
         style3->line_height.type = css_val_percent;
         style3->line_height.value = 100 << 8;
+        style3->cr_hint = css_cr_hint_none;
 
         el1->setStyle(style1);
         css_style_ref_t s1 = el1->getStyle();


### PR DESCRIPTION
Adds support for a private CSS property `-cr-hint:`
This will allow tuning a few crengine features with style tweaks (more details in a coming buddy frontend PR).

Currently supported named values:

For footnote popup detection (handled in base/cre.cpp):
`noteref`          link is to a footnote
`noteref-ignore`   link is not to a footnote (even if everything else indicates it is)
`footnote`         block is a footnote (must be a full footnote block container)
`footnote-ignore`  block is not a footnote (even if everything else indicates it is)

In-page display of footnotes (see below for screenshots):
`footnote-inpage`  block is a footnote (must be a full footnote block container), and to be displayed at the bottom of all pages that contain a link to it.

Alternative TOC hinting:
`toc-level1`  to be considered as TOC item of level N when building alternate TOC
`toc-level2`
`toc-level3`
`toc-level4`
`toc-level5`
`toc-level6`
`toc-ignore`  to ignore H1...H6 when building alternate TOC

Some screenshots of "in-page" footnotes (this feature was already there in crengine, we could previously just witness it in FB2 documents):
<kbd>![image](https://user-images.githubusercontent.com/24273478/50574839-ad297c00-0df0-11e9-9a1f-14f0ce313568.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50574793-e57c8a80-0def-11e9-8561-1c114c2e85be.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50574801-02b15900-0df0-11e9-8835-dccada0d192e.png)</kbd>

Note that this will not work for links inside table cells.


Also fix restore of last xpointer in scroll mode
In scroll mode, when leaving a book with the top of current page being inside an image, or in some empty elements, or in some margin area, when re-opening the book, the previous saved position (last_xpointer) would be invalid, and we would end up with book opened on page 1.

