### PR TITLE
line-height: reworked implemenation for better conformance

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -255,7 +255,8 @@ enum css_orphans_widows_value_t { // supported only if in range 1-9
 };
 
 enum css_generic_value_t {
-    css_generic_auto = -1 // for (css_val_unspecified, css_value_auto), for "margin: auto"
+    css_generic_auto = -1,   // (css_val_unspecified, css_generic_auto), for "margin: auto"
+    css_generic_normal = -2  // (css_val_unspecified, css_generic_normal), for "line-height: normal"
 };
 
 // Non standard property for providing hints to crengine via style tweaks

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -59,7 +59,7 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 int LVRendGetFontEmbolden();
 
 int measureBorder(ldomNode *enode,int border);
-int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em=false );
+int lengthToPx( css_length_t val, int base_px, int base_em );
 int scaleForRenderDPI( int value );
 
 #define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -59,7 +59,7 @@ void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
 int LVRendGetFontEmbolden();
 
 int measureBorder(ldomNode *enode,int border);
-int lengthToPx( css_length_t val, int base_px, int base_em );
+int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em=false );
 int scaleForRenderDPI( int value );
 
 #define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px
@@ -68,5 +68,9 @@ int scaleForRenderDPI( int value );
 extern int gRenderDPI;
 extern bool gRenderScaleFontWithDPI;
 extern int gRootFontSize;
+
+#define INTERLINE_SCALE_FACTOR_NO_SCALE 1024
+#define INTERLINE_SCALE_FACTOR_SHIFT 10
+extern int gInterlineScaleFactor;
 
 #endif

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -73,7 +73,7 @@ typedef struct
     void *          object;   /**< \brief pointer to object which represents source */
     lInt16          margin;   /**< \brief first line margin */
     lInt16          valign_dy; /* drift y from baseline */
-    lUInt8          interval; /**< \brief line interval, *16 (16=normal, 32=double) */
+    lInt16          interval; /**< \brief line height in screen pixels */
     lInt16          letter_spacing; /**< \brief additional letter spacing, pixels */
     lUInt32         color;    /**< \brief color */
     lUInt32         bgcolor;  /**< \brief background color */
@@ -225,7 +225,7 @@ void lvtextAddSourceLine(
    lUInt32         color,    /* text color */
    lUInt32         bgcolor,  /* background color */
    lUInt32         flags,    /* flags */
-   lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval, /* line height in screen pixels */
    lInt16          valign_dy,/* drift y from baseline */
    lUInt16         margin,   /* first line margin */
    void *          object,   /* pointer to custom object */
@@ -242,7 +242,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
-   lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+   lInt16          interval,  /* line height in screen pixels */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -290,7 +290,7 @@ public:
 
     void AddSourceObject(
                 lUInt16         flags,     /* flags */
-                lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
+                lInt16          interval,  /* line height in screen pixels */
                 lInt16          valign_dy, /* drift y from baseline */
                 lUInt16         margin,    /* first line margin */
                 void *          object,    /* pointer to custom object */
@@ -303,8 +303,8 @@ public:
            lUInt32         color,       /* text color */
            lUInt32         bgcolor,     /* background color */
            LVFont          * font,      /* font to draw string */
-           lUInt32         flags=LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT,
-           lUInt8          interval=16, /* interline space, *16 (16=single, 32=double) */
+           lUInt32         flags,       /* (had default =LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT) */
+           lInt16          interval,    /* line height in screen pixels */
            lInt16          valign_dy=0, /* drift y from baseline */
            lUInt16         margin=0,    /* first line margin */
            void *          object=NULL,

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -73,7 +73,7 @@ typedef struct
     void *          object;   /**< \brief pointer to object which represents source */
     lInt16          margin;   /**< \brief first line margin */
     lInt16          valign_dy; /* drift y from baseline */
-    lInt16          interval; /**< \brief line interval, *256 (256=normal, 512=double) */
+    lUInt8          interval; /**< \brief line interval, *16 (16=normal, 32=double) */
     lInt16          letter_spacing; /**< \brief additional letter spacing, pixels */
     lUInt32         color;    /**< \brief color */
     lUInt32         bgcolor;  /**< \brief background color */
@@ -225,7 +225,7 @@ void lvtextAddSourceLine(
    lUInt32         color,    /* text color */
    lUInt32         bgcolor,  /* background color */
    lUInt32         flags,    /* flags */
-   lInt16          interval, /* interline space, *256 (256=single, 512=double) */
+   lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
    lInt16          valign_dy,/* drift y from baseline */
    lUInt16         margin,   /* first line margin */
    void *          object,   /* pointer to custom object */
@@ -242,7 +242,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
-   lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
+   lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -290,7 +290,7 @@ public:
 
     void AddSourceObject(
                 lUInt16         flags,     /* flags */
-                lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
+                lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
                 lInt16          valign_dy, /* drift y from baseline */
                 lUInt16         margin,    /* first line margin */
                 void *          object,    /* pointer to custom object */
@@ -304,7 +304,7 @@ public:
            lUInt32         bgcolor,     /* background color */
            LVFont          * font,      /* font to draw string */
            lUInt32         flags=LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT,
-           lInt16          interval=256, /* interline space, *256 (256=single, 512=double) */
+           lUInt8          interval=16, /* interline space, *16 (16=single, 32=double) */
            lInt16          valign_dy=0, /* drift y from baseline */
            lUInt16         margin=0,    /* first line margin */
            void *          object=NULL,

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1008,12 +1008,15 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
 	LFormattedText txform;
 	if (!authors.empty())
 		txform.AddSourceLine(authors.c_str(), authors.length(), 0xFFFFFFFF,
-				0xFFFFFFFF, author_fnt.get(), LTEXT_ALIGN_CENTER, 18);
+				0xFFFFFFFF, author_fnt.get(), LTEXT_ALIGN_CENTER,
+				author_fnt->getHeight() * 18 / 16);
 	txform.AddSourceLine(title.c_str(), title.length(), 0xFFFFFFFF, 0xFFFFFFFF,
-			title_fnt.get(), LTEXT_ALIGN_CENTER, 18);
+			title_fnt.get(), LTEXT_ALIGN_CENTER,
+			title_fnt->getHeight() * 18 / 16);
 	if (!series.empty())
 		txform.AddSourceLine(series.c_str(), series.length(), 0xFFFFFFFF,
-				0xFFFFFFFF, series_fnt.get(), LTEXT_ALIGN_CENTER, 18);
+				0xFFFFFFFF, series_fnt.get(), LTEXT_ALIGN_CENTER,
+				series_fnt->getHeight() * 18 / 16);
 	int title_w = rc.width() - rc.width() / 4;
 	int h = txform.Format((lUInt16)title_w, (lUInt16)rc.height());
 
@@ -3332,9 +3335,13 @@ static int findBestFit(LVArray<int> & v, int n, bool rollCyclic = false) {
 }
 
 void LVDocView::setDefaultInterlineSpace(int percent) {
-	LVLock lock(getMutex());
+    LVLock lock(getMutex());
     REQUEST_RENDER("setDefaultInterlineSpace")
-	m_def_interline_space = percent;
+    m_def_interline_space = percent; // not used
+    if (percent == 100) // (avoid any rounding issue)
+        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
+    else
+        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE * percent / 100;
     _posIsSet = false;
 //	goToBookmark( _posBookmark);
 //        updateBookMarksRanges();

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1904,37 +1904,31 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // to the original behaviour when gRenderDPI = 0
             if (gRenderDPI) {
                 // line_h is named 'interval' in lvtextfm.cpp, and described as:
-                //   *256 (256=normal, 512=double)
-                // so both % and em should be related to the value '256'
+                //   *16 (16=normal, 32=double)
+                // so both % and em should be related to the value '16'
                 // line_height can be a number without unit, and it behaves as "em"
                 css_length_t line_height = css_length_t(
                     style->line_height.type == css_val_unspecified ? css_val_em : style->line_height.type,
                     style->line_height.value);
-                line_h = lengthToPx(line_height, 256, 256);
+                line_h = lengthToPx(line_height, 16, 16);
                 // line_height should never be css_val_inherited as spreadParent
                 // had updated it with its parent value, which could be the root
                 // element value, which is a value in % (90, 100 or 120), so we
                 // always got a valid style->line_height, and there is no need
                 // to keep the provided line_h like the original computation does
             }
-            else { // original crengine computation (used when gRenderDPI off)
+            else { // original crengine computation
                 css_length_t len = style->line_height;
                 switch( len.type )
                 {
                 case css_val_percent:
-                    // line_h = len.value * 16 / 100 >> 8;
-                    // line_h = len.value * 256 / 100 >> 8; // 20190315: 100% = 256 instead of 16
-                    line_h = len.value / 100; // simplified
+                    line_h = len.value * 16 / 100 >> 8;
                     break;
                 case css_val_px:
-                    // line_h = len.value * 16 / enode->getFont()->getHeight() >> 8;
-                    // line_h = len.value * 256 / enode->getFont()->getHeight() >> 8; // 20190315
-                    line_h = len.value / enode->getFont()->getHeight(); // simplified
+                    line_h = len.value * 16 / enode->getFont()->getHeight() >> 8;
                     break;
                 case css_val_em:
-                    // line_h = len.value * 16 / 256;
-                    // line_h = len.value * 256 / 256; // 20190315
-                    line_h = len.value; // simplified
+                    line_h = len.value * 16 / 256;
                     break;
                 default:
                     break;
@@ -1952,7 +1946,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // and https://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align
             int fh = enode->getFont()->getHeight();
             int fb = enode->getFont()->getBaseline();
-            int f_line_h = (fh * line_h) >> 8; // font height + interline space
+            int f_line_h = (fh * line_h) >> 4; // font height + interline space
             int f_half_leading = (f_line_h - fh) /2;
             txform->setStrut(f_line_h, fb + f_half_leading);
         }
@@ -2006,7 +2000,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             //   and related values, so we have to approximate them from height and baseline.
             int fh = enode->getFont()->getHeight();
             int fb = enode->getFont()->getBaseline();
-            int f_line_h = (fh * line_h) >> 8; // font height + interline space
+            int f_line_h = (fh * line_h) >> 4; // font height + interline space
             int f_half_leading = (f_line_h - fh) /2;
             // Use the current font values if no parent (should not happen thus) to
             // avoid the need for if-checks below
@@ -2020,7 +2014,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 pem = parent->getFont()->getSize();
                 pfh = parent->getFont()->getHeight();
                 pfb = parent->getFont()->getBaseline();
-                pf_line_h = (pfh * line_h) >> 8; // font height + interline space
+                pf_line_h = (pfh * line_h) >> 4; // font height + interline space
                 pf_half_leading = (pf_line_h - pfh) /2;
             }
             if (vertical_align.type == css_val_unspecified) { // named values
@@ -2117,7 +2111,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // But using the current font size looks correct and similar when
                 // comparing to Firefox rendering.
                 int base_em = em; // use current font ->getSize()
-                int base_pct = (fh * line_h) >> 8; // font height + interline space (as in lvtextfm.cpp)
+                int base_pct = (fh * line_h) >> 4; // font height + interline space (as in lvtextfm.cpp)
                 // positive values push text up, so reduce dy
                 valign_dy -= lengthToPx(vertical_align, base_pct, base_em);
             }
@@ -3036,7 +3030,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                         // Get marker width and height
                         LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
                         int list_marker_width;
-                        lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 256, 0);
+                        lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 16, 0);
                         list_marker_height = txform->Format( (lUInt16)(width - list_marker_width), (lUInt16)enode->getDocument()->getPageHeight() );
                         if ( enode->getStyle()->list_style_position == css_lsp_outside &&
                             enode->getStyle()->text_align != css_ta_center && enode->getStyle()->text_align != css_ta_right) {
@@ -3981,7 +3975,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     // we just need to draw the marker in the space we made
                     LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
                     int list_marker_width;
-                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 256, 0);
+                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 16, 0);
                     lUInt32 h = txform->Format( (lUInt16)width, (lUInt16)page_height );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
@@ -4039,7 +4033,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     // this node.
                     LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
                     int list_marker_width;
-                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 256, 0);
+                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), 16, 0);
                     lUInt32 h = txform->Format( (lUInt16)width, (lUInt16)page_height );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
@@ -4604,7 +4598,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, bool ignor
         bool list_marker_width_as_padding = false;
         if ( node->getStyle()->display == css_d_list_item_block ) {
             LFormattedTextRef txform( node->getDocument()->createFormattedText() );
-            lString16 marker = renderListItemMarker( node, list_marker_width, txform.get(), 256, 0);
+            lString16 marker = renderListItemMarker( node, list_marker_width, txform.get(), 16, 0);
             #ifdef DEBUG_GETRENDEREDWIDTHS
                 printf("GRW: list_marker_width: %d\n", list_marker_width);
             #endif

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -968,11 +968,7 @@ public:
             src_text_fragment_t * srcline = m_srcs[start];
             LVFont * font = (LVFont*)srcline->t.font;
             int fh = font->getHeight();
-            int fhWithInterval; // font height + interline space
-            if (interval < 0) // absolute size
-                fhWithInterval = - interval;
-            else // line-height as unitless number
-                fhWithInterval = (fh * interval) >> 8;
+            int fhWithInterval = (fh * interval) >> 8; // font height + interline space
             frmline->height = (lUInt16) fhWithInterval;
             m_y += frmline->height;
             m_pbuffer->height = m_y;
@@ -1171,15 +1167,8 @@ public:
                     int vertical_align = srcline->flags & LTEXT_VALIGN_MASK;
                     int fh = font->getHeight();
                     // Accounts for line-height (adds what most documentation calls half-leading to top and to bottom):
-                    int fhWithInterval; // font height + interline space
-                    if (interval < 0) // absolute size
-                        fhWithInterval = - interval;
-                    else // line-height as unitless number
-                        fhWithInterval = (fh * interval) >> 8;
+                    int fhWithInterval = (fh * interval) >> 8; // font height + interline space
                     int fhInterval = fhWithInterval - fh;      // interline space only (negative for intervals < 100%)
-                    // Note: not sure if we should ensure these values stays positive
-                    // with absolute size interval, which may be small. As we do
-                    // only +/- arithmetic, it fells we should be fine.
                     top_to_baseline = font->getBaseline() + fhInterval/2;
                     baseline_to_bottom = fhWithInterval - top_to_baseline;
                     // vertical-align computation is now done in lvrend.cpp renderFinalBlock()

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -161,7 +161,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
    lUInt32         color,    /* color */
    lUInt32         bgcolor,  /* bgcolor */
    lUInt32         flags,    /* flags */
-   lInt16          interval, /* interline space, *256 (256=single, 512=double) */
+   lUInt8          interval, /* interline space, *16 (16=single, 32=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,   /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -214,7 +214,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
-   lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
+   lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
    lInt16          valign_dy, /* drift y from baseline */
    lUInt16         margin,    /* first line margin */
    void *          object,    /* pointer to custom object */
@@ -252,7 +252,7 @@ bool gFlgFloatingPunctuationEnabled = true;
 
 void LFormattedText::AddSourceObject(
             lUInt16         flags,     /* flags */
-            lInt16          interval,  /* interline space, *256 (256=single, 512=double) */
+            lUInt8          interval,  /* interline space, *16 (16=single, 32=double) */
             lInt16          valign_dy, /* drift y from baseline */
             lUInt16         margin,    /* first line margin */
             void *          object,    /* pointer to custom object */
@@ -968,7 +968,7 @@ public:
             src_text_fragment_t * srcline = m_srcs[start];
             LVFont * font = (LVFont*)srcline->t.font;
             int fh = font->getHeight();
-            int fhWithInterval = (fh * interval) >> 8; // font height + interline space
+            int fhWithInterval = (fh * interval) >> 4; // font height + interline space
             frmline->height = (lUInt16) fhWithInterval;
             m_y += frmline->height;
             m_pbuffer->height = m_y;
@@ -1167,7 +1167,7 @@ public:
                     int vertical_align = srcline->flags & LTEXT_VALIGN_MASK;
                     int fh = font->getHeight();
                     // Accounts for line-height (adds what most documentation calls half-leading to top and to bottom):
-                    int fhWithInterval = (fh * interval) >> 8; // font height + interline space
+                    int fhWithInterval = (fh * interval) >> 4; // font height + interline space
                     int fhInterval = fhWithInterval - fh;      // interline space only (negative for intervals < 100%)
                     top_to_baseline = font->getBaseline() + fhInterval/2;
                     baseline_to_bottom = fhWithInterval - top_to_baseline;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.23k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0014
+#define FORMATTING_VERSION_ID 0x0016
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -365,6 +365,7 @@ lUInt32 calcGlobalSettingsHash(int documentId)
     hash = hash * 31 + HyphMan::getTrustSoftHyphens();
     hash = hash * 31 + gRenderDPI;
     hash = hash * 31 + gRootFontSize;
+    hash = hash * 31 + gInterlineScaleFactor;
     return hash;
 }
 
@@ -3694,6 +3695,7 @@ private:
 /// renders (formats) document in memory
 bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*y0*/, font_ref_t def_font, int def_interline_space, CRPropRef props )
 {
+    // Note: def_interline_space is no more used here
     bool changed = false;
     _renderedBlockCache.clear();
     changed = _imgScalingOptions.update(props, def_font->getSize()) || changed;
@@ -3726,8 +3728,10 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_style = css_fs_normal;
     s->text_indent.type = css_val_px;
     s->text_indent.value = 0;
-    s->line_height.type = css_val_percent;
-    s->line_height.value = def_interline_space << 8;
+    // s->line_height.type = css_val_percent;
+    // s->line_height.value = def_interline_space << 8;
+    s->line_height.type = css_val_unspecified;
+    s->line_height.value = css_generic_normal; // line-height: normal
     s->orphans = css_orphans_widows_1; // default to allow orphans and widows
     s->widows = css_orphans_widows_1;
     s->cr_hint = css_cr_hint_none;
@@ -13031,7 +13035,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object
     int flags = styleToTextFmtFlags( getStyle(), 0 );
-    ::renderFinalBlock( this, f.get(), fmt, flags, 0, 16 );
+    ::renderFinalBlock( this, f.get(), fmt, flags, 0, -1 );
     cache.set( this, f );
     bool flg=gFlgFloatingPunctuationEnabled;
     if (this->getNodeName()=="th"||this->getNodeName()=="td"||
@@ -13587,8 +13591,8 @@ void runBasicTinyDomUnitTests()
         style1->font_style = css_fs_normal;
         style1->text_indent.type = css_val_px;
         style1->text_indent.value = 0;
-        style1->line_height.type = css_val_percent;
-        style1->line_height.value = 100 << 8;
+        style1->line_height.type = css_val_unspecified;
+        style1->line_height.value = css_generic_normal; // line-height: normal
         style1->cr_hint = css_cr_hint_none;
 
         css_style_ref_t style2;
@@ -13617,8 +13621,8 @@ void runBasicTinyDomUnitTests()
         style2->font_style = css_fs_normal;
         style2->text_indent.type = css_val_px;
         style2->text_indent.value = 0;
-        style2->line_height.type = css_val_percent;
-        style2->line_height.value = 100 << 8;
+        style2->line_height.type = css_val_unspecified;
+        style2->line_height.value = css_generic_normal; // line-height: normal
         style2->cr_hint = css_cr_hint_none;
 
         css_style_ref_t style3;
@@ -13647,8 +13651,8 @@ void runBasicTinyDomUnitTests()
         style3->font_style = css_fs_normal;
         style3->text_indent.type = css_val_px;
         style3->text_indent.value = 0;
-        style3->line_height.type = css_val_percent;
-        style3->line_height.value = 100 << 8;
+        style3->line_height.type = css_val_unspecified;
+        style3->line_height.value = css_generic_normal; // line-height: normal
         style3->cr_hint = css_cr_hint_none;
 
         el1->setStyle(style1);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13031,7 +13031,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object
     int flags = styleToTextFmtFlags( getStyle(), 0 );
-    ::renderFinalBlock( this, f.get(), fmt, flags, 0, 256 );
+    ::renderFinalBlock( this, f.get(), fmt, flags, 0, 16 );
     cache.set( this, f );
     bool flg=gFlgFloatingPunctuationEnabled;
     if (this->getNodeName()=="th"||this->getNodeName()=="td"||

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.23k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0015
+#define FORMATTING_VERSION_ID 0x0014
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -3726,8 +3726,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_style = css_fs_normal;
     s->text_indent.type = css_val_px;
     s->text_indent.value = 0;
-    s->line_height.type = css_val_unspecified;        // line-height as a unitless number (0.9, 1, 1.2)
-    s->line_height.value = (def_interline_space << 8) / 100;  // 100 > 256
+    s->line_height.type = css_val_percent;
+    s->line_height.value = def_interline_space << 8;
     s->orphans = css_orphans_widows_1; // default to allow orphans and widows
     s->widows = css_orphans_widows_1;
     s->cr_hint = css_cr_hint_none;


### PR DESCRIPTION
Revert #272 , and re-implement line-height handling more correctly, fixing issues noticed in https://github.com/koreader/koreader/pull/4785#issuecomment-474569391:

- CSS: parse `normal` keyword length: can happen with `line-height: normal` and `letter-spacing: normal`.
- (CSS More generic support for parsing or not negative lengths.)
- Handle CSS `line-height` only in lvrend.cpp, and pass an already computed value (in screen pixels) to lvtextfm.cpp (`line_h`/`interval`).
- Compute it for each inline node, as we should (it was computed only from the containing block node, and used by all inline nodes; inline nodes can provide their own line-height, which we should ensure, for the lines this node spans, if it is higher than the "strut".)
- Fix computing of `line-height` in em, % or unitless lengths to use the font size, and not the font height ("font height" is "font size" + the font's internal line gap), as they should according to CSS specs.
- Adds support for `line-height: normal`, which is the only one that should use the font height (so, ensuring the font's natural line gap).
- Switch document root's line-height from `100%` to `normal`.
- Fix `line-height` inheritance: % and em were handled just like unitless values, being inherited as is, and absolute size computed height were just wrong. Now, compute an absolute size in screen pixels that can be inherited as is, as it should.
- `setDefaultInterlineSpace()` (called from frontent Interline choice buttons): don't change the document root line-height anymore, but set a global interline scaling factor, that is applied on all computed line heights. Granularity of 0.1%.
- Also fix `vertical-align: top` and `bottom`, now that line-height is known and fixed when laying out text.

Also, keep something like the previous behaviour when "Zoom/DPI" is "off" for some time so we can quickly see any differences. Should probably be dropped at some point to use "normal" for anything in absolute lengths.