### PR TITLE
 CSS: adds support for 'orphans:' and 'widows:' properties

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -241,6 +241,19 @@ enum css_border_collapse_value_t {
     css_border_c_none
 };
 
+enum css_orphans_widows_value_t { // supported only if in range 1-9
+    css_orphans_widows_inherit,
+    css_orphans_widows_1,
+    css_orphans_widows_2,
+    css_orphans_widows_3,
+    css_orphans_widows_4,
+    css_orphans_widows_5,
+    css_orphans_widows_6,
+    css_orphans_widows_7,
+    css_orphans_widows_8,
+    css_orphans_widows_9
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1 // for (css_val_unspecified, css_value_auto), for "margin: auto"
 };

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -76,7 +76,9 @@ enum css_style_rec_important_bit {
     imp_bit_border_collapse       = 1ULL << 49,
     imp_bit_border_spacing_h      = 1ULL << 50,
     imp_bit_border_spacing_v      = 1ULL << 51,
-    imp_bit_cr_hint               = 1ULL << 52
+    imp_bit_orphans               = 1ULL << 52,
+    imp_bit_widows                = 1ULL << 53,
+    imp_bit_cr_hint               = 1ULL << 54
 };
 
 /**
@@ -88,8 +90,8 @@ typedef struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
     lUInt64              important;  // bitmap for !important (used only by LVCssDeclaration)
-                                     // we have currently below 53 css properties
-                                     // lvstsheet knows about 68, which are mapped to these 52
+                                     // we have currently below 55 css properties
+                                     // lvstsheet knows about 70, which are mapped to these 55
                                      // update bits above if you add new properties below
     lUInt64              importance; // bitmap for important bit's importance/origin
                                      // (allows for 2 level of !important importance)
@@ -132,6 +134,8 @@ typedef struct css_style_rec_tag {
     css_background_position_value_t background_position;
     css_border_collapse_value_t border_collapse;
     css_length_t border_spacing[2];//first horizontal and the second vertical spacing
+    css_orphans_widows_value_t orphans;
+    css_orphans_widows_value_t widows;
     css_cr_hint_t          cr_hint;
     css_style_rec_tag()
     : refCount(0)
@@ -170,6 +174,8 @@ typedef struct css_style_rec_tag {
     , background_attachment(css_background_a_none)
     , background_position(css_background_p_none)
     , border_collapse(css_border_seperate)
+    , orphans(css_orphans_widows_inherit)
+    , widows(css_orphans_widows_inherit)
     , cr_hint(css_cr_hint_none)
     {
         // css_length_t fields are initialized by css_length_tag()

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1245,12 +1245,12 @@ public:
                 posInfo->offset = glyph_pos[cluster].x_offset >> 6;
                 posInfo->width = glyph_pos[cluster].x_advance >> 6;
             } else {
-                // hb_shape() failed or glyph omited in this font, use fallback font
+                // hb_shape() failed or glyph omitted in this font, use fallback font
                 glyph_info_t glyph;
                 LVFont *fallback = getFallbackFont();
                 if (fallback) {
                     if (fallback->getGlyphInfo(triplet.Char, &glyph, def_char)) {
-                        posInfo->offset = glyph.originX;
+                        posInfo->offset = 0;
                         posInfo->width = glyph.width;
                     }
                 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -96,6 +96,8 @@ enum css_decl_code {
     cssd_background_position,
     cssd_border_collapse,
     cssd_border_spacing,
+    cssd_orphans,
+    cssd_widows,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
     cssd_stop
@@ -171,6 +173,8 @@ static const char * css_decl_name[] = {
     "background-position",
     "border-collapse",
     "border-spacing",
+    "orphans",
+    "widows",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
     NULL
@@ -927,6 +931,23 @@ static const char * css_bc_names[]={
         "collapse",
         "initial",
         "inherit",
+        NULL
+};
+
+// orphans and widows values (supported only if in range 1-9)
+// https://drafts.csswg.org/css-break-3/#widows-orphans
+//   "Negative values and zero are invalid and must cause the declaration to be ignored."
+static const char * css_orphans_widows_names[]={
+        "inherit",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
         NULL
 };
 
@@ -1843,6 +1864,12 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance )
             case cssd_border_collapse:
                 n=parse_name(decl,css_bc_names,-1);
                 break;
+            case cssd_orphans:
+                n=parse_name(decl, css_orphans_widows_names, -1);
+                break;
+            case cssd_widows:
+                n=parse_name(decl, css_orphans_widows_names, -1);
+                break;
             case cssd_stop:
             case cssd_unknown:
             default:
@@ -2117,6 +2144,12 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_border_collapse:
             style->Apply( (css_border_collapse_value_t) *p++, &style->border_collapse, imp_bit_border_collapse, is_important );
+            break;
+        case cssd_orphans:
+            style->Apply( (css_orphans_widows_value_t) *p++, &style->orphans, imp_bit_orphans, is_important );
+            break;
+        case cssd_widows:
+            style->Apply( (css_orphans_widows_value_t) *p++, &style->widows, imp_bit_widows, is_important );
             break;
         case cssd_cr_hint:
             style->Apply( (css_cr_hint_t) *p++, &style->cr_hint, imp_bit_cr_hint, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -42,7 +42,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((
            (lUInt32)(rec.important >> 32)) * 31
          + (lUInt32)(rec.important & 0xFFFFFFFFULL)) * 31
          + (lUInt32)(rec.importance >> 32)) * 31
@@ -96,6 +96,8 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.border_collapse)*31
          + (lUInt32)rec.border_spacing[0].pack())*31
          + (lUInt32)rec.border_spacing[1].pack())*31
+         + (lUInt32)rec.orphans) * 31
+         + (lUInt32)rec.widows) * 31
          + (lUInt32)rec.cr_hint) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash());
@@ -156,6 +158,8 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.border_collapse==r2.border_collapse&&
            r1.border_spacing[0]==r2.border_spacing[0]&&
            r1.border_spacing[1]==r2.border_spacing[1]&&
+           r1.orphans==r2.orphans&&
+           r1.widows==r2.widows&&
            r1.cr_hint==r2.cr_hint;
 }
 
@@ -337,6 +341,8 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(border_collapse);
     ST_PUT_LEN(border_spacing[0]);
     ST_PUT_LEN(border_spacing[1]);
+    ST_PUT_ENUM(orphans);
+    ST_PUT_ENUM(widows);
     ST_PUT_ENUM(cr_hint);
     lUInt32 hash = calcHash(*this);
     buf << hash;
@@ -390,6 +396,8 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_border_collapse_value_t ,border_collapse);
     ST_GET_LEN(border_spacing[0]);
     ST_GET_LEN(border_spacing[1]);
+    ST_GET_ENUM(css_orphans_widows_value_t, orphans);
+    ST_GET_ENUM(css_orphans_widows_value_t, widows);
     ST_GET_ENUM(css_cr_hint_t, cr_hint);
     lUInt32 hash = 0;
     buf >> hash;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -62,7 +62,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.20k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.21k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0010
 
@@ -3728,6 +3728,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->text_indent.value = 0;
     s->line_height.type = css_val_percent;
     s->line_height.value = def_interline_space << 8;
+    s->orphans = css_orphans_widows_1; // default to allow orphans and widows
+    s->widows = css_orphans_widows_1;
     s->cr_hint = css_cr_hint_none;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();


### PR DESCRIPTION
Because it was easy to do and fits well into the page splitting model.
Discussed in https://github.com/koreader/koreader/issues/4484.
If we later decide the previous behaviour (of allowing widow and orphan lines) is to be enforced, we can just get it back by adding to epub.css:
`* { orphans: 1 !important; widows: 1 !important; ` or
`* { orphans: inherit !important; widows: inherit !important; }`
Or we'll just have style tweaks to play with, and one with these to "Ignore publisher orphans and widows specifications".

Also includes Harfbuzz light fixe by @virxkane provided in https://github.com/koreader/crengine/pull/251#issuecomment-454943894

(I also forgot to bump FORMATTING_VERSION_ID in the previous commits, so this one will do that with a bumpier bump of CACHE_FILE_FORMAT_VERSION.)