### PR TITLE
(Upstream) DocX: fix paragraphs with single hyperlink

### DIFF
--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -325,15 +325,13 @@ public:
     static const int PROP_COUNT = N;
 
     virtual void reset() {
-        for(int i = 0; i < N; i++) {
-            m_properties[i].type = css_val_unspecified;
-            m_properties[i].value = 0;
-        }
+        init();
     }
+
     virtual ~docx_PropertiesContainer() {}
 
     docx_PropertiesContainer() {
-        reset();
+        init();
     }
 
     css_length_t get(int index) const {
@@ -384,6 +382,13 @@ public:
 
 protected:
     css_length_t m_properties[N];
+private:
+    void init() {
+        for(int i = 0; i < N; i++) {
+            m_properties[i].type = css_val_unspecified;
+            m_properties[i].value = 0;
+        }
+    }
 };
 
 enum docx_run_properties
@@ -931,16 +936,17 @@ class docx_hyperlinkHandler  : public docx_ElementHandler
 {
     docx_rHandler m_rHandler;
     lString16 m_target;
+    int m_runCount;
 public:
     docx_hyperlinkHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_pHandler* pHandler) :
         docx_ElementHandler(reader, writer, context, docx_el_hyperlink, hyperlink_elements),
-        m_rHandler(reader, writer, context, pHandler)
+        m_rHandler(reader, writer, context, pHandler), m_runCount(0)
     {
     }
     ldomNode * handleTagOpen(int tagId);
     void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
     void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
-    void reset() { m_target.clear(); m_rHandler.reset(); }
+    void reset() { m_target.clear(); m_rHandler.reset(); m_runCount = 0; }
 };
 
 class docx_documentHandler;
@@ -1919,6 +1925,7 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
 {
     switch(tagId) {
     case docx_el_r:
+    case docx_el_hyperlink:
         if ( 0 == m_runCount ) {
             m_pPr.combineWith(m_importContext->get_pPrDefault());
             css_length_t outlineLevel = m_pPr.getOutlineLvl();
@@ -1949,14 +1956,15 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
                 m_writer->OnAttribute(L"", L"style", style.c_str());
             m_writer->OnTagBody();
         }
-        m_rHandler.start();
+        if(docx_el_r == tagId)
+            m_rHandler.start();
+        else
+            m_hyperlinkHandler.start();
         m_runCount++;
         break;
     case docx_el_bookmarkStart:
         m_state = tagId;
         break;
-    case docx_el_hyperlink:
-        m_hyperlinkHandler.start();
         break;
     case docx_el_pPr:
         m_pPrHandler.start(&m_pPr);
@@ -2726,6 +2734,12 @@ ldomNode *docx_hyperlinkHandler::handleTagOpen(int tagId)
 {
     switch(tagId) {
     case docx_el_r:
+        if ( !m_target.empty() && 0 == m_runCount ) {
+            m_writer->OnTagOpen(L"", L"a");
+            m_writer->OnAttribute(L"", L"href", m_target.c_str());
+            m_writer->OnTagBody();
+        }
+        m_runCount++;
         m_rHandler.start();
         break;
     default:
@@ -2737,12 +2751,11 @@ ldomNode *docx_hyperlinkHandler::handleTagOpen(int tagId)
 
 void docx_hyperlinkHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
 {
-    if( docx_el_hyperlink == m_state && !lStr_cmp(attrname, "id") ) {
-        m_target = m_importContext->getLinkTarget(lString16(attrvalue));
-        if( !m_target.empty() ) {
-            m_writer->OnTagOpen(L"", L"a");
-            m_writer->OnAttribute(L"", L"href", m_target.c_str());
-            m_writer->OnTagBody();
+    if( docx_el_hyperlink == m_state) {
+        if ( !lStr_cmp(attrname, "id") ) {
+            m_target = m_importContext->getLinkTarget(lString16(attrvalue));
+        } else if (!lStr_cmp(attrname, "anchor") && m_target.empty()) {
+            m_target = cs16("#") + lString16(attrvalue);
         }
     }
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.31k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.32k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001D
 


### PR DESCRIPTION
By @pkb, from https://github.com/buggins/coolreader/pull/119
- Fixed processing of a paragraph with single hyperlink element, no runs
- Don't call virtual method in constructor just to avoid warning
- Handle anchor attribute in hyperlink element
- Added missing # to href

(Needed a bump of CACHE_FILE_FORMAT_VERSION to actually re-parse the docx and have the fix applied on previously opened documents.)

Actually fix in-document table of contents :) Thanks !
Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70893758-ff58b280-1feb-11ea-9e6e-ee7ee52cdc6b.png)</kbd>

After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/70894202-d8e74700-1fec-11ea-8736-320732aec719.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/323)
<!-- Reviewable:end -->
