### PR TITLE
2-pages view tweaks, fix words stuck when hyphenating on italic

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -719,7 +719,7 @@ public:
     /// converts point from window to document coordinates, returns true if success
     bool windowToDocPoint( lvPoint & pt );
     /// converts point from document to window coordinates, returns true if success
-    bool docToWindowPoint( lvPoint & pt, bool isRectBottom=false );
+    bool docToWindowPoint( lvPoint & pt, bool isRectBottom=false, bool fitToPage=false );
 
     /// returns document
     ldomDocument * getDocument() { return m_doc; }

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -387,7 +387,6 @@ protected:
 
     virtual void getNavigationBarRectangle( int pageIndex, lvRect & rc );
 
-    virtual void getPageRectangle( int pageIndex, lvRect & pageRect );
     /// returns document offset for next page
     int getNextPageOffset();
     /// returns document offset for previous page
@@ -399,6 +398,8 @@ protected:
     /// get document rectangle for specified cursor position, returns false if not visible
     bool getCursorDocRect( ldomXPointer ptr, lvRect & rc );
 public:
+    /// get outer (before margins are applied) page rectangle
+    virtual void getPageRectangle( int pageIndex, lvRect & pageRect );
     /// get screen rectangle for specified cursor position, returns false if not visible
     bool getCursorRect( ldomXPointer ptr, lvRect & rc, bool scrollToCursor = false );
     /// set status bar and clock mode
@@ -853,12 +854,15 @@ public:
     /// set vertical position of view inside document
     int SetPos( int pos, bool savePos=true, bool allowScrollAfterEnd = false);
 
-	int getPageHeight(int pageIndex);
+    // get page start y (in full document height)
+    int getPageStartY(int pageIndex);
+    // get page height
+    int getPageHeight(int pageIndex);
 
     /// get number of current page
     int getCurPage();
     /// move to specified page
-    bool goToPage(int page, bool updatePosBookmark = true);
+    bool goToPage(int page, bool updatePosBookmark = true, bool regulateTwoPages = true);
     /// returns page count
     int getPageCount();
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2474,8 +2474,26 @@ void LVDocView::updateLayout() {
 	m_pageRects[1] = rc;
 	if (getVisiblePageCount() == 2) {
 		int middle = (rc.left + rc.right) >> 1;
-		m_pageRects[0].right = middle - m_pageMargins.right / 2;
-		m_pageRects[1].left = middle + m_pageMargins.left / 2;
+		// m_pageRects[0].right = middle - m_pageMargins.right / 2;
+		// m_pageRects[1].left = middle + m_pageMargins.left / 2;
+		// ^ seems wrong, as we later add the margins to these m_pageRects
+		// so this would add to much uneeded middle margin
+                // We will ensure a max middle margin the size of a single
+                // left or right margin, whichever is the greatest.
+		// We still want to ensure a minimal middle margin in case
+		// the requested pageMargins are really small. Say 1.2em.
+		int min_middle_margin = 1.2 * m_font_size;
+		int max_middle_margin = m_pageMargins.left > m_pageMargins.right ? m_pageMargins.left : m_pageMargins.right;
+		int additional_middle_margin = 0;
+		int middle_margin = m_pageMargins.right + m_pageMargins.left;
+		if (middle_margin < min_middle_margin)
+			additional_middle_margin = min_middle_margin - middle_margin;
+		else if (middle_margin > max_middle_margin && max_middle_margin > min_middle_margin)
+			additional_middle_margin = max_middle_margin - middle_margin; // negative
+		// Note: with negative values, we allow these 2 m_pageRects to
+		// overlap. But it seems there is no issue doing that.
+		m_pageRects[0].right = middle - additional_middle_margin / 2;
+		m_pageRects[1].left = middle + additional_middle_margin / 2;
 	}
 }
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2013,10 +2013,16 @@ void LVDocView::GetPos(lvRect & rc) {
 
 int LVDocView::getPageHeight(int pageIndex)
 {
-    CR_UNUSED(pageIndex);
-	if (isPageMode() && _page >= 0 && _page < m_pages.length())
-		return m_pages[_page]->height;
+	if (isPageMode() && pageIndex >= 0 && pageIndex < m_pages.length())
+		return m_pages[pageIndex]->height;
 	return 0;
+}
+
+int LVDocView::getPageStartY(int pageIndex)
+{
+	if (isPageMode() && pageIndex >= 0 && pageIndex < m_pages.length())
+		return m_pages[pageIndex]->start;
+	return -1;
 }
 
 /// get vertical position of view inside document
@@ -2073,7 +2079,7 @@ int LVDocView::getCurPage() {
 	return m_pages.FindNearestPage(_pos, 0);
 }
 
-bool LVDocView::goToPage(int page, bool updatePosBookmark) {
+bool LVDocView::goToPage(int page, bool updatePosBookmark, bool regulateTwoPages) {
 	LVLock lock(getMutex());
     CHECK_RENDER("goToPage()")
 	if (!m_pages.length())
@@ -2098,8 +2104,8 @@ bool LVDocView::goToPage(int page, bool updatePosBookmark) {
 			page = 0;
 			res = false;
 		}
-		if (pc == 2)
-			page &= ~1;
+		if (pc == 2 && regulateTwoPages)
+			page &= ~1; // first page will always be odd (page are counted from 0)
 		if (page >= 0 && page < m_pages.length()) {
 			_pos = m_pages[page]->start;
 			_page = page;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1502,6 +1502,13 @@ public:
             int lastMandatoryWrap = -1;
             int spaceReduceWidth = 0; // max total line width which can be reduced by narrowing of spaces
             int firstCharMargin = getAdditionalCharWidthOnLeft(pos); // for first italic char with elements below baseline
+            // We might not need to bother with negative left side bearing, as we now
+            // can have them in the margin as we don't clip anymore. So we could just have:
+            // int firstCharMargin = 0;
+            // and italic "J" or "f" would be drawn a bit in the margin.
+            // (But as I don't know about the wanted effect with visualAlignmentEnabled,
+            // and given it's only about italic chars, and that we would need to remove
+            // stuff in getRenderedWidths... letting it as it is.)
 
             spaceReduceWidth -= visualAlignmentWidth/2;
             firstCharMargin += visualAlignmentWidth/2;
@@ -1707,6 +1714,10 @@ public:
                 // So, not touching it...
             }
             int dw = lastnonspace>=start ? getAdditionalCharWidth(lastnonspace, lastnonspace+1) : 0;
+            // If we ended the line with some hyphenation, no need to account for italic
+            // right side bearing overflow, as the last glyph will be an hyphen.
+            if (m_flags[endp-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER)
+                dw = 0;
             if (dw) {
                 TR("additional width = %d, after char %s", dw, LCSTR(lString16(m_text + lastnonspace, 1)));
                 m_widths[lastnonspace] += dw;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.23k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0013
+#define FORMATTING_VERSION_ID 0x0014
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -5975,6 +5975,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended) const
                             }
                             else {
                                 int chw = w[ offset - word->t.start ] - chx;
+                                bool hyphen_added = false;
                                 if ( offset == word->t.start + word->t.len - 1
                                         && (word->flags & LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER)
                                         && !gFlgFloatingPunctuationEnabled ) {
@@ -5984,6 +5985,9 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended) const
                                     // to keep nice looking rectangles on multi lines
                                     // text selection)
                                     chw += font->getHyphenWidth();
+                                    // We then should not account for the right side
+                                    // bearing below
+                                    hyphen_added = true;
                                 }
                                 rect.right = rect.left + chw;
                                 // Extend left or right if this glyph overflows its
@@ -5995,7 +5999,8 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended) const
                                 // looking rectangles on the sides when highlighting
                                 // multiple lines.
                                 rect.left += font->getLeftSideBearing(str[offset], true);
-                                rect.right -= font->getRightSideBearing(str[offset], true);
+                                if ( !hyphen_added )
+                                    rect.right -= font->getRightSideBearing(str[offset], true);
                             }
                         }
                         else


### PR DESCRIPTION
See individual commits and message for details.

### docToWindowPoint(): adds fitToPage parameter
Will help solving that rare issue described at https://github.com/koreader/crengine/pull/268#issuecomment-470661095

### 2-pages mode: add and fix some functions, tweak middle margin sizing
Will allow toggling `one page | two pages` in landscape mode on any device, and allow the little tweaks made by frontend on pages (extending text selection across pages, showing marker in the margin when following a footnote or back). See https://github.com/koreader/koreader/issues/772#issuecomment-470493499 and https://github.com/koreader/crengine/pull/268#issuecomment-470833786

I tweaked the middle margin sizing to something that I feel is right in all conditions of margins and font size. Some samples:

<kbd>![2pages1](https://user-images.githubusercontent.com/24273478/54221725-5dec7f80-44f4-11e9-85ac-14a71b80f238.png)</kbd>

<kbd>![2pages2](https://user-images.githubusercontent.com/24273478/54221730-5fb64300-44f4-11e9-8e3c-8050631886a5.png)</kbd>

<kbd>![2pages3](https://user-images.githubusercontent.com/24273478/54221735-61800680-44f4-11e9-8831-ac1568eccfed.png)</kbd>

<kbd>![2pages4](https://user-images.githubusercontent.com/24273478/54221739-6349ca00-44f4-11e9-97d6-90147b81a01a.png)</kbd>

### Text rendering: fix words stuck when hyphenating on italic 

A bit similar to #261 with hyphenation on HB, but different as it happens with all kerning methods.
Noticed at https://github.com/koreader/crengine/pull/261#issuecomment-470841914.

Before (_fusecompassion_ stuck, _dif-_ hyphen not aligned like the others):
![before](https://user-images.githubusercontent.com/24273478/54221985-cb98ab80-44f4-11e9-8fde-b85984e07af1.png)

After:
![after](https://user-images.githubusercontent.com/24273478/54221990-cd626f00-44f4-11e9-8fa6-f717478d37a8.png)

