### PR TITLE
2-pages mode: fix middle margin sizing

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2489,10 +2489,15 @@ void LVDocView::updateLayout() {
 		int max_middle_margin = m_pageMargins.left > m_pageMargins.right ? m_pageMargins.left : m_pageMargins.right;
 		int additional_middle_margin = 0;
 		int middle_margin = m_pageMargins.right + m_pageMargins.left;
-		if (middle_margin < min_middle_margin)
+		if (middle_margin < min_middle_margin) {
 			additional_middle_margin = min_middle_margin - middle_margin;
-		else if (middle_margin > max_middle_margin && max_middle_margin > min_middle_margin)
-			additional_middle_margin = max_middle_margin - middle_margin; // negative
+		}
+		else if (middle_margin > max_middle_margin) {
+			if (max_middle_margin > min_middle_margin)
+				additional_middle_margin = max_middle_margin - middle_margin; // negative
+			else
+				additional_middle_margin = min_middle_margin - middle_margin; // negative
+		}
 		// Note: with negative values, we allow these 2 m_pageRects to
 		// overlap. But it seems there is no issue doing that.
 		m_pageRects[0].right = middle - additional_middle_margin / 2;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2051,17 +2051,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             int pem = em;
             int pfh = fh;
             int pfb = fb;
-            int pf_line_h = f_line_h;
-            int pf_half_leading = f_half_leading;
             ldomNode *parent = enode->getParentNode();
             if (parent && !parent->isNull()) {
                 pem = parent->getFont()->getSize();
                 pfh = parent->getFont()->getHeight();
                 pfb = parent->getFont()->getBaseline();
-                // We assume our parent line_h is the same as ours (which may not be the
-                // case, but that should be rare)
-                pf_line_h = line_h;
-                pf_half_leading = (pf_line_h - pfh) /2;
             }
             if (vertical_align.type == css_val_unspecified) { // named values
                 switch (style->vertical_align.value) {


### PR DESCRIPTION
When increasing the margin from frontend, at some point it would decrease before increasing again (forgot to include that in previous PR).
Also removed unused variables from previous commit (#273) noticed by clang-tidy.