### PR TITLE
Fix segmentation fault because of typo

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1304,8 +1304,8 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance )
                             {
                             buf<<(lUInt32) css_val_inherited;
                             buf<<(lUInt32) 0;
-                            break;
                             }
+                            break;
                         default:break;
                     }
                     break;


### PR DESCRIPTION
Hello, I was experiencing recurring crashes with few books, and I managed to find the fault, which was a typo. All epub books that previously were crashing koreader now successfully load on my machine.