### PR TITLE
Support RTL/bidi text, some font and harfbuzz fixes

### DIFF
--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -124,6 +124,8 @@ XS_TAG1I( span )
 XS_TAG1I( strong )
 XS_TAG1I( sub )
 XS_TAG1I( sup )
+XS_TAG1I( bdi )
+XS_TAG1I( bdo )
 
 // EPUB3 elements (in ns_epub - otherwise set to inline like any unknown element)
 XS_TAG1I( switch )  // <epub:switch>

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -21,7 +21,7 @@
 class HyphMethod
 {
 public:
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth ) = 0;
+    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 ) = 0;
     virtual ~HyphMethod() { }
 };
 
@@ -123,9 +123,9 @@ public:
     HyphMan();
     ~HyphMan();
 
-    inline static bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth )
+    inline static bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 )
     {
-        return _method->hyphenate( str, len, widths, flags, hyphCharWidth, maxWidth );
+        return _method->hyphenate( str, len, widths, flags, hyphCharWidth, maxWidth, flagSize );
     }
 };
 

--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -231,7 +231,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
 #define LCHAR_ALLOW_HYPH_WRAP_AFTER  0x0008 ///< flag: line break after this char is allowed with addition of hyphen
                                             //         It is set by Hyphman when finding hyphenation points in a word.
 #define LCHAR_MANDATORY_NEWLINE      0x0010 ///< flag: this char must start with new line
-#define LCHAR_IS_LIGATURE_TAIL       0x0020 ///< flag: this char is a tail of a cluster (eg. ligature,
+#define LCHAR_IS_CLUSTER_TAIL        0x0020 ///< flag: this char is a tail of a cluster (eg. ligature,
                                             //         whose glyph is carried by first char)
                                             //         It is set by harfbuzz when used.
 
@@ -249,7 +249,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
 #define LCHAR_IS_CJK_PUNCT           0x6000 ///< flag: (for checking) this char is a CJK punctuation (neutral if set)
 #define LCHAR_IS_CJK                 0x7000 ///< flag: (for checking) this char is a CJK char
 
-// LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_LIGATURE_TAIL
+// LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_CLUSTER_TAIL
 // #define LCHAR_IS_EOL              0x0010 ///< flag: this char is CR or LF
 
 /** \brief returns true if character is unicode space 

--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -215,16 +215,42 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
                     lChar16 def_char
                  );
 
-#define LCHAR_IS_SPACE               1 ///< flag: this char is one of unicode space chars
-#define LCHAR_ALLOW_WRAP_AFTER       2 ///< flag: line break after this char is allowed
-#define LCHAR_DEPRECATED_WRAP_AFTER  4 ///< flag: line break after this char is possible but deprecated
-#define LCHAR_ALLOW_HYPH_WRAP_AFTER  8 ///< flag: line break after this char is allowed with addition of hyphen
-#define LCHAR_IS_LIGATURE_TAIL      16 ///< flag: this char is a tail of a ligature (ligature is carried by first char)
-#define LCHAR_IS_OBJECT             32 ///< flag: this char is object or image
-#define LCHAR_MANDATORY_NEWLINE     64 ///< flag: this char must start with new line
-#define LCHAR_IS_COLLAPSED_SPACE   128 ///< flag: this char is a space that should not be displayed
+// These lower than 0x0100 (that fit in a lUint8) may be set by lvfntman's measureText()
+// (to possibly get some informative flags back from harfbuzz) and hyphman's hyphenate().
+// (These should be changed or dropped with care, as they may be used by some other parts of CoolReader)
+#define LCHAR_IS_SPACE               0x0001 ///< flag: this char is one of the unicode space chars.
+                                            //         It is set only on the normal space and the normal non-breakable
+                                            //         space (spaces that can have their widths expanded or shrunk).
+                                            //         It is not set on the unicode fixed width spaces.
+#define LCHAR_ALLOW_WRAP_AFTER       0x0002 ///< flag: line break after this char is allowed.
+                                            //         It is set on all spaces, except non-breakable ones.
+                                            //         It is set on soft-hyphen.
+                                            //         It is not set on CJK chars.
+#define LCHAR_DEPRECATED_WRAP_AFTER  0x0004 ///< flag: line break after this char is possible but deprecated
+                                            //         It is set on '-' and other unicode hyphens.
+#define LCHAR_ALLOW_HYPH_WRAP_AFTER  0x0008 ///< flag: line break after this char is allowed with addition of hyphen
+                                            //         It is set by Hyphman when finding hyphenation points in a word.
+#define LCHAR_MANDATORY_NEWLINE      0x0010 ///< flag: this char must start with new line
+#define LCHAR_IS_LIGATURE_TAIL       0x0020 ///< flag: this char is a tail of a cluster (eg. ligature,
+                                            //         whose glyph is carried by first char)
+                                            //         It is set by harfbuzz when used.
+
+/// The next ones, not fitting in a lUInt8, should only be set and used by lvtextfm
+#define LCHAR_IS_OBJECT              0x0100 ///< flag: this char is object (image, float)
+#define LCHAR_IS_COLLAPSED_SPACE     0x0200 ///< flag: this char is a space that should not be rendered
+#define LCHAR_IS_TO_IGNORE           0x0400 ///< flag: this char is to be ignored/skipped in text measurement and drawing
+#define LCHAR_IS_RTL                 0x0800 ///< flag: this char is part of a RTL segment
+
+// (Next ones are not yet used and can be removed/changed)
+#define LCHAR_IS_CJK_NOT_PUNCT       0x1000 ///< flag: this char is part a CJK char but not a punctuation
+#define LCHAR_IS_CJK_LEFT_PUNCT      0x2000 ///< flag: this char is part a CJK left punctuation
+#define LCHAR_IS_CJK_RIGHT_PUNCT     0x4000 ///< flag: this char is part a CJK right punctuation
+
+#define LCHAR_IS_CJK_PUNCT           0x6000 ///< flag: (for checking) this char is a CJK punctuation (neutral if set)
+#define LCHAR_IS_CJK                 0x7000 ///< flag: (for checking) this char is a CJK char
+
 // LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_LIGATURE_TAIL
-// #define LCHAR_IS_EOL             16 ///< flag: this char is CR or LF
+// #define LCHAR_IS_EOL              0x0010 ///< flag: this char is CR or LF
 
 /** \brief returns true if character is unicode space 
     \param code is character

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -172,6 +172,21 @@ enum kerning_mode_t {
 };
 
 
+// Hint flags for measuring and drawing (some used only with full Harfbuzz)
+// These 4 translate (after mask & shift) from LTEXT_WORD_* equivalents
+// (see lvtextfm.h). Keep them in sync.
+#define LFNT_HINT_DIRECTION_KNOWN        0x0001 /// segment direction is known
+#define LFNT_HINT_DIRECTION_IS_RTL       0x0002 /// segment direction is RTL
+#define LFNT_HINT_BEGINS_PARAGRAPH       0x0004 /// segment is at start of paragraph
+#define LFNT_HINT_ENDS_PARAGRAPH         0x0008 /// segment is at end of paragraph
+
+// These 4 translate from LTEXT_TD_* equivalents (see lvtextfm.h). Keep them in sync.
+#define LFNT_DRAW_UNDERLINE              0x0100 /// underlined text
+#define LFNT_DRAW_OVERLINE               0x0200 /// overlined text
+#define LFNT_DRAW_LINE_THROUGH           0x0400 /// striked through text
+#define LFNT_DRAW_BLINK                  0x0800 /// blinking text (implemented as underline)
+#define LFNT_DRAW_DECORATION_MASK        0x0F00
+
 /** \brief base class for fonts
 
     implements single interface for font of any engine
@@ -215,6 +230,7 @@ public:
         \param max_width is maximum width to measure line 
         \param def_char is character to replace absent glyphs in font
         \param letter_spacing is number of pixels to add between letters
+        \param hints: hint flags (direction, begin/end of paragraph, for Harfbuzz - unrelated to font hinting)
         \return number of characters before max_width reached 
     */
     virtual lUInt16 measureText( 
@@ -224,7 +240,8 @@ public:
                         int max_width,
                         lChar16 def_char,
                         int letter_spacing=0,
-                        bool allow_hyphenation=true
+                        bool allow_hyphenation=true,
+                        lUInt32 hints=0
                      ) = 0;
 
     /** \brief measure text
@@ -269,8 +286,8 @@ public:
     virtual lString8 getTypeFace() const = 0;
     /// returns font family id
     virtual css_font_family_t getFontFamily() const = 0;
-    /// draws text string
-    virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
+    /// draws text string (returns x advance)
+    virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette = NULL, bool addHyphen = false,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
@@ -448,8 +465,8 @@ public:
     virtual lString8 getTypeFace() const { return _typeface; }
     /// returns font family id
     virtual css_font_family_t getFontFamily() const { return _family; }
-    /// draws text string
-    virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
+    /// draws text string (returns x advance)
+    virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
@@ -472,7 +489,8 @@ public:
                         int max_width,
                         lChar16 def_char,
                         int letter_spacing=0,
-                        bool allow_hyphenation=true
+                        bool allow_hyphenation=true,
+                        lUInt32 hints=0
                      );
     /** \brief measure text
         \param text is text string pointer
@@ -633,7 +651,8 @@ public:
                         int max_width,
                         lChar16 def_char,
                         int letter_spacing=0,
-                        bool allow_hyphenation=true
+                        bool allow_hyphenation=true,
+                        lUInt32 hints=0
                      );
     /** \brief measure text
         \param text is text string pointer
@@ -647,8 +666,8 @@ public:
     /// returns char width
     virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 );
 
-    /// draws text string
-    virtual void DrawTextString( LVDrawBuf * buf, int x, int y, 
+    /// draws text string (returns x advance)
+    virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
                        const lChar16 * text, int len,
                        lChar16 def_char, lUInt32 * palette, bool addHyphen,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
@@ -810,7 +829,8 @@ public:
                         int max_width,
                         lChar16 def_char,
                         int letter_spacing=0,
-                        bool allow_hyphenation=true
+                        bool allow_hyphenation=true,
+                        lUInt32 hints=0
                      );
     /** \brief measure text
         \param text is text string pointer

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -226,26 +226,27 @@ public:
                         int letter_spacing=0,
                         bool allow_hyphenation=true
                      ) = 0;
+
     /** \brief measure text
         \param text is text string pointer
         \param len is number of characters to measure
         \return width of specified string 
     */
-    virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len
-        ) = 0;
+    virtual lUInt32 getTextWidth( const lChar16 * text, int len ) = 0;
 
-//    /** \brief get glyph image in 1 byte per pixel format
-//        \param code is unicode character
-//        \param buf is buffer [width*height] to place glyph data
-//        \return true if glyph was found
-//    */
-//    virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char=0) = 0;
+    // /** \brief get glyph image in 1 byte per pixel format
+    //     \param code is unicode character
+    //     \param buf is buffer [width*height] to place glyph data
+    //     \return true if glyph was found
+    // */
+    // virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char=0) = 0;
+
     /** \brief get glyph item
         \param code is unicode character
         \return glyph pointer if glyph was found, NULL otherwise
     */
     virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0) = 0;
+
     /// returns font baseline offset
     virtual int getBaseline() = 0;
     /// returns font height including normal interline space

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -375,6 +375,8 @@ public:
     virtual lString8 GetFallbackFontFace() { return lString8::empty_str; }
     /// returns fallback font for specified size
     virtual LVFontRef GetFallbackFont(int /*size*/) { return LVFontRef(); }
+    /// returns fallback font for specified size, weight and italic
+    virtual LVFontRef GetFallbackFont(int size, int weight=400, bool italic=false ) { return LVFontRef(); }
     /// registers font by name
     virtual bool RegisterFont( lString8 name ) = 0;
     /// registers font by name and face

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -289,11 +289,20 @@ public:
     {
         clear();
     }
-    void addLink( LVFootNote * note )
+    int getLinksCount()
+    {
+        if ( links==NULL )
+            return 0;
+        return links->length();
+    }
+    void addLink( LVFootNote * note, int pos=-1 )
     {
         if ( links==NULL )
             links = new LVFootNoteList();
-        links->add( note );
+        if ( pos >= 0 ) // insert at pos
+            links->insert( pos, note );
+        else // append
+            links->add( note );
         flags |= RN_SPLIT_FOOT_LINK;
     }
 };
@@ -371,8 +380,12 @@ public:
     }
     bool updateRenderProgress( int numFinalBlocksRendered );
 
-    /// append footnote link to last added line
-    void addLink( lString16 id );
+    /// Get the number of links in the current line links list, or
+    // in link_ids when no page_list
+    int getCurrentLinksCount();
+
+    /// append or insert footnote link to last added line
+    void addLink( lString16 id, int pos=-1 );
 
     /// get gathered links when no page_list
     // (returns a reference to avoid lString16Collection destructor from

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -756,6 +756,7 @@ public:
         for (int i=0; i<v.length(); i++)
 			add( v[i] );
 	}
+    int insert( int pos, const lString16 & str );
     void erase(int offset, int count);
     /// split into several lines by delimiter
     void split(const lString16 & str, const lString16 & delimiter);

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -57,6 +57,7 @@ extern "C" {
 #define LTEXT_TD_LINE_THROUGH  0x0400  /**< \brief striked through text */
 #define LTEXT_TD_BLINK         0x0800  /**< \brief blinking text */
 #define LTEXT_TD_MASK          0x0F00  /**< \brief text decoration mask */
+    // These 4 above translate to LFNT_DRAW_* equivalents (see lvfntman.h). Keep them in sync.
 
 #define LTEXT_SRC_IS_OBJECT    0x8000  /**< \brief object (image) */
 #define LTEXT_IS_LINK          0x4000  /**< \brief link */

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -128,24 +128,31 @@ typedef struct
 } formatted_word_t;
 
 // formatted_word_t flags
-/// can add space after this word
-#define LTEXT_WORD_CAN_ADD_SPACE_AFTER       1
-/// can break line after this word
-#define LTEXT_WORD_CAN_BREAK_LINE_AFTER      2
-/// can break with hyphenation after this word
-#define LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER 4
-/// must break line after this word
-#define LTEXT_WORD_MUST_BREAK_LINE_AFTER     8
-/// object flag
-#define LTEXT_WORD_IS_OBJECT         0x80
-/// first word of link flag
-#define LTEXT_WORD_IS_LINK_START     0x40
+#define LTEXT_WORD_CAN_ADD_SPACE_AFTER       0x0001 /// can add space after this word
+#define LTEXT_WORD_CAN_BREAK_LINE_AFTER      0x0002 /// can break line after this word (not used anywhere)
+#define LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER 0x0004 /// can break with hyphenation after this word
+#define LTEXT_WORD_MUST_BREAK_LINE_AFTER     0x0008 /// must break line after this word (not used anywhere)
+
+#define LTEXT_WORD_IS_LINK_START             0x0010 /// first word of link flag
+#define LTEXT_WORD_IS_OBJECT                 0x0020 /// object flag
+
+#define LTEXT_WORD_DIRECTION_KNOWN           0x0100 /// word has been thru bidi: if next flag is unset, it is LTR.
+#define LTEXT_WORD_DIRECTION_IS_RTL          0x0200 /// word is RTL
+#define LTEXT_WORD_BEGINS_PARAGRAPH          0x0400 /// word is the first word of a paragraph
+#define LTEXT_WORD_ENDS_PARAGRAPH            0x0800 /// word is the last word of a paragraph
+    // These 4 translate (after mask & shift) to LFNT_HINT_* equivalents
+    // (see lvfntman.h). Keep them in sync.
+#define LTEXT_WORD_DIRECTION_PARA_MASK       0x0F00
+#define LTEXT_WORD_DIRECTION_PARA_TO_LFNT_SHIFT   8
+#define WORD_FLAGS_TO_FNT_FLAGS(f) ( (f & LTEXT_WORD_DIRECTION_PARA_MASK)>>LTEXT_WORD_DIRECTION_PARA_TO_LFNT_SHIFT)
 
 //#define LTEXT_BACKGROUND_MARK_FLAGS 0xFFFF0000l
 
 // formatted_line_t flags
-#define LTEXT_LINE_SPLIT_AVOID_BEFORE        1
-#define LTEXT_LINE_SPLIT_AVOID_AFTER         2
+#define LTEXT_LINE_SPLIT_AVOID_BEFORE        0x01
+#define LTEXT_LINE_SPLIT_AVOID_AFTER         0x02
+#define LTEXT_LINE_IS_BIDI                   0x04
+#define LTEXT_LINE_PARA_IS_RTL               0x08
 
 /** \brief Text formatter formatted line
 */

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -111,7 +111,7 @@ typedef struct
    lUInt16  min_width;       /**< \brief index of source text line */
    lInt16   x;               /**< \brief word x position in line */
    lInt16   y;               /**< \brief baseline y position */
-   lUInt8   flags;           /**< \brief flags */
+   lUInt16  flags;           /**< \brief flags */
    union {
           /// for text word
        struct {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2456,6 +2456,10 @@ private:
     lString8 headStyleText;
     int headStyleState;
 
+    lString16 htmlDir;
+    lString16 htmlLang;
+    bool insideHtmlTag;
+
 public:
 
     /// return content of html/head/style element
@@ -2486,6 +2490,9 @@ public:
         insideTag = false;
         headStyleText.clear();
         headStyleState = 0;
+        insideHtmlTag = false;
+        htmlDir.clear();
+        htmlLang.clear();
     }
     /// called on parsing end
     virtual void OnStop()
@@ -2525,7 +2532,8 @@ public:
     /// constructor
     ldomDocumentFragmentWriter( LVXMLParserCallback * parentWriter, lString16 baseTagName, lString16 baseTagReplacementName, lString16 fragmentFilePath )
     : parent(parentWriter), baseTag(baseTagName), baseTagReplacement(baseTagReplacementName),
-    insideTag(false), styleDetectionState(0), pathSubstitutions(100), baseElement(NULL), lastBaseElement(NULL), headStyleState(0)
+    insideTag(false), styleDetectionState(0), pathSubstitutions(100), baseElement(NULL), lastBaseElement(NULL),
+    headStyleState(0), insideHtmlTag(false)
     {
         setCodeBase( fragmentFilePath );
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -836,7 +836,8 @@ lString8 familyName( FT_Face face )
 // The 2 slots with "LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER" on the 2nd line previously
 // were: "LCHAR_IS_SPACE | LCHAR_IS_EOL | LCHAR_ALLOW_WRAP_AFTER".
 // LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_LIGATURE_TAIL
-// (as flags are usually lUInt8, and the 8 bits were used, one needed to be dropped).
+// (as flags were lUInt8, and the 8 bits were used, one needed to be dropped - they
+// have since been upgraded to be lUInt16)
 static lUInt16 char_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, // 0    00
     0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, // 8    08

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -77,25 +77,25 @@ static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
-	// faces we want
-	lString8Collection list;
-	splitPropertyValueList(commaSeparatedFaceList.c_str(), list);
-	// faces we have
-	lString16Collection faces;
-	getFaceList(faces);
-	// find first matched
-	for (int i = 0; i < list.length(); i++) {
-		lString8 wantFace = list[i];
-		for (int j = 0; j < faces.length(); j++) {
-			lString16 haveFace = faces[j];
-			if (wantFace == haveFace)
-				return wantFace;
-		}
-	}
-	// not matched - get by family name
+    // faces we want
+    lString8Collection list;
+    splitPropertyValueList(commaSeparatedFaceList.c_str(), list);
+    // faces we have
+    lString16Collection faces;
+    getFaceList(faces);
+    // find first matched
+    for (int i = 0; i < list.length(); i++) {
+        lString8 wantFace = list[i];
+        for (int j = 0; j < faces.length(); j++) {
+            lString16 haveFace = faces[j];
+            if (wantFace == haveFace)
+                return wantFace;
+        }
+    }
+    // not matched - get by family name
     LVFontRef fnt = GetFont(10, 400, false, fallbackByFamily, lString8("Arial"));
     if (fnt.isNull())
-    	return lString8::empty_str; // not found
+        return lString8::empty_str; // not found
     // get face from found font
     return fnt->getTypeFace();
 }
@@ -134,8 +134,8 @@ double LVFontManager::GetGamma() {
 
 /// sets current gamma level
 void LVFontManager::SetGamma( double gamma ) {
-//    gammaLevel = cr_ft_gamma_levels[GAMMA_LEVELS/2];
-//    gammaIndex = GAMMA_LEVELS/2;
+    // gammaLevel = cr_ft_gamma_levels[GAMMA_LEVELS/2];
+    // gammaIndex = GAMMA_LEVELS/2;
     int oldGammaIndex = gammaIndex;
     for ( int i=0; i<GAMMA_LEVELS; i++ ) {
         double diff1 = cr_gamma_levels[i] - gamma;
@@ -216,7 +216,7 @@ bool LVEmbeddedFontList::add(lString16 url, lString8 face, bool bold, bool itali
     }
     def = new LVEmbeddedFontDef(url, face, bold, italic);
     add(def);
-	return false;
+    return false;
 }
 
 bool LVEmbeddedFontList::serialize(SerialBuf & buf) {
@@ -255,11 +255,11 @@ bool LVEmbeddedFontList::deserialize(SerialBuf & buf) {
 /**
  * Max width of -/./,/!/? to use for visial alignment by width
  */
-int LVFont::getVisualAligmentWidth()
-{
+int LVFont::getVisualAligmentWidth() {
     FONT_GUARD
     if ( _visual_alignment_width==-1 ) {
-        lChar16 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';', (lChar16)L'，', (lChar16)L'。', (lChar16)L'！', 0 };
+        lChar16 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';',
+                    (lChar16)L'，', (lChar16)L'。', (lChar16)L'！', 0 };
         int maxw = 0;
         for ( int i=0; chars[i]; i++ ) {
             int w = getCharWidth( chars[i] );
@@ -345,32 +345,33 @@ private:
     LVByteArrayRef    _buf;
     int               _bias;
 public:
-    LVFontDef(const lString8 & name, int size, int weight, int italic, css_font_family_t family, const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
-    : _size(size)
-    , _weight(weight)
-    , _italic(italic)
-    , _family(family)
-    , _typeface(typeface)
-    , _name(name)
-    , _index(index)
-    , _documentId(documentId)
-    , _buf(buf)
-    , _bias(0)
-    {
-    }
+    LVFontDef(const lString8 & name, int size, int weight, int italic, css_font_family_t family,
+                const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
+        : _size(size)
+        , _weight(weight)
+        , _italic(italic)
+        , _family(family)
+        , _typeface(typeface)
+        , _name(name)
+        , _index(index)
+        , _documentId(documentId)
+        , _buf(buf)
+        , _bias(0)
+        {
+        }
     LVFontDef(const LVFontDef & def)
-    : _size(def._size)
-    , _weight(def._weight)
-    , _italic(def._italic)
-    , _family(def._family)
-    , _typeface(def._typeface)
-    , _name(def._name)
-    , _index(def._index)
-    , _documentId(def._documentId)
-    , _buf(def._buf)
-    , _bias(def._bias)
-    {
-    }
+        : _size(def._size)
+        , _weight(def._weight)
+        , _italic(def._italic)
+        , _family(def._family)
+        , _typeface(def._typeface)
+        , _name(def._name)
+        , _index(def._index)
+        , _documentId(def._documentId)
+        , _buf(def._buf)
+        , _bias(def._bias)
+        {
+        }
 
     /// returns true if definitions are equal
     bool operator == ( const LVFontDef & def ) const
@@ -441,8 +442,8 @@ public:
     LVFontRef & getFont() { return _fnt; }
     void setFont(LVFontRef & fnt) { _fnt = fnt; }
     LVFontCacheItem( const LVFontDef & def )
-    : _def( def )
-    { }
+        : _def( def )
+        { }
 };
 
 /// font cache
@@ -463,8 +464,10 @@ public:
     LVFontCacheItem * findFallback( lString8 face, int size );
     LVFontCacheItem * findDuplicate( const LVFontDef * def );
     LVFontCacheItem * findDocumentFontDuplicate(int documentId, lString8 name);
+
     /// get hash of installed fonts and fallback font
-    virtual lUInt32 GetFontListHash(int documentId) {
+    virtual lUInt32 GetFontListHash(int documentId)
+    {
         lUInt32 hash = 0;
         for ( int i=0; i<_registered_list.length(); i++ ) {
             int doc = _registered_list[i]->getDef()->getDocumentId();
@@ -581,8 +584,8 @@ public:
     }
 };
 
-
 class LVFreeTypeFace;
+
 static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar16 ch, FT_GlyphSlot slot ) // , bool drawMonochrome
 {
     FONT_LOCAL_GLYPH_CACHE_GUARD
@@ -608,8 +611,9 @@ static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lCha
             }
             ptr += bitmap->pitch;//rowsize;
         }
-    } else {
-#if 0
+    }
+    else {
+        #if 0
         if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) {
             memset( item->bmp, 0, w*h );
             lUInt8 * srcrow = bitmap->buffer;
@@ -624,12 +628,12 @@ static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lCha
                 srcrow += bitmap->pitch;
                 dstrow += w;
             }
-        } else {
-#endif
-            memcpy( item->bmp, bitmap->buffer, w*h );
-            // correct gamma
-            if ( gammaIndex!=GAMMA_NO_CORRECTION_INDEX )
-                cr_correct_gamma_buf(item->bmp, w*h, gammaIndex);
+        } // else:
+        #endif
+        memcpy( item->bmp, bitmap->buffer, w*h );
+        // correct gamma
+        if ( gammaIndex!=GAMMA_NO_CORRECTION_INDEX )
+            cr_correct_gamma_buf(item->bmp, w*h, gammaIndex);
     }
     item->origin_x =   (lInt16)slot->bitmap_left;
     item->origin_y =   (lInt16)slot->bitmap_top;
@@ -640,43 +644,58 @@ static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lCha
 #if USE_HARFBUZZ==1
 static LVFontGlyphIndexCacheItem * newItem(lUInt32 index, FT_GlyphSlot slot )
 {
-	FONT_LOCAL_GLYPH_CACHE_GUARD
-	FT_Bitmap*  bitmap = &slot->bitmap;
-	int w = bitmap->width;
-	int h = bitmap->rows;
-	LVFontGlyphIndexCacheItem* item = LVFontGlyphIndexCacheItem::newItem(index, w, h );
-	if (!item)
-		return 0;
-	if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
-		lUInt8 mask = 0x80;
-		const lUInt8 * ptr = (const lUInt8 *)bitmap->buffer;
-		lUInt8 * dst = item->bmp;
-		//int rowsize = ((w + 15) / 16) * 2;
-		for ( int y=0; y<h; y++ ) {
-			const lUInt8 * row = ptr;
-			mask = 0x80;
-			for ( int x=0; x<w; x++ ) {
-				*dst++ = (*row & mask) ? 0xFF : 00;
-				mask >>= 1;
-				if ( !mask && x!=w-1) {
-					mask = 0x80;
-					row++;
-				}
-			}
-			ptr += bitmap->pitch;//rowsize;
-		}
-	} else {
-			memcpy( item->bmp, bitmap->buffer, w*h );
-			// correct gamma
-			if ( gammaIndex!=GAMMA_NO_CORRECTION_INDEX )
-				cr_correct_gamma_buf(item->bmp, w*h, gammaIndex);
-	}
-	item->origin_x =   (lInt16)slot->bitmap_left;
-	item->origin_y =   (lInt16)slot->bitmap_top;
-	item->advance =    (lUInt16)(myabs(slot->metrics.horiAdvance) >> 6);
-	return item;
+    FONT_LOCAL_GLYPH_CACHE_GUARD
+    FT_Bitmap*  bitmap = &slot->bitmap;
+    int w = bitmap->width;
+    int h = bitmap->rows;
+    LVFontGlyphIndexCacheItem* item = LVFontGlyphIndexCacheItem::newItem(index, w, h );
+    if (!item)
+        return 0;
+    if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
+        lUInt8 mask = 0x80;
+        const lUInt8 * ptr = (const lUInt8 *)bitmap->buffer;
+        lUInt8 * dst = item->bmp;
+        //int rowsize = ((w + 15) / 16) * 2;
+        for ( int y=0; y<h; y++ ) {
+            const lUInt8 * row = ptr;
+            mask = 0x80;
+            for ( int x=0; x<w; x++ ) {
+                *dst++ = (*row & mask) ? 0xFF : 00;
+                mask >>= 1;
+                if ( !mask && x!=w-1) {
+                    mask = 0x80;
+                    row++;
+                }
+            }
+            ptr += bitmap->pitch;//rowsize;
+        }
+    }
+    else {
+        memcpy( item->bmp, bitmap->buffer, w*h );
+        // correct gamma
+        if ( gammaIndex!=GAMMA_NO_CORRECTION_INDEX )
+            cr_correct_gamma_buf(item->bmp, w*h, gammaIndex);
+    }
+    item->origin_x =   (lInt16)slot->bitmap_left;
+    item->origin_y =   (lInt16)slot->bitmap_top;
+    item->advance =    (lUInt16)(myabs(slot->metrics.horiAdvance) >> 6);
+    return item;
 }
 #endif
+
+// Each LVFontGlyphCacheItem is put in 2 caches:
+// - the LVFontLocalGlyphCache LVFreeTypeFace->_glyph_cache of the
+//   font it comes from
+// - the LVFontGlobalGlyphCache LVFreeTypeFontManager->_globalCache of
+//   the global and unique FontManager.
+// The first one is used for quick iteration to find the glyph in a
+// known font/size instance.
+// The global one is used to limit the number of cached glyphs, globally
+// across all fonts.
+// When adding the glyph to the local cache, the local cache adds it
+// to the global cache. When that happens, the global cache checks
+// its max_size, and remove any LRU item, by deleting it from itself,
+// and asking the relevant local cache to remove it too.
 
 void LVFontLocalGlyphCache::clear()
 {
@@ -820,7 +839,8 @@ lString8 familyName( FT_Face face )
 // (as flags are usually lUInt8, and the 8 bits were used, one needed to be dropped).
 static lUInt16 char_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, // 0    00
-    0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, // 8    08
+    0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, // 8    08
+    0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, // 12   0C
     0, 0, 0, 0, 0, 0, 0, 0, // 16   10
     0, 0, 0, 0, 0, 0, 0, 0, // 24   18
     LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, 0, 0, 0, 0, 0, // 32   20
@@ -840,12 +860,13 @@ static lUInt16 char_flags[] = {
         (ch>=UNICODE_EN_QUAD && ch<=UNICODE_ZERO_WIDTH_SPACE ? LCHAR_ALLOW_WRAP_AFTER: \
          0)))))))
 
+// For use with Harfbuzz light
 struct LVCharTriplet
 {
     lChar16 prevChar;
     lChar16 Char;
     lChar16 nextChar;
-    bool operator==(const struct LVCharTriplet& other) {
+    bool operator == (const struct LVCharTriplet& other) {
         return prevChar == other.prevChar && Char == other.Char && nextChar == other.nextChar;
     }
 };
@@ -872,7 +893,7 @@ inline lUInt32 getHash( const struct LVCharTriplet& triplet )
 class LVFreeTypeFace : public LVFont
 {
 protected:
-    LVMutex &      _mutex;
+    LVMutex &     _mutex;
     lString8      _fileName;
     lString8      _faceName;
     css_font_family_t _fontFamily;
@@ -884,26 +905,31 @@ protected:
     int           _height; // full line height in pixels
     int           _hyphen_width;
     int           _baseline;
-    int            _weight;
-    int            _italic;
+    int           _weight;
+    int           _italic;
     LVFontGlyphUnsignedMetricCache   _wcache;   // glyph width cache
     LVFontGlyphSignedMetricCache     _lsbcache; // glyph left side bearing cache
     LVFontGlyphSignedMetricCache     _rsbcache; // glyph right side bearing cache
-    LVFontLocalGlyphCache _glyph_cache;
-    bool          _drawMonochrome;
+    LVFontLocalGlyphCache            _glyph_cache;
+    bool           _drawMonochrome;
     hinting_mode_t _hintingMode;
     kerning_mode_t _kerningMode;
-    bool          _fallbackFontIsSet;
-    LVFontRef     _fallbackFont;
+    bool           _fallbackFontIsSet;
+    LVFontRef      _fallbackFont;
+
 #if USE_HARFBUZZ==1
     hb_font_t* _hb_font;
+    //
     // For use with KERNING_MODE_HARFBUZZ:
+    #define HARFBUZZ_FULL_FEATURES_NB 2
     hb_buffer_t* _hb_buffer;
-    hb_feature_t _hb_features[2];
+    hb_feature_t _hb_features[HARFBUZZ_FULL_FEATURES_NB];
     LVHashTable<lUInt32, LVFontGlyphIndexCacheItem*> _glyph_cache2;
+    //
     // For use with KERNING_MODE_HARFBUZZ_LIGHT:
+    #define HARFBUZZ_LIGHT_FEATURES_NB 22
     hb_buffer_t* _hb_light_buffer;
-    hb_feature_t _hb_light_features[22];
+    hb_feature_t _hb_light_features[HARFBUZZ_LIGHT_FEATURES_NB];
     LVHashTable<struct LVCharTriplet, struct LVCharPosInfo> _width_cache2;
 #endif
 public:
@@ -920,7 +946,8 @@ public:
     LVFont * getFallbackFont() {
         if ( _fallbackFontIsSet )
             return _fallbackFont.get();
-        if ( fontMan->GetFallbackFontFace()!=_faceName ) // to avoid circular link, disable fallback for fallback font
+        // To avoid circular link, disable fallback for fallback font:
+        if ( fontMan->GetFallbackFontFace()!=_faceName )
             _fallbackFont = fontMan->GetFallbackFont(_size);
         _fallbackFontIsSet = true;
         return _fallbackFont.get();
@@ -937,39 +964,46 @@ public:
     FT_Library getLibrary() { return _library; }
 
     LVFreeTypeFace( LVMutex &mutex, FT_Library  library, LVFontGlobalGlyphCache * globalCache )
-    : _mutex(mutex), _fontFamily(css_ff_sans_serif), _library(library), _face(NULL), _size(0), _hyphen_width(0), _baseline(0)
-    , _weight(400), _italic(0)
-    , _glyph_cache(globalCache), _drawMonochrome(false), _kerningMode(KERNING_MODE_DISABLED), _hintingMode(HINTING_MODE_AUTOHINT), _fallbackFontIsSet(false)
-#if USE_HARFBUZZ==1
-    , _glyph_cache2(256)
-    , _width_cache2(1024)
-#endif
+        : _mutex(mutex), _fontFamily(css_ff_sans_serif), _library(library), _face(NULL)
+        , _size(0), _hyphen_width(0), _baseline(0)
+        , _weight(400), _italic(0)
+        , _glyph_cache(globalCache), _drawMonochrome(false)
+        , _kerningMode(KERNING_MODE_DISABLED), _hintingMode(HINTING_MODE_AUTOHINT)
+        , _fallbackFontIsSet(false)
+        #if USE_HARFBUZZ==1
+        , _glyph_cache2(256)
+        , _width_cache2(1024)
+        #endif
     {
         _matrix.xx = 0x10000;
         _matrix.yy = 0x10000;
         _matrix.xy = 0;
         _matrix.yx = 0;
         _hintingMode = fontMan->GetHintingMode();
-#if USE_HARFBUZZ==1
+
+        #if USE_HARFBUZZ==1
         _hb_font = 0;
         _hb_buffer = hb_buffer_create();
         _hb_light_buffer = hb_buffer_create();
+
         // HarfBuzz features for full text shaping
+        // Update HARFBUZZ_FULL_FEATURES_NB when adding/removing
         hb_feature_from_string("+kern", -1, &_hb_features[0]);      // font kerning
         hb_feature_from_string("+liga", -1, &_hb_features[1]);      // ligatures
 
         // HarfBuzz features for lighweight characters width calculating with caching
+        // Update HARFBUZZ_LIGHT_FEATURES_NB when adding/removing
         // We need to disable all the features, enabled by default in Harfbuzz, that
         // may split a char into more glyphs, or merge chars into one glyph.
         // (see harfbuzz/src/hb-ot-shape.cc hb_ot_shape_collect_features() )
-
+        //
         // We can enable these ones:
         hb_feature_from_string("+kern", -1, &_hb_light_features[0]);  // Kerning: Fine horizontal positioning of one glyph to the next, based on the shapes of the glyphs
         hb_feature_from_string("+mark", -1, &_hb_light_features[1]);  // Mark Positioning: Fine positioning of a mark glyph to a base character
         hb_feature_from_string("+mkmk", -1, &_hb_light_features[2]);  // Mark-to-mark Positioning: Fine positioning of a mark glyph to another mark character
         hb_feature_from_string("+curs", -1, &_hb_light_features[3]);  // Cursive Positioning: Precise positioning of a letter's connection to an adjacent one
         hb_feature_from_string("+locl", -1, &_hb_light_features[4]);  // Substitutes character with the preferred form based on script language
-
+        //
         // We should disable these ones:
         hb_feature_from_string("-liga", -1, &_hb_light_features[5]);  // Standard Ligatures: replaces (by default) sequence of characters with a single ligature glyph
         hb_feature_from_string("-rlig", -1, &_hb_light_features[6]);  // Ligatures required for correct text display (any script, but in cursive) - Arabic, semitic
@@ -993,17 +1027,17 @@ public:
         // Especially needed with Fedra Serif and "The", "Thuringe": -calt
         // These tweaks seem fragile (adding here +smcp to experiment with small caps would break FreeSerif again).
         // So, when tuning these, please check it still behave well with FreeSerif.
-#endif
+        #endif
     }
 
     virtual ~LVFreeTypeFace()
     {
-#if USE_HARFBUZZ==1
+        #if USE_HARFBUZZ==1
         if (_hb_buffer)
             hb_buffer_destroy(_hb_buffer);
         if (_hb_light_buffer)
             hb_buffer_destroy(_hb_light_buffer);
-#endif
+        #endif
         Clear();
     }
 
@@ -1012,7 +1046,7 @@ public:
         _wcache.clear();
         _lsbcache.clear();
         _rsbcache.clear();
-#if USE_HARFBUZZ==1
+        #if USE_HARFBUZZ==1
         LVHashTable<lUInt32, LVFontGlyphIndexCacheItem*>::pair* pair;
         LVHashTable<lUInt32, LVFontGlyphIndexCacheItem*>::iterator it = _glyph_cache2.forwardIterator();
         while ((pair = it.next())) {
@@ -1022,11 +1056,10 @@ public:
         }
         _glyph_cache2.clear();
         _width_cache2.clear();
-#endif
+        #endif
     }
 
-    virtual int getHyphenWidth()
-    {
+    virtual int getHyphenWidth() {
         FONT_GUARD
         if ( !_hyphen_width ) {
             _hyphen_width = getCharWidth( UNICODE_SOFT_HYPHEN_CODE );
@@ -1034,18 +1067,16 @@ public:
         return _hyphen_width;
     }
 
-    virtual kerning_mode_t getKerningMode() const { return _kerningMode; }
-
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
         _kerningMode = kerningMode;
         _hash = 0; // Force lvstyles.cpp calcHash(font_ref_t) to recompute the hash
-#if USE_HARFBUZZ==1
+        #if USE_HARFBUZZ==1
         // in cache may be found some ligatures, so clear it
         clearCache();
-#endif
+        #endif
     }
+    virtual kerning_mode_t getKerningMode() const { return _kerningMode; }
 
-    /// sets current hinting mode
     virtual void setHintingMode(hinting_mode_t mode) {
         if (_hintingMode == mode)
             return;
@@ -1053,12 +1084,9 @@ public:
         _hash = 0; // Force lvstyles.cpp calcHash(font_ref_t) to recompute the hash
         clearCache();
     }
-    /// returns current hinting mode
     virtual hinting_mode_t  getHintingMode() const { return _hintingMode; }
 
-    /// get bitmap mode (true=bitmap, false=antialiased)
-    virtual bool getBitmapMode() { return _drawMonochrome; }
-    /// set bitmap mode (true=bitmap, false=antialiased)
+    /// get/set bitmap mode (true=bitmap, false=antialiased)
     virtual void setBitmapMode( bool drawBitmap )
     {
         if ( _drawMonochrome == drawBitmap )
@@ -1066,9 +1094,11 @@ public:
         _drawMonochrome = drawBitmap;
         clearCache();
     }
+    virtual bool getBitmapMode() { return _drawMonochrome; }
 
-    bool loadFromBuffer(LVByteArrayRef buf, int index, int size, css_font_family_t fontFamily, bool monochrome, bool italicize )
-    {
+    // Used when an embedded font (registered by RegisterDocumentFont()) is intantiated
+    bool loadFromBuffer(LVByteArrayRef buf, int index, int size, css_font_family_t fontFamily,
+                                            bool monochrome, bool italicize ) {
         FONT_GUARD
         _hintingMode = fontMan->GetHintingMode();
         _drawMonochrome = monochrome;
@@ -1082,9 +1112,11 @@ public:
             lString8 kernFile = _fileName.substr(0, _fileName.length()-4);
             if ( LVFileExists(Utf8ToUnicode(kernFile) + ".afm" ) ) {
                 kernFile += ".afm";
-            } else if ( LVFileExists(Utf8ToUnicode(kernFile) + ".pfm" ) ) {
+            }
+            else if ( LVFileExists(Utf8ToUnicode(kernFile) + ".pfm" ) ) {
                 kernFile += ".pfm";
-            } else {
+            }
+            else {
                 kernFile.clear();
             }
             if ( !kernFile.empty() )
@@ -1097,19 +1129,21 @@ public:
         //if ( !FT_IS_SCALABLE( _face ) ) {
         //    Clear();
         //    return false;
-       // }
+        //}
         error = FT_Set_Pixel_Sizes(
             _face,    /* handle to face object */
             0,        /* pixel_width           */
-            size );  /* pixel_height          */
-#if USE_HARFBUZZ==1
+            size );   /* pixel_height          */
+
+        #if USE_HARFBUZZ==1
         if (FT_Err_Ok == error) {
             if (_hb_font)
                 hb_font_destroy(_hb_font);
             _hb_font = hb_ft_font_create(_face, NULL);
             if (!_hb_font) {
                 error = FT_Err_Invalid_Argument;
-            } else {
+            }
+            else {
                 // NOTE: Commented out for now, it's prohibitively expensive. c.f., #230
                 /*
                 // Use the same load flags as we do when using FT directly, to avoid mismatching advances & raster
@@ -1117,28 +1151,33 @@ public:
                 flags |= (!_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
                 if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
                     flags |= FT_LOAD_NO_AUTOHINT;
-                } else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+                }
+                else if (_hintingMode == HINTING_MODE_AUTOHINT) {
                     flags |= FT_LOAD_FORCE_AUTOHINT;
-                } else if (_hintingMode == HINTING_MODE_DISABLED) {
+                }
+                else if (_hintingMode == HINTING_MODE_DISABLED) {
                     flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
                 }
                 hb_ft_font_set_load_flags(_hb_font, flags);
                 */
             }
         }
-#endif
+        #endif
+
         if (error) {
             Clear();
             return false;
         }
-#if 0
+
+        #if 0
         int nheight = _face->size->metrics.height;
         int targetheight = size << 6;
         error = FT_Set_Pixel_Sizes(
             _face,    /* handle to face object */
             0,        /* pixel_width           */
-            (size * targetheight + nheight/2)/ nheight );  /* pixel_height          */
-#endif
+            (size * targetheight + nheight/2)/ nheight );  /* pixel_height */
+        #endif
+
         _height = _face->size->metrics.height >> 6;
         _size = size; //(_face->size->metrics.height >> 6);
         _baseline = _height + (_face->size->metrics.descender >> 6);
@@ -1152,14 +1191,14 @@ public:
         }
 
         if ( error ) {
-            // error
             return false;
         }
         return true;
     }
 
-    bool loadFromFile( const char * fname, int index, int size, css_font_family_t fontFamily, bool monochrome, bool italicize )
-    {
+    // Load font from file path
+    bool loadFromFile( const char * fname, int index, int size, css_font_family_t fontFamily,
+                                           bool monochrome, bool italicize ) {
         FONT_GUARD
         _hintingMode = fontMan->GetHintingMode();
         _drawMonochrome = monochrome;
@@ -1174,16 +1213,18 @@ public:
         if (error)
             return false;
         if ( _fileName.endsWith(".pfb") || _fileName.endsWith(".pfa") ) {
-        	lString8 kernFile = _fileName.substr(0, _fileName.length()-4);
+            lString8 kernFile = _fileName.substr(0, _fileName.length()-4);
             if ( LVFileExists(Utf8ToUnicode(kernFile) + ".afm") ) {
-        		kernFile += ".afm";
-            } else if ( LVFileExists(Utf8ToUnicode(kernFile) + ".pfm" ) ) {
-        		kernFile += ".pfm";
-        	} else {
-        		kernFile.clear();
-        	}
-        	if ( !kernFile.empty() )
-        		error = FT_Attach_File( _face, kernFile.c_str() );
+                kernFile += ".afm";
+            }
+            else if ( LVFileExists(Utf8ToUnicode(kernFile) + ".pfm" ) ) {
+                kernFile += ".pfm";
+            }
+            else {
+                kernFile.clear();
+            }
+            if ( !kernFile.empty() )
+                error = FT_Attach_File( _face, kernFile.c_str() );
         }
         //FT_Face_SetUnpatentedHinting( _face, 1 );
         _slot = _face->glyph;
@@ -1192,19 +1233,21 @@ public:
         //if ( !FT_IS_SCALABLE( _face ) ) {
         //    Clear();
         //    return false;
-       // }
+        //}
         error = FT_Set_Pixel_Sizes(
             _face,    /* handle to face object */
             0,        /* pixel_width           */
             size );  /* pixel_height          */
-#if USE_HARFBUZZ==1
+
+        #if USE_HARFBUZZ==1
         if (FT_Err_Ok == error) {
             if (_hb_font)
                 hb_font_destroy(_hb_font);
             _hb_font = hb_ft_font_create(_face, NULL);
             if (!_hb_font) {
                 error = FT_Err_Invalid_Argument;
-            } else {
+            }
+            else {
                 // NOTE: Commented out for now, it's prohibitively expensive. c.f., #230
                 /*
                 // Use the same load flags as we do when using FT directly, to avoid mismatching advances & raster
@@ -1212,28 +1255,33 @@ public:
                 flags |= (!_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
                 if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
                     flags |= FT_LOAD_NO_AUTOHINT;
-                } else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+                }
+                else if (_hintingMode == HINTING_MODE_AUTOHINT) {
                     flags |= FT_LOAD_FORCE_AUTOHINT;
-                } else if (_hintingMode == HINTING_MODE_DISABLED) {
+                }
+                else if (_hintingMode == HINTING_MODE_DISABLED) {
                     flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
                 }
                 hb_ft_font_set_load_flags(_hb_font, flags);
                 */
             }
         }
-#endif
+        #endif
+
         if (error) {
             Clear();
             return false;
         }
-#if 0
+
+        #if 0
         int nheight = _face->size->metrics.height;
         int targetheight = size << 6;
         error = FT_Set_Pixel_Sizes(
             _face,    /* handle to face object */
             0,        /* pixel_width           */
             (size * targetheight + nheight/2)/ nheight );  /* pixel_height          */
-#endif
+        #endif
+
         _height = _face->size->metrics.height >> 6;
         _size = size; //(_face->size->metrics.height >> 6);
         _baseline = _height + (_face->size->metrics.descender >> 6);
@@ -1269,8 +1317,9 @@ public:
                 FT_Select_Charmap(_face, FT_ENCODING_UNICODE);
             }
         }
-        if (0 != ch_glyph_index)
+        if (0 != ch_glyph_index) {
             res = code;
+        }
         else {
             res = getReplacementChar(code);
             if (0 == res)
@@ -1298,7 +1347,7 @@ public:
         }
         hb_buffer_set_content_type(_hb_light_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
         hb_buffer_guess_segment_properties(_hb_light_buffer);
-        hb_shape(_hb_font, _hb_light_buffer, _hb_light_features, 22);
+        hb_shape(_hb_font, _hb_light_buffer, _hb_light_features, HARFBUZZ_LIGHT_FEATURES_NB);
         unsigned int glyph_count = hb_buffer_get_length(_hb_light_buffer);
         if (segLen == glyph_count) {
             hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(_hb_light_buffer, &glyph_count);
@@ -1306,7 +1355,8 @@ public:
             if (0 != glyph_info[cluster].codepoint) {        // glyph found for this char in this font
                 posInfo->offset = glyph_pos[cluster].x_offset >> 6;
                 posInfo->width = glyph_pos[cluster].x_advance >> 6;
-            } else {
+            }
+            else {
                 // hb_shape() failed or glyph omitted in this font, use fallback font
                 glyph_info_t glyph;
                 LVFont *fallback = getFallbackFont();
@@ -1317,15 +1367,16 @@ public:
                     }
                 }
             }
-        } else {
-#ifdef _DEBUG
+        }
+        else {
+            #ifdef _DEBUG
             CRLog::debug("hbCalcCharWidthWithKerning(): hb_buffer_get_length() return %d, must be %d, return value (-1)", glyph_count, segLen);
-#endif
+            #endif
             return false;
         }
         return true;
     }
-#endif
+#endif // USE_HARFBUZZ==1
 
     FT_UInt getCharIndex( lChar16 code, lChar16 def_char ) {
         if ( code=='\t' )
@@ -1355,8 +1406,7 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0 )
-    {
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0 ) {
         //FONT_GUARD
         int glyph_index = getCharIndex( code, 0 );
         if ( glyph_index==0 ) {
@@ -1366,27 +1416,32 @@ public:
                 glyph_index = getCharIndex( code, def_char );
                 if ( glyph_index==0 )
                     return false;
-            } else {
+            }
+            else {
                 // Fallback
                 return fallback->getGlyphInfo(code, glyph, def_char);
             }
         }
+
         int flags = FT_LOAD_DEFAULT;
         flags |= (!_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO);
         if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
             flags |= FT_LOAD_NO_AUTOHINT;
-        } else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+        }
+        else if (_hintingMode == HINTING_MODE_AUTOHINT) {
             flags |= FT_LOAD_FORCE_AUTOHINT;
-        } else if (_hintingMode == HINTING_MODE_DISABLED) {
+        }
+        else if (_hintingMode == HINTING_MODE_DISABLED) {
             flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
-        updateTransform();
+        updateTransform(); // no-op
         int error = FT_Load_Glyph(
             _face,          /* handle to face object */
             glyph_index,   /* glyph index           */
             flags );  /* load flags, see below */
         if ( error )
             return false;
+
         glyph->blackBoxX = (lUInt16)(_slot->metrics.width >> 6);
         glyph->blackBoxY = (lUInt16)(_slot->metrics.height >> 6);
         glyph->originX =   (lInt16)(_slot->metrics.horiBearingX >> 6);
@@ -1417,8 +1472,8 @@ public:
 
         return true;
     }
-/*
-  // USE GET_CHAR_FLAGS instead
+#if 0
+    // USE GET_CHAR_FLAGS instead
     inline int calcCharFlags( lChar16 ch )
     {
         switch ( ch ) {
@@ -1435,7 +1490,8 @@ public:
             return 0;
         }
     }
-  */
+#endif
+
     /** \brief measure text
         \param text is text string pointer
         \param len is number of characters to measure
@@ -1455,11 +1511,10 @@ public:
         FONT_GUARD
         if ( len <= 0 || _face==NULL )
             return 0;
-        if ( letter_spacing < 0 )
-        {
+        if ( letter_spacing < 0 ) {
             letter_spacing = 0;
-        } else if ( letter_spacing > MAX_LETTER_SPACING )
-        {
+        }
+        else if ( letter_spacing > MAX_LETTER_SPACING ) {
             letter_spacing = MAX_LETTER_SPACING;
         }
 
@@ -1467,10 +1522,10 @@ public:
 
         lUInt16 prev_width = 0;
         int lastFitChar = 0;
-        updateTransform();
+        updateTransform(); // no-op
         // measure character widths
 
-#if USE_HARFBUZZ==1
+    #if USE_HARFBUZZ==1
         if (_kerningMode == KERNING_MODE_HARFBUZZ) {
 
             unsigned int glyph_count;
@@ -1483,18 +1538,13 @@ public:
                 hb_buffer_add(_hb_buffer, (hb_codepoint_t)filterChar(text[i]), i);
             hb_buffer_set_content_type(_hb_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
             hb_buffer_guess_segment_properties(_hb_buffer);
-            // shape
-            hb_shape(_hb_font, _hb_buffer, _hb_features, 2);
+            // Shape
+            hb_shape(_hb_font, _hb_buffer, _hb_features, HARFBUZZ_FULL_FEATURES_NB);
+
             glyph_count = hb_buffer_get_length(_hb_buffer);
             glyph_info = hb_buffer_get_glyph_infos(_hb_buffer, 0);
             glyph_pos = hb_buffer_get_glyph_positions(_hb_buffer, 0);
-#ifdef _DEBUG
-            if ((int)glyph_count != len) {
-                CRLog::debug(
-                        "measureText(): glyph_count not equal source text length (ligature detected?), glyph_count=%d, len=%d",
-                        glyph_count, len);
-            }
-#endif
+
             uint32_t j;
             uint32_t cluster;
             uint32_t prev_cluster = 0;
@@ -1578,7 +1628,8 @@ public:
                 if (prev_width > max_width) {
                     if (lastFitChar < cluster + 7)
                         break;
-                } else {
+                }
+                else {
                     lastFitChar = cluster + 1;
                 }
             }
@@ -1634,7 +1685,8 @@ public:
                 if ( prev_width > max_width ) {
                     if ( lastFitChar < i + 7)
                         break;
-                } else {
+                }
+                else {
                     lastFitChar = i + 1;
                 }
             }
@@ -1642,13 +1694,13 @@ public:
         } // _kerningMode == KERNING_MODE_HARFBUZZ_LIGHT
         else { // _kerningMode == KERNING_MODE_DISABLED or KERNING_MODE_FREETYPE:
                // fallback to the non harfbuzz code
-#endif // USE_HARFBUZZ
+    #endif // USE_HARFBUZZ
 
         FT_UInt previous = 0;
         int error;
-#if (ALLOW_KERNING==1)
+        #if (ALLOW_KERNING==1)
         int use_kerning = _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
-#endif
+        #endif
         for ( i=0; i<len; i++) {
             lChar16 ch = text[i];
             bool isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
@@ -1662,7 +1714,7 @@ public:
             }
             FT_UInt ch_glyph_index = (FT_UInt)-1;
             int kerning = 0;
-#if (ALLOW_KERNING==1)
+            #if (ALLOW_KERNING==1)
             if ( use_kerning && previous>0  ) {
                 if ( ch_glyph_index==(FT_UInt)-1 )
                     ch_glyph_index = getCharIndex( ch, def_char );
@@ -1677,7 +1729,7 @@ public:
                         kerning = delta.x;
                 }
             }
-#endif
+            #endif
 
             flags[i] = GET_CHAR_FLAGS(ch); //calcCharFlags( ch );
 
@@ -1688,20 +1740,21 @@ public:
                 if ( getGlyphInfo( ch, &glyph, def_char ) ) {
                     w = glyph.width;
                     _wcache.put(ch, w);
-                } else {
+                }
+                else {
                     widths[i] = prev_width;
                     lastFitChar = i + 1;
                     continue;  /* ignore errors */
                 }
-//                if ( ch_glyph_index==(FT_UInt)-1 )
-//                    ch_glyph_index = getCharIndex( ch, 0 );
-//                error = FT_Load_Glyph( _face,          /* handle to face object */
-//                        ch_glyph_index,                /* glyph index           */
-//                        FT_LOAD_DEFAULT );             /* load flags, see below */
-//                if ( error ) {
-//                    widths[i] = prev_width;
-//                    continue;  /* ignore errors */
-//                }
+                // if ( ch_glyph_index==(FT_UInt)-1 )
+                //     ch_glyph_index = getCharIndex( ch, 0 );
+                // error = FT_Load_Glyph( _face,          /* handle to face object */
+                //         ch_glyph_index,                /* glyph index           */
+                //         FT_LOAD_DEFAULT );             /* load flags, see below */
+                // if ( error ) {
+                //     widths[i] = prev_width;
+                //     continue;  /* ignore errors */
+                // }
             }
             if ( use_kerning ) {
                 if ( ch_glyph_index==(FT_UInt)-1 )
@@ -1714,21 +1767,20 @@ public:
             if ( prev_width > max_width ) {
                 if ( lastFitChar < i + 7)
                     break;
-            } else {
+            }
+            else {
                 lastFitChar = i + 1;
             }
         }
-#if USE_HARFBUZZ==1
-    } // else fallback to the non harfbuzz code
-#endif
+
+    #if USE_HARFBUZZ==1
+        } // else fallback to the non harfbuzz code
+    #endif
 
         // fill props for rest of chars
         for ( int ii=i; ii<len; ii++ ) {
             flags[ii] = GET_CHAR_FLAGS( text[ii] );
         }
-
-        //maxFit = i;
-
 
         // find last word
         if ( allow_hyphenation ) {
@@ -1751,10 +1803,7 @@ public:
         \param len is number of characters to measure
         \return width of specified string
     */
-    virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len
-        )
-    {
+    virtual lUInt32 getTextWidth( const lChar16 * text, int len) {
         static lUInt16 widths[MAX_LINE_CHARS+1];
         static lUInt8 flags[MAX_LINE_CHARS+1];
         if ( len>MAX_LINE_CHARS )
@@ -1774,12 +1823,12 @@ public:
         return 0;
     }
 
-    void updateTransform() {
-//        static void * transformOwner = NULL;
-//        if ( transformOwner!=this ) {
-//            FT_Set_Transform(_face, &_matrix, NULL);
-//            transformOwner = this;
-//        }
+    void updateTransform() { // called, but no-op
+        // static void * transformOwner = NULL;
+        // if ( transformOwner!=this ) {
+        //     FT_Set_Transform(_face, &_matrix, NULL);
+        //     transformOwner = this;
+        // }
     }
 
     /** \brief get glyph item
@@ -1796,31 +1845,35 @@ public:
                 ch_glyph_index = getCharIndex( ch, def_char );
                 if ( ch_glyph_index==0 )
                     return NULL;
-            } else {
+            }
+            else {
                 // Fallback
                 return fallback->getGlyph(ch, def_char);
             }
         }
         LVFontGlyphCacheItem * item = _glyph_cache.get( ch );
         if ( !item ) {
-
-            int rend_flags = FT_LOAD_RENDER | ( !_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO ); //|FT_LOAD_MONOCHROME|FT_LOAD_FORCE_AUTOHINT
+            int rend_flags = FT_LOAD_RENDER | ( !_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO );
+                                                    //|FT_LOAD_MONOCHROME|FT_LOAD_FORCE_AUTOHINT
             if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT;
-            } else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+            }
+            else if (_hintingMode == HINTING_MODE_AUTOHINT) {
                 rend_flags |= FT_LOAD_FORCE_AUTOHINT;
-            } else if (_hintingMode == HINTING_MODE_DISABLED) {
+            }
+            else if (_hintingMode == HINTING_MODE_DISABLED) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
-            /* load glyph image into the slot (erase previous one) */
 
-            updateTransform();
-            int error = FT_Load_Glyph( _face,          /* handle to face object */
-                    ch_glyph_index,                /* glyph index           */
+            /* load glyph image into the slot (erase previous one) */
+            updateTransform(); // no-op
+            int error = FT_Load_Glyph( _face, /* handle to face object */
+                    ch_glyph_index,           /* glyph index           */
                     rend_flags );             /* load flags, see below */
             if ( error ) {
                 return NULL;  /* ignore errors */
             }
+
             item = newItem( &_glyph_cache, ch, _slot ); //, _drawMonochrome
             _glyph_cache.put( item );
         }
@@ -1831,35 +1884,33 @@ public:
     LVFontGlyphIndexCacheItem * getGlyphByIndex(lUInt32 index) {
         //FONT_GUARD
         LVFontGlyphIndexCacheItem * item = 0;
-        //std::map<lUInt32, LVFontGlyphIndexCacheItem*>::const_iterator it;
-        //it = _glyph_cache2.find(index);
-        //if (it == _glyph_cache2.end()) {
         if (!_glyph_cache2.get(index, item)) {
             // glyph not found in cache, rendering...
-            int rend_flags = FT_LOAD_RENDER | ( !_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO ); //|FT_LOAD_MONOCHROME|FT_LOAD_FORCE_AUTOHINT
+            int rend_flags = FT_LOAD_RENDER | ( !_drawMonochrome ? FT_LOAD_TARGET_NORMAL : FT_LOAD_TARGET_MONO );
+                                                    //|FT_LOAD_MONOCHROME|FT_LOAD_FORCE_AUTOHINT
             if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT;
-            } else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+            }
+            else if (_hintingMode == HINTING_MODE_AUTOHINT) {
                 rend_flags |= FT_LOAD_FORCE_AUTOHINT;
-            } else if (_hintingMode == HINTING_MODE_DISABLED) {
+            }
+            else if (_hintingMode == HINTING_MODE_DISABLED) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
-            /* load glyph image into the slot (erase previous one) */
 
-            updateTransform();
-            int error = FT_Load_Glyph( _face,          /* handle to face object */
-                    index,                /* glyph index           */
+            /* load glyph image into the slot (erase previous one) */
+            updateTransform(); // no-op
+            int error = FT_Load_Glyph( _face, /* handle to face object */
+                    index,                    /* glyph index           */
                     rend_flags );             /* load flags, see below */
             if ( error ) {
                 return NULL;  /* ignore errors */
             }
+
             item = newItem(index, _slot);
             if (item)
-                //_glyph_cache2.insert(std::pair<lUInt32, LVFontGlyphIndexCacheItem*>(index, item));
                 _glyph_cache2.set(index, item);
         }
-        //else
-        //    item = it->second;
         return item;
     }
 #endif
@@ -1903,7 +1954,8 @@ public:
             glyph_info_t glyph;
             if ( getGlyphInfo( ch, &glyph, def_char ) ) {
                 w = glyph.width;
-            } else {
+            }
+            else {
                 w = 0;
             }
             _wcache.put(ch, w);
@@ -1921,7 +1973,8 @@ public:
             glyph_info_t glyph;
             if ( getGlyphInfo( ch, &glyph, '?' ) ) {
                 b = glyph.originX;
-            } else {
+            }
+            else {
                 b = 0;
             }
             _lsbcache.put(ch, b);
@@ -1941,7 +1994,8 @@ public:
             glyph_info_t glyph;
             if ( getGlyphInfo( ch, &glyph, '?' ) ) {
                 b = glyph.rsb;
-            } else {
+            }
+            else {
                 b = 0;
             }
             _rsbcache.put(ch, b);
@@ -1970,16 +2024,16 @@ public:
     }
 
     virtual bool kerningEnabled() {
-#if (ALLOW_KERNING==1)
-    #if USE_HARFBUZZ==1
-        return _kerningMode == KERNING_MODE_HARFBUZZ
-            || (_kerningMode == KERNING_MODE_FREETYPE && FT_HAS_KERNING( _face ));
-    #else
-        return _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
-    #endif
-#else
-        return false;
-#endif
+        #if (ALLOW_KERNING==1)
+            #if USE_HARFBUZZ==1
+                return _kerningMode == KERNING_MODE_HARFBUZZ
+                    || (_kerningMode == KERNING_MODE_FREETYPE && FT_HAS_KERNING( _face ));
+            #else
+                return _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
+            #endif
+        #else
+            return false;
+        #endif
     }
 
     /// draws text string
@@ -1992,16 +2046,15 @@ public:
         FONT_GUARD
         if ( len <= 0 || _face==NULL )
             return;
-        if ( letter_spacing < 0 )
-        {
+        if ( letter_spacing < 0 ) {
             letter_spacing = 0;
-        } else if ( letter_spacing > MAX_LETTER_SPACING )
-        {
+        }
+        else if ( letter_spacing > MAX_LETTER_SPACING ) {
             letter_spacing = MAX_LETTER_SPACING;
         }
         lvRect clip;
         buf->GetClipRect( &clip );
-        updateTransform();
+        updateTransform(); // no-op
         if ( y + _height < clip.top || y >= clip.bottom )
             return;
 
@@ -2011,7 +2064,8 @@ public:
         // measure character widths
         bool isHyphen = false;
         int x0 = x;
-#if USE_HARFBUZZ==1
+
+    #if USE_HARFBUZZ==1
         if (_kerningMode == KERNING_MODE_HARFBUZZ) {
             hb_glyph_info_t *glyph_info = 0;
             hb_glyph_position_t *glyph_pos = 0;
@@ -2033,18 +2087,13 @@ public:
             }
             hb_buffer_set_content_type(_hb_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
             hb_buffer_guess_segment_properties(_hb_buffer);
-            // shape
-            hb_shape(_hb_font, _hb_buffer, _hb_features, 2);
+            // Shape
+            hb_shape(_hb_font, _hb_buffer, _hb_features, HARFBUZZ_FULL_FEATURES_NB);
+
             glyph_count = hb_buffer_get_length(_hb_buffer);
             glyph_info = hb_buffer_get_glyph_infos(_hb_buffer, 0);
             glyph_pos = hb_buffer_get_glyph_positions(_hb_buffer, 0);
-#ifdef _DEBUG
-            if (glyph_count != len_new) {
-                CRLog::debug(
-                        "DrawTextString(): glyph_count not equal source text length, glyph_count=%d, len=%d",
-                        glyph_count, len_new);
-            }
-#endif
+
             for (i = 0; i < glyph_count; i++) {
                 if (0 == glyph_info[i].codepoint) {
                     // If HarfBuzz can't find glyph in current font
@@ -2115,7 +2164,8 @@ public:
                         ch = ' ';
                     // don't draw any soft hyphens inside text string
                     isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
-                } else {
+                }
+                else {
                     ch = UNICODE_SOFT_HYPHEN_CODE;
                     isHyphen = false; // an hyphen, but not one to not draw
                 }
@@ -2148,15 +2198,16 @@ public:
                 }
             }
         } // _kerningMode == KERNING_MODE_HARFBUZZ_LIGHT
+
         else { // _kerningMode == KERNING_MODE_DISABLED or KERNING_MODE_FREETYPE:
                // fallback to the non harfbuzz code
-#endif // USE_HARFBUZZ
+    #endif // USE_HARFBUZZ
 
         FT_UInt previous = 0;
         int error;
-#if (ALLOW_KERNING==1)
+        #if (ALLOW_KERNING==1)
         int use_kerning = _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
-#endif
+        #endif
         for ( i=0; i<=(unsigned int)len; i++) {
             if ( i==len && !addHyphen )
                 break;
@@ -2166,13 +2217,14 @@ public:
                     ch = ' ';
                 // don't draw any soft hyphens inside text string
                 isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
-            } else {
+            }
+            else {
                 ch = UNICODE_SOFT_HYPHEN_CODE;
                 isHyphen = false; // an hyphen, but not one to not draw
             }
             FT_UInt ch_glyph_index = getCharIndex( ch, def_char );
             int kerning = 0;
-#if (ALLOW_KERNING==1)
+            #if (ALLOW_KERNING==1)
             if ( use_kerning && previous>0 && ch_glyph_index>0 ) {
                 FT_Vector delta;
                 error = FT_Get_Kerning( _face,          /* handle to face object */
@@ -2183,7 +2235,7 @@ public:
                 if ( !error )
                     kerning = delta.x;
             }
-#endif
+            #endif
             LVFontGlyphCacheItem * item = getGlyph(ch, def_char);
             if ( !item )
                 continue;
@@ -2200,9 +2252,11 @@ public:
                 previous = ch_glyph_index;
             }
         }
-#if USE_HARFBUZZ==1
-    } // else fallback to the non harfbuzz code
-#endif
+
+    #if USE_HARFBUZZ==1
+        } // else fallback to the non harfbuzz code
+    #endif
+
         if ( flags & LTEXT_TD_MASK ) {
             // text decoration: underline, etc.
             // Don't overflow the provided width (which may be lower than our
@@ -2223,7 +2277,7 @@ public:
                 buf->FillRect( x0, liney, x, liney+h, cl );
             }
             if ( flags & LTEXT_TD_LINE_THROUGH ) {
-//                int liney = y + _baseline - _size/4 - h/2;
+                // int liney = y + _baseline - _size/4 - h/2;
                 int liney = y + _baseline - _size*2/7;
                 buf->FillRect( x0, liney, x, liney+h, cl );
             }
@@ -2245,12 +2299,12 @@ public:
     {
         LVLock lock(_mutex);
         clearCache();
-#if USE_HARFBUZZ==1
+        #if USE_HARFBUZZ==1
         if (_hb_font) {
             hb_font_destroy(_hb_font);
             _hb_font = 0;
         }
-#endif
+        #endif
         if ( _face ) {
             FT_Done_Face(_face);
             _face = NULL;
@@ -2362,10 +2416,7 @@ public:
         \param len is number of characters to measure
         \return width of specified string
     */
-    virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len
-        )
-    {
+    virtual lUInt32 getTextWidth( const lChar16 * text, int len) {
         static lUInt16 widths[MAX_LINE_CHARS+1];
         static lUInt8 flags[MAX_LINE_CHARS+1];
         if ( len>MAX_LINE_CHARS )
@@ -2552,11 +2603,10 @@ public:
     {
         if ( len <= 0 )
             return;
-        if ( letter_spacing < 0 )
-        {
+        if ( letter_spacing < 0 ) {
             letter_spacing = 0;
-        } else if ( letter_spacing > MAX_LETTER_SPACING )
-        {
+        }
+        else if ( letter_spacing > MAX_LETTER_SPACING ) {
             letter_spacing = MAX_LETTER_SPACING;
         }
         lvRect clip;
@@ -2579,7 +2629,8 @@ public:
             if ( i<len ) {
                 ch = text[i];
                 isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
-            } else {
+            }
+            else {
                 ch = UNICODE_SOFT_HYPHEN_CODE;
                 isHyphen = 0;
             }
@@ -2823,19 +2874,20 @@ public:
             fonts->get(i)->getFont()->setKerningMode( mode );
         }
     }
+
     /// clear glyph cache
     virtual void clearGlyphCache()
     {
         FONT_MAN_GUARD
         _globalCache.clear();
-#if USE_HARFBUZZ==1
+        #if USE_HARFBUZZ==1
         // needs to clear each font _glyph_cache2 (for Gamma change, which
         // does not call any individual font method)
         LVPtrVector< LVFontCacheItem > * fonts = _cache.getInstances();
         for ( int i=0; i<fonts->length(); i++ ) {
             fonts->get(i)->getFont()->clearCache();
         }
-#endif
+        #endif
     }
 
     virtual int GetFontCount()
@@ -2897,7 +2949,8 @@ public:
                 lString8 fn( (const char *)s );
                 lString16 fn16( fn.c_str() );
                 fn16.lowercase();
-                if (!fn16.endsWith(".ttf") && !fn16.endsWith(".odf") && !fn16.endsWith(".otf") && !fn16.endsWith(".pfb") && !fn16.endsWith(".pfa")  ) {
+                if (!fn16.endsWith(".ttf") && !fn16.endsWith(".odf") && !fn16.endsWith(".otf") &&
+                                              !fn16.endsWith(".pfb") && !fn16.endsWith(".pfa") ) {
                     continue;
                 }
                 int weight = FC_WEIGHT_MEDIUM;
@@ -2938,12 +2991,12 @@ public:
                 //case FC_WEIGHT_HEAVY:             FC_WEIGHT_BLACK
                     weight = 900;
                     break;
-#ifdef FC_WEIGHT_EXTRABLACK
+            #ifdef FC_WEIGHT_EXTRABLACK
                 case FC_WEIGHT_EXTRABLACK:    //    215
                 //case FC_WEIGHT_ULTRABLACK:        FC_WEIGHT_EXTRABLACK
                     weight = 900;
                     break;
-#endif
+            #endif
                 default:
                     weight = 400;
                     break;
@@ -2979,15 +3032,15 @@ public:
                     //CRLog::debug("no FC_SPACING for %s", s);
                     //continue;
                 }
-//                int cr_weight;
-//                switch(weight) {
-//                    case FC_WEIGHT_LIGHT: cr_weight = 200; break;
-//                    case FC_WEIGHT_MEDIUM: cr_weight = 300; break;
-//                    case FC_WEIGHT_DEMIBOLD: cr_weight = 500; break;
-//                    case FC_WEIGHT_BOLD: cr_weight = 700; break;
-//                    case FC_WEIGHT_BLACK: cr_weight = 800; break;
-//                    default: cr_weight=300; break;
-//                }
+                // int cr_weight;
+                // switch(weight) {
+                //     case FC_WEIGHT_LIGHT: cr_weight = 200; break;
+                //     case FC_WEIGHT_MEDIUM: cr_weight = 300; break;
+                //     case FC_WEIGHT_DEMIBOLD: cr_weight = 500; break;
+                //     case FC_WEIGHT_BOLD: cr_weight = 700; break;
+                //     case FC_WEIGHT_BLACK: cr_weight = 800; break;
+                //     default: cr_weight=300; break;
+                // }
                 css_font_family_t fontFamily = css_ff_sans_serif;
                 lString16 face16((const char *)family);
                 face16.lowercase();
@@ -3024,7 +3077,8 @@ public:
                     index
                 );
 
-                CRLog::debug("FONTCONFIG: Font family:%s style:%s weight:%d slant:%d spacing:%d file:%s", family, style, weight, slant, spacing, s);
+                CRLog::debug("FONTCONFIG: Font family:%s style:%s weight:%d slant:%d spacing:%d file:%s",
+                                                family, style, weight, slant, spacing, s);
                 if ( _cache.findDuplicate( &def ) ) {
                     CRLog::debug("is duplicate, skipping");
                     continue;
@@ -3039,8 +3093,6 @@ public:
                 }
 
                 facesFound++;
-
-
             }
 
             FcFontSetDestroy(fontset);
@@ -3057,13 +3109,14 @@ public:
                 if ( SetFallbackFontFace(lString8(fallback_faces[i])) ) {
                     CRLog::info("Fallback font %s is found", fallback_faces[i]);
                     break;
-                } else {
+                }
+                else {
                     CRLog::trace("Fallback font %s is not found", fallback_faces[i]);
                 }
 
             return facesFound > 0;
         }
-        #else
+        #else // !USE_FONTCONFIG
         return false;
         #endif
     }
@@ -3075,11 +3128,11 @@ public:
         _cache.clear();
         if ( _library )
             FT_Done_FreeType( _library );
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            fclose(_log);
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( _log ) {
+                fclose(_log);
+            }
+        #endif
     }
 
     LVFreeTypeFontManager()
@@ -3089,14 +3142,14 @@ public:
         int error = FT_Init_FreeType( &_library );
         if ( error ) {
             // error
-        	CRLog::error("Error while initializing freetype library");
+            CRLog::error("Error while initializing freetype library");
         }
-    #if (DEBUG_FONT_MAN==1)
-        _log = fopen(DEBUG_FONT_MAN_LOG_FILE, "at");
-        if ( _log ) {
-            fprintf(_log, "=========================== LOGGING STARTED ===================\n");
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            _log = fopen(DEBUG_FONT_MAN_LOG_FILE, "at");
+            if ( _log ) {
+                fprintf(_log, "=========================== LOGGING STARTED ===================\n");
+            }
+        #endif
         _requiredChars = L"azAZ09";//\x0410\x042F\x0430\x044F";
     }
 
@@ -3129,11 +3182,11 @@ public:
         _cache.getFontFileNameList(list);
     }
 
-	bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)
-{
-    FONT_MAN_GUARD
-    lString8 fontname=lString8("\0");
-    LVFontDef def(
+    bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)
+    {
+        FONT_MAN_GUARD
+        lString8 fontname=lString8("\0");
+        LVFontDef def(
             fontname,
             -1,
             bold?700:400,
@@ -3142,9 +3195,9 @@ public:
             facename,
             -1,
             id
-    );
+        );
         LVFontCacheItem * item = _cache.find( &def);
-    LVFontDef def1(
+        LVFontDef def1(
             fontname,
             -1,
             bold?700:400,
@@ -3153,89 +3206,89 @@ public:
             alias,
             -1,
             id
-    );
+        );
 
-                int index = 0;
+        int index = 0;
 
-            FT_Face face = NULL;
+        FT_Face face = NULL;
 
-            // for all faces in file
-            for ( ;; index++ ) {
-                int error = FT_New_Face( _library, item->getDef()->getName().c_str(), index, &face ); /* create face object */
-                if ( error ) {
-                    if (index == 0) {
-                        CRLog::error("FT_New_Face returned error %d", error);
-                    }
-                    break;
+        // for all faces in file
+        for ( ;; index++ ) {
+            int error = FT_New_Face( _library, item->getDef()->getName().c_str(), index, &face ); /* create face object */
+            if ( error ) {
+                if (index == 0) {
+                    CRLog::error("FT_New_Face returned error %d", error);
                 }
-                int num_faces = face->num_faces;
-
-                css_font_family_t fontFamily = css_ff_sans_serif;
-                if ( face->face_flags & FT_FACE_FLAG_FIXED_WIDTH )
-                    fontFamily = css_ff_monospace;
-                lString8 familyName(!facename.empty() ? facename : ::familyName(face));
-                // We don't need this here and in other places below: all fonts (except
-                // monospaces) will be marked as sans-serif, and elements with
-                // style {font-family:serif;} will use the default font too.
-                // (we don't ship any Times, and someone having unluckily such
-                // a font among his would see it used for {font-family:serif;}
-                // elements instead of his default font)
-                /*
-                if ( familyName=="Times" || familyName=="Times New Roman" )
-                    fontFamily = css_ff_serif;
-                */
-
-                bool boldFlag = !facename.empty() ? bold : (face->style_flags & FT_STYLE_FLAG_BOLD) != 0;
-                bool italicFlag = !facename.empty() ? italic : (face->style_flags & FT_STYLE_FLAG_ITALIC) != 0;
-
-                LVFontDef def2(
-                        item->getDef()->getName(),
-                        -1, // height==-1 for scalable fonts
-                        boldFlag ? 700 : 400,
-                        italicFlag,
-                        fontFamily,
-                        alias,
-                        index,
-                        id
-                );
-
-                if ( face ) {
-                    FT_Done_Face( face );
-                    face = NULL;
-                }
-
-                if ( _cache.findDuplicate( &def2 ) ) {
-                    CRLog::trace("font definition is duplicate");
-                    return false;
-                }
-                _cache.update( &def2, LVFontRef(NULL) );
-                if (!def.getItalic()) {
-                    LVFontDef newDef( def2 );
-                    newDef.setItalic(2); // can italicize
-                    if ( !_cache.findDuplicate( &newDef ) )
-                        _cache.update( &newDef, LVFontRef(NULL) );
-                }
-                if ( index>=num_faces-1 )
-                    break;
+                break;
             }
+            int num_faces = face->num_faces;
+
+            css_font_family_t fontFamily = css_ff_sans_serif;
+            if ( face->face_flags & FT_FACE_FLAG_FIXED_WIDTH )
+                fontFamily = css_ff_monospace;
+            lString8 familyName(!facename.empty() ? facename : ::familyName(face));
+            // We don't need this here and in other places below: all fonts (except
+            // monospaces) will be marked as sans-serif, and elements with
+            // style {font-family:serif;} will use the default font too.
+            // (we don't ship any Times, and someone having unluckily such
+            // a font among his would see it used for {font-family:serif;}
+            // elements instead of his default font)
+            /*
+            if ( familyName=="Times" || familyName=="Times New Roman" )
+                fontFamily = css_ff_serif;
+            */
+
+            bool boldFlag = !facename.empty() ? bold : (face->style_flags & FT_STYLE_FLAG_BOLD) != 0;
+            bool italicFlag = !facename.empty() ? italic : (face->style_flags & FT_STYLE_FLAG_ITALIC) != 0;
+
+            LVFontDef def2(
+                    item->getDef()->getName(),
+                    -1, // height==-1 for scalable fonts
+                    boldFlag ? 700 : 400,
+                    italicFlag,
+                    fontFamily,
+                    alias,
+                    index,
+                    id
+            );
+
+            if ( face ) {
+                FT_Done_Face( face );
+                face = NULL;
+            }
+
+            if ( _cache.findDuplicate( &def2 ) ) {
+                CRLog::trace("font definition is duplicate");
+                return false;
+            }
+            _cache.update( &def2, LVFontRef(NULL) );
+            if (!def.getItalic()) {
+                LVFontDef newDef( def2 );
+                newDef.setItalic(2); // can italicize
+                if ( !_cache.findDuplicate( &newDef ) )
+                    _cache.update( &newDef, LVFontRef(NULL) );
+            }
+            if ( index>=num_faces-1 )
+                break;
+        }
         item = _cache.find( &def1);
-        if (item->getDef()->getTypeFace()==alias ){
+        if (item->getDef()->getTypeFace()==alias ) {
             return true;
         }
-    else
-        {
+        else {
             return false;
         }
-}
+    }
+
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId, bool useBias=false)
     {
         FONT_MAN_GUARD
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-             fprintf(_log, "GetFont(size=%d, weight=%d, italic=%d, family=%d, typeface='%s')\n",
-                size, weight, italic?1:0, (int)family, typeface.c_str() );
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( _log ) {
+                 fprintf(_log, "GetFont(size=%d, weight=%d, italic=%d, family=%d, typeface='%s')\n",
+                    size, weight, italic?1:0, (int)family, typeface.c_str() );
+            }
+        #endif
         lString8 fontname;
         LVFontDef def(
             fontname,
@@ -3247,31 +3300,33 @@ public:
             -1,
             documentId
         );
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log )
-            fprintf( _log, "GetFont: %s %d %s %s\n",
-                typeface.c_str(),
-                size,
-                weight>400?"bold":"",
-                italic?"italic":"" );
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( _log )
+                fprintf( _log, "GetFont: %s %d %s %s\n",
+                    typeface.c_str(),
+                    size,
+                    weight>400?"bold":"",
+                    italic?"italic":"" );
+        #endif
+
         LVFontCacheItem * item = _cache.find( &def, useBias );
-    #if (DEBUG_FONT_MAN==1)
-        if ( item && _log ) { //_log &&
-            fprintf(_log, "   found item: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s, weightDelta=%d) FontRef=%d\n",
-                item->getDef()->getName().c_str(), item->getDef()->getIndex(), item->getDef()->getSize(), item->getDef()->getWeight(), item->getDef()->getItalic()?1:0,
-                (int)item->getDef()->getFamily(), item->getDef()->getTypeFace().c_str(),
-                weight - item->getDef()->getWeight(), item->getFont().isNull()?0:item->getFont()->getHeight()
-            );
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( item && _log ) { //_log &&
+                fprintf(_log, "   found item: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s, weightDelta=%d) FontRef=%d\n",
+                    item->getDef()->getName().c_str(), item->getDef()->getIndex(), item->getDef()->getSize(),
+                    item->getDef()->getWeight(), item->getDef()->getItalic()?1:0,
+                    (int)item->getDef()->getFamily(), item->getDef()->getTypeFace().c_str(),
+                    weight - item->getDef()->getWeight(), item->getFont().isNull()?0:item->getFont()->getHeight()
+                );
+            }
+        #endif
+
         bool italicize = false;
 
         LVFontDef newDef(*item->getDef());
         // printf("  got %s\n", newDef.getTypeFace().c_str());
 
-        if (!item->getFont().isNull())
-        {
+        if (!item->getFont().isNull()) {
             int deltaWeight = weight - item->getDef()->getWeight();
             if ( deltaWeight >= 200 ) {
                 // embolden
@@ -3280,23 +3335,25 @@ public:
                 LVFontRef ref = LVFontRef( new LVFontBoldTransform( item->getFont(), &_globalCache ) );
                 _cache.update( &newDef, ref );
                 return ref;
-            } else {
+            }
+            else {
                 //fprintf(_log, "    : fount existing\n");
                 return item->getFont();
             }
         }
+
         lString8 fname = item->getDef()->getName();
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            int index = item->getDef()->getIndex();
-            fprintf(_log, "   no instance: adding new one for filename=%s, index = %d\n", fname.c_str(), index );
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( _log ) {
+                int index = item->getDef()->getIndex();
+                fprintf(_log, "   no instance: adding new one for filename=%s, index = %d\n", fname.c_str(), index );
+            }
+        #endif
         LVFreeTypeFace * font = new LVFreeTypeFace(_lock, _library, &_globalCache);
         lString8 pathname = makeFontFileName( fname );
+
         //def.setName( fname );
         //def.setIndex( index );
-
         //if ( fname.empty() || pathname.empty() ) {
         //    pathname = lString8("arial.ttf");
         //}
@@ -3307,14 +3364,15 @@ public:
             italicize = true;
         }
 
-        //printf("going to load font file %s\n", fname.c_str());
-        bool loaded = false;
         // Use the family of the font we found in the cache (it may be different
         // from the requested family).
         // Assigning the requested familly to this new font could be wrong, and
         // may cause a style or font mismatch when loading from cache, forcing a
         // full re-rendering).
         family = item->getDef()->getFamily();
+
+        //printf("going to load font file %s\n", fname.c_str());
+        bool loaded = false;
         if (item->getDef()->getBuf().isNull())
             loaded = font->loadFromFile( pathname.c_str(), item->getDef()->getIndex(), size, family, isBitmapModeForSize(size), italicize );
         else
@@ -3337,15 +3395,14 @@ public:
                 ref = LVFontRef( new LVFontBoldTransform( ref, &_globalCache ) );
                 _cache.update( &newDef, ref );
             }
-//            int rsz = ref->getSize();
-//            if ( rsz!=size ) {
-//                size++;
-//            }
+            // int rsz = ref->getSize();
+            // if ( rsz!=size ) {
+            //     size++;
+            // }
             //delete def;
             return ref;
         }
-        else
-        {
+        else {
             //printf("    not found!\n");
         }
         //delete def;
@@ -3421,10 +3478,9 @@ public:
         lvsize_t bytesRead = 0;
         if (stream->Read(buf->get(), size, &bytesRead) != LVERR_OK || bytesRead != size)
             return false;
+
         bool res = false;
-
         int index = 0;
-
         FT_Face face = NULL;
 
         // for all faces in file
@@ -3436,23 +3492,22 @@ public:
                 }
                 break;
             }
-//            bool scal = FT_IS_SCALABLE( face );
-//            bool charset = checkCharSet( face );
-//            //bool monospaced = isMonoSpaced( face );
-//            if ( !scal || !charset ) {
-//    //#if (DEBUG_FONT_MAN==1)
-//     //           if ( _log ) {
-//                CRLog::debug("    won't register font %s: %s",
-//                    name.c_str(), !charset?"no mandatory characters in charset" : "font is not scalable"
-//                    );
-//    //            }
-//    //#endif
-//                if ( face ) {
-//                    FT_Done_Face( face );
-//                    face = NULL;
-//                }
-//                break;
-//            }
+            // bool scal = FT_IS_SCALABLE( face );
+            // bool charset = checkCharSet( face );
+            // //bool monospaced = isMonoSpaced( face );
+            // if ( !scal || !charset ) {
+            //     //#if (DEBUG_FONT_MAN==1)
+            //     //    if ( _log ) {
+            //               CRLog::debug("    won't register font %s: %s",
+            //               name.c_str(), !charset?"no mandatory characters in charset" : "font is not scalable");
+            //     //    }
+            //     //#endif
+            //     if ( face ) {
+            //         FT_Done_Face( face );
+            //         face = NULL;
+            //     }
+            //     break;
+            // }
             int num_faces = face->num_faces;
 
             css_font_family_t fontFamily = css_ff_sans_serif;
@@ -3478,17 +3533,17 @@ public:
                 documentId,
                 buf
             );
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
-                def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(), def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str()
-            );
-        }
-    #endif
-			if ( face ) {
-				FT_Done_Face( face );
-				face = NULL;
-			}
+            #if (DEBUG_FONT_MAN==1)
+                if ( _log ) {
+                    fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
+                        def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(),
+                        def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str() );
+                }
+            #endif
+            if ( face ) {
+                FT_Done_Face( face );
+                face = NULL;
+            }
 
             if ( _cache.findDuplicate( &def ) ) {
                 CRLog::trace("font definition is duplicate");
@@ -3506,25 +3561,23 @@ public:
             if ( index>=num_faces-1 )
                 break;
         }
-
         return res;
     }
+
     /// unregisters all document fonts
     virtual void UnregisterDocumentFonts(int documentId) {
         _cache.removeDocumentFonts(documentId);
     }
 
     virtual bool RegisterExternalFont( lString16 name, lString8 family_name, bool bold, bool italic) {
-		if (name.startsWithNoCase(lString16("res://")))
-			name = name.substr(6);
-		else if (name.startsWithNoCase(lString16("file://")))
-			name = name.substr(7);
-		lString8 fname = UnicodeToUtf8(name);
+        if (name.startsWithNoCase(lString16("res://")))
+            name = name.substr(6);
+        else if (name.startsWithNoCase(lString16("file://")))
+            name = name.substr(7);
+        lString8 fname = UnicodeToUtf8(name);
 
         bool res = false;
-
         int index = 0;
-
         FT_Face face = NULL;
 
         // for all faces in file
@@ -3547,13 +3600,9 @@ public:
             }
             //bool monospaced = isMonoSpaced( face );
             if ( !scal || !charset ) {
-    //#if (DEBUG_FONT_MAN==1)
-     //           if ( _log ) {
                 CRLog::debug("    won't register font %s: %s",
                     name.c_str(), !charset?"no mandatory characters in charset" : "font is not scalable"
                     );
-    //            }
-    //#endif
                 if ( face ) {
                     FT_Done_Face( face );
                     face = NULL;
@@ -3580,13 +3629,14 @@ public:
                 family_name,
                 index
             );
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
-                def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(), def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str()
-            );
-        }
-    #endif
+            #if (DEBUG_FONT_MAN==1)
+                if ( _log ) {
+                    fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
+                        def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(),
+                        def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str()
+                    );
+                }
+            #endif
             if ( _cache.findDuplicate( &def ) ) {
                 CRLog::trace("font definition is duplicate");
                 return false;
@@ -3604,35 +3654,35 @@ public:
                 FT_Done_Face( face );
                 face = NULL;
             }
-
             if ( index>=num_faces-1 )
                 break;
         }
-
         return res;
-	}
+    }
 
+    // RegisterFont (and the 2 similar functions above) adds to the cache
+    // definitions for all the fonts in their font file.
+    // Font instances will be created as need from the LVFontDef name or buf.
+    // (The similar functions do most of the same work, and some code
+    // could be factorized between them.)
     virtual bool RegisterFont( lString8 name )
     {
         FONT_MAN_GUARD
-#ifdef LOAD_TTF_FONTS_ONLY
+        #ifdef LOAD_TTF_FONTS_ONLY
         if ( name.pos( cs8(".ttf") ) < 0 && name.pos( cs8(".TTF") ) < 0 )
             return false; // load ttf fonts only
-#endif
+        #endif
         //CRLog::trace("RegisterFont(%s)", name.c_str());
         lString8 fname = makeFontFileName( name );
         //CRLog::trace("font file name : %s", fname.c_str());
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            fprintf(_log, "RegisterFont( %s ) path=%s\n",
-                name.c_str(), fname.c_str()
-            );
-        }
-    #endif
+        #if (DEBUG_FONT_MAN==1)
+            if ( _log ) {
+                fprintf(_log, "RegisterFont( %s ) path=%s\n", name.c_str(), fname.c_str());
+            }
+        #endif
+
         bool res = false;
-
         int index = 0;
-
         FT_Face face = NULL;
 
         // for all faces in file
@@ -3656,13 +3706,8 @@ public:
 
             //bool monospaced = isMonoSpaced( face );
             if ( !scal || !charset ) {
-    //#if (DEBUG_FONT_MAN==1)
-     //           if ( _log ) {
                 CRLog::debug("    won't register font %s: %s",
-                    name.c_str(), !charset?"no mandatory characters in charset" : "font is not scalable"
-                    );
-    //            }
-    //#endif
+                    name.c_str(), !charset?"no mandatory characters in charset" : "font is not scalable");
                 if ( face ) {
                     FT_Done_Face( face );
                     face = NULL;
@@ -3689,20 +3734,21 @@ public:
                 familyName,
                 index
             );
-    #if (DEBUG_FONT_MAN==1)
-        if ( _log ) {
-            fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
-                def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(), def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str()
-            );
-        }
-    #endif
+            #if (DEBUG_FONT_MAN==1)
+                if ( _log ) {
+                    fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
+                        def.getName().c_str(), def.getIndex(), def.getSize(), def.getWeight(),
+                        def.getItalic()?1:0, (int)def.getFamily(), def.getTypeFace().c_str()
+                    );
+                }
+            #endif
 
-			if ( face ) {
-				FT_Done_Face( face );
-				face = NULL;
-			}
+            if ( face ) {
+                FT_Done_Face( face );
+                face = NULL;
+            }
 
-			if ( _cache.findDuplicate( &def ) ) {
+            if ( _cache.findDuplicate( &def ) ) {
                 CRLog::trace("font definition is duplicate");
                 return false;
             }
@@ -3718,7 +3764,6 @@ public:
             if ( index>=num_faces-1 )
                 break;
         }
-
         return res;
     }
 
@@ -3729,7 +3774,8 @@ public:
         return (_library != NULL);
     }
 };
-#endif
+#endif // (USE_FREETYPE==1)
+
 
 #if (USE_BITMAP_FONTS==1)
 class LVBitmapFontManager : public LVFontManager
@@ -3782,7 +3828,7 @@ public:
         //    weight>400?"bold":"",
         //    italic?"italic":"" );
         LVFontCacheItem * item = _cache.find( def );
-	delete def;
+        delete def;
         if (!item->getFont().isNull())
         {
             //fprintf(_log, "    : fount existing\n");
@@ -3851,7 +3897,7 @@ public:
         return true;
     }
 };
-#endif
+#endif // (USE_BITMAP_FONTS==1)
 
 
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1
@@ -3919,11 +3965,11 @@ public:
             return item->getFont();
         }
 
-#if COLOR_BACKBUFFER==0
+        #if COLOR_BACKBUFFER==0
         LVWin32Font * font = new LVWin32Font;
-#else
+        #else
         LVWin32DrawFont * font = new LVWin32DrawFont;
-#endif
+        #endif
 
         LVFontDef * fdef = item->getDef();
         LVFontDef def2( fdef->getName(), size, weight, italic,
@@ -4042,7 +4088,7 @@ int CALLBACK LVWin32FontEnumFontFamExProc(
     }
     return 1;
 }
-#endif
+#endif // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1
 
 #if (USE_BITMAP_FONTS==1)
 
@@ -4061,12 +4107,13 @@ LVFontRef LoadFontFromFile( const char * fname )
     return ref;
 }
 
-#endif
+#endif // (USE_BITMAP_FONTS==1)
 
+// Init unique font manager: either win32, freetype, or bitmap
 bool InitFontManager( lString8 path )
 {
     if ( fontMan ) {
-    	return true;
+        return true;
         //delete fontMan;
     }
 #if (USE_WIN32_FONTS==1)
@@ -4090,17 +4137,26 @@ bool ShutdownFontManager()
     return false;
 }
 
+// Font definitions matching/scoring
 int LVFontDef::CalcDuplicateMatch( const LVFontDef & def ) const
 {
     if (def._documentId != -1 && _documentId != def._documentId)
         return false;
-    bool size_match = (_size==-1 || def._size==-1) ? true
-        : (def._size == _size);
-    bool weight_match = (_weight==-1 || def._weight==-1) ? true
-        : (def._weight == _weight);
+
+    bool size_match = (_size==-1 || def._size==-1) ?
+              true
+            : (def._size == _size);
+
+    bool weight_match = (_weight==-1 || def._weight==-1) ?
+              true
+            : (def._weight == _weight);
+
     bool italic_match = (_italic == def._italic || _italic==-1 || def._italic==-1);
+
     bool family_match = (_family==css_ff_inherit || def._family==css_ff_inherit || def._family == _family);
+
     bool typeface_match = (_typeface == def._typeface);
+
     return size_match && weight_match && italic_match && family_match && typeface_match;
 }
 
@@ -4108,29 +4164,50 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
 {
     if (_documentId != -1 && _documentId != def._documentId)
         return 0;
-    int size_match = (_size==-1 || def._size==-1) ? 256
-        : (def._size>_size ? _size*256/def._size : def._size*256/_size );
+
+    // size
+    int size_match = (_size==-1 || def._size==-1) ?
+              256
+            : (def._size>_size ?
+                      _size*256/def._size
+                    : def._size*256/_size );
+
+    // weight
     int weight_diff = def._weight - _weight;
-    if ( weight_diff<0 )
+    if ( weight_diff < 0 )
         weight_diff = -weight_diff;
     if ( weight_diff > 800 )
         weight_diff = 800;
-    int weight_match = (_weight==-1 || def._weight==-1) ? 256
-        : ( 256 - weight_diff * 256 / 800 );
-    int italic_match = (_italic == def._italic || _italic==-1 || def._italic==-1) ? 256 : 0;
+    int weight_match = (_weight==-1 || def._weight==-1) ?
+                256
+            : ( 256 - weight_diff * 256 / 800 );
+
+    // italic
+    int italic_match = (_italic == def._italic || _italic==-1 || def._italic==-1) ?
+              256
+            :   0;
     if ( (_italic==2 || def._italic==2) && _italic>0 && def._italic>0 )
         italic_match = 128;
-    int family_match = (_family==css_ff_inherit || def._family==css_ff_inherit || def._family == _family)
-        ? 256
-        : ( (_family==css_ff_monospace)==(def._family==css_ff_monospace) ? 64 : 0 );
+
+    // family
+    int family_match = (_family==css_ff_inherit || def._family==css_ff_inherit || def._family == _family) ?
+              256
+            : ( (_family==css_ff_monospace)==(def._family==css_ff_monospace) ? 64 : 0 );
+
+    // typeface
     int typeface_match = (_typeface == def._typeface) ? 256 : 0;
+
+    // bias
     int bias = useBias ? _bias : 0;
+
+    // final score
     int score = bias
         + (size_match     * 100)
         + (weight_match   * 5)
         + (italic_match   * 5)
         + (family_match   * 100)
         + (typeface_match * 1000);
+
 //    printf("### %s (%d) vs %s (%d): size=%d weight=%d italic=%d family=%d typeface=%d bias=%d => %d\n",
 //        _typeface.c_str(), _family, def._typeface.c_str(), def._family,
 //        size_match, weight_match, italic_match, family_match, typeface_match, _bias, score);
@@ -4143,20 +4220,24 @@ int LVFontDef::CalcFallbackMatch( lString8 face, int size ) const
         //CRLog::trace("'%s'' != '%s'", face.c_str(), _typeface.c_str());
         return 0;
     }
-    int size_match = (_size==-1 || size==-1 || _size==size) ? 256 : 0;
-    int weight_match = (_weight==-1) ? 256 : ( 256 - _weight * 256 / 800 );
-    int italic_match = _italic == 0 ? 256 : 0;
+
+    int size_match = (_size==-1 || size==-1 || _size==size) ?
+              256
+            :   0;
+
+    int weight_match = (_weight==-1) ?
+              256
+            : ( 256 - _weight * 256 / 800 );
+
+    int italic_match = _italic == 0 ?
+              256
+            :   0;
+
     return
         + (size_match     * 100)
         + (weight_match   * 5)
         + (italic_match   * 5);
 }
-
-
-
-
-
-
 
 
 void LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
@@ -4166,54 +4247,49 @@ void LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
     //static lUInt8 glyph_buf[16384];
     //LVFont::glyph_info_t info;
     int baseline = getBaseline();
-    while (len>=(addHyphen?0:1))
-    {
-      if (len<=1 || *text != UNICODE_SOFT_HYPHEN_CODE)
-      {
-          lChar16 ch = ((len==0)?UNICODE_SOFT_HYPHEN_CODE:*text);
+    while (len>=(addHyphen?0:1)) {
+        if (len<=1 || *text != UNICODE_SOFT_HYPHEN_CODE) {
+            lChar16 ch = ((len==0)?UNICODE_SOFT_HYPHEN_CODE:*text);
 
-          LVFontGlyphCacheItem * item = getGlyph(ch, def_char);
-          int w  = 0;
-          if ( item ) {
-              // avoid soft hyphens inside text string
-              w = item->advance;
-              if ( item->bmp_width && item->bmp_height ) {
-                  buf->Draw( x + item->origin_x,
-                      y + baseline - item->origin_y,
-                      item->bmp,
-                      item->bmp_width,
-                      item->bmp_height,
-                      palette);
-              }
-          }
-          x  += w; // + letter_spacing;
+            LVFontGlyphCacheItem * item = getGlyph(ch, def_char);
+            int w  = 0;
+            if ( item ) {
+                // avoid soft hyphens inside text string
+                w = item->advance;
+                if ( item->bmp_width && item->bmp_height ) {
+                    buf->Draw( x + item->origin_x,
+                        y + baseline - item->origin_y,
+                        item->bmp,
+                        item->bmp_width,
+                        item->bmp_height,
+                        palette);
+                }
+            }
+            x  += w; // + letter_spacing;
 
-//          if ( !getGlyphInfo( ch, &info, def_char ) )
-//          {
-//              ch = def_char;
-//              if ( !getGlyphInfo( ch, &info, def_char ) )
-//                  ch = 0;
-//          }
-//          if (ch && getGlyphImage( ch, glyph_buf, def_char ))
-//          {
-//              if (info.blackBoxX && info.blackBoxY)
-//              {
-//                  buf->Draw( x + info.originX,
-//                      y + baseline - info.originY,
-//                      glyph_buf,
-//                      info.blackBoxX,
-//                      info.blackBoxY,
-//                      palette);
-//              }
-//              x += info.width;
-//          }
-      }
-      else if (*text != UNICODE_SOFT_HYPHEN_CODE)
-      {
-          //len = len;
-      }
-      len--;
-      text++;
+            // if ( !getGlyphInfo( ch, &info, def_char ) ) {
+            //     ch = def_char;
+            //     if ( !getGlyphInfo( ch, &info, def_char ) )
+            //         ch = 0;
+            // }
+            // if (ch && getGlyphImage( ch, glyph_buf, def_char )) {
+            //     if (info.blackBoxX && info.blackBoxY)
+            //     {
+            //         buf->Draw( x + info.originX,
+            //             y + baseline - info.originY,
+            //             glyph_buf,
+            //             info.blackBoxX,
+            //             info.blackBoxY,
+            //             palette);
+            //     }
+            //     x += info.width;
+            // }
+        }
+        else if (*text != UNICODE_SOFT_HYPHEN_CODE) {
+            //len = len;
+        }
+        len--;
+        text++;
     }
 }
 
@@ -4246,7 +4322,6 @@ lUInt16 LBitmapFont::measureText(
 
 lUInt32 LBitmapFont::getTextWidth( const lChar16 * text, int len )
 {
-    //
     static lUInt16 widths[MAX_LINE_CHARS+1];
     static lUInt8 flags[MAX_LINE_CHARS+1];
     if ( len>MAX_LINE_CHARS )
@@ -4299,12 +4374,12 @@ int LBitmapFont::LoadFromFile( const char * fname )
     _family = (css_font_family_t) hdr->fontFamily;
     return 1;
 }
-#endif
+#endif // (USE_BITMAP_FONTS==1)
 
+// Font cache management
 LVFontCacheItem * LVFontCache::findDuplicate( const LVFontDef * def )
 {
-    for (int i=0; i<_registered_list.length(); i++)
-    {
+    for (int i=0; i<_registered_list.length(); i++) {
         if ( _registered_list[i]->_def.CalcDuplicateMatch( *def ) )
             return _registered_list[i];
     }
@@ -4327,20 +4402,16 @@ LVFontCacheItem * LVFontCache::findFallback( lString8 face, int size )
     int best_instance_index = -1;
     int best_instance_match = -1;
     int i;
-    for (i=0; i<_instance_list.length(); i++)
-    {
+    for (i=0; i<_instance_list.length(); i++) {
         int match = _instance_list[i]->_def.CalcFallbackMatch( face, size );
-        if (match > best_instance_match)
-        {
+        if (match > best_instance_match) {
             best_instance_match = match;
             best_instance_index = i;
         }
     }
-    for (i=0; i<_registered_list.length(); i++)
-    {
+    for (i=0; i<_registered_list.length(); i++) {
         int match = _registered_list[i]->_def.CalcFallbackMatch( face, size );
-        if (match > best_match)
-        {
+        if (match > best_match) {
             best_match = match;
             best_index = i;
         }
@@ -4362,26 +4433,21 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef, bool useBias )
     LVFontDef def(*fntdef);
     lString8Collection list;
     splitPropertyValueList( fntdef->getTypeFace().c_str(), list );
-    for (int nindex=0; nindex==0 || nindex<list.length(); nindex++)
-    {
+    for (int nindex=0; nindex==0 || nindex<list.length(); nindex++) {
         if ( nindex<list.length() )
             def.setTypeFace( list[nindex] );
         else
             def.setTypeFace(lString8::empty_str);
-        for (i=0; i<_instance_list.length(); i++)
-        {
+        for (i=0; i<_instance_list.length(); i++) {
             int match = _instance_list[i]->_def.CalcMatch( def, useBias );
-            if (match > best_instance_match)
-            {
+            if (match > best_instance_match) {
                 best_instance_match = match;
                 best_instance_index = i;
             }
         }
-        for (i=0; i<_registered_list.length(); i++)
-        {
+        for (i=0; i<_registered_list.length(); i++) {
             int match = _registered_list[i]->_def.CalcMatch( def, useBias );
-            if (match > best_match)
-            {
+            if (match > best_match) {
                 best_match = match;
                 best_index = i;
             }
@@ -4398,13 +4464,11 @@ bool LVFontCache::setAsPreferredFontWithBias( lString8 face, int bias, bool clea
 {
     bool found = false;
     int i;
-    for (i=0; i<_instance_list.length(); i++)
-    {
+    for (i=0; i<_instance_list.length(); i++) {
         if (_instance_list[i]->_def.setBiasIfNameMatch( face, bias, clearOthersBias ))
             found = true;
     }
-    for (i=0; i<_registered_list.length(); i++)
-    {
+    for (i=0; i<_registered_list.length(); i++) {
         if (_registered_list[i]->_def.setBiasIfNameMatch( face, bias, clearOthersBias ))
             found = true;
     }
@@ -4424,16 +4488,12 @@ void LVFontCache::update( const LVFontDef * def, LVFontRef ref )
 {
     int i;
     if ( !ref.isNull() ) {
-        for (i=0; i<_instance_list.length(); i++)
-        {
-            if ( _instance_list[i]->_def == *def )
-            {
-                if (ref.isNull())
-                {
+        for (i=0; i<_instance_list.length(); i++) {
+            if ( _instance_list[i]->_def == *def ) {
+                if (ref.isNull()) {
                     _instance_list.erase(i, 1);
                 }
-                else
-                {
+                else {
                     _instance_list[i]->_fnt = ref;
                 }
                 return;
@@ -4443,11 +4503,10 @@ void LVFontCache::update( const LVFontDef * def, LVFontRef ref )
         //LVFontCacheItem * item;
         //item = new LVFontCacheItem(*def);
         addInstance( def, ref );
-    } else {
-        for (i=0; i<_registered_list.length(); i++)
-        {
-            if ( _registered_list[i]->_def == *def )
-            {
+    }
+    else {
+        for (i=0; i<_registered_list.length(); i++) {
+            if ( _registered_list[i]->_def == *def ) {
                 return;
             }
         }
@@ -4476,15 +4535,17 @@ void LVFontCache::gc()
 {
     int droppedCount = 0;
     int usedCount = 0;
-    for (int i=_instance_list.length()-1; i>=0; i--)
-    {
-        if ( _instance_list[i]->_fnt.getRefCount()<=1 )
-        {
-            if ( CRLog::isTraceEnabled() )
-                CRLog::trace("dropping font instance %s[%d] by gc()", _instance_list[i]->getDef()->getTypeFace().c_str(), _instance_list[i]->getDef()->getSize() );
+    for (int i=_instance_list.length()-1; i>=0; i--) {
+        if ( _instance_list[i]->_fnt.getRefCount()<=1 ) {
+            if ( CRLog::isTraceEnabled() ) {
+                CRLog::trace("dropping font instance %s[%d] by gc()",
+                        _instance_list[i]->getDef()->getTypeFace().c_str(),
+                        _instance_list[i]->getDef()->getSize() );
+            }
             _instance_list.erase(i,1);
             droppedCount++;
-        } else {
+        }
+        else {
             usedCount++;
         }
     }
@@ -5128,20 +5189,20 @@ bool LVWin32Font::Create(int size, int weight, bool italic, css_font_family_t fa
     return true;
 }
 
-#endif
+#endif // !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1
 
 /// to compare two fonts
 bool operator == (const LVFont & r1, const LVFont & r2)
 {
     if ( &r1 == &r2 )
         return true;
-    return r1.getSize()==r2.getSize()
-            && r1.getWeight()==r2.getWeight()
-            && r1.getItalic()==r2.getItalic()
-            && r1.getFontFamily()==r2.getFontFamily()
-            && r1.getTypeFace()==r2.getTypeFace()
-            && r1.getKerningMode()==r2.getKerningMode()
-            && r1.getHintingMode()==r2.getHintingMode()
+    return     r1.getSize() == r2.getSize()
+            && r1.getWeight() == r2.getWeight()
+            && r1.getItalic() == r2.getItalic()
+            && r1.getFontFamily() == r2.getFontFamily()
+            && r1.getTypeFace() == r2.getTypeFace()
+            && r1.getKerningMode() == r2.getKerningMode()
+            && r1.getHintingMode() == r2.getHintingMode()
             ;
 }
 

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -71,17 +71,33 @@ bool LVRendPageContext::updateRenderProgress( int numFinalBlocksRendered )
     return false;
 }
 
-/// append footnote link to last added line
-void LVRendPageContext::addLink( lString16 id )
+/// Get the number of links in the current line links list, or
+// in link_ids when no page_list
+int LVRendPageContext::getCurrentLinksCount()
 {
     if ( !page_list ) {
-        link_ids.add( id ); // gather links even if no page_list
+        return link_ids.length();
+    }
+    if ( lines.empty() )
+        return 0;
+    return lines.last()->getLinksCount();
+}
+
+/// append or insert footnote link to last added line
+void LVRendPageContext::addLink( lString16 id, int pos )
+{
+    if ( !page_list ) {
+        // gather links even if no page_list
+        if ( pos >= 0 ) // insert at pos
+            link_ids.insert( pos, id );
+        else // append
+            link_ids.add( id );
         return;
     }
     if ( lines.empty() )
         return;
     LVFootNote * note = getOrCreateFootNote( id );
-    lines.last()->addLink(note);
+    lines.last()->addLink(note, pos);
 }
 
 /// mark start of foot note

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2029,7 +2029,6 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
 // (todo: replace 'fmt' with 'int basewidth' to avoid confusion)
 void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, int & baseflags, int ident, int line_h, int valign_dy, bool * is_link_start )
 {
-    int txform_src_count = txform->GetSrcCount(); // to track if we added lines to txform
     if ( enode->isElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
         if ( rm == erm_invisible )
@@ -2723,6 +2722,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
             case css_c_both:
                 baseflags |= LTEXT_SRC_IS_CLEAR_BOTH;
+                break;
+            default:
                 break;
             }
         }
@@ -3470,7 +3471,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                             // is erm_invisible)
                             // (No need to do anything when  list-style-type none.)
                             ldomNode * tmpnode = enode;
-                            while ( tmpnode->hasChildren() ) {
+                            while ( tmpnode && tmpnode->hasChildren() ) {
                                 tmpnode = tmpnode->getChildNode( 0 );
                                 if (tmpnode && tmpnode->getRendMethod() == erm_final) {
                                     // We need renderFinalBlock() to be able to reach the current
@@ -5827,7 +5828,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // is erm_invisible)
                         // (No need to do anything when  list-style-type none.)
                         ldomNode * tmpnode = enode;
-                        while ( tmpnode->hasChildren() ) {
+                        while ( tmpnode && tmpnode->hasChildren() ) {
                             tmpnode = tmpnode->getChildNode( 0 );
                             if (tmpnode && tmpnode->getRendMethod() == erm_final) {
                                 // We need renderFinalBlock() to be able to reach the current

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3657,6 +3657,12 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                     }
                     // footnote links analysis
                     if ( !isFootNoteBody && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) { // disable footnotes for footnotes
+                        // If paragraph is RTL, we are meeting words in the reverse of the reading order:
+                        // so, insert each link for this line at the same position, instead of at the end.
+                        int link_insert_pos = -1; // append
+                        if ( line->flags & LTEXT_LINE_PARA_IS_RTL ) {
+                            link_insert_pos = context.getCurrentLinksCount();
+                        }
                         for ( int w=0; w<line->word_count; w++ ) {
                             // check link start flag for every word
                             if ( line->words[w].flags & LTEXT_WORD_IS_LINK_START ) {
@@ -3674,7 +3680,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                         lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
-                                            context.addLink( href );
+                                            context.addLink( href, link_insert_pos );
                                         }
                                     }
                                 }
@@ -3690,6 +3696,12 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                 for (int i=0; i<count; i++) {
                     const formatted_line_t * line = txform->GetLineInfo(i);
                     if ( !isFootNoteBody && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) {
+                        // If paragraph is RTL, we are meeting words in the reverse of the reading order:
+                        // so, insert each link for this line at the same position, instead of at the end.
+                        int link_insert_pos = -1; // append
+                        if ( line->flags & LTEXT_LINE_PARA_IS_RTL ) {
+                            link_insert_pos = context.getCurrentLinksCount();
+                        }
                         for ( int w=0; w<line->word_count; w++ ) {
                             // check link start flag for every word
                             if ( line->words[w].flags & LTEXT_WORD_IS_LINK_START ) {
@@ -3703,7 +3715,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                         lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
-                                            context.addLink( href );
+                                            context.addLink( href, link_insert_pos );
                                         }
                                     }
                                 }
@@ -6253,6 +6265,12 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     // a reference to it so page splitting can bring the footnotes
                     // text on this page, and then decide about page split.
                     if ( !isFootNoteBody && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) { // disable footnotes for footnotes
+                        // If paragraph is RTL, we are meeting words in the reverse of the reading order:
+                        // so, insert each link for this line at the same position, instead of at the end.
+                        int link_insert_pos = -1; // append
+                        if ( line->flags & LTEXT_LINE_PARA_IS_RTL ) {
+                            link_insert_pos = flow->getPageContext()->getCurrentLinksCount();
+                        }
                         for ( int w=0; w<line->word_count; w++ ) {
                             // check link start flag for every word
                             if ( line->words[w].flags & LTEXT_WORD_IS_LINK_START ) {
@@ -6270,7 +6288,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                         lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
-                                            flow->getPageContext()->addLink( href );
+                                            flow->getPageContext()->addLink( href, link_insert_pos );
                                         }
                                     }
                                 }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1304,6 +1304,17 @@ int lString16Collection::add( const lString16 & str )
     str.addref();
     return count++;
 }
+int lString16Collection::insert( int pos, const lString16 & str )
+{
+    if (pos<0 || pos>=count)
+        return add(str);
+    reserve( 1 );
+    for (int i=count; i>pos; --i)
+        chunks[i] = chunks[i-1];
+    chunks[pos] = str.pchunk;
+    str.addref();
+    return count++;
+}
 void lString16Collection::clear()
 {
     if (chunks) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3424,6 +3424,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );
         }
     }
+    delete absmarks;
 }
 
 #endif

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1661,7 +1661,7 @@ public:
 //                    lChar16 lastch = m_text[i-1];
 //                    if ( lastch==UNICODE_NO_BREAK_SPACE )
 //                        CRLog::trace("last char is UNICODE_NO_BREAK_SPACE");
-                    if ( m_flags[wstart] & LCHAR_IS_LIGATURE_TAIL ) {
+                    if ( m_flags[wstart] & LCHAR_IS_CLUSTER_TAIL ) {
                         // The start of this word is part of a ligature that started
                         // in a previous word: some hyphenation wrap happened on
                         // this ligature, which will not be rendered as such.
@@ -1675,7 +1675,7 @@ public:
                         }
                     }
                     if ( m_flags[i-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
-                        if ( m_flags[i] & LCHAR_IS_LIGATURE_TAIL ) {
+                        if ( m_flags[i] & LCHAR_IS_CLUSTER_TAIL ) {
                             // The end of this word is part of a ligature that, because
                             // of hyphenation, has been splitted onto next word.
                             // We are the first part of the hyphenated word, and
@@ -2715,6 +2715,8 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         buf->SetTextColor( cl );
                     if ( bgcl!=0xFFFFFFFF )
                         buf->SetBackgroundColor( bgcl );
+                    // Add drawing flags: text decoration (underline...)
+                    lUInt32 drawFlags = srcline->flags & LTEXT_TD_MASK;
                     font->DrawTextString(
                         buf,
                         x + frmline->x + word->x,
@@ -2724,7 +2726,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         '?',
                         NULL,
                         flgHyphen,
-                        srcline->flags & 0x0F00,
+                        drawFlags,
                         srcline->letter_spacing,
                         word->width,
                         text_decoration_back_gap);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5392,7 +5392,7 @@ void ldomNode::initNodeRendMethod()
                 // (If new floats appear after loading, we won't render well, but
                 // a style hash mismatch will happen and the user will be
                 // suggested to reload the book with cache cleaned.)
-                if ( this->getDocument()->_cacheFile == NULL ) {
+                if ( parent && this->getDocument()->_cacheFile == NULL ) {
                     // Replace this element with a floatBox in its parent children collection,
                     // and move it inside, as the single child of this floatBox.
                     int pos = getNodeIndex();
@@ -5732,7 +5732,7 @@ ldomNode * ldomDocumentWriter::OnTagOpen( const lChar16 * nsname, const lChar16 
     // if we see a BODY coming and we are a DocFragment, its time to apply the
     // styles set to the DocFragment before switching to BODY (so the styles can
     // be applied to BODY)
-    if (id == el_body && _currNode->_element->getNodeId() == el_DocFragment) {
+    if (id == el_body && _currNode && _currNode->_element->getNodeId() == el_DocFragment) {
         _currNode->_stylesheetIsSet = _currNode->getElement()->applyNodeStylesheet();
         // _stylesheetIsSet will be used to pop() the stylesheet when
         // leaving/destroying this DocFragment ldomElementWriter
@@ -6604,7 +6604,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
         //CRLog::trace("ldomXPointer::getRect() - p==NULL");
     }
     //printf("getRect( p=%08X type=%d )\n", (unsigned)p, (int)p->getNodeType() );
-    if ( !p->getDocument() ) {
+    else if ( !p->getDocument() ) {
         //CRLog::trace("ldomXPointer::getRect() - p->getDocument()==NULL");
     }
     ldomNode * mainNode = p->getDocument()->getRootNode();
@@ -6793,11 +6793,12 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             }
                             else {
                                 bestBidiRect.left = word->x + rc.left + frmline->x;
-                                if (extended)
+                                if (extended) {
                                     if (word->flags & LTEXT_WORD_IS_OBJECT && word->width > 0)
                                         bestBidiRect.right = bestBidiRect.left + word->width; // width of image
                                     else
                                         bestBidiRect.right = bestBidiRect.left + 1;
+                                }
                             }
                             hasBestBidiRect = true;
                             nearestForwardSrcIndex = word->src_text_index;
@@ -7007,13 +7008,15 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                         rect.left = word->x + rc.left + frmline->x;
                         //rect.top = word->y + rc.top + frmline->y + frmline->baseline;
                         rect.top = rc.top + frmline->y;
-                        if (extended)
+                        if (extended) {
                             if (word->flags & LTEXT_WORD_IS_OBJECT && word->width > 0)
                                 rect.right = rect.left + word->width; // width of image
                             else
                                 rect.right = rect.left + 1; // not the right word: no char width
-                        else
+                        }
+                        else {
                             rect.right = rect.left + 1;
+                        }
                         rect.bottom = rect.top + frmline->height;
                         return true;
                     } else if ( (offset < word->t.start+word->t.len)
@@ -10541,7 +10544,8 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
     lUInt16 id = _document->getElementNameIndex(tagname);
 
     // HTML title detection
-    if ( id==el_title && _currNode->_element->getParentNode()!= NULL && _currNode->_element->getParentNode()->getNodeId()==el_head ) {
+    if ( id==el_title && _currNode && _currNode->_element && _currNode->_element->getParentNode() != NULL
+                                   && _currNode->_element->getParentNode()->getNodeId() == el_head ) {
         lString16 s = _currNode->_element->getText();
         s.trim();
         if ( !s.empty() ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13364,6 +13364,10 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                 css_style_ref_t cs = child->getStyle();
                 if ( cs.isNull() )
                     continue;
+                if ( cs->display!=css_d_list_item_block && cs->display!=css_d_list_item) {
+                    // Alien element among list item nodes, skip it to not mess numbering
+                    continue;
+                }
                 switch ( cs->list_style_type ) {
                 case css_lst_decimal:
                 case css_lst_lower_roman:

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.26k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.27k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001B
 


### PR DESCRIPTION
See individual commit messages for details. Some technical notes in #307.

Some additional work on the block rendering code (list item bullets on the right, ordering of table cells/columns from right to left, H1,H2 `text-align` should be `start` instead of `left` in our epub.css...) is still needed to have full support for RTL documents - but a few style tweaks to force text right alignment may help in the meantime.

For now, we get the following (showing these limitations):
<kbd>![image](https://user-images.githubusercontent.com/24273478/64908045-32448f00-d6fb-11e9-8436-6369b250ff2e.png)</kbd>
More screenshots of arabic and hebrew texts in https://github.com/koreader/koreader/issues/5359#issuecomment-530354985.

Note: we won't draw highlights well when they span bidi segment boundaries, as Firefox would do well (I have no idea how to do that as well):
<kbd>![image](https://user-images.githubusercontent.com/24273478/64908313-b2b8bf00-d6fe-11e9-9f0d-5d241eae82ae.png)</kbd>

The whole `<bdi>` and `<bdo>` handling in lvrend.cpp was to have these kind of samples (found on the web) work as expected:
<kbd>![bdi_bdo](https://user-images.githubusercontent.com/24273478/64907970-1096d800-d6fa-11e9-9324-f6861da26325.png)</kbd>

----
Some visual examples regarding the first commits related to fonts:

This is some text rendered with Harfbuzz with a font with its bold and italic variants present (note the different italic `f`, and the `fi` ligature in all variants):
<kbd>![with_bold_italic_fonts](https://user-images.githubusercontent.com/24273478/64907942-aaaa5080-d6f9-11e9-945c-9e800e4ffd66.png)</kbd>

If I remove the italic, bold and bold italic font files, it previously rendered (with former crengine embolden code loosing the harfbuzz `fi` ligature on the bold):
<kbd>![before](https://user-images.githubusercontent.com/24273478/64907958-dfb6a300-d6f9-11e9-93a1-db2117921697.png)</kbd>

With this PR, it will render as (note the regular `f` in italic, and the preserved `fi` ligature):
<kbd>![after](https://user-images.githubusercontent.com/24273478/64907960-ef35ec00-d6f9-11e9-96c8-42087c1b9777.png)</kbd>

This helps correctly rendering arabic drawn with the fallback font (here, our regular-only FreeSerif):
<kbd>![after_hb_fallback](https://user-images.githubusercontent.com/24273478/64907967-05dc4300-d6fa-11e9-951f-bff0cb81b017.png)</kbd>

Previously, with our limited to western ligatures harfbuzz code, it was this mess (even messier with a bigger font size):
<kbd>![image](https://user-images.githubusercontent.com/24273478/64908257-ee9f5480-d6fd-11e9-8ac1-4d1b8316678b.png)</kbd>

