### PR TITLE
Add support for display: inline-block/inline-table. And other fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -20,6 +20,7 @@
 #include "lvref.h"
 #include "lvstring.h"
 
+// The order of items in following enums should match the order in the tables in src/lvstsheet.cpp
 /// display property values
 enum css_display_t {
     css_d_inherit,
@@ -27,11 +28,12 @@ enum css_display_t {
     css_d_block,
     css_d_list_item,        // display: -cr-list-item-final (was used before 20180524 for display: list-item)
     css_d_list_item_block,  // display: list-item
+    css_d_inline_block,
+    css_d_inline_table, // (needs to be before css_d_table, as we use tests like if: (style->display > css_d_table))
     css_d_run_in, 
     css_d_compact, 
     css_d_marker, 
     css_d_table, 
-    css_d_inline_table, 
     css_d_table_row_group, 
     css_d_table_header_group, 
     css_d_table_footer_group, 

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -33,6 +33,8 @@ XS_BEGIN_TAGS
 XS_TAG1T( autoBoxing )
 // Internal element for float rendering
 XS_TAG1T( floatBox )
+// Internal element for inline-block and inline-table rendering
+XS_TAG1I( inlineBox )
 // Internal element for EPUB, containing each individual HTML file
 XS_TAG1( DocFragment )
 

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -119,6 +119,7 @@ public:
     static bool setRightHyphenMin( int right_hyphen_min );
     static int getTrustSoftHyphens() { return _TrustSoftHyphens; }
     static bool setTrustSoftHyphens( int trust_soft_hyphen );
+    static bool isEnabled();
 
     HyphMan();
     ~HyphMan();

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -48,6 +48,12 @@
 #define RENDER_RECT_HAS_DIRECTION_RTL(r)  ( (bool)(r.getFlags() & RENDER_RECT_FLAG_DIRECTION_MASK == REND_DIRECTION_RTL) )
 #define RENDER_RECT_PTR_HAS_DIRECTION_RTL(r)  ( (bool)(r->getFlags() & RENDER_RECT_FLAG_DIRECTION_MASK == REND_DIRECTION_RTL) )
 
+// To be provided via the initial value to renderBlockElement(... int *baseline ...) to
+// have FlowState compute baseline (different rules whether inline-block or inline-table).
+#define REQ_BASELINE_NOT_NEEDED       0
+#define REQ_BASELINE_FOR_INLINE_BLOCK 1
+#define REQ_BASELINE_FOR_INLINE_TABLE 2
+
 class FlowState;
 
 // Footprint of block floats (from FlowState) on a final block,
@@ -116,9 +122,9 @@ int styleToTextFmtFlags( const css_style_ref_t & style, int oldflags, int direct
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags,
                        int ident, int line_h, int valign_dy=0, bool * is_link_start=NULL );
 /// renders block which contains subblocks (with gRenderBlockRenderingFlags as flags)
-int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction=REND_DIRECTION_UNSET );
+int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );
 /// renders block which contains subblocks
-int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int rend_flags );
+int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int * baseline, int rend_flags );
 /// renders table element
 int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
                  bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -29,12 +29,12 @@
 // Flags for RenderRectAccessor
 #define RENDER_RECT_FLAG_DIRECTION_SET                      0x0001
 #define RENDER_RECT_FLAG_DIRECTION_INVERTED                 0x0002
-#define RENDER_RECT_FLAG_DIRECTION_VERTICAL                 0x0004 // only horizontal supported
+#define RENDER_RECT_FLAG_DIRECTION_VERTICAL                 0x0004 // not used (only horizontal currently supported)
 #define RENDER_RECT_FLAG_INNER_FIELDS_SET                   0x0008
-#define RENDER_RECT_FLAG_NO_CLEAR_OWN_FLOATS                0x0010
-#define RENDER_RECT_FLAG_FINAL_FOOTPRINT_AS_SAVED_FLOAT_IDS 0x0020
-#define RENDER_RECT_FLAG_FLOATBOX_IS_RIGHT                  0x0040
-#define RENDER_RECT_FLAG_FLOATBOX_IS_RENDERED               0x0080
+#define RENDER_RECT_FLAG_BOX_IS_RENDERED                    0x0010 // for floatBox and inlineBox
+#define RENDER_RECT_FLAG_NO_CLEAR_OWN_FLOATS                0x0020
+#define RENDER_RECT_FLAG_FINAL_FOOTPRINT_AS_SAVED_FLOAT_IDS 0x0040
+#define RENDER_RECT_FLAG_FLOATBOX_IS_RIGHT                  0x0080
 
 #define RENDER_RECT_SET_FLAG(r, f)   ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )
 #define RENDER_RECT_UNSET_FLAG(r, f) ( r.setFlags( r.getFlags() & ~RENDER_RECT_FLAG_##f ) )
@@ -144,7 +144,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * node, int x0, int y0, int dx,
 //   minWidth: width with a wrap on all spaces (no hyphenation), so width taken by the longest word
 // full function for recursive use:
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction, bool ignorePadding, int rendFlags,
-            int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth, int indent);
+            int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth, int indent, bool isStartNode=false);
 // simpler function for first call:
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction=REND_DIRECTION_UNSET, bool ignorePadding=false, int rendFlags=0);
 
@@ -205,6 +205,9 @@ extern int gRenderBlockRenderingFlags;
 #define BLOCK_RENDERING_ALLOW_EXACT_FLOATS_FOOTPRINTS      0x00200000 // When 5 or less outer floats have impact on a final
                                                                       // block, store their ids instead of the 2 top left/right
                                                                       // rectangle, allowing text layout staircase-like.
+// Inline block/table
+#define BLOCK_RENDERING_BOX_INLINE_BLOCKS                  0x01000000 // Wrap inline-block in an internal inlineBox element.
+
 // Enable everything
 #define BLOCK_RENDERING_FULL_FEATURED                      0x7FFFFFFF
 

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -283,7 +283,12 @@ protected:
     short  _inner_width; // = _width - left and right borders and paddings
     short  _inner_x;     // = left border + padding
     short  _inner_y;     // = top border + padding
-    short  _available1;  // (no need for any _inner_height currently)
+                         // (no need for any _inner_height currently)
+
+    short  _baseline;    // reference baseline y (only set for inline-block box)
+        // (Note: it's limited to 32767px here, but images and inline-box height
+        // is also limited to that for being carried in lInt16 slots when
+        // formatting text in lvtextfm.cpp.)
 
     // Children blocks should be fully contained in their parent block,
     // and sibling nodes blocks should not overlap with other siblings,
@@ -313,17 +318,17 @@ protected:
     int  _extra5;
 
     // Added for padding from 14 to 16 32-bits ints
+    int _available1;
     int _available2;
-    int _available3;
 
 public:
     lvdomElementFormatRec()
     : _x(0), _width(0), _y(0), _height(0)
-    , _inner_width(0), _inner_x(0), _inner_y(0), _available1(0)
+    , _inner_width(0), _inner_x(0), _inner_y(0), _baseline(0)
     , _top_overflow(0), _bottom_overflow(0), _listprop_node_idx(0)
     , _flags(0), _extra0(0)
     , _extra1(0), _extra2(0), _extra3(0), _extra4(0), _extra5(0)
-    , _available2(0), _available3(0)
+    , _available1(0), _available2(0)
     {
     }
     ~lvdomElementFormatRec()
@@ -332,37 +337,37 @@ public:
     void clear()
     {
         _x = _width = _y = _height = 0;
-        _inner_width = _inner_x = _inner_y = _available1 = 0;
+        _inner_width = _inner_x = _inner_y = _baseline = 0;
         _top_overflow = _bottom_overflow = 0;
         _listprop_node_idx = 0;
         _flags = _extra0 = 0;
         _extra1 = _extra2 = _extra3 = _extra4 = _extra5 = 0;
-        _available2 = 0; _available3 = 0;
+        _available1 = 0; _available2 = 0;
     }
     bool operator == ( lvdomElementFormatRec & v )
     {
         return (_height==v._height && _y==v._y && _width==v._width && _x==v._x &&
                 _inner_width==v._inner_width && _inner_x==v._inner_x &&
-                _inner_y==v._inner_y && _available1==v._available1 &&
+                _inner_y==v._inner_y && _baseline==v._baseline &&
                 _top_overflow==v._top_overflow && _bottom_overflow==v._bottom_overflow &&
                 _listprop_node_idx==v._listprop_node_idx &&
                 _flags==v._flags && _extra0==v._extra0 &&
                 _extra1==v._extra1 && _extra2==v._extra2 && _extra3==v._extra3 &&
                 _extra4==v._extra4 && _extra5==v._extra5 &&
-                _available2==v._available2 && _available3==v._available3
+                _available1==v._available1 && _available2==v._available2
                 );
     }
     bool operator != ( lvdomElementFormatRec & v )
     {
         return (_height!=v._height || _y!=v._y || _width!=v._width || _x!=v._x ||
                 _inner_width!=v._inner_width || _inner_x!=v._inner_x ||
-                _inner_y!=v._inner_y || _available1!=v._available1 ||
+                _inner_y!=v._inner_y || _baseline!=v._baseline ||
                 _top_overflow!=v._top_overflow || _bottom_overflow!=v._bottom_overflow ||
                 _listprop_node_idx!=v._listprop_node_idx ||
                 _flags!=v._flags || _extra0!=v._extra0 ||
                 _extra1!=v._extra1 || _extra2!=v._extra2 || _extra3!=v._extra3 ||
                 _extra4!=v._extra4 || _extra5!=v._extra5 ||
-                _available2!=v._available2 || _available3!=v._available3
+                _available1!=v._available1 || _available2!=v._available2
                 );
     }
     // Get/Set

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -124,6 +124,8 @@ typedef struct
            lUInt16  height;          /**< \brief height of image */
        } o;
    };
+   lInt16   _top_to_baseline;        /* temporary storage slots when delaying y computation, */
+   lInt16   _baseline_to_bottom;     /* when valign top or bottom */
    // lUInt16  padding;         /**< \brief not used */
 } formatted_word_t;
 
@@ -145,6 +147,10 @@ typedef struct
 #define LTEXT_WORD_DIRECTION_PARA_MASK       0x0F00
 #define LTEXT_WORD_DIRECTION_PARA_TO_LFNT_SHIFT   8
 #define WORD_FLAGS_TO_FNT_FLAGS(f) ( (f & LTEXT_WORD_DIRECTION_PARA_MASK)>>LTEXT_WORD_DIRECTION_PARA_TO_LFNT_SHIFT)
+
+
+#define LTEXT_WORD_VALIGN_TOP                0x1000 /// word is to be vertical-align: top
+#define LTEXT_WORD_VALIGN_BOTTOM             0x2000 /// word is to be vertical-align: bottom
 
 //#define LTEXT_BACKGROUND_MARK_FLAGS 0xFFFF0000l
 

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -73,6 +73,7 @@ extern "C" {
 
 #define LTEXT_SRC_IS_FLOAT           0x01000000  /**< \brief float:'ing node */
 #define LTEXT_SRC_IS_FLOAT_DONE      0x02000000  /**< \brief float:'ing node (already dealt with) */
+#define LTEXT_SRC_IS_INLINE_BOX      0x04000000  /**< \brief inlineBox wrapping node */
 
 /** \brief Source text line
 */
@@ -96,8 +97,10 @@ typedef struct
             lUInt16         offset;   /**< \brief offset from node start to beginning of line */
         } t;
         struct {
-            lInt16         width;    /**< \brief handle of font to draw string */
-            lInt16         height;   /**< \brief pointer to unicode text string */
+            // (Note: width & height will be stored negative when they are in % unit)
+            lInt16         width;    /**< \brief width of image or inline-block-box */
+            lInt16         height;   /**< \brief height of image or inline-block box */
+            lUInt16        baseline; /**< \brief baseline of inline-block box */
         } o;
     };
 } src_text_fragment_t;
@@ -121,7 +124,8 @@ typedef struct
        } t;
        /// for object
        struct {
-           lUInt16  height;          /**< \brief height of image */
+           lUInt16  height;          /**< \brief height of image or inline-block box */
+           lUInt16  baseline;        /**< \brief baseline of inline-block box */
        } o;
    };
    lInt16   _top_to_baseline;        /* temporary storage slots when delaying y computation, */
@@ -136,7 +140,8 @@ typedef struct
 #define LTEXT_WORD_MUST_BREAK_LINE_AFTER     0x0008 /// must break line after this word (not used anywhere)
 
 #define LTEXT_WORD_IS_LINK_START             0x0010 /// first word of link flag
-#define LTEXT_WORD_IS_OBJECT                 0x0020 /// object flag
+#define LTEXT_WORD_IS_OBJECT                 0x0020 /// word is an image
+#define LTEXT_WORD_IS_INLINE_BOX             0x0040 /// word is a inline-block or inline-table wrapping box
 
 #define LTEXT_WORD_DIRECTION_KNOWN           0x0100 /// word has been thru bidi: if next flag is unset, it is LTR.
 #define LTEXT_WORD_DIRECTION_IS_RTL          0x0200 /// word is RTL

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -664,6 +664,8 @@ public:
     void setTopOverflow( int dy );
     void setBottomOverflow( int dy );
 
+    int  getBaseline();
+    void setBaseline( int baseline );
     int  getListPropNodeIndex();
     void setListPropNodeIndex( int idx );
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1004,6 +1004,9 @@ public:
     bool getNodeListMarker( int & counterValue, lString16 & marker, int & markerWidth );
     /// is node a floating floatBox
     bool isFloatingBox();
+    /// is node an inlineBox that has not been re-inlined by having
+    /// its child no more inline-block/inline-table
+    bool isBoxingInlineBox();
 };
 
 
@@ -2321,7 +2324,7 @@ public:
     ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr );
 #if BUILD_LITE!=1
     /// create xpointer from doc point
-    ldomXPointer createXPointer( lvPoint pt, int direction=0, bool strictBounds=false );
+    ldomXPointer createXPointer( lvPoint pt, int direction=0, bool strictBounds=false, ldomNode * from_node=NULL );
     /// get rendered block cache object
     CVRendBlockCache & getRendBlockCache() { return _renderedBlockCache; }
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1740,6 +1740,11 @@ public:
 class ldomXRange {
     ldomXPointerEx _start;
     ldomXPointerEx _end;
+    /// _flags, only used by ldomXRangeList.getRanges() when making a ldomMarkedRangeList (for native
+    //  highlighting of a text selection being made, and for crengine internal bookmarks):
+    //  0: not shown (filtered out in LVDocView::updateSelections() by ldomXRangeList ranges(..., true))
+    //  1: legacy drawing (will make a single ldomMarkedRange spanning multiple lines, assuming full width LTR paragraphs)
+    //  2: enhanced drawing (will make multiple segmented ldomMarkedRange, each spanning a single line)
     lUInt32 _flags;
 public:
     ldomXRange()
@@ -1884,7 +1889,10 @@ public:
     lvPoint   start;
     /// end document point
     lvPoint   end;
-    /// flags
+    /// flags:
+    //  0: not shown
+    //  1: legacy drawing (a single mark may spans multiple lines, assuming full width LTR paragraphs)
+    //  2: enhanced drawing (segmented mark, spanning a single line)
     lUInt32   flags;
     bool empty()
     {

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -208,6 +208,10 @@ bool HyphMan::setTrustSoftHyphens( int trust_soft_hyphens ) {
     return true;
 }
 
+bool HyphMan::isEnabled() {
+    return _selectedDictionary != NULL && _selectedDictionary->getId() != HYPH_DICT_ID_NONE;
+}
+
 bool HyphDictionary::activate()
 {
     if (HyphMan::_selectedDictionary == this)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3931,6 +3931,8 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
 //     kind of decicated crengine cache for storing a variable number
 //     of things related to a node.
 
+#define NO_BASELINE_UPDATE 0x7FFFFFFF
+
 class FlowState {
 private:
     // BlockShift: backup of some FlowState fields when entering
@@ -4000,6 +4002,9 @@ private:
     int  in_y_max;    //   that overflow this level height)
     int  x_min;       // current left min x
     int  x_max;       // current right max x
+    int  baseline_req; // baseline type requested (REQ_BASELINE_FOR_INLINE_BLOCK or REQ_BASELINE_FOR_INLINE_TABLE)
+    int  baseline_y;   // baseline y relative to formatting context top (computed when rendering inline-block/table)
+    bool baseline_set; // (set to true on first baseline met)
     bool is_main_flow;
     int  top_clear_level; // level to attach floats for final clearance when leaving the flow
     bool avoid_pb_inside; // To carry this fact from upper elements to inner children
@@ -4033,6 +4038,9 @@ public:
         in_y_max(0),
         x_min(0),
         x_max(width),
+        baseline_req(REQ_BASELINE_NOT_NEEDED),
+        baseline_y(0),
+        baseline_set(false),
         avoid_pb_inside(false),
         avoid_pb_inside_just_toggled_on(false),
         avoid_pb_inside_just_toggled_off(false),
@@ -4099,6 +4107,87 @@ public:
     }
     bool getAvoidPbInside() {
         return avoid_pb_inside;
+    }
+
+    void setRequestedBaselineType(int baseline_req_type) {
+        baseline_req = baseline_req_type;
+    }
+    int getBaselineAbsoluteY(ldomNode * node=NULL) {
+        // Quotes from https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align
+        // Note that our table rendering code has not been updated to use FlowState,
+        // so, if top element is a table, we haven't got any baseline.
+        if ( baseline_req == REQ_BASELINE_FOR_INLINE_TABLE ) {
+            // "The baseline of an 'inline-table' is the baseline of the first
+            //  row of the table.
+            // Tests show that this is true even if the element with
+            // display: inline-table is not iself a table, but has a table
+            // as a child. But if there's any text non-table before the table,
+            // the baseline for that text is used.
+            // So, we should check for a table even when we have baseline_set
+            // and a baseline_y. The returned baseline will be the smallest
+            // of the two.
+            //
+            // Try to find the first table row, looking at descendants of the
+            // provided node (which must be the top node of this FlowState).
+            // Walk the tree up and down (avoid the need for recursion):
+            ldomNode * n = node;
+            ldomNode * rowNode = NULL;
+            if ( n && n->getChildCount() > 0 ) {
+                int nextChildIndex = 0;
+                n = n->getChildNode(nextChildIndex);
+                while ( true ) {
+                    // Check the node only the first time we meet it
+                    // (nextChildIndex == 0) and not when we get back
+                    // to it from a child to process next sibling
+                    if ( nextChildIndex == 0 ) {
+                        if ( n->getRendMethod() == erm_table_row ) {
+                            rowNode = n;
+                            break; // found the first row
+                        }
+                    }
+                    // Process next child
+                    if ( nextChildIndex < n->getChildCount() ) {
+                        n = n->getChildNode(nextChildIndex);
+                        nextChildIndex = 0;
+                        continue;
+                    }
+                    // No more child, get back to parent and have it process our sibling
+                    nextChildIndex = n->getNodeIndex() + 1;
+                    n = n->getParentNode();
+                    if ( n == node ) // all children done and back to top node
+                        break;
+                }
+            }
+            if ( rowNode ) {
+                // Get this row bottom y related to the top node y
+                RenderRectAccessor fmt( rowNode );
+                int row_bottom = fmt.getY() + fmt.getHeight();
+                ldomNode * n = rowNode->getParentNode();
+                for (; n && n!=node; n=n->getParentNode()) {
+                    RenderRectAccessor fmt(n);
+                    row_bottom += fmt.getY();
+                }
+                if ( !baseline_set || (row_bottom < baseline_y) ) {
+                    baseline_y = row_bottom;
+                }
+                // Not implemented: it seems that if any of this row cell has
+                // "vertical-align: baseline", it's no more the bottom of the
+                // row that should be the baseline, but this cell baseline...
+                // See (which has a hidden "#cell-of-first-row {vertical-align: baseline;}"
+                // which makes it behave as advertised:
+                // http://www.gtalbot.org/BrowserBugsSection/Safari3Bugs/baseline-inline-table-vertical-align.html
+                baseline_set = true;
+            }
+        }
+        if ( !baseline_set ) {
+            // "The baseline of an 'inline-block' is the baseline of its last line
+            //  box in the normal flow, unless it has either no in-flow line boxes
+            //  [or ...], in which case the baseline is the bottom margin edge."
+            // So, return what will be returned as height just after this
+            // function is called in renderBlockElement().
+            return getCurrentAbsoluteY();
+        }
+        return baseline_y;
     }
 
     bool hasActiveFloats() {
@@ -4177,7 +4266,7 @@ public:
         last_split_after_flag = RN_GET_SPLIT_AFTER(flags);
     }
 
-    int addContentLine( int height, int flags, bool is_padding=false ) {
+    int addContentLine( int height, int flags, int baseline=NO_BASELINE_UPDATE, bool is_padding=false ) {
         // As we may push vertical margins, we return the total height moved
         // (needed when adding bottom padding that may push inner vertical
         // margins, which should be accounted in the element height).
@@ -4226,6 +4315,39 @@ public:
         moveDown( height );
         if ( vm_disabled ) // Re-enable it now that some real content has been seen
             enableVerticalMargin();
+        if ( baseline_req != REQ_BASELINE_NOT_NEEDED ) {
+            // We don't update last baseline when adding padding or when none is provided
+            if ( !is_padding && baseline != NO_BASELINE_UPDATE ) {
+                // https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align
+                //   "The baseline of an 'inline-table' is the baseline of the first row
+                //    of the table.
+                //    The baseline of an 'inline-block' is the baseline of its last line
+                //    box in the normal flow, unless it has either no in-flow line boxes
+                //    [or ...], in which case the baseline is the bottom margin edge."
+                // Also see for some interesting sample snippet:
+                // https://stackoverflow.com/questions/19352072/what-is-the-difference-between-inline-block-and-inline-table/56305302#56305302
+                // A tricky thing with inline-table is that the baseline is different if
+                // there is a table of if there's not
+                // - if the first content line is a table row, it should be the bottom
+                //   margin of the row (and not the baseline of the first or last line
+                //   of any table cell of that row).
+                // - if the first content line is not a table row (we can have inline-table
+                //   containing no table-like elements), it is the real baseline of the
+                //   first line.
+                // As the rendering table code does not use FlowState, we manage the
+                // first case in getBaselineAbsoluteY() when we're done.
+                if ( baseline_req == REQ_BASELINE_FOR_INLINE_TABLE && baseline_set ) {
+                    // inline-table: first baseline already met, it will stay the final baseline
+                }
+                else { // inline-block
+                    // We update it from c_y which accounts for any vertical margins
+                    // pushed // when adding this line:
+                    baseline_y = c_y - height + baseline;
+                    if ( !baseline_set)
+                        baseline_set = true;
+                }
+            }
+        }
         return c_y - start_c_y;
     }
 
@@ -5979,7 +6101,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // We shift it half to the left, so a bit of it can be
                 // seen if some element on the right covers it with some
                 // background color.
-            flow->addContentLine( fmt.getHeight(), RN_SPLIT_BOTH_AVOID );
+            flow->addContentLine( fmt.getHeight(), RN_SPLIT_BOTH_AVOID, fmt.getHeight() );
             return;
         }
     }
@@ -6119,7 +6241,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
                 if (padding_top>0) {
                     // This may push accumulated vertical margin
-                    flow->addContentLine(padding_top, RN_SPLIT_AFTER_AVOID, true);
+                    flow->addContentLine(padding_top, RN_SPLIT_AFTER_AVOID, 0, true);
                 }
 
                 // Enter footnote body only after padding, to get rid of it
@@ -6280,7 +6402,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // (Firefox, with a float taller than text, both in another
                 // float, applies bottom padding after the inner float)
                 if (padding_bottom>0) {
-                    int padding_bottom_with_inner_pushed_vm = flow->addContentLine(padding_bottom, RN_SPLIT_BEFORE_AVOID, true);
+                    int padding_bottom_with_inner_pushed_vm = flow->addContentLine(padding_bottom, RN_SPLIT_BEFORE_AVOID, 0, true);
                     h += padding_bottom_with_inner_pushed_vm;
                     bottom_overflow -= padding_bottom_with_inner_pushed_vm;
                 }
@@ -6470,7 +6592,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
                 if (padding_top>0) {
                     // This may add accumulated margin
-                    flow->addContentLine(padding_top, RN_SPLIT_AFTER_AVOID, true);
+                    flow->addContentLine(padding_top, RN_SPLIT_AFTER_AVOID, 0, true);
                 }
 
                 // Enter footnote body after padding, to get rid of it
@@ -6521,7 +6643,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                             line_flags |= RN_SPLIT_AFTER_AVOID;
                     }
 
-                    flow->addContentLine(line->height, line_flags);
+                    flow->addContentLine(line->height, line_flags, line->baseline);
 
                     // See if there are links to footnotes in that line, and add
                     // a reference to it so page splitting can bring the footnotes
@@ -6588,7 +6710,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 }
 
                 if (padding_bottom>0) {
-                    flow->addContentLine(padding_bottom, RN_SPLIT_BEFORE_AVOID, true);
+                    flow->addContentLine(padding_bottom, RN_SPLIT_BEFORE_AVOID, 0, true);
                 }
 
                 // We need to forward our overflow for it to be carried
@@ -6605,14 +6727,14 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             break;
         default:
             CRLog::error("Unsupported render method %d", m);
-            crFatalError(); // error
+            crFatalError(141, "Unsupported render method"); // error
             break;
     }
     return;
 }
 
 // Entry points for rendering the root node, a table cell or a float
-int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int rend_flags )
+int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int * baseline, int rend_flags )
 {
     if ( BLOCK_RENDERING(rend_flags, ENHANCED) ) {
         // Create a flow state (aka "block formatting context") for the rendering
@@ -6621,7 +6743,15 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         // met along walking the root node hierarchy - and when meeting a new float
         // in a float, etc...)
         FlowState flow( context, width, rend_flags, direction );
+        if (baseline != NULL) {
+            flow.setRequestedBaselineType(*baseline);
+        }
         renderBlockElementEnhanced( &flow, enode, x, width, rend_flags );
+        if (baseline != NULL) {
+            // (We pass the top node, so it can find the first table row
+            // if needed with inline-table.)
+            *baseline = flow.getBaselineAbsoluteY(enode);
+        }
         // The block height is c_y when we are done
         return flow.getCurrentAbsoluteY();
     }
@@ -6630,11 +6760,11 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         return renderBlockElementLegacy( context, enode, x, y, width);
     }
 }
-int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction )
+int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int * baseline )
 {
     // Use global rendering flags
     // Note: we're not currently using it with other flags that the global ones.
-    return renderBlockElement( context, enode, x, y, width, direction, gRenderBlockRenderingFlags );
+    return renderBlockElement( context, enode, x, y, width, direction, baseline, gRenderBlockRenderingFlags );
 }
 
 //draw border lines,support color,width,all styles, not support border-collapse

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7774,7 +7774,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 fmt.push();
                 {
                     lvRect rc;
-                    enode->getAbsRect( rc );
+                    enode->getAbsRect( rc, true );
                     ldomMarkedRangeList *nbookmarks = NULL;
                     if ( bookmarks && bookmarks->length()) { // internal crengine bookmarked text highlights
                         nbookmarks = new ldomMarkedRangeList( bookmarks, rc );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4152,7 +4152,7 @@ public:
             line_h = 1;
         bool is_first = true;
         bool is_last = false;
-        int flags;
+        int flags = 0;;
         int y0 = starty;
         while (y0 < endy) {
             int y1 = y0 + line_h;
@@ -4435,6 +4435,13 @@ public:
             return;
         int line_dir_flag = direction == REND_DIRECTION_RTL ? RN_LINE_IS_RTL : 0;
 
+        // If this is a node at level 0 (root node, floatBox, inlineBox) or
+        // level 1 (body, floatBox or inlineBox single child), drop any back
+        // margin as we should get its full bottom margin (we should be called
+        // twice: for the top margin, and there is not back margin yet - and
+        // for the bottom margin, where there may be).
+        if (level <= (is_main_flow ? 0 : 1))
+            vm_back_usable_as_margin = 0;
         // Compute the single margin to add along our flow y and to pages context.
         int margin = getCurrentVerticalMargin();
         vm_back_usable_as_margin = 0;
@@ -5092,8 +5099,13 @@ public:
         // than 5), so we can fetch their real positions and dimensions
         // each time a final block is to be (re-)formatted, to allow
         // for a nicer layout of text around these (at most 5) floats.
-        BlockFloatFootprint footprint = BlockFloatFootprint( this, d_left, d_top,
-                                            BLOCK_RENDERING(rend_flags, DO_NOT_CLEAR_OWN_FLOATS) );
+
+        // We need erm_final at level 1 (body, floatBox or inlineBox child)
+        // to clear their own floats, to get them accounted in the document,
+        // float, or inlineBox height, so they are fully contained in it and
+        // don't overflow. (Level 0 can't be erm_final).
+        bool no_clear_own_floats = (level > 1) && BLOCK_RENDERING(rend_flags, DO_NOT_CLEAR_OWN_FLOATS);
+        BlockFloatFootprint footprint = BlockFloatFootprint( this, d_left, d_top, no_clear_own_floats);
         if (_floats.length() == 0) // zero footprint if no float
             return footprint;
         int top_y = c_y + d_top;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2385,7 +2385,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         // With valign_dy=0, they are centered on the baseline. We want
                         // them centered on their bottom line
                         if (is_object)
-                            valign_dy += (pfh - pfb);
+                            valign_dy += (pfh - pfb); // y for bottom of image (lvtextfm.cpp will know from flags)
                         else
                             valign_dy += (pfh - pfb) - (fh - fb) - f_half_leading;
                         flags |= LTEXT_VALIGN_TEXT_BOTTOM;
@@ -2402,16 +2402,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         break;
                     case css_va_bottom:
                         // "Align the bottom of the aligned subtree with the bottom of the line box"
-                        // This should most probably be re-computed once a full line has been laid
-                        // out, which would need us to do this in lvtextfm.cpp, and we would need to
-                        // go back words when the last word has been laid out...
-                        // This will be computed in lvtextfm.cpp to at least align according to the strut
+                        // This will be computed in lvtextfm.cpp when the full line has been laid out.
                         valign_dy = 0; // dummy value
                         flags |= LTEXT_VALIGN_BOTTOM;
                         break;
                     case css_va_top:
                         // "Align the top of the aligned subtree with the top of the line box."
-                        // This will be computed in lvtextfm.cpp to at least align according to the strut
+                        // This will be computed in lvtextfm.cpp when the full line has been laid out.
                         valign_dy = 0; // dummy value
                         flags |= LTEXT_VALIGN_TOP;
                         break;
@@ -2489,6 +2486,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
             // Also, the floating element vertical-align drift is dropped
             valign_dy = 0;
+            flags &= ~LTEXT_VALIGN_MASK; // also remove any such flag we've set
             // (Looks like nothing special to do with indent or line_h)
         }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1441,7 +1441,8 @@ public:
                             }
                         }
 
-                    } else if ( cell->elem->getRendMethod()!=erm_invisible ) {
+                    }
+                    else if ( cell->elem->getRendMethod()!=erm_invisible ) {
                         // We must use a different context (used by rendering
                         // functions to record, with context.AddLine(), each
                         // rendered block's height, to be used for splitting
@@ -2042,7 +2043,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
     // The UL > LI parent-child chain may have had a floatBox element
     // inserted if the LI has some float: style (also handled below
     // when walking this parent's children).
-    if ( parent->getNodeId() == el_floatBox ) {
+    if ( parent->getNodeId() == el_floatBox || parent->getNodeId() == el_inlineBox ) {
         parent = parent->getParentNode();
     }
     ListNumberingPropsRef listProps =  enode->getDocument()->getNodeNumberingProps( parent->getDataIndex() );
@@ -2053,7 +2054,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             lString16 marker;
             int markerWidth = 0;
             ldomNode * child = parent->getChildElementNode(i);
-            if ( child->getNodeId() == el_floatBox ) {
+            if ( child->getNodeId() == el_floatBox || child->getNodeId() == el_inlineBox ) {
                 child = child->getChildNode(0);
             }
             if ( child && child->getNodeListMarker( counterValue, marker, markerWidth ) ) {
@@ -2179,8 +2180,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         const css_elem_def_props_t * ntype = enode->getElementTypePtr();
         if ( ntype && ntype->is_object )
             is_object = true;
-        //RenderRectAccessor fmt2( enode );
-        //fmt = &fmt2;
+        // inline-block boxes are handled below quite just like inline images/is_object
+        bool is_inline_box = enode->isBoxingInlineBox();
 
         int direction = RENDER_RECT_PTR_GET_DIRECTION(fmt);
         bool is_rtl = direction == REND_DIRECTION_RTL;
@@ -2201,6 +2202,9 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         int width = fmt->getWidth();
         int em = enode->getFont()->getSize();
         css_style_rec_t * style = enode->getStyle().get();
+        ldomNode * parent = enode->getParentNode(); // Needed for various checks below
+        if (parent && parent->isNull())
+            parent = NULL;
 
         // As seen with Firefox, an inline node line-height: do apply, so we need
         // to compute it for all inline nodes, and not only in the "the top and
@@ -2337,8 +2341,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             int pem = em;
             int pfh = fh;
             int pfb = fb;
-            ldomNode *parent = enode->getParentNode();
-            if (parent && !parent->isNull()) {
+            if (parent) {
                 pem = parent->getFont()->getSize();
                 pfh = parent->getFont()->getHeight();
                 pfb = parent->getFont()->getBaseline();
@@ -2369,7 +2372,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         // For CSS lengths, we approximate 'ex' with 1/2 'em'. Let's do the same here.
                         // (Firefox falls back to 0.56 x ascender for x-height:
                         //   valign_dy -= 0.56 * pfb / 2;  but this looks a little too low)
-                        if (is_object)
+                        if (is_object || is_inline_box)
                             valign_dy -= pem/4; // y for middle of image (lvtextfm.cpp will know from flags)
                         else {
                             valign_dy += fb - fh/2; // move down current middle point to baseline
@@ -2384,7 +2387,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         // "Align the bottom of the box with the bottom of the parent's content area"
                         // With valign_dy=0, they are centered on the baseline. We want
                         // them centered on their bottom line
-                        if (is_object)
+                        if (is_object || is_inline_box)
                             valign_dy += (pfh - pfb); // y for bottom of image (lvtextfm.cpp will know from flags)
                         else
                             valign_dy += (pfh - pfb) - (fh - fb) - f_half_leading;
@@ -2394,7 +2397,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         // "Align the top of the box with the top of the parent's content area"
                         // With valign_dy=0, they are centered on the baseline. We want
                         // them centered on their top line
-                        if (is_object)
+                        if (is_object || is_inline_box)
                             valign_dy -= pfb; // y for top of image (lvtextfm.cpp will know from flags)
                         else
                             valign_dy -= pfb - fb - f_half_leading;
@@ -2460,7 +2463,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
         // Firefox has some specific behaviour with floats, which
         // is not obvious from the specs. Let's do as it does.
-        if ( enode->getParentNode() && enode->getParentNode()->isFloatingBox() ) {
+        // It looks like we should do the same for inline-block boxes
+        if ( parent && (parent->isFloatingBox() || parent->isBoxingInlineBox()) ) {
             if ( rm == erm_final && is_object ) {
                 // When an image is the single top final node in a float (which is
                 // the case for individual floating images (<IMG style="float: left">),
@@ -2484,7 +2488,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     style = enode->getStyle().get(); // update to the new style
                 }
             }
-            // Also, the floating element vertical-align drift is dropped
+            // Also, the floating element or inline-block inner element vertical-align drift is dropped
             valign_dy = 0;
             flags &= ~LTEXT_VALIGN_MASK; // also remove any such flag we've set
             // (Looks like nothing special to do with indent or line_h)
@@ -2498,7 +2502,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             ListNumberingPropsRef listProps =  enode->getDocument()->getNodeNumberingProps( enode->getParentNode()->getDataIndex() );
             if ( listProps.isNull() ) {
                 int counterValue = 0;
-                ldomNode * parent = enode->getParentNode();
                 int maxWidth = 0;
                 for ( int i=0; i<parent->getChildCount(); i++ ) {
                     lString16 marker;
@@ -2564,9 +2567,9 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         }
 
         if ( is_object ) { // object element, like <IMG>
-#ifdef DEBUG_DUMP_ENABLED
-            logfile << "+OBJECT ";
-#endif
+            #ifdef DEBUG_DUMP_ENABLED
+                logfile << "+OBJECT ";
+            #endif
             bool isBlock = style->display == css_d_block;
             if ( isBlock ) {
                 // If block image, forget any current flags and start from baseflags (?)
@@ -2607,11 +2610,20 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
+        else if ( is_inline_box ) { // inline-block wrapper
+            #ifdef DEBUG_DUMP_ENABLED
+                logfile << "+INLINEBOX ";
+            #endif
+            // We use the flags computed previously (and not baseflags) as they
+            // carry vertical alignment
+            txform->AddSourceObject(flags|LTEXT_SRC_IS_INLINE_BOX, line_h, valign_dy, ident, enode );
+            flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
+        }
         else { // non-IMG element: render children (elements or text nodes)
             int cnt = enode->getChildCount();
-#ifdef DEBUG_DUMP_ENABLED
-            logfile << "+BLOCK [" << cnt << "]";
-#endif
+            #ifdef DEBUG_DUMP_ENABLED
+                logfile << "+BLOCK [" << cnt << "]";
+            #endif
             // Usual elements
             bool thisIsRunIn = style->display==css_d_run_in;
             if ( thisIsRunIn )
@@ -2778,18 +2790,15 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
 
-
-#ifdef DEBUG_DUMP_ENABLED
-      for (int i=0; i<enode->getNodeLevel(); i++)
-        logfile << " . ";
-#endif
-#ifdef DEBUG_DUMP_ENABLED
-        lvRect rect;
-        enode->getAbsRect( rect );
-        logfile << "<" << enode->getNodeName() << ">     flags( "
-            << baseflags << "-> " << flags << ")  rect( "
-            << rect.left << rect.top << rect.right << rect.bottom << ")\n";
-#endif
+        #ifdef DEBUG_DUMP_ENABLED
+            for (int i=0; i<enode->getNodeLevel(); i++)
+                logfile << " . ";
+            lvRect rect;
+            enode->getAbsRect( rect );
+            logfile << "<" << enode->getNodeName() << ">     flags( "
+                << baseflags << "-> " << flags << ")  rect( "
+                << rect.left << rect.top << rect.right << rect.bottom << ")\n";
+        #endif
 
         // Children may have consumed the newline flag, or may have added one
         // (if the last one of them is a <BR>, it will not have been consumed
@@ -2879,17 +2888,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
     else if ( enode->isText() ) {
         // text nodes
         lString16 txt = enode->getText();
-        if ( !txt.empty() )
-        {
-
-#ifdef DEBUG_DUMP_ENABLED
-      for (int i=0; i<enode->getNodeLevel(); i++)
-        logfile << " . ";
-#endif
-#ifdef DEBUG_DUMP_ENABLED
-            logfile << "#text" << " flags( "
-                << baseflags << ")\n";
-#endif
+        if ( !txt.empty() ) {
+            #ifdef DEBUG_DUMP_ENABLED
+                for (int i=0; i<enode->getNodeLevel(); i++)
+                    logfile << " . ";
+                logfile << "#text" << " flags( "
+                    << baseflags << ")\n";
+            #endif
 
             ldomNode * parent = enode->getParentNode();
             int tflags = LTEXT_FLAG_OWNTEXT;
@@ -2979,7 +2984,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         }
     }
     else {
-        crFatalError();
+        crFatalError(142, "Unexpected node type");
     }
 }
 
@@ -3408,6 +3413,12 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                 style_width_pct_em_only = false; // width for <hr> is safe, whether px or %
             }
 
+            // Note: we should not handle css_d_inline_table like css_d_table,
+            // as it may be used with non-table elements.
+            // But we might want to handle (css_d_inline_table & el_table) like we
+            // handle css_d_table here and in the 3 other places below - but after
+            // some quick thinking (but no check in a browser) it feels we should not,
+            // and we'd better ensure and apply style width.
             if (apply_style_width && style->display >= css_d_table ) {
                 // table elements are managed elsewhere: we'd rather not mess with the table
                 // layout algorithm by applying styles width here (even if this algorithm
@@ -3734,7 +3745,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                 return 0;
             default:
                 CRLog::error("Unsupported render method %d", m);
-                crFatalError(); // error
+                crFatalError(141, "Unsupported render method"); // error
                 break;
             }
         }
@@ -5611,6 +5622,9 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool is_floating = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES) && enode->isFloatingBox();
     bool is_floatbox_child = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES)
             && enode->getParentNode() && enode->getParentNode()->isFloatingBox();
+    // is this a inline block container (inlineBox)?
+    bool is_inline_box = enode->isBoxingInlineBox();
+    bool is_inline_box_child = enode->getParentNode() && enode->getParentNode()->isBoxingInlineBox();
 
     int em = enode->getFont()->getSize();
 
@@ -5656,7 +5670,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool apply_style_height = false;
     css_length_t style_height;
     int style_height_base_em;
-    if ( is_floating ) {
+    if ( is_floating || is_inline_box ) {
         // Nothing special to do: the child style height will be
         // enforced by subcall to renderBlockElement(child)
     }
@@ -5691,8 +5705,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool auto_width = false;
     bool table_shrink_to_fit = false;
 
-    if ( is_floating ) {
-        // Floats width computation
+    if ( is_floating || is_inline_box ) {
+        // Floats width computation - which should also work as-is for inline block box
         // We need to have a width for floats, so we don't ignore anything no
         // matter the flags.
         // As the el_floatBox itself does not have any style->width or margins,
@@ -5791,7 +5805,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         auto_width = true; // no more width tweaks (nor any x adjustment if is_rtl)
         // printf("floatBox width: max_w=%d min_w=%d => %d", max_content_width, min_content_width, width);
     }
-    else if ( is_floatbox_child ) {
+    else if ( is_floatbox_child || is_inline_box_child ) {
         // The float style or rendered width has been applied to the wrapping
         // floatBox, so just remove node's margins of the container (the
         // floatBox) to get the child width.
@@ -6019,10 +6033,12 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         // We'll push it immediately below
         no_margin_collapse = true;
     }
-    else if ( flow->getCurrentLevel() == 1 && enode->getParentNode()->isFloatingBox() ) {
+    else if ( flow->getCurrentLevel() == 1 && (enode->getParentNode()->isFloatingBox() ||
+                                               enode->getParentNode()->isBoxingInlineBox()) ) {
         // The inner margin of the real float element (the single child of a floatBox)
         // have to be pushed and not collapse with outer margins so they can
         // get accounted in the float height.
+        // (This must be true also with inline-block boxes, but not tested/verified.)
         no_margin_collapse = true;
     }
 
@@ -6177,7 +6193,17 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             }
             break;
         case erm_block:
+        case erm_inline: // For inlineBox elements only
             {
+                if (m == erm_inline && enode->getNodeId() != el_inlineBox) {
+                    printf("CRE WARNING: node discarded (unexpected erm_inline for elem %s)\n",
+                                UnicodeToLocal(ldomXPointer(enode, 0).toString()).c_str());
+                                // (add %s and enode->getText8().c_str() to see text content)
+                    // Might be too early after introducing inline-block support to crash:
+                    // let's just output this warning and ignore the node content.
+                    // crFatalError(143, "erm_inline for element not inlineBox");
+                    return;
+                }
                 // Deal with list item marker
                 // List item marker rendering when css_d_list_item_block
                 int list_marker_padding = 0; // set to non-zero when list-style-position = outside
@@ -7483,7 +7509,13 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 color = colors2[enode->getNodeLevel() & 7];
         #endif
 
-        switch( enode->getRendMethod() )
+        int m = enode->getRendMethod();
+        // We should not get erm_inline, except for inlineBox elements, that
+        // we must draw as erm_block
+        if ( m == erm_inline && enode->isBoxingInlineBox() ) {
+            m = erm_block;
+        }
+        switch( m )
         {
         case erm_table:
         case erm_table_row:
@@ -7925,6 +7957,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
 
+    // display before stylesheet is applied (for fallback below if legacy mode)
+    css_display_t orig_elem_display = pstyle->display;
+
     // not used (could be used for 'rem', but we have it in gRootFontSize)
     // int baseFontSize = enode->getDocument()->getDefaultFont()->getSize();
 
@@ -8010,7 +8045,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                         pstyle->display = css_d_block;
                     }
                 }
-                // Else (child_style non-null), it's a re-rendering: nothing special
+                // Else (child_style is null), it's a re-rendering: nothing special
                 // to do, this will be dealt with later by initNodeRendMethod().
             }
         }
@@ -8021,6 +8056,56 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         // and a popup inviting the user to reload, to get rid of
         // floatBox elements.
         pstyle->float_ = css_f_none;
+    }
+
+    if ( BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) ) {
+        // See above, same reasoning
+        if ( enode->getNodeId() == el_inlineBox ) {
+            if (enode->getChildCount() == 1) {
+                ldomNode * child = enode->getChildNode(0);
+                css_style_ref_t child_style = child->getStyle();
+                if ( ! child_style.isNull() ) { // Initial XML loading phase
+                    // This child_style is only non-null on the initial XML loading.
+                    // We do as in ldomNode::initNodeRendMethod() when the inlineBox
+                    // is already there (on re-renderings):
+                    // (If this is an inlineBox in the initial XML loading phase,
+                    // child is necessarily css_d_inline_block or css_d_inline_table.
+                    // The following 'else's should never trigger.
+                    if (child_style->display == css_d_inline_block || child_style->display == css_d_inline_table) {
+                        pstyle->display = css_d_inline; // become an inline wrapper
+                        pstyle->vertical_align = child_style->vertical_align;
+                    }
+                    else if (child_style->display == css_d_inline) {
+                        pstyle->display = css_d_inline; // wrap inline in inline
+                    }
+                    else if (child_style->display == css_d_none) {
+                        pstyle->display = css_d_none; // stay invisible
+                    }
+                    else { // everything else must be wrapped by a block
+                        pstyle->display = css_d_block;
+                    }
+                }
+                // Else (child_style is null), it's a re-rendering: nothing special
+                // to do, this will be dealt with later by initNodeRendMethod().
+            }
+        }
+    }
+    else {
+        // Legacy rendering or enhanced with no inline-block support
+        // Fallback to the default style for the element
+        // (before enhanced rendering, css_d_inline_block did not exist, so the
+        // node probably stayed with the default display: of the element when
+        // no other lower specificity CSS set another).
+        if ( pstyle->display == css_d_inline_block || pstyle->display == css_d_inline_table ) {
+            if ( !BLOCK_RENDERING_G(ENHANCED) && pstyle->display == css_d_inline_table ) {
+                // In legacy mode, inline-table was handled like css_d_block (as all
+                // not specifically handled css_d_* are, so probably unwillingly).
+                pstyle->display = css_d_block;
+            }
+            else {
+                pstyle->display = orig_elem_display;
+            }
+        }
     }
 
     // update inherited style attributes
@@ -8273,13 +8358,14 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
     int lastSpaceWidth = 0; // trailing spaces width to remove
     // These do not need to be passed by reference, as they are only valid for inner nodes/calls
     int indent = 0;         // text-indent: used on first text, and set again on <BR/>
+    bool isStartNode = true; // we are starting measurement on that node
     // Start measurements and recursions:
     getRenderedWidths(node, maxWidth, minWidth, direction, ignoreMargin, rendFlags,
-        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent);
+        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, isStartNode);
 }
 
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction, bool ignoreMargin, int rendFlags,
-    int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth, int indent)
+    int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth, int indent, bool isStartNode)
 {
     // This does mostly what renderBlockElement, renderFinalBlock and lvtextfm.cpp
     // do, but only with widths and horizontal margin/border/padding and indent
@@ -8295,6 +8381,15 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         int m = node->getRendMethod();
         if (m == erm_invisible)
             return;
+
+        if ( isStartNode && node->isBoxingInlineBox() ) {
+            // The inlineBox is erm_inline, and we'll be measuring it below
+            // as part of measuring other erm_inline in some erm_final.
+            // If isStartNode, we want to measure its content, so switch
+            // to handle it like erm_block.
+            m = erm_block;
+        }
+
         css_style_rec_t * style = node->getStyle().get();
 
         // Get image size early
@@ -8388,6 +8483,22 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 curWordWidth = indent;
                 collapseNextSpace = true; // skip leading spaces
                 lastSpaceWidth = 0;
+                return;
+            }
+            if ( node->isBoxingInlineBox() ) {
+                // Get done with previous word
+                if (curWordWidth > minWidth)
+                    minWidth = curWordWidth;
+                curWordWidth = 0;
+                collapseNextSpace = false;
+                lastSpaceWidth = 0;
+                // Get the rendered width of the inlineBox
+                int _maxw = 0;
+                int _minw = 0;
+                getRenderedWidths(node, _maxw, _minw, direction, false, rendFlags);
+                maxWidth += _maxw;
+                if (_minw > minWidth)
+                    minWidth = _minw;
                 return;
             }
             // Contains only other inline or text nodes:

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -317,6 +317,15 @@ void LFormattedText::AddSourceObject(
             // as the code may grab them from the first source)
         return;
     }
+    if (flags & LTEXT_SRC_IS_INLINE_BOX) { // not an image but a inline-block wrapping node
+        // Nothing much to do with it at this point: we can't yet render it to
+        // get its width & neight, as they might be in % of our main width, that
+        // we don't know yet (but only when ->Format() is called).
+        lvtextAddSourceObject(m_pbuffer, 0, 0,
+            flags, interval, valign_dy, margin, object, letter_spacing );
+            // lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT
+        return;
+    }
 
     LVImageSourceRef img = node->getObjectImageSource();
     if ( img.isNull() )
@@ -396,8 +405,14 @@ public:
     bool m_has_bidi; // true when Bidi (or pure RTL) detected
     bool m_para_dir_is_rtl; // boolean shortcut of m_para_bidi_type
 
-#define OBJECT_CHAR_INDEX ((lUInt16)0xFFFF)
-#define FLOAT_CHAR_INDEX  ((lUInt16)0xFFFE)
+// These are not unicode codepoints: these values are put where we
+// store text indexes in the source text node.
+// So, when checking for these, also checks for m_flags[i] & LCHAR_IS_OBJECT.
+// Note that m_charindex, being lUInt16, assume text nodes are not longer
+// than 65535 chars. Things will get messy with longer text nodes...
+#define OBJECT_CHAR_INDEX     ((lUInt16)0xFFFF)
+#define FLOAT_CHAR_INDEX      ((lUInt16)0xFFFE)
+#define INLINEBOX_CHAR_INDEX  ((lUInt16)0xFFFD)
 
     LVFormatter(formatted_text_fragment_t * pbuffer)
     : m_pbuffer(pbuffer), m_length(0), m_size(0), m_staticBufs(true), m_y(0)
@@ -557,7 +572,7 @@ public:
         bool already_rendered = false;
         { // in its own scope, so this RenderRectAccessor is forgotten when left
             RenderRectAccessor fmt( node );
-            if ( RENDER_RECT_HAS_FLAG(fmt, FLOATBOX_IS_RENDERED) )
+            if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_RENDERED) )
                 already_rendered = true;
             // We could also directly use fmt.getX/Y() if it has already been
             // positionned, and avoid the positionning code below.
@@ -614,7 +629,7 @@ public:
                             RENDER_RECT_SET_FLAG(fmt, FLOATBOX_IS_RIGHT);
                         else
                             RENDER_RECT_UNSET_FLAG(fmt, FLOATBOX_IS_RIGHT);
-                        RENDER_RECT_SET_FLAG(fmt, FLOATBOX_IS_RENDERED);
+                        RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
                         // Small trick for elements with negative margins (invert dropcaps)
                         // that would overflow above flt->x, to avoid a page split by
                         // sticking the line to the hopefully present margin-top that
@@ -654,7 +669,7 @@ public:
                 RENDER_RECT_SET_FLAG(fmt, FLOATBOX_IS_RIGHT);
             else
                 RENDER_RECT_UNSET_FLAG(fmt, FLOATBOX_IS_RIGHT);
-            RENDER_RECT_SET_FLAG(fmt, FLOATBOX_IS_RENDERED);
+            RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
         }
         m_has_float_to_position = false;
     }
@@ -765,6 +780,9 @@ public:
             if ( src->flags & LTEXT_SRC_IS_FLOAT ) {
                 pos++;
             }
+            else if ( src->flags & LTEXT_SRC_IS_INLINE_BOX ) {
+                pos++;
+            }
             else if ( src->flags & LTEXT_SRC_IS_OBJECT ) {
                 pos++;
                 if (!m_has_images) {
@@ -784,7 +802,8 @@ public:
                         m_has_images = true;
                     }
                 }
-            } else {
+            }
+            else {
                 pos += src->t.len;
             }
         }
@@ -913,6 +932,15 @@ public:
                     // to change what we did for floats to use a new flag.
                 pos++;
                 // No need to update prev_was_space or last_non_space_pos
+            }
+            else if ( src->flags & LTEXT_SRC_IS_INLINE_BOX ) {
+                m_text[pos] = 0;
+                m_srcs[pos] = src;
+                m_flags[pos] = LCHAR_IS_OBJECT | LCHAR_ALLOW_WRAP_AFTER;
+                m_charindex[pos] = INLINEBOX_CHAR_INDEX; //0xFFFD;
+                last_non_space_pos = pos;
+                prev_was_space = false;
+                pos++;
             }
             else if ( src->flags & LTEXT_SRC_IS_OBJECT ) {
                 m_text[pos] = 0;
@@ -1350,8 +1378,7 @@ public:
             bool prevCharIsObject = false;
             if ( i<m_length ) {
                 newSrc = m_srcs[i];
-                isObject = m_charindex[i] == OBJECT_CHAR_INDEX ||
-                           m_charindex[i] == FLOAT_CHAR_INDEX;
+                isObject = m_flags[i] & LCHAR_IS_OBJECT; // image, float or inline box
                 newFont = isObject ? NULL : (LVFont *)newSrc->t.font;
                 newLetterSpacing = newSrc->letter_spacing; // 0 for objects
                 #if (USE_HARFBUZZ==1)
@@ -1365,8 +1392,7 @@ public:
                 #endif
             }
             if (i > 0)
-                prevCharIsObject = m_charindex[i-1] == OBJECT_CHAR_INDEX ||
-                                   m_charindex[i-1] == FLOAT_CHAR_INDEX;
+                prevCharIsObject = m_flags[i-1] & LCHAR_IS_OBJECT; // image, float or inline box
             if ( !lastFont )
                 lastFont = newFont;
             if (i == 0) {
@@ -1434,7 +1460,7 @@ public:
                              || (m_flags[i] & LCHAR_IS_TO_IGNORE)
                              || (m_flags[i] & LCHAR_MANDATORY_NEWLINE) ) ) {
                 // measure start..i-1 chars
-                if ( m_charindex[i-1]!=OBJECT_CHAR_INDEX && m_charindex[i-1]!=FLOAT_CHAR_INDEX ) {
+                if ( !(m_flags[i-1] & LCHAR_IS_OBJECT) ) { // neither image, float, nor inline box
                     // measure text
                     // Note: we provide text in the logical order, and measureText()
                     // will apply kerning in that order, which might be wrong if some
@@ -1536,27 +1562,91 @@ public:
                     //m_flags[len] = 0;
                     // TODO: letter spacing letter_spacing
                 }
-                else if ( m_charindex[start] == FLOAT_CHAR_INDEX) {
-                    // Embedded floats can have a zero width in this process of
-                    // text measurement. They'll be measured when positionned.
-                    m_widths[start] = lastWidth;
-                }
-                else {
-                    // measure object
-                    // assume i==start+1
-                    int width = m_srcs[start]->o.width;
-                    int height = m_srcs[start]->o.height;
-                    width=width<0?-width*(m_pbuffer->width)/100:width;
-                    height=height<0?-height*(m_pbuffer->width)/100:height;
-                    /*
-                    printf("measureText img: o.w=%d o.h=%d > w=%d h=%d (max %d %d is_inline=%d) %s\n",
-                        m_srcs[start]->o.width, m_srcs[start]->o.height, width, height,
-                        m_pbuffer->width, m_max_img_height, m_length>1,
-                        UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
-                    */
-                    resizeImage(width, height, m_pbuffer->width, m_max_img_height, m_length>1);
-                    lastWidth += width;
-                    m_widths[start] = lastWidth;
+                else { // measure object
+                    // We have start=i-1 and m_flags[i-1] & LCHAR_IS_OBJECT
+                    if (start != i-1) {
+                        crFatalError(126, "LCHAR_IS_OBJECT with start!=i-1");
+                    }
+                    if ( m_charindex[start] == FLOAT_CHAR_INDEX ) {
+                        // Embedded floats can have a zero width in this process of
+                        // text measurement. They'll be measured when positionned.
+                        m_widths[start] = lastWidth;
+                    }
+                    else if ( m_charindex[start] == INLINEBOX_CHAR_INDEX ) {
+                        // Render this inlineBox to get its width, similarly to how we
+                        // render floats in addFloat(). See there for more comments.
+                        src_text_fragment_t * src = m_srcs[start];
+                        ldomNode * node = (ldomNode *) src->object;
+                        bool already_rendered = false;
+                        { // in its own scope, so this RenderRectAccessor is forgotten when left
+                            RenderRectAccessor fmt( node );
+                            if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_RENDERED) ) {
+                                already_rendered = true;
+                            }
+                        }
+                        if ( !already_rendered ) {
+                            LVRendPageContext emptycontext( NULL, m_pbuffer->page_height );
+                            // inline-block and inline-table have a baseline, that renderBlockElement()
+                            // will compute and give us back.
+                            int baseline = REQ_BASELINE_FOR_INLINE_BLOCK;
+                            if ( node->getChildNode(0)->getStyle()->display == css_d_inline_table )
+                                baseline = REQ_BASELINE_FOR_INLINE_TABLE;
+                            // We render the inlineBox with the specified direction (from upper dir=), even
+                            // if UNSET (and not with the direction determined by fribidi from the text).
+                            renderBlockElement( emptycontext, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );
+                            // (renderBlockElement will ensure style->height if requested.)
+
+                            RenderRectAccessor fmt( node );
+                            fmt.setBaseline(baseline);
+                            RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
+                            // We'll have alignLine() do the fmt.setX/Y once it is fully positionned
+
+                            // We'd like to gather footnote links accumulated by emptycontext
+                            // (we do that for floats), but it's quite more complicated:
+                            // we have them here too early, and we would need to associate
+                            // the links to this "char" index, so needing in LVFormatter
+                            // something like:
+                            //   LVHashTable<lUInt32, lString16Collection> m_inlinebox_links
+                            // When adding this inlineBox to a frmline, we could then get back
+                            // the links, and associate them to the frmline (so, needing a
+                            // new field holding a lString16Collection, which would hold
+                            // all the links in all the inlineBoxs part of that line).
+                            // Finally, in renderBlockElementEnhanced, when adding
+                            // links for words, we'd also need to add the one found
+                            // in the frmline's lString16Collection.
+                            // A bit complicated, for a probably very rare case, so
+                            // let's just forget it and not have footnotes from inlineBox
+                            // among our in-page footnotes...
+                        }
+                        // (renderBlockElement() above may update our RenderRectAccessor(),
+                        // so (re)get it only now)
+                        RenderRectAccessor fmt( node );
+                        int width = fmt.getWidth();
+                        int height = fmt.getHeight();
+                        int baseline = fmt.getBaseline();
+                        m_srcs[start]->o.width = width;
+                        m_srcs[start]->o.height = height;
+                        m_srcs[start]->o.baseline = baseline;
+                        lastWidth += width;
+                        m_widths[start] = lastWidth;
+                    }
+                    else {
+                        // measure image
+                        // assume i==start+1
+                        int width = m_srcs[start]->o.width;
+                        int height = m_srcs[start]->o.height;
+                        width=width<0?-width*(m_pbuffer->width)/100:width;
+                        height=height<0?-height*(m_pbuffer->width)/100:height;
+                        /*
+                        printf("measureText img: o.w=%d o.h=%d > w=%d h=%d (max %d %d is_inline=%d) %s\n",
+                            m_srcs[start]->o.width, m_srcs[start]->o.height, width, height,
+                            m_pbuffer->width, m_max_img_height, m_length>1,
+                            UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
+                        */
+                        resizeImage(width, height, m_pbuffer->width, m_max_img_height, m_length>1);
+                        lastWidth += width;
+                        m_widths[start] = lastWidth;
+                    }
                 }
                 start = i;
                 #if (USE_HARFBUZZ==1)
@@ -1603,7 +1693,7 @@ public:
 #define MAX_WORD_SIZE 64
 
     /// align line: add or reduce widths of spaces to achieve desired text alignment
-    void alignLine( formatted_line_t * frmline, int alignment, int rightIndent=0 ) {
+    void alignLine( formatted_line_t * frmline, int alignment, int rightIndent=0, bool hasInlineBoxes=false ) {
         // Fetch current line x offset and max width
         int x_offset;
         int width = getAvailableWidthAtY(m_y, m_pbuffer->strut_height, x_offset);
@@ -1641,38 +1731,58 @@ public:
                     }
                 }
             }
-        } else if ( alignment==LTEXT_ALIGN_LEFT )
-            return; // no additional alignment necessary
+        }
+        else if ( alignment==LTEXT_ALIGN_LEFT ) {
+            // no additional alignment necessary
+        }
         else if ( alignment==LTEXT_ALIGN_CENTER ) {
             frmline->x += available_width / 2;
-        } else if ( alignment==LTEXT_ALIGN_RIGHT ) {
+        }
+        else if ( alignment==LTEXT_ALIGN_RIGHT ) {
             frmline->x += available_width;
-        } else {
+        }
+        else {
             // LTEXT_ALIGN_WIDTH
-            if ( available_width <= 0 )
-                return; // no space to distribute
-            int extraSpace = available_width;
-            int addSpacePoints = 0;
-            int i;
-            for ( i=0; i<(int)frmline->word_count-1; i++ ) {
-                if ( frmline->words[i].flags & LTEXT_WORD_CAN_ADD_SPACE_AFTER )
-                    addSpacePoints++;
-            }
-            if ( addSpacePoints>0 ) {
-                int addSpaceDiv = extraSpace / addSpacePoints;
-                int addSpaceMod = extraSpace % addSpacePoints;
-                int delta = 0;
-                for ( i=0; i<(int)frmline->word_count; i++ ) {
-                    frmline->words[i].x += delta;
-                    if ( frmline->words[i].flags & LTEXT_WORD_CAN_ADD_SPACE_AFTER ) {
-                        delta += addSpaceDiv;
-                        if ( addSpaceMod>0 ) {
-                            addSpaceMod--;
-                            delta++;
+            if ( available_width > 0 ) {
+                // distribute additional space
+                int extraSpace = available_width;
+                int addSpacePoints = 0;
+                int i;
+                for ( i=0; i<(int)frmline->word_count-1; i++ ) {
+                    if ( frmline->words[i].flags & LTEXT_WORD_CAN_ADD_SPACE_AFTER )
+                        addSpacePoints++;
+                }
+                if ( addSpacePoints>0 ) {
+                    int addSpaceDiv = extraSpace / addSpacePoints;
+                    int addSpaceMod = extraSpace % addSpacePoints;
+                    int delta = 0;
+                    for ( i=0; i<(int)frmline->word_count; i++ ) {
+                        frmline->words[i].x += delta;
+                        if ( frmline->words[i].flags & LTEXT_WORD_CAN_ADD_SPACE_AFTER ) {
+                            delta += addSpaceDiv;
+                            if ( addSpaceMod>0 ) {
+                                addSpaceMod--;
+                                delta++;
+                            }
                         }
                     }
+                    frmline->width += extraSpace;
                 }
-                frmline->width += extraSpace;
+            }
+        }
+        if ( hasInlineBoxes ) {
+            // Now that we have the final x of each word, we can update
+            // the RenderRectAccessor x/y of each word that is a inlineBox
+            // (needed to correctly draw highlighted text in them).
+            for ( int i=0; i<frmline->word_count; i++ ) {
+                if ( frmline->words[i].flags & LTEXT_WORD_IS_INLINE_BOX ) {
+                    formatted_word_t * word = &frmline->words[i];
+                    src_text_fragment_t * srcline = &m_pbuffer->srctext[word->src_text_index];
+                    ldomNode * node = (ldomNode *) srcline->object;
+                    RenderRectAccessor fmt( node );
+                    fmt.setX( frmline->x + word->x );
+                    fmt.setY( frmline->y + frmline->baseline - word->o.baseline + word->y );
+                }
             }
         }
     }
@@ -1966,9 +2076,12 @@ public:
             // Not used yet, but might be useful (we may have a bidi line
             // in a LTR paragraph).
         }
+
         // Some words vertical-align positionning might need to be fixed
         // only once the whole line has been laid out
         bool delayed_valign_computation = false;
+        // alignLine() will have more work to do if we have inlineBox elements
+        bool has_inline_boxes = false;
 
         // Ignore space at start of line (this rarely happens, as line
         // splitting discards the space on which a split is made - but it
@@ -2168,36 +2281,45 @@ public:
                 bool adjust_line_box = true;
 
                 if ( lastSrc->flags & LTEXT_SRC_IS_OBJECT ) {
-                    // object
+                    // object: image or inline-block box (floats have been skipped above)
                     word->x = frmline->width;
-                    word->flags = LTEXT_WORD_IS_OBJECT;
                     word->width = lastSrc->o.width;
                     word->min_width = word->width;
                     word->o.height = lastSrc->o.height;
-                    //int maxw = m_pbuffer->width - x;
+                    if ( lastSrc->flags & LTEXT_SRC_IS_INLINE_BOX ) { // inline-block
+                        has_inline_boxes = true;
+                        word->flags = LTEXT_WORD_IS_INLINE_BOX;
+                        // For inline-block boxes, the baseline may not be the bottom; it has
+                        // been computed in measureText().
+                        word->o.baseline = lastSrc->o.baseline;
+                        top_to_baseline = word->o.baseline;
+                        baseline_to_bottom = word->o.height - word->o.baseline;
+                    }
+                    else { // image
+                        word->flags = LTEXT_WORD_IS_OBJECT;
+                        word->o.height = lastSrc->o.height;
+                        // Resize image so it fits in our available width
+                        int width = lastSrc->o.width;
+                        int height = lastSrc->o.height;
+                        // Negative width and height mean the value is a % (of our final block width)
+                        width = width<0 ? (-width * (m_pbuffer->width - x) / 100) : width;
+                        height = height<0 ? (-height * (m_pbuffer->width-x) / 100) : height;
+                        // todo: adjust m_max_img_height with this image valign_dy/vertical_align_flag
+                        resizeImage(width, height, m_pbuffer->width - x, m_max_img_height, m_length>1);
+                            // Note: it can happen with a standalone image in a small container
+                            // where text-indent is greater than width, that 'm_pbuffer->width - x'
+                            // can be negative. We could cap it to zero and resize the image to 0,
+                            // but let it be shown un-resized, possibly overflowing or overriding
+                            // other content.
+                        word->width = width;
+                        word->o.height = height;
+                        // Per specs, the baseline is the bottom of the image
+                        top_to_baseline = word->o.height;
+                        baseline_to_bottom = 0;
+                    }
 
-                    int width = lastSrc->o.width;
-                    int height = lastSrc->o.height;
-                    width = width<0? -width*(m_pbuffer->width-x)/100 : width;
-                    height = height<0? -height*(m_pbuffer->width-x)/100 : height;
-                    // todo: adjust m_max_img_height with this image valign_dy/vertical_align_flag
-                    resizeImage(width, height, m_pbuffer->width - x, m_max_img_height, m_length>1);
-                        // Note: it can happen with a standalone image in a small container
-                        // where text-indent is greater than width, that 'm_pbuffer->width - x'
-                        // can be negative. We could cap it to zero and resize the image to 0,
-                        // but let it be shown un-resized, possibly overflowing or overriding
-                        // other content.
-                    word->width = width;
-                    word->o.height = height;
-
-                    // For images, the baseline is the bottom of the image
                     // srcline->valign_dy sets the baseline, except in a few specific cases
                     // word->y has to be set to where the baseline should be
-                    top_to_baseline = word->o.height;
-                    baseline_to_bottom = 0;
-                    // Next code could be simplified, baseline_to_bottom being 0, but
-                    // let's use the logical code if this wasn't the case (it will be
-                    // when we implement display: inline-block).
                     // For vertical-align: top or bottom, delay computation as we need to
                     // know the final frmline height and baseline, which might change
                     // with upcoming words.
@@ -2222,15 +2344,15 @@ public:
                         word->y = - baseline_to_bottom;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_TEXT_TOP ) {
-                        // srcline->valign_dy has been set to where top of image should be
+                        // srcline->valign_dy has been set to where top of image or box should be
                         word->y = srcline->valign_dy + top_to_baseline;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_TEXT_BOTTOM ) {
-                        // srcline->valign_dy has been set to where bottom of image should be
+                        // srcline->valign_dy has been set to where bottom of image or box should be
                         word->y = srcline->valign_dy - baseline_to_bottom;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_MIDDLE ) {
-                        // srcline->valign_dy has been set to where the middle of image should be
+                        // srcline->valign_dy has been set to where the middle of image or box should be
                         word->y = srcline->valign_dy - (top_to_baseline + baseline_to_bottom)/2 + top_to_baseline;
                     }
                     else { // otherwise, align baseline according to valign_dy (computed in lvrend.cpp)
@@ -2544,7 +2666,7 @@ public:
         }
         if ( delayed_valign_computation ) {
             // Delayed computation and line box adjustment when we have some words
-            // or images with vertical-align: top or bottom.
+            // (or images, or inline-boxes) with vertical-align: top or bottom.
             // First, see if we need to adjust frmline->baseline and frmline->height,
             // similarly as done above if adjust_line_box:
             for ( int i=0; i<frmline->word_count; i++ ) {
@@ -2585,7 +2707,7 @@ public:
                 }
             }
         }
-        alignLine( frmline, align, rightIndent );
+        alignLine( frmline, align, rightIndent, has_inline_boxes );
         m_y += frmline->height;
         m_pbuffer->height = m_y;
         checkOngoingFloat();
@@ -2789,7 +2911,7 @@ public:
             // Find candidates where end of line is possible
             bool seen_non_collapsed_space = false;
             for ( i=pos; i<m_length; i++ ) {
-                if (m_charindex[i] == FLOAT_CHAR_INDEX) { // float
+                if ( (m_flags[i] & LCHAR_IS_OBJECT) && (m_charindex[i] == FLOAT_CHAR_INDEX) ) { // float
                     src_text_fragment_t * src = m_srcs[i];
                     // Not sure if we can be called again on the same LVFormatter
                     // object, but the whole code allows for re-formatting and
@@ -2853,7 +2975,7 @@ public:
                     bool avoidWrap = false;
                     // Look first at following char(s)
                     for (int j = i+1; j < m_length; j++) {
-                        if (m_charindex[j] == FLOAT_CHAR_INDEX) // skip floats
+                        if ( (m_flags[j] & LCHAR_IS_OBJECT) && (m_charindex[j] == FLOAT_CHAR_INDEX) ) // skip floats
                             continue;
                         if ( !(m_flags[j] & LCHAR_ALLOW_WRAP_AFTER) ) { // not another (collapsible) space
                             avoidWrap = lGetCharProps(m_text[j]) & CH_PROP_AVOID_WRAP_BEFORE;
@@ -2864,7 +2986,7 @@ public:
                         // (but not if it is the last char, where a wrap is fine
                         // even if it ends after a CH_PROP_AVOID_WRAP_AFTER char)
                         for (int j = i-1; j >= 0; j--) {
-                            if (m_charindex[j] == FLOAT_CHAR_INDEX) // skip floats
+                            if ( (m_flags[j] & LCHAR_IS_OBJECT) && (m_charindex[j] == FLOAT_CHAR_INDEX) ) // skip floats
                                 continue;
                             if ( !(m_flags[j] & LCHAR_ALLOW_WRAP_AFTER) ) { // not another (collapsible) space
                                 avoidWrap = lGetCharProps(m_text[j]) & CH_PROP_AVOID_WRAP_AFTER;
@@ -3091,12 +3213,13 @@ public:
                 // Find the real last displayed glyph, skipping spaces and floats
                 int lastnonspace = endp-1;
                 for ( int k=endp-1; k>=start; k-- ) {
-                    if ( !(m_flags[k] & LCHAR_IS_SPACE) && !(m_charindex[k] == FLOAT_CHAR_INDEX) ) {
+                    if ( !(m_flags[k] & LCHAR_IS_SPACE) &&
+                         !( (m_flags[k] & LCHAR_IS_OBJECT) && (m_charindex[k] == FLOAT_CHAR_INDEX) ) ) {
                         lastnonspace = k;
                         break;
                     }
                 }
-                // If the last non-space/non-float is an image, we don't do it.
+                // If the last non-space/non-float is an image or an inline-block box, we don't do it.
                 // Note: it feels we should do that for the char before ANY image on the line (so the italic
                 // glyph does not overlap with the image). It's unclear whether the former code did that
                 // (or not) for the char before an image at end of line only...
@@ -3373,6 +3496,53 @@ void DrawBookmarkTextUnderline(LVDrawBuf & drawbuf, int x0, int y0, int x1, int 
     }
 }
 
+static void getAbsMarksFromMarks(ldomMarkedRangeList * marks, ldomMarkedRangeList * absmarks, ldomNode * node) {
+    // Provided ldomMarkedRangeList * marks are ranges made from the words
+    // of a selection currently being made (native highlights by crengine).
+    // Their coordinates have been translated from absolute to relative
+    // to the final node, by the DrawDocument() that called
+    // LFormattedText::Draw() for this final node.
+    // In LFormattedText::Draw(), when we need to call DrawDocument() to
+    // draw floats or inlineBoxes, we need to translate them back to
+    // absolute coordinates (DrawDocument() will translate them again
+    // to relative coordinates in the drawn float or inlineBox).
+    // (They are matched in LFormattedText::Draw() against the lineRect,
+    // which have coordinates in the context of where we are drawing.)
+    // The 'node' provided to this function must be a floatBox or inlineBox:
+    // its parent is either the final node that contains them, or some
+    // inline node contained in it.
+
+    // We need to know the current final node that contains the provided
+    // node, and its absolute coordinates
+    ldomNode * final_node = node->getParentNode();
+    for ( ; final_node; final_node = final_node->getParentNode() ) {
+        int rm = final_node->getRendMethod();
+        if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption )
+            break;
+    }
+    lvRect final_node_rect;
+    final_node->getAbsRect( final_node_rect );
+        // Note: looks like we should not use getAbsRect(..., inner=true) here,
+        // probably because the marks are not shifted by the inner shift.
+
+    // Fill the second provided ldomMarkedRangeList with marks in absolute
+    // coordinates.
+    for ( int i=0; i<marks->length(); i++ ) {
+        ldomMarkedRange * mark = marks->get(i);
+        ldomMarkedRange * newmark = new ldomMarkedRange( *mark );
+        newmark->start.y += final_node_rect.top;
+        newmark->end.y += final_node_rect.top;
+        newmark->start.x += final_node_rect.left;
+        newmark->end.x += final_node_rect.left;
+            // (Note: early when developping this, NOT updating x gave the
+            // expected results, althought logically it should be updated...
+            // But now, it seems to work, and is needed to correctly shift
+            // highlight marks in inlineBox by the containing final block's
+            // left margin...)
+        absmarks->add(newmark);
+    }
+}
+
 void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * marks, ldomMarkedRangeList *bookmarks )
 {
     int i, j;
@@ -3384,6 +3554,12 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
     buf->GetClipRect( &clip );
     const lChar16 * str;
     int line_y = y;
+
+    // We might need to translate "marks" (native highlights) from relative
+    // coordinates to absolute coordinates if we have to draw floats or
+    // inlineBoxes: we'll do that when dealing with the first of these if any.
+    ldomMarkedRangeList * absmarks = new ldomMarkedRangeList();
+    bool absmarks_update_needed = marks!=NULL && marks->length()>0;
 
     // printf("x/y: %d/%d clip.top/bottom: %d %d\n", x, y, clip.top, clip.bottom);
     // When drawing a paragraph that spans 3 pages, we may get:
@@ -3420,6 +3596,10 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 if (word->flags & LTEXT_WORD_IS_OBJECT)
                 {
                     // no background, TODO
+                }
+                else if (word->flags & LTEXT_WORD_IS_INLINE_BOX)
+                {
+                    // background if any will be drawn when drawing the box below
                 }
                 else
                 {
@@ -3497,6 +3677,31 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         buf->Draw( img, xx, yy, word->width, word->o.height );
                         //buf->FillRect( xx, yy, xx+word->width, yy+word->height, 1 );
                     }
+                }
+                else if (word->flags & LTEXT_WORD_IS_INLINE_BOX)
+                {
+                    srcline = &m_pbuffer->srctext[word->src_text_index];
+                    ldomNode * node = (ldomNode *) srcline->object;
+                    // Logically, the coordinates of the top left of the box are:
+                    // int x0 = x + frmline->x + word->x;
+                    // int y0 = line_y + frmline->baseline - word->o.baseline + word->y;
+                    // But we have updated the node's RenderRectAccesor x/y in alignLine(),
+                    // ahd DrawDocument() will by default fetch them to shift the block
+                    // it has to draw. So, we can use the provided x/y as-is, with
+                    // the offsets from the RenderRectAccesor.
+                    RenderRectAccessor fmt( node );
+                    int x0 = x + fmt.getX();
+                    int y0 = y + fmt.getY();
+                    int doc_x = 0 - fmt.getX();
+                    int doc_y = 0 - fmt.getY();
+                    int dx = m_pbuffer->width;
+                    int dy = m_pbuffer->page_height;
+                    int page_height = m_pbuffer->page_height;
+                    if ( absmarks_update_needed ) {
+                        getAbsMarksFromMarks(marks, absmarks, node);
+                        absmarks_update_needed = false;
+                    }
+                    DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );
                 }
                 else
                 {
@@ -3590,12 +3795,6 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
     }
 
     // Draw floats if any
-    // We'll need to know the current final node to correct and draw "marks"
-    // (native highlights): we'll get it when dealing with the first float if any.
-    ldomNode * this_final_node = NULL;
-    lvRect this_final_node_rect;
-    ldomMarkedRangeList * absmarks = new ldomMarkedRangeList();
-
     for (i=0; i<m_pbuffer->floatcount; i++) {
         embedded_float_t * flt = m_pbuffer->floats[i];
         if (flt->srctext == NULL) {
@@ -3625,38 +3824,10 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             int dx = m_pbuffer->width;
             int dy = m_pbuffer->page_height;
             int page_height = m_pbuffer->page_height;
-
-            if ( marks!=NULL && marks->length()>0 && this_final_node == NULL ) {
-                // Provided ldomMarkedRangeList * marks are ranges made from the words
-                // of a selection currently being made (native highlights by crengine).
-                // Their coordinates have been translated from absolute to relative
-                // to our final node by the DrawDocument() that called us.
-                // As we are going to call DrawDocument() to draw the floats, we need
-                // to translate them back to absolute coordinates (DrawDocument() will
-                // translate them again to relative coordinates in the drawn float).
-                // (They are matched above against the lineRect, which have coordinates
-                // in the context of where we are drawing.)
-
-                // We need to know the current final node and its absolute coordinates
-                this_final_node = node->getParentNode();
-                for ( ; this_final_node; this_final_node = this_final_node->getParentNode() ) {
-                    int rm = this_final_node->getRendMethod();
-                    if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption )
-                        break;
-                }
-                this_final_node->getAbsRect( this_final_node_rect );
-
-                // Create a new ldomMarkedRangeList with marks in absolute coordinates,
-                // that will be used by this float we just met, and the next ones.
-                for ( int i=0; i<marks->length(); i++ ) {
-                    ldomMarkedRange * mark = marks->get(i);
-                    ldomMarkedRange * newmark = new ldomMarkedRange( *mark );
-                    newmark->start.y += this_final_node_rect.top;
-                    newmark->end.y += this_final_node_rect.top;
-                    absmarks->add(newmark);
-                }
+            if ( absmarks_update_needed ) {
+                getAbsMarksFromMarks(marks, absmarks, node);
+                absmarks_update_needed = false;
             }
-
             DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );
         }
     }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1966,6 +1966,9 @@ public:
             // Not used yet, but might be useful (we may have a bidi line
             // in a LTR paragraph).
         }
+        // Some words vertical-align positionning might need to be fixed
+        // only once the whole line has been laid out
+        bool delayed_valign_computation = false;
 
         // Ignore space at start of line (this rarely happens, as line
         // splitting discards the space on which a split is made - but it
@@ -2158,6 +2161,12 @@ public:
                 int baseline_to_bottom; // descender below baseline for this word (formerly named 'h')
                 word->src_text_index = m_srcs[wstart]->index;
 
+                // For each word, we'll have to check and adjust line height and baseline,
+                // except when LTEXT_VALIGN_TOP and LTEXT_VALIGN_BOTTOM where it has to
+                // be delayed until the full line is laid out. Until that, we store some
+                // info into word->_top_to_baseline and word->_baseline_to_bottom.
+                bool adjust_line_box = true;
+
                 if ( lastSrc->flags & LTEXT_SRC_IS_OBJECT ) {
                     // object
                     word->x = frmline->width;
@@ -2186,47 +2195,91 @@ public:
                     // word->y has to be set to where the baseline should be
                     top_to_baseline = word->o.height;
                     baseline_to_bottom = 0;
-                    if ( vertical_align_flag == LTEXT_VALIGN_MIDDLE ) {
-                        // srcline->valign_dy has been set to where the middle of image should be
-                        word->y = srcline->valign_dy + top_to_baseline/2;
+                    // Next code could be simplified, baseline_to_bottom being 0, but
+                    // let's use the logical code if this wasn't the case (it will be
+                    // when we implement display: inline-block).
+                    // For vertical-align: top or bottom, delay computation as we need to
+                    // know the final frmline height and baseline, which might change
+                    // with upcoming words.
+                    if ( vertical_align_flag == LTEXT_VALIGN_TOP ) {
+                        // was (before we delayed computation):
+                        // word->y = top_to_baseline - frmline->baseline;
+                        adjust_line_box = false;
+                        delayed_valign_computation = true;
+                        word->flags |= LTEXT_WORD_VALIGN_TOP;
+                        word->_top_to_baseline = top_to_baseline;
+                        word->_baseline_to_bottom = baseline_to_bottom;
+                        word->y = top_to_baseline;
+                    }
+                    else if ( vertical_align_flag == LTEXT_VALIGN_BOTTOM ) {
+                        // was (before we delayed computation):
+                        // word->y = frmline->height - frmline->baseline;
+                        adjust_line_box = false;
+                        delayed_valign_computation = true;
+                        word->flags |= LTEXT_WORD_VALIGN_BOTTOM;
+                        word->_top_to_baseline = top_to_baseline;
+                        word->_baseline_to_bottom = baseline_to_bottom;
+                        word->y = - baseline_to_bottom;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_TEXT_TOP ) {
                         // srcline->valign_dy has been set to where top of image should be
                         word->y = srcline->valign_dy + top_to_baseline;
                     }
-                    else if ( vertical_align_flag == LTEXT_VALIGN_TOP ) {
-                        word->y = top_to_baseline - frmline->baseline;
+                    else if ( vertical_align_flag == LTEXT_VALIGN_TEXT_BOTTOM ) {
+                        // srcline->valign_dy has been set to where bottom of image should be
+                        word->y = srcline->valign_dy - baseline_to_bottom;
                     }
-                    else if ( vertical_align_flag == LTEXT_VALIGN_BOTTOM ) {
-                        word->y = frmline->height - frmline->baseline;
+                    else if ( vertical_align_flag == LTEXT_VALIGN_MIDDLE ) {
+                        // srcline->valign_dy has been set to where the middle of image should be
+                        word->y = srcline->valign_dy - (top_to_baseline + baseline_to_bottom)/2 + top_to_baseline;
                     }
-                    else { // in all other cases, bottom of image is its baseline
+                    else { // otherwise, align baseline according to valign_dy (computed in lvrend.cpp)
                         word->y = srcline->valign_dy;
                     }
-                } else {
+                }
+                else {
                     // word
                     // wstart points to the previous first non-space char
                     // i points to a non-space char that will be in next word
                     // i-1 may be a space, or not (when different html tag/text nodes stuck to each other)
                     src_text_fragment_t * srcline = m_srcs[wstart];
                     LVFont * font = (LVFont*)srcline->t.font;
+                    word->flags = 0;
 
                     int vertical_align_flag = srcline->flags & LTEXT_VALIGN_MASK;
                     int line_height = srcline->interval;
                     int fh = font->getHeight();
                     // As we do only +/- arithmetic, the following values being negative should be fine.
-                    // Accounts for line-height (adds what most documentation calls half-leading to top and to bottom):
+                    // Accounts for line-height (adds what most documentation calls half-leading to top
+                    // and to bottom  - note that "leading" is a typography term referring to "lead" the
+                    // metal, and not to lead/leader/head/header - so the half use for bottom should not
+                    // be called half-tailing :):
                     int half_leading = (line_height - fh) / 2;
+                    int half_leading_bottom = line_height - fh - half_leading;
                     top_to_baseline = font->getBaseline() + half_leading;
                     baseline_to_bottom = line_height - top_to_baseline;
-                    // For vertical-align: top or bottom, align to the current frmline as it is at
-                    // this point (at minima, the strut), even if frmline height and baseline might
-                    // be moved by some coming up words
+                    // For vertical-align: top or bottom, delay computation as we need to
+                    // know the final frmline height and baseline, which might change
+                    // with upcoming words.
                     if ( vertical_align_flag == LTEXT_VALIGN_TOP ) {
-                        word->y = font->getBaseline() - frmline->baseline + half_leading;
+                        // was (before we delayed computation):
+                        // word->y = font->getBaseline() - frmline->baseline + half_leading;
+                        adjust_line_box = false;
+                        delayed_valign_computation = true;
+                        word->flags |= LTEXT_WORD_VALIGN_TOP;
+                        word->_top_to_baseline = top_to_baseline;
+                        word->_baseline_to_bottom = baseline_to_bottom;
+                        word->y = font->getBaseline() + half_leading;
                     }
                     else if ( vertical_align_flag == LTEXT_VALIGN_BOTTOM ) {
-                        word->y = frmline->height - fh + font->getBaseline() - frmline->baseline - half_leading;
+                        // was (before we delayed computation):
+                        // word->y = frmline->height - fh + font->getBaseline() - frmline->baseline - half_leading;
+                        adjust_line_box = false;
+                        delayed_valign_computation = true;
+                        word->flags |= LTEXT_WORD_VALIGN_BOTTOM;
+                        word->_top_to_baseline = top_to_baseline;
+                        word->_baseline_to_bottom = baseline_to_bottom;
+                        word->y = - fh + font->getBaseline() - half_leading_bottom;
                     }
                     else {
                         // For others, vertical-align computation is done in lvrend.cpp renderFinalBlock()
@@ -2234,9 +2287,6 @@ public:
                     }
                     // printf("baseline_to_bottom=%d top_to_baseline=%d word->y=%d txt=|%s|\n", baseline_to_bottom,
                     //   top_to_baseline, word->y, UnicodeToLocal(lString16(srcline->t.text, srcline->t.len)).c_str());
-
-                    word->x = frmline->width;
-                    word->flags = 0;
 
                     // For Harfbuzz, which may shape differently words at start or end of paragraph
                     if (first && frmline->word_count == 1) // first line of paragraph + first word of line
@@ -2282,6 +2332,7 @@ public:
                         word->t.len = m_charindex[i-1] + 1 - m_charindex[wstart];
                     }
 
+                    word->x = frmline->width;
                     word->width = m_widths[i>0 ? i-1 : 0] - (wstart>0 ? m_widths[wstart-1] : 0);
                     word->min_width = word->width;
                     TR("addLine - word(%d, %d) x=%d (%d..%d)[%d] |%s|", wstart, i, frmline->width, wstart>0 ? m_widths[wstart-1] : 0, m_widths[i-1], word->width, LCSTR(lString16(m_text+wstart, i-wstart)));
@@ -2452,33 +2503,35 @@ public:
                     } // done if floating punctuation enabled
                 }
 
-                // Adjust full line box height and baseline if needed:
-                // frmline->height is the current line height
-                // frmline->baseline is the distance from line top to the main baseline of the line
-                // top_to_baseline (normally positive number) is the distance from this word top to its own baseline.
-                // baseline_to_bottom (normally positive number) is the descender below baseline for this word
-                // word->y is the distance from this word baseline to the line main baseline
-                //   it is positive when word is subscript, negative when word is superscript
-                //
-                // negative word->y means it's superscript, so the line's baseline might need to go
-                // down (increase) to make room for the superscript
-                int needed_baseline = top_to_baseline - word->y;
-                if ( needed_baseline > frmline->baseline ) {
-                    // shift the line baseline and height by the amount needed at top
-                    int shift_down = needed_baseline - frmline->baseline;
-                    // if (frmline->baseline) printf("pushed down +%d\n", shift_down);
-                    // if (frmline->baseline && lastSrc->object)
-                    //     printf("%s\n", UnicodeToLocal(ldomXPointer((ldomNode*)lastSrc->object, 0).toString()).c_str());
-                    frmline->baseline += shift_down;
-                    frmline->height += shift_down;
-                }
-                // positive word->y means it's subscript, so the line's baseline does not need to be
-                // changed, but more room below might be needed to display the subscript: increase
-                // line height so next line is pushed down and dont overwrite the subscript
-                int needed_height = frmline->baseline + baseline_to_bottom + word->y;
-                if ( needed_height > frmline->height ) {
-                    // printf("extended down +%d\n", needed_height-frmline->height);
-                    frmline->height = needed_height;
+                if ( adjust_line_box ) {
+                    // Adjust full line box height and baseline if needed:
+                    // frmline->height is the current line height
+                    // frmline->baseline is the distance from line top to the main baseline of the line
+                    // top_to_baseline (normally positive number) is the distance from this word top to its own baseline.
+                    // baseline_to_bottom (normally positive number) is the descender below baseline for this word
+                    // word->y is the distance from this word baseline to the line main baseline
+                    //   it is positive when word is subscript, negative when word is superscript
+                    //
+                    // negative word->y means it's superscript, so the line's baseline might need to go
+                    // down (increase) to make room for the superscript
+                    int needed_baseline = top_to_baseline - word->y;
+                    if ( needed_baseline > frmline->baseline ) {
+                        // shift the line baseline and height by the amount needed at top
+                        int shift_down = needed_baseline - frmline->baseline;
+                        // if (frmline->baseline) printf("pushed down +%d\n", shift_down);
+                        // if (frmline->baseline && lastSrc->object)
+                        //     printf("%s\n", UnicodeToLocal(ldomXPointer((ldomNode*)lastSrc->object, 0).toString()).c_str());
+                        frmline->baseline += shift_down;
+                        frmline->height += shift_down;
+                    }
+                    // positive word->y means it's subscript, so the line's baseline does not need to be
+                    // changed, but more room below might be needed to display the subscript: increase
+                    // line height so next line is pushed down and dont overwrite the subscript
+                    int needed_height = frmline->baseline + baseline_to_bottom + word->y;
+                    if ( needed_height > frmline->height ) {
+                        // printf("extended down +%d\n", needed_height-frmline->height);
+                        frmline->height = needed_height;
+                    }
                 }
 
                 frmline->width += word->width;
@@ -2488,6 +2541,49 @@ public:
             }
             lastIsSpace = isSpace;
             lastIsRTL = isRTL;
+        }
+        if ( delayed_valign_computation ) {
+            // Delayed computation and line box adjustment when we have some words
+            // or images with vertical-align: top or bottom.
+            // First, see if we need to adjust frmline->baseline and frmline->height,
+            // similarly as done above if adjust_line_box:
+            for ( int i=0; i<frmline->word_count; i++ ) {
+                if ( frmline->words[i].flags & (LTEXT_WORD_VALIGN_TOP|LTEXT_WORD_VALIGN_BOTTOM) ) {
+                    formatted_word_t * word = &frmline->words[i];
+                    // Update incomplete word->y with current frmline baseline & height,
+                    // just as it would have been done if not delayed
+                    int cur_word_y;
+                    if ( word->flags & LTEXT_WORD_VALIGN_TOP )
+                        cur_word_y = word->y - frmline->baseline;
+                    else if ( word->flags & LTEXT_WORD_VALIGN_BOTTOM )
+                        cur_word_y = word->y + frmline->height - frmline->baseline;
+                    else // should not happen
+                        cur_word_y = word->y;
+                    int needed_baseline = word->_top_to_baseline - cur_word_y;
+                    if ( needed_baseline > frmline->baseline ) {
+                        // shift the line baseline and height by the amount needed at top
+                        int shift_down = needed_baseline - frmline->baseline;
+                        frmline->baseline += shift_down;
+                        frmline->height += shift_down;
+                    }
+                    int needed_height = frmline->baseline + word->_baseline_to_bottom + cur_word_y;
+                    if ( needed_height > frmline->height ) {
+                        frmline->height = needed_height;
+                    }
+                }
+            }
+            // Then, get the final word->y (baseline) that aligns the word to top or bottom of frmline
+            for ( int i=0; i<frmline->word_count; i++ ) {
+                if ( frmline->words[i].flags & (LTEXT_WORD_VALIGN_TOP|LTEXT_WORD_VALIGN_BOTTOM) ) {
+                    formatted_word_t * word = &frmline->words[i];
+                    if ( word->flags & LTEXT_WORD_VALIGN_TOP ) {
+                        word->y = word->y - frmline->baseline;
+                    }
+                    else if ( word->flags & LTEXT_WORD_VALIGN_BOTTOM ) {
+                        word->y = word->y + frmline->height - frmline->baseline;
+                    }
+                }
+            }
         }
         alignLine( frmline, align, rightIndent );
         m_y += frmline->height;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1895,15 +1895,16 @@ public:
         }
         #endif
 
+        // Note: not certain why or how useful this lastnonspace (used below) is.
         int lastnonspace = 0;
-        if ( align==LTEXT_ALIGN_WIDTH || splitBySpaces ) {
-            for ( int i=start; i<end; i++ )
-                if ( !((m_flags[i] & LCHAR_IS_SPACE) && !(m_flags[i] & LCHAR_IS_OBJECT)) )
-                    lastnonspace = i;
-                // This "!( SPACE && !OBJECT)" looks wrong, as an OBJECT can't be also a SPACE,
-                // and it feels it's a parens error and should be "(!SPACE && !OBJECT)", but with
-                // that, we'll be ignoring multiple stuck OBJECTs at end of line.
-                // So, not touching it...
+        if ( splitBySpaces || align==LTEXT_ALIGN_WIDTH ) { // always true with current code
+            for ( int k=end-1; k>=start; k-- ) {
+                // Also not certain if we should skip floats or LCHAR_IS_OBJECT
+                if ( !(m_flags[k] & LCHAR_IS_SPACE) ) {
+                    lastnonspace = k;
+                    break;
+                }
+            }
         }
 
         formatted_line_t * frmline =  lvtextAddFormattedLine( m_pbuffer );
@@ -2987,28 +2988,33 @@ public:
                 }
             }
             // Best position to end this line found.
-            int lastnonspace = endp-1;
-            for ( int k=endp-1; k>=start; k-- ) {
-                if ( !((m_flags[k] & LCHAR_IS_SPACE) && !(m_flags[k] & LCHAR_IS_OBJECT)) ) {
-                    lastnonspace = k;
-                    break;
+            // We need to possibly extend the last char width to account for italic
+            // right side bearing overflow (but not if we ended the line with some
+            // hyphenation, as the last glyph will then be the hyphen).
+            if ( !(m_flags[endp-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER) ) {
+                // Find the real last displayed glyph, skipping spaces and floats
+                int lastnonspace = endp-1;
+                for ( int k=endp-1; k>=start; k-- ) {
+                    if ( !(m_flags[k] & LCHAR_IS_SPACE) && !(m_charindex[k] == FLOAT_CHAR_INDEX) ) {
+                        lastnonspace = k;
+                        break;
+                    }
                 }
-                // This "!( SPACE && !OBJECT)" looks wrong, as an OBJECT can't be also a SPACE,
-                // and it feels it's a parens error and should be "(!SPACE && !OBJECT)", but with
-                // that, we'll be ignoring multiple stuck OBJECTs at end of line.
-                // So, not touching it...
+                // If the last non-space/non-float is an image, we don't do it.
+                // Note: it feels we should do that for the char before ANY image on the line (so the italic
+                // glyph does not overlap with the image). It's unclear whether the former code did that
+                // (or not) for the char before an image at end of line only...
+                if ( !(m_flags[lastnonspace] & LCHAR_IS_OBJECT) ) {
+                    // todo: probably need be avoided if bidi/rtl:
+                    int dw = lastnonspace>=start ? getAdditionalCharWidth(lastnonspace, lastnonspace+1) : 0;
+                    if (dw) {
+                        TR("additional width = %d, after char %s", dw, LCSTR(lString16(m_text + lastnonspace, 1)));
+                        m_widths[lastnonspace] += dw;
+                    }
+                }
             }
-            // todo: probably need be avoided if bidi/rtl:
-            int dw = lastnonspace>=start ? getAdditionalCharWidth(lastnonspace, lastnonspace+1) : 0;
-            // If we ended the line with some hyphenation, no need to account for italic
-            // right side bearing overflow, as the last glyph will be an hyphen.
-            if (m_flags[endp-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER)
-                dw = 0;
-            if (dw) {
-                TR("additional width = %d, after char %s", dw, LCSTR(lString16(m_text + lastnonspace, 1)));
-                m_widths[lastnonspace] += dw;
-            }
-            if (endp>m_length) endp=m_length;
+            if (endp > m_length)
+                endp = m_length;
             addLine(pos, endp, x + firstCharMargin, para, interval, pos==0, wrapPos>=m_length-1, preFormattedOnly, needReduceSpace, isLastPara);
             pos = wrapPos + 1;
         }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3520,10 +3520,9 @@ static void getAbsMarksFromMarks(ldomMarkedRangeList * marks, ldomMarkedRangeLis
         if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption )
             break;
     }
-    lvRect final_node_rect;
-    final_node->getAbsRect( final_node_rect );
-        // Note: looks like we should not use getAbsRect(..., inner=true) here,
-        // probably because the marks are not shifted by the inner shift.
+    lvRect final_node_rect = lvRect();
+    if ( final_node )
+        final_node->getAbsRect( final_node_rect, true );
 
     // Fill the second provided ldomMarkedRangeList with marks in absolute
     // coordinates.
@@ -3626,6 +3625,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 for ( int i=0; i<marks->length(); i++ ) {
                     lvRect mark;
                     ldomMarkedRange * range = marks->get(i);
+                    // printf("marks #%d %d %d > %d %d\n", i, range->start.x, range->start.y, range->end.x, range->end.y);
                     if ( range->intersects( lineRect, mark ) ) {
                         //
                         buf->FillRect(mark.left + x, mark.top + y, mark.right + x, mark.bottom + y, m_pbuffer->highlight_options.selectionColor);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1620,6 +1620,31 @@ void RenderRectAccessor::setBottomOverflow( int dy )
         _modified = true;
     }
 }
+int RenderRectAccessor::getBaseline()
+{
+    if ( _dirty ) {
+        _dirty = false;
+        _node->getRenderData(*this);
+#ifdef DEBUG_RENDER_RECT_ACCESS
+        rr_lock( _node );
+#endif
+    }
+    return _baseline;
+}
+void RenderRectAccessor::setBaseline( int baseline )
+{
+    if ( _dirty ) {
+        _dirty = false;
+        _node->getRenderData(*this);
+#ifdef DEBUG_RENDER_RECT_ACCESS
+        rr_lock( _node );
+#endif
+    }
+    if ( _baseline != baseline ) {
+        _baseline = baseline;
+        _modified = true;
+    }
+}
 int RenderRectAccessor::getListPropNodeIndex()
 {
     if ( _dirty ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -14580,8 +14580,8 @@ ldomNode * ldomNode::persist()
         } else {
             // TEXT->PTEXT
             lString8 utf8 = _data._text_ptr->getText();
-            delete _data._text_ptr;
             lUInt32 parentIndex = _data._text_ptr->getParentIndex();
+            delete _data._text_ptr;
             _handle._dataIndex = (_handle._dataIndex & ~0xF) | NT_PTEXT;
             _data._ptext_addr = getDocument()->_textStorage.allocText(_handle._dataIndex, parentIndex, utf8 );
             // change type

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.32k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.33k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001D
 
@@ -3782,7 +3782,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             // rendering method, which gives us a visual hint of it.
             lvdom_element_render_method rm = node->getRendMethod();
             // Text and inline nodes stay stuck together, but not all others
-            if (rm != erm_inline) {
+            if (rm != erm_inline || node->isBoxingInlineBox()) {
                 doNewLineBeforeStartTag = true;
                 doNewLineAfterStartTag = true;
                 // doNewLineBeforeEndTag = false; // done by child elements
@@ -3801,6 +3801,10 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                         doNewlineBeforeIndentBeforeStartTag = true;
                         doIndentAfterNewLineAfterEndTag = true;
                     }
+                }
+                else if (node->isBoxingInlineBox()) {
+                    doNewlineBeforeIndentBeforeStartTag = true;
+                    doIndentAfterNewLineAfterEndTag = true;
                 }
             }
             // Do something specific when erm_invisible ?
@@ -4681,11 +4685,12 @@ static bool isBlockNode( ldomNode * node )
     switch ( node->getStyle()->display )
     {
     case css_d_block:
+    case css_d_inline_block:
+    case css_d_inline_table:
     case css_d_list_item:
     case css_d_list_item_block:
     case css_d_table:
     case css_d_table_row:
-    case css_d_inline_table:
     case css_d_table_row_group:
     case css_d_table_header_group:
     case css_d_table_footer_group:
@@ -4726,9 +4731,17 @@ static bool isFloatingNode( ldomNode * node )
     return node->getStyle()->float_ > css_f_none;
 }
 
-static bool isNotFloatingNode( ldomNode * node )
+static bool isNotBoxWrappingNode( ldomNode * node )
 {
-    return node->getStyle()->float_ <= css_f_none;
+    if ( BLOCK_RENDERING_G(PREPARE_FLOATBOXES) && node->getStyle()->float_ > css_f_none )
+        return false; // floatBox
+    // isBoxingInlineBox() already checks for BLOCK_RENDERING_G(BOX_INLINE_BLOCKS)
+    return !node->isBoxingInlineBox();
+}
+
+static bool isNotBoxingInlineBoxNode( ldomNode * node )
+{
+    return !node->isBoxingInlineBox();
 }
 
 static lString16 getSectionHeader( ldomNode * section )
@@ -5024,7 +5037,7 @@ static void resetRendMethodToInline( ldomNode * node )
     // hide other nodes)
     if (node->getStyle()->display != css_d_none)
         node->setRendMethod(erm_inline);
-    if (gDOMVersionRequested < 20180528) // do that in all cases
+    else if (gDOMVersionRequested < 20180528) // do that in all cases
         node->setRendMethod(erm_inline);
 }
 
@@ -5070,7 +5083,9 @@ static void detectChildTypes( ldomNode * parent, bool & hasBlockItems, bool & ha
 int initTableRendMethods( ldomNode * enode, int state )
 {
     //main node: table
-    if ( state==0 && enode->getStyle()->display==css_d_table )
+    if ( state==0 && (enode->getStyle()->display==css_d_table ||
+                      enode->getStyle()->display==css_d_inline_table ||
+                      (enode->getStyle()->display==css_d_inline_block && enode->getNodeId()==el_table)) )
         enode->setRendMethod( erm_table ); // for table
     int cellCount = 0;
     int cnt = enode->getChildCount();
@@ -5184,6 +5199,25 @@ bool ldomNode::isFloatingBox()
     return false;
 }
 
+/// is node an inlineBox that has not been re-inlined by having
+/// its child no more inline-block/inline-table
+bool ldomNode::isBoxingInlineBox()
+{
+    // BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) is what ensures inline-block
+    // are boxed and rendered as an inline block, but we may have them
+    // wrapping a node that is no more inline-block (when some style
+    // tweaks have changed the display: property).
+    if ( getNodeId() == el_inlineBox && BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) ) {
+        if (getChildCount() == 1) {
+            css_display_t d = getChildNode(0)->getStyle()->display;
+            if (d == css_d_inline_block || d == css_d_inline_table) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void ldomNode::initNodeRendMethod()
 {
     // This method is called when re-rendering, but also while
@@ -5227,15 +5261,13 @@ void ldomNode::initNodeRendMethod()
         //recurseElements( resetRendMethodToInvisible );
         setRendMethod(erm_invisible);
     } else if ( d==css_d_inline ) {
-        // inline: an inline parent reset all its children to inline
-        // (so, if some block content is erroneously wrapped in a SPAN,
-        // all the content become inline...)
         //CRLog::trace("switch all children elements of <%s> to inline", LCSTR(getNodeName()));
-        if ( BLOCK_RENDERING_G(PREPARE_FLOATBOXES) )
-            // Don't reset nodes with float: which can stay block among inlines
-            recurseMatchingElements( resetRendMethodToInline, isNotFloatingNode );
-        else
-            recurseElements( resetRendMethodToInline );
+        // inline: an inline parent resets all its children to inline
+        // (so, if some block content is erroneously wrapped in a SPAN, all
+        // the content become inline...), except, depending on what's enabled:
+        // - nodes with float: which can stay block among inlines
+        // - the inner content of inlineBoxes (the inlineBox is already inline)
+        recurseMatchingElements( resetRendMethodToInline, isNotBoxWrappingNode );
     } else if ( d==css_d_run_in ) {
         // runin
         //CRLog::trace("switch all children elements of <%s> to inline", LCSTR(getNodeName()));
@@ -5244,8 +5276,16 @@ void ldomNode::initNodeRendMethod()
     } else if ( d==css_d_list_item ) {
         // list item (no more used, obsolete rendering method)
         setRendMethod(erm_list_item);
-    } else if (d == css_d_table) {
+    } else if ( d==css_d_table ) {
         // table
+        initTableRendMethods( this, 0 );
+    } else if ( (d==css_d_inline_table || d==css_d_inline_block) && getNodeId()==el_table ) {
+        // table with inline-block or inline-table (other elements can have
+        // display: inline-table without being a table) should be rendered as table
+        // Note: inline-table support is not 100% per specs, we don't do as good as
+        // https://stackoverflow.com/questions/19352072/what-is-the-difference-between-inline-block-and-inline-table/19352149#19352149
+        // explains. An element with display: inline-table needs to be a <table>
+        // to be rendered as a table.
         initTableRendMethods( this, 0 );
     } else {
         // block or final
@@ -5303,7 +5343,7 @@ void ldomNode::initNodeRendMethod()
                     if ( !BLOCK_RENDERING_G(FLOAT_FLOATBOXES) ) {
                         // If we don't want floatBoxes floating, reset them to be
                         // rendered inline among inlines
-                        recurseElements( resetRendMethodToInline );
+                        recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
                     }
                     setRendMethod( erm_final );
                 }
@@ -5398,6 +5438,7 @@ void ldomNode::initNodeRendMethod()
         }
     }
 
+    bool handled_as_float = false;
     if (BLOCK_RENDERING_G(WRAP_FLOATS)) {
         // While loading the document, we want to put any element with float:left/right
         // inside an internal floatBox element with no margin in its style: this
@@ -5433,6 +5474,7 @@ void ldomNode::initNodeRendMethod()
         bool isFloating = getStyle()->float_ > css_f_none;
         bool isFloatBox = (getNodeId() == el_floatBox);
         if ( isFloating || isFloatBox ) {
+            handled_as_float = true;
             ldomNode * parent = getParentNode();
             bool isFloatBoxChild = (parent && (parent->getNodeId() == el_floatBox));
             if ( isFloatBox ) {
@@ -5469,6 +5511,8 @@ void ldomNode::initNodeRendMethod()
                 // when !PREPARE_FLOATBOXES
                 if (child->getRendMethod() == erm_inline)
                     setRendMethod( erm_inline );
+                else if (child->getRendMethod() == erm_invisible)
+                    setRendMethod( erm_invisible );
                 else
                     setRendMethod( erm_block );
             }
@@ -5535,6 +5579,111 @@ void ldomNode::initNodeRendMethod()
                     // So, we'll have a floatBox with float: that contains a span
                     // or div with float: - the rendering code may have to check
                     // for that: ->isFloatingBox() was added for that.
+                }
+            }
+        }
+    }
+
+    // (If a node is both inline-block and float: left/right, float wins.)
+    if (BLOCK_RENDERING_G(BOX_INLINE_BLOCKS) && !handled_as_float) {
+        // (Similar to what we do above for floats, but simpler.)
+        // While loading the document, we want to put any element with
+        // display: inline-block or inline-table inside an internal inlineBox
+        // element with no margin in its style: this inlineBox's RenderRectAccessor
+        // will have the width/height of the outer element (with margins inside),
+        // while the RenderRectAccessor of the wrapped original element itself
+        // will have the w/h of the element, including borders but excluding
+        // margins (as it is done for all elements by crengine).
+        // That makes out the following rules:
+        // - a inlineBox has a single child: the original inline-block element.
+        // - an element with style->display: inline-block/inline-table must be
+        //   wrapped in a inlineBox, which will get the same style->vertical_align
+        //   (happens in the initial document loading)
+        // - if it already has a inlineBox parent, no need to do it again, just ensure
+        //   the style->vertical_align are the same (happens when re-rendering)
+        // - if the element has lost its style->display: inline-block (style tweak
+        //   applied), or BOX_INLINE_BLOCKS disabled, as we can't remove the
+        //   inlineBox (we can't modify the DOM once a cache has been made):
+        //   the inlineBox and its children will both be set to erm_inline
+        //   (but as ->display has changed, a full re-loading will be suggested
+        //   to the user, and should probably be accepted).
+        // - a inlineBox has ALWAYS ->display=css_d_inline and erm_method=erm_inline
+        // - a inlineBox child keeps its original ->display, and may have
+        //   erm_method = erm_final or erm_block (depending on its content)
+        bool isInlineBlock = (d == css_d_inline_block || d == css_d_inline_table);
+        bool isInlineBox = (getNodeId() == el_inlineBox);
+        if ( isInlineBlock || isInlineBox ) {
+            ldomNode * parent = getParentNode();
+            bool isInlineBoxChild = (parent && (parent->getNodeId() == el_inlineBox));
+            if ( isInlineBox ) {
+                // Wrapping inlineBox already made
+                if (getChildCount() != 1) {
+                    CRLog::error("inlineBox with zero or more than one child");
+                    crFatalError();
+                }
+                // Update inlineBox style according to child's one
+                ldomNode * child = getChildNode(0);
+                css_style_ref_t child_style = child->getStyle();
+                css_style_ref_t my_style = getStyle();
+                css_style_ref_t my_new_style( new css_style_rec_t );
+                copystyle(my_style, my_new_style);
+                if (child_style->display == css_d_inline_block || child_style->display == css_d_inline_table) {
+                    my_new_style->display = css_d_inline; // become an inline wrapper
+                    // We need it to have the vertical_align from the child
+                    // (it's the only style we need for proper inline layout).
+                    my_new_style->vertical_align = child_style->vertical_align;
+                    setRendMethod( erm_inline );
+                }
+                else if (child_style->display == css_d_inline) {
+                    my_new_style->display = css_d_inline; // wrap inline in inline
+                    setRendMethod( erm_inline );
+                }
+                else if (child_style->display == css_d_none) {
+                    my_new_style->display = css_d_none; // stay invisible
+                    setRendMethod( erm_invisible );
+                }
+                else { // everything else must be wrapped by a block
+                    my_new_style->display = css_d_block;
+                    setRendMethod( erm_block );
+                }
+                setStyle(my_new_style);
+                // When re-rendering, setNodeStyle() has already been called to set
+                // our style and font, so no need for calling initNodeFont() here,
+                // as we didn't change anything related to font in the style (and
+                // calling it can cause a style hash mismatch for some reason).
+            }
+            else if ( isInlineBoxChild ) {
+                // Already inlineBox'ed, nothing special to do
+            }
+            else { // !isInlineBox && !isInlineBoxChild
+                // Element with display: inline-block/inline-table, that has not yet
+                // been wrapped in a inlineBox.
+                // Like above, don't do any node moving when there is already a
+                // cache file, to avoid some unclear segfaults.
+                // (If new inline-block appear after loading, we won't render well,
+                // but a style hash mismatch will happen and the user will be
+                // suggested to reload the book with cache cleaned.)
+                if ( parent && this->getDocument()->_cacheFile == NULL ) {
+                    // Replace this element with a inlineBox in its parent children collection,
+                    // and move it inside, as the single child of this inlineBox.
+                    int pos = getNodeIndex();
+                    ldomNode * ibox = parent->insertChildElement( pos, LXML_NS_NONE, el_inlineBox );
+                    parent->moveItemsTo( ibox, pos+1, pos+1 ); // move this element from parent into ibox
+                    ibox->setRendMethod( erm_inline );
+
+                    // We want this inlineBox to have no real style (and it surely
+                    // should not have the margins of the child), but it should probably
+                    // have the inherited properties of the node parent, just like the child
+                    // had them. We can't just copy the parent style into this inlineBox, as
+                    // we don't want its non-inherited properties like background-color which
+                    // could be drawn over some other content if this float has some negative
+                    // margins.
+                    // Best to use lvrend.cpp setNodeStyle(), which will properly set
+                    // this new node style with inherited properties from its parent,
+                    // and we made it do this specific propagation of vertical_align
+                    // from its single child, only when it has styles defined (so,
+                    // only on initial loading and not on re-renderings).
+                    setNodeStyle( ibox, parent->getStyle(), parent->getFont() );
                 }
             }
         }
@@ -6457,15 +6606,44 @@ bool ldomXPointer::isFinalNode() const
 }
 
 /// create xpointer from doc point
-ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool strictBounds )
+ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool strictBounds, ldomNode * fromNode )
 {
     //
     lvPoint orig_pt = lvPoint(pt);
     ldomXPointer ptr;
     if ( !getRootNode() )
         return ptr;
-    ldomNode * finalNode = getRootNode()->elementFromPoint( pt, direction );
+    ldomNode * startNode;
+    if ( fromNode ) {
+        // Start looking from the fromNode provided - only used when we are
+        // looking inside a floatBox or an inlineBox below and we have this
+        // recursive call to createXPointer().
+        // Even with a provided fromNode, pt must be provided in full absolute
+        // coordinates. But we need to give to startNode->elementFromPoint()
+        // a pt with coordinates relative to fromNode.
+        // And because elementFromPoint() uses the fmt x/y offsets of the
+        // start node (relative to the containing final block), we would
+        // need to have pt relative to that containing final block - and so,
+        // we'd need to lookup the final node from here (or have it provided
+        // as an additional parameter if it's known by caller).
+        // But because we're called only for floatBox and inlineBox, which
+        // have only a single child, we can use the trick of calling
+        // ->elementFromPoint() on that first child, while still getting
+        // pt relative to fromNode itself:
+        startNode = fromNode->getChildNode(0);
+        lvRect rc;
+        fromNode->getAbsRect( rc, true );
+        pt.x -= rc.left;
+        pt.y -= rc.top;
+    }
+    else {
+        startNode = getRootNode();
+    }
+    ldomNode * finalNode = startNode->elementFromPoint( pt, direction );
+    if ( fromNode )
+        pt = orig_pt; // restore orig pt
     if ( !finalNode ) {
+        // printf("no finalNode found from %s\n", UnicodeToLocal(ldomXPointer(fromNode, 0).toString()).c_str());
         // No node found, return start or end of document if pt overflows it, otherwise NULL
         if ( pt.y >= getFullHeight()) {
             ldomNode * node = getRootNode()->getLastTextChild();
@@ -6535,34 +6713,16 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             continue;
         if (pt.x >= flt->x && pt.x < flt->x + flt->width && pt.y >= flt->y && pt.y < flt->y + flt->height ) {
             // pt is inside this float.
-            // This node is not a final node, we need to find the right final node
-            ldomNode * floatNode = (ldomNode *) flt->srctext->object;
-            finalNode = floatNode->elementFromPoint( pt, direction );
-            // printf("float finaleNode %s\n", UnicodeToLocal(ldomXPointer(finalNode, 0).toString()).c_str());
-            if ( finalNode ) { // found it
-                lvdom_element_render_method rm = finalNode->getRendMethod();
-                if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption ) {
-                    // We just update the local variables created above and used below,
-                    // with similar code as above (but no need for the legacy way, as
-                    // we don't get float in legacy rendering).
-                    finalNode->getAbsRect( rc, true ); // inner = true
-                    pt = orig_pt; // re-set to the original one, as we're back in absolute coordinates
-                    pt.x -= rc.left;
-                    pt.y -= rc.top;
-                    fmt = RenderRectAccessor( finalNode );
-                    if ( RENDER_RECT_HAS_FLAG(fmt, INNER_FIELDS_SET) ) {
-                        inner_width = fmt.getInnerWidth();
-                    }
-                    else { // should not happen, but fallback to rc width
-                        inner_width = rc.width();
-                    }
-                    finalNode->renderFinalBlock( txtform, &fmt, inner_width );
-                    break; // go on looking at words in this new txtform
-                }
+            ldomNode * node = (ldomNode *) flt->srctext->object; // floatBox node
+            ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
+            if ( !inside_ptr.isNull() ) {
+                return inside_ptr;
             }
+            // Otherwise, return xpointer to the floatNode itself
+            return ldomXPointer(node, 0);
+            // (Or should we let just go on looking only at the text in the original final node?)
         }
-        // If no containing float, or no inner final node found in it,
-        // go on looking at the text of the original final node
+        // If no containing float, go on looking at the text of the original final node
     }
 
     // Look at words in the rendered final node (whether it's the original
@@ -6599,7 +6759,16 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 if ( !node ) // Ignore crengine added text (spacing, list item bullets...)
                     continue;
 
-                if ( src->flags & LTEXT_SRC_IS_OBJECT ) {
+                if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
+                    // pt is inside this inline-block inlineBox node
+                    ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
+                    if ( !inside_ptr.isNull() ) {
+                        return inside_ptr;
+                    }
+                    // Otherwise, return xpointer to the inlineBox itself
+                    return ldomXPointer(node, 0);
+                }
+                if ( word->flags & LTEXT_WORD_IS_OBJECT ) {
                     // Object (image)
                     #if 1
                     // return image object itself
@@ -6744,8 +6913,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
         // When in enhanced rendering mode, we can get the FormattedText coordinates
         // and its width (inner_width) directly
         int inner_width;
-        int shift_x;
-        int shift_y;
         if ( RENDER_RECT_HAS_FLAG(fmt, INNER_FIELDS_SET) ) {
             inner_width = fmt.getInnerWidth();
             // if extended=true, we got directly the adjusted rc.top and rc.left
@@ -6884,7 +7051,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             else {
                                 bestBidiRect.left = word->x + rc.left + frmline->x;
                                 if (extended) {
-                                    if (word->flags & LTEXT_WORD_IS_OBJECT && word->width > 0)
+                                    if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                         bestBidiRect.right = bestBidiRect.left + word->width; // width of image
                                     else
                                         bestBidiRect.right = bestBidiRect.left + 1;
@@ -6892,14 +7059,14 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             }
                             hasBestBidiRect = true;
                             nearestForwardSrcIndex = word->src_text_index;
-                            if (word->flags & LTEXT_WORD_IS_OBJECT)
+                            if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX))
                                 nearestForwardSrcOffset = 0;
                             else
                                 nearestForwardSrcOffset = word->t.start;
                         }
                         else if (word->src_text_index == srcIndex) {
                             // Found word in that exact source text node
-                            if ( word->flags & LTEXT_WORD_IS_OBJECT ) {
+                            if ( word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) ) {
                                 // An image is the single thing in its srcIndex
                                 rect.top = rc.top + frmline->y;
                                 rect.bottom = rect.top + frmline->height;
@@ -7087,7 +7254,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                 // Generic code when visual order = logical order
                 if ( word->src_text_index>=srcIndex || lastWord ) {
                     // found word from same src line
-                    if ( word->flags & LTEXT_WORD_IS_OBJECT
+                    if ( word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX)
                             || word->src_text_index > srcIndex
                             || (!extended && offset <= word->t.start)
                             || (extended && offset < word->t.start)
@@ -7099,7 +7266,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                         //rect.top = word->y + rc.top + frmline->y + frmline->baseline;
                         rect.top = rc.top + frmline->y;
                         if (extended) {
-                            if (word->flags & LTEXT_WORD_IS_OBJECT && word->width > 0)
+                            if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                 rect.right = rect.left + word->width; // width of image
                             else
                                 rect.right = rect.left + 1; // not the right word: no char width
@@ -13175,9 +13342,10 @@ void ldomNode::getAbsRect( lvRect & rect, bool inner )
         if ( RENDER_RECT_HAS_FLAG(fmt, INNER_FIELDS_SET) ) {
             // getAbsRect() is mostly used on erm_final nodes. So,
             // if we meet another erm_final node in our parent, we are
-            // probably an embedded floatBox. Embedded floatBoxes are
-            // positionned according to the inner LFormattedText, so
-            // we need to account for these padding shifts.
+            // probably an embedded floatBox or inlineBox. Embedded
+            // floatBoxes or inlineBoxes are positionned according
+            // to the inner LFormattedText, so we need to account
+            // for these padding shifts.
             rect.left += fmt.getInnerX();     // add padding left
             rect.top += fmt.getInnerY();      // add padding top
         }
@@ -13798,7 +13966,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             // The UL > LI parent-child chain may have had a floatBox element
             // inserted if the LI has some float: style (also handled below
             // when walking this parent's children).
-            if ( parent->getNodeId() == el_floatBox ) {
+            if ( parent->getNodeId() == el_floatBox || parent->getNodeId() == el_inlineBox ) {
                 parent = parent->getParentNode();
             }
             counterValue = 0;
@@ -13813,7 +13981,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             }
             for (int i = 0; i < parent->getChildCount(); i++) {
                 ldomNode * child = parent->getChildNode(i);
-                if ( child->getNodeId() == el_floatBox ) {
+                if ( child->getNodeId() == el_floatBox || child->getNodeId() == el_inlineBox ) {
                     child = child->getChildNode(0);
                 }
                 css_style_ref_t cs = child->getStyle();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3545,7 +3545,7 @@ static void writeNode( LVStream * stream, ldomNode * node, bool treeLayout )
 }
 
 // Extended version of previous function for displaying selection HTML, with tunable output
-#define WRITENODEEX_ADD_UPPER_DIR_LANG_ATTR      0x0001 ///< add dir= and lang= grabbed from upper nodes
+#define WRITENODEEX_TEXT_HYPHENATE               0x0001 ///< add soft-hyphens where hyphenation is allowed
 #define WRITENODEEX_TEXT_MARK_NODE_BOUNDARIES    0x0002 ///< mark start and end of text nodes (useful when indented)
 #define WRITENODEEX_TEXT_SHOW_UNICODE_CODEPOINT  0x0004 ///< show unicode codepoint after char
 #define WRITENODEEX_TEXT_UNESCAPED               0x0008 ///< let &, < and > unescaped in text nodes (makes HTML invalid)
@@ -3553,16 +3553,18 @@ static void writeNode( LVStream * stream, ldomNode * node, bool treeLayout )
 #define WRITENODEEX_NEWLINE_BLOCK_NODES          0x0020 ///< start only nodes rendered as block/final on a new line,
                                                         ///  so inline elements and text nodes are stuck together
 #define WRITENODEEX_NEWLINE_ALL_NODES            0x0040 ///< start all nodes on a new line
-#define WRITENODEEX_UNUSED_3                     0x0080 ///<
+#define WRITENODEEX_UNUSED_1                     0x0080 ///<
 #define WRITENODEEX_NB_SKIPPED_CHARS             0x0100 ///< show number of skipped chars in text nodes: (...43...)
 #define WRITENODEEX_NB_SKIPPED_NODES             0x0200 ///< show number of skipped sibling nodes: [...17...]
 #define WRITENODEEX_SHOW_REND_METHOD             0x0400 ///< show rendering method at end of tag (<div ~F> =Final, <b ~i>=Inline...)
-#define WRITENODEEX_UNUSED_5                     0x0800 ///<
-#define WRITENODEEX_GET_CSS_FILES                0x1000 ///< ensure css files that apply to initial node are returned
+#define WRITENODEEX_UNUSED_2                     0x0800 ///<
+#define WRITENODEEX_ADD_UPPER_DIR_LANG_ATTR      0x1000 ///< add dir= and lang= grabbed from upper nodes
+#define WRITENODEEX_GET_CSS_FILES                0x2000 ///< ensure css files that apply to initial node are returned
                                                         ///  in &cssFiles (needed when not starting from root node)
-#define WRITENODEEX_INCLUDE_STYLESHEET_ELEMENT   0x2000 ///< includes crengine <stylesheet> element in HTML
+#define WRITENODEEX_INCLUDE_STYLESHEET_ELEMENT   0x4000 ///< includes crengine <stylesheet> element in HTML
                                                         ///  (not done if outside of sub-tree)
-#define WRITENODEEX_COMPUTED_STYLES_AS_ATTR      0x4000 ///< set style='' from computed styles (not implemented)
+#define WRITENODEEX_COMPUTED_STYLES_AS_ATTR      0x8000 ///< set style='' from computed styles (not implemented)
+
 
 #define WNEFLAG(x) ( wflags & WRITENODEEX_##x )
 
@@ -3716,11 +3718,65 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             while ( txt.replace( cs16("<"), cs16("&lt;") ) ) ;
             while ( txt.replace( cs16(">"), cs16("&gt;") ) ) ;
         }
+        #define HYPH_MIN_WORD_LEN_TO_HYPHENATE 4
+        #define HYPH_MAX_WORD_SIZE 64
+        // (No hyphenation if we are showing unicode codepoint)
         if ( WNEFLAG(TEXT_SHOW_UNICODE_CODEPOINT) ) {
             *stream << prefix;
             for ( int i=0; i<txt.length(); i++ )
                 *stream << UnicodeToUtf8(txt.substr(i, 1)) << "⟨U+" << lString8().appendHex(txt[i]) << "⟩";
             *stream << suffix;
+        }
+        else if ( WNEFLAG(TEXT_HYPHENATE) && HyphMan::isEnabled() && txt.length() >= HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
+            // Add soft-hyphens where HyphMan (with the user or language current hyphenation
+            // settings) says hyphenation is allowed.
+            // We do that here while we output the text to avoid the need
+            // for temporary storage of a string with soft-hyphens added.
+            const lChar16 * text16 = txt.c_str();
+            int txtlen = txt.length();
+            lUInt8 * flags = (lUInt8*)calloc(txtlen, sizeof(*flags));
+            lUInt16 widths[HYPH_MAX_WORD_SIZE] = { 0 }; // array needed by hyphenate()
+            // Lookup words starting from the end, just because lStr_findWordBounds()
+            // will ensure the iteration that way.
+            int wordpos = txtlen;
+            while ( wordpos > 0 ) {
+                // lStr_findWordBounds() will find the word contained at wordpos
+                // (or the previous word if wordpos happens to be a space or some
+                // punctuation) by looking only for alpha chars in m_text.
+                int start, end;
+                lStr_findWordBounds( text16, txtlen, wordpos, start, end );
+                if ( end <= HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
+                    // Too short word at start, we're done
+                    break;
+                }
+                int len = end - start;
+                if ( len < HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
+                    // Too short word found, skip it
+                    wordpos = start - 1;
+                    continue;
+                }
+                if ( start >= wordpos ) {
+                    // Shouldn't happen, but let's be sure we don't get stuck
+                    wordpos = wordpos - HYPH_MIN_WORD_LEN_TO_HYPHENATE;
+                    continue;
+                }
+                // We have a valid word to look for hyphenation
+                if ( len > HYPH_MAX_WORD_SIZE ) // hyphenate() stops/truncates at 64 chars
+                    len = HYPH_MAX_WORD_SIZE;
+                // Have HyphMan set flags inside 'flags'
+                HyphMan::hyphenate(text16+start, len, widths, flags+start, 0, 0xFFFF, 1);
+                // Continue with previous word
+                wordpos = start - 1;
+            }
+            // Output text, and add a soft-hyphen where there are flags
+            *stream << prefix;
+            for ( int i=0; i<txt.length(); i++ ) {
+                *stream << UnicodeToUtf8(txt.substr(i, 1));
+                if ( flags[i] & LCHAR_ALLOW_HYPH_WRAP_AFTER )
+                    *stream << "­";
+            }
+            *stream << suffix;
+            free(flags);
         }
         else {
             *stream << prefix << UnicodeToUtf8(txt) << suffix;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8287,6 +8287,9 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
 }
 
 /// fill marked ranges list
+// Transform a list of ldomXRange (start and end xpointers) into a list
+// of ldomMarkedRange (start and end point coordinates) for native
+// drawing of highlights
 void ldomXRangeList::getRanges( ldomMarkedRangeList &dst )
 {
     dst.clear();
@@ -8294,25 +8297,46 @@ void ldomXRangeList::getRanges( ldomMarkedRangeList &dst )
         return;
     for ( int i=0; i<length(); i++ ) {
         ldomXRange * range = get(i);
-        // For native highlights to correctly grab glyphs left and right
-        // overflows, some tweaking might be needed here.
-        lvPoint ptStart = range->getStart().toPoint();
-        lvPoint ptEnd = range->getEnd().toPoint();
-//        // LVE:DEBUG
-//        CRLog::trace("selectRange( %d,%d : %d,%d : %s, %s )", ptStart.x, ptStart.y, ptEnd.x, ptEnd.y, LCSTR(range->getStart().toString()), LCSTR(range->getEnd().toString()) );
-        if ( ptStart.y > ptEnd.y || ( ptStart.y == ptEnd.y && ptStart.x >= ptEnd.x ) ) {
-            // Swap ptStart and ptEnd if coordinates seems inverted (or we would
-            // get item->empty()), which is needed for bidi/rtl.
-            // Hoping this has no side effect.
-            lvPoint ptTmp = ptStart;
-            ptStart = ptEnd;
-            ptEnd = ptTmp;
+        if (range->getFlags() < 2) {
+            // Legacy marks drawing: make a single ldomMarkedRange spanning
+            // multiple lines, assuming full width LTR paragraphs)
+            // (Updated to use toPoint(extended=true) to have them shifted
+            // by the margins and paddings of final blocks, to be compatible
+            // with getSegmentRects() below that does that internally.)
+            lvPoint ptStart = range->getStart().toPoint(true);
+            lvPoint ptEnd = range->getEnd().toPoint(true);
+            // LVE:DEBUG
+            // CRLog::trace("selectRange( %d,%d : %d,%d : %s, %s )", ptStart.x, ptStart.y, ptEnd.x, ptEnd.y,
+            //              LCSTR(range->getStart().toString()), LCSTR(range->getEnd().toString()) );
+            if ( ptStart.y > ptEnd.y || ( ptStart.y == ptEnd.y && ptStart.x >= ptEnd.x ) ) {
+                // Swap ptStart and ptEnd if coordinates seems inverted (or we would
+                // get item->empty()), which is needed for bidi/rtl.
+                // Hoping this has no side effect.
+                lvPoint ptTmp = ptStart;
+                ptStart = ptEnd;
+                ptEnd = ptTmp;
+            }
+            ldomMarkedRange * item = new ldomMarkedRange( ptStart, ptEnd, range->getFlags() );
+            if ( !item->empty() )
+                dst.add( item );
+            else
+                delete item;
         }
-        ldomMarkedRange * item = new ldomMarkedRange( ptStart, ptEnd, range->getFlags() );
-        if ( !item->empty() )
-            dst.add( item );
-        else
-            delete item;
+        else {
+            // Enhanced marks drawing: from a single ldomXRange, make multiple segmented
+            // ldomMarkedRange, each spanning a single line.
+            LVArray<lvRect> rects;
+            range->getSegmentRects(rects);
+            for (int i=0; i<rects.length(); i++) {
+                lvRect r = rects[i];
+                // printf("r %d %dx%d %dx%d\n", i, r.topLeft().x, r.topLeft().y, r.bottomRight().x, r.bottomRight().y);
+                ldomMarkedRange * item = new ldomMarkedRange( r.topLeft(), r.bottomRight(), range->getFlags() );
+                if ( !item->empty() )
+                    dst.add( item );
+                else
+                    delete item;
+            }
+        }
     }
 }
 
@@ -8671,22 +8695,38 @@ bool ldomXRange::getWordRange( ldomXRange & range, ldomXPointer & p )
 /// returns true if intersects specified line rectangle
 bool ldomMarkedRange::intersects( lvRect & rc, lvRect & intersection )
 {
-    if ( start.y>=rc.bottom )
-        return false;
-    if ( end.y<rc.top )
-        return false;
-    intersection = rc;
-    if ( start.y>=rc.top && start.y<rc.bottom ) {
-        if ( start.x > rc.right )
+    if ( flags < 2 ) {
+        // This assumes lines (rc) are from full-width LTR paragraphs, and
+        // takes some shortcuts when checking intersection (it can be wrong
+        // when floats, table cells, or RTL/BiDi text are involved).
+        if ( start.y>=rc.bottom )
             return false;
+        if ( end.y<rc.top )
+            return false;
+        intersection = rc;
+        if ( start.y>=rc.top && start.y<rc.bottom ) {
+            if ( start.x > rc.right )
+                return false;
+            intersection.left = rc.left > start.x ? rc.left : start.x;
+        }
+        if ( end.y>=rc.top && end.y<rc.bottom ) {
+            if ( end.x < rc.left )
+                return false;
+            intersection.right = rc.right < end.x ? rc.right : end.x;
+        }
+        return true;
+    }
+    else {
+        // Don't take any shortcut and check the full intersection
+        if ( rc.bottom <= start.y || rc.top >= end.y || rc.right <= start.x || rc.left >= end.x ) {
+            return false; // no intersection
+        }
+        intersection.top = rc.top > start.y ? rc.top : start.y;
+        intersection.bottom = rc.bottom < end.y ? rc.bottom : end.y;
         intersection.left = rc.left > start.x ? rc.left : start.x;
-    }
-    if ( end.y>=rc.top && end.y<rc.bottom ) {
-        if ( end.x < rc.left )
-            return false;
         intersection.right = rc.right < end.x ? rc.right : end.x;
+        return !intersection.isEmpty();
     }
-    return true;
 }
 
 /// create bounded by RC list, with (0,0) coordinates at left top corner
@@ -13446,7 +13486,10 @@ static void updateStyleDataRecursive( ldomNode * node, LVDocViewCallback * progr
         // this recursive phase. Do that anyway as we progress among
         // the collection of DocFragments.
         if ( progressCallback && node->getNodeId()==el_DocFragment ) {
-            int percent = 100 * node->getNodeIndex() / node->getParentNode()->getChildCount();
+            int nbDocFragments = node->getParentNode()->getChildCount();
+            if (nbDocFragments == 0) // should not happen (but avoid clang-tidy warning)
+                nbDocFragments = 1;
+            int percent = 100 * node->getNodeIndex() / nbDocFragments;
             if ( percent != lastProgressPercent ) {
                 progressCallback->OnNodeStylesUpdateProgress( percent );
                 lastProgressPercent = percent;


### PR DESCRIPTION
See individual commit messages for details.
Some additional notes:
- `lvtinydom.cpp: fix Use-after-free` Closes #324.
- `lvtextfm: fix/cleanup lastnonspace code bits` hopefully makes some dubious code right
- `lvtextfm: fix vertical-align: top & bottom` should implement them the right way, by delaying positionning until the full line is laid out. Closes https://github.com/koreader/crengine/pull/302#issuecomment-570061251.
Previous work on vertical-align in #240 and #273.
- `Better selection highlighting by using getSegmentRects()` should have in-progress text selection show just as already-made highlights, which will improve text selection in RTL text.
Should close https://github.com/koreader/koreader/issues/5735

- `Add support for display: inline-block/inline-table` and `renderBlockElementEnhanced: compute baseline of block`
Follow up to #299 `Enhanced block rendering (floats, collapsing margins...)`, many of its stuff is re-used to render inline-block boxes (box among text, laid out just like inline images) just like we render float content.

I did not find much specs and docs about inline-block / inline-table, here are the ones I read:
https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align only the last 2 paragraphs :)
https://blog.mozilla.org/webdev/2009/02/20/cross-browser-inline-block/
http://www.gtalbot.org/BrowserBugsSection/Safari3Bugs/baseline-inline-table-vertical-align.html
https://stackoverflow.com/questions/19352072/what-is-the-difference-between-inline-block-and-inline-table
https://www.brunildo.org/test/inline-block.html
https://www.brunildo.org/test/inline-block2.html

Some screenshots:
KOReader showing https://www.brunildo.org/test/inline-block.html:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72159832-86b3fe80-33bd-11ea-87ad-530e1155ede1.png)</kbd>

Mix of floats and inline-block:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72159917-a9deae00-33bd-11ea-8e33-6036642f0a0c.png)</kbd>

Inline-block in a float in an inline-block in a float:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72159949-b95df700-33bd-11ea-8976-90bea64c0775.png)</kbd>

Snippet from https://stackoverflow.com/questions/19352072/what-is-the-difference-between-inline-block-and-inline-table/56305302#56305302, Firefox on the left, KOReader on the right:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72160168-2bced700-33be-11ea-9019-205f01a39d1f.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/325)
<!-- Reviewable:end -->
