### PR TITLE
Fix 32bpp rendering (for our own target BB pixelformat)

### DIFF
--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -195,10 +195,10 @@ public:
     /// draws text string
     /*
     virtual void DrawTextString( int x, int y, LVFont * pfont,
-                       const lChar16 * text, int len, 
+                       const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen=false ) = 0;
-    */                       
-                      
+    */
+
 /*
     /// draws formatted text
     virtual void DrawFormattedText( formatted_text_fragment_t * text, int x, int y ) = 0;
@@ -258,8 +258,8 @@ public:
     /// draws text string
     /*
     virtual void DrawTextString( int x, int y, LVFont * pfont,
-                       const lChar16 * text, int len, 
-                       lChar16 def_char, 
+                       const lChar16 * text, int len,
+                       lChar16 def_char,
                        lUInt32 * palette, bool addHyphen=false );
     */
     /// draws formatted text
@@ -269,7 +269,7 @@ public:
     int getDrawnImagesCount() { return _drawnImagesCount; }
     /// Get surface of images drawn on buffer
     int getDrawnImagesSurface() { return _drawnImagesSurface; }
-    
+
     LVBaseDrawBuf() : _dx(0), _dy(0), _rowsize(0), _data(NULL), _hidePartialGlyphs(true),
                         _drawnImagesCount(0), _drawnImagesSurface(0) { }
     virtual ~LVBaseDrawBuf() { }
@@ -387,16 +387,33 @@ public:
     virtual void DrawLine(int x0, int y0, int x1, int y1, lUInt32 color0,int length1,int length2,int direction=0);
 };
 
-inline lUInt32 RevRGB( lUInt32 cl )
-{
-    return ((cl>>16)&255) | ((cl<<16)&0xFF0000) | (cl&0x00FF00);
+// NOTE: By default, CRe assumes RGB (array order) actually means BGR
+//       We don't, so, instead of fixing this at the root (i.e., in a *lot* of places),
+//       we simply swap R<->B when rendering to 32bpp, limiting the tweaks to lvdrawbuf
+//       c.f., https://github.com/koreader/koreader-base/pull/878#issuecomment-476723747
+#ifdef CR_RENDER_32BPP_RGB_PXFMT
+inline lUInt32 RevRGB( lUInt32 cl ) {
+    return ((cl>>16)&0x0000FF) | ((cl<<16)&0xFF0000) | (cl&0x00FF00);
 }
 
-inline lUInt32 rgb565to888(lUInt32 cl ) {
+inline lUInt32 RevRGBA( lUInt32 cl ) {
+    return (cl&0xFF000000) | ((cl>>16)&0x0000FF) | ((cl<<16)&0xFF0000) | (cl&0x00FF00);
+}
+#else
+inline lUInt32 RevRGB( lUInt32 cl ) {
+    return cl;
+}
+
+inline lUInt32 RevRGBA( lUInt32 cl ) {
+    return cl;
+}
+#endif
+
+inline lUInt32 rgb565to888( lUInt32 cl ) {
     return ((cl & 0xF800)<<8) | ((cl & 0x07E0)<<5) | ((cl & 0x001F)<<3);
 }
 
-inline lUInt16 rgb888to565(lUInt32 cl ) {
+inline lUInt16 rgb888to565( lUInt32 cl ) {
     return (lUInt16)(((cl>>8)& 0xF800) | ((cl>>5 )& 0x07E0) | ((cl>>3 )& 0x001F));
 }
 

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1,6 +1,6 @@
 /*******************************************************
 
-   CoolReader Engine 
+   CoolReader Engine
 
    lvdrawbuf.cpp:  Gray bitmap buffer class
 
@@ -86,7 +86,7 @@ static void ApplyAlphaRGB( lUInt32 &dst, lUInt32 src, lUInt32 alpha )
         dst = src;
     else if ( alpha<255 ) {
         src &= 0xFFFFFF;
-        lUInt32 opaque = 256 - alpha;
+        lUInt32 opaque = alpha ^ 0xFF;
         lUInt32 n1 = (((dst & 0xFF00FF) * alpha + (src & 0xFF00FF) * opaque) >> 8) & 0xFF00FF;
         lUInt32 n2 = (((dst & 0x00FF00) * alpha + (src & 0x00FF00) * opaque) >> 8) & 0x00FF00;
         dst = n1 | n2;
@@ -98,7 +98,7 @@ static void ApplyAlphaRGB565( lUInt16 &dst, lUInt16 src, lUInt32 alpha )
     if ( alpha==0 )
         dst = src;
     else if ( alpha<255 ) {
-        lUInt32 opaque = 256 - alpha;
+        lUInt32 opaque = alpha ^ 0xFF;
         lUInt32 r = (((dst & 0xF800) * alpha + (src & 0xF800) * opaque) >> 8) & 0xF800;
         lUInt32 g = (((dst & 0x07E0) * alpha + (src & 0x07E0) * opaque) >> 8) & 0x07E0;
         lUInt32 b = (((dst & 0x001F) * alpha + (src & 0x001F) * opaque) >> 8) & 0x001F;
@@ -113,7 +113,7 @@ static void ApplyAlphaGray( lUInt8 &dst, lUInt8 src, lUInt32 alpha, int bpp )
     else if ( alpha<255 ) {
         int mask = ((1<<bpp)-1) << (8-bpp);
         src &= mask;
-        lUInt32 opaque = 256 - alpha;
+        lUInt32 opaque = alpha ^ 0xFF;
         lUInt32 n1 = ((dst * alpha + src * opaque)>>8 ) & mask;
         dst = (lUInt8)n1;
     }
@@ -127,14 +127,14 @@ static void ApplyAlphaGray( lUInt8 &dst, lUInt8 src, lUInt32 alpha, int bpp )
 //};
 
 static const short dither_2bpp_8x8[] = {
-0, 32, 12, 44, 2, 34, 14, 46, 
-48, 16, 60, 28, 50, 18, 62, 30, 
-8, 40, 4, 36, 10, 42, 6, 38, 
-56, 24, 52, 20, 58, 26, 54, 22, 
-3, 35, 15, 47, 1, 33, 13, 45, 
-51, 19, 63, 31, 49, 17, 61, 29, 
-11, 43, 7, 39, 9, 41, 5, 37, 
-59, 27, 55, 23, 57, 25, 53, 21, 
+0, 32, 12, 44, 2, 34, 14, 46,
+48, 16, 60, 28, 50, 18, 62, 30,
+8, 40, 4, 36, 10, 42, 6, 38,
+56, 24, 52, 20, 58, 26, 54, 22,
+3, 35, 15, 47, 1, 33, 13, 45,
+51, 19, 63, 31, 49, 17, 61, 29,
+11, 43, 7, 39, 9, 41, 5, 37,
+59, 27, 55, 23, 57, 25, 53, 21,
 };
 
 // returns byte with higher significant bits, lower bits are 0
@@ -688,17 +688,17 @@ public:
 
 
 int  LVBaseDrawBuf::GetWidth()
-{ 
+{
     return _dx;
 }
 
 int  LVBaseDrawBuf::GetHeight()
-{ 
-    return _dy; 
+{
+    return _dy;
 }
 
 int  LVGrayDrawBuf::GetBitsPerPixel()
-{ 
+{
     return _bpp;
 }
 
@@ -1182,7 +1182,7 @@ void LVGrayDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int he
                     if ( b>=mask )
                         *dst = color;
                     else {
-                        int alpha = 256 - b;
+                        int alpha = b ^ 0xFF;
                         ApplyAlphaGray( *dst, color, alpha, _bpp );
                     }
                 }
@@ -1615,8 +1615,8 @@ void LVColorDrawBuf::Resize( int dx, int dy )
         _dx = 0;
         _dy = 0;
     }
-    
-    if (dx>0 && dy>0) 
+
+    if (dx>0 && dy>0)
     {
         // create new bitmap
         _dx = dx;
@@ -1636,7 +1636,7 @@ void LVColorDrawBuf::Resize( int dx, int dy )
         bmi.bmiHeader.biYPelsPerMeter = 1024;
         bmi.bmiHeader.biClrUsed = 0;
         bmi.bmiHeader.biClrImportant = 0;
-    
+
         _drawbmp = CreateDIBSection( NULL, &bmi, DIB_RGB_COLORS, (void**)(&_data), NULL, 0 );
         _drawdc = CreateCompatibleDC(NULL);
         SelectObject(_drawdc, _drawbmp);
@@ -2013,7 +2013,7 @@ void LVGrayDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 
                             c |= (cl&0xFF);
                             *(dst+1) = c;
                         }
-                    }    
+                    }
                     dst++;
                     src++;
                 }
@@ -2039,7 +2039,7 @@ void LVGrayDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32 
                             c |= (cl&0xFF);
                             *(dst+1) = c;
                         }
-                    }    
+                    }
                     dst++;
                     src++;
                 }
@@ -2596,7 +2596,7 @@ void LVGrayDrawBuf::DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, 
                     if ( x+xx >= clip.left && x+xx < clip.right ) {
                         int srcx16 = srcdx * xx * 16 / dx;
                         lUInt32 cl = src->GetInterpolatedColor(srcx16, srcy16);
-                        lUInt32 alpha = (cl >> 24) & 255;
+                        lUInt32 alpha = (cl >> 24) & 0xFF;
                         if (_bpp==1)
                         {
                             if (alpha >= 128)
@@ -2630,7 +2630,7 @@ void LVGrayDrawBuf::DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy, 
                             if (alpha < 16)
                                 *dst = (lUInt8)dithered;
                             else if (alpha < 240) {
-                                lUInt32 nalpha = 255 - alpha;
+                                lUInt32 nalpha = alpha ^ 0xFF;
                                 lUInt32 pixel = *dst;
                                 if (_bpp == 4)
                                     pixel = ((pixel * alpha + dithered * nalpha) >> 8) & 0xF0;

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -536,12 +536,12 @@ public:
                     if ( xx<clip.left || xx>=clip.right || alpha==0xFF )
                         continue;
                     if ( !alpha )
-                        row[ x ] = cl;
+                        row[ x ] = RevRGB(cl);
                     else {
                     	if ((row[x] & 0xFF000000) == 0xFF000000)
-                            row[ x ] = cl; // copy as is if buffer pixel is transparent
+                            row[ x ] = RevRGBA(cl); // copy as is if buffer pixel is transparent
                     	else
-                    		ApplyAlphaRGB( row[x], cl, alpha );
+                    		ApplyAlphaRGB( row[x], RevRGB(cl), alpha );
                     }
                 }
             }
@@ -1324,7 +1324,7 @@ void LVColorDrawBuf::Clear( lUInt32 color )
             lUInt32 * line = (lUInt32 *)GetScanLine(y);
             for (int x=0; x<_dx; x++)
             {
-                line[x] = color;
+                line[x] = RevRGBA(color);
             }
         }
     }
@@ -1502,9 +1502,9 @@ void LVColorDrawBuf::FillRect( int x0, int y0, int x1, int y1, lUInt32 color )
             for (int x=x0; x<x1; x++)
             {
                 if (alpha)
-                    ApplyAlphaRGB(line[x], color, alpha);
+                    ApplyAlphaRGB(line[x], RevRGB(color), alpha);
                 else
-                    line[x] = color;
+                    line[x] = RevRGBA(color);
             }
         }
     }
@@ -1539,8 +1539,8 @@ void LVColorDrawBuf::DrawLine(int x0,int y0,int x1,int y1,lUInt32 color0 ,int le
             lUInt32 * line = (lUInt32 *)GetScanLine(y);
             for (int x=x0; x<x1; x++)
             {
-                if (direction==0 &&x%(length1+length2)<length1)line[x] = color0;
-                if (direction==1 &&y%(length1+length2)<length1)line[x] = color0;
+                if (direction==0 &&x%(length1+length2)<length1)line[x] = RevRGBA(color0);
+                if (direction==1 &&y%(length1+length2)<length1)line[x] = RevRGBA(color0);
             }
         }
     }
@@ -1579,7 +1579,7 @@ void LVColorDrawBuf::FillRectPattern( int x0, int y0, int x1, int y1, lUInt32 co
             for (int x=x0; x<x1; x++)
             {
                 lUInt8 patternBit = (patternMask << (x&7)) & 0x80;
-                line[x] = patternBit ? color1 : color0;
+                line[x] = patternBit ? RevRGBA(color1) : RevRGBA(color0);
             }
         }
     }
@@ -1740,6 +1740,8 @@ void LVColorDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int h
     } else {
 
 
+        lUInt32 bmpcl32 = RevRGBA(bmpcl);
+
         lUInt32 * dst;
         lUInt32 * dstline;
 
@@ -1754,11 +1756,11 @@ void LVColorDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int h
             {
                 lUInt32 opaque = ((*(src++))>>1)&0x7F;
                 if ( opaque>=0x78 )
-                    *dst = bmpcl;
+                    *dst = bmpcl32;
                 else if ( opaque>0 ) {
                     lUInt32 alpha = 0x7F-opaque;
-                    lUInt32 cl1 = ((alpha*((*dst)&0xFF00FF) + opaque*(bmpcl&0xFF00FF))>>7) & 0xFF00FF;
-                    lUInt32 cl2 = ((alpha*((*dst)&0x00FF00) + opaque*(bmpcl&0x00FF00))>>7) & 0x00FF00;
+                    lUInt32 cl1 = ((alpha*((*dst)&0xFF00FF) + opaque*(bmpcl32&0xFF00FF))>>7) & 0xFF00FF;
+                    lUInt32 cl2 = ((alpha*((*dst)&0x00FF00) + opaque*(bmpcl32&0x00FF00))>>7) & 0x00FF00;
                     *dst = cl1 | cl2;
                 }
                 /* next pixel */
@@ -2418,7 +2420,7 @@ void LVColorDrawBuf::DrawTo( LVDrawBuf * buf, int x, int y, int options, lUInt32
                     lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y + yy)) + x;
                     for (int xx = 0; xx < _dx; xx++) {
                         if (x+xx >= clip.left && x + xx < clip.right) {
-                            *dst = *src;
+                            *dst = RevRGBA(*src);
                         }
                         dst++;
                         src++;
@@ -2561,7 +2563,7 @@ void LVColorDrawBuf::DrawOnTop( LVDrawBuf * buf, int x, int y)
                     lUInt32 * dst = ((lUInt32 *)buf->GetScanLine(y + yy)) + x;
                     for (int xx = 0; xx < _dx; xx++) {
                         if (x+xx >= clip.left && x + xx < clip.right) {
-                            if(*src!=0) *dst = *src;
+                            if(*src!=0) *dst = RevRGBA(*src);
                         }
                         dst++;
                         src++;
@@ -2732,7 +2734,7 @@ void LVColorDrawBuf::DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy,
 							dst[x + xx] = rgb888to565(cl);
 						} else {
 							lUInt32 * dst = (lUInt32 *)GetScanLine(y + yy);
-							dst[x + xx] = cl;
+							dst[x + xx] = RevRGBA(cl);
 						}
 					}
 				}
@@ -2751,7 +2753,7 @@ void LVColorDrawBuf::DrawRescaled(LVDrawBuf * src, int x, int y, int dx, int dy,
 							dst[x + xx] = rgb888to565(cl);
 						} else {
 							lUInt32 * dst = (lUInt32 *)GetScanLine(y + yy);
-							dst[x + xx] = cl;
+							dst[x + xx] = RevRGBA(cl);
 						}
 					}
 				}

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2491,9 +2491,9 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
                                 n++;
                     }
                     n++; // this is our position
-                    if (_value == "even" && (n % 2)==0)
+                    if (_value == "even" && (n & 1)==0)
                         return true;
-                    if (_value == "odd" && (n % 2)==1)
+                    if (_value == "odd" && (n & 1)==1)
                         return true;
                     // other values ( 5, 5n3...) not supported (yet)
                     return false;
@@ -2510,9 +2510,9 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
                                 n++;
                     }
                     n++; // this is our position
-                    if (_value == "even" && (n % 2)==0)
+                    if (_value == "even" && (n & 1)==0)
                         return true;
-                    if (_value == "odd" && (n % 2)==1)
+                    if (_value == "odd" && (n & 1)==1)
                         return true;
                     // other values ( 5, 5n3...) not supported (yet)
                     return false;


### PR DESCRIPTION
BGR -> RGB (c.f., https://github.com/koreader/koreader-base/pull/878#issuecomment-476723747).

Also includes a few minor cosmetic tweaks around suspicious-looking alpha-blending codepaths.
And a minor tweak to oddness checks to use AND instead of MOD

(I squashed stuff in logical units, so this should probably be rebased and not squashed ;)).