### PR TITLE
Various fixes: dot in paths, CSS transparent color, line-height

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -463,7 +463,7 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
             if ( !href.empty() && !id.empty() ) {
                 if (id == coverId) {
                     // coverpage file
-                    lString16 coverFileName = codeBase + href;
+                    lString16 coverFileName = LVCombinePaths(codeBase, href);
                     CRLog::info("EPUB coverpage file: %s", LCSTR(coverFileName));
                     coverPageImageStream = m_arc->OpenStream(coverFileName.c_str(), LVOM_READ);
                 }
@@ -885,7 +885,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 href = DecodeHTMLUrlString(href);
                 if ( id==coverId ) {
                     // coverpage file
-                    lString16 coverFileName = codeBase + href;
+                    lString16 coverFileName = LVCombinePaths(codeBase, href);
                     CRLog::info("EPUB coverpage file: %s", LCSTR(coverFileName));
                     LVStreamRef stream = m_arc->OpenStream(coverFileName.c_str(), LVOM_READ);
                     if ( !stream.isNull() ) {
@@ -938,7 +938,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 EpubItem * ncx = epubItems.findById( spine->getAttributeValue("toc") ); //TODO
                 //EpubItem * ncx = epubItems.findById(cs16("ncx"));
                 if ( ncx!=NULL )
-                    ncxHref = codeBase + ncx->href;
+                    ncxHref = LVCombinePaths(codeBase, ncx->href);
 
                 for ( int i=1; i<50000; i++ ) {
                     ldomNode * item = doc->nodeFromXPath(lString16("package/spine/itemref[") << fmt::decimal(i) << "]");
@@ -981,7 +981,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     int fragmentCount = 0;
     for ( int i=0; i<spineItems.length(); i++ ) {
         if (spineItems[i]->mediaType == "application/xhtml+xml") {
-            lString16 name = codeBase + spineItems[i]->href;
+            lString16 name = LVCombinePaths(codeBase, spineItems[i]->href);
             lString16 subst = cs16("_doc_fragment_") + fmt::decimal(i);
             appender.addPathSubstitution( name, subst );
             //CRLog::trace("subst: %s => %s", LCSTR(name), LCSTR(subst));
@@ -989,7 +989,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     }
     for ( int i=0; i<spineItems.length(); i++ ) {
         if (spineItems[i]->mediaType == "application/xhtml+xml") {
-            lString16 name = codeBase + spineItems[i]->href;
+            lString16 name = LVCombinePaths(codeBase, spineItems[i]->href);
             {
                 CRLog::debug("Checking fragment: %s", LCSTR(name));
                 LVStreamRef stream = m_arc->OpenStream(name.c_str(), LVOM_READ);

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -3783,7 +3783,13 @@ lString16 LVCombinePaths( lString16 basePath, lString16 newPath )
             }
         }
     } while ( changed && s.length()>=pattern.length() );
-    // "./"
+    // Replace "/./" inside with "/"
+    pattern.clear();
+    pattern << separator << "." << separator;
+    lString16 replacement;
+    replacement << separator;
+    while ( s.replace( pattern, replacement ) ) ;
+    // Remove "./" at start
     if ( s.length()>2 && s[0]=='.' && s[1]==separator )
         s.erase(0, 2);
     return s;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -683,6 +683,13 @@ bool parse_color_value( const char * & str, css_length_t & value )
             return true;
         }
     }
+    if ( substr_icompare( "transparent", str ) ) {
+        // Make it an invalid color, but a valid parsing so it
+        // can be inherited or flagged with !important
+        value.type = css_val_unspecified;
+        value.value = 0;
+        return true;
+    }
     return false;
 }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -118,6 +118,9 @@ formatted_text_fragment_t * lvtextAllocFormatter( lUInt16 width )
     pbuffer->strut_baseline = 0;
     int defMode = MAX_IMAGE_SCALE_MUL > 1 ? (ARBITRARY_IMAGE_SCALE_ENABLED==1 ? 2 : 1) : 0;
     int defMult = MAX_IMAGE_SCALE_MUL;
+    // Notes from thornyreader:
+    // mode: 0=disabled, 1=integer scaling factors, 2=free scaling
+    // scale: 0=auto based on font size, 1=no zoom, 2=scale up to *2, 3=scale up to *3
     pbuffer->img_zoom_in_mode_block = defMode; /**< can zoom in block images: 0=disabled, 1=integer scale, 2=free scale */
     pbuffer->img_zoom_in_scale_block = defMult; /**< max scale for block images zoom in: 1, 2, 3 */
     pbuffer->img_zoom_in_mode_inline = defMode; /**< can zoom in inline images: 0=disabled, 1=integer scale, 2=free scale */
@@ -967,8 +970,10 @@ public:
             // a frmline as Draw() loops thru these lines - a frmline
             // with no word will do).
             src_text_fragment_t * srcline = m_srcs[start];
-            if (srcline->interval > 0) // should always be the case
-                frmline->height = srcline->interval;
+            if (srcline->interval > 0) { // should always be the case
+                if (srcline->interval > frmline->height) // keep strut_height if greater
+                    frmline->height = srcline->interval;
+            }
             else { // fall back to line-height: normal
                 LVFont * font = (LVFont*)srcline->t.font;
                 frmline->height = font->getHeight();


### PR DESCRIPTION
#### Supports './' and '/./' in file paths/href in EPUB

See https://github.com/koreader/koreader/issues/4353#issuecomment-479858881

#### Text rendering: ensure strut height on empty lines

Small thing missed in #273

#### CSS: adds support for color 'transparent' 

See https://github.com/koreader/crengine/issues/176#issuecomment-478321727

#### Fix getPageDocumentRange() on some pages (again)

More generic implementation of #105. See there for details. In some cases, this could happen at start too.