### PR TITLE
Various small fixes, adds some CSS attribute selectors

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -120,18 +120,28 @@ static const char * css_pseudo_classes[] =
 
 enum LVCssSelectorRuleType
 {
-    cssrt_universal,     // *
-    cssrt_parent,        // E > F
-    cssrt_ancessor,      // E F
-    cssrt_predecessor,   // E + F
-    cssrt_predsibling,   // E ~ F
-    cssrt_attrset,       // E[foo]
-    cssrt_attreq,        // E[foo="value"]
-    cssrt_attrhas,       // E[foo~="value"]
-    cssrt_attrstarts,    // E[foo|="value"]
-    cssrt_id,            // E#id
-    cssrt_class,         // E.class
-    cssrt_pseudoclass    // E:pseudo-class, E:pseudo-class(value)
+    cssrt_universal,         // *
+    cssrt_parent,            // E > F
+    cssrt_ancessor,          // E F
+    cssrt_predecessor,       // E + F
+    cssrt_predsibling,       // E ~ F
+    cssrt_attrset,           // E[foo]
+    cssrt_attrset_i,         // E[foo i] (case insensitive)
+    cssrt_attreq,            // E[foo="value"]
+    cssrt_attreq_i,          // E[foo="value i"]
+    cssrt_attrhas,           // E[foo~="value"]
+    cssrt_attrhas_i,         // E[foo~="value i"]
+    cssrt_attrstarts_word,   // E[foo|="value"]
+    cssrt_attrstarts_word_i, // E[foo|="value i"]
+    cssrt_attrstarts,        // E[foo^="value"]
+    cssrt_attrstarts_i,      // E[foo^="value i"]
+    cssrt_attrends,          // E[foo$="value"]
+    cssrt_attrends_i,        // E[foo$="value i"]
+    cssrt_attrcontains,      // E[foo*="value"]
+    cssrt_attrcontains_i,    // E[foo*="value i"]
+    cssrt_id,                // E#id
+    cssrt_class,             // E.class
+    cssrt_pseudoclass        // E:pseudo-class, E:pseudo-class(value)
 };
 
 class LVCssSelectorRule

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2226,9 +2226,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // render the marker if any, and continue rendering text on same line
         // Rendering hack: we do that too when list-style-position = outside AND text-align "right"
         // or "center", as this will draw the marker at the near left of the text (otherwise,
-        // the marker would be drawn on the far left of the whole available width, which is ugly.
+        // the marker would be drawn on the far left of the whole available width, which is
+        // ugly) - but we don't draw anything when list-style-type=none.
         if ( style->display == css_d_list_item_block && ( style->list_style_position == css_lsp_inside ||
-                (style->list_style_position == css_lsp_outside &&
+                (style->list_style_position == css_lsp_outside && style->list_style_type != css_lst_none &&
                     (style->text_align == css_ta_center || style->text_align == css_ta_right)) ) ) {
             // list_item_block rendered as final (containing only text and inline elements)
             int marker_width;
@@ -3079,12 +3080,13 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
                             // Rendering hack: we treat it just as "inside" when text-align "right" or "center"
                             list_marker_padding = list_marker_width;
                         }
-                        else {
+                        else if ( enode->getStyle()->list_style_type != css_lst_none ) {
                             // When list_style_position = inside, we need to let renderFinalBlock()
                             // know there is a marker to prepend when rendering the first of our
                             // children (or grand-children, depth first) that is erm_final
                             // (caveat: the marker will not be shown if any of the first children
                             // is erm_invisible)
+                            // (No need to do anything when  list-style-type none.)
                             ldomNode * tmpnode = enode;
                             while ( tmpnode->hasChildren() ) {
                                 tmpnode = tmpnode->getChildNode( 0 );
@@ -4698,6 +4700,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, bool ignor
                 // (same hack as in rendering code: we render 'outside' just
                 // like 'inside' when center or right aligned)
                 list_marker_width_as_padding = true;
+            }
+            else if ( node->getStyle()->list_style_type == css_lst_none ) {
+                // When css_lsp_inside, or with that hack when outside & center/right,
+                // no space should be used if list-style-type: none.
+                list_marker_width = 0;
             }
         }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1466,11 +1466,12 @@ public:
                 }
                 context.AddLine(last_y, table_y0 + table_h, line_flags);
                 last_y = table_y0 + table_h;
-                // Add links gathered from this row's cells
-                if (row->links.length() > 0) {
-                    for ( int n=0; n<row->links.length(); n++ ) {
-                        context.addLink( row->links[n] );
-                    }
+            }
+            // Add links gathered from this row's cells (even if !splitPages
+            // in case of imbricated tables)
+            if (row->links.length() > 0) {
+                for ( int n=0; n<row->links.length(); n++ ) {
+                    context.addLink( row->links[n] );
                 }
             }
         }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1023,8 +1023,14 @@ public:
                 //isObject = (m_flags[i] & LCHAR_IS_OBJECT)!=0;
                 isSpace = (m_flags[i] & LCHAR_IS_SPACE)!=0; // current char is a space
                 //nextIsSpace = i<end-1 && (m_flags[i+1] & LCHAR_IS_SPACE);
-                space = splitBySpaces && lastIsSpace && !isSpace && i<lastnonspace;
+                space = splitBySpaces && lastIsSpace && !isSpace && i<=lastnonspace;
                 // /\ previous char was a space, current char is not a space
+                //     Note: last check was initially "&& i<lastnonspace", but with
+                //     this, a line containing "thing inside a " (ending with a
+                //     1-char word) would be considered only 2 words ("thing" and
+                //     "inside a") and, when justify'ing text, space would not be
+                //     distributed between "inside" and "a"...
+                //     Not really sure what's the purpose of this last test...
             } else {
                 lastWord = true;
             }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12365,7 +12365,10 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
         marker = L"\x25A0";
         break;
     case css_lst_none:
-        marker = L"\x0020";
+        // When css_lsp_inside, no space is used by the invisible marker
+        if ( s->list_style_position != css_lsp_inside ) {
+            marker = L"\x0020";
+        }
         break;
     case css_lst_decimal:
     case css_lst_lower_roman:


### PR DESCRIPTION
Various small fixes, see individual commit message for details.

1st commit fixes some lines that may look rendered like the following (which was noticable in table cells):
<kbd>![image](https://user-images.githubusercontent.com/24273478/61145496-e5b0bd80-a4d7-11e9-97af-095c5096097e.png)</kbd>

2nd commits fixes small issue described in https://github.com/koreader/crengine/pull/111#issuecomment-510476050.

I'll bump this after 2019.07, because I haven't really tested these standalone much (they were parts of some bigger float rendering changes, but unrelated, so made into this individual PR).

