### PR TITLE
Various font, text rendering and highlights fixes and enhancements

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -265,9 +265,9 @@ public:
     virtual css_font_family_t getFontFamily() const = 0;
     /// draws text string
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
-                       const lChar16 * text, int len, 
+                       const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette = NULL, bool addHyphen = false,
-                       lUInt32 flags=0, int letter_spacing=0 ) = 0;
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1 ) = 0;
     /// constructor
     LVFont() : _visual_alignment_width(-1), _hash(0) { }
 
@@ -441,8 +441,9 @@ public:
     virtual css_font_family_t getFontFamily() const { return _family; }
     /// draws text string
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
-                       const lChar16 * text, int len, 
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 flags=0, int letter_spacing=0 );
+                       const lChar16 * text, int len,
+                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1 );
 };
 
 #if (USE_FREETYPE!=1) && (USE_BITMAP_FONTS==1)
@@ -634,8 +635,9 @@ public:
 
     /// draws text string
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
-                       const lChar16 * text, int len, 
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 flags=0, int letter_spacing=0 );
+                       const lChar16 * text, int len,
+                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1 );
         
     /** \brief get glyph image in 1 byte per pixel format
         \param code is unicode character

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -184,11 +184,12 @@ public:
     lUInt32 _hash;
     /// glyph properties structure
     struct glyph_info_t {
-        lUInt8  blackBoxX;   ///< 0: width of glyph
-        lUInt8  blackBoxY;   ///< 1: height of glyph black box
-        lInt8   originX;     ///< 2: X origin for glyph
-        lInt8   originY;     ///< 3: Y origin for glyph
-        lUInt8  width;       ///< 4: full width of glyph
+        lUInt16 blackBoxX;   ///< 0: width of glyph
+        lUInt16 blackBoxY;   ///< 1: height of glyph black box
+        lInt16  originX;     ///< 2: X origin for glyph (left side bearing)
+        lInt16  originY;     ///< 3: Y origin for glyph
+        lUInt16 width;       ///< 4: full advance width of glyph
+        lInt16  rsb;         ///< 5: right side bearing
     };
 
     /// hyphenation character
@@ -255,8 +256,12 @@ public:
     virtual int getWeight() const = 0;
     /// returns italic flag
     virtual int getItalic() const = 0;
-    /// returns char width
+    /// returns char glyph advance width
     virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 ) = 0;
+    /// returns char glyph left side bearing
+    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) = 0;
+    /// returns char glyph right side bearing
+    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) = 0;
     /// retrieves font handle
     virtual void * GetHandle() = 0;
     /// returns font typeface name

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -74,7 +74,7 @@ typedef struct
     lInt16          margin;   /**< \brief first line margin */
     lInt16          valign_dy; /* drift y from baseline */
     lUInt8          interval; /**< \brief line interval, *16 (16=normal, 32=double) */
-    lInt8           letter_spacing; /**< \brief additional letter spacing, pixels */
+    lInt16          letter_spacing; /**< \brief additional letter spacing, pixels */
     lUInt32         color;    /**< \brief color */
     lUInt32         bgcolor;  /**< \brief background color */
     lUInt32         flags;    /**< \brief flags */
@@ -99,24 +99,24 @@ typedef struct
 */
 typedef struct
 {
-   lUInt16  src_text_index;  /**< \brief 00 index of source text line */
-   lUInt16  width;           /**< \brief 06 word width, pixels, when at line end */
-   lUInt16  x;               /**< \brief 08 word x position in line */
-   lInt8    y;               /**< \brief 10 baseline y position */
-   lUInt8   flags;           /**< \brief 11 flags */
+   lUInt16  src_text_index;  /**< \brief index of source text line */
+   lUInt16  width;           /**< \brief word width, pixels, when at line end */
+   lUInt16  min_width;       /**< \brief index of source text line */
+   lInt16   x;               /**< \brief word x position in line */
+   lInt16   y;               /**< \brief baseline y position */
+   lUInt8   flags;           /**< \brief flags */
    union {
           /// for text word
        struct {
-           lUInt16  start;           /**< \brief 12 position of word in source text */
-           lUInt16  len;             /**< \brief 14 number of chars in word */
+           lUInt16  start;           /**< \brief position of word in source text */
+           lUInt16  len;             /**< \brief number of chars in word */
        } t;
        /// for object
        struct {
-           lUInt16  height;           /**< \brief 12 height of image */
+           lUInt16  height;          /**< \brief height of image */
        } o;
    };
-   lUInt16 min_width;        /**< \brief 16 index of source text line */
-   lUInt16 padding;          /**< \brief 18 not used */
+   // lUInt16  padding;         /**< \brief not used */
 } formatted_word_t;
 
 /// can add space after this word
@@ -141,7 +141,7 @@ typedef struct
    formatted_word_t * words;       /**< array of words */
    lInt32             word_count;  /**< number of words */
    lUInt32            y;           /**< start y position of line */
-   lUInt16            x;           /**< start x position */
+   lInt16             x;           /**< start x position */
    lUInt16            width;       /**< width */
    lUInt16            height;      /**< height */
    lUInt16            baseline;    /**< baseline y offset */
@@ -230,7 +230,7 @@ void lvtextAddSourceLine(
    lUInt16         margin,   /* first line margin */
    void *          object,   /* pointer to custom object */
    lUInt16         offset,    /* offset from node/object start to start of line */
-   lInt8           letter_spacing
+   lInt16          letter_spacing
                          );
 
 /** Add source object
@@ -246,7 +246,7 @@ void lvtextAddSourceObject(
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
-   lInt8           letter_spacing
+   lInt16          letter_spacing
                          );
 
 
@@ -294,7 +294,7 @@ public:
                 lInt16          valign_dy, /* drift y from baseline */
                 lUInt16         margin,    /* first line margin */
                 void *          object,    /* pointer to custom object */
-                lInt8           letter_spacing=0
+                lInt16          letter_spacing=0
          );
 
     void AddSourceLine(
@@ -309,7 +309,7 @@ public:
            lUInt16         margin=0,    /* first line margin */
            void *          object=NULL,
            lUInt32         offset=0,
-           lInt8           letter_spacing=0
+           lInt16          letter_spacing=0
         )
     {
         lvtextAddSourceLine(m_pbuffer, 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1935,9 +1935,12 @@ void LVDocView::drawPageTo(LVDrawBuf * drawbuf, LVRendPageInfo & page,
 				int fstart = page.footnotes[fn].start;
 				int fheight = page.footnotes[fn].height;
 				clip.top = fy + offset;
-				clip.left = pageRect->left + m_pageMargins.left;
-				clip.right = pageRect->right - m_pageMargins.right;
 				clip.bottom = fy + offset + fheight;
+				// Also avoid left and right clipping of page margins with footnotes
+				// clip.left = pageRect->left + m_pageMargins.left;
+				// clip.right = pageRect->right - m_pageMargins.right;
+				clip.left = pageRect->left;
+				clip.right = pageRect->right;
 				drawbuf->SetClipRect(&clip);
 				DrawDocument(*drawbuf, m_doc->getRootNode(), pageRect->left
 						+ m_pageMargins.left, fy + offset, pageRect->width()
@@ -2360,6 +2363,7 @@ bool LVDocView::docToWindowPoint(lvPoint & pt) {
                     index = 1;
                 }
                 if (index >= 0) {
+                    /*
                     int x = pt.x + m_pageRects[index].left + m_pageMargins.left;
                     // We shouldn't get x ouside page width as we never crop on the
                     // width: if we do (if bug somewhere else), force it to be at the
@@ -2372,6 +2376,13 @@ bool LVDocView::docToWindowPoint(lvPoint & pt) {
                         pt.y = pt.y + getPageHeaderHeight() + m_pageMargins.top - m_pages[page + index]->start;
                         return true;
                     }
+                    */
+                    // We don't crop on the left, so it feels like we don't need to
+                    // ensure anything and crop on the right, and this allows text
+                    // selection to grab bits of overflowed glyph
+                    pt.x = pt.x + m_pageRects[index].left + m_pageMargins.left;
+                    pt.y = pt.y + getPageHeaderHeight() + m_pageMargins.top - m_pages[page + index]->start;
+                    return true;
                 }
             }
             return false;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1862,7 +1862,8 @@ public:
     /// draws text string
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 flags, int letter_spacing )
+                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       lUInt32 flags, int letter_spacing, int width )
     {
         FONT_GUARD
         if ( len <= 0 || _face==NULL )
@@ -2080,6 +2081,10 @@ public:
 #endif
         if ( flags & LTEXT_TD_MASK ) {
             // text decoration: underline, etc.
+            // Don't overflow the provided width (which may be lower than our
+            // pen x if last glyph was a space not accounted in word width)
+            if ( width >= 0 && x > x0 + width)
+                x = x0 + width;
             int h = _size > 30 ? 2 : 1;
             lUInt32 cl = buf->GetTextColor();
             if ( (flags & LTEXT_TD_UNDERLINE) || (flags & LTEXT_TD_BLINK) ) {
@@ -2403,7 +2408,7 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                       lUInt32 flags, int letter_spacing )
+                       lUInt32 flags, int letter_spacing, int width )
     {
         if ( len <= 0 )
             return;
@@ -2457,6 +2462,10 @@ public:
         }
         if ( flags & LTEXT_TD_MASK ) {
             // text decoration: underline, etc.
+            // Don't overflow the provided width (which may be lower than our
+            // pen x if last glyph was a space not accounted in word width)
+            if ( width >= 0 && x > x0 + width)
+                x = x0 + width;
             int h = _size > 30 ? 2 : 1;
             lUInt32 cl = buf->GetTextColor();
             if ( (flags & LTEXT_TD_UNDERLINE) || (flags & LTEXT_TD_BLINK) ) {
@@ -4005,7 +4014,7 @@ int LVFontDef::CalcFallbackMatch( lString8 face, int size ) const
 
 void LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
                    const lChar16 * text, int len,
-                   lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 , int )
+                   lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 , int , int )
 {
     //static lUInt8 glyph_buf[16384];
     //LVFont::glyph_info_t info;
@@ -4611,7 +4620,8 @@ lUInt16 LVWin32DrawFont::measureText(
 /// draws text string
 void LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
                    const lChar16 * text, int len,
-                   lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 flags, int letter_spacing )
+                   lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                   lUInt32 flags, int letter_spacing, int width )
 {
     if (_hfont==NULL)
         return;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2017,7 +2017,8 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         NULL,
                         flgHyphen,
                         srcline->flags & 0x0F00,
-                        srcline->letter_spacing);
+                        srcline->letter_spacing,
+                        word->width);
                     if ( cl!=0xFFFFFFFF )
                         buf->SetTextColor( oldColor );
                     if ( bgcl!=0xFFFFFFFF )


### PR DESCRIPTION
Followup to #261. Fix most of the other things noticed along https://github.com/koreader/koreader/issues/4577, summarized in https://github.com/koreader/koreader/issues/4577#issuecomment-463557555.
See individual commit messages for details.

Was surprised to see some speed up in rendering (my test book went from 10s-loading +5s-rendering to 10s + 3s), probably thanks to the use of the new caches.