### PR TITLE
Ignore cr3gui/data/tessdata/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ cr3gui/data/cr3.css
 cr3gui/data/cr3.ini
 cr3gui/data/dict/
 cr3gui/data/dict_ext
+cr3gui/data/tessdata/
 thirdparty


### PR DESCRIPTION
During testing, we need to populate `cr3gui/data/tessdata` with training data. This causes spam in git status all the way up the submodule chain. I propose we gitignore the directory altogether.