### PR TITLE
Fix font clipping and harfbuzz hyphenation rendering issues

### DIFF
--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -215,14 +215,16 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
                     lChar16 def_char
                  );
 
-#define LCHAR_IS_SPACE              1 ///< flag: this char is one of unicode space chars
-#define LCHAR_ALLOW_WRAP_AFTER      2 ///< flag: line break after this char is allowed
-#define LCHAR_DEPRECATED_WRAP_AFTER 4 ///< flag: line break after this char is possible but deprecated
-#define LCHAR_ALLOW_HYPH_WRAP_AFTER 8 ///< flag: line break after this char is allowed with addition of hyphen
-#define LCHAR_IS_EOL               16 ///< flag: this char is CR or LF
-#define LCHAR_IS_OBJECT            32 ///< flag: this char is object or image
-#define LCHAR_MANDATORY_NEWLINE    64 ///< flag: this char must start with new line
-#define LCHAR_IS_COLLAPSED_SPACE  128 ///< flag: this char is a space that should not be displayed
+#define LCHAR_IS_SPACE               1 ///< flag: this char is one of unicode space chars
+#define LCHAR_ALLOW_WRAP_AFTER       2 ///< flag: line break after this char is allowed
+#define LCHAR_DEPRECATED_WRAP_AFTER  4 ///< flag: line break after this char is possible but deprecated
+#define LCHAR_ALLOW_HYPH_WRAP_AFTER  8 ///< flag: line break after this char is allowed with addition of hyphen
+#define LCHAR_IS_LIGATURE_TAIL      16 ///< flag: this char is a tail of a ligature (ligature is carried by first char)
+#define LCHAR_IS_OBJECT             32 ///< flag: this char is object or image
+#define LCHAR_MANDATORY_NEWLINE     64 ///< flag: this char must start with new line
+#define LCHAR_IS_COLLAPSED_SPACE   128 ///< flag: this char is a space that should not be displayed
+// LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_LIGATURE_TAIL
+// #define LCHAR_IS_EOL             16 ///< flag: this char is CR or LF
 
 /** \brief returns true if character is unicode space 
     \param code is character

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1853,11 +1853,15 @@ void LVDocView::drawPageTo(LVDrawBuf * drawbuf, LVRendPageInfo & page,
 	//    offset = 0;
 	int offset = 0;
 	lvRect clip;
-	clip.left = pageRect->left + m_pageMargins.left;
 	clip.top = pageRect->top + m_pageMargins.top + headerHeight + offset;
-	clip.bottom = pageRect->top + m_pageMargins.top + height + headerHeight
-			+ offset;
-	clip.right = pageRect->left + pageRect->width() - m_pageMargins.right;
+	clip.bottom = pageRect->top + m_pageMargins.top + height + headerHeight + offset;
+	// clip.left = pageRect->left + m_pageMargins.left;
+	// clip.right = pageRect->left + pageRect->width() - m_pageMargins.right;
+	// We don't really need to enforce left and right clipping of page margins:
+	// this allows glyphs that need to (like 'J' at start of line or 'f' at
+	// end of line with some fonts) to not be cut by this clipping.
+	clip.left = pageRect->left;
+	clip.right = pageRect->left + pageRect->width();
 	if (page.type == PAGE_TYPE_COVER)
 		clip.top = pageRect->top + m_pageMargins.top;
     if (((m_pageHeaderInfo || !m_pageHeaderOverride.empty()) && page.type

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -797,9 +797,13 @@ lString8 familyName( FT_Face face )
     return faceName;
 }
 
+// The 2 slots with "LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER" on the 2nd line previously
+// were: "LCHAR_IS_SPACE | LCHAR_IS_EOL | LCHAR_ALLOW_WRAP_AFTER".
+// LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_LIGATURE_TAIL
+// (as flags are usually lUint8, and the 8 bits were used, one needed to be dropped).
 static lUInt16 char_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, // 0    00
-    0, 0, LCHAR_IS_SPACE | LCHAR_IS_EOL | LCHAR_ALLOW_WRAP_AFTER, 0, 0, LCHAR_IS_SPACE | LCHAR_IS_EOL | LCHAR_ALLOW_WRAP_AFTER, 0, 0, // 8    08
+    0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, // 8    08
     0, 0, 0, 0, 0, 0, 0, 0, // 16   10
     0, 0, 0, 0, 0, 0, 0, 0, // 24   18
     LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, 0, 0, 0, 0, 0, // 32   20
@@ -1473,7 +1477,7 @@ public:
                     // fill flags and widths for chars skipped (because they are part of a
                     // ligature and are accounted in the previous cluster - we didn't know
                     // how many until we processed the next cluster)
-                    flags[j] = GET_CHAR_FLAGS(text[j]);
+                    flags[j] = GET_CHAR_FLAGS(text[j]) | LCHAR_IS_LIGATURE_TAIL;
                     widths[j] = prev_width; // so 2nd char of a ligature has width=0
                     skipped_chars++;
                     // This will ensure we get (with word "afloat"):
@@ -1502,7 +1506,7 @@ public:
             // For case when ligature is the last glyph in measured text
             if (prev_cluster < (uint32_t)(len - 1) && prev_width < (lUInt16)max_width) {
                 for (j = prev_cluster + 1; j < (uint32_t)len; j++) {
-                    flags[j] = GET_CHAR_FLAGS(text[j]);
+                    flags[j] = GET_CHAR_FLAGS(text[j]) | LCHAR_IS_LIGATURE_TAIL;
                     widths[j] = prev_width;
                     skipped_chars++;
                 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3927,6 +3927,15 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         case erm_table_footer_group:
         case erm_block:
             {
+                // Draw border before content, so inner content can bleed if necessary on
+                // the border (some glyphs like 'J' at start or 'f' at end may be drawn
+                // outside the text content box).
+                // Don't draw border for TR TBODY... as their borders are never directly
+                // rendered by Firefox (they are rendered only when border-collapse, when
+                // they did collapse to the cell, and made out the cell border)
+                if ( !isTableRowLike )
+                    DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
+
                 // recursive draw all sub-blocks for blocks
                 int cnt = enode->getChildCount();
 
@@ -3975,17 +3984,17 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt.getHeight()-1,
                                       doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), tableBorderColorDark );
                 }*/
-                // Don't draw border for TR TBODY... as their borders are never directly
-                // rendered by Firefox (they are rendered only when border-collapse, when
-                // they did collapse to the cell, and made out the cell border)
-                if ( !isTableRowLike )
-                    DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
+                // Border was previously drawn here, but has been moved above for earlier drawing.
             	}
             break;
         case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
         case erm_final:
         case erm_table_caption:
             {
+                // Draw border before content, so inner content can bleed if necessary on
+                // the border (some glyphs like 'J' at start or 'f' at end may be drawn
+                // outside the text content box).
+                DrawBorder(enode, drawbuf, x0, y0, doc_x, doc_y, fmt);
 
                 // List item marker drawing when css_d_list_item_block and list-style-position = outside
                 // and list_item_block rendered as final (containing only text and inline elements)
@@ -4041,7 +4050,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 drawbuf.FillRect( doc_x+x0+fmt.getWidth()-1, doc_y+y0, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
                 drawbuf.FillRect( doc_x+x0, doc_y+y0+fmt.getHeight()-1, doc_x+x0+fmt.getWidth(), doc_y+y0+fmt.getHeight(), color );
 #endif
-                DrawBorder(enode, drawbuf, x0, y0, doc_x, doc_y, fmt);
+                // Border was previously drawn here, but has been moved above for earlier drawing.
+
                 /*lUInt32 tableBorderColor = 0x555555;
                 lUInt32 tableBorderColorDark = 0xAAAAAA;
                 bool needBorder = enode->getStyle()->display==css_d_table_cell;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.22k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0010
+#define FORMATTING_VERSION_ID 0x0011
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
Fix some of the issues noticed and discussed along https://github.com/koreader/koreader/issues/4577.
Including the rendering issue with harfbuzz kerning full (aka "best") described in https://github.com/koreader/koreader/issues/4577#issuecomment-462908911.
See individual commit messages for detail.