### PR TITLE
(Upstream) Adds new kerning method: Harfbuzz light, without ligatures

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -167,6 +167,7 @@ enum hinting_mode_t {
 enum kerning_mode_t {
     KERNING_MODE_DISABLED,
     KERNING_MODE_FREETYPE,
+    KERNING_MODE_HARFBUZZ_LIGHT,
     KERNING_MODE_HARFBUZZ
 };
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5783,8 +5783,8 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #endif
 	static int int_option_hinting[] = { 0, 1, 2 };
 	props->limitValueList(PROP_FONT_HINTING, int_option_hinting, 3);
-	static int int_option_kerning[] = { 0, 1, 2 };
-	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 3);
+	static int int_option_kerning[] = { 0, 1, 2, 3 };
+	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 4);
     static int int_options_1_2[] = { 2, 1 };
 	props->limitValueList(PROP_LANDSCAPE_PAGES, int_options_1_2, 2);
 	props->limitValueList(PROP_PAGE_VIEW_MODE, bool_options_def_true, 2);
@@ -5955,7 +5955,7 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         //     REQUEST_RENDER("propsApply - kerning")
         } else if (name == PROP_FONT_KERNING) {
             int mode = props->getIntDef(PROP_FONT_KERNING, (int)KERNING_MODE_DISABLED);
-            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=2) {
+            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=3) {
                 //CRLog::debug("Setting kerning mode to %d", mode);
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 requestRender();


### PR DESCRIPTION
Original work by @virxkane from https://github.com/buggins/coolreader/pull/58, tweaked for the way we handle the kerning setting and soft hyphens.
 
Should be nearly as fast as Freetype kerning (full Harfbuzz with ligatures takes ~ 1.5 more time than light Harfbuzz). On my sample big book, a re-rendering takes:
```
Kerning off: 10s
Freetype kerning: 11s (sometimes 14s when switching from some HB kerning).
Harfbuzz light: 13s
Harfbuzz full: 20s.
```

So, that makes 4 kerning option, which is a bit too much for our toggle :)
<kbd>![image](https://user-images.githubusercontent.com/24273478/51089121-6761a180-1768-11e9-8420-24eb7bfe1f27.png)</kbd>
Best I could come up in english:
<kbd>![image](https://user-images.githubusercontent.com/24273478/51089131-7b0d0800-1768-11e9-8d61-5ca6c5a339df.png)</kbd>
But that won't be as easy for other languages...

We could kill one of these (off & freetype looks often similar with most fonts, except with some fonts like FreeSerif or Rockwell), but it sucks losing one, the Off to see how it looks when nothing applies, and the Freetype one which is more airy than Harfbuzz.
Or we could use cryptic names (off | FT | HBlight | HB).
Or we could make that 2 settings (kerning as it is now, and a ligature one, enabled only when enhanced is used), but that would a bit tedious to code, and would increase that menu height, hiding even more text to see how this kerning option affects it).

Closes #247.

Also includes a fix to full Harfbuzz:
Flags could be wrong at end of measured text segments when that text contains ligatures: some non-space chars at near-end of segment could be flagged as space when the last char was a space, causing some line layout and rendering issues (text drawn outside page right margin, leading space on next line...)

Before (2 ligatures and 2 issues highlighted)
<kbd>![image](https://user-images.githubusercontent.com/24273478/51086564-851f0e80-1748-11e9-8898-e2e21aeb6312.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/51089203-9fb5af80-1769-11e9-9d20-f39c89d2f862.png)</kbd>
