### PR TITLE
Use utf8proc for string uppercase/lowercase/capitalize

### DIFF
--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -4425,7 +4425,8 @@ public:
         lString8 buf;
         for ( Block * p = _firstBlock; p; p = p->next ) {
             char s[1000];
-            sprintf(s, "%x ", (int)p->block_start);
+            snprintf(s, 999, "%x ", (int)p->block_start);
+            s[999] = 0;
             buf << s;
         }
         CRLog::trace("BLOCKS (%s): %s   count=%d", context, buf.c_str(), _count);
@@ -4458,6 +4459,16 @@ public:
                 blockBytesRead = blockSpaceLeft;
                 res = LVERR_OK;
             } else {
+                lvpos_t fsize = _baseStream->GetSize();
+                if ( _pos + blockSpaceLeft > fsize && fsize < _size) {
+#if TRACE_BLOCK_WRITE_STREAM
+                    CRLog::trace("stream::Read: inconsistent cache state detected: fsize=%d, _size=%d, force flush...", (int)fsize, (int)_size);
+#endif
+                    // Workaround to exclude fatal error in ldomTextStorageChunk::ensureUnpacked()
+                    // Write cached data to a file stream if the required read block is larger than the rest of the file.
+                    // This is a very rare case.
+                    Flush(true);
+                }
 #if TRACE_BLOCK_WRITE_STREAM
                 CRLog::trace("direct reading from stream (%x, %x)", (int)_pos, (int)blockSpaceLeft);
 #endif
@@ -4496,7 +4507,7 @@ public:
                 blockSpaceLeft = count;
             lvsize_t blockBytesWritten = 0;
 
-            // read from Write buffers if possible, otherwise - from base stream
+            // write to Write buffers
             res = writeToCache(buf, _pos, blockSpaceLeft);
             if ( res!=LVERR_OK )
                 break;

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -30,6 +30,10 @@
 #include <zlib.h>
 #endif
 
+#if (USE_UTF8PROC==1)
+#include <utf8proc.h>
+#endif
+
 #if !defined(__SYMBIAN32__) && defined(_WIN32)
 extern "C" {
 #include <windows.h>
@@ -2613,6 +2617,9 @@ void lStr_uppercase( lChar16 * str, int len )
 {
     for ( int i=0; i<len; i++ ) {
         lChar16 ch = str[i];
+#if (USE_UTF8PROC==1)
+        str[i] = utf8proc_toupper(ch);
+#else
         if ( ch>='a' && ch<='z' ) {
             str[i] = ch - 0x20;
         } else if ( ch>=0xE0 && ch<=0xFF ) {
@@ -2631,6 +2638,7 @@ void lStr_uppercase( lChar16 * str, int len )
                 str[i] = ch | 8;
             }
         }
+#endif
     }
 }
 
@@ -2638,6 +2646,9 @@ void lStr_lowercase( lChar16 * str, int len )
 {
     for ( int i=0; i<len; i++ ) {
         lChar16 ch = str[i];
+#if (USE_UTF8PROC==1)
+        str[i] = utf8proc_tolower(ch);
+#else
         if ( ch>='A' && ch<='Z' ) {
             str[i] = ch + 0x20;
         } else if ( ch>=0xC0 && ch<=0xDF ) {
@@ -2656,6 +2667,7 @@ void lStr_lowercase( lChar16 * str, int len )
                 str[i] = ch & (~8);
             }
         }
+#endif
     }
 }
 
@@ -2679,6 +2691,9 @@ void lStr_capitalize( lChar16 * str, int len )
         lChar16 ch = str[i];
         if (prev_is_word_sep) {
             // as done as in lStr_uppercase()
+#if (USE_UTF8PROC==1)
+            str[i] = utf8proc_toupper(ch);
+#else
             if ( ch>='a' && ch<='z' ) {
                 str[i] = ch - 0x20;
             } else if ( ch>=0xE0 && ch<=0xFF ) {
@@ -2697,6 +2712,7 @@ void lStr_capitalize( lChar16 * str, int len )
                     str[i] = ch | 8;
                 }
             }
+#endif
         }
         // update prev_is_word_sep for next char
         prev_is_word_sep = lStr_isWordSeparator(ch);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -897,7 +897,7 @@ bool CacheFile::read( lUInt16 type, lUInt16 dataIndex, lUInt8 * &buf, int &size 
     lvsize_t bytesRead = 0;
     _stream->Read(buf, size, &bytesRead );
     if ( (int)bytesRead!=size ) {
-        CRLog::error("CacheFile::read: Cannot read block %d:%d of size %d", type, dataIndex, (int)size);
+        CRLog::error("CacheFile::read: Cannot read block %d:%d of size %d, bytesRead=%d", type, dataIndex, (int)size, (int)bytesRead);
         free(buf);
         buf = NULL;
         size = 0;
@@ -1643,7 +1643,7 @@ bool tinyNodeCollection::openCacheFile()
         return false;
     }
 
-    CRLog::info("ldomDocument::openCacheFile() - looking for cache file", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - looking for cache file %s", UnicodeToUtf8(fname).c_str() );
 
     lString16 cache_path;
     LVStreamRef map = ldomDocCache::openExisting( fname, crc, getPersistenceFlags(), cache_path );
@@ -1651,13 +1651,13 @@ bool tinyNodeCollection::openCacheFile()
         delete f;
         return false;
     }
-    CRLog::info("ldomDocument::openCacheFile() - cache file found, trying to read index", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - cache file found, trying to read index %s", UnicodeToUtf8(fname).c_str() );
 
     if ( !f->open( map ) ) {
         delete f;
         return false;
     }
-    CRLog::info("ldomDocument::openCacheFile() - index read successfully", UnicodeToUtf8(fname).c_str() );
+    CRLog::info("ldomDocument::openCacheFile() - index read successfully %s", UnicodeToUtf8(fname).c_str() );
     f->setCachePath(cache_path);
     _cacheFile = f;
     _textStorage.setCache( f );


### PR DESCRIPTION
Use new thirdparty lib https://github.com/JuliaStrings/utf8proc added by https://github.com/koreader/koreader-base/pull/915 for more complete and accurate string uppercase, lowercase and capitalize, used by CSS `text-transform`.
See https://github.com/koreader/koreader/issues/4958#issuecomment-486385893.

Also includes upstream fix for a rare crash https://github.com/buggins/coolreader/pull/89. I don't really know if we could ever be infected, but it looks harmless enough.