### PR TITLE
Adds HTML5 suggested rendering stylesheet (html5.css)

### DIFF
--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -1,0 +1,1073 @@
+/* From https://github.com/FriendsOfEpub/WillThatBeOverriden/blob/master/ReadingSystems/html5/html5.css */
+/* HTML5 Suggested Rendering -> https://www.w3.org/TR/html5/rendering.html#rendering */
+/* Changed for KOReader/crengine marked with "crengine" */
+
+/* @namespace url(http://www.w3.org/1999/xhtml); */
+
+/* crengine: support for page-breaks and internal elements */
+    /* EPUB container of each individual HTML file */
+    DocFragment {
+        page-break-before: always;
+    }
+    h1, h2, h3, h4, h5, h6 {
+        page-break-inside: avoid;
+        page-break-after: avoid;
+    }
+    /* Don't break page on headings in EPUBs: publishers may not expect it,
+     * as most EPUB renderers only break page on a new DocFragment. */
+    h1 {
+        -cr-only-if: -epub-document; /* only if NOT EPUB document */
+            page-break-before: always;
+    }
+    /* Element added for each empty line when rendering plain txt files */
+    empty-line {
+        height: 1em;
+    }
+
+/* Hidden elements */
+
+[hidden], area, base, basefont, datalist, head, link,
+meta, noembed, noframes, param, rp, script, source, style, template, track, title {
+  display: none;
+}
+
+embed[hidden] {
+  display: inline;
+  height: 0;
+  width: 0;
+}
+
+/* The page */
+
+html, body {
+  display: block;
+}
+
+/* Flow content */
+
+address, blockquote, center, div, figure, figcaption, footer, form,
+header, hr, legend, listing, p, plaintext, pre, xmp {
+  display: block;
+}
+
+blockquote, figure, listing, p, plaintext, pre, xmp {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+blockquote, figure {
+  margin-left: 40px;
+  margin-right: 40px;
+}
+
+address {
+  font-style: italic;
+}
+
+listing, plaintext, pre, xmp {
+  font-family: monospace;
+  white-space: pre;
+}
+
+pre[wrap] {
+  white-space: pre-wrap;
+}
+
+/* Phrasing content */
+
+cite, dfn, em, i, var {
+  font-style: italic;
+}
+
+b, strong {
+  font-weight: bolder;
+}
+
+code, kbd, samp, tt {
+  font-family: monospace;
+}
+
+big {
+  font-size: larger;
+}
+
+small {
+  font-size: smaller;
+}
+
+sub {
+  vertical-align: sub;
+}
+
+sup {
+  vertical-align: super;
+}
+
+sub, sup {
+  line-height: normal;
+  font-size: smaller;
+}
+
+/* crengine? : these display: ruby* would fallback to 'inline', should it be 'none' ? */
+ruby {
+  display: ruby;
+}
+
+rb {
+  display: ruby-base;
+  white-space: nowrap;
+}
+
+rt {
+  display: ruby-text;
+  white-space: nowrap;
+  font-size: 50%;
+  font-variant-east-asian: ruby;
+  text-emphasis: none;
+}
+
+rbc {
+  display: ruby-base-container;
+}
+
+rtc {
+  display: ruby-text-container;
+}
+
+ruby, rb, rt, rbc, rtc {
+  unicode-bidi: isolate;
+}
+
+/* crengine-: not supported
+:link {
+  color: #0000EE;
+}
+
+:visited {
+  color: #551A8B;
+}
+
+:link, :visited {
+  text-decoration: underline;
+}
+
+a:link[rel~=help], a:visited[rel~=help],
+area:link[rel~=help], area:visited[rel~=help] {
+  cursor: help;
+}
+
+:focus {
+  outline: auto;
+}
+*/
+
+mark {
+  background: yellow;
+  color: black;
+} /* this color is just a suggestion and can be changed based on implementation feedback */
+
+abbr[title], acronym[title] {
+  /* text-decoration: dotted underline; */ /* crengine-: multi not supported */
+  text-decoration: underline;
+}
+
+ins, u {
+  text-decoration: underline;
+}
+
+del, s, strike {
+  text-decoration: line-through;
+}
+
+blink {
+  text-decoration: blink;
+}
+
+q::before {
+  content: open-quote;
+}
+
+q::after {
+  content: close-quote;
+}
+
+/* crengine-: not supported, uneeded
+br {
+  content: '\A';
+  white-space: pre;
+} */ /* this also has bidi implications */
+nobr {
+  white-space: nowrap;
+}
+
+/* crengine-: not supported, uneeded
+wbr {
+  content: '\200B';
+} */ /* this also has bidi implications */
+nobr wbr {
+  white-space: normal;
+}
+
+br[clear=left i] {
+  clear: left;
+}
+
+br[clear=right i] {
+  clear: right;
+}
+
+br[clear=all i], br[clear=both i] {
+  clear: both;
+}
+
+/* Bidirectional text */
+/* crengine-: not supported
+[dir]:dir(ltr), bdi:dir(ltr), input[type=tel]:dir(ltr) {
+  direction: ltr;
+}
+
+[dir]:dir(rtl), bdi:dir(rtl) {
+  direction: rtl;
+}
+
+address, blockquote, center, div, figure, figcaption, footer, form,
+header, hr, legend, listing, p, plaintext, pre, xmp, article,
+aside, h1, h2, h3, h4, h5, h6, hgroup, main, nav, section, table, caption,
+colgroup, col, thead, tbody, tfoot, tr, td, th, dir, dd, dl, dt,
+ol, ul, li, bdi, output, [dir=ltr i], [dir=rtl i], [dir=auto i] {
+  unicode-bidi: isolate;
+}
+
+bdo, bdo[dir] {
+  unicode-bidi: isolate-override;
+}
+
+textarea[dir=auto i], input[type=text][dir=auto i], input[type=search][dir=auto i],
+input[type=tel][dir=auto i], input[type=url][dir=auto i], input[type=email][dir=auto i],
+pre[dir=auto i] {
+  unicode-bidi: plaintext;
+}
+*/
+
+/* Quotes */
+/* crengine-: not supported
+:root {
+  quotes: '\201c' '\201d' '\2018' '\2019';
+}
+:root:lang(af),       :not(:lang(af)) > :lang(af) {
+  quotes: '\201c' '\201d' '\2018' '\2019';
+}
+[... big amount of things like that removed...]
+*/
+
+/* Sections and headings */
+
+article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section {
+  display: block;
+}
+
+h1 {
+  margin-top: 0.67em;
+  margin-bottom: 0.67em;
+  font-size: 2.00em;
+  font-weight: bold;
+}
+
+h2 {
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  font-size: 1.50em;
+  font-weight: bold;
+}
+
+h3 {
+  margin-top: 1.00em;
+  margin-bottom: 1.00em;
+  font-size: 1.17em;
+  font-weight: bold;
+}
+
+h4 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+  font-weight: bold;
+}
+
+h5 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+  font-weight: bold;
+}
+
+h6 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+  font-weight: bold;
+}
+
+/* The article, aside, nav, and section elements are expected to affect the margins and font size of h1 elements, as well as h2–h5 elements that follow h1 elements in hgroup elements, based on the nesting depth. If x is a selector that matches elements that are either article, aside, nav, or section elements, then the following rules capture what is expected: */
+
+/* crengine-: would need huge lists to simulate 'x', or support :match(section, article, aside, nav) selector
+x h1 {
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  font-size: 1.50em;
+}
+
+x x h1 {
+  margin-top: 1.00em;
+  margin-bottom: 1.00em;
+  font-size: 1.17em;
+}
+
+x x x h1 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+x x x x h1 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+x x x x x h1 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+x hgroup > h1 ~ h2 {
+  margin-top: 1.00em;
+  margin-bottom: 1.00em;
+  font-size: 1.17em;
+}
+
+x x hgroup > h1 ~ h2 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+x x x hgroup > h1 ~ h2 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+x x x x hgroup > h1 ~ h2 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+x hgroup > h1 ~ h3 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+x x hgroup > h1 ~ h3 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+x x x hgroup > h1 ~ h3 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+x hgroup > h1 ~ h4 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+x x hgroup > h1 ~ h4 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+x hgroup > h1 ~ h5 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+*/
+/* crengine+: but implement a bit of them */
+/* One level for all */
+section h1, article h1, aside h1, nav h1 {
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  font-size: 1.50em;
+}
+/* Two levels for all */
+section section h1, section article h1, section aside h1, section nav h1,
+article section h1, article article h1, article aside h1, article nav h1,
+aside section h1, aside article h1, aside aside h1, aside nav h1,
+nav section h1, nav article h1, nav aside h1, nav nav h1 {
+  margin-top: 1.00em;
+  margin-bottom: 1.00em;
+  font-size: 1.17em;
+}
+/* More levels for section only */
+section section section h1 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+section section section section h1 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+section section section section section h1 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+section hgroup > h1 ~ h2 {
+  margin-top: 1.00em;
+  margin-bottom: 1.00em;
+  font-size: 1.17em;
+}
+
+section section hgroup > h1 ~ h2 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+section section section hgroup > h1 ~ h2 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+section section section section hgroup > h1 ~ h2 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+section hgroup > h1 ~ h3 {
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  font-size: 1.00em;
+}
+
+section section hgroup > h1 ~ h3 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+section section section hgroup > h1 ~ h3 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+section hgroup > h1 ~ h4 {
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  font-size: 0.83em;
+}
+
+section section hgroup > h1 ~ h4 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+
+section hgroup > h1 ~ h5 {
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  font-size: 0.67em;
+}
+/* crengine done with that */
+
+/* Lists */
+
+dir, dd, dl, dt, ol, ul {
+  display: block;
+}
+
+li {
+  display: list-item;
+}
+
+dir, dl, ol, ul {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+dir dir, dir dl, dir ol, dir ul,
+dl dir, dl dl, dl ol, dl ul,
+ol dir, ol dl, ol ol, ol ul,
+ul dir, ul dl, ul ol, ul ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+dd {
+  margin-left: 40px;
+} /* LTR-specific: use 'margin-right' for rtl elements */
+dir, ol, ul {
+  padding-left: 40px;
+} /* LTR-specific: use 'padding-right' for rtl elements */
+
+ol {
+  list-style-type: decimal;
+}
+
+dir, ul {
+  list-style-type: disc;
+}
+
+dir dir, dir ul,
+ol dir, ol ul,
+ul dir, ul ul {
+  list-style-type: circle;
+}
+
+dir dir dir, dir dir ul,
+dir ol dir, dir ol ul,
+dir ul dir, dir ul ul,
+ol dir dir, ol dir ul,
+ol ol dir, ol ol ul,
+ol ul dir, ol ul ul,
+ul dir dir, ul dir ul,
+ul ol dir, ul ol ul,
+ul ul dir, ul ul ul {
+  list-style-type: square;
+}
+
+ol[type=1], li[type=1] {
+  list-style-type: decimal;
+}
+
+ol[type=a], li[type=a] {
+  list-style-type: lower-alpha;
+}
+
+ol[type=A], li[type=A] {
+  list-style-type: upper-alpha;
+}
+
+ol[type=i], li[type=i] {
+  list-style-type: lower-roman;
+}
+
+ol[type=I], li[type=I] {
+  list-style-type: upper-roman;
+}
+
+ul[type=disc i], li[type=disc i] {
+  list-style-type: disc;
+}
+
+ul[type=circle i], li[type=circle i] {
+  list-style-type: circle;
+}
+
+ul[type=square i], li[type=square i] {
+  list-style-type: square;
+}
+
+/* Tables */
+
+table {
+  display: table;
+}
+
+caption {
+  display: table-caption;
+}
+
+colgroup, colgroup[hidden] {
+  display: table-column-group;
+}
+
+col, col[hidden] {
+  display: table-column;
+}
+
+thead, thead[hidden] {
+  display: table-header-group;
+}
+
+tbody, tbody[hidden] {
+  display: table-row-group;
+}
+
+tfoot, tfoot[hidden] {
+  display: table-footer-group;
+}
+
+tr, tr[hidden] {
+  display: table-row;
+}
+
+td, th, td[hidden], th[hidden] {
+  display: table-cell;
+}
+
+colgroup[hidden], col[hidden], thead[hidden], tbody[hidden],
+tfoot[hidden], tr[hidden], td[hidden], th[hidden] {
+  visibility: collapse;
+}
+
+table {
+  box-sizing: border-box;
+  border-spacing: 2px;
+  border-collapse: separate;
+  /* text-indent: initial; */ /* crengine- */
+  text-indent: 0; /* crengine+ */
+}
+
+td, th {
+  padding: 1px;
+}
+
+th {
+  font-weight: bold;
+}
+
+thead, tbody, tfoot, table > tr {
+  vertical-align: middle;
+}
+
+tr, td, th {
+  vertical-align: inherit;
+}
+
+table, td, th {
+  border-color: gray;
+}
+
+thead, tbody, tfoot, tr {
+  border-color: inherit;
+}
+
+table[rules=none i], table[rules=groups i], table[rules=rows i],
+table[rules=cols i], table[rules=all i], table[frame=void i],
+table[frame=above i], table[frame=below i], table[frame=hsides i],
+table[frame=lhs i], table[frame=rhs i], table[frame=vsides i],
+table[frame=box i], table[frame=border i],
+table[rules=none i] > tr > td, table[rules=none i] > tr > th,
+table[rules=groups i] > tr > td, table[rules=groups i] > tr > th,
+table[rules=rows i] > tr > td, table[rules=rows i] > tr > th,
+table[rules=cols i] > tr > td, table[rules=cols i] > tr > th,
+table[rules=all i] > tr > td, table[rules=all i] > tr > th,
+table[rules=none i] > thead > tr > td, table[rules=none i] > thead > tr > th,
+table[rules=groups i] > thead > tr > td, table[rules=groups i] > thead > tr > th,
+table[rules=rows i] > thead > tr > td, table[rules=rows i] > thead > tr > th,
+table[rules=cols i] > thead > tr > td, table[rules=cols i] > thead > tr > th,
+table[rules=all i] > thead > tr > td, table[rules=all i] > thead > tr > th,
+table[rules=none i] > tbody > tr > td, table[rules=none i] > tbody > tr > th,
+table[rules=groups i] > tbody > tr > td, table[rules=groups i] > tbody > tr > th,
+table[rules=rows i] > tbody > tr > td, table[rules=rows i] > tbody > tr > th,
+table[rules=cols i] > tbody > tr > td, table[rules=cols i] > tbody > tr > th,
+table[rules=all i] > tbody > tr > td, table[rules=all i] > tbody > tr > th,
+table[rules=none i] > tfoot > tr > td, table[rules=none i] > tfoot > tr > th,
+table[rules=groups i] > tfoot > tr > td, table[rules=groups i] > tfoot > tr > th,
+table[rules=rows i] > tfoot > tr > td, table[rules=rows i] > tfoot > tr > th,
+table[rules=cols i] > tfoot > tr > td, table[rules=cols i] > tfoot > tr > th,
+table[rules=all i] > tfoot > tr > td, table[rules=all i] > tfoot > tr > th {
+  border-color: black;
+}
+
+table[align=left i] {
+  float: left;
+}
+
+table[align=right i] {
+  float: right;
+}
+
+table[align=center i] {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+thead[align=absmiddle i], tbody[align=absmiddle i], tfoot[align=absmiddle i],
+tr[align=absmiddle i], td[align=absmiddle i], th[align=absmiddle i] {
+  text-align: center;
+}
+
+caption[align=bottom i] {
+  caption-side: bottom;
+}
+
+p[align=left i], h1[align=left i], h2[align=left i], h3[align=left i],
+h4[align=left i], h5[align=left i], h6[align=left i] {
+  text-align: left;
+}
+
+p[align=right i], h1[align=right i], h2[align=right i], h3[align=right i],
+h4[align=right i], h5[align=right i], h6[align=right i] {
+  text-align: right;
+}
+
+p[align=center i], h1[align=center i], h2[align=center i], h3[align=center i],
+h4[align=center i], h5[align=center i], h6[align=center i] {
+  text-align: center;
+}
+
+p[align=justify i], h1[align=justify i], h2[align=justify i], h3[align=justify i],
+h4[align=justify i], h5[align=justify i], h6[align=justify i] {
+  text-align: justify;
+}
+
+thead[valign=top i], tbody[valign=top i], tfoot[valign=top i],
+tr[valign=top i], td[valign=top i], th[valign=top i] {
+  vertical-align: top;
+}
+
+thead[valign=middle i], tbody[valign=middle i], tfoot[valign=middle i],
+tr[valign=middle i], td[valign=middle i], th[valign=middle i] {
+  vertical-align: middle;
+}
+
+thead[valign=bottom i], tbody[valign=bottom i], tfoot[valign=bottom i],
+tr[valign=bottom i], td[valign=bottom i], th[valign=bottom i] {
+  vertical-align: bottom;
+}
+
+thead[valign=baseline i], tbody[valign=baseline i], tfoot[valign=baseline i],
+tr[valign=baseline i], td[valign=baseline i], th[valign=baseline i] {
+  vertical-align: baseline;
+}
+
+td[nowrap], th[nowrap] {
+  white-space: nowrap;
+}
+
+table[rules=none i], table[rules=groups i], table[rules=rows i],
+table[rules=cols i], table[rules=all i] {
+  border-style: hidden;
+  border-collapse: collapse;
+}
+
+table[border] {
+  border-style: outset;
+} /* only if border is not equivalent to zero */
+table[frame=void i] {
+  border-style: hidden;
+}
+
+table[frame=above i] {
+  border-style: outset hidden hidden hidden;
+}
+
+table[frame=below i] {
+  border-style: hidden hidden outset hidden;
+}
+
+table[frame=hsides i] {
+  border-style: outset hidden outset hidden;
+}
+
+table[frame=lhs i] {
+  border-style: hidden hidden hidden outset;
+}
+
+table[frame=rhs i] {
+  border-style: hidden outset hidden hidden;
+}
+
+table[frame=vsides i] {
+  border-style: hidden outset;
+}
+
+table[frame=box i], table[frame=border i] {
+  border-style: outset;
+}
+
+table[border] > tr > td, table[border] > tr > th,
+table[border] > thead > tr > td, table[border] > thead > tr > th,
+table[border] > tbody > tr > td, table[border] > tbody > tr > th,
+table[border] > tfoot > tr > td, table[border] > tfoot > tr > th {
+  /* only if border is not equivalent to zero */
+  border-width: 1px;
+  border-style: inset;
+}
+
+table[rules=none i] > tr > td, table[rules=none i] > tr > th,
+table[rules=none i] > thead > tr > td, table[rules=none i] > thead > tr > th,
+table[rules=none i] > tbody > tr > td, table[rules=none i] > tbody > tr > th,
+table[rules=none i] > tfoot > tr > td, table[rules=none i] > tfoot > tr > th,
+table[rules=groups i] > tr > td, table[rules=groups i] > tr > th,
+table[rules=groups i] > thead > tr > td, table[rules=groups i] > thead > tr > th,
+table[rules=groups i] > tbody > tr > td, table[rules=groups i] > tbody > tr > th,
+table[rules=groups i] > tfoot > tr > td, table[rules=groups i] > tfoot > tr > th,
+table[rules=rows i] > tr > td, table[rules=rows i] > tr > th,
+table[rules=rows i] > thead > tr > td, table[rules=rows i] > thead > tr > th,
+table[rules=rows i] > tbody > tr > td, table[rules=rows i] > tbody > tr > th,
+table[rules=rows i] > tfoot > tr > td, table[rules=rows i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: none;
+}
+
+table[rules=cols i] > tr > td, table[rules=cols i] > tr > th,
+table[rules=cols i] > thead > tr > td, table[rules=cols i] > thead > tr > th,
+table[rules=cols i] > tbody > tr > td, table[rules=cols i] > tbody > tr > th,
+table[rules=cols i] > tfoot > tr > td, table[rules=cols i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: none solid;
+}
+
+table[rules=all i] > tr > td, table[rules=all i] > tr > th,
+table[rules=all i] > thead > tr > td, table[rules=all i] > thead > tr > th,
+table[rules=all i] > tbody > tr > td, table[rules=all i] > tbody > tr > th,
+table[rules=all i] > tfoot > tr > td, table[rules=all i] > tfoot > tr > th {
+  border-width: 1px;
+  border-style: solid;
+}
+
+table[rules=groups i] > colgroup {
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-right-width: 1px;
+  border-right-style: solid;
+}
+
+table[rules=groups i] > thead,
+table[rules=groups i] > tbody,
+table[rules=groups i] > tfoot {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+table[rules=rows i] > tr, table[rules=rows i] > thead > tr,
+table[rules=rows i] > tbody > tr, table[rules=rows i] > tfoot > tr {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+/* Form controls */
+
+input, select, option, optgroup, button, textarea, keygen {
+  /* text-indent: initial; */ /* crengine- */
+  text-indent: 0; /* crengine+ */
+}
+
+textarea {
+  white-space: pre-wrap;
+}
+
+input[type="radio"], input[type="checkbox"], input[type="reset"], input[type="button"],
+input[type="submit"], select, button {
+  box-sizing: border-box;
+}
+
+/* Horizontal rule */
+
+hr {
+  color: gray;
+  border-style: inset;
+  border-width: 1px;
+  margin: 0.5em auto;
+}
+
+hr[align=left] {
+  margin-left: 0;
+  margin-right: auto;
+}
+
+hr[align=right] {
+  margin-left: auto;
+  margin-right: 0;
+}
+
+hr[align=center] {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+hr[color], hr[noshade] {
+  border-style: solid;
+}
+
+/* Fieldset + Legend */
+
+fieldset {
+  margin-left: 2px;
+  margin-right: 2px;
+  border: groove 2px ThreeDFace;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+legend {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+/* Embedded content */
+
+iframe {
+  border: 2px inset;
+}
+
+video {
+  object-fit: contain;
+}
+
+iframe[frameborder=0], iframe[frameborder=no i] {
+  border: none;
+}
+
+applet[align=left i], embed[align=left i], iframe[align=left i],
+img[align=left i], input[type=image i][align=left i], object[align=left i] {
+  float: left;
+}
+
+applet[align=right i], embed[align=right i], iframe[align=right i],
+img[align=right i], input[type=image i][align=right i], object[align=right i] {
+  float: right;
+}
+
+applet[align=top i], embed[align=top i], iframe[align=top i],
+img[align=top i], input[type=image i][align=top i], object[align=top i] {
+  vertical-align: top;
+}
+
+applet[align=baseline i], embed[align=baseline i], iframe[align=baseline i],
+img[align=baseline i], input[type=image i][align=baseline i], object[align=baseline i] {
+  vertical-align: baseline;
+}
+
+applet[align=texttop i], embed[align=texttop i], iframe[align=texttop i],
+img[align=texttop i], input[type=image i][align=texttop i], object[align=texttop i] {
+  vertical-align: text-top;
+}
+
+applet[align=absmiddle i], embed[align=absmiddle i], iframe[align=absmiddle i],
+img[align=absmiddle i],keygen {
+  binding: keygen;
+}
+
+input[type=image i][align=absmiddle i], object[align=absmiddle i],
+applet[align=abscenter i], embed[align=abscenter i], iframe[align=abscenter i],
+img[align=abscenter i], input[type=image i][align=abscenter i], object[align=abscenter i] {
+  vertical-align: middle;
+}
+
+applet[align=bottom i], embed[align=bottom i], iframe[align=bottom i],
+img[align=bottom i], input[type=image i][align=bottom i],
+object[align=bottom i] {
+  vertical-align: bottom;
+}
+
+/* Bindings */
+
+/* crengine-: not supported
+button {
+  binding: button;
+}
+
+input {
+  binding: input-textfield;
+}
+
+input[type=password i] {
+  binding: input-password;
+}
+
+input[type=date i] {
+  binding: input-date;
+}
+
+input[type=time i] {
+  binding: input-time;
+}
+
+input[type=number i] {
+  binding: input-number;
+}
+
+input[type=range i] {
+  binding: input-range;
+}
+
+input[type=color i] {
+  binding: input-color;
+}
+
+input[type=file i] {
+  binding: input-file;
+}
+
+input[type=submit i], input[type=reset i], input[type=button i] {
+  binding: input-button;
+}
+
+marquee {
+  binding: marquee;
+}
+
+meter {
+  binding: meter;
+}
+
+progress {
+  binding: progress;
+}
+
+select {
+  binding: select;
+}
+
+textarea {
+  binding: textarea;
+  white-space: pre-wrap;
+}
+
+keygen {
+  binding: keygen;
+}
+*/
+
+/* QUIRKS MODE -> https://www.w3.org/TR/html5/infrastructure.html#quirks-mode */
+/* crengine-
+form {
+  margin-bottom: 1em;
+}
+
+table {
+  font-weight: initial;
+  font-style: initial;
+  font-variant: initial;
+  font-size: initial;
+  line-height: initial;
+  white-space: initial;
+  text-align: initial;
+}
+
+input:not([type=image]), textarea {
+  box-sizing: border-box;
+}
+
+img[align=left i] {
+  margin-right: 3px;
+}
+
+img[align=right i] {
+  margin-left: 3px;
+}
+*/

--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -13,11 +13,15 @@
         page-break-inside: avoid;
         page-break-after: avoid;
     }
-    /* Don't break page on headings in EPUBs: publishers may not expect it,
-     * as most EPUB renderers only break page on a new DocFragment. */
-    h1 {
+    /* Don't break page on headings or section in EPUBs: publishers may not
+     * expect it; most EPUB renderers only break page on a new DocFragment. */
+    section, h1 {
         -cr-only-if: -epub-document; /* only if NOT EPUB document */
             page-break-before: always;
+    }
+    section > h1:first-of-type, section section {
+        -cr-only-if: -epub-document; /* only if NOT EPUB document */
+            page-break-before: auto;
     }
     /* Element added for each empty line when rendering plain txt files */
     empty-line {


### PR DESCRIPTION
Implement HTML5 Suggested Rendering: https://www.w3.org/TR/html5/rendering.html#rendering
Adapted for crengine from:
    https://github.com/FriendsOfEpub/WillThatBeOverriden/blob/master/ReadingSystems/html5/html5.css

(I found a few other ones, including some cleaner at https://github.com/Kozea/WeasyPrint/tree/master/weasyprint/css - but the WillThatBeOverriden one seems to follow the rendering.html page ordering quite as-is.)

Will allow quick switching from epub.css to html5.css in case books expect this HTML5 rendering as their base stylesheet. Discussed in #294.
Still keeping epub.css as our default because we're used to it, it looks better, and html5.css would bring too much changes (see https://github.com/koreader/crengine/issues/294#issuecomment-507227926).

@Frenzie : you understand that HTML5 section/article/aside/nav business more than I do, so, do you think we need additional rules with them that should have `page-break-before: always` (in epub-document and in not epub-document) ? (as the specs and browsers' stylesheet don't really care about page breaks).

edit: we don't support `:matches(article, aside, nav, section)` CSS selector, so it has only a limited set of these declarations.