### PR TITLE
epub.css: add style for empty-line (used on text files)

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -140,6 +140,10 @@ nobr {
     white-space: nowrap;
 }
 
+/* Element added for each empty line when rendering plain txt files */
+empty-line {
+    height: 1em;
+}
 
 
 /* Old element or className based selectors involving display: that


### PR DESCRIPTION
It was present in the obsoleted txt.css, but its absence from our now generic epub.css made empty lines in plain text files not rendered.
Details in https://github.com/koreader/koreader/issues/5042#issuecomment-496020267