### PR TITLE
Line height tweaks: more granularity, fix handlling and inheritance

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -31,7 +31,7 @@ changed_files="$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep -E '\.([CcHh
 if [ -n "${changed_files}" ]; then
     echo "Running cppcheck on ${changed_files}"
     # shellcheck disable=SC2086
-    cppcheck -j 4 --error-exitcode=2 --quiet ${changed_files}
+    cppcheck -j 4 --error-exitcode=2 ${changed_files}
 
     # ignore header files in clang-tidy for now
     # @TODO rename to *.hpp (or *.hxx)?

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -59,7 +59,7 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 int LVRendGetFontEmbolden();
 
 int measureBorder(ldomNode *enode,int border);
-int lengthToPx( css_length_t val, int base_px, int base_em );
+int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em=false );
 int scaleForRenderDPI( int value );
 
 #define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -73,7 +73,7 @@ typedef struct
     void *          object;   /**< \brief pointer to object which represents source */
     lInt16          margin;   /**< \brief first line margin */
     lInt16          valign_dy; /* drift y from baseline */
-    lUInt8          interval; /**< \brief line interval, *16 (16=normal, 32=double) */
+    lInt16          interval; /**< \brief line interval, *256 (256=normal, 512=double) */
     lInt16          letter_spacing; /**< \brief additional letter spacing, pixels */
     lUInt32         color;    /**< \brief color */
     lUInt32         bgcolor;  /**< \brief background color */
@@ -225,7 +225,7 @@ void lvtextAddSourceLine(
    lUInt32         color,    /* text color */
    lUInt32         bgcolor,  /* background color */
    lUInt32         flags,    /* flags */
-   lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval, /* interline space, *256 (256=single, 512=double) */
    lInt16          valign_dy,/* drift y from baseline */
    lUInt16         margin,   /* first line margin */
    void *          object,   /* pointer to custom object */
@@ -242,7 +242,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
-   lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -290,7 +290,7 @@ public:
 
     void AddSourceObject(
                 lUInt16         flags,     /* flags */
-                lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+                lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
                 lInt16          valign_dy, /* drift y from baseline */
                 lUInt16         margin,    /* first line margin */
                 void *          object,    /* pointer to custom object */
@@ -304,7 +304,7 @@ public:
            lUInt32         bgcolor,     /* background color */
            LVFont          * font,      /* font to draw string */
            lUInt32         flags=LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT,
-           lUInt8          interval=16, /* interline space, *16 (16=single, 32=double) */
+           lInt16          interval=256, /* interline space, *256 (256=single, 512=double) */
            lInt16          valign_dy=0, /* drift y from baseline */
            lUInt16         margin=0,    /* first line margin */
            void *          object=NULL,

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1717,7 +1717,7 @@ int styleToTextFmtFlags( const css_style_ref_t & style, int oldflags )
 }
 
 // Convert CSS value (type + number value) to screen px
-int lengthToPx( css_length_t val, int base_px, int base_em )
+int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em )
 {
     if (val.type == css_val_screen_px) { // use value as is
         return val.value;
@@ -1734,8 +1734,12 @@ int lengthToPx( css_length_t val, int base_px, int base_em )
     // we do that early to not lose precision
     int value = scaleForRenderDPI(val.value);
 
+    css_value_type_t type = val.type;
+    if (unspecified_as_em && type == css_val_unspecified)
+        type = css_val_em;
+
     // value for all units is stored *256 to not lose fractional part
-    switch( val.type )
+    switch( type )
     {
     /* absolute value, most often seen */
     case css_val_px:
@@ -1906,16 +1910,50 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // line_h is named 'interval' in lvtextfm.cpp, and described as:
                 //   *256 (256=normal, 512=double)
                 // so both % and em should be related to the value '256'
-                // line_height can be a number without unit, and it behaves as "em"
-                css_length_t line_height = css_length_t(
-                    style->line_height.type == css_val_unspecified ? css_val_em : style->line_height.type,
-                    style->line_height.value);
-                line_h = lengthToPx(line_height, 256, 256);
-                // line_height should never be css_val_inherited as spreadParent
-                // had updated it with its parent value, which could be the root
-                // element value, which is a value in % (90, 100 or 120), so we
-                // always got a valid style->line_height, and there is no need
-                // to keep the provided line_h like the original computation does
+                switch( style->line_height.type ) {
+                    case css_val_unspecified:
+                        // line_height can be a number without unit, and it's just a factor
+                        // (that gets inherited unchanged) to apply to the element font height
+                        // For the sake of computation, we use lengthToPx() with em to scale
+                        // the value 256 which means line-height: 1
+                        line_h = lengthToPx(style->line_height, 0, 256, true);
+                        break;
+                    case css_val_em:
+                    case css_val_ex:
+                    case css_val_percent:
+                        line_h = lengthToPx(style->line_height, 256, 256);
+                        break;
+                    case css_val_rem: // related to font size of the root element, managed by lengthToPx()
+                    case css_val_px:
+                    case css_val_in:
+                    case css_val_cm:
+                    case css_val_mm:
+                    case css_val_pt:
+                    case css_val_pc:
+                    case css_val_screen_px:  // screen px: for already scaled values
+                        // Absolute units:
+                        // lvtextfm.cpp uses our line_h (= interval) that way:
+                        // when positive:
+                        //    int fh = font->getHeight();
+                        //    frmline->height = (fh * interval) >> 8; // font height + interline space
+                        // when negative:
+                        //    frmline->height = -interval;
+                        // So, make line_h negative when we know its absolute size
+                        {
+                        int abs_line_h = lengthToPx(style->line_height, 0, 0);
+                        if (abs_line_h > 0) // make sure we got a positive number
+                            line_h = - abs_line_h;
+                        }
+                        break;
+                    case css_val_inherited:
+                    default:
+                        // line_height should never be css_val_inherited as spreadParent
+                        // had updated it from its parent value, which could be the root
+                        // element value, which is a value in unspecified unit (0.9, 1 or 1.2),
+                        // so we always got a valid style->line_height, and there is no need
+                        // to keep the provided line_h like the original computation does
+                        break;
+                }
             }
             else { // original crengine computation (used when gRenderDPI off)
                 css_length_t len = style->line_height;
@@ -1952,7 +1990,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // and https://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align
             int fh = enode->getFont()->getHeight();
             int fb = enode->getFont()->getBaseline();
-            int f_line_h = (fh * line_h) >> 8; // font height + interline space
+            int f_line_h; // font height + interline space
+            if (line_h < 0) // absolute size
+                f_line_h = - line_h;
+            else // line-height as unitless number
+                f_line_h = (fh * line_h) >> 8;
             int f_half_leading = (f_line_h - fh) /2;
             txform->setStrut(f_line_h, fb + f_half_leading);
         }
@@ -4164,7 +4206,6 @@ inline void spreadParent( css_length_t & val, css_length_t & parent_val, bool un
 
 void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef parent_font )
 {
-    CR_UNUSED(parent_font);
     //lvdomElementFormatRec * fmt = node->getRenderData();
     css_style_ref_t style( new css_style_rec_t );
     css_style_rec_t * pstyle = style.get();
@@ -4411,9 +4452,46 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         // printf("CRE WARNING: font-size css_val_unspecified or color, fallback to inherited\n");
         break;
     }
+
     // line_height
+    // spreadParent( pstyle->line_height, parent_style->line_height, false ); // css_val_unspecified is a valid unit
+    if (pstyle->line_height.type == css_val_inherited) {
+        int pfh = parent_font->getHeight(); // value in screen px
+        switch( parent_style->line_height.type ) {
+            // We didn't have yet the parent font when dealing with parent style
+            // inheritance to compute an absolute size line-height for em/ex/percent
+            // that we could just inherit as-is here.
+            // But we have it now, so compute its absolute size so it can be
+            // inherited as-is by our children.
+            case css_val_em:        // value = em*256 ; 256 = 1em = x1
+                pstyle->line_height.value = pfh * parent_style->line_height.value / 256;
+                pstyle->line_height.type = css_val_screen_px;
+                break;
+            case css_val_ex:        // value = ex*256 ; 512 = 2ex = 1em = x1
+                pstyle->line_height.value = pfh * parent_style->line_height.value / 512;
+                pstyle->line_height.type = css_val_screen_px;
+                break;
+            case css_val_percent:   // value = percent number * 256; 100*256 = 100% => x1
+                pstyle->line_height.value = pfh * parent_style->line_height.value / 100 / 256;
+                pstyle->line_height.type = css_val_screen_px;
+                break;
+            // For all others, we can inherit as-is
+            case css_val_rem:         // related to font size of the root element
+            case css_val_screen_px:   // absolute sizes
+            case css_val_px:
+            case css_val_in:
+            case css_val_cm:
+            case css_val_mm:
+            case css_val_pt:
+            case css_val_pc:
+            case css_val_unspecified: // unitless number: factor to element own font size: no relation to parent font
+            default:
+                pstyle->line_height = parent_style->line_height; // inherit as-is
+                break;
+        }
+    }
+
     spreadParent( pstyle->letter_spacing, parent_style->letter_spacing );
-    spreadParent( pstyle->line_height, parent_style->line_height, false ); // css_val_unspecified is a valid unit
     spreadParent( pstyle->color, parent_style->color );
 
     // background_color

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -968,7 +968,11 @@ public:
             src_text_fragment_t * srcline = m_srcs[start];
             LVFont * font = (LVFont*)srcline->t.font;
             int fh = font->getHeight();
-            int fhWithInterval = (fh * interval) >> 8; // font height + interline space
+            int fhWithInterval; // font height + interline space
+            if (interval < 0) // absolute size
+                fhWithInterval = - interval;
+            else // line-height as unitless number
+                fhWithInterval = (fh * interval) >> 8;
             frmline->height = (lUInt16) fhWithInterval;
             m_y += frmline->height;
             m_pbuffer->height = m_y;
@@ -1167,8 +1171,15 @@ public:
                     int vertical_align = srcline->flags & LTEXT_VALIGN_MASK;
                     int fh = font->getHeight();
                     // Accounts for line-height (adds what most documentation calls half-leading to top and to bottom):
-                    int fhWithInterval = (fh * interval) >> 8; // font height + interline space
+                    int fhWithInterval; // font height + interline space
+                    if (interval < 0) // absolute size
+                        fhWithInterval = - interval;
+                    else // line-height as unitless number
+                        fhWithInterval = (fh * interval) >> 8;
                     int fhInterval = fhWithInterval - fh;      // interline space only (negative for intervals < 100%)
+                    // Note: not sure if we should ensure these values stays positive
+                    // with absolute size interval, which may be small. As we do
+                    // only +/- arithmetic, it fells we should be fine.
                     top_to_baseline = font->getBaseline() + fhInterval/2;
                     baseline_to_bottom = fhWithInterval - top_to_baseline;
                     // vertical-align computation is now done in lvrend.cpp renderFinalBlock()

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -161,7 +161,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
    lUInt32         color,    /* color */
    lUInt32         bgcolor,  /* bgcolor */
    lUInt32         flags,    /* flags */
-   lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval, /* interline space, *256 (256=single, 512=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,   /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -214,7 +214,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
-   lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -252,7 +252,7 @@ bool gFlgFloatingPunctuationEnabled = true;
 
 void LFormattedText::AddSourceObject(
             lUInt16         flags,     /* flags */
-            lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+            lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
             lInt16          valign_dy, /* drift y from baseline */
             lUInt16         margin,    /* first line margin */
             void *          object,    /* pointer to custom object */
@@ -968,7 +968,7 @@ public:
             src_text_fragment_t * srcline = m_srcs[start];
             LVFont * font = (LVFont*)srcline->t.font;
             int fh = font->getHeight();
-            int fhWithInterval = (fh * interval) >> 4; // font height + interline space
+            int fhWithInterval = (fh * interval) >> 8; // font height + interline space
             frmline->height = (lUInt16) fhWithInterval;
             m_y += frmline->height;
             m_pbuffer->height = m_y;
@@ -1167,7 +1167,7 @@ public:
                     int vertical_align = srcline->flags & LTEXT_VALIGN_MASK;
                     int fh = font->getHeight();
                     // Accounts for line-height (adds what most documentation calls half-leading to top and to bottom):
-                    int fhWithInterval = (fh * interval) >> 4; // font height + interline space
+                    int fhWithInterval = (fh * interval) >> 8; // font height + interline space
                     int fhInterval = fhWithInterval - fh;      // interline space only (negative for intervals < 100%)
                     top_to_baseline = font->getBaseline() + fhInterval/2;
                     baseline_to_bottom = fhWithInterval - top_to_baseline;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13031,7 +13031,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object
     int flags = styleToTextFmtFlags( getStyle(), 0 );
-    ::renderFinalBlock( this, f.get(), fmt, flags, 0, 16 );
+    ::renderFinalBlock( this, f.get(), fmt, flags, 0, 256 );
     cache.set( this, f );
     bool flg=gFlgFloatingPunctuationEnabled;
     if (this->getNodeName()=="th"||this->getNodeName()=="td"||

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.23k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0014
+#define FORMATTING_VERSION_ID 0x0015
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -3726,8 +3726,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_style = css_fs_normal;
     s->text_indent.type = css_val_px;
     s->text_indent.value = 0;
-    s->line_height.type = css_val_percent;
-    s->line_height.value = def_interline_space << 8;
+    s->line_height.type = css_val_unspecified;        // line-height as a unitless number (0.9, 1, 1.2)
+    s->line_height.value = (def_interline_space << 8) / 100;  // 100 > 256
     s->orphans = css_orphans_widows_1; // default to allow orphans and widows
     s->widows = css_orphans_widows_1;
     s->cr_hint = css_cr_hint_none;


### PR DESCRIPTION
#### More granularity
Switch base from 16 to 256 for more granularity. Move it from lUint8 to lInt16 (and not lUInt16, as we'll soon want to use negative values to store fixed size line heights).
Details in https://github.com/koreader/koreader/pull/4785#issuecomment-473111879.


#### Fix handling and inheritance

`%` and `em` were handled just like unitless values, being inherited as is, and absolute sizes computed height was just wrong.
Introduce negative line_h/interval to support computed sizes to be used as-is, keeping positive values for
unitless line-height as a factor with base 256. (a)
Switch document root line-height from being 100% to being unitless def_interline_space.
(a) we could probaly kill that and just compute the absolute size even for unitless value in lvrend.cpp - just didn't want to change too much.
Details in https://github.com/koreader/koreader/pull/4785#issuecomment-473511976.

With this, we look more like Firefox when rendering bad line-heights:
(Firefox on the left, KOReader on the right)

<kbd>![lineheight-diff2](https://user-images.githubusercontent.com/24273478/54532621-7511ee00-4988-11e9-9028-2d5eaa06a41e.png)</kbd>

If this gives unwanted results with some books that would wrongly use `%` or `em`, one can try the `Zoom/DPI: off` or CSS tweak `Ignore publisher line-height`.
