### PR TITLE
Supports book text encoded in WTF-8, workaround ZIP files with corrupted central directories

### DIFF
--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -2097,6 +2097,10 @@ struct ZipHd2
     lUInt16     getZIPAttr() { return _Attr_and_Offset[0]; }
     lUInt32     getAttr() { return _Attr_and_Offset[1] | ((lUInt32)_Attr_and_Offset[2]<<16); }
     lUInt32     getOffset() { return _Attr_and_Offset[3] | ((lUInt32)_Attr_and_Offset[4]<<16); }
+    void        setOffset(lUInt32 offset) {
+        _Attr_and_Offset[3] = (lUInt16)(offset & 0xFFFF);
+        _Attr_and_Offset[4] = (lUInt16)(offset >> 16);
+    }
     void byteOrderConv()
     {
         //
@@ -2491,14 +2495,20 @@ public:
 
 class LVZipArc : public LVArcContainerBase
 {
+protected:
+    // whether the alternative "truncated" method was used, or is to be used
+    bool m_alt_reading_method = false;
 public:
+    bool usedAltReadingMethod() { return m_alt_reading_method; }
+    void useAltReadingMethod() { m_alt_reading_method = true; }
+
     virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t /*mode*/ )
     {
         if ( fname[0]=='/' )
             fname++;
         int found_index = -1;
         for (int i=0; i<m_list.length(); i++) {
-            if ( !lStr_cmp( fname, m_list[i]->GetName() ) ) {
+            if ( m_list[i]->GetName() != NULL && !lStr_cmp( fname, m_list[i]->GetName() ) ) {
                 if ( m_list[i]->IsContainer() ) {
                     // found directory with same name!!!
                     return LVStreamRef();
@@ -2593,6 +2603,18 @@ public:
         }
 
         truncated = !found;
+
+        // If the main reading method (using zip header at the end of the
+        // archive) failed, we can try using the alternative method used
+        // when this zip header is missing ("truncated"), which uses
+        // local zip headers met along while scanning the zip.
+        if (m_alt_reading_method)
+            truncated = true; // do as if truncated
+        else if (truncated) // archive detected as truncated
+            // flag that, so there's no need to try that alt method,
+            // as it was used on first scan
+            m_alt_reading_method = true;
+
         if (truncated)
             NextPosition=0;
 
@@ -2613,6 +2635,11 @@ public:
 
             if (truncated)
             {
+                // The offset (that we don't find in a local header, but
+                // that we will store in the ZipHeader we're building)
+                // happens to be the current position here.
+                lUInt32 offset = (lUInt32)m_stream->GetPos();
+
                 m_stream->Read( &ZipHd1, ZipHd1_size, &ReadSize);
                 ZipHd1.byteOrderConv();
 
@@ -2637,6 +2664,10 @@ public:
                 ZipHeader.NameLen=ZipHd1.getNameLen();
                 ZipHeader.AddLen=ZipHd1.getAddLen();
                 ZipHeader.Method=ZipHd1.getMethod();
+                ZipHeader.setOffset(offset);
+                // We may get a last invalid record with NameLen=0, which shouldn't hurt.
+                // If it does, use:
+                // if (ZipHeader.NameLen == 0) break;
             } else {
 
                 m_stream->Read( &ZipHeader, ZipHeader_size, &ReadSize);
@@ -2727,8 +2758,17 @@ public:
                 return NULL;
         LVZipArc * arc = new LVZipArc( stream );
         int itemCount = arc->ReadContents();
+        if ( itemCount > 0 && arc->usedAltReadingMethod() ) {
+            printf("CRE WARNING: zip file truncated: going on with possibly partial content.\n");
+        }
+        else if ( itemCount <= 0 && !arc->usedAltReadingMethod() ) {
+            printf("CRE WARNING: zip file corrupted or invalid: trying alternative processing...\n");
+            arc->useAltReadingMethod();
+            itemCount = arc->ReadContents();
+        }
         if ( itemCount <= 0 )
         {
+            printf("CRE WARNING: zip file corrupted or invalid: processing failure.\n");
             delete arc;
             return NULL;
         }


### PR DESCRIPTION
#### Supports book text encoded in WTF-8 

Because Why The F*** not?! :)
https://en.wikipedia.org/wiki/UTF-8#WTF-8
WTF-8 is a superset of UTF-8, that includes UTF-16 surrogates in UTF-8 bytes (forbidden in well-formed UTF-8).
We may get UTF-8 with these from bad producers or converters.

Actually, our JSON decoder used to build Wikipedia EPUBs may produce such WTF8 content when it gets from the Wikipedia API 4-bytes UTF8 chars (it will be hard to fix in that decoder, and upstream has marked it low priority `https://github.com/harningt/luajson/issues/12`).
Noticed on this https://fr.wikipedia.org/wiki/Wulfila which includes words in _gotique_, which are in Unicode > U+10000, and encoded in 4-bytes UTF8, and returned by the API as:
`<span class=\"lang-got\" lang=\"got\">\ud800\udf45\ud800\udf3f\ud800\udf3b\ud800\udf46\ud800\udf39\ud800\udf3b\ud800\udf30</span>`

(I'll add support for WTF-8 in frontend too, as we'll continue to get such WTF-8 from Wikipedia, and we may find it in some dictionnaries. And will fix missing support for 4-bytes UTF8 chars in base/ffi/util.lua.)

More info about WTF-8 and sample code:
https://simonsapin.github.io/wtf-8/
https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs
https://unicodebook.readthedocs.io/issues.html#non-strict-utf-8-decoder-overlong-byte-sequences-and-surrogates
https://github.com/b4n/wtf8tools
https://github.com/lautis/wtf8/blob/master/wtf8.cc

#### EPUB: workaround ZIP files with corrupted central directories

If the main reading method (using zip header at the end of the archive) fails, we can try using the alternative method already used when this zip header is missing ("truncated"), which uses local zip headers met along while scanning the zip.
Closes https://github.com/koreader/koreader/issues/4464