### PR TITLE
CSS: fix some attempts to read memory that has been freed

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1155,7 +1155,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance )
                                 // remove family name from font list
                                 list.erase( i, 1 );
                             }
-                            if ( substr_icompare( "!important", name ) ) {
+                            else if ( substr_icompare( "!important", name ) ) {
                                 // !important may be caught by splitPropertyValueList()
                                 list.erase( i, 1 );
                                 parsed_important = IMPORTANT_DECL_SET;
@@ -1841,9 +1841,8 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance )
                 while (*tmp && *tmp !=';' && *tmp!='}' && *tmp!='!')
                 {tmp++;len++;}
                 str.append(decl,len);
-                tmp=str.c_str();
                 str.trim();
-                skip_spaces(tmp);
+                tmp=str.c_str();
                 int offset=len-str.length();//offset for removed spaces
                 if (Utf8ToUnicode(str).lowercase().startsWith("url")) {
                     len=0;


### PR DESCRIPTION
Fix some issues noticed by valgrind, reported by @Frenzie at https://github.com/koreader/crengine/commit/8f15e01c8aea15920381f14ea85b0b4abeb36cfd#r32972995

```
==11314== Invalid read of size 1
==11314==    at 0x1B16FCD1: substr_icompare(char const*, char const*&) (lvstsheet.cpp:221)
==11314==    by 0x1B170D92: LVCssDeclaration::parse(char const*&, bool) (lvstsheet.cpp:1153)
==11314==    by 0x1B1783B8: LVStyleSheet::parse(char const*, bool) (lvstsheet.cpp:3009)
==11314==    by 0x1B109BD8: lxmlDocBase::setStyleSheet(char const*, bool) (lvtinydom.cpp:10890)
==11314==  Address 0x145503c9 is 9 bytes inside a block of size 10 free'd
==11314==    at 0x48369AB: free (vg_replace_malloc.c:530)
==11314==    by 0x1B0F1738: lString8::free() (lvstring.cpp:1656)
==11314==    by 0x1B0F1862: release (lvstring.h:235)
==11314==    by 0x1B0F1862: lString8Collection::erase(int, int) (lvstring.cpp:1374)
==11314==    by 0x1B170E02: LVCssDeclaration::parse(char const*&, bool) (lvstsheet.cpp:1151)
==11314==    by 0x1B1783B8: LVStyleSheet::parse(char const*, bool) (lvstsheet.cpp:3009)
```

```
==11314== Invalid read of size 1
==11314==    at 0x1B16FD89: skip_spaces(char const*&) (lvstsheet.cpp:240)
==11314==    by 0x1B172AF3: LVCssDeclaration::parse(char const*&, bool) (lvstsheet.cpp:1841)
==11314==    by 0x1B1E67D9: setNodeStyle(ldomNode*, LVFastRef<css_style_rec_tag>, LVProtectedFastRef<LVFont>) (lvrend.cpp:4300)
==11314==    by 0x1B122743: ldomNode::initNodeStyle() (lvtinydom.cpp:12306)
==11314==    by 0x1B123040: updateStyleDataRecursive(ldomNode*) (lvtinydom.cpp:11968)
==11314==  Address 0x7909d50 is 0 bytes inside a block of size 1 free'd
==11314==    at 0x48369AB: free (vg_replace_malloc.c:530)
==11314==    by 0x1B0F1738: lString8::free() (lvstring.cpp:1656)
==11314==    by 0x1B0F3233: release (lvstring.h:235)
==11314==    by 0x1B0F3233: clear (lvstring.h:376)
==11314==    by 0x1B0F3233: lString8::trim() (lvstring.cpp:2396)
==11314==    by 0x1B172AE7: LVCssDeclaration::parse(char const*&, bool) (lvstsheet.cpp:1840)
```

(Small PR, but I have nothing else to PR soon, so let's get rid of that.)