### PR TITLE
Inter word text decoration, fix TOC page numbers, reproducible cache files

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -272,7 +272,8 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette = NULL, bool addHyphen = false,
-                       lUInt32 flags=0, int letter_spacing=0, int width=-1 ) = 0;
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1,
+                       int text_decoration_back_gap=0 ) = 0;
     /// constructor
     LVFont() : _visual_alignment_width(-1), _hash(0) { }
 
@@ -448,7 +449,8 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                       lUInt32 flags=0, int letter_spacing=0, int width=-1 );
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1,
+                       int text_decoration_back_gap=0 );
 };
 
 #if (USE_FREETYPE!=1) && (USE_BITMAP_FONTS==1)
@@ -646,7 +648,8 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                       lUInt32 flags=0, int letter_spacing=0, int width=-1 );
+                       lUInt32 flags=0, int letter_spacing=0, int width=-1,
+                       int text_decoration_back_gap=0 );
         
     /** \brief get glyph image in 1 byte per pixel format
         \param code is unicode character

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2009,6 +2009,11 @@ public:
     /// For use on the root toc item only (_page, otherwise unused, can be used to store this flag)
     void setAlternativeTocFlag() { if (_level==0) _page = 1; }
     bool hasAlternativeTocFlag() { return _level==0 && _page==1; }
+
+    /// When page numbers have been calculated, LVDocView::updatePageNumbers()
+    /// sets the root toc item _percent to -1. So let's use it to know that fact.
+    bool hasValidPageNumbers() { return _level==0 && _percent == -1; }
+    void invalidatePageNumbers() { if (_level==0) _percent = 0; }
 };
 
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -778,7 +778,7 @@ LVTocItem * LVDocView::getToc() {
         // Avoid calling updatePageNumbers() in that case (as it is expensive
         // and would delay book opening when loaded from cache - it will be
         // called when it is really needed: after next full rendering)
-        if (!m_doc->isTocFromCacheValid())
+        if (!m_doc->isTocFromCacheValid() || !m_doc->getToc()->hasValidPageNumbers())
             updatePageNumbers(m_doc->getToc());
 	return m_doc->getToc();
 }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1980,7 +1980,8 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                       lUInt32 flags, int letter_spacing, int width )
+                       lUInt32 flags, int letter_spacing, int width,
+                       int text_decoration_back_gap )
     {
         FONT_GUARD
         if ( len <= 0 || _face==NULL )
@@ -2202,6 +2203,9 @@ public:
             // pen x if last glyph was a space not accounted in word width)
             if ( width >= 0 && x > x0 + width)
                 x = x0 + width;
+            // And start the decoration before x0 if it is continued
+            // from previous word
+            x0 -= text_decoration_back_gap;
             int h = _size > 30 ? 2 : 1;
             lUInt32 cl = buf->GetTextColor();
             if ( (flags & LTEXT_TD_UNDERLINE) || (flags & LTEXT_TD_BLINK) ) {
@@ -2537,7 +2541,8 @@ public:
     virtual void DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                       lUInt32 flags, int letter_spacing, int width )
+                       lUInt32 flags, int letter_spacing, int width,
+                       int text_decoration_back_gap )
     {
         if ( len <= 0 )
             return;
@@ -2595,6 +2600,9 @@ public:
             // pen x if last glyph was a space not accounted in word width)
             if ( width >= 0 && x > x0 + width)
                 x = x0 + width;
+            // And start the decoration before x0 if it is continued
+            // from previous word
+            x0 -= text_decoration_back_gap;
             int h = _size > 30 ? 2 : 1;
             lUInt32 cl = buf->GetTextColor();
             if ( (flags & LTEXT_TD_UNDERLINE) || (flags & LTEXT_TD_BLINK) ) {
@@ -4148,7 +4156,7 @@ int LVFontDef::CalcFallbackMatch( lString8 face, int size ) const
 
 void LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
                    const lChar16 * text, int len,
-                   lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 , int , int )
+                   lChar16 def_char, lUInt32 * palette, bool addHyphen, lUInt32 , int , int, int )
 {
     //static lUInt8 glyph_buf[16384];
     //LVFont::glyph_info_t info;
@@ -4755,7 +4763,8 @@ lUInt16 LVWin32DrawFont::measureText(
 void LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
                    const lChar16 * text, int len,
                    lChar16 def_char, lUInt32 * palette, bool addHyphen,
-                   lUInt32 flags, int letter_spacing, int width )
+                   lUInt32 flags, int letter_spacing, int width,
+                   int text_decoration_back_gap )
 {
     if (_hfont==NULL)
         return;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1961,6 +1961,9 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 }
             }
 #endif
+
+            int text_decoration_back_gap;
+            lUInt16 lastWordSrcIndex;
             for (j=0; j<frmline->word_count; j++)
             {
                 word = &frmline->words[j];
@@ -1998,6 +2001,14 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         buf->FillRect( rc.left, rc.top, rc.right, rc.bottom, 0xAAAAAA );
                     }
                     */
+                    // Check if we need to continue the text decoration from previous word.
+                    // For now, we only ensure it if this word and previous one are in the
+                    // same text node. We wrongly won't when one of these is in a sub <SPAN>
+                    // because we can't detect that rightly at this point anymore...
+                    text_decoration_back_gap = 0;
+                    if (j > 0 && word->src_text_index == lastWordSrcIndex) {
+                        text_decoration_back_gap = word->x - lastWordEnd;
+                    }
                     lUInt32 oldColor = buf->GetTextColor();
                     lUInt32 oldBgColor = buf->GetBackgroundColor();
                     lUInt32 cl = srcline->color;
@@ -2017,12 +2028,15 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         flgHyphen,
                         srcline->flags & 0x0F00,
                         srcline->letter_spacing,
-                        word->width);
+                        word->width,
+                        text_decoration_back_gap);
                     if ( cl!=0xFFFFFFFF )
                         buf->SetTextColor( oldColor );
                     if ( bgcl!=0xFFFFFFFF )
                         buf->SetBackgroundColor( oldBgColor );
                 }
+                lastWordSrcIndex = word->src_text_index;
+                lastWordEnd = word->x + word->width;
             }
 
 #ifdef CR_USE_INVERT_FOR_SELECTION_MARKS

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3934,6 +3934,9 @@ int ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback, 
     if ( !_rendered ) {
         setCacheFileStale(true); // new rendering: cache file will be updated
         _toc_from_cache_valid = false;
+        // force recalculation of page numbers (even if not computed in this
+        // session, they will be when loaded from cache next session)
+        m_toc.invalidatePageNumbers();
         pages->clear();
         if ( showCover )
             pages->add( new LVRendPageInfo( _page_height ) );


### PR DESCRIPTION
#### Ensure text decoration (underline) is continued over word gaps

Depending on the added space between words to ensure text justification, underline (eg: for links spanning multiple words) could have some cuts.
(We can still have some cuts when the words are in distinct text nodes, eg with `<a href="">Louis <span class=roman>XIV</span></a>`, less easy to fix.)

Before:
<kbd>![before](https://user-images.githubusercontent.com/24273478/57122869-d139a180-6d7f-11e9-80e9-3c8dab625bbb.png)</kbd>

After:
<kbd>![after](https://user-images.githubusercontent.com/24273478/57122874-d4349200-6d7f-11e9-863b-c2b249d1d73a.png)</kbd>

#### Invalidate TOC page numbers on rendering change
As page numbers are calculated only when needed, they could still gather old numbers after book re-rendering, which could lead to wrong TOC page numbers when loading from cache. Details along https://github.com/koreader/koreader/pull/4972#issuecomment-487380928

#### Ensure reproducible cache files when same rendering settings 
Have cache files have the same file checksum by zero'ing struct padding, getting rid of random data when they are serialized into the cache file. Details along https://github.com/koreader/koreader/pull/4972#issuecomment-487123345
