### PR TITLE
Fix vertical-align: top/bottom/text-top/text-bottom

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2259,7 +2259,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         if (is_object)
                             valign_dy += (pfh - pfb);
                         else
-                            valign_dy += (pfh - pfb) - (fh - fb);
+                            valign_dy += (pfh - pfb) - (fh - fb) - f_half_leading;
                         flags |= LTEXT_VALIGN_TEXT_BOTTOM;
                         break;
                     case css_va_text_top:
@@ -2269,7 +2269,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         if (is_object)
                             valign_dy -= pfb; // y for top of image (lvtextfm.cpp will know from flags)
                         else
-                            valign_dy -= pfb - fb;
+                            valign_dy -= pfb - fb - f_half_leading;
                         flags |= LTEXT_VALIGN_TEXT_TOP;
                         break;
                     case css_va_bottom:

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1639,10 +1639,10 @@ public:
                     // this point (at minima, the strut), even if frmline height and baseline might
                     // be moved by some coming up words
                     if ( vertical_align_flag == LTEXT_VALIGN_TOP ) {
-                        word->y = font->getBaseline() - frmline->baseline;
+                        word->y = font->getBaseline() - frmline->baseline + half_leading;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_BOTTOM ) {
-                        word->y = frmline->height - fh + font->getBaseline() - frmline->baseline;
+                        word->y = frmline->height - fh + font->getBaseline() - frmline->baseline - half_leading;
                     }
                     else {
                         // For others, vertical-align computation is done in lvrend.cpp renderFinalBlock()


### PR DESCRIPTION
Fix really bad `vertical-align: top/bottom` and wrong `vertical-align: text-top/text-bottom` when there is some large `line-height:` involved (noticed at https://github.com/koreader/crengine/pull/273#issuecomment-512762418).
(Adding or removing `half_leading` was just tried until it works and we look like Firefox by chance, without much thinking... so, these may be wrong or need additional tweaks).

KOReader before:

<kbd>![valign_bad_top](https://user-images.githubusercontent.com/24273478/61462198-88eb5200-a972-11e9-90e4-485c0ba2baef.png)</kbd> <kbd>![valign_bad_bottom](https://user-images.githubusercontent.com/24273478/61462205-8be64280-a972-11e9-822d-f26946ec9f96.png)</kbd>

This text moving effect was not intended by the HTML, which just looks like:
```html
<div style="line-height: 3">
<div class="blue">aaeepTe² <span style="vertical-align: top">top top top</span> no more<br/></div>
<div class="green">aaeepTe² <span style="vertical-align: top; line-height: 1">top line height 1</span> no more<br/></div>
<div class="blue" style="line-height: normal">aaeepTe² <span style="vertical-align: top; line-height: 3">top line height 3 in normal</span> no more<br/></div>
<div class="red" style="line-height: 2">aaeepTe² <span style="vertical-align: top; line-height: 3">top line height 3 in 2</span> no more<br/></div>
<div class="green" style="line-height: 4">aaeepTe² <span style="vertical-align: top; line-height: 3">top line height 3 in 4</span> no more<br/></div>
```

The same after:
(Firefox rendering on the left, KOReader on the right):

<kbd>![valign_top](https://user-images.githubusercontent.com/24273478/61462402-e2538100-a972-11e9-8c87-b800ee7e31fe.png)</kbd>
<kbd>![valign_bottom](https://user-images.githubusercontent.com/24273478/61462387-d9fb4600-a972-11e9-8f0c-2434d186172d.png)</kbd>

(my day of luck: easier fix than I expected, and I never managed before to have Firefox and KOReader be nearly pixel perfectly similarly sized and aligned on the y-axis :)