### PR TITLE
Some CSS attribute selectors and pseudoclasses fixes

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -93,10 +93,16 @@ enum LVCssSelectorPseudoClass
 {
     csspc_first_child,      // :first-child
     csspc_first_of_type,    // :first-of-type
-    csspc_last_child,       // :last-child
-    csspc_last_of_type,     // :last-of-type
     csspc_nth_child,        // :nth-child(even), :nth-child(3n+4)
     csspc_nth_of_type,      // :nth-of-type()
+    // Those after this won't be valid when checked in the initial
+    // document loading phase when the XML is being parsed, as at
+    // this point, the checked node is always the last node as we
+    // haven't yet parsed its following siblings. When meeting one,
+    // we'll need to re-render and re-check styles after load with
+    // a fully built DOM.
+    csspc_last_child,       // :last-child
+    csspc_last_of_type,     // :last-of-type
     csspc_nth_last_child,   // :nth-last-child()
     csspc_nth_last_of_type, // :nth-last-of-type()
     csspc_only_child,       // :only-child
@@ -107,10 +113,10 @@ static const char * css_pseudo_classes[] =
 {
     "first-child",
     "first-of-type",
-    "last-child",
-    "last-of-type",
     "nth-child",
     "nth-of-type",
+    "last-child",
+    "last-of-type",
     "nth-last-child",
     "nth-last-of-type",
     "only-child",

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -439,6 +439,7 @@ protected:
     lUInt32 _nodeStyleHash;
     lUInt32 _nodeDisplayStyleHash;
     lUInt32 _nodeDisplayStyleHashInitial;
+    bool _nodeStylesInvalidIfLoading;
 
     int calcFinalBlocks();
     void dropStyles();
@@ -564,6 +565,9 @@ public:
     bool isBuiltDomStale() {
         return _nodeDisplayStyleHashInitial != NODE_DISPLAY_STYLE_HASH_UNITIALIZED &&
                 _nodeDisplayStyleHash != _nodeDisplayStyleHashInitial;
+    }
+    void setNodeStylesInvalidIfLoading() {
+        _nodeStylesInvalidIfLoading = true;
     }
 
     /// if a cache file is in use

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1039,6 +1039,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // set document font list, and register fonts
         m_doc->getEmbeddedFontList().set(fontList);
         m_doc->registerEmbeddedFonts();
+        printf("CRE: document loaded, but styles re-init needed (cause: embedded fonts)\n");
         m_doc->forceReinitStyles();
     }
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2437,17 +2437,17 @@ lUInt32 LVCssSelectorRule::getWeight() {
             break;
         case cssrt_attrset:           // E[foo]
         case cssrt_attreq:            // E[foo="value"]
-        case cssrt_attreq_i:          // E[foo="value i"]
+        case cssrt_attreq_i:          // E[foo="value" i]
         case cssrt_attrhas:           // E[foo~="value"]
-        case cssrt_attrhas_i:         // E[foo~="value i"]
+        case cssrt_attrhas_i:         // E[foo~="value" i]
         case cssrt_attrstarts_word:   // E[foo|="value"]
-        case cssrt_attrstarts_word_i: // E[foo|="value i"]
+        case cssrt_attrstarts_word_i: // E[foo|="value" i]
         case cssrt_attrstarts:        // E[foo^="value"]
-        case cssrt_attrstarts_i:      // E[foo^="value i"]
+        case cssrt_attrstarts_i:      // E[foo^="value" i]
         case cssrt_attrends:          // E[foo$="value"]
-        case cssrt_attrends_i:        // E[foo$="value i"]
+        case cssrt_attrends_i:        // E[foo$="value" i]
         case cssrt_attrcontains:      // E[foo*="value"]
-        case cssrt_attrcontains_i:    // E[foo*="value i"]
+        case cssrt_attrcontains_i:    // E[foo*="value" i]
         case cssrt_class:             // E.class
         case cssrt_pseudoclass:       // E:pseudo-class
             return 1 << 8;
@@ -2578,8 +2578,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attreq:        // E[foo="value"]
-    case cssrt_attreq_i:      // E[foo="value i"]
+    case cssrt_attreq_i:      // E[foo="value" i]
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             lString16 val = node->getAttributeValue(_attrid);
             if (_type == cssrt_attreq_i)
                 val.lowercase();
@@ -2587,9 +2589,11 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attrhas:       // E[foo~="value"]
-    case cssrt_attrhas_i:     // E[foo~="value i"]
+    case cssrt_attrhas_i:     // E[foo~="value" i]
         // one of space separated values
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             lString16 val = node->getAttributeValue(_attrid);
             if (_type == cssrt_attrhas_i)
                 val.lowercase();
@@ -2603,8 +2607,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attrstarts_word:    // E[foo|="value"]
-    case cssrt_attrstarts_word_i:  // E[foo|="value i"]
+    case cssrt_attrstarts_word_i:  // E[foo|="value" i]
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             // value can be exactly value or can begin with value
             // immediately followed by a hyphen
             lString16 val = node->getAttributeValue(_attrid);
@@ -2624,8 +2630,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attrstarts:    // E[foo^="value"]
-    case cssrt_attrstarts_i:  // E[foo^="value i"]
+    case cssrt_attrstarts_i:  // E[foo^="value" i]
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             lString16 val = node->getAttributeValue(_attrid);
             int val_len = val.length();
             int value_len = _value.length();
@@ -2638,8 +2646,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attrends:    // E[foo$="value"]
-    case cssrt_attrends_i:  // E[foo$="value i"]
+    case cssrt_attrends_i:  // E[foo$="value" i]
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             lString16 val = node->getAttributeValue(_attrid);
             int val_len = val.length();
             int value_len = _value.length();
@@ -2652,8 +2662,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         }
         break;
     case cssrt_attrcontains:    // E[foo*="value"]
-    case cssrt_attrcontains_i:  // E[foo*="value i"]
+    case cssrt_attrcontains_i:  // E[foo*="value" i]
         {
+            if ( !node->hasAttribute(_attrid) )
+                return false;
             lString16 val = node->getAttributeValue(_attrid);
             if (_value.length()>val.length())
                 return false;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2951,6 +2951,16 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         lString16 s( attrvalue );
         rule->setAttr(n, s);
         // printf("made pseudo class rule %d with %s\n", n, UnicodeToLocal(s).c_str());
+        if ( n >= csspc_last_child ) {
+            // Pseudoclasses after csspc_last_child can't be accurately checked
+            // in the initial loading phase: a re-render will be needed.
+            doc->setNodeStylesInvalidIfLoading();
+            // There might still be some issues if CSS would set some display: property
+            // as, when re-rendering, a cache might be present and prevent modifying
+            // the DOM for some needed autoBoxing - or the invalid styles set now
+            // while loading would have created some autoBoxing that we won't be
+            // able to remove...
+        }
         return rule;
     } else if (*str != '[')
         return NULL;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2871,16 +2871,18 @@ bool parse_attr_value( const char * &str, char * buf, bool &parse_trailing_i, ch
         buf[pos] = 0;
         str += pos+1;
         skip_spaces( str );
+        // The trailing ' i' must be outside the quotes
+        if (parse_trailing_i) {
+            parse_trailing_i = false;
+            if (*str == 'i' || *str == 'I') {
+                parse_trailing_i = true;
+                str++;
+                skip_spaces( str );
+            }
+        }
         if (*str != stop_char)
             return false;
         str++;
-        if (parse_trailing_i && pos >=2) {
-            parse_trailing_i = false;
-            if ( (buf[pos-2]==' ') && (buf[pos-1]=='i' || buf[pos-1]=='I') ) {
-                parse_trailing_i = true;
-                buf[pos-2] = 0;
-            }
-        }
         return true;
     }
     else
@@ -2893,6 +2895,8 @@ bool parse_attr_value( const char * &str, char * buf, bool &parse_trailing_i, ch
         int end_pos = pos;
         if (parse_trailing_i) {
             parse_trailing_i = false;
+            if (end_pos == 0) // Empty value, or some leading space: this is invalid
+                return false;
             if (str[pos] && str[pos]==' ' && str[pos+1] && (str[pos+1]=='i' || str[pos+1]=='I')) {
                 parse_trailing_i = true;
                 pos+=2;


### PR DESCRIPTION
See individual commit messages for details.
First commit fixes the _another strange thing_ noticed in https://github.com/koreader/crengine/pull/276#issuecomment-513905987:
> There's another strange thing with this book: when you change some rendering parameters (font size, margins), it triggers a `Styles have changed in such a way that fully reloading the document may be needed for a correct rendering.` popup - which I've never seen happening before when ... styles have no reason to have changed :|

Second commit fixes attribute selectors that should not match when there is no such attribute. It should avoid some uneeded expensive work, as noticed in https://github.com/koreader/crengine/pull/276#issuecomment-517592585.
Third commit makes the parsing of attribute selectors more correct that what was done in 3430e5114795b42b6e1c53aff7c9e877d71467bd.

Before 2nd and 3rd commits, this HTML:
```html
<html>
<head>
<style>
div[tutu= i], blockquote { font-weight: bold; }
div[toto=], blockquote { font-style: italic; } /* should be fully skipped as invalid */
div[tutu="" i] { color: red; }
div[toto=""] { background-color: yellow; }
div[tutu="def i"] { color: orange; }
div[tutu="def" i] { text-decoration: underline; }
div[toto=abc i] { color: yellow; }
</style>
</head>
<body>
 <div>Some text no toto no tutu</div>
 <div toto="">Some text with empty toto</div>
 <div tutu="">Some text with empty tutu</div>
 <div toto="abc">Some text with non empty toto</div>
 <div tutu="def">Some text with non empty tutu</div>
 <blockquote>Some text in blockquote</blockquote>
</body>
</html>
```
would render as that (Firefox on the left, KOReader on the right):
<kbd>![before](https://user-images.githubusercontent.com/24273478/62414996-62404300-b623-11e9-8dd2-28c8551a0c8a.png)</kbd>

With 2nd and 3rd commits, we now render as Firefox:
<kbd>![after](https://user-images.githubusercontent.com/24273478/62414998-65d3ca00-b623-11e9-85c2-cf18c42c4ed3.png)</kbd>
