### PR TITLE
docToWindowPoint(): adds isRectBottom parameter 

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -718,8 +718,8 @@ public:
     bool drawImage(LVDrawBuf * buf, LVImageSourceRef img, int x, int y, int dx, int dy);
     /// converts point from window to document coordinates, returns true if success
     bool windowToDocPoint( lvPoint & pt );
-    /// converts point from documsnt to window coordinates, returns true if success
-    bool docToWindowPoint( lvPoint & pt );
+    /// converts point from document to window coordinates, returns true if success
+    bool docToWindowPoint( lvPoint & pt, bool isRectBottom=false );
 
     /// returns document
     ldomDocument * getDocument() { return m_doc; }


### PR DESCRIPTION
Will help fixing highlights in 2-pages mode, specifically https://github.com/koreader/koreader/issues/772#issuecomment-470107420 : 

<kbd>![after](https://user-images.githubusercontent.com/24273478/53966556-ade1d580-40f3-11e9-9d16-ef0c6ea0b269.png)</kbd>

The first line of the 2nd page was previously not highlighted, because its top y was considered part of the first page. Making it considered part of the 2nd page (by using `<` instead of `<=`, and it was highlighted - but then, the bottom line of the first page was not highlighted, because its bottom y was considered part of the 2nd page (see comments in the code for details.)

This will allow using that in cre.cpp to get things right:
```diff
 bool docToWindowRect(LVDocView *tv, lvRect &rc) {
     lvPoint topLeft = rc.topLeft();
     lvPoint bottomRight = rc.bottomRight();
-    if (tv->docToWindowPoint(topLeft)) {
+    // In 2-pages mode, the bottom of a rect at the
+    // bottom of 1st page shares the same y coordinate
+    // as the top of a rect at the top of 2nd page.
+    // We need to tell docToWindowPoint() to favorize
+    // the 2nd page for the top left corner.
+    // (It will by default not do that for the bottom
+    // right corner.)
+    bool topLeftPreferSecondPage = tv->getVisiblePageCount() > 1;
+    if (tv->docToWindowPoint(topLeft, topLeftPreferSecondPage)) {
         rc.setTopLeft(topLeft);
     }
     else {
         return false;
     }
     if (tv->docToWindowPoint(bottomRight)) {
         rc.setBottomRight(bottomRight);
     }
     else {
         return false;
     }
     return true;
 }
```

(The 2nd standalone highlight was also not shown, but this will need a fix in frontend.)

As the whole set of changes will depend on having `getVisiblePageCount() == 2`, it shouldn't hurt common 1-page usage.