### PR TITLE
Some small fixes after Enhanced Block Rendering big changes

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -54,8 +54,7 @@ blockquote {
 hr {
     height: 2px;
     background-color: #808080;
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+    margin: 0.5em auto;
 }
 center {
     text-align: center;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2549,7 +2549,9 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // as wanted by a <BR/>.
                 // (This makes consecutive and stuck <br><br><br> work)
                 LVFont * font = enode->getFont().get();
-                txform->AddSourceLine( L" ", 1, 0, 0, font, baseflags | LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
+                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
+                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                txform->AddSourceLine( L" ", 1, cl, bgcl, font, baseflags | LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
                 // baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
                 // No need to clear the flag, as we set it just below
                 // (any LTEXT_ALIGN_* set implies LTEXT_FLAG_NEWLINE)
@@ -2599,7 +2601,9 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // by lvtextfm.cpp splitParagraphs() to not add this empty
             // string to text, and just call floatClearText().
             LVFont * font = enode->getFont().get();
-            txform->AddSourceLine( L" ", 1, 0, 0, font, baseflags|LTEXT_SRC_IS_CLEAR_LAST|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
+            lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
+            lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+            txform->AddSourceLine( L" ", 1, cl, bgcl, font, baseflags|LTEXT_SRC_IS_CLEAR_LAST|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
         }
     }
     else if ( enode->isText() ) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5140,7 +5140,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // Adjust box size and position
 
-    // <HR> gets its style width and height no matter flags
+    // <HR> gets its style width, height and margin:auto no matter flags
     bool is_hr = enode->getNodeId() == el_hr;
     // <EMPTY-LINE> block element with height added for empty lines in txt document
     bool is_empty_line_elem = enode->getNodeId() == el_empty_line;
@@ -5435,7 +5435,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             // by even overflow on each side?)
         }
         else { // We fit into container_width
-            if ( BLOCK_RENDERING(flags, ENSURE_MARGIN_AUTO_ALIGNMENT) ) {
+            if ( BLOCK_RENDERING(flags, ENSURE_MARGIN_AUTO_ALIGNMENT) || is_hr ) {
                 // https://www.hongkiat.com/blog/css-margin-auto/
                 //  "what do you think will happen when the value auto is given
                 //   to only one of those? A left or right margin with auto will

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6583,13 +6583,23 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
     ldomNode * mainNode = p->getDocument()->getRootNode();
     for ( ; p; p = p->getParentNode() ) {
         int rm = p->getRendMethod();
-        if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption ) {
+        if ( rm == erm_final || rm == erm_table_caption ) {
             // With floats, we may get multiple erm_final when walking up
             // to root node: keep the first one met (but go on up to the
             // root node in case we're in some upper erm_invisible).
             if (!finalNode)
                 finalNode = p; // found final block
-        } else if ( p->getRendMethod() == erm_invisible ) {
+        }
+        else if (rm == erm_list_item) {
+            // This obsolete rendering method is considered just like erm_final
+            // for many purposes, but can contain real erm_final nodes.
+            // So, if we found an erm_final, and if we find an erm_list_item
+            // when going up, we should use it (unlike in previous case).
+            // (This is needed to correctly display highlights on books opened
+            // with some older DOM_VERSION.)
+            finalNode = p;
+        }
+        else if ( p->getRendMethod() == erm_invisible ) {
             return false; // invisible !!!
         }
         if ( p==mainNode )


### PR DESCRIPTION
- Forgot to have `<HR>`  centered by default in enhanced block rendering.
- Some black squares were shown on empty lines when I enabled floating punctuation:
<kbd>![black_BR](https://user-images.githubusercontent.com/24273478/62476456-541b2f80-b7a7-11e9-9062-083181525c00.png)</kbd>
- Highlights in some old test file about list items (opened and still re-opened with an older `cre_dom_version` that use some old list item code) were totally messed up (because of some change related to floats support):
<kbd>![before_list_item](https://user-images.githubusercontent.com/24273478/62476506-6f863a80-b7a7-11e9-828f-2f5547b3d115.png)</kbd>
They are now rendered as they were before:
<kbd>![after_list_item](https://user-images.githubusercontent.com/24273478/62476539-8036b080-b7a7-11e9-8505-de00d3f12619.png)</kbd>

