### PR TITLE
Fix possible crash with backward search

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -138,9 +138,8 @@ enum LVCssSelectorRuleType
     cssrt_predecessor,       // E + F
     cssrt_predsibling,       // E ~ F
     cssrt_attrset,           // E[foo]
-    cssrt_attrset_i,         // E[foo i] (case insensitive)
     cssrt_attreq,            // E[foo="value"]
-    cssrt_attreq_i,          // E[foo="value i"]
+    cssrt_attreq_i,          // E[foo="value i"] (case insensitive)
     cssrt_attrhas,           // E[foo~="value"]
     cssrt_attrhas_i,         // E[foo~="value i"]
     cssrt_attrstarts_word,   // E[foo|="value"]

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7084,9 +7084,9 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                         }
                         rect.bottom = rect.top + frmline->height;
                         return true;
-                    } else if ( (offset < word->t.start+word->t.len)
-                               || (offset==srcLen
-                                   && offset == word->t.start+word->t.len) ) {
+                    } else if ( (word->src_text_index == srcIndex) &&
+                                ( (offset < word->t.start+word->t.len) ||
+                                  (offset==srcLen && offset == word->t.start+word->t.len) ) ) {
                         // pointer inside this word
                         LVFont *font = (LVFont *) txtform->GetSrcInfo(srcIndex)->t.font;
                         lUInt16 w[512];

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.30k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.31k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001D
 


### PR DESCRIPTION
Backward search could meet the last text node in a paragraph that could be not part of any word, if that last text node contains only spaces (e.g. `<td><span>A few words</span> </td>`).
It could then segfault when `measureText()` that one-space string with` t.start+t.len` of the previous word.

Witnessed on this:
<kbd>![image](https://user-images.githubusercontent.com/24273478/69977710-940edb00-152b-11ea-983e-1bf2d9b1e288.png)</kbd>

Also remove invalid and unused item in CSS selector enum: `E[foo i]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/321)
<!-- Reviewable:end -->
