### PR TITLE
Enhanced block rendering: handle RTL direction

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -51,6 +51,10 @@ blockquote {
     margin-left: 2em;
     margin-right: 1em;
 }
+blockquote:dir(rtl) {
+    margin-left: 1em;
+    margin-right: 2em;
+}
 hr {
     height: 2px;
     background-color: #808080;
@@ -69,6 +73,10 @@ ol {
     list-style-type: decimal;
     margin-left: 1em;
 }
+ul:dir(rtl), ol:dir(rtl) {
+    margin-left: 0;
+    margin-right: 1em;
+}
 li {
     display: list-item;
     text-indent: 0;
@@ -85,6 +93,10 @@ dt {
 }
 dd {
     margin-left: 1.3em;
+}
+dd:dir(rtl) {
+    margin-left: 0;
+    margin-right: 1.3em;
 }
 
 /* Tables */

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -57,7 +57,9 @@ enum css_text_align_t {
     css_ta_left,
     css_ta_right,
     css_ta_center,
-    css_ta_justify
+    css_ta_justify,
+    css_ta_start, // = left if LTR, right if RTL
+    css_ta_end    // = right if LTR, left if LTR
 };
 
 /// vertical-align property values

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -274,6 +274,14 @@ enum css_clear_t {
     css_c_both
 };
 
+/// direction property values
+enum css_direction_t {
+    css_dir_inherit,
+    css_dir_unset,
+    css_dir_ltr,
+    css_dir_rtl
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,   // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2, // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -52,13 +52,15 @@
 
 #define RN_SPLIT_DISCARD_AT_START 0x400
 
+#define RN_LINE_IS_RTL 0x1000
+
 #define RN_GET_SPLIT_BEFORE(flags) (flags & 0x7)
 #define RN_GET_SPLIT_AFTER(flags) (flags >> 3)
 
-enum page_type_t {
-    PAGE_TYPE_NORMAL = 0,
-    PAGE_TYPE_COVER = 1
-};
+#define RN_PAGE_TYPE_NORMAL           0x01
+#define RN_PAGE_TYPE_COVER            0x02
+#define RN_PAGE_MOSTLY_RTL            0x10
+#define RN_PAGE_FOOTNOTES_MOSTLY_RTL  0x20
 
 /// footnote fragment inside page
 class LVPageFootNoteInfo {
@@ -215,14 +217,14 @@ public:
     int start; /// start of page
     int index;  /// index of page
     lInt16 height; /// height of page, does not include footnotes
-    lInt16 type;   /// type: PAGE_TYPE_NORMAL, PAGE_TYPE_COVER
+    lInt8 flags;   /// RN_PAGE_*
     CompactArray<LVPageFootNoteInfo, 1, 4> footnotes; /// footnote fragment list for page
     LVRendPageInfo(int pageStart, lUInt16 pageHeight, int pageIndex)
-    : start(pageStart), index(pageIndex), height(pageHeight), type(PAGE_TYPE_NORMAL) {}
+    : start(pageStart), index(pageIndex), height(pageHeight), flags(RN_PAGE_TYPE_NORMAL) {}
     LVRendPageInfo(lUInt16 coverHeight)
-    : start(0), index(0), height(coverHeight), type(PAGE_TYPE_COVER) {}
+    : start(0), index(0), height(coverHeight), flags(RN_PAGE_TYPE_COVER) {}
     LVRendPageInfo() 
-    : start(0), index(0), height(0), type(PAGE_TYPE_NORMAL) { }
+    : start(0), index(0), height(0), flags(RN_PAGE_TYPE_NORMAL) { }
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
 };

--- a/crengine/include/lvptrvec.h
+++ b/crengine/include/lvptrvec.h
@@ -198,6 +198,17 @@ public:
         }
         _list[ indexTo ] = p;
     }
+    /// reverse items
+    void reverse()
+    {
+        if ( empty() )
+            return;
+        for ( int i=0; i < _count/2; i++ ) {
+            T * tmp = _list[i];
+            _list[i] = _list[_count-1 - i];
+            _list[_count-1 - i] = tmp;
+        }
+    }
     /// copy constructor
     LVPtrVector( const LVPtrVector & v )
         : _list(NULL), _size(0), _count(0)

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -120,8 +120,9 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
 /// renders block which contains subblocks
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int rend_flags );
 /// renders table element
-int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width, bool shrink_to_fit,
-                 int & fitted_width, bool pb_inside_avoid=false, bool enhanced_rendering=false );
+int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
+                 bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,
+                 bool pb_inside_avoid=false, bool enhanced_rendering=false );
 /// sets node style
 void setNodeStyle( ldomNode * node, css_style_ref_t parent_style, LVFontRef parent_font );
 /// copy style

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -91,6 +91,8 @@ typedef LVRef<LVCssDeclaration> LVCssDeclRef;
 // See https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
 enum LVCssSelectorPseudoClass
 {
+    csspc_root,             // :root
+    csspc_dir,              // :dir(rtl), :dir(ltr)
     csspc_first_child,      // :first-child
     csspc_first_of_type,    // :first-of-type
     csspc_nth_child,        // :nth-child(even), :nth-child(3n+4)
@@ -107,10 +109,13 @@ enum LVCssSelectorPseudoClass
     csspc_nth_last_of_type, // :nth-last-of-type()
     csspc_only_child,       // :only-child
     csspc_only_of_type,     // :only-of-type
+    csspc_empty,            // :empty
 };
 
 static const char * css_pseudo_classes[] =
 {
+    "root",
+    "dir",
     "first-child",
     "first-of-type",
     "nth-child",
@@ -121,6 +126,7 @@ static const char * css_pseudo_classes[] =
     "nth-last-of-type",
     "only-child",
     "only-of-type",
+    "empty",
     NULL
 };
 

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -80,7 +80,8 @@ enum css_style_rec_important_bit {
     imp_bit_widows                = 1ULL << 53,
     imp_bit_float                 = 1ULL << 54,
     imp_bit_clear                 = 1ULL << 55,
-    imp_bit_cr_hint               = 1ULL << 56
+    imp_bit_direction             = 1ULL << 56,
+    imp_bit_cr_hint               = 1ULL << 57
 };
 
 /**
@@ -92,8 +93,8 @@ typedef struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
     lUInt64              important;  // bitmap for !important (used only by LVCssDeclaration)
-                                     // we have currently below 57 css properties
-                                     // lvstsheet knows about 72, which are mapped to these 57
+                                     // we have currently below 58 css properties
+                                     // lvstsheet knows about 73, which are mapped to these 58
                                      // update bits above if you add new properties below
     lUInt64              importance; // bitmap for important bit's importance/origin
                                      // (allows for 2 level of !important importance)
@@ -140,6 +141,7 @@ typedef struct css_style_rec_tag {
     css_orphans_widows_value_t widows;
     css_float_t            float_; // "float" is a C++ keyword...
     css_clear_t            clear;
+    css_direction_t        direction;
     css_cr_hint_t          cr_hint;
     css_style_rec_tag()
     : refCount(0)
@@ -182,6 +184,7 @@ typedef struct css_style_rec_tag {
     , widows(css_orphans_widows_inherit)
     , float_(css_f_none)
     , clear(css_c_none)
+    , direction(css_dir_inherit)
     , cr_hint(css_cr_hint_none)
     {
         // css_length_t fields are initialized by css_length_tag()

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -356,7 +356,9 @@ public:
             flags, interval, valign_dy, margin, object, (lUInt16)offset, letter_spacing );
     }
 
-    lUInt32 Format(lUInt16 width, lUInt16 page_height, BlockFloatFootprint * float_footprint = NULL);
+    lUInt32 Format(lUInt16 width, lUInt16 page_height,
+                        int para_direction=0, // = REND_DIRECTION_UNSET in lvrend.h
+                        BlockFloatFootprint * float_footprint = NULL );
 
     int GetSrcCount()
     {
@@ -393,7 +395,7 @@ public:
         return m_pbuffer->floats[index];
     }
 
-    void Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * marks,  ldomMarkedRangeList *bookmarks = NULL );
+    void Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * marks = NULL,  ldomMarkedRangeList *bookmarks = NULL );
 
     LFormattedText() { m_pbuffer = lvtextAllocFormatter( 0 ); }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2945,6 +2945,7 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->widows = source->widows;
     dest->float_ = source->float_;
     dest->clear = source->clear;
+    dest->direction = source->direction;
     dest->cr_hint = source->cr_hint;
 }
 
@@ -7680,6 +7681,10 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( widows, css_orphans_widows_inherit );
     UPDATE_STYLE_FIELD( list_style_type, css_lst_inherit );
     UPDATE_STYLE_FIELD( list_style_position, css_lsp_inherit );
+
+    // Note: we don't inherit "direction" (which should be inherited per specs);
+    // We'll handle inheritance of direction in renderBlockEnhanced, because
+    // it is also specified, with higher priority, by dir= attributes.
 
     // page_break_* should not be inherited per CSS specs, and as we set
     // each node to start with css_pb_auto, they shouldn't get a chance

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -785,6 +785,8 @@ static const char * css_ta_names[] =
     "right",
     "center",
     "justify",
+    "start",
+    "end",
     NULL
 };
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -104,6 +104,7 @@ enum css_decl_code {
     cssd_widows,
     cssd_float,
     cssd_clear,
+    cssd_direction,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
     cssd_cr_only_if,
@@ -187,6 +188,7 @@ static const char * css_decl_name[] = {
     "widows",
     "float",
     "clear",
+    "direction",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
     "-cr-only-if",
@@ -1052,6 +1054,16 @@ static const char * css_c_names[] =
     "left",
     "right",
     "both",
+    NULL
+};
+
+// direction value names
+static const char * css_dir_names[] =
+{
+    "inherit",
+    "unset",
+    "ltr",
+    "rtl",
     NULL
 };
 
@@ -1925,6 +1937,9 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             case cssd_clear:
                 n = parse_name( decl, css_c_names, -1 );
                 break;
+            case cssd_direction:
+                n = parse_name( decl, css_dir_names, -1 );
+                break;
             case cssd_stop:
             case cssd_unknown:
             default:
@@ -2205,6 +2220,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_clear:
             style->Apply( (css_clear_t) *p++, &style->clear, imp_bit_clear, is_important );
+            break;
+        case cssd_direction:
+            style->Apply( (css_direction_t) *p++, &style->direction, imp_bit_direction, is_important );
             break;
         case cssd_cr_hint:
             style->Apply( (css_cr_hint_t) *p++, &style->cr_hint, imp_bit_cr_hint, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -42,7 +42,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
            (lUInt32)(rec.important >> 32)) * 31
          + (lUInt32)(rec.important & 0xFFFFFFFFULL)) * 31
          + (lUInt32)(rec.importance >> 32)) * 31
@@ -100,6 +100,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.widows) * 31
          + (lUInt32)rec.float_) * 31
          + (lUInt32)rec.clear) * 31
+         + (lUInt32)rec.direction) * 31
          + (lUInt32)rec.cr_hint) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash());
@@ -164,6 +165,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.widows==r2.widows&&
            r1.float_ == r2.float_&&
            r1.clear == r2.clear&&
+           r1.direction == r2.direction&&
            r1.cr_hint==r2.cr_hint;
 }
 
@@ -349,6 +351,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(widows);
     ST_PUT_ENUM(float_);
     ST_PUT_ENUM(clear);
+    ST_PUT_ENUM(direction);
     ST_PUT_ENUM(cr_hint);
     lUInt32 hash = calcHash(*this);
     buf << hash;
@@ -406,6 +409,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_orphans_widows_value_t, widows);
     ST_GET_ENUM(css_float_t, float_);
     ST_GET_ENUM(css_clear_t, clear);
+    ST_GET_ENUM(css_direction_t, direction);
     ST_GET_ENUM(css_cr_hint_t, cr_hint);
     lUInt32 hash = 0;
     buf >> hash;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4013,8 +4013,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     css_style_ref_t s( new css_style_rec_t );
     s->display = css_d_block;
     s->white_space = css_ws_normal;
-    s->text_align = css_ta_left;
-    s->text_align_last = css_ta_left;
+    s->text_align = css_ta_start;
+    s->text_align_last = css_ta_start;
     s->text_decoration = css_td_none;
     s->text_transform = css_tt_none;
     s->hyphenate = css_hyph_auto;
@@ -14408,7 +14408,8 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
         return 0;
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object
-    int flags = styleToTextFmtFlags( getStyle(), 0 );
+    int direction = RENDER_RECT_PTR_GET_DIRECTION(fmt);
+    int flags = styleToTextFmtFlags( getStyle(), 0, direction );
     ::renderFinalBlock( this, f.get(), fmt, flags, 0, -1 );
     cache.set( this, f );
     bool flg=gFlgFloatingPunctuationEnabled;
@@ -14431,7 +14432,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
         float_footprint = &restored_float_footprint;
         float_footprint->restore( this, (lUInt16)width );
     }
-    int h = f->Format((lUInt16)width, (lUInt16)page_h, float_footprint);
+    int h = f->Format((lUInt16)width, (lUInt16)page_h, direction, float_footprint);
     gFlgFloatingPunctuationEnabled=flg;
     frmtext = f;
     //CRLog::trace("Created new formatted object for node #%08X", (lUInt32)this);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.27k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.28k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001C
 
@@ -4047,6 +4047,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->widows = css_orphans_widows_1;
     s->float_ = css_f_none;
     s->clear = css_c_none;
+    s->direction = css_dir_inherit;
     s->cr_hint = css_cr_hint_none;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -14364,10 +14364,11 @@ int ldomNode::getSurroundingAddedHeight()
                 base_width = fmt.getWidth();
             }
             int em = n->getFont()->getSize();
-            h += lengthToPx( n->getStyle()->margin[2], base_width, em );  // top margin
-            h += lengthToPx( n->getStyle()->margin[3], base_width, em );  // bottom margin
-            h += lengthToPx( n->getStyle()->padding[2], base_width, em ); // top padding
-            h += lengthToPx( n->getStyle()->padding[3], base_width, em ); // bottom padding
+            css_style_ref_t style = n->getStyle();
+            h += lengthToPx( style->margin[2], base_width, em );  // top margin
+            h += lengthToPx( style->margin[3], base_width, em );  // bottom margin
+            h += lengthToPx( style->padding[2], base_width, em ); // top padding
+            h += lengthToPx( style->padding[3], base_width, em ); // bottom padding
             h += measureBorder(n, 0); // top border
             h += measureBorder(n, 2); // bottom border
         }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13438,17 +13438,26 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         // We are given a x>0 when tap/hold to highlight text or find
         // a link, and checking x vs fmt.x and width allows for doing
         // that correctly in 2nd+ table cells.
-        // (No need to check if ( pt.x < fmt.getX() ): we probably
-        // meet the multiple elements that can be formatted on a same
-        // line in the order they appear as children of their parent,
-        // we can simply just ignore those who end before our pt.x)
         if ( pt.x >= fmt.getX() + fmt.getWidth() ) {
             return NULL;
         }
+        // No more true:
+        //   (No need to check if ( pt.x < fmt.getX() ): we probably
+        //   meet the multiple elements that can be formatted on a same
+        //   line in the order they appear as children of their parent,
+        //   we can simply just ignore those who end before our pt.x)
         // But check x if we happen to be on a floating node (which,
         // with float:right, can appear first in the DOM but be
         // displayed at a higher x)
-        if ( pt.x < fmt.getX() && enode->isFloatingBox() ) {
+        //  if ( pt.x < fmt.getX() && enode->isFloatingBox() ) {
+        //      return NULL;
+        //  }
+        //
+        // Now that we support RTL tables, we can meet cells
+        // no more in logical order.
+        // We could add more conditions (like parentNode->getRendMethod()>=erm_table),
+        // but let's just check this in all cases.
+        if ( pt.x < fmt.getX() ) {
             return NULL;
         }
     }


### PR DESCRIPTION
Followup to #309, which added support for RTL/bidi text. Some technical notes in #307.

This PR completes support for RTL documents, by handling the `dir=` attribute in block nodes, drawing list item markers on the right of the page, and drawing RTL tables' cells from right to left.
See commit messages for details.

Some screenshots:
<kbd>![image](https://user-images.githubusercontent.com/24273478/65821999-72e4f200-e23d-11e9-82b3-d12d455f82fb.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/65822002-82643b00-e23d-11e9-83b9-7e4cd9a5438a.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/65822010-9445de00-e23d-11e9-97e3-0846df9ab20d.png)</kbd>
(/\ [source](https://ar.wikipedia.org/wiki/%D8%A7%D9%84%D8%A8%D8%AA%D8%B1%D8%A7%D8%A1) - \\/ [source](https://he.wikipedia.org/wiki/%D7%A4%D7%98%D7%A8%D7%94))
<kbd>![image](https://user-images.githubusercontent.com/24273478/65822022-f999cf00-e23d-11e9-9428-3821d44e5a2d.png)</kbd>

----

I'll add to frontend a `Style tweaks> Text> Text direction>` section:
<kbd>![image](https://user-images.githubusercontent.com/24273478/65822060-893f7d80-e23e-11e9-9744-e9de5a604a1b.png)</kbd>
which will allow setting direction on any kind of document (needed for plain text files in arabic or hebrew).

Some english page in normal LTR => switched to RTL:
<kbd>![image](https://user-images.githubusercontent.com/24273478/65822173-da03a600-e23f-11e9-8d2f-37c5b3655d41.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/65822171-d112d480-e23f-11e9-9d39-cb653ff3d911.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/65822186-00294600-e240-11e9-87f9-eaa708f32e3d.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/65822210-39fa4c80-e240-11e9-93bf-6aa9c0a8f53c.png)</kbd>

Note that the absence/bad handling of left/right side bearings when in RTL context in getRenderedWidths makes all the perfect fitting stuff we did for LTR, not working so well in RTL:
<kbd>![image](https://user-images.githubusercontent.com/24273478/65822231-99585c80-e240-11e9-91d0-381c846a8b42.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/65822239-ae34f000-e240-11e9-83da-02b7b89afe10.png)</kbd>

Except for the getRenderedWidths() (to size table cells or floats) limitations, we should have now proper RTL support.
(I have not added some CSS properties and named values that could help simplifying our .css, like `float: inline-start` or `margin-inline-start: 1em` (that mean `left` in LTR and `right` in RTL) because ... well, that's too much work :)

One last remaining (minor) issue is the the landscape/dual pages, mode which will still show the first page on the left, while I guess for RTL documents it should show it on the right.




