### PR TITLE
Fix CSS ancessor rule parsing, and text search getting stuck on some pages

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6690,8 +6690,24 @@ bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool rever
     int fh = getFullHeight();
     if ( maxY<=0 || maxY>fh )
         maxY = fh;
-    ldomXPointer start = createXPointer( lvPoint(0, minY), reverse?-1:1 );
-    ldomXPointer end = createXPointer( lvPoint(10000, maxY), reverse?-1:1 );
+    // ldomXPointer start = createXPointer( lvPoint(0, minY), reverse?-1:1 );
+    // ldomXPointer end = createXPointer( lvPoint(10000, maxY), reverse?-1:1 );
+    // If we're provided with minY or maxY in some empty space (margins, empty
+    // elements...), they may not resolve to a XPointer.
+    // Find a valid y near each of them that does resolve to a XPointer:
+    ldomXPointer start;
+    ldomXPointer end;
+    for (int y = minY; y >= 0; y--) {
+        start = createXPointer( lvPoint(0, y), reverse?-1:1 );
+        if (!start.isNull())
+            break;
+    }
+    for (int y = maxY; y <= fh; y++) {
+        end = createXPointer( lvPoint(10000, y), reverse?-1:1 );
+        if (!end.isNull())
+            break;
+    }
+
     if ( start.isNull() || end.isNull() )
         return false;
     ldomXRange range( start, end );


### PR DESCRIPTION
####  cre:findText(): fix search getting stuck on some pages

We could get stuck on some page (not able to go see next or previous pages that do contain the search
pattern) when this page (or its neighbours) starts with some margin or empty elements that would not
resolve to a XPointer.
This ensures we always find a XPointer to work with by moving a bit the provided y till we find one.

#### CSS: fix ancessor rule parsing

`DIV .classname` would not work as expected, as it was parsed just like `DIV.classname`.
(Note that ancessor rules are still limited because of the non-deterministic/multiple paths to take for checking that we do not take, and work much like just a parent rule.)