### PR TITLE
Delay some style computations until needed

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3932,20 +3932,20 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         // A few things differ when done for TR, THEAD, TBODY and TFOOT
         bool isTableRowLike = rm == erm_table_row || rm == erm_table_row_group ||
                               rm == erm_table_header_group || rm == erm_table_footer_group;
-        int em = enode->getFont()->getSize();
-        int width = fmt.getWidth();
         int height = fmt.getHeight();
-        bool draw_padding_bg = true; //( enode->getRendMethod()==erm_final );
-        int padding_left = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,3);
-        int padding_right = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,1);
-        int padding_top = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,0);
-        //int padding_bottom = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[3], width, em ) + DEBUG_TREE_DRAW;
         if ( (doc_y + height <= 0 || doc_y > 0 + dy) && !isTableRowLike ) {
             // TR may have cells with rowspan>1, and even though this TR
             // is out of range, it must draw a rowspan>1 cell, so it it
             // not empty when a next TR (not out of range) is drawn.
             return; // out of range
         }
+        int em = enode->getFont()->getSize();
+        int width = fmt.getWidth();
+        bool draw_padding_bg = true; //( enode->getRendMethod()==erm_final );
+        int padding_left = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[0], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,3);
+        int padding_right = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[1], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,1);
+        int padding_top = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[2], width, em ) + DEBUG_TREE_DRAW+measureBorder(enode,0);
+        //int padding_bottom = !draw_padding_bg ? 0 : lengthToPx( enode->getStyle()->padding[3], width, em ) + DEBUG_TREE_DRAW;
         css_length_t bg = enode->getStyle()->background_color;
         lUInt32 oldColor = 0;
         // Don't draw background color for TR and THEAD/TFOOT/TBODY as it could

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12076,25 +12076,23 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         return NULL;
     ldomNode * enode = this;
     lvdom_element_render_method rm = enode->getRendMethod();
-
-    RenderRectAccessor fmt( this );
-    int top_margin = lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
-    int bottom_margin = lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
-    if ( rm == erm_table_row || rm == erm_table_row_group || rm == erm_table_header_group || rm == erm_table_footer_group ) {
-        // Styles margins set on <TR>, <THEAD> and the like are ignored
-        // by table layout algorithm (as per CSS specs)
-        top_margin = 0;
-        bottom_margin = 0;
-    }
-
     if ( rm == erm_invisible ) {
         return NULL;
     }
+    RenderRectAccessor fmt( this );
+
+    // Styles margins set on <TR>, <THEAD> and the like are ignored
+    // by table layout algorithm (as per CSS specs)
+    bool ignore_margins = ( rm == erm_table_row || rm == erm_table_row_group ||
+                            rm == erm_table_header_group || rm == erm_table_footer_group );
+
+    int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
     if ( pt.y < fmt.getY() - top_margin) {
         if ( direction>0 && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
             return this;
         return NULL;
     }
+    int bottom_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
     if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
         if ( direction<0 && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
             return this;


### PR DESCRIPTION
In DrawDocument() and elementFromPoint(), where we loop thru all the children of an element to check if their y is inside current page, compute only what's needed before tests that can return early.
This brings some speedup when turning pages on document that have thousands of small paragraphs in a single body/DocFragment.
Details and some profiling data in #277.