### PR TITLE
Increase max nodes limit, avoid hash mismatch on kerning change

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -978,6 +978,7 @@ public:
 
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
         _kerningMode = kerningMode;
+        _hash = 0; // Force lvstyles.cpp calcHash(font_ref_t) to recompute the hash
 #if USE_HARFBUZZ==1
         // in cache may be found some ligatures, so clear it
         clearCache();
@@ -989,6 +990,7 @@ public:
         if (_hintingMode == mode)
             return;
         _hintingMode = mode;
+        _hash = 0; // Force lvstyles.cpp calcHash(font_ref_t) to recompute the hash
         clearCache();
     }
     /// returns current hinting mode

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1062,6 +1062,35 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance )
             case cssd_list_style_position:
                 n = parse_name( decl, css_lsp_names, -1 );
                 break;
+            case cssd_list_style:
+                {
+                    // The list-style property is specified as one, two, or three keywords in any order,
+                    // the keywords being those of list-style-type, list-style-position and list-style-image.
+                    // We don't support (and will fail parsing the declaration) a list-style-image url(...)
+                    // component, but we can parse the declaration when it contains a type (square, decimal) and/or
+                    // a position (inside, outside) in any order.
+                    int ntype=-1;
+                    int nposition=-1;
+                    // check order "type position"
+                    ntype = parse_name( decl, css_lst_names, -1 );
+                    skip_spaces( decl );
+                    nposition = parse_name( decl, css_lsp_names, -1 );
+                    skip_spaces( decl );
+                    if (ntype == -1) { // check again if order was "position type"
+                        ntype = parse_name( decl, css_lst_names, -1 );
+                        skip_spaces( decl );
+                    }
+                    parsed_important = parse_important(decl);
+                    if (ntype != -1) {
+                        buf<<(lUInt32) (cssd_list_style_type | importance | parsed_important);
+                        buf<<(lUInt32) ntype;
+                    }
+                    if (nposition != -1) {
+                        buf<<(lUInt32) (cssd_list_style_position | importance | parsed_important);
+                        buf<<(lUInt32) nposition;
+                    }
+                }
+                break;
             case cssd_vertical_align:
                 {
                     css_length_t len;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -62,7 +62,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.21k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.22k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0010
 


### PR DESCRIPTION
Includes:
- CSS: adds (limited) parsing of [list-style:](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style) property
The property was there, but its parsing was not implemented, so I added some limited parsing:
It will fail when this shortcut property contains a "url(...)" like list-style-image (we don't support this property), but allows parsing simple ones like "list-style: none" or "list-style: square inside".
Witnessed on the screenshots differences in https://github.com/koreader/koreader/issues/2878.
(There's some code for parsing url() in the section dealing with background-image. Including it there while still allowing in-any-order parsing would take me a few hours and obligatory headaches with that string walking stuff... so may be for later.)

- Avoid "style hash mismatch" on kerning or hinting change
After change of kerning or hinting mode, the cache saved on quit would be considered invalid on next load and crengine would log "style hash mismatch" and do a full rendering.

- Increase max number of nodes from 1M to 16M
By grabbing 4 bits from the number of max simultaneously opened documents and decreasing it from 256 to 16, as KOReader does not need that many.
Details in https://github.com/koreader/crengine/pull/121#issuecomment-457244709. Closes https://github.com/koreader/koreader/issues/4503

