### PR TITLE
Harfbuzz light: disable additional HB features

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -499,6 +499,10 @@ public:
             return glyph.width;
         return 0;
     }
+    /// returns char glyph left side bearing (not implemented)
+    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
+    /// returns char glyph right side bearing (not implemented)
+    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
 
     virtual lvfont_handle GetHandle() { return m_font; }
     


### PR DESCRIPTION
Fix issue with FreeSerif with the "good" kerning implementation, noticed at https://github.com/koreader/koreader/pull/4744#issuecomment-473113760 and investigated in followup posts.

Disalbing "liga" was not enough, there are other such features that need to be disabled to keep one glyph by codepoint, which is a requirement for the HARFBUZZ_LIGHT algorithm.
Glitches could be espacially witnessed with latest FreeSerif on french texts.

Also clear glyph caches when changing fallback font to prevent previous fallback font glyphs from leaking (reason why that happened not found).