### PR TITLE
DrawBuf: count nb of images and surface drawn

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -48,7 +48,7 @@ blockquote {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
     margin-left: 2em;
-    margin-right: 2em;
+    margin-right: 1em;
 }
 hr {
     height: 2px;

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -228,6 +228,8 @@ protected:
     lUInt32 _backgroundColor;
     lUInt32 _textColor;
     bool _hidePartialGlyphs;
+    int _drawnImagesCount;
+    int _drawnImagesSurface;
 public:
     virtual void setHidePartialGlyphs( bool hide ) { _hidePartialGlyphs = hide; }
     /// returns current background color
@@ -262,8 +264,14 @@ public:
     */
     /// draws formatted text
     //virtual void DrawFormattedText( formatted_text_fragment_t * text, int x, int y );
+
+    /// Get nb of images drawn on buffer
+    int getDrawnImagesCount() { return _drawnImagesCount; }
+    /// Get surface of images drawn on buffer
+    int getDrawnImagesSurface() { return _drawnImagesSurface; }
     
-    LVBaseDrawBuf() : _dx(0), _dy(0), _rowsize(0), _data(NULL), _hidePartialGlyphs(true) { }
+    LVBaseDrawBuf() : _dx(0), _dy(0), _rowsize(0), _data(NULL), _hidePartialGlyphs(true),
+                        _drawnImagesCount(0), _drawnImagesSurface(0) { }
     virtual ~LVBaseDrawBuf() { }
 };
 

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -709,6 +709,8 @@ void LVGrayDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int hei
         return;
     LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither );
     img->Decode( &drawcb );
+    _drawnImagesCount++;
+    _drawnImagesSurface += width*height;
 }
 
 
@@ -1299,6 +1301,8 @@ void LVColorDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int he
     //fprintf( stderr, "LVColorDrawBuf::Draw( img(%d, %d), %d, %d, %d, %d\n", img->GetWidth(), img->GetHeight(), x, y, width, height );
     LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither );
     img->Decode( &drawcb );
+    _drawnImagesCount++;
+    _drawnImagesSurface += width*height;
 }
 
 /// fills buffer with specified color


### PR DESCRIPTION
#### DrawBuf: count nb of images and surface drawn

This will allow frontend code to decide if refresh with (possibly costly) dithering should be used or not on devices with HW dithering capabilities. See https://github.com/koreader/koreader/pull/4541 , https://github.com/koreader/koreader/pull/4541#issuecomment-459947281

#### epub.css: update style for 'blockquote'
Decrease margin-right to give more room to text (as Opera does, even if most other browsers uses the same margin on each side). See https://github.com/koreader/crengine/pull/243#issuecomment-458100435

