### PR TITLE
CSS parsing code: formatting cleanup and optimisations

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -6789,6 +6789,11 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
             drawbuf.GetClipRect( &orig_clip ); // Backup the original one
             // Set a new one to the target area
             lvRect target_clip = lvRect(x0+doc_x, y0+doc_y, x0+doc_x+width, y0+doc_y+height);;
+            // But don't overflow page top and bottom, in case target spans multiple pages
+            if ( target_clip.top < orig_clip.top )
+                target_clip.top = orig_clip.top;
+            if ( target_clip.bottom > orig_clip.bottom )
+                target_clip.bottom = orig_clip.bottom;
             drawbuf.SetClipRect( &target_clip );
             // Draw
             drawbuf.Draw(transformed, x0+doc_x+draw_x, y0+doc_y+draw_y, transform_w, transform_h);


### PR DESCRIPTION
- Cleanup formatting, simplify the parsing of some properties.
- Fix slow parsing of `border`, `border-top`... properties, where some uneeded strings containing the full CSS file content were created (and memory allocated). See https://github.com/koreader/koreader/issues/5226#issuecomment-522630738.
Parsing simplified and made conforming to specs (border style is allowed to be absent and default to 'none', instead of skipping the declaration).

Small optimisations to CSS parsing:
 - avoid some lowercasing
 - compare specific color name before scanning the whole table (may help with our `Pure black & white` styletweak setting `background-color: transparent` on all elements)

Small optimisations to CSS checking:
 - `E#id` and `E.class`: skip string manipulations when empty or absent `id=` or `class=` attribute.
 - skip string comparisons when matching element names shorter than "floatBox" for lowercasing

(Haven't really checked each of all properties parsing, hoping I haven't messed some up... but things shows up correctly on my regular testing documents.)

Also fix background-image drawing possibly overflowing page.
