### PR TITLE
Allow drawing images inverted + Some CSS fixes

### DIFF
--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -97,6 +97,8 @@ public:
     virtual void SetClipRect( const lvRect * clipRect ) = 0;
     /// set to true for drawing in Paged mode, false for Scroll mode
     virtual void setHidePartialGlyphs( bool hide ) = 0;
+    /// set to true to invert images only (so they get inverted back to normal by nightmode)
+    virtual void setInvertImages( bool invert ) = 0;
     /// invert image
     virtual void  Invert() = 0;
     /// get buffer width, pixels
@@ -228,10 +230,14 @@ protected:
     lUInt32 _backgroundColor;
     lUInt32 _textColor;
     bool _hidePartialGlyphs;
+    bool _invertImages;
     int _drawnImagesCount;
     int _drawnImagesSurface;
 public:
+    /// set to true for drawing in Paged mode, false for Scroll mode
     virtual void setHidePartialGlyphs( bool hide ) { _hidePartialGlyphs = hide; }
+    /// set to true to invert images only (so they get inverted back to normal by nightmode)
+    virtual void setInvertImages( bool invert ) { _invertImages = invert; }
     /// returns current background color
     virtual lUInt32 GetBackgroundColor() { return _backgroundColor; }
     /// sets current background color
@@ -271,7 +277,7 @@ public:
     int getDrawnImagesSurface() { return _drawnImagesSurface; }
 
     LVBaseDrawBuf() : _dx(0), _dy(0), _rowsize(0), _data(NULL), _hidePartialGlyphs(true),
-                        _drawnImagesCount(0), _drawnImagesSurface(0) { }
+                        _invertImages(false), _drawnImagesCount(0), _drawnImagesSurface(0) { }
     virtual ~LVBaseDrawBuf() { }
 };
 

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -154,6 +154,10 @@ public:
     ~LVCssSelectorRule() { if (_next) delete _next; }
     /// check condition for node
     bool check( const ldomNode * & node );
+    /// check next rules for node
+    bool checkNextRules( const ldomNode * node );
+    /// Some selector rule types do the full rules chain check themselves
+    bool isFullChecking() { return _type == cssrt_ancessor || _type == cssrt_predsibling; }
     lUInt32 getHash();
     lUInt32 getWeight();
 };

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1391,9 +1391,10 @@ public:
 	}
 #if BUILD_LITE!=1
     /// returns caret rectangle for pointer inside formatted document
-    bool getRect(lvRect & rect, bool extended=false) const;
-    /// returns caret rectangle for pointer inside formatted document considering paddings and borders
-    bool getRectEx(lvRect & rect) const { return getRect(rect, true); };
+    bool getRect(lvRect & rect, bool extended=false, bool adjusted=false) const;
+    /// returns glyph rectangle for pointer inside formatted document considering paddings and borders
+    /// (with adjusted=true, adjust for left and right side bearing of the glyph, for cleaner highlighting)
+    bool getRectEx(lvRect & rect, bool adjusted=false) const { return getRect(rect, true, adjusted); };
     /// returns coordinates of pointer inside formatted document
     lvPoint toPoint( bool extended=false ) const;
 #endif

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -709,6 +709,9 @@ void LVGrayDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int hei
         return;
     LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither );
     img->Decode( &drawcb );
+    if ( _invertImages )
+        InvertRect(x, y, x+width, y+height);
+
     _drawnImagesCount++;
     _drawnImagesSurface += width*height;
 }
@@ -1301,6 +1304,8 @@ void LVColorDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int he
     //fprintf( stderr, "LVColorDrawBuf::Draw( img(%d, %d), %d, %d, %d, %d\n", img->GetWidth(), img->GetHeight(), x, y, width, height );
     LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither );
     img->Decode( &drawcb );
+    if ( _invertImages )
+        InvertRect(x, y, x+width, y+height);
     _drawnImagesCount++;
     _drawnImagesSurface += width*height;
 }
@@ -1647,9 +1652,36 @@ void LVColorDrawBuf::Resize( int dx, int dy )
     }
     SetClipRect( NULL );
 }
+
 void LVColorDrawBuf::InvertRect(int x0, int y0, int x1, int y1)
 {
-    CR_UNUSED4(x0, y0, x1, y1);
+    if (x0<_clip.left)
+        x0 = _clip.left;
+    if (y0<_clip.top)
+        y0 = _clip.top;
+    if (x1>_clip.right)
+        x1 = _clip.right;
+    if (y1>_clip.bottom)
+        y1 = _clip.bottom;
+    if (x0>=x1 || y0>=y1)
+        return;
+
+    if (_bpp==16) {
+        for (int y=y0; y<y1; y++) {
+            lUInt16 * line = (lUInt16 *)GetScanLine(y);
+            for (int x=x0; x<x1; x++) {
+                line[x] ^= 0xFFFF;
+            }
+        }
+    }
+    else {
+        for (int y=y0; y<y1; y++) {
+            lUInt32 * line = (lUInt32 *)GetScanLine(y);
+            for (int x=x0; x<x1; x++) {
+                line[x] ^= 0x00FFFFFF;
+            }
+        }
+    }
 }
 
 /// draws bitmap (1 byte per pixel) using specified palette

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -295,9 +295,14 @@ static int parse_name( const char * & str, const char * * names, int def_value )
 static lUInt32 parse_important( const char *str ) // does not advance the original *str
 {
     skip_spaces( str );
-    if (substr_icompare( "!important", str )) {
-        // returns directly what should be | to prop_code
-        return IMPORTANT_DECL_SET;
+    // "!  important", with one or more spaces in between, is valid
+    if (*str == '!') {
+        str++;
+        skip_spaces( str );
+        if (substr_icompare( "important", str )) {
+            // returns directly what should be | to prop_code
+            return IMPORTANT_DECL_SET;
+        }
     }
     return 0;
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.23k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0016
+#define FORMATTING_VERSION_ID 0x0017
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
#### DrawBuf: allow drawing images inverted

Will be requested when in night mode: inverted images will then get inverted back by night mode and displayed normally. See https://github.com/koreader/koreader/issues/2571#issuecomment-477339586

#### ldomXPointer::getRect(): adds adjusted=false parameter

Commit https://github.com/koreader/crengine/commit/12c8e4e11d104c43eff0d423c0a9cf3443eb0ba4 from #263 (_lvtinydom: Adjust ldomXPointer::getRectEx(), used to get the rect of a char, to include its glyph's left and right overflows_) is nice for getting nice rects to highlight, but should generally not be done for other things - so have it done only when needed. Will avoid having "not a coherent xpointer" as seen in https://github.com/koreader/koreader/issues/4840#issuecomment-476603558.

#### CSS: fix parsing of "! important" with spaces 

That's [allowed](https://www.w3.org/TR/css-syntax-3/#%21important-diagram), and used in the testsuite:
<kbd>![image](https://user-images.githubusercontent.com/24273478/55240316-f09d5600-5238-11e9-8d9c-a8f766a416dd.png)</kbd>

#### CSS: fix non-deterministic combinators

E F (descendant combinator) and E ~ F (general sibling combinator) had a limited implementation, that could miss some matches.
This implements the correct logic: check the multiple possible paths, possibly all, until a match is found.
This may be expensive on books with lots of such selectors, and may increase the loading and re-rendering times (some quick test on a book with an absurdly lot of these shows a +20% load time).
It fixes the css3-modsel-86, css3-modsel-88 (and others css3-modsel-8xx) from #176, see https://github.com/koreader/crengine/issues/176#issuecomment-386811364.

