### PR TITLE
Freetype kerning: fix possible unstable rendering

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1691,8 +1691,8 @@ public:
                     lastFitChar = i + 1;
                     continue;  /* ignore errors */
                 }
-                if ( ch_glyph_index==(FT_UInt)-1 )
-                    ch_glyph_index = getCharIndex( ch, 0 );
+//                if ( ch_glyph_index==(FT_UInt)-1 )
+//                    ch_glyph_index = getCharIndex( ch, 0 );
 //                error = FT_Load_Glyph( _face,          /* handle to face object */
 //                        ch_glyph_index,                /* glyph index           */
 //                        FT_LOAD_DEFAULT );             /* load flags, see below */
@@ -1701,8 +1701,12 @@ public:
 //                    continue;  /* ignore errors */
 //                }
             }
+            if ( use_kerning ) {
+                if ( ch_glyph_index==(FT_UInt)-1 )
+                    ch_glyph_index = getCharIndex( ch, 0 );
+                previous = ch_glyph_index;
+            }
             widths[i] = prev_width + w + (kerning >> 6) + letter_spacing;
-            previous = ch_glyph_index;
             if ( !isHyphen ) // avoid soft hyphens inside text string
                 prev_width = widths[i];
             if ( prev_width > max_width ) {


### PR DESCRIPTION
Fix small logic error: 'previous' was updated with a valid 'ch_glyph_index' only when going thru char width calculation.
Once that width is cached, we could stay with a possible invalide previous char, and get a different kerning value.

Very minor fix, probably hardly noticable.
I noticed it by accident, by selecting the highlighted word, in a book with embedded fonts that was using Times (which seems to have more kerning rules than any other font) for that title:

<kbd>![image](https://user-images.githubusercontent.com/24273478/58172566-399de380-7c99-11e9-8b7b-6a223c2af26a.png)</kbd>

When selecting that word, some part of the sentence was sliding to the right :) because the `L'` at the start, that should have a -2px kerning, was loosing it on further renderings (which happen when you select some text, or just show and quit some menu.)
