### PR TITLE
 In-page footnotes: various fixes + CSS !important importance handling

### DIFF
--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -336,6 +336,8 @@ class LVRendPageContext
     LVRendPageList * page_list;
     // page height
     int          page_h;
+    // Links gathered when no page_list
+    lString16Collection link_ids;
 
     LVHashTable<lString16, LVFootNoteRef> footNotes;
 
@@ -363,6 +365,11 @@ public:
 
     /// append footnote link to last added line
     void addLink( lString16 id );
+
+    /// get gathered links when no page_list
+    // (returns a reference to avoid lString16Collection destructor from
+    // being called twice and a double free crash)
+    lString16Collection * getLinkIds() { return &link_ids; }
 
     /// mark start of foot note
     void enterFootNote( lString16 id );

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -29,7 +29,7 @@ int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing 
 /// converts style to text formatting API flags
 int styleToTextFmtFlags( const css_style_ref_t & style, int oldflags );
 /// renders block as single text formatter object
-void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags, int ident, int line_h, int valign_dy=0 );
+void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags, int ident, int line_h, int valign_dy=0, bool * is_link_start=NULL );
 /// renders block which contains subblocks
 int renderBlockElement( LVRendPageContext & context, ldomNode * node, int x, int y, int width );
 /// renders table element

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -80,7 +80,7 @@ private:
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
-    bool parse( const char * & decl );
+    bool parse( const char * & decl, bool higher_importance=false );
     lUInt32 getHash();
     LVCssDeclaration() : _data(NULL) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }
@@ -253,7 +253,7 @@ public:
     /// copy constructor
     LVStyleSheet( LVStyleSheet & sheet );
     /// parse stylesheet, compile and add found rules to sheet
-    bool parse( const char * str );
+    bool parse( const char * str, bool higher_importance=false );
     /// apply stylesheet to node style
     void apply( const ldomNode * node, css_style_rec_t * style );
     /// calculate hash

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1920,7 +1920,9 @@ void LVDocView::drawPageTo(LVDrawBuf * drawbuf, LVRendPageInfo & page,
 				footnotes_height += page.footnotes[fn].height;
 			}
 			if (footnotes_height > 0) {
-				int h_avail = m_dy - m_pageMargins.top - m_pageMargins.bottom - height - footnote_margin;
+				int h_avail = m_dy - getPageHeaderHeight()
+						   - m_pageMargins.top - m_pageMargins.bottom
+						   - height - footnote_margin;
 				fny += h_avail - footnotes_height; // put empty space before first footnote
 			}
 			int fy = fny;

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -74,8 +74,10 @@ bool LVRendPageContext::updateRenderProgress( int numFinalBlocksRendered )
 /// append footnote link to last added line
 void LVRendPageContext::addLink( lString16 id )
 {
-    if ( !page_list )
+    if ( !page_list ) {
+        link_ids.add( id ); // gather links even if no page_list
         return;
+    }
     if ( lines.empty() )
         return;
     LVFootNote * note = getOrCreateFootNote( id );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -42,9 +42,11 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((
-           (lUInt32)(rec.important>>32)) * 31
-         + (lUInt32)(rec.important&0xFFFFFFFFULL)) * 31
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((
+           (lUInt32)(rec.important >> 32)) * 31
+         + (lUInt32)(rec.important & 0xFFFFFFFFULL)) * 31
+         + (lUInt32)(rec.importance >> 32)) * 31
+         + (lUInt32)(rec.importance & 0xFFFFFFFFULL)) * 31
          + (lUInt32)rec.display) * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
@@ -104,6 +106,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
 {
     return 
            r1.important == r2.important &&
+           r1.importance == r2.importance &&
            r1.display == r2.display &&
            r1.white_space == r2.white_space &&
            r1.text_align == r2.text_align &&
@@ -293,6 +296,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
         return false;
     buf.putMagic(style_magic);
     ST_PUT_UI64(important);         //    lUInt64              important;
+    ST_PUT_UI64(importance);        //    lUInt64              importance;
     ST_PUT_ENUM(display);           //    css_display_t        display;
     ST_PUT_ENUM(white_space);       //    css_white_space_t    white_space;
     ST_PUT_ENUM(text_align);        //    css_text_align_t     text_align;
@@ -345,6 +349,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
         return false;
     buf.putMagic(style_magic);
     ST_GET_UI64(important);                                 //    lUInt64              important;
+    ST_GET_UI64(importance);                                //    lUInt64              importance;
     ST_GET_ENUM(css_display_t, display);                    //    css_display_t        display;
     ST_GET_ENUM(css_white_space_t, white_space);            //    css_white_space_t    white_space;
     ST_GET_ENUM(css_text_align_t, text_align);              //    css_text_align_t     text_align;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1211,7 +1211,7 @@ public:
                     if ( m_flags[i-1] & LCHAR_ALLOW_WRAP_AFTER )
                         word->flags |= LTEXT_WORD_CAN_BREAK_LINE_AFTER; // not used anywhere
                     if ( word->t.start==0 && srcline->flags & LTEXT_IS_LINK )
-                        word->flags |= LTEXT_WORD_IS_LINK_START; // for footnotes (not used by koreader)
+                        word->flags |= LTEXT_WORD_IS_LINK_START; // for in-page footnotes
 
                     if ( visualAlignmentEnabled && lastWord ) { // if floating punctuation enabled
                         int endp = i-1;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -62,7 +62,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.19k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.20k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x000F
 
@@ -10835,7 +10835,14 @@ void lxmlDocBase::setStyleSheet( const char * css, bool replace )
     }
     if ( css && *css ) {
         //CRLog::debug("appending stylesheet contents: \n%s", css);
-        _stylesheet.parse( css );
+        _stylesheet.parse( css, true );
+        // We use override_important=true: we are the only code
+        // that sets the main CSS (including style tweaks). We allow
+        // any !important to override any previous !important.
+        // Other calls to _stylesheet.parse() elsewhere are used to
+        // include document embedded or inline CSS, with the default
+        // of override_important=false, so they won't override
+        // the ones we set here.
     }
     lUInt32 newHash = _stylesheet.getHash();
     if (oldHash != newHash) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.20k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x000F
+#define FORMATTING_VERSION_ID 0x0010
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
See individual commit messages for details.

`CSS: avoid publisher's !important from overriding ours` : see https://github.com/koreader/koreader/issues/4196#issuecomment-451016032 and follow ups

`In-page footnotes: fix vertical position when full status bar` : closes https://github.com/koreader/koreader/issues/4444

The other commits fix some issues, and allow getting now in-page footnotes for links in tables (they were previously ignored and so not shown):

<kbd>![image](https://user-images.githubusercontent.com/24273478/50737019-ebde7e00-11c4-11e9-931c-a13c3c35fa6e.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50737022-f8fb6d00-11c4-11e9-8bd3-c65a36c16669.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/50737041-1597a500-11c5-11e9-9d28-184f2001974f.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/50737049-26481b00-11c5-11e9-90a6-f2a3ff4538c9.png)</kbd>



