### PR TITLE
Minor zero-initalization cleanups

### DIFF
--- a/crengine/include/lvhashtable.h
+++ b/crengine/include/lvhashtable.h
@@ -104,8 +104,7 @@ public:
     {
         if (size < 16 )
             size = 16;
-        _table = new pair* [ size ];
-        memset( _table, 0, sizeof(pair*) * size );
+        _table = new pair* [ size ]();
         _size = size;
         _count = 0;
     }
@@ -133,8 +132,7 @@ public:
     int size() { return _size; }
     void resize( int nsize )
     {
-        pair ** new_table = new pair * [ nsize ];
-        memset( new_table, 0, sizeof(pair*) * nsize );
+        pair ** new_table = new pair * [ nsize ]();
 		if (_table) {
 			for ( int i=0; i<_size; i++ ) {
 				pair * p = _table[i];

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -263,15 +263,15 @@ static const lChar16 __cp1251[128] = {
 
 static const lChar16 __cp1252[128] = {
     /* 0x80*/
-    0x0402, 0x0403, 0x201a, 0x0453, 
-    0x201e, 0x2026, 0x2020, 0x2021, 
-    0x20ac, 0x2030, 0x0409, 0x2039, 
-    0x040a, 0x040c, 0x040b, 0x040f, 
+    0x0402, 0x0403, 0x201a, 0x0453,
+    0x201e, 0x2026, 0x2020, 0x2021,
+    0x20ac, 0x2030, 0x0409, 0x2039,
+    0x040a, 0x040c, 0x040b, 0x040f,
     /* 0x90*/
-    0x0452, 0x2018, 0x2019, 0x201c, 
-    0x201d, 0x2022, 0x2013, 0x2014, 
-    0x0000, 0x2122, 0x0459, 0x203a, 
-    0x045a, 0x045c, 0x045b, 0x045f, 
+    0x0452, 0x2018, 0x2019, 0x201c,
+    0x201d, 0x2022, 0x2013, 0x2014,
+    0x0000, 0x2122, 0x0459, 0x203a,
+    0x045a, 0x045c, 0x045b, 0x045f,
     /* 0xa0*/
     0x00a0, 0x00a1, 0x00a2, 0x00a3,
     0x00a4, 0x00a5, 0x00a6, 0x00a7,
@@ -1431,8 +1431,8 @@ const lChar8 ** GetCharsetUnicode2ByteTable( const lChar16 * enc_name )
 #define DBL_CHAR_STAT_SIZE 256
 
 class CDoubleCharStat
-{ 
-   
+{
+
    struct CDblCharNode
    {
       unsigned char ch1;
@@ -1637,7 +1637,7 @@ int sort_dblstats_by_ch( const void * p1, const void * p2 )
 }
 
 class CDoubleCharStat2
-{ 
+{
 private:
     lUInt16 * * stats;
     int total;
@@ -1649,15 +1649,13 @@ public:
     void Add( unsigned char c1, unsigned char c2 )
     {
         if ( !stats ) {
-            stats = new lUInt16* [256];
-            memset( stats, 0, sizeof(lUInt16*)*256);
+            stats = new lUInt16* [256]();
         }
         if (c1==' ' && c2==' ')
             return;
         total++;
         if ( stats[c1]==NULL ) {
-            stats[c1] = new lUInt16[256];
-            memset( stats[c1], 0, sizeof(lUInt16)*256 );
+            stats[c1] = new lUInt16[256]();
         }
         if ( stats[c1][c2]++ == 0)
             items++;
@@ -1792,8 +1790,7 @@ void MakeDblCharStat(const unsigned char * buf, int buf_size, dbl_char_stat_t * 
 
 void MakeCharStat(const unsigned char * buf, int buf_size, short stat_table[256], bool skipHtml)
 {
-   int stat[256];
-   memset( stat, 0, sizeof(int)*256 );
+   int stat[256] = { 0 };
    int total=0;
    unsigned char ch;
    bool insideTag = false;
@@ -2085,8 +2082,7 @@ void MakeStatsForFile( const char * fname, const char * cp_name, const char * la
    fseek( in, 0, SEEK_SET );
    unsigned char * buf = new unsigned char[buf_size];
    fread(buf, 1, buf_size, in);
-   short char_stat[256];
-   memset(char_stat, 0, sizeof(short)*256);
+   short char_stat[256] = { 0 };
    dbl_char_stat_t dbl_char_stat[DBL_CHAR_STAT_SIZE];
    bool skipHtml = hasXmlTags(buf, buf_size);
    MakeCharStat(buf, buf_size, char_stat, skipHtml);
@@ -2095,7 +2091,7 @@ void MakeStatsForFile( const char * fname, const char * cp_name, const char * la
    int i;
    for (i=0; i<16; i++)
    {
-      for (int j=0; j<16; j++) 
+      for (int j=0; j<16; j++)
       {
          fprintf(f, "0x%04x,", (unsigned int)char_stat[i*16+j] );
       }
@@ -2105,7 +2101,7 @@ void MakeStatsForFile( const char * fname, const char * cp_name, const char * la
    fprintf(f, "static const dbl_char_stat_t dbl_ch_stat_%s_%s%d[%d] = {\n", cp_name, lang_name, index, DBL_CHAR_STAT_SIZE  );
    for (i=0; i<DBL_CHAR_STAT_SIZE/16; i++)
    {
-      for (int j=0; j<16; j++) 
+      for (int j=0; j<16; j++)
       {
          fprintf(f, "{0x%02x,0x%02x,0x%04x}, ", (unsigned int)dbl_char_stat[i*16+j].ch1, (unsigned int)dbl_char_stat[i*16+j].ch2, (unsigned int)((lUInt16)dbl_char_stat[i*16+j].count) );
       }

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -394,8 +394,7 @@ int CRFileHistRecord::getLastShortcutBookmark()
 int CRFileHistRecord::getFirstFreeShortcutBookmark()
 {
     //int last = -1;
-    char flags[MAX_SHORTCUT_BOOKMARKS+1];
-    memset( flags, 0, sizeof(flags) );
+    char flags[MAX_SHORTCUT_BOOKMARKS+1] = { 0 };
     for ( int i=0; i<_bookmarks.length(); i++ ) {
         if ( _bookmarks[i]->getShortcut()>0 && _bookmarks[i]->getShortcut() < MAX_SHORTCUT_BOOKMARKS && _bookmarks[i]->getType() == bmkt_pos )
             flags[ _bookmarks[i]->getShortcut() ] = 1;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -813,7 +813,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
         return false;
     if ( len>=WORD_LENGTH )
         len = WORD_LENGTH - 2;
-    lChar16 word[WORD_LENGTH+4];
+    lChar16 word[WORD_LENGTH+4] = { 0 };
     char mask[WORD_LENGTH+4] = { 0 };
 
     // Make word from str, with soft-hyphens stripped out.
@@ -828,9 +828,6 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     }
     wlen = w-1;
     word[w++] = ' ';
-    word[w++] = 0;
-    word[w++] = 0;
-    word[w++] = 0;
     if ( wlen<=3 )
         return false;
     lStr_lowercase(word+1, wlen);
@@ -842,6 +839,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 
     // Find matches from dict patterns, at any position in word.
     // Places where hyphenation is allowed are put into 'mask'.
+    memset( mask, '0', wlen+3 );	// 0x30!
     bool found = false;
     for ( int i=0; i<=wlen; i++ ) {
         found = match( word + i, mask + i ) || found;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -261,10 +261,10 @@ bool HyphDictionary::activate()
 bool HyphDictionaryList::activate( lString16 id )
 {
     CRLog::trace("HyphDictionaryList::activate(%s)", LCSTR(id));
-	HyphDictionary * p = find(id); 
-	if ( p ) 
-		return p->activate(); 
-	else 
+	HyphDictionary * p = find(id);
+	if ( p )
+		return p->activate();
+	else
 		return false;
 }
 
@@ -279,7 +279,7 @@ void HyphDictionaryList::addDefault()
 	if ( !find( lString16( HYPH_DICT_ID_SOFTHYPHENS ) ) ) {
 		_list.add( new HyphDictionary( HDT_SOFTHYPHENS, _16("[Soft-hyphens Hyphenation]"), lString16(HYPH_DICT_ID_SOFTHYPHENS), lString16(HYPH_DICT_ID_SOFTHYPHENS) ) );
 	}
-		
+
 }
 
 HyphDictionary * HyphDictionaryList::find( lString16 id )
@@ -328,7 +328,7 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
                 t = HDT_DICT_TEX;
             } else
                 continue;
-            
+
 
 
 			lString16 filename = hyphDirectory + name;
@@ -336,7 +336,7 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
 			lString16 title = name;
 			if ( title.endsWith( suffix ) )
 				title.erase( title.length() - suffix.length(), suffix.length() );
-            
+
 			_list.add( new HyphDictionary( t, title, id, filename ) );
             count++;
 		}
@@ -408,12 +408,12 @@ static int isCorrectHyphFile(LVStream * stream)
     stream->SetPos(0);
     lvByteOrderConv cnv;
     w=cnv.msf(HDR.numrec);
-    if (dw!=78 || w>0xff) 
+    if (dw!=78 || w>0xff)
         w = 0;
 
-    if (strncmp((const char*)&HDR.type, "HypHAlR4", 8) != 0) 
+    if (strncmp((const char*)&HDR.type, "HypHAlR4", 8) != 0)
         w = 0;
-        
+
     return w;
 }
 
@@ -639,13 +639,12 @@ bool TexHyph::load( LVStreamRef stream )
         stream->SetPos(p);
         if ( stream->SetPos(p)!=p )
             return false;
-        lChar16 charMap[256];
+        lChar16 charMap[256] = { 0 };
         unsigned char buf[0x10000];
-        memset( charMap, 0, sizeof( charMap ) );
         // make char map table
         for (i=0; i<hyph_count; i++)
         {
-            if ( stream->Read( &hyph, 522, &dw )!=LVERR_OK || dw!=522 ) 
+            if ( stream->Read( &hyph, 522, &dw )!=LVERR_OK || dw!=522 )
                 return false;
             cnv.msf( &hyph.len ); //rword(_main_hyph[i].len);
             lvpos_t newPos;
@@ -687,11 +686,11 @@ bool TexHyph::load( LVStreamRef stream )
         for (i=0; i<hyph_count; i++)
         {
             stream->Read( &hyph, 522, &dw );
-            if (dw!=522) 
+            if (dw!=522)
                 return false;
             cnv.msf( &hyph.len );
 
-            stream->Read(buf, hyph.len, &dw); 
+            stream->Read(buf, hyph.len, &dw);
             if (dw!=hyph.len)
                 return false;
 
@@ -815,7 +814,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     if ( len>=WORD_LENGTH )
         len = WORD_LENGTH - 2;
     lChar16 word[WORD_LENGTH+4];
-    char mask[WORD_LENGTH+4];
+    char mask[WORD_LENGTH+4] = { 0 };
 
     // Make word from str, with soft-hyphens stripped out.
     // Prepend and append a space so patterns can match word boundaries.
@@ -843,8 +842,6 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 
     // Find matches from dict patterns, at any position in word.
     // Places where hyphenation is allowed are put into 'mask'.
-    memset( mask, '0', wlen+3 );
-    mask[wlen+3] = 0;
     bool found = false;
     for ( int i=0; i<=wlen; i++ ) {
         found = match( word + i, mask + i ) || found;

--- a/crengine/src/lstridmap.cpp
+++ b/crengine/src/lstridmap.cpp
@@ -1,6 +1,6 @@
 /*******************************************************
 
-   CoolReader Engine DOM Tree 
+   CoolReader Engine DOM Tree
 
    LDOMNodeIdMap.cpp:  Name to Id map
 
@@ -153,10 +153,8 @@ LDOMNameIdMap::LDOMNameIdMap(lUInt16 maxId)
 {
     m_size = maxId+1;
     m_count = 0;
-    m_by_id   = new LDOMNameIdMapItem * [m_size];
-    memset( m_by_id, 0, sizeof(LDOMNameIdMapItem *)*m_size );  
-    m_by_name = new LDOMNameIdMapItem * [m_size];
-    memset( m_by_name, 0, sizeof(LDOMNameIdMapItem *)*m_size );  
+    m_by_id   = new LDOMNameIdMapItem * [m_size]();
+    m_by_name = new LDOMNameIdMapItem * [m_size]();
     m_sorted = true;
     m_changed = false;
 }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -265,8 +265,7 @@ void LVGrayDrawBuf::Rotate( cr_rotate_angle_t angle )
     }
     int newrowsize = _bpp<=2 ? (_dy * _bpp + 7) / 8 : _dy;
     sz = (newrowsize * _dx);
-    lUInt8 * dst = (lUInt8 *)malloc(sz);
-    memset( dst, 0, sz );
+    lUInt8 * dst = (lUInt8 *)calloc(sz, sizeof(*dst));
     for ( int y=0; y<_dy; y++ ) {
         lUInt8 * src = _data + _rowsize*y;
         int dstx, dsty;
@@ -1389,8 +1388,7 @@ void LVGrayDrawBuf::ConvertToBitmap(bool flgDither)
         return;
     // TODO: implement for byte per pixel mode
     int sz = GetRowSize();
-    lUInt8 * bitmap = (lUInt8*) malloc( sizeof(lUInt8) * sz );
-    memset( bitmap, 0, sz );
+    lUInt8 * bitmap = (lUInt8*) calloc(sz, sizeof(*bitmap));
     if (flgDither)
     {
         static const lUInt8 cmap[4][4] = {
@@ -1773,8 +1771,7 @@ void LVColorDrawBuf::Resize( int dx, int dy )
         _dy = dy;
         _rowsize = dx*(_bpp>>3);
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && !defined(QT_GL)
-        BITMAPINFO bmi;
-        memset( &bmi, 0, sizeof(bmi) );
+        BITMAPINFO bmi = { 0 };
         bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
         bmi.bmiHeader.biWidth = _dx;
         bmi.bmiHeader.biHeight = _dy;
@@ -1790,10 +1787,10 @@ void LVColorDrawBuf::Resize( int dx, int dy )
         _drawbmp = CreateDIBSection( NULL, &bmi, DIB_RGB_COLORS, (void**)(&_data), NULL, 0 );
         _drawdc = CreateCompatibleDC(NULL);
         SelectObject(_drawdc, _drawbmp);
-#else
-        _data = (lUInt8 *)malloc( (_bpp>>3) * _dx * _dy);
-#endif
         memset( _data, 0, _rowsize * _dy );
+#else
+        _data = (lUInt8 *)calloc((_bpp>>3) * _dx * _dy, sizeof(*_data));
+#endif
     }
     SetClipRect( NULL );
 }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1095,10 +1095,11 @@ void LVGrayDrawBuf::Resize( int dx, int dy )
     _dy = dy;
     _rowsize = _bpp<=2 ? (_dx * _bpp + 7) / 8 : _dx;
     if (dx > 0 && dy > 0) {
-        _data = (unsigned char *)malloc(_rowsize * _dy + 1);
+        _data = (unsigned char *)calloc(_rowsize * _dy + 1, sizeof(*_data));
         _data[_rowsize * _dy] = GUARD_BYTE;
+    } else {
+        Clear(0);
     }
-    Clear(0);
     SetClipRect( NULL );
 }
 
@@ -1142,9 +1143,8 @@ LVGrayDrawBuf::LVGrayDrawBuf(int dx, int dy, int bpp, void * auxdata )
         _data = (lUInt8 *) auxdata;
         _ownData = false;
     } else if (_dx && _dy) {
-        _data = (lUInt8 *) malloc(_rowsize * _dy + 1);
+        _data = (lUInt8 *) calloc(_rowsize * _dy + 1, sizeof(*_data));
         _data[_rowsize * _dy] = GUARD_BYTE;
-        Clear(0);
     }
     SetClipRect( NULL );
     CHECK_GUARD_BYTE;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -3982,8 +3982,7 @@ public:
     virtual bool Init( lString8 path )
     {
         LVColorDrawBuf drawbuf(1,1);
-        LOGFONTA lf;
-        memset(&lf, 0, sizeof(lf));
+        LOGFONTA lf = { 0 };
         lf.lfCharSet = ANSI_CHARSET;
         int res =
         EnumFontFamiliesExA(
@@ -4531,8 +4530,7 @@ bool LVBaseWin32Font::Create(int size, int weight, bool italic, css_font_family_
     if (!IsNull())
         Clear();
     //
-    LOGFONTA lf;
-    memset(&lf, 0, sizeof(LOGFONTA));
+    LOGFONTA lf = { 0 };
     lf.lfHeight = size;
     lf.lfWeight = weight;
     lf.lfItalic = italic?1:0;
@@ -4604,8 +4602,7 @@ int LVWin32DrawFont::getCharWidth( lChar16 ch, lChar16 def_char )
     if (_hfont==NULL)
         return 0;
     // measure character widths
-    GCP_RESULTSW gcpres;
-    memset( &gcpres, 0, sizeof(gcpres) );
+    GCP_RESULTSW gcpres = { 0 };
     gcpres.lStructSize = sizeof(gcpres);
     lChar16 str[2];
     str[0] = ch;
@@ -4683,8 +4680,7 @@ lUInt16 LVWin32DrawFont::measureText(
     }
     assert(pstr[len]==0);
     // measure character widths
-    GCP_RESULTSW gcpres;
-    memset( &gcpres, 0, sizeof(gcpres) );
+    GCP_RESULTSW gcpres = { 0 };
     gcpres.lStructSize = sizeof(gcpres);
     LVArray<int> dx( len+1, 0 );
     gcpres.lpDx = dx.ptr();

--- a/crengine/src/lvmemman.cpp
+++ b/crengine/src/lvmemman.cpp
@@ -48,11 +48,7 @@ void crSetSignalHandler()
 	if (signals_are_set)
 		return;
 	signals_are_set = true;
-	struct sigaction handler; // = {0};
-	//size_t s = sizeof(handler);
-	//void * p = &handler;
-	//memset(p, 0, s);
-	memset(&handler, 0, sizeof(handler));
+	struct sigaction handler = { 0 };
 	handler.sa_sigaction = cr_sigaction;
 	handler.sa_flags = SA_RESETHAND;
 #define CATCHSIG(X) sigaction(X, &handler, &old_sa[X])

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -3046,7 +3046,7 @@ public:
 		m_bufsize = 4096;
 		m_size = 0;
 		m_pos = 0;
-        m_pBuffer = (lUInt8*)malloc((int)m_bufsize);
+		m_pBuffer = (lUInt8*)malloc((int)m_bufsize);
 		m_own_buffer = true;
 		m_mode = LVOM_READWRITE;
 		return LVERR_OK;

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -698,7 +698,7 @@ public:
 		}
         return LVERR_OK;
     }
-	
+
     lverror_t OpenFile( lString16 fname, lvopen_mode_t mode, lvsize_t minSize = (lvsize_t)-1 )
     {
         m_mode = mode;
@@ -812,7 +812,7 @@ public:
         return LVERR_OK;
 #endif
     }
-    LVFileMappedStream() 
+    LVFileMappedStream()
 #if defined(_WIN32)
 		: m_hFile(NULL), m_hMap(NULL),
 #else
@@ -1558,10 +1558,8 @@ public:
 #if !defined(__SYMBIAN32__) && defined(_WIN32)
         // WIN32 API
         fn << mask;
-        WIN32_FIND_DATAW data;
-        WIN32_FIND_DATAA dataa;
-        memset(&data, 0, sizeof(data));
-        memset(&dataa, 0, sizeof(dataa));
+        WIN32_FIND_DATAW data = { 0 };
+        WIN32_FIND_DATAA dataa = { 0 };
         //lString8 bs = DOMString(path).ToAnsiString();
         HANDLE hFind = FindFirstFileW(fn.c_str(), &data);
         bool unicode=true;
@@ -1870,8 +1868,7 @@ public:
         m_bufSize = (bufSize + CACHE_BUF_BLOCK_SIZE - 1) >> CACHE_BUF_BLOCK_SHIFT;
         if (m_bufSize<3)
             m_bufSize = 3;
-        m_buf = new BufItem* [m_bufItems];
-        memset( m_buf, 0, sizeof( BufItem*) * m_bufItems );
+        m_buf = new BufItem* [m_bufItems]();
         SetName( stream->GetName() );
     }
     virtual ~LVCachedStream()
@@ -1945,8 +1942,7 @@ public:
         int extraItems = (m_bufSize - count); // max move backward
         if (extraItems<0)
             extraItems = 0;
-        char * flags = new char[ count ];
-        memset( flags, 0, count );
+        char * flags = new char[ count ]();
 
         //if ( m_stream
         int start = (int)m_pos;
@@ -2624,7 +2620,7 @@ public:
 
 
         ZipLocalFileHdr ZipHd1;
-        ZipHd2 ZipHeader;
+        ZipHd2 ZipHeader = { 0 };
         unsigned ZipHeader_size = 0x2E; //sizeof(ZipHd2); //0x34; //
         unsigned ZipHd1_size = 0x1E; //sizeof(ZipHd1); //sizeof(ZipHd1)
           //lUInt32 ReadSize;
@@ -2653,8 +2649,6 @@ public:
                         return m_list.length();
                     return 0;
                 }
-
-                memset(&ZipHeader,0,ZipHeader_size);
 
                 ZipHeader.UnpVer=ZipHd1.UnpVer;
                 ZipHeader.UnpOS=ZipHd1.UnpOS;
@@ -4104,9 +4098,8 @@ class LVBlockWriteStream : public LVNamedStream
             , modified_start((lvpos_t)-1), modified_end((lvpos_t)-1)
             , size( block_size ), next(NULL)
         {
-            buf = (lUInt8*)malloc( size );
+            buf = (lUInt8*)calloc(size, sizeof(*buf));
             if ( buf ) {
-                memset(buf, 0, size);
     //            modified_start = 0;
     //            modified_end = size;
             }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -427,8 +427,7 @@ inline void _lStr_memcpy(lChar16 * dst, const lChar16 * src, int count)
 
 inline void _lStr_memcpy(lChar8 * dst, const lChar8 * src, int count)
 {
-    while ( count-- > 0)
-        (*dst++ = *src++);
+    memcpy(dst, (const lChar8 *) src, count);
 }
 
 inline void _lStr_memset(lChar16 * dst, lChar16 value, int count)
@@ -439,8 +438,7 @@ inline void _lStr_memset(lChar16 * dst, lChar16 value, int count)
 
 inline void _lStr_memset(lChar8 * dst, lChar8 value, int count)
 {
-    while ( count-- > 0)
-        *dst++ = value;
+    memset(dst, (lChar8) value, count);
 }
 
 int lStr_len(const lChar16 * str)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -55,15 +55,13 @@
 
 formatted_line_t * lvtextAllocFormattedLine( )
 {
-    formatted_line_t * pline = (formatted_line_t *)malloc(sizeof(formatted_line_t));
-    memset( pline, 0, sizeof(formatted_line_t) );
+    formatted_line_t * pline = (formatted_line_t *)calloc(1, sizeof(*pline));
     return pline;
 }
 
 formatted_line_t * lvtextAllocFormattedLineCopy( formatted_word_t * words, int word_count )
 {
-    formatted_line_t * pline = (formatted_line_t *)malloc(sizeof(formatted_line_t));
-    memset( pline, 0, sizeof(formatted_line_t) );
+    formatted_line_t * pline = (formatted_line_t *)calloc(1, sizeof(*pline));
     lUInt32 size = (word_count + FRM_ALLOC_SIZE-1) / FRM_ALLOC_SIZE * FRM_ALLOC_SIZE;
     pline->words = (formatted_word_t*)malloc( sizeof(formatted_word_t)*(size) );
     memcpy( pline->words, words, word_count * sizeof(formatted_word_t) );
@@ -112,8 +110,7 @@ formatted_line_t * lvtextAddFormattedLineCopy( formatted_text_fragment_t * pbuff
 
 embedded_float_t * lvtextAllocEmbeddedFloat( )
 {
-    embedded_float_t * flt = (embedded_float_t *)malloc(sizeof(embedded_float_t));
-    memset( flt, 0, sizeof(embedded_float_t) );
+    embedded_float_t * flt = (embedded_float_t *)calloc(1, sizeof(*flt));
     return flt;
 }
 
@@ -131,8 +128,7 @@ embedded_float_t * lvtextAddEmbeddedFloat( formatted_text_fragment_t * pbuffer )
 
 formatted_text_fragment_t * lvtextAllocFormatter( lUInt16 width )
 {
-    formatted_text_fragment_t * pbuffer = (formatted_text_fragment_t*)malloc( sizeof(formatted_text_fragment_t) );
-    memset( pbuffer, 0, sizeof(formatted_text_fragment_t));
+    formatted_text_fragment_t * pbuffer = (formatted_text_fragment_t*)calloc(1, sizeof(*pbuffer));
     pbuffer->width = width;
     pbuffer->strut_height = 0;
     pbuffer->strut_baseline = 0;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10554,8 +10554,7 @@ bool ldomDocument::loadCacheFileContent(CacheLoadingCallback * formatCallback)
             registerEmbeddedFonts();
         }
 
-        DocFileHeader h;
-        memset(&h, 0, sizeof(h));
+        DocFileHeader h = { 0 };
         SerialBuf hdrbuf(0,true);
         if ( !_cacheFile->read( CBT_REND_PARAMS, hdrbuf ) ) {
             CRLog::error("Error while reading header data");

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10554,7 +10554,7 @@ bool ldomDocument::loadCacheFileContent(CacheLoadingCallback * formatCallback)
             registerEmbeddedFonts();
         }
 
-        DocFileHeader h = { 0 };
+        DocFileHeader h = {};
         SerialBuf hdrbuf(0,true);
         if ( !_cacheFile->read( CBT_REND_PARAMS, hdrbuf ) ) {
             CRLog::error("Error while reading header data");

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2185,8 +2185,8 @@ bool tinyNodeCollection::loadNodeData()
         return false;
     if ( textcount<=0 )
         return false;
-    ldomNode * elemList[TNC_PART_COUNT] = { 0 };
-    ldomNode * textList[TNC_PART_COUNT] = { 0 };
+    ldomNode * elemList[TNC_PART_COUNT] = nullptr;
+    ldomNode * textList[TNC_PART_COUNT] = nullptr;
     if ( !loadNodeData( CBT_ELEM_NODE, elemList, elemcount+1 ) ) {
         for ( int i=0; i<TNC_PART_COUNT; i++ )
             if ( elemList[i] )

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10554,7 +10554,8 @@ bool ldomDocument::loadCacheFileContent(CacheLoadingCallback * formatCallback)
             registerEmbeddedFonts();
         }
 
-        DocFileHeader h = { 0 };
+        DocFileHeader h;
+        memset(&h, 0, sizeof(h));
         SerialBuf hdrbuf(0,true);
         if ( !_cacheFile->read( CBT_REND_PARAMS, hdrbuf ) ) {
             CRLog::error("Error while reading header data");

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -442,10 +442,9 @@ struct CacheFileItem
 
 struct SimpleCacheFileHeader
 {
-    char _magic[CACHE_FILE_MAGIC_SIZE]; // magic
+    char _magic[CACHE_FILE_MAGIC_SIZE] = { 0 }; // magic
     lUInt32 _dirty;
     SimpleCacheFileHeader( lUInt32 dirtyFlag ) {
-        memset( _magic, 0, sizeof(_magic));
         memcpy( _magic, _compressCachedData ? COMPRESSED_CACHE_FILE_MAGIC : UNCOMPRESSED_CACHE_FILE_MAGIC, CACHE_FILE_MAGIC_SIZE );
         _dirty = dirtyFlag;
     }
@@ -725,9 +724,8 @@ bool CacheFile::writeIndex()
         indexItem = findBlock(CBT_INDEX, 0);
         count = _index.length();
     }
-    CacheFileItem * index = new CacheFileItem[count];
+    CacheFileItem * index = new CacheFileItem[count]();
     int sz = count * sizeof(CacheFileItem);
-    memset(index, 0, sz);
     for ( int i = 0; i < count; i++ ) {
         memcpy( &index[i], _index[i], sizeof(CacheFileItem) );
         if (index[i]._dataType == CBT_INDEX) {
@@ -2187,10 +2185,8 @@ bool tinyNodeCollection::loadNodeData()
         return false;
     if ( textcount<=0 )
         return false;
-    ldomNode * elemList[TNC_PART_COUNT];
-    memset( elemList, 0, sizeof(elemList) );
-    ldomNode * textList[TNC_PART_COUNT];
-    memset( textList, 0, sizeof(textList) );
+    ldomNode * elemList[TNC_PART_COUNT] = { 0 };
+    ldomNode * textList[TNC_PART_COUNT] = { 0 };
     if ( !loadNodeData( CBT_ELEM_NODE, elemList, elemcount+1 ) ) {
         for ( int i=0; i<TNC_PART_COUNT; i++ )
             if ( elemList[i] )
@@ -2247,8 +2243,7 @@ ldomNode * tinyNodeCollection::allocTinyNode( int type )
                 crFatalError(1003, "allocTinyNode: can't create any more element nodes (hard limit)");
             ldomNode * part = _elemList[_elemCount >> TNC_PART_SHIFT];
             if ( !part ) {
-                part = (ldomNode*)malloc( sizeof(ldomNode) * TNC_PART_LEN );
-                memset( part, 0, sizeof(ldomNode) * TNC_PART_LEN );
+                part = (ldomNode*)calloc(TNC_PART_LEN, sizeof(*part));
                 _elemList[ _elemCount >> TNC_PART_SHIFT ] = part;
             }
             res = &part[_elemCount & TNC_PART_MASK];
@@ -2271,8 +2266,7 @@ ldomNode * tinyNodeCollection::allocTinyNode( int type )
                 crFatalError(1003, "allocTinyNode: can't create any more text nodes (hard limit)");
             ldomNode * part = _textList[_textCount >> TNC_PART_SHIFT];
             if ( !part ) {
-                part = (ldomNode*)malloc( sizeof(ldomNode) * TNC_PART_LEN );
-                memset( part, 0, sizeof(ldomNode) * TNC_PART_LEN );
+                part = (ldomNode*)calloc(TNC_PART_LEN, sizeof(*part));
                 _textList[ _textCount >> TNC_PART_SHIFT ] = part;
             }
             res = &part[_textCount & TNC_PART_MASK];
@@ -2758,8 +2752,7 @@ ldomTextStorageChunk::ldomTextStorageChunk(int preAllocSize, ldomDataStorageMana
 	, _type( manager->_type )
 	, _saved(false)
 {
-    _buf = (lUInt8*)malloc(preAllocSize);
-    memset(_buf, 0, preAllocSize);
+    _buf = (lUInt8*)calloc(preAllocSize, sizeof(*_buf));
     _manager->_uncompressedSize += _bufsize;
 }
 
@@ -2874,8 +2867,7 @@ int ldomTextStorageChunk::addText( lUInt32 dataIndex, lUInt32 parentIndex, const
     if ( !_buf ) {
         // create new buffer, if necessary
         _bufsize = _manager->_chunkSize > itemsize ? _manager->_chunkSize : itemsize;
-        _buf = (lUInt8*)malloc(sizeof(lUInt8) * _bufsize);
-        memset(_buf, 0, _bufsize );
+        _buf = (lUInt8*)calloc(_bufsize, sizeof(*_buf));
         _bufpos = 0;
         _manager->_uncompressedSize += _bufsize;
     }
@@ -2900,8 +2892,7 @@ int ldomTextStorageChunk::addElem(lUInt32 dataIndex, lUInt32 parentIndex, int ch
     if ( !_buf ) {
         // create new buffer, if necessary
         _bufsize = _manager->_chunkSize > itemsize ? _manager->_chunkSize : itemsize;
-        _buf = (lUInt8*)malloc(sizeof(lUInt8) * _bufsize);
-        memset(_buf, 0, _bufsize );
+        _buf = (lUInt8*)calloc(_bufsize, sizeof(*_buf));
         _bufpos = 0;
         _manager->_uncompressedSize += _bufsize;
     }
@@ -3050,8 +3041,7 @@ bool ldomUnpack( const lUInt8 * compbuf, int compsize, lUInt8 * &dstbuf, lUInt32
 {
     lUInt8 tmp[UNPACK_BUF_SIZE]; // 256K buffer for uncompressed data
     int ret;
-    z_stream z;
-    memset( &z, 0, sizeof(z) );
+    z_stream z = { 0 };
     z.zalloc = Z_NULL;
     z.zfree = Z_NULL;
     z.opaque = Z_NULL;
@@ -10564,8 +10554,7 @@ bool ldomDocument::loadCacheFileContent(CacheLoadingCallback * formatCallback)
             registerEmbeddedFonts();
         }
 
-        DocFileHeader h;
-        memset(&h, 0, sizeof(h));
+        DocFileHeader h = { 0 };
         SerialBuf hdrbuf(0,true);
         if ( !_cacheFile->read( CBT_REND_PARAMS, hdrbuf ) ) {
             CRLog::error("Error while reading header data");

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2185,8 +2185,8 @@ bool tinyNodeCollection::loadNodeData()
         return false;
     if ( textcount<=0 )
         return false;
-    ldomNode * elemList[TNC_PART_COUNT] = nullptr;
-    ldomNode * textList[TNC_PART_COUNT] = nullptr;
+    ldomNode * elemList[TNC_PART_COUNT] = { 0 };
+    ldomNode * textList[TNC_PART_COUNT] = { 0 };
     if ( !loadNodeData( CBT_ELEM_NODE, elemList, elemcount+1 ) ) {
         for ( int i=0; i<TNC_PART_COUNT; i++ )
             if ( elemList[i] )

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -750,7 +750,7 @@ public:
             if (!validateContent)
                 contentFormat = doc_format_pdb;
 
-            MobiPreamble preamble = { 0 };
+            MobiPreamble preamble = {};
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream, _mobiExtraDataFlags) )
                 return false; // invalid preamble

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -750,7 +750,8 @@ public:
             if (!validateContent)
                 contentFormat = doc_format_pdb;
 
-            MobiPreamble preamble = { 0 };
+            MobiPreamble preamble;
+            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream, _mobiExtraDataFlags) )
                 return false; // invalid preamble

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -750,8 +750,7 @@ public:
             if (!validateContent)
                 contentFormat = doc_format_pdb;
 
-            MobiPreamble preamble;
-            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
+            MobiPreamble preamble = { 0 };
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream, _mobiExtraDataFlags) )
                 return false; // invalid preamble

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -672,9 +672,8 @@ public:
         _format = UNKNOWN;
         stream->SetPos(0);
         lUInt32 fsize = stream->GetSize();
-        PDBHdr hdr;
+        PDBHdr hdr = { 0 };
         PDBRecordEntry entry;
-        memset(&hdr, 0, sizeof(hdr)); // avoid cppcheck warning
         if ( !hdr.read(stream) )
             return false;
         if ( hdr.recordCount==0 )
@@ -715,8 +714,7 @@ public:
         if ( _format==EREADER ) {
             if ( _records[0].size<sizeof(EReaderHeader) )
                 return false;
-            EReaderHeader preamble;
-            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
+            EReaderHeader preamble = { 0 };
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream) )
                 return false; // invalid preamble
@@ -735,8 +733,7 @@ public:
                         stream->SetPos(_records[index].offset);
                         if ( stream->ReadByte()=='P' && stream->ReadByte()=='N' && stream->ReadByte()=='G' && stream->ReadByte()==' ' ) {
                             // header ok, adding item
-                            char name[33];
-                            memset(name, 0, 33);
+                            char name[33] = { 0 };
                             lvsize_t bytesRead = 0;
                             stream->Read(name, 32, &bytesRead);
                             if ( name[0] ) {
@@ -753,8 +750,7 @@ public:
             if (!validateContent)
                 contentFormat = doc_format_pdb;
 
-            MobiPreamble preamble;
-            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
+            MobiPreamble preamble = { 0 };
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream, _mobiExtraDataFlags) )
                 return false; // invalid preamble
@@ -850,8 +846,7 @@ public:
         } else if (_format==PALMDOC ) {
             if ( _records[0].size<sizeof(PalmDocPreamble) )
                 return false;
-            PalmDocPreamble preamble;
-            memset(&preamble, 0, sizeof(preamble)); // avoid cppcheck warning
+            PalmDocPreamble preamble = { 0 };
             stream->SetPos(_records[0].offset);
             if ( !preamble.read(stream) )
                 return false; // invalid preamble

--- a/crengine/src/w32utils.cpp
+++ b/crengine/src/w32utils.cpp
@@ -33,8 +33,7 @@ void DrawBuf2DC(HDC dc, int x, int y, LVDrawBuf * buf, COLORREF * palette, int s
 
     int buf_width = buf->GetWidth();
     int bytesPerRow = (buf_width * buf->GetBitsPerPixel() + 7) / 8;
-    BITMAPINFO bmi;
-    memset( &bmi, 0, sizeof(bmi) );
+    BITMAPINFO bmi = { 0 };
     bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
     bmi.bmiHeader.biWidth = buf_width * scale;
     bmi.bmiHeader.biHeight = 1;
@@ -51,7 +50,7 @@ void DrawBuf2DC(HDC dc, int x, int y, LVDrawBuf * buf, COLORREF * palette, int s
     drawdc = CreateCompatibleDC(NULL);
     SelectObject(drawdc, drawbmp);
 
-    
+
     int pixelsPerByte = (8 / buf->GetBitsPerPixel());
     int mask = (1<<buf->GetBitsPerPixel()) - 1;
     for (int yy=0; yy<buf->GetHeight(); yy++)
@@ -92,13 +91,11 @@ void SaveBitmapToFile( const char * fname, LVGrayDrawBuf * bmp )
     int rowsize = ((bmp->GetWidth()+1)/2);
     int img_size = rowsize * bmp->GetHeight();
     int padding = rowsize - rowsize;
-    BITMAPFILEHEADER fh;
+    BITMAPFILEHEADER fh = { 0 };
     struct {
         BITMAPINFOHEADER hdr;
         RGBQUAD colors[16];
-    } bmi;
-    memset(&fh, 0, sizeof(fh));
-    memset(&bmi, 0, sizeof(bmi));
+    } bmi = { 0 };
     fh.bfType = 0x4D42;
     fh.bfSize = sizeof(fh) + sizeof(bmi) + img_size;
     fh.bfOffBits = sizeof(fh) + sizeof(bmi);

--- a/crengine/src/wolutil.cpp
+++ b/crengine/src/wolutil.cpp
@@ -4,7 +4,7 @@
 
    wolutil.cpp:  WOL file format support
 
-   Based on code by SeNS   
+   Based on code by SeNS
 
 *******************************************************/
 
@@ -39,23 +39,23 @@ class LZSSUtil {
     lUInt16 lson[N + 1], rson[N + 257], dad[N + 1];  /* left & right children &
               parents -- These constitute binary search trees. */
 
-    // private methods              
+    // private methods
     void InsertNode(int r);
     void DeleteNode(int p);
-    
+
 public:
     /// init tables
     LZSSUtil();
     /// encode buffer
     bool Encode(
-      const lUInt8 * in_buf, 
+      const lUInt8 * in_buf,
       int in_length,
-      lUInt8 * out_buf, 
+      lUInt8 * out_buf,
       int & out_length
     );
     /// decode buffer
     bool Decode(
-      const lUInt8 * in_buf, 
+      const lUInt8 * in_buf,
       int in_length,
       lUInt8 * out_buf,
       int & out_length
@@ -101,7 +101,7 @@ public:
     int getPos() { return _pos; }
 };
 
-LZSSUtil::LZSSUtil()  
+LZSSUtil::LZSSUtil()
 {
     /* initialize trees */
     int  i;
@@ -112,9 +112,9 @@ LZSSUtil::LZSSUtil()
        For i = 0 to 255, rson[N + i + 1] is the root of the tree
        for strings that begin with character i.  These are initialized
        to NIL.  Note there are 256 trees. */
-    for (i = N + 1; i <= N + 256; i++) 
+    for (i = N + 1; i <= N + 256; i++)
         rson[i] = NIL;
-    for (i = 0; i < N; i++) 
+    for (i = 0; i < N; i++)
         dad[i] = NIL;
 }
 
@@ -138,9 +138,9 @@ void LZSSUtil::InsertNode(int r)
         } else {
             if (lson[p] != NIL)
                   p = lson[p];
-            else { 
-                lson[p] = r;  
-                dad[r] = p; 
+            else {
+                lson[p] = r;
+                dad[r] = p;
                 return;
             }
         }
@@ -164,7 +164,7 @@ void LZSSUtil::InsertNode(int r)
         lson[dad[p]] = r;
     dad[p] = NIL;  /* remove p */
 }
-    
+
 void LZSSUtil::DeleteNode(int p)  /* deletes node p from tree */
 {
     int  q;
@@ -187,9 +187,9 @@ void LZSSUtil::DeleteNode(int p)  /* deletes node p from tree */
 }
 
 bool LZSSUtil::Encode(
-  const lUInt8 * in_buf, 
+  const lUInt8 * in_buf,
   int in_length,
-  lUInt8 * out_buf, 
+  lUInt8 * out_buf,
   int & out_length
 )
 {
@@ -204,7 +204,7 @@ bool LZSSUtil::Encode(
          (2 bytes).  Thus, eight units require at most 16 bytes of code. */
     code_buf_ptr = mask = 1;
     s = 0;  r = N - F;
-    for (i = s; i < r; i++) 
+    for (i = s; i < r; i++)
         text_buf[i] = ' ';  /* Clear the buffer with
          any character that will appear often. */
     for (len = 0; len < F && in.get(c); len++)
@@ -212,7 +212,7 @@ bool LZSSUtil::Encode(
               the buffer */
     if ((textsize = len) == 0)
         return false;  /* text of size zero */
-    //for (i = 1; i <= F; i++) InsertNode(r - i);  
+    //for (i = 1; i <= F; i++) InsertNode(r - i);
     /* Insert the F strings,
          each of which begins with one or more 'space' characters.  Note
          the order in which these strings are inserted.  This way,
@@ -243,7 +243,7 @@ bool LZSSUtil::Encode(
          for (i = 0; i < last_match_length && in.get(c); i++) {
               DeleteNode(s);      /* Delete old strings and */
               text_buf[s] = (lUInt8)c;    /* read new bytes */
-              if (s < F - 1) 
+              if (s < F - 1)
                     text_buf[s + N] = (lUInt8)c;  /* If the position is
                    near the end of buffer, extend the buffer to make
                    string comparison easier. */
@@ -259,7 +259,7 @@ bool LZSSUtil::Encode(
          }
     } while (len > 0);  /* until length of string to be processed is zero */
     if (code_buf_ptr > 1) {       /* Send remaining code. */
-         for (i = 0; i < code_buf_ptr; i++) 
+         for (i = 0; i < code_buf_ptr; i++)
            out.put(code_buf[i]);
          codesize += code_buf_ptr;
     }
@@ -272,11 +272,11 @@ bool LZSSUtil::Encode(
 #if 0
 
 bool LZSSUtil::Decode(
-  const lUInt8 * in_buf, 
+  const lUInt8 * in_buf,
   int in_length,
-  lUInt8 * out_buf, 
+  lUInt8 * out_buf,
   int & out_length
-)  
+)
 {
     InBitStream in( in_buf, in_length );
     OutBuf out( out_buf, out_length );
@@ -321,11 +321,11 @@ bool LZSSUtil::Decode(
 #endif
 
 bool LZSSUtil::Decode(
-  const lUInt8 * in_buf, 
+  const lUInt8 * in_buf,
   int in_length,
-  lUInt8 * out_buf, 
+  lUInt8 * out_buf,
   int & out_length
-)  
+)
 {
     InBuf in( in_buf, in_length );
     OutBuf out( out_buf, out_length );
@@ -338,7 +338,7 @@ bool LZSSUtil::Decode(
     r = N - F;  flags = 0;
     for ( ; ; ) {
         if (((flags >>= 1) & 256) == 0) {
-            if (!in.get(c)) 
+            if (!in.get(c))
                 break;
             flags = c | 0xff00;      /* uses higher byte cleverly */
         }                                  /* to count eight */
@@ -407,9 +407,9 @@ static void readMem( const lUInt8 * buf, int offset, lUInt16 & dest )
 
 static void readMem( const lUInt8 * buf, int offset, lUInt32 & dest )
 {
-    dest = ((lUInt32)buf[offset+3]<<24) 
-        | ((lUInt32)buf[offset+2]<<16) 
-        | ((lUInt32)buf[offset+1]<<8) 
+    dest = ((lUInt32)buf[offset+3]<<24)
+        | ((lUInt32)buf[offset+2]<<16)
+        | ((lUInt32)buf[offset+1]<<8)
         | buf[offset];
 }
 
@@ -421,7 +421,7 @@ bool WOLReader::readHeader()
     if (memcmp(header, "WolfEbook1.11", 13))
         return false;
     readMem(header, 0x17, _book_title_size);
-    readMem(header, 0x19, _cover_image_size); // 0x19    
+    readMem(header, 0x19, _cover_image_size); // 0x19
     readMem(header, 0x5F, _subcatalog_level23_items);  // 0x5F
     readMem(header, 0x61, _subcatalog_offset);  // 0x61
     readMem(header, 0x22, _catalog_level1_items);  // 0x1E
@@ -446,8 +446,8 @@ bool WOLReader::readHeader()
         wolf_img_params params;
         //img bitcount=1 compact=1 width=794 height=1123 length=34020
         if (sscanf(str.c_str(), "img bitcount=%d compact=%d width=%d height=%d length=%d",
-            &params.bitcount, &params.compact, 
-            &params.width, &params.height, 
+            &params.bitcount, &params.compact,
+            &params.width, &params.height,
             &params.length)!=5)
             return false;
         params.offset = (lUInt32)_stream->GetPos();
@@ -492,7 +492,7 @@ LVGrayDrawBuf * WOLReader::getImage( int index )
                uncomp[i]= ~uncomp[i];
             }
         }
-        
+
         LVGrayDrawBuf * image = new LVGrayDrawBuf(img->width, img->height, img->bitcount);
         memcpy(image->GetScanLine(0), uncomp.ptr(), img_size);
         return image;
@@ -542,15 +542,14 @@ LVArray<lUInt8> * WOLReader::getBookCover()
     LVArray<lUInt8> * cover = new LVArray<lUInt8>(_cover_image_size, 0);
     _stream->SetPos( 0x80 + _book_title_size );
     _stream->Read( cover->ptr(), _cover_image_size, NULL);
-    return cover;    
+    return cover;
 }
 
 WOLWriter::WOLWriter( LVStream * stream )
 : WOLBase(stream)
 , _catalog_opened(false)
 {
-    lUInt8 header[0x80];
-    memset(header, 0, sizeof(header));
+    lUInt8 header[0x80] = { 0 };
     memcpy(header, "WolfEbook1.11", 13);
     header[0x11]=1;
     header[0x12]=2;
@@ -572,7 +571,7 @@ void WOLWriter::startCatalog()
 
 void WOLWriter::endCatalog()
 {
-    if (_catalog_opened) 
+    if (_catalog_opened)
     {
         *_stream << "</catalog>";
         _catalog_opened=false;
@@ -625,15 +624,14 @@ void WOLWriter::writeToc()
             }
         }
         *_stream << "</catalog>";
-    
+
         //============================================================
         // subcatalog
-    
+
         // allocate TOC
         _subcatalog_offset = (lUInt32) _stream->GetPos();
-        wol_toc_subcatalog_item * toc = new wol_toc_subcatalog_item[len];
+        wol_toc_subcatalog_item * toc = new wol_toc_subcatalog_item[len]();
         int catsize = sizeof(wol_toc_subcatalog_item) * len;
-        memset( toc, 0, catsize );
         lString8 names;
         for ( int lvl=1; lvl<=3; lvl++ ) {
             for ( int i=0; i<_tocItems.length(); i++ ) {
@@ -669,7 +667,7 @@ void WOLWriter::writeToc()
         for ( i=0; i<len; i++ ) {
             wol_toc_subcatalog_item * item = &toc[i];
             lUInt32 currOffset = i * 80 + _subcatalog_offset + 12;
-            fprintf( log, "%2d   %07d : (%d,%d,%d) \t parent=%07d  child=%07d  prev=%07d  next=%07d\t %s\n", 
+            fprintf( log, "%2d   %07d : (%d,%d,%d) \t parent=%07d  child=%07d  prev=%07d  next=%07d\t %s\n",
                 i, currOffset, item->Level1Idx, item->Level2Idx, item->Level3Idx, item->ParentOffs, item->ChildOffs, item->PrevPeerOffs, item->NextPeerOffs, item->ItemName );
         }
 #endif
@@ -756,8 +754,8 @@ void WOLWriter::addCoverImage( const lUInt8 * buf, int size )
 }
 
 void WOLWriter::addImage(
-  int width, 
-  int height, 
+  int width,
+  int height,
   const lUInt8 * bitmap, // [width*height/4]
   int num_bits
 )
@@ -785,12 +783,12 @@ void WOLWriter::addImage(
       compressed.push_back(bitmap[i++]);
     }
   }
-  compressed.push_back((unsigned char)0x0); // extra last dummy char 
+  compressed.push_back((unsigned char)0x0); // extra last dummy char
 #else
   compressed.resize(bitmap.size()*2);
   int compressed_len;
 #if 1
-  Encode((const unsigned char*)&(bitmap[0]), bitmap.size(), 
+  Encode((const unsigned char*)&(bitmap[0]), bitmap.size(),
     (unsigned char*)&(compressed[0]), &compressed_len);
 #else
   EncodeLZSS(&(bitmap[0]), bitmap.size(), &(compressed[0]),
@@ -802,12 +800,12 @@ void WOLWriter::addImage(
 
     int compressed_len = bmp_sz * 9/8 + 18;
     lUInt8 * compressed = new lUInt8 [compressed_len];
-    
+
     LZSSUtil packer;
     packer.Encode(bitmap, bmp_sz, compressed, compressed_len);
 
     compressed[ compressed_len++ ] = 0; // extra last dummy char
-    
+
 #if 0 //def _DEBUG_LOG
     LZSSUtil unpacker;
     lUInt8 * decomp = new lUInt8 [bmp_sz*2];
@@ -821,10 +819,10 @@ void WOLWriter::addImage(
 #endif
 
     _page_starts.add( (lUInt32)_stream->GetPos() );
-    
+
     lString8 buf;
     buf.reserve(128);
-    buf << "<img bitcount=" 
+    buf << "<img bitcount="
         << fmt::decimal(num_bits)
         << " compact=1 width="
         << fmt::decimal(width)
@@ -833,14 +831,14 @@ void WOLWriter::addImage(
         << " length="
         << fmt::decimal((int)compressed_len)
         << ">";
-    *_stream << buf; 
+    *_stream << buf;
 
     //_page_starts.add( (lUInt32)_stream->GetPos() );
 
     _stream->Write( compressed, compressed_len, NULL );
     endPage();
     *_stream << cs8("</img>");
-  
+
     // cleanup
     delete[] compressed;
     //if (inversed)
@@ -888,22 +886,22 @@ void WOLWriter::writePageIndex()
     //*_stream << "<catalog><item>" << _book_name
     //    << "</item>";
     //*_stream << (lUInt32)0x11 << "</catalog>";
-    
+
     int pos1 = (int)_stream->GetPos();
 
     //_page_index_size = pos1-pos0; //0x1E
-    
+
 #if (USE_001_FORMAT==1)
     *_stream << "<pagetable ver=\"001\">";
 #else
     *_stream << "<pagetable ver=\"021211 \">";
 #endif
-    
+
     int start_of_catalog_table = (int)_stream->GetPos();
-    
-    LVArray<lUInt32> pagegroup_1; 
-    LVArray<lUInt32> pagegroup_2; 
-    LVArray<lUInt32> pagegroup_delim; 
+
+    LVArray<lUInt32> pagegroup_1;
+    LVArray<lUInt32> pagegroup_2;
+    LVArray<lUInt32> pagegroup_delim;
 
     pagegroup_delim.add( 0xFFFFFFFF );
     pagegroup_1.add( cnv.lsf( _catalog_start ) );
@@ -921,7 +919,7 @@ void WOLWriter::writePageIndex()
     }
     int pagegroups_start = start_of_catalog_table + 13*4 + 12;
     lUInt32 p = pagegroups_start;
-    LVArray<lUInt32> catalog; 
+    LVArray<lUInt32> catalog;
     catalog.add( cnv.lsf( p ) ); p += pagegroup_1.length()*4;
     catalog.add( cnv.lsf( p ) ); p += pagegroup_1.length()*4;
     catalog.add( cnv.lsf( p ) ); p += pagegroup_delim.length()*4;
@@ -957,7 +955,7 @@ void WOLWriter::writePageIndex()
 
 void WOLWriter::addImage( LVGrayDrawBuf & image )
 {
-    addImage( image.GetWidth(), image.GetHeight(), 
+    addImage( image.GetWidth(), image.GetHeight(),
         image.GetScanLine(0), image.GetBitsPerPixel() );
 }
 
@@ -990,7 +988,7 @@ void WOLWriter::addCoverImage( LVGrayDrawBuf & image )
     _stream->Write(&hdr, sizeof(hdr), NULL);
 
     int bmp_sz = bpl * height;
-    
+
     lUInt8 * data = new lUInt8[ bmp_sz ];
     memcpy( data, image.GetScanLine(0), bmp_sz );
     if ( hdr.bpp == 2 )
@@ -1001,7 +999,7 @@ void WOLWriter::addCoverImage( LVGrayDrawBuf & image )
 
     int compressed_len = bmp_sz * 9/8 + 18;
     lUInt8 * compressed = new lUInt8 [compressed_len];
-    
+
     LZSSUtil packer;
     packer.Encode(data, bmp_sz, compressed, compressed_len);
 
@@ -1010,11 +1008,11 @@ void WOLWriter::addCoverImage( LVGrayDrawBuf & image )
     delete[] data;
 
     _stream->Write( compressed, compressed_len, NULL );
-    
+
     _wolf_start_pos = (lUInt32) _stream->GetPos();
     _cover_image_size = _wolf_start_pos - cover_start_pos;
     *_stream << "<wolf>\r\n";
-    
+
 #else
     image.ConvertToBitmap(true);
     int sz = (image.GetWidth()+7)/8 * image.GetHeight();

--- a/crengine/src/xxhash.c
+++ b/crengine/src/xxhash.c
@@ -603,8 +603,7 @@ XXH_PUBLIC_API XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
 
 XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int seed)
 {
-    XXH32_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
-    memset(&state, 0, sizeof(state));
+    XXH32_state_t state = { 0 };   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
     state.seed = seed;
     state.v1 = seed + PRIME32_1 + PRIME32_2;
     state.v2 = seed + PRIME32_2;
@@ -617,8 +616,7 @@ XXH_PUBLIC_API XXH_errorcode XXH32_reset(XXH32_state_t* statePtr, unsigned int s
 
 XXH_PUBLIC_API XXH_errorcode XXH64_reset(XXH64_state_t* statePtr, unsigned long long seed)
 {
-    XXH64_state_t state;   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
-    memset(&state, 0, sizeof(state));
+    XXH64_state_t state = { 0 };   /* using a local state to memcpy() in order to avoid strict-aliasing warnings */
     state.seed = seed;
     state.v1 = seed + PRIME64_1 + PRIME64_2;
     state.v2 = seed + PRIME64_2;


### PR DESCRIPTION
Gets rid of explicit memset 0 calls on init, as there are often better ways to achieve that ;).

Also swaps a few malloc + memset 0 to calloc, which should be faster on Linux, because magic.