### PR TITLE
New option to tune word spacing: space width scale percent

### DIFF
--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -57,6 +57,8 @@
 #define PROP_AUTOSAVE_BOOKMARKS      "crengine.autosave.bookmarks"
 
 #define PROP_FLOATING_PUNCTUATION    "crengine.style.floating.punctuation.enabled"
+
+#define PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT "crengine.style.space.width.scale.percent"
 #define PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT "crengine.style.space.condensing.percent"
 
 #define PROP_FILE_PROPS_FONT_SIZE    "cr3.file.props.font.size"

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -220,10 +220,13 @@ typedef struct
    lUInt32               height;        /**< height of text fragment */
    lUInt16               width;         /**< width of text fragment */
    lUInt16               page_height;   /**< max page height */
-                         // Each line box starts with a zero-width inline box (called "strut") with
-                         // the element's font and line height properties:
+
+    // Each line box starts with a zero-width inline box (called "strut") with
+    // the element's font and line height properties:
    lUInt16               strut_height;   /**< strut height */
    lUInt16               strut_baseline; /**< strut baseline */
+
+   // Image scaling options
    lInt32                img_zoom_in_mode_block; /**< can zoom in block images: 0=disabled, 1=integer scale, 2=free scale */
    lInt32                img_zoom_in_scale_block; /**< max scale for block images zoom in: 1, 2, 3 */
    lInt32                img_zoom_in_mode_inline; /**< can zoom in inline images: 0=disabled, 1=integer scale, 2=free scale */
@@ -232,7 +235,12 @@ typedef struct
    lInt32                img_zoom_out_scale_block; /**< max scale for block images zoom out: 1, 2, 3 */
    lInt32                img_zoom_out_mode_inline; /**< can zoom out inline images: 0=disabled, 1=integer scale, 2=free scale */
    lInt32                img_zoom_out_scale_inline; /**< max scale for inline images zoom out: 1, 2, 3 */
-   lInt32                min_space_condensing_percent; /**< min size of space (relative to normal size) to allow fitting line by reducing of spaces */
+
+   // Space width
+   lInt32                space_width_scale_percent; /**< scale the normal width of all spaces in all fonts by this percent */
+   lInt32                min_space_condensing_percent; /**< min size of space (relative to scaled size) to allow fitting line by reducing of spaces */
+
+   // Highlighting
    text_highlight_options_t highlight_options; /**< options for selection/bookmark highlighting */
 } formatted_text_fragment_t;
 
@@ -313,7 +321,12 @@ public:
     /// set image scaling options
     void setImageScalingOptions( img_scaling_options_t * options );
 
+    /// set space glyph width scaling percent option (10..500%)
+    // (scale the normal width of all spaces in all fonts by this percent)
+    void setSpaceWidthScalePercent(int spaceWidthScalePercent);
+
     /// set space condensing line fitting option (25..100%)
+    // (applies after spaceWidthScalePercent has been applied)
     void setMinSpaceCondensingPercent(int minSpaceWidthPercent);
 
     /// set colors for selection and bookmarks

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -100,6 +100,7 @@ extern int gDOMVersionRequested;
 #define DOC_PROP_CODE_BASE       "doc.file.code.base"
 #define DOC_PROP_COVER_FILE      "doc.cover.file"
 
+#define DEF_SPACE_WIDTH_SCALE_PERCENT 100
 #define DEF_MIN_SPACE_CONDENSING_PERCENT 50
 
 #define NODE_DISPLAY_STYLE_HASH_UNITIALIZED 0xFFFFFFFF
@@ -448,6 +449,7 @@ protected:
     int  _mapSavingStage;
 
     img_scaling_options_t _imgScalingOptions;
+    int  _spaceWidthScalePercent;
     int  _minSpaceCondensingPercent;
 
     lUInt32 _nodeStyleHash;
@@ -507,6 +509,13 @@ protected:
     tinyNodeCollection( tinyNodeCollection & v );
 
 public:
+
+    bool setSpaceWidthScalePercent(int spaceWidthScalePercent) {
+        if (spaceWidthScalePercent == _spaceWidthScalePercent)
+            return false;
+        _spaceWidthScalePercent = spaceWidthScalePercent;
+        return true;
+    }
 
     bool setMinSpaceCondensingPercent(int minSpaceCondensingPercent) {
         if (minSpaceCondensingPercent == _minSpaceCondensingPercent)

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4383,6 +4383,7 @@ void LVDocView::createEmptyDocument() {
 			PROP_EMBEDDED_STYLES, true));
     m_doc->setDocFlag(DOC_FLAG_ENABLE_DOC_FONTS, m_props->getBoolDef(
             PROP_EMBEDDED_FONTS, true));
+    m_doc->setSpaceWidthScalePercent(m_props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, 100));
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, 50));
 
     m_doc->setContainer(m_container);
@@ -6081,7 +6082,14 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
     props->setIntDef(PROP_IMG_SCALING_ZOOMIN_BLOCK_MODE, defImgScaling.mode);
     props->setIntDef(PROP_IMG_SCALING_ZOOMIN_INLINE_MODE, defImgScaling.mode);
 
-    int p = props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT);
+    int p = props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, DEF_SPACE_WIDTH_SCALE_PERCENT);
+    if (p<10)
+        p = 10;
+    if (p>500)
+        p = 500;
+    props->setInt(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, p);
+
+    p = props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT);
     if (p<25)
         p = 25;
     if (p>100)
@@ -6379,6 +6387,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 gRenderScaleFontWithDPI = value;
                 REQUEST_RENDER("propsApply render scale font with dpi")
             }
+        } else if (name == PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT) {
+            int value = props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, DEF_SPACE_WIDTH_SCALE_PERCENT);
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setSpaceWidthScalePercent(value))
+                    REQUEST_RENDER("propsApply space width scale percent")
         } else if (name == PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT) {
             int value = props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT);
             if (m_doc) // not when noDefaultDocument=true

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1851,6 +1851,7 @@ tinyNodeCollection::tinyNodeCollection()
 , _mapped(false)
 , _maperror(false)
 , _mapSavingStage(0)
+, _spaceWidthScalePercent(DEF_SPACE_WIDTH_SCALE_PERCENT)
 , _minSpaceCondensingPercent(DEF_MIN_SPACE_CONDENSING_PERCENT)
 , _nodeStyleHash(0)
 , _nodeDisplayStyleHash(NODE_DISPLAY_STYLE_HASH_UNITIALIZED)
@@ -1887,6 +1888,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 , _mapped(false)
 , _maperror(false)
 , _mapSavingStage(0)
+, _spaceWidthScalePercent(DEF_SPACE_WIDTH_SCALE_PERCENT)
 , _minSpaceCondensingPercent(DEF_MIN_SPACE_CONDENSING_PERCENT)
 , _nodeStyleHash(0)
 , _nodeDisplayStyleHash(NODE_DISPLAY_STYLE_HASH_UNITIALIZED)
@@ -3348,6 +3350,7 @@ LFormattedText * lxmlDocBase::createFormattedText()
 {
     LFormattedText * p = new LFormattedText();
     p->setImageScalingOptions(&_imgScalingOptions);
+    p->setSpaceWidthScalePercent(_spaceWidthScalePercent);
     p->setMinSpaceCondensingPercent(_minSpaceCondensingPercent);
     p->setHighlightOptions(&_highlightOptions);
     return p;
@@ -11378,6 +11381,7 @@ lUInt32 tinyNodeCollection::calcStyleHash()
     }
     CRLog::info("Calculating style hash...  elemCount=%d, globalHash=%08x, docFlags=%08x, nodeStyleHash=%08x", _elemCount, globalHash, docFlags, res);
     res = res * 31 + _imgScalingOptions.getHash();
+    res = res * 31 + _spaceWidthScalePercent;
     res = res * 31 + _minSpaceCondensingPercent;
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);


### PR DESCRIPTION
Allow setting a factor that will be applied to the width of all spaces in all fonts (the regular and non-break space only, it won't apply to fixed width spaces). The default option of 100 (%) makes it do nothing.
The existing option "min space condensing percent", used only when trying to find a better line wrap position for text justification, now applies after/on the scaled width.

Details and discussion about that around https://github.com/koreader/koreader/pull/5628#issuecomment-557834352.

Much code just to handle the option passing - the real work is the 2 middle chunks in lvtextfm.cpp.

So, that percentage is applied on the rounded(+truncated with >>6) space width.
I initially thought we'd better do it on the original metric before the >>6, to avoid shifts due to rounding errors. But it looked quite more complicated (having to pass the factor the the font code, and implement it in the 3 kerning methods...), than the simple way to do it I quickly drafted just for testing (14 lines of code with comments).
Which seems to work good enough :) So I hope we can just go with that - and I don't have to kludge that in the font code and wonder if kerning space can happen, or if harfbuzz can vary the width of spaces or make cluster out of them :)

So, with the rounding done, and applying the % on a final width in pixels, any % lower than 100%, even 99%, will make all spaces lose at least 1px.

I also removed the check that limited the min_space_condensing setting from going below 1/4 of font size - so one can experiment with low values for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/319)
<!-- Reviewable:end -->
