### PR TITLE
Various small rendering fixes

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1454,7 +1454,11 @@ public:
                 else if ( i==nb_rows-1 ) { // last row
                     // Avoid a split between last row and previous to last (really?)
                     // Avoid a split between last row and table bottom padding/border
-                    line_flags = RN_SPLIT_BEFORE_AVOID | RN_SPLIT_AFTER_AVOID;
+                    //   line_flags = RN_SPLIT_BEFORE_AVOID | RN_SPLIT_AFTER_AVOID;
+                    // Let's not avoid a split between last and previous last, as
+                    // the last row is most often not a bottom TH, and it would just
+                    // drag them onto next page, leaving a hole on previous page.
+                    line_flags = RN_SPLIT_BEFORE_AUTO | RN_SPLIT_AFTER_AVOID;
                 }
                 else {
                     // Otherwise, allow any split between rows

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4018,7 +4018,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     drawbuf.GetClipRect( &clip );
                     if (doc_y + h <= clip.bottom) { // draw only if marker fully fits on page
                         DrawBackgroundImage(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
-                        txform->Draw( &drawbuf, doc_x+x0 + padding_left, doc_y+y0 + padding_top, NULL, NULL );
+                        // (Don't shift by padding left, the list marker is outside padding left)
+                        txform->Draw( &drawbuf, doc_x+x0, doc_y+y0 + padding_top, NULL, NULL );
                     }
                 }
 
@@ -4076,7 +4077,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     drawbuf.GetClipRect( &clip );
                     if (doc_y + h <= clip.bottom) { // draw only if marker fully fits on page
                         DrawBackgroundImage(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
-                        txform->Draw( &drawbuf, doc_x+x0 + padding_left - list_marker_width, doc_y+y0 + padding_top, NULL, NULL );
+                        // (Don't shift by padding left, the list marker is outside padding left)
+                        txform->Draw( &drawbuf, doc_x+x0 - list_marker_width, doc_y+y0 + padding_top, NULL, NULL );
                     }
                 }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4283,6 +4283,13 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     //////////////////////////////////////////////////////
     enode->getDocument()->applyStyle( enode, pstyle );
 
+    // Ensure any <stylesheet> element (that crengine "added BODY>stylesheet child
+    // element with HEAD>STYLE&LINKS content") stays invisible (it could end up being
+    // made visible when some book stylesheet contains "body > * {display: block;}")
+    if (enode->getNodeId() == el_stylesheet) {
+        pstyle->display = css_d_none;
+    }
+
     if ( enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasAttribute( LXML_NS_ANY, attr_style ) ) {
         lString16 nodeStyle = enode->getAttributeValue( LXML_NS_ANY, attr_style );
         if ( !nodeStyle.empty() ) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -767,6 +767,10 @@ public:
                         int newlen = chars_measured; // TODO: find best wrap position
                         i = start + newlen;
                         len = newlen;
+                        // As we're going to continue measuring this text node,
+                        // reset newFont (the font of the next text node), so
+                        // it does not replace lastFont at the end of the loop.
+                        newFont = NULL;
                     }
 
                     // Deal with chars flagged as collapsed spaces:

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1100,8 +1100,18 @@ public:
                     // block cut by <BR>): most browsers don't display the line break
                     // implied by the BR when we have: "<div>some text<br/> </div>more text"
                     // or "<div>some text<br/> <span> </span> </div>more text".
-                    if (lastWord && frmline->word_count == 0 && !isLastPara) {
-                        wstart--; // make a single word with a single collapsed space
+                    if (lastWord && frmline->word_count == 0) {
+                        if (!isLastPara) {
+                            wstart--; // make a single word with a single collapsed space
+                        }
+                        else { // Last or single para with no word
+                            // A line has already been added: just make
+                            // it zero height.
+                            frmline->height = 0;
+                            frmline->baseline = 0;
+                            continue;
+                            // We'll then just exit the loop as we are lastWord
+                        }
                     }
                     else {
                         // no word made, get ready for next loop

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -605,6 +605,16 @@ public:
             printf("CRE WARNING: resizeImage(width=0 or height=0)\n");
             return;
         }
+        if (width < 0 || height < 0) {
+            // Avoid invalid resizing if we are provided with negative values
+            printf("CRE WARNING: resizeImage(width<0 or height<0)\n");
+            return;
+        }
+        if (maxw < 0 || maxh < 0) {
+            // Avoid invalid resizing if we are provided with negative max values
+            printf("CRE WARNING: resizeImage(maxw<0 or maxh<0)\n");
+            return;
+        }
         //CRLog::trace("Resize image (%dx%d) max %dx%d %s  *%d", width, height, maxw, maxh, arbitraryImageScaling ? "arbitrary" : "integer", maxScaleMult);
         if ( maxScaleMult<1 ) maxScaleMult = 1;
         if ( arbitraryImageScaling ) {
@@ -1121,6 +1131,11 @@ public:
                     height = height<0? -height*(m_pbuffer->width-x)/100 : height;
                     // todo: adjust m_max_img_height with this image valign_dy/vertical_align_flag
                     resizeImage(width, height, m_pbuffer->width - x, m_max_img_height, m_length>1);
+                        // Note: it can happen with a standalone image in a small container
+                        // where text-indent is greater than width, that 'm_pbuffer->width - x'
+                        // can be negative. We could cap it to zero and resize the image to 0,
+                        // but let it be shown un-resized, possibly overflowing or overriding
+                        // other content.
                     word->width = width;
                     word->o.height = height;
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -64,7 +64,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.24k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0019
+#define FORMATTING_VERSION_ID 0x001A
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12461,7 +12461,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
     if ( !marker.empty() ) {
         LVFont * font = getFont().get();
         if ( font ) {
-            markerWidth = font->getTextWidth((marker + "  ").c_str(), marker.length()+2) + s->font_size.value/8;
+            markerWidth = font->getTextWidth((marker + "  ").c_str(), marker.length()+2) + font->getSize()/8;
             res = true;
         } else {
             marker.clear();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13010,19 +13010,27 @@ int ldomNode::getSurroundingAddedHeight()
     int h = 0;
     ldomNode * n = this;
     while (true) {
+        ldomNode * parent = n->getParentNode();
         lvdom_element_render_method rm = n->getRendMethod();
         if ( rm != erm_inline && rm != erm_invisible && rm != erm_killed) {
-            RenderRectAccessor fmt( n );
-            h += lengthToPx( n->getStyle()->margin[2], fmt.getWidth(), n->getFont()->getSize() ); // top margin
-            h += lengthToPx( n->getStyle()->margin[3], fmt.getWidth(), n->getFont()->getSize() ); // bottom margin
-            h += lengthToPx( n->getStyle()->padding[2], fmt.getWidth(), n->getFont()->getSize() ); // top padding
-            h += lengthToPx( n->getStyle()->padding[3], fmt.getWidth(), n->getFont()->getSize() ); // bottom padding
+            // Add offset of border and padding
+            int base_width = 0;
+            if ( parent && !(parent->isNull()) ) {
+                // margins and padding in % are scaled according to parent's width
+                RenderRectAccessor fmt( parent );
+                base_width = fmt.getWidth();
+            }
+            int em = n->getFont()->getSize();
+            h += lengthToPx( n->getStyle()->margin[2], base_width, em );  // top margin
+            h += lengthToPx( n->getStyle()->margin[3], base_width, em );  // bottom margin
+            h += lengthToPx( n->getStyle()->padding[2], base_width, em ); // top padding
+            h += lengthToPx( n->getStyle()->padding[3], base_width, em ); // bottom padding
             h += measureBorder(n, 0); // top border
             h += measureBorder(n, 2); // bottom border
         }
-        n = n->getParentNode();
-        if ( !n || n->isNull() )
+        if ( !parent || parent->isNull() )
             break;
+        n = parent;
     }
     return h;
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1564,7 +1564,7 @@ tinyNodeCollection::tinyNodeCollection()
 , _tinyElementCount(0)
 , _itemCount(0)
 #if BUILD_LITE!=1
-, _renderedBlockCache( 32 )
+, _renderedBlockCache( 256 )
 , _cacheFile(NULL)
 , _cacheFileStale(true)
 , _cacheFileLeaveAsDirty(false)
@@ -1599,7 +1599,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 , _tinyElementCount(0)
 , _itemCount(0)
 #if BUILD_LITE!=1
-, _renderedBlockCache( 32 )
+, _renderedBlockCache( 256 )
 , _cacheFile(NULL)
 , _cacheFileStale(true)
 , _cacheFileLeaveAsDirty(false)
@@ -3712,7 +3712,9 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
 {
     // Note: def_interline_space is no more used here
     bool changed = false;
-    _renderedBlockCache.clear();
+    // Don't clear this cache of LFormattedText if
+    // render props don't change.
+    //   _renderedBlockCache.clear();
     changed = _imgScalingOptions.update(props, def_font->getSize()) || changed;
     css_style_ref_t s( new css_style_rec_t );
     s->display = css_d_block;
@@ -3910,6 +3912,8 @@ int ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback, 
             printf("CRE: document loaded, but styles re-init needed (possible epub with embedded fonts)\n");
         }
         CRLog::info("rendering context is changed - full render required...");
+        // Clear LFormattedTextRef cache
+        _renderedBlockCache.clear();
         CRLog::trace("init format data...");
         //CRLog::trace("validate 1...");
         //validateDocument();


### PR DESCRIPTION
Various small rendering fixes, see individual commit message for details.

8th commit _Fix: empty single or last paragraph line should have 0-height_ brings back the proper rendering shown on the screenshots in #223 that was lost when #240 decided to ensure the strut height on all lines.