### PR TITLE
Various fixes related to text-indent, CSS order. Adds -cr-hint: strut-confined

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -308,7 +308,8 @@ enum css_cr_hint_t {
     css_cr_hint_toc_level4,
     css_cr_hint_toc_level5,
     css_cr_hint_toc_level6,
-    css_cr_hint_toc_ignore
+    css_cr_hint_toc_ignore,
+    css_cr_hint_strut_confined
 };
 
 /// css length value

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -46,6 +46,7 @@ XS_TAG1( html )
 XS_TAG1( head )
 XS_TAG1D( title, true, css_d_block, css_ws_normal )
 XS_TAG1D( style, true, css_d_none, css_ws_normal )
+XS_TAG1D( script, true, css_d_none, css_ws_normal )
 XS_TAG1T( body )
 XS_TAG1( param ) /* quite obsolete, child of <object>... was there, let's keep it */
 

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -120,7 +120,7 @@ int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing 
 int styleToTextFmtFlags( const css_style_ref_t & style, int oldflags, int direction=REND_DIRECTION_UNSET );
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, int & flags,
-                       int ident, int line_h, int valign_dy=0, bool * is_link_start=NULL );
+                       int indent, int line_h, int valign_dy=0, bool * is_link_start=NULL );
 /// renders block which contains subblocks (with gRenderBlockRenderingFlags as flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );
 /// renders block which contains subblocks

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -75,6 +75,8 @@ extern "C" {
 #define LTEXT_SRC_IS_FLOAT_DONE      0x02000000  /**< \brief float:'ing node (already dealt with) */
 #define LTEXT_SRC_IS_INLINE_BOX      0x04000000  /**< \brief inlineBox wrapping node */
 
+#define LTEXT_STRUT_CONFINED         0x08000000  /**< \brief text should not overflow/modify its paragraph strut baseline and height */
+
 /** \brief Source text line
 */
 typedef struct
@@ -156,6 +158,8 @@ typedef struct
 
 #define LTEXT_WORD_VALIGN_TOP                0x1000 /// word is to be vertical-align: top
 #define LTEXT_WORD_VALIGN_BOTTOM             0x2000 /// word is to be vertical-align: bottom
+#define LTEXT_WORD_STRUT_CONFINED            0x4000 /// word is to be fully contained into strut bounds
+                                                    /// (used only when one of the 2 previous is set)
 
 //#define LTEXT_BACKGROUND_MARK_FLAGS 0xFFFF0000l
 

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -82,7 +82,7 @@ extern "C" {
 typedef struct
 {
     void *          object;   /**< \brief pointer to object which represents source */
-    lInt16          margin;   /**< \brief first line margin */
+    lInt16          indent;   /**< \brief first line indent (or all but first, when negative) */
     lInt16          valign_dy; /* drift y from baseline */
     lInt16          interval; /**< \brief line height in screen pixels */
     lInt16          letter_spacing; /**< \brief additional letter spacing, pixels */
@@ -287,7 +287,7 @@ void lvtextAddSourceLine(
    lUInt32         flags,    /* flags */
    lInt16          interval, /* line height in screen pixels */
    lInt16          valign_dy,/* drift y from baseline */
-   lUInt16         margin,   /* first line margin */
+   lInt16          indent,   /* first line indent (or all but first, when negative) */
    void *          object,   /* pointer to custom object */
    lUInt16         offset,    /* offset from node/object start to start of line */
    lInt16          letter_spacing
@@ -304,7 +304,7 @@ void lvtextAddSourceObject(
    lUInt32         flags,     /* flags */
    lInt16          interval,  /* line height in screen pixels */
    lInt16          valign_dy, /* drift y from baseline */
-   lUInt16         margin,    /* first line margin */
+   lInt16          indent,    /* first line indent (or all but first, when negative) */
    void *          object,    /* pointer to custom object */
    lInt16          letter_spacing
                          );
@@ -358,7 +358,7 @@ public:
                 lUInt32         flags,     /* flags */
                 lInt16          interval,  /* line height in screen pixels */
                 lInt16          valign_dy, /* drift y from baseline */
-                lUInt16         margin,    /* first line margin */
+                lInt16          indent,    /* first line indent (or all but first, when negative) */
                 void *          object,    /* pointer to custom object */
                 lInt16          letter_spacing=0
          );
@@ -372,7 +372,7 @@ public:
            lUInt32         flags,       /* (had default =LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT) */
            lInt16          interval,    /* line height in screen pixels */
            lInt16          valign_dy=0, /* drift y from baseline */
-           lUInt16         margin=0,    /* first line margin */
+           lInt16          indent=0,    /* first line indent (or all but first, when negative) */
            void *          object=NULL,
            lUInt32         offset=0,
            lInt16          letter_spacing=0
@@ -381,7 +381,7 @@ public:
         lvtextAddSourceLine(m_pbuffer, 
             font,  //font->GetHandle()
             text, len, color, bgcolor, 
-            flags, interval, valign_dy, margin, object, (lUInt16)offset, letter_spacing );
+            flags, interval, valign_dy, indent, object, (lUInt16)offset, letter_spacing );
     }
 
     lUInt32 Format(lUInt16 width, lUInt16 page_height,

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1743,8 +1743,11 @@ class ldomXRange {
     /// _flags, only used by ldomXRangeList.getRanges() when making a ldomMarkedRangeList (for native
     //  highlighting of a text selection being made, and for crengine internal bookmarks):
     //  0: not shown (filtered out in LVDocView::updateSelections() by ldomXRangeList ranges(..., true))
-    //  1: legacy drawing (will make a single ldomMarkedRange spanning multiple lines, assuming full width LTR paragraphs)
-    //  2: enhanced drawing (will make multiple segmented ldomMarkedRange, each spanning a single line)
+    //  1,2,3: legacy drawing (will make a single ldomMarkedRange spanning multiple lines, assuming
+    //         full width LTR paragraphs) (2 & 3 might be used for crengine internal bookmarks,
+    //         see hist.h for enum bmk_type)
+    //  0x11, 0x12, 0x13:  enhanced drawing (will make multiple segmented ldomMarkedRange,
+    //                     each spanning a single line)
     lUInt32 _flags;
 public:
     ldomXRange()
@@ -1891,8 +1894,10 @@ public:
     lvPoint   end;
     /// flags:
     //  0: not shown
-    //  1: legacy drawing (a single mark may spans multiple lines, assuming full width LTR paragraphs)
-    //  2: enhanced drawing (segmented mark, spanning a single line)
+    //  1,2,3: legacy drawing (a single mark may spans multiple lines, assuming full width
+    //         LTR paragraphs) (2 & 3 might be used for crengine internal bookmarks,
+    //         see hist.h for enum bmk_type)
+    //  0x11, 0x12, 0x13:  enhanced drawing (segmented mark, spanning a single line)
     lUInt32   flags;
     bool empty()
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -105,6 +105,27 @@ extern int gDOMVersionRequested;
 
 #define NODE_DISPLAY_STYLE_HASH_UNITIALIZED 0xFFFFFFFF
 
+// To be used for 'direction' in ldomNode->elementFromPoint(lvPoint pt, int direction)
+// and ldomDocument->createXPointer(lvPoint pt, int direction...) as a way to
+// self-document what's expected (but the code does > and < comparisons, so
+// don't change these values - some clients may also already use 0/1/-1).
+// Use PT_DIR_EXACT to find the exact node at pt (with y AND x check),
+// which is needed when selecting text or checking if tap is on a link,
+// (necessary in table cells or floats, and in RTL text).
+// Use PT_DIR_SCAN_* when interested only in finding the slice of a page
+// at y (eg. to get the current page top), finding the nearest node in
+// direction if pt.y happens to be in some node margin area.
+// Use PT_DIR_SCAN_BACKWARD_LOGICAL_* when looking a whole page range
+// xpointers, to not miss words on first or last line in bidi/RTL text.
+#define PT_DIR_SCAN_BACKWARD_LOGICAL_LAST   -3
+#define PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST  -2
+#define PT_DIR_SCAN_BACKWARD                -1
+#define PT_DIR_EXACT                         0
+#define PT_DIR_SCAN_FORWARD                  1
+#define PT_DIR_SCAN_FORWARD_LOGICAL_FIRST    2
+#define PT_DIR_SCAN_FORWARD_LOGICAL_LAST     3
+
+
 //#if BUILD_LITE!=1
 /// final block cache
 typedef LVRef<LFormattedText> LFormattedTextRef;
@@ -2337,7 +2358,7 @@ public:
     ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr );
 #if BUILD_LITE!=1
     /// create xpointer from doc point
-    ldomXPointer createXPointer( lvPoint pt, int direction=0, bool strictBounds=false, ldomNode * from_node=NULL );
+    ldomXPointer createXPointer( lvPoint pt, int direction=PT_DIR_EXACT, bool strictBounds=false, ldomNode * from_node=NULL );
     /// get rendered block cache object
     CVRendBlockCache & getRendBlockCache() { return _renderedBlockCache; }
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -531,6 +531,7 @@ protected:
 
 public:
 
+#if BUILD_LITE!=1
     bool setSpaceWidthScalePercent(int spaceWidthScalePercent) {
         if (spaceWidthScalePercent == _spaceWidthScalePercent)
             return false;
@@ -544,7 +545,9 @@ public:
         _minSpaceCondensingPercent = minSpaceCondensingPercent;
         return true;
     }
+#endif
 
+#if BUILD_LITE!=1
     /// add named BLOB data to document
     bool addBlob(lString16 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
     /// get BLOB by name
@@ -553,7 +556,6 @@ public:
     /// called on document loading end
     bool validateDocument();
 
-#if BUILD_LITE!=1
     /// swaps to cache file or saves changes, limited by time interval (can be called again to continue after TIMEOUT)
     virtual ContinuousOperationResult swapToCache(CRTimerUtil & maxTime) = 0;
     /// try opening from cache file, find by source file name (w/o path) and crc32
@@ -602,6 +604,7 @@ public:
     /// returns doc properties collection
     void setProps( CRPropRef props ) { _docProps = props; }
 
+#if BUILD_LITE!=1
     /// set cache file stale flag
     void setCacheFileStale( bool stale ) { _cacheFileStale = stale; }
 
@@ -620,6 +623,7 @@ public:
     void invalidateCacheFile() { _cacheFileLeaveAsDirty = true; };
     /// get cache file full path
     lString16 getCacheFilePath();
+#endif
 
     /// minimize memory consumption
     void compact();
@@ -1481,7 +1485,7 @@ public:
 	{
 		return *_data != *v._data;
 	}
-#if BUILD_LITE!=1
+//#if BUILD_LITE!=1
     /// returns caret rectangle for pointer inside formatted document
     bool getRect(lvRect & rect, bool extended=false, bool adjusted=false) const;
     /// returns glyph rectangle for pointer inside formatted document considering paddings and borders
@@ -1489,7 +1493,7 @@ public:
     bool getRectEx(lvRect & rect, bool adjusted=false) const { return getRect(rect, true, adjusted); };
     /// returns coordinates of pointer inside formatted document
     lvPoint toPoint( bool extended=false ) const;
-#endif
+//#endif
     /// converts to string
 	lString16 toString();
     /// returns XPath node text
@@ -2233,13 +2237,13 @@ protected:
 
 public:
 
+#if BUILD_LITE!=1
     void forceReinitStyles() {
         dropStyles();
         _hdr.render_style_hash = 0;
         _rendered = false;
     }
 
-#if BUILD_LITE!=1
     ListNumberingPropsRef getNodeNumberingProps( lUInt32 nodeDataIndex );
     void setNodeNumberingProps( lUInt32 nodeDataIndex, ListNumberingPropsRef v );
     void resetNodeNumberingProps();
@@ -2272,9 +2276,9 @@ public:
     /// build TOC from headings
     void buildTocFromHeadings();
 
+#if BUILD_LITE!=1
     bool isTocFromCacheValid() { return _toc_from_cache_valid; }
 
-#if BUILD_LITE!=1
     /// save document formatting parameters after render
     void updateRenderContext();
     /// check document formatting parameters before render - whether we need to reformat; returns false if render is necessary
@@ -2453,7 +2457,13 @@ public:
     /// called on text
     virtual void OnText( const lChar16 * text, int len, lUInt32 flags );
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) { return _document->addBlob(name, data, size); }
+    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) {
+#if BUILD_LITE!=1
+        return _document->addBlob(name, data, size);
+#else
+        return false;
+#endif
+    }
     /// set document property
     virtual void OnDocProperty(const char * name, lString8 value) { _document->getProps()->setString(name, value); }
 

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -527,7 +527,7 @@ public:
                 if (!_url.empty()) {
 //                    CRLog::trace("@font { face: %s; bold: %s; italic: %s; url: %s", _face.c_str(), _bold ? "yes" : "no",
 //                                 _italic ? "yes" : "no", LCSTR(_url));
-                    if (islocal.length()==5 and _basePath.length()!=0)
+                    if (islocal.length()==5 && _basePath.length()!=0)
                         _url = _url.substr((_basePath.length()+1), (_url.length()-_basePath.length()));
                     if (_fontList.findByUrl(_url))
                         _url=_url.append(lString16(" ")); //avoid add() replaces existing local name
@@ -539,7 +539,7 @@ public:
         case ',':
             if (_state == 2) {
                 if (!_url.empty()) {
-                      if (islocal.length() == 5 and _basePath.length()!=0) _url=(_url.substr((_basePath.length()+1),(_url.length()-_basePath.length())));
+                      if (islocal.length() == 5 && _basePath.length()!=0) _url=(_url.substr((_basePath.length()+1),(_url.length()-_basePath.length())));
                         if (_fontList.findByUrl(_url)) _url=_url.append(lString16(" "));
                     _fontList.add(_url, _face, _bold, _italic);
                 }

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -461,6 +461,7 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
             lString16 href = item->getAttributeValue("href");
             lString16 id = item->getAttributeValue("id");
             if ( !href.empty() && !id.empty() ) {
+                href = DecodeHTMLUrlString(href);
                 if (id == coverId) {
                     // coverpage file
                     lString16 coverFileName = LVCombinePaths(codeBase, href);

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -161,6 +161,8 @@ bool HyphMan::activateDictionaryFromStream( LVStreamRef stream )
     if (method->largest_overflowed_word)
         printf("CRE WARNING: hyph dict from stream: some hyphenation patterns were too long and have been ignored: increase MAX_PATTERN_SIZE from %d to %d\n", MAX_PATTERN_SIZE, method->largest_overflowed_word);
     CRLog::debug("Dictionary is loaded successfully. Activating.");
+    if (!_dictList)
+        _dictList = new HyphDictionaryList();
     HyphMan::_method = method;
     if ( HyphMan::_dictList->find(lString16(HYPH_DICT_ID_DICTIONARY))==NULL ) {
         HyphDictionary * dict = new HyphDictionary( HDT_DICT_ALAN, cs16("Dictionary"), lString16(HYPH_DICT_ID_DICTIONARY), lString16::empty_str );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2454,7 +2454,7 @@ ldomXPointer LVDocView::getNodeByPoint(lvPoint pt, bool strictBounds) {
 	LVLock lock(getMutex());
     CHECK_RENDER("getNodeByPoint()")
 	if (windowToDocPoint(pt) && m_doc) {
-		ldomXPointer ptr = m_doc->createXPointer(pt, 0, strictBounds);
+		ldomXPointer ptr = m_doc->createXPointer(pt, PT_DIR_EXACT, strictBounds);
 		//CRLog::debug("  ptr (%d, %d) node=%08X offset=%d", pt.x, pt.y, (lUInt32)ptr.getNode(), ptr.getOffset() );
 		return ptr;
 	}
@@ -2573,11 +2573,15 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
     // With floats, a page may actually show more than one range,
     // not sure how to deal with that (return a range including all
     // subranges, so possibly including stuff not shown on the page?)
+    // We also want to get the xpointer to the first or last node
+    // on a line in "logical order" instead of "visual order", which
+    // is needed with bidi text to not miss some text on the first
+    // or last line of the page.
     ldomXPointer start;
     ldomXPointer end;
     int start_h;
     for (start_h=0; start_h < height; start_h++) {
-        start = m_doc->createXPointer(lvPoint(0, start_y + start_h), 1);
+        start = m_doc->createXPointer(lvPoint(0, start_y + start_h), PT_DIR_SCAN_FORWARD_LOGICAL_FIRST);
         // printf("  start (%d=%d): %s\n", start_h, start_y + start_h, UnicodeToLocal(start.toString()).c_str());
         if (!start.isNull()) {
             // Check what we got is really in current page
@@ -2589,8 +2593,8 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
     }
     int end_h;
     for (end_h=height; end_h >= start_h; end_h--) {
-        end = m_doc->createXPointer(lvPoint(GetWidth(), start_y + end_h), -1);
-                                // x=GetWidth() to get XPointer of end of line
+        end = m_doc->createXPointer(lvPoint(GetWidth(), start_y + end_h), PT_DIR_SCAN_BACKWARD_LOGICAL_LAST);
+            // (x=GetWidth() might be redundant with PT_DIR_SCAN_BACKWARD_LOGICAL_LAST, but it might help skiping floats)
         // printf("  end (%d=%d): %s\n", end_h, start_y + end_h, UnicodeToLocal(end.toString()).c_str());
         if (!end.isNull()) {
             // Check what we got is really in current page
@@ -4250,7 +4254,7 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 			{
 				Clear();
 				if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("File with supported extension not fouind in archive.") );
+                    m_callback->OnLoadFileError( cs16("File with supported extension not found in archive.") );
 				}
 				return false;
 			}
@@ -4769,13 +4773,12 @@ ldomXPointer LVDocView::getBookmark() {
 				// In some edge cases, getting the xpointer for y=m_pages[_page]->start
 				// could resolve back to the previous page. We need to check for that
 				// and increase y until we find a coherent one.
+				// (In the following, we always want to find the first logical word/char.)
 				LVRendPageInfo * page = m_pages[_page];
 				bool found = false;
 				ldomXPointer fallback_ptr;
 				for (int y = page->start; y < page->start + page->height; y++) {
-					// Use direction=1 to avoid any x check (in case there
-					// is some left margin)
-					ptr = m_doc->createXPointer(lvPoint(0, y), 1);
+					ptr = m_doc->createXPointer(lvPoint(0, y), PT_DIR_SCAN_FORWARD_LOGICAL_FIRST);
 					lvPoint pt = ptr.toPoint();
 					if (pt.y >= page->start) {
 						if (!fallback_ptr)
@@ -4789,10 +4792,9 @@ ldomXPointer LVDocView::getBookmark() {
 				}
 				if (!found) {
 					// None looking forward resolved to that same page, we
-					// might find a better one looking backward (eg: when
-					// an element contains some floats that overflow its
-					// height) with direction=-1:
-					ptr = m_doc->createXPointer(lvPoint(0, page->start), -1);
+					// might find a better one looking backward (eg: when an
+					// element contains some floats that overflows its height).
+					ptr = m_doc->createXPointer(lvPoint(0, page->start), PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST);
 					lvPoint pt = ptr.toPoint();
 					if (pt.y >= page->start && pt.y < page->start + page->height ) {
 						found = true;
@@ -4804,7 +4806,7 @@ ldomXPointer LVDocView::getBookmark() {
 					}
 					else {
 						// fallback to the one for page->start, even if not good
-						ptr = m_doc->createXPointer(lvPoint(0, page->start));
+						ptr = m_doc->createXPointer(lvPoint(0, page->start), PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST);
 					}
 				}
 			}
@@ -4819,7 +4821,7 @@ ldomXPointer LVDocView::getBookmark() {
 			// Let's do the same in that case: get the previous text node
 			// position
 			for (int y = _pos; y >= 0; y--) {
-				ptr = m_doc->createXPointer(lvPoint(0, y), -1);
+				ptr = m_doc->createXPointer(lvPoint(0, y), PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST);
 				if (!ptr.isNull())
 					break;
 			}

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -550,6 +550,7 @@ void LVDocView::clearImageCache() {
 
 /// invalidate formatted data, request render
 void LVDocView::requestRender() {
+	LVLock lock(getMutex());
 	if (!m_doc) // nothing to render when noDefaultDocument=true
 		return;
 	m_is_rendered = false;
@@ -1244,6 +1245,8 @@ int LVDocView::GetFullHeight() {
 /// calculate page header height
 int LVDocView::getPageHeaderHeight() {
 	if (!getPageHeaderInfo())
+		return 0;
+	if (!getInfoFont())
 		return 0;
         int h = getInfoFont()->getHeight();
         int bh = m_batteryIcons.length()>0 ? m_batteryIcons[0]->GetHeight() * 11/10 + HEADER_MARGIN / 2 : 0;

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -34,6 +34,7 @@ extern "C" {
 
 #include <jerror.h>
 
+#if (USE_NANOSVG==1)
 // Support for SVG
 #include <math.h>
 #define NANOSVG_ALL_COLOR_KEYWORDS
@@ -43,6 +44,7 @@ extern "C" {
 #include <nanosvg.h>
 #include <nanosvgrast.h>
 #include <stb_image_write.h> // for svg to png conversion
+#endif
 
 #if !defined(HAVE_WXJPEG_BOOLEAN)
 typedef boolean wxjpeg_boolean;
@@ -1627,6 +1629,7 @@ void LVGifFrame::Clear()
 // ======= end of GIF support
 
 
+#if (USE_NANOSVG==1)
 // SVG support
 
 class LVSvgImageSource : public LVNodeImageSource
@@ -1843,7 +1846,7 @@ unsigned char * convertSVGtoPNG(unsigned char *svg_data, int svg_data_size, floa
 }
 
 // ======= end of SVG support
-
+#endif
 
 
 LVImageDecoderCallback::~LVImageDecoderCallback()
@@ -1885,10 +1888,13 @@ LVImageSourceRef LVCreateStreamImageSource( ldomNode * node, LVStreamRef stream 
         img = new LVGifImageSource( node, stream );
     else
 #endif
+#if (USE_NANOSVG==1)
     if ( LVSvgImageSource::CheckPattern( hdr, (lUInt32)bytesRead ) )
         img = new LVSvgImageSource( node, stream );
     else
+#endif
         img = new LVDummyImageSource( node, 50, 50 );
+
     if ( !img )
         return ref;
     ref = LVImageSourceRef( img );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2094,9 +2094,14 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
                 flags |= LTEXT_STRUT_CONFINED;
         }
         marker += "\t";
-        // Not sure what that "\t" was used for, but coincidentally, it acts for fribidi
-        // as a text segment separator (SS) which will bidi-isolate the marker from the
-        // followup text, and will ensure, for example, that:
+        // That "\t" had some purpose in legacy rendering (erm_list_item) to mark the end
+        // of the marker, and by providing the marker_width as negative indent, so that
+        // the following text can have some constant indent by rendering it just like
+        // negative/hanging text-indent. It has no real use if we provide a 0-indent
+        // like we do below.
+        // But coincidentally, this "\t" acts for fribidi as a text segment separator (SS)
+        // which will bidi-isolate the marker from the followup text, and will ensure,
+        // for example, that:
         //   <li style="list-style-type: lower-roman; list-style-type: inside">Some text</li>
         // in a RTL direction context, will be rightly rendered as:
         //   "Some text   xviii"
@@ -2154,9 +2159,9 @@ bool renderAsListStylePositionInside( const css_style_rec_t * style, bool is_rtl
 // to do the actual width-constrained rendering of the AddSource*'ed objects.
 // Note: fmt is the RenderRectAccessor of the final block itself, and is passed
 // as is to the inline children elements: it is only used to get the width of
-// the container, which is only needed to compute ident (text-indent) values in %,
+// the container, which is only needed to compute indent (text-indent) values in %,
 // and to get paragraph direction (LTR/RTL/UNSET).
-void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, int & baseflags, int ident, int line_h, int valign_dy, bool * is_link_start )
+void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, int & baseflags, int indent, int line_h, int valign_dy, bool * is_link_start )
 {
     if ( enode->isElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
@@ -2173,7 +2178,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // be guessed and renderBlockElement() called to render it
             // and get is height, so LFormattedText knows how to render
             // this erm_final text around it.
-            txform->AddSourceObject(baseflags|LTEXT_SRC_IS_FLOAT, line_h, valign_dy, ident, enode );
+            txform->AddSourceObject(baseflags|LTEXT_SRC_IS_FLOAT, line_h, valign_dy, indent, enode );
             baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             return;
         }
@@ -2269,9 +2274,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
         if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline) {
             // Non-inline node in a final block: this is the top and single 'final' node:
-            // get text-indent (mispelled 'ident' here and elsewhere) and line-height
-            // that will apply to the full final block
-            ident = lengthToPx(style->text_indent, width, em);
+            // get text-indent and line-height that will apply to the full final block
+            indent = lengthToPx(style->text_indent, width, em);
 
             // We set the LFormattedText strut_height and strut_baseline
             // with the values from this "final" node. All lines made out from
@@ -2480,7 +2484,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // text-indent (but it does when in <SPAN style="float: left"><IMG/></SPAN>).
                 txform->setStrut(0, 0);
                 line_h = 0;
-                ident = 0;
+                indent = 0;
                 valign_dy = 0;
                 // Also, when such a floating image has a width in %, this width
                 // has been used to set the width of the floating box. We need to
@@ -2534,7 +2538,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
                 int margin = 0;
                 if ( sp==css_lsp_outside )
-                    margin = -marker_width;
+                    margin = -marker_width; // will ensure negative/hanging indent-like rendering
                 marker += "\t";
                 txform->AddSourceLine( marker.c_str(), marker.length(), cl, bgcl, font, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy,
                                         margin, NULL );
@@ -2597,7 +2601,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     for ( int i=0; i<lines.length(); i++ )
                         txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
                 }
-                txform->AddSourceObject(flags, line_h, valign_dy, ident, enode );
+                txform->AddSourceObject(flags, line_h, valign_dy, indent, enode );
                 title = enode->getAttributeValue(attr_subtitle);
                 if ( !title.empty() ) {
                     lString16Collection lines;
@@ -2615,7 +2619,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else { // inline image
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
-                txform->AddSourceObject(flags, line_h, valign_dy, ident, enode );
+                txform->AddSourceObject(flags, line_h, valign_dy, indent, enode );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
@@ -2625,7 +2629,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             #endif
             // We use the flags computed previously (and not baseflags) as they
             // carry vertical alignment
-            txform->AddSourceObject(flags|LTEXT_SRC_IS_INLINE_BOX, line_h, valign_dy, ident, enode );
+            txform->AddSourceObject(flags|LTEXT_SRC_IS_INLINE_BOX, line_h, valign_dy, indent, enode );
             flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
         }
         else { // non-IMG element: render children (elements or text nodes)
@@ -2757,7 +2761,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             for (int i=0; i<cnt; i++)
             {
                 ldomNode * child = enode->getChildNode( i );
-                renderFinalBlock( child, txform, fmt, flags, ident, line_h, valign_dy, is_link_start_p );
+                renderFinalBlock( child, txform, fmt, flags, indent, line_h, valign_dy, is_link_start_p );
             }
 
             if ( addGeneratedContent ) {
@@ -2851,7 +2855,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
             case css_ta_justify:
                 baseflags |= LTEXT_ALIGN_WIDTH;
-                ident = 0;
+                indent = 0;
                 break;
             case css_ta_start:
                 baseflags |= (is_rtl ? LTEXT_ALIGN_RIGHT : LTEXT_ALIGN_LEFT);
@@ -2987,7 +2991,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             */
             if ( txt.length()>0 ) {
                 txform->AddSourceLine( txt.c_str(), txt.length(), cl, bgcl, font, baseflags | tflags,
-                    line_h, valign_dy, ident, enode, 0, letter_spacing );
+                    line_h, valign_dy, indent, enode, 0, letter_spacing );
                 baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2275,7 +2275,32 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline) {
             // Non-inline node in a final block: this is the top and single 'final' node:
             // get text-indent and line-height that will apply to the full final block
+
+            // text-indent should really not have to be handled here: it would be
+            // better handled in ldomNode::renderFinalBlock(), grabbing it from the
+            // final node, and only passed as an arg to LFormattedText->Format(),
+            // like we pass to it the text block width.
+            // Current code passes indent to all txform->AddSource*(.., indent,..), so
+            // it is stored in each src_text_fragment_t->indent, while it's really
+            // a property of the whole paragraph, as it is fetched from the top node,
+            // like we do here. (It is never updated, and as it is not passed by reference,
+            // updates/reset would not apply to sibling or parent nodes.)
+            // There is just one case that sets it to a different value: in the
+            // legacy/obsolete erm_list_item rendering method with lsp_outside, where
+            // it is set to a negative value (the width of the marker), so to handle text
+            // indentation from the outside marker just like regular negative text-indent.
+            // So, sadly, let's keep it that way to not break legacy rendering.
             indent = lengthToPx(style->text_indent, width, em);
+            // lvstsheet sets the lowest bit to 1 when text-indent has the "hanging" keyword:
+            if ( style->text_indent.value & 0x00000001 ) {
+                // lvtextfm handles negative indent as "indent by the negated (so, then
+                // positive) value all lines but the first"
+                indent = -indent;
+                // We keep real negative values as negative here. They are also handled
+                // in renderBlockElementEnhanced() to possibly have the text block shifted
+                // to the left to properly apply the negative effect ("hanging" text-indent
+                // does not need that).
+            }
 
             // We set the LFormattedText strut_height and strut_baseline
             // with the values from this "final" node. All lines made out from
@@ -2855,7 +2880,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
             case css_ta_justify:
                 baseflags |= LTEXT_ALIGN_WIDTH;
-                indent = 0;
                 break;
             case css_ta_start:
                 baseflags |= (is_rtl ? LTEXT_ALIGN_RIGHT : LTEXT_ALIGN_LEFT);
@@ -6508,6 +6532,52 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         fmt.push();
                     }
                 }
+                // Deal with negative text-indent
+                if ( style->text_indent.value < 0 ) {
+                    int indent = - lengthToPx(style->text_indent, container_width, em);
+                    // We'll need to have text written this positive distance outside
+                    // the nominal text inner_width.
+                    // We can remove it from left padding if indent is smaller than padding.
+                    // If it is larger, we can't remove the excess from left margin, as
+                    // these margin should stay fixed for proper background drawing in their
+                    // limits (the text with negative text-indent should overflow the
+                    // margin and background color).
+                    // But, even if CSS forbids negative padding, the followup code might
+                    // be just fine with negative values for padding_left/_right !
+                    // (Not super sure of that, but it looks like it works, so let's
+                    // go with it - if issues, one can switch to a rendering mode
+                    // without the ALLOW_HORIZONTAL_BLOCK_OVERFLOW flag).
+                    // (Text selection on the overflowing text may not work, but it's
+                    // the same for negative margins.)
+                    if ( !is_rtl ) {
+                        padding_left -= indent;
+                        if ( padding_left < 0 ) {
+                            if ( !BLOCK_RENDERING(flags, ALLOW_HORIZONTAL_BLOCK_OVERFLOW) ) {
+                                padding_left = 0; // be safe, drop excessive part of indent
+                            }
+                            else if ( !BLOCK_RENDERING(flags, ALLOW_HORIZONTAL_PAGE_OVERFLOW) ) {
+                                // Limit to top node (page, float) left margin
+                                int abs_x = flow->getCurrentAbsoluteX();
+                                if ( abs_x + padding_left < 0 )
+                                    padding_left = -abs_x;
+                            }
+                        }
+                    }
+                    else {
+                        padding_right -= indent;
+                        if ( padding_right < 0 ) {
+                            if ( !BLOCK_RENDERING(flags, ALLOW_HORIZONTAL_BLOCK_OVERFLOW) ) {
+                                padding_right = 0;
+                            }
+                            else if ( !BLOCK_RENDERING(flags, ALLOW_HORIZONTAL_PAGE_OVERFLOW) ) {
+                                int o_width = flow->getOriginalContainerWidth();
+                                int abs_x = flow->getCurrentAbsoluteX();
+                                if ( abs_x + width + padding_right < o_width )
+                                    padding_right = o_width - width - abs_x;
+                            }
+                        }
+                    }
+                }
 
                 // To get an accurate BlockFloatFootprint, we need to push vertical
                 // margin now (and not delay it to the first addContentLine()).
@@ -8491,7 +8561,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     maxWidth = curMaxWidth;
                 if (curWordWidth > minWidth)
                     minWidth = curWordWidth;
-                // Next word on new line has text-indent in its width
+                // First word after a <BR> should not have positive text-indent in its width,
+                // but we did reset 'indent' to 0 after the first word of the final block.
+                // If we get some non-zero indent here, it is actually negated negative indent
+                // that should be applied to all words, including the one after a <BR/>, and
+                // so it should contribute to the new line full width (curMaxWidth).
                 curMaxWidth = indent;
                 curWordWidth = indent;
                 collapseNextSpace = true; // skip leading spaces
@@ -8603,8 +8677,29 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 // curMaxWidth and curWordWidth are not used in our parents (which
                 // are block-like elements), we can just reset them.
                 // First word will have text-indent has its width
-                curMaxWidth = indent;
-                curWordWidth = indent;
+                if ( style->text_indent.value & 0x00000001 ) {
+                    // lvstsheet sets the lowest bit to 1 when text-indent has the "hanging" keyword,
+                    // which will be handled like negative margins
+                    indent = -indent;
+                }
+                if ( indent >= 0 ) {
+                    // Positive indent applies only on the first line, so account
+                    // for it only on the first word.
+                    curMaxWidth = indent;
+                    curWordWidth = indent;
+                    indent = 0; // but no more on following words in this final node, even after <BR>
+                }
+                else {
+                    // Negative indent does not apply on the first word, but may apply on each
+                    // followup word if a wrap happens before thema so don't reset it.
+                    // To keep things simple and readable here, we only apply it to the first
+                    // word after a <BR> - but it should really apply on each word, everytime
+                    // we reset curWordWidth, which would make the below code quite ugly and
+                    // hard to understand. Hopefully, negative or hanging indents should be
+                    // rare in floats, inline boxes and table cells.
+                    // (We don't handle the shift/overlap with padding that a real negative
+                    // indent can cause - so, we may return excessive widths.)
+                }
                 if (list_marker_width > 0 && !list_marker_width_as_padding) {
                     // with additional list marker if list-style-position: inside
                     curMaxWidth += list_marker_width;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -6907,7 +6907,7 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
     bc = style->border_color[3];
     hasleftBorder = hasleftBorder & !(bc.type == css_val_unspecified && bc.value == css_generic_transparent);
 
-    if (hasbottomBorder or hasleftBorder or hasrightBorder or hastopBorder) {
+    if (hasbottomBorder || hasleftBorder || hasrightBorder || hastopBorder) {
         lUInt32 shadecolor=0x555555;
         lUInt32 lightcolor=0xAAAAAA;
         int em = enode->getFont()->getSize();
@@ -7956,6 +7956,7 @@ inline void spreadParent( css_length_t & val, css_length_t & parent_val, bool un
 
 void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef parent_font )
 {
+    CR_UNUSED(parent_font);
     //lvdomElementFormatRec * fmt = node->getRenderData();
     css_style_ref_t style( new css_style_rec_t );
     css_style_rec_t * pstyle = style.get();

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2090,6 +2090,8 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             // Scale it according to gInterlineScaleFactor
             if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
                 line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            if ( style->cr_hint == css_cr_hint_strut_confined )
+                flags |= LTEXT_STRUT_CONFINED;
         }
         marker += "\t";
         // Not sure what that "\t" was used for, but coincidentally, it acts for fribidi
@@ -2285,6 +2287,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             int fb = enode->getFont()->getBaseline();
             int f_half_leading = (line_h - fh) / 2;
             txform->setStrut(line_h, fb + f_half_leading);
+        }
+        else if ( style->cr_hint == css_cr_hint_strut_confined ) {
+            // Previous branch for the top final node has set the strut.
+            // Inline nodes having "-cr-hint: strut-confined" will be confined
+            // inside that strut.
+            flags |= LTEXT_STRUT_CONFINED;
         }
 
         // Now, process styles that may differ between inline nodes, and
@@ -2491,6 +2499,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // Also, the floating element or inline-block inner element vertical-align drift is dropped
             valign_dy = 0;
             flags &= ~LTEXT_VALIGN_MASK; // also remove any such flag we've set
+            flags &= ~LTEXT_STRUT_CONFINED; // remove this if it's been set above
             // (Looks like nothing special to do with indent or line_h)
         }
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1089,6 +1089,14 @@ static const char * css_cr_hint_names[]={
         "toc-level5",
         "toc-level6",
         "toc-ignore",       // ignore these H1...H6 when building alternate TOC
+
+        // Next one is not really a hint, but might have some active effect on rendering/layout.
+        // It has effect on inline nodes only, while the ones above mostly apply to block
+        // nodes. So, provide it with a lower specificity if those above also need to be used.
+        "strut-confined",   // text and images should not overflow/modify their paragraph strut
+                            // baseline and height (it could have been a non-standard named
+                            // value for line-height:, but we want to be able to not override
+                            // existing line-height: values)
         NULL
 };
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2266,6 +2266,20 @@ static bool parse_ident( const char * &str, char * ident )
     return true;
 }
 
+// We are storing specificity/weight in a lUInt32.
+// We also want to include in it the order in which we have
+// seen/parsed the selectors, so we store in the lower bits
+// of this lUInt32 some sequence number to ensure selectors
+// with the same specificity are applied in the order we've
+// seen them when parsing.
+// So, apply the real CSS specificity in higher bits, allowing
+// for the following number of such rules in a single selector
+// (we're not checking for overflow thus...)
+#define WEIGHT_SPECIFICITY_ID       1<<29 // allow for 8 #id (b in comment below)
+#define WEIGHT_SPECIFICITY_ATTRCLS  1<<24 // allow for 32 .class and [attr...] (c)
+#define WEIGHT_SPECIFICITY_ELEMENT  1<<19 // allow for 32 element names div > p span (d)
+#define WEIGHT_SELECTOR_ORDER       1     // allow for counting 524288 selectors
+
 lUInt32 LVCssSelectorRule::getWeight() {
     /* Each LVCssSelectorRule will add its own weight to
        its LVCssSelector container specifity.
@@ -2297,7 +2311,7 @@ lUInt32 LVCssSelectorRule::getWeight() {
     //
     switch (_type) {
         case cssrt_id:            // E#id
-            return 1 << 16;
+            return WEIGHT_SPECIFICITY_ID;
             break;
         case cssrt_attrset:           // E[foo]
         case cssrt_attreq:            // E[foo="value"]
@@ -2314,14 +2328,16 @@ lUInt32 LVCssSelectorRule::getWeight() {
         case cssrt_attrcontains_i:    // E[foo*="value" i]
         case cssrt_class:             // E.class
         case cssrt_pseudoclass:       // E:pseudo-class
-            return 1 << 8;
+            return WEIGHT_SPECIFICITY_ATTRCLS;
             break;
         case cssrt_parent:        // E > F
         case cssrt_ancessor:      // E F
         case cssrt_predecessor:   // E + F
         case cssrt_predsibling:   // E ~ F
-            // But not when they don't have an element (_id=0)
-            return _id != 0 ? 1 : 0;
+            // These don't contribute to specificity. If they
+            // come with an element name, WEIGHT_SPECIFICITY_ELEMENT
+            // has already been added in LVCssSelector::parse().
+            return 0;
             break;
         case cssrt_universal:     // *
             return 0;
@@ -3067,7 +3083,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
                 // selectors (eg: blah {font-style: italic}) may have different values
                 // returned by getElementNameIndex() across book loadings, and cause:
                 // "cached rendering is invalid (style hash mismatch): doing full rendering"
-            _specificity += 1; // we have an element: this adds 1 to specificity
+            _specificity += WEIGHT_SPECIFICITY_ELEMENT; // we have an element: update specificity
             if (*str==' ' || *str=='\t' || *str=='\n' || *str == '\r')
                 check_attribute_rules = false;
             skip_spaces( str );
@@ -3202,6 +3218,7 @@ LVStyleSheet::LVStyleSheet( LVStyleSheet & sheet )
 :   _doc( sheet._doc )
 {
     set( sheet._selectors );
+    _selector_count = sheet._selector_count;
 }
 
 void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style )
@@ -3211,6 +3228,15 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style )
         
     lUInt16 id = node->getNodeId();
     
+    // _selectors[0] holds the ordered chain of selectors starting (from
+    // the right of the selector) with a rule with no element name attached
+    // (eg. "div p .quote1", class name .quote1 should be checked against
+    // all elements' classnames before continuing checking for ancestors).
+    // _selectors[element_name_id] holds the ordered chain of selector starting
+    // with that element name (eg. ".body div.chapter > p" should be
+    // first checked agains all <p>).
+    // To see which selectors apply to a <p>, we must iterate thru both chains,
+    // checking and applying them in the order of specificity/parsed position.
     LVCssSelector * selector_0 = _selectors[0];
     LVCssSelector * selector_id = id>0 && id<_selectors.length() ? _selectors[id] : NULL;
 
@@ -3297,7 +3323,11 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
         for (;*str;)
         {
             // parse selector(s)
-            selector = new LVCssSelector;
+            // Have selector count number make the initial value
+            // of _specificity, so order of selectors is preserved
+            // when applying selectors with the same CSS specificity.
+            selector = new LVCssSelector(_selector_count);
+            _selector_count += 1; // = +WEIGHT_SELECTOR_ORDER
             selector->setNext( prev_selector );
             if ( !selector->parse(str, _doc) )
             {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2975,8 +2975,12 @@ public:
                     bool avoidWrap = false;
                     // Look first at following char(s)
                     for (int j = i+1; j < m_length; j++) {
-                        if ( (m_flags[j] & LCHAR_IS_OBJECT) && (m_charindex[j] == FLOAT_CHAR_INDEX) ) // skip floats
-                            continue;
+                        if ( m_flags[j] & LCHAR_IS_OBJECT ) {
+                            if (m_charindex[j] == FLOAT_CHAR_INDEX) // skip floats
+                                continue;
+                            else // allow wrap between space/CJK and image or inline-box
+                                break;
+                        }
                         if ( !(m_flags[j] & LCHAR_ALLOW_WRAP_AFTER) ) { // not another (collapsible) space
                             avoidWrap = lGetCharProps(m_text[j]) & CH_PROP_AVOID_WRAP_BEFORE;
                             break;
@@ -2986,8 +2990,12 @@ public:
                         // (but not if it is the last char, where a wrap is fine
                         // even if it ends after a CH_PROP_AVOID_WRAP_AFTER char)
                         for (int j = i-1; j >= 0; j--) {
-                            if ( (m_flags[j] & LCHAR_IS_OBJECT) && (m_charindex[j] == FLOAT_CHAR_INDEX) ) // skip floats
-                                continue;
+                            if ( m_flags[j] & LCHAR_IS_OBJECT ) {
+                                if (m_charindex[j] == FLOAT_CHAR_INDEX) // skip floats
+                                    continue;
+                                else // allow wrap after a space following an image or inline-box
+                                    break;
+                            }
                             if ( !(m_flags[j] & LCHAR_ALLOW_WRAP_AFTER) ) { // not another (collapsible) space
                                 avoidWrap = lGetCharProps(m_text[j]) & CH_PROP_AVOID_WRAP_AFTER;
                                 break;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <lvtextfm.h>
 #include "../include/crsetup.h"
 #include "../include/lvfnt.h"
 #include "../include/lvtextfm.h"
@@ -2613,7 +2612,7 @@ public:
                                     word->width -= w; // first line with text-indent
                             }
                         }
-                        if (frmline->width!=0 and last and align!=LTEXT_ALIGN_CENTER) {
+                        if (frmline->width!=0 && last && align!=LTEXT_ALIGN_CENTER) {
                             // (Chinese) add spaces between words in last line or single line
                             // (so they get visually aligned on a grid with the char on the
                             // previous justified lines)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -205,7 +205,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
    lUInt32         flags,    /* flags */
    lInt16          interval, /* line height in screen pixels */
    lInt16          valign_dy, /* drift y from baseline */
-   lUInt16         margin,   /* first line margin */
+   lInt16          indent,    /* first line indent (or all but first, when negative) */
    void *          object,    /* pointer to custom object */
    lUInt16         offset,
    lInt16          letter_spacing
@@ -241,7 +241,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
     pline->index = (lUInt16)(pbuffer->srctextlen-1);
     pline->object = object;
     pline->t.len = (lUInt16)len;
-    pline->margin = margin;
+    pline->indent = indent;
     pline->flags = flags;
     pline->interval = interval;
     pline->valign_dy = valign_dy;
@@ -258,7 +258,7 @@ void lvtextAddSourceObject(
    lUInt32         flags,     /* flags */
    lInt16          interval,  /* line height in screen pixels */
    lInt16          valign_dy, /* drift y from baseline */
-   lUInt16         margin,    /* first line margin */
+   lInt16          indent,    /* first line indent (or all but first, when negative) */
    void *          object,    /* pointer to custom object */
    lInt16          letter_spacing
                          )
@@ -274,7 +274,7 @@ void lvtextAddSourceObject(
     pline->o.width = width;
     pline->o.height = height;
     pline->object = object;
-    pline->margin = margin;
+    pline->indent = indent;
     pline->flags = flags | LTEXT_SRC_IS_OBJECT;
     pline->interval = interval;
     pline->valign_dy = valign_dy;
@@ -296,7 +296,7 @@ void LFormattedText::AddSourceObject(
             lUInt32         flags,     /* flags */
             lInt16          interval,  /* line height in screen pixels */
             lInt16          valign_dy, /* drift y from baseline */
-            lUInt16         margin,    /* first line margin */
+            lInt16          indent,    /* first line indent (or all but first, when negative) */
             void *          object,    /* pointer to custom object */
             lInt16          letter_spacing
      )
@@ -310,7 +310,7 @@ void LFormattedText::AddSourceObject(
     if (flags & LTEXT_SRC_IS_FLOAT) { // not an image but a float:'ing node
         // Nothing much to do with it at this point
         lvtextAddSourceObject(m_pbuffer, 0, 0,
-            flags, interval, valign_dy, margin, object, letter_spacing );
+            flags, interval, valign_dy, indent, object, letter_spacing );
             // lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT
             // (only flags & object parameter will be used, the others are not,
             // but they matter if this float is the first node in a paragraph,
@@ -322,7 +322,7 @@ void LFormattedText::AddSourceObject(
         // get its width & neight, as they might be in % of our main width, that
         // we don't know yet (but only when ->Format() is called).
         lvtextAddSourceObject(m_pbuffer, 0, 0,
-            flags, interval, valign_dy, margin, object, letter_spacing );
+            flags, interval, valign_dy, indent, object, letter_spacing );
             // lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT
         return;
     }
@@ -368,7 +368,7 @@ void LFormattedText::AddSourceObject(
     height = h;
 
     lvtextAddSourceObject(m_pbuffer, width, height,
-        flags, interval, valign_dy, margin, object, letter_spacing );
+        flags, interval, valign_dy, indent, object, letter_spacing );
 }
 
 class LVFormatter {
@@ -1680,8 +1680,10 @@ public:
                     lastBidiLevel = newBidiLevel;
             #endif
         }
-        if ( tabIndex>=0 ) {
-            int tabPosition = -m_srcs[0]->margin;
+        if ( tabIndex >= 0 && m_srcs[0]->indent < 0) {
+            // Used by obsolete rendering method erm_list_item when css_lsp_outside,
+            // where the marker width is provided as negative/hanging indent.
+            int tabPosition = -m_srcs[0]->indent; // has been set to marker_width
             if ( tabPosition>0 && tabPosition > m_widths[tabIndex] ) {
                 int dx = tabPosition - m_widths[tabIndex];
                 for ( i=tabIndex; i<m_length; i++ )
@@ -2899,7 +2901,7 @@ public:
         // split paragraph into lines, export lines
         int pos = 0;
         int upSkipPos = -1;
-        int indent = m_srcs[0]->margin;
+        int indent = m_srcs[0]->indent;
 
         /* We'd rather not have this final node text just dropped if there
          * is not enough width for the indent !

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2515,7 +2515,7 @@ public:
                             word->min_width = word->width;
                         }
                     }
-                    if ( m_flags[i-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
+                    if ( lastWord && m_flags[i-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
                         if ( m_flags[i] & LCHAR_IS_CLUSTER_TAIL ) {
                             // The end of this word is part of a ligature that, because
                             // of hyphenation, has been splitted onto next word.

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3168,30 +3168,30 @@ public:
                     // if we shoud correct it, here or there - or if this is fine - but
                     // let's go with it as-is as it might be a safety and might help
                     // us not be stuck in some infinite loop here.
-                    int start, end;
-                    lStr_findWordBounds( m_text, m_length, wordpos, start, end );
-                    if ( end <= lastNormalWrap ) {
+                    int wstart, wend;
+                    lStr_findWordBounds( m_text, m_length, wordpos, wstart, wend );
+                    if ( wend <= lastNormalWrap ) {
                         // We passed back lastNormalWrap: no need to look for more
                         break;
                     }
-                    int len = end - start;
+                    int len = wend - wstart;
                     if ( len < MIN_WORD_LEN_TO_HYPHENATE ) {
                         // Too short word found, skip it
-                        wordpos = start - 1;
+                        wordpos = wstart - 1;
                         continue;
                     }
-                    if ( start >= wordpos ) {
+                    if ( wstart >= wordpos ) {
                         // Shouldn't happen, but let's be sure we don't get stuck
                         wordpos = wordpos - MIN_WORD_LEN_TO_HYPHENATE;
                         continue;
                     }
                     #ifdef DEBUG_HYPH_EXTRA_LOOPS
                         if (debug_loop_num > 1)
-                            printf("  hyphenating: %s\n", LCSTR(lString16(m_text+start, len)));
+                            printf("  hyphenating: %s\n", LCSTR(lString16(m_text+wstart, len)));
                     #endif
                     #if TRACE_LINE_SPLITTING==1
                         TR("wordBounds(%s) unusedSpace=%d wordWidth=%d",
-                                LCSTR(lString16(m_text+start, len)), unusedSpace, m_widths[end]-m_widths[start]);
+                                LCSTR(lString16(m_text+wstart, len)), unusedSpace, m_widths[wend]-m_widths[wstart]);
                     #endif
                     // We have a valid word to look for hyphenation
                     if ( len > MAX_WORD_SIZE ) // hyphenate() stops/truncates at 64 chars
@@ -3199,27 +3199,35 @@ public:
                     // HyphMan::hyphenate(), which is used by some other parts of the code,
                     // expects a lUInt8 array. We added flagSize=1|2 so it can set the correct
                     // flags on our upgraded (from lUInt8 to lUInt16) m_flags.
-                    lUInt8 * flags = (lUInt8*) (m_flags + start);
+                    lUInt8 * flags = (lUInt8*) (m_flags + wstart);
                     // Fill static array with cumulative widths relative to word start
                     static lUInt16 widths[MAX_WORD_SIZE];
-                    int wordStart_w = start>0 ? m_widths[start-1] : 0;
+                    int wordStart_w = wstart>0 ? m_widths[wstart-1] : 0;
                     for ( int i=0; i<len; i++ ) {
-                        widths[i] = m_widths[start+i] - wordStart_w;
+                        widths[i] = m_widths[wstart+i] - wordStart_w;
                     }
                     int max_width = maxWidth + spaceReduceWidth - x - (wordStart_w - w0) - firstCharMargin;
                     // In some rare cases, a word here can be made with parts from multiple text nodes.
-                    // Use the font of the text node at start to compute the hyphen width, which
-                    // might then be wrong - but that will be smoothed by alignLine()
-                    int _hyphen_width = ((LVFont*)m_srcs[start]->t.font)->getHyphenWidth();
-                    if ( HyphMan::hyphenate(m_text+start, len, widths, flags, _hyphen_width, max_width, 2) ) {
+                    // Use the font of the first text node to compute the hyphen width, which
+                    // might then be wrong - but that will be smoothed by alignLine().
+                    // (lStr_findWordBounds() might grab objects or inlineboxes as part of
+                    // the word, so skip them when looking for a font)
+                    int _hyphen_width = 0;
+                    for ( int i=wstart; i<wend; i++ ) {
+                        if ( !(m_srcs[i]->flags & LTEXT_SRC_IS_OBJECT) ) {
+                            _hyphen_width = ((LVFont*)m_srcs[i]->t.font)->getHyphenWidth();
+                            break;
+                        }
+                    }
+                    if ( HyphMan::hyphenate(m_text+wstart, len, widths, flags, _hyphen_width, max_width, 2) ) {
                         for ( int i=0; i<len; i++ ) {
-                            if ( m_flags[start+i] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
+                            if ( m_flags[wstart+i] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
                                 if ( widths[i] + _hyphen_width > max_width ) {
                                     TR("hyphen found, but max width reached at char %d", i);
                                     break; // hyph is too late
                                 }
-                                if ( start + i > pos+1 ) {
-                                    lastHyphWrap = start + i;
+                                if ( wstart + i > pos+1 ) {
+                                    lastHyphWrap = wstart + i;
                                     // Keep looking for some other candidates in that word
                                 }
                             }
@@ -3231,7 +3239,7 @@ public:
                     }
                     TR("no hyphen found - max_width=%d", max_width);
                     // Look at previous words if any
-                    wordpos = start - 1;
+                    wordpos = wstart - 1;
                 }
             }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -391,6 +391,7 @@ public:
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
+    bool m_allow_strut_confinning;
     bool m_has_multiple_scripts;
     int m_specified_para_dir;
     #if (USE_FRIBIDI==1)
@@ -912,6 +913,10 @@ public:
         if ( m_specified_para_dir == REND_DIRECTION_RTL ) {
             has_rtl = true;
         }
+        // Whether any "-cr-hint: strut-confined" should be applied: only when
+        // we have non-space-only text in the paragraph - standalone images
+        // possibly separated by spaces don't need to be reduced in size.
+        m_allow_strut_confinning = false;
 
         int pos = 0;
         int i;
@@ -1029,6 +1034,8 @@ public:
                     }
                     if ( !is_space || preformatted ) // don't strip traling spaces if pre
                         last_non_space_pos = pos;
+                    if ( !is_space )
+                        m_allow_strut_confinning = true;
                     prev_was_space = is_space;
 
                     /* non-optimized implementation of "(a) A sequence of segment breaks
@@ -2279,6 +2286,9 @@ public:
                 // be delayed until the full line is laid out. Until that, we store some
                 // info into word->_top_to_baseline and word->_baseline_to_bottom.
                 bool adjust_line_box = true;
+                // We will make sure elements with "-cr-hint: strut-confined"
+                // do not change the strut baseline and height
+                bool strut_confined = (lastSrc->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confinning;
 
                 if ( lastSrc->flags & LTEXT_SRC_IS_OBJECT ) {
                     // object: image or inline-block box (floats have been skipped above)
@@ -2294,6 +2304,8 @@ public:
                         word->o.baseline = lastSrc->o.baseline;
                         top_to_baseline = word->o.baseline;
                         baseline_to_bottom = word->o.height - word->o.baseline;
+                        // We can't really ensure strut_confined with inline-block boxes,
+                        // or we could miss content (it would be overwritten by next lines)
                     }
                     else { // image
                         word->flags = LTEXT_WORD_IS_OBJECT;
@@ -2304,6 +2316,16 @@ public:
                         // Negative width and height mean the value is a % (of our final block width)
                         width = width<0 ? (-width * (m_pbuffer->width - x) / 100) : width;
                         height = height<0 ? (-height * (m_pbuffer->width-x) / 100) : height;
+                        if ( strut_confined && height > m_pbuffer->strut_height ) {
+                            // Don't make image taller than initial strut height.
+                            // (We could have checked height against frmline->height (which may
+                            // be larger than m_pbuffer->strut_height if not all elements have
+                            // "-cr-hint: strut-confined"), but in processParagraph() we checked
+                            // against m_pbuffer->strut_height, so keep doing that to not
+                            // have this line width different.
+                            width = width * m_pbuffer->strut_height / height; // keep aspect ratio
+                            height = frmline->height;
+                        }
                         // todo: adjust m_max_img_height with this image valign_dy/vertical_align_flag
                         resizeImage(width, height, m_pbuffer->width - x, m_max_img_height, m_length>1);
                             // Note: it can happen with a standalone image in a small container
@@ -2329,6 +2351,8 @@ public:
                         adjust_line_box = false;
                         delayed_valign_computation = true;
                         word->flags |= LTEXT_WORD_VALIGN_TOP;
+                        if ( strut_confined )
+                            word->flags |= LTEXT_WORD_STRUT_CONFINED;
                         word->_top_to_baseline = top_to_baseline;
                         word->_baseline_to_bottom = baseline_to_bottom;
                         word->y = top_to_baseline;
@@ -2339,6 +2363,8 @@ public:
                         adjust_line_box = false;
                         delayed_valign_computation = true;
                         word->flags |= LTEXT_WORD_VALIGN_BOTTOM;
+                        if ( strut_confined )
+                            word->flags |= LTEXT_WORD_STRUT_CONFINED;
                         word->_top_to_baseline = top_to_baseline;
                         word->_baseline_to_bottom = baseline_to_bottom;
                         word->y = - baseline_to_bottom;
@@ -2371,6 +2397,13 @@ public:
                     int vertical_align_flag = srcline->flags & LTEXT_VALIGN_MASK;
                     int line_height = srcline->interval;
                     int fh = font->getHeight();
+                    if ( strut_confined && line_height > m_pbuffer->strut_height ) {
+                        // If we'll be confining text inside the strut, get rid of any
+                        // excessive line-height for the following computations).
+                        // But we should keep it at least fh so drawn text doesn't
+                        // overflow the box we'll try to confine into the strut.
+                        line_height = fh > m_pbuffer->strut_height ? fh : m_pbuffer->strut_height;
+                    }
                     // As we do only +/- arithmetic, the following values being negative should be fine.
                     // Accounts for line-height (adds what most documentation calls half-leading to top
                     // and to bottom  - note that "leading" is a typography term referring to "lead" the
@@ -2389,6 +2422,8 @@ public:
                         adjust_line_box = false;
                         delayed_valign_computation = true;
                         word->flags |= LTEXT_WORD_VALIGN_TOP;
+                        if ( strut_confined )
+                            word->flags |= LTEXT_WORD_STRUT_CONFINED;
                         word->_top_to_baseline = top_to_baseline;
                         word->_baseline_to_bottom = baseline_to_bottom;
                         word->y = font->getBaseline() + half_leading;
@@ -2399,6 +2434,8 @@ public:
                         adjust_line_box = false;
                         delayed_valign_computation = true;
                         word->flags |= LTEXT_WORD_VALIGN_BOTTOM;
+                        if ( strut_confined )
+                            word->flags |= LTEXT_WORD_STRUT_CONFINED;
                         word->_top_to_baseline = top_to_baseline;
                         word->_baseline_to_bottom = baseline_to_bottom;
                         word->y = - fh + font->getBaseline() - half_leading_bottom;
@@ -2643,8 +2680,15 @@ public:
                         // if (frmline->baseline) printf("pushed down +%d\n", shift_down);
                         // if (frmline->baseline && lastSrc->object)
                         //     printf("%s\n", UnicodeToLocal(ldomXPointer((ldomNode*)lastSrc->object, 0).toString()).c_str());
-                        frmline->baseline += shift_down;
-                        frmline->height += shift_down;
+                        if ( !strut_confined ) {
+                            // move line away from the strut baseline
+                            frmline->baseline += shift_down;
+                            frmline->height += shift_down;
+                        }
+                        else { // except if "-cr-hint: strut-confined":
+                            // Keep the strut, move the word down
+                            word->y += shift_down;
+                        }
                     }
                     // positive word->y means it's subscript, so the line's baseline does not need to be
                     // changed, but more room below might be needed to display the subscript: increase
@@ -2652,7 +2696,21 @@ public:
                     int needed_height = frmline->baseline + baseline_to_bottom + word->y;
                     if ( needed_height > frmline->height ) {
                         // printf("extended down +%d\n", needed_height-frmline->height);
-                        frmline->height = needed_height;
+                        if ( !strut_confined ) {
+                            frmline->height = needed_height;
+                        }
+                        else { // except if "-cr-hint: strut-confined":
+                            // We'd rather move the word up, but it shouldn't go
+                            // above the top of the line, so it's not drawn over
+                            // previous line text. If it's taller than line height,
+                            // it's ok to have it overflow bottom: some part of
+                            // it might be overwritten by next line, which we'd
+                            // rather have fully readable.
+                            word->y -= needed_height - frmline->height;
+                            int top_dy = top_to_baseline - word->y - frmline->baseline;
+                            if ( top_dy > 0 )
+                                word->y += top_dy;
+                        }
                     }
                 }
 
@@ -2672,6 +2730,8 @@ public:
             for ( int i=0; i<frmline->word_count; i++ ) {
                 if ( frmline->words[i].flags & (LTEXT_WORD_VALIGN_TOP|LTEXT_WORD_VALIGN_BOTTOM) ) {
                     formatted_word_t * word = &frmline->words[i];
+                    if ( word->flags & LTEXT_WORD_STRUT_CONFINED )
+                        continue; // don't have such words affect current line height & baseline
                     // Update incomplete word->y with current frmline baseline & height,
                     // just as it would have been done if not delayed
                     int cur_word_y;
@@ -2703,6 +2763,13 @@ public:
                     }
                     else if ( word->flags & LTEXT_WORD_VALIGN_BOTTOM ) {
                         word->y = word->y + frmline->height - frmline->baseline;
+                    }
+                    if ( word->flags & LTEXT_WORD_STRUT_CONFINED ) {
+                        // If this word is taller than final line height,
+                        // we'd rather have it overflows bottom.
+                        int top_dy = word->_top_to_baseline - word->y - frmline->baseline;
+                        if ( top_dy > 0 )
+                            word->y += top_dy; // move it down
                     }
                 }
             }
@@ -2938,6 +3005,29 @@ public:
                 if ( m_text[i]=='\n' ) {
                     lastMandatoryWrap = i;
                     break;
+                }
+                // Text with "-cr-hint: strut-confined" might just be vertically shifted,
+                // but won't change widths. But images who will change height must also
+                // have their width reduced to keep their aspect ratio.
+                if ( (m_srcs[i]->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confinning &&
+                        (m_flags[i] & LCHAR_IS_OBJECT) && (m_charindex[i] == OBJECT_CHAR_INDEX) ) {
+                    int width = m_srcs[i]->o.width;
+                    int height = m_srcs[i]->o.height;
+                    // Negative width and height mean the value is a % (of our final block width)
+                    width = width<0 ? (-width * (m_pbuffer->width - x) / 100) : width;
+                    height = height<0 ? (-height * (m_pbuffer->width - x) / 100) : height;
+                    resizeImage(width, height, m_pbuffer->width - x, m_max_img_height, m_length>1);
+                    if ( height > m_pbuffer->strut_height ) {
+                        // Don't make image taller than initial strut height, so adjust width
+                        // to keep aspect ratio.
+                        width = width * m_pbuffer->strut_height / height;
+                        int orig_width = i > 0 ? m_widths[i] - m_widths[i-1] : m_widths[i];
+                        // Coding shortcut: instead of messing with m_widths, or having a
+                        // strutConfinedReclaimedWidth variable to be used everywhere, add the
+                        // reclaimed width to w0 (which holds the cumulative width at start of
+                        // line) as it is already used everywhere to get the width of the line.
+                        w0 += orig_width - width;
+                    }
                 }
                 bool grabbedExceedingSpace = false;
                 if ( x + m_widths[i]-w0 > maxWidth + spaceReduceWidth - firstCharMargin) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2388,6 +2388,28 @@ public:
                     else { // otherwise, align baseline according to valign_dy (computed in lvrend.cpp)
                         word->y = srcline->valign_dy;
                     }
+
+                    // Inline image or inline-block: ensure any "page-break-before/after: avoid"
+                    // specified on them (the specs say those apply to "block-level elements
+                    // in the normal flow of the root element. User agents may also apply it
+                    // to other elements like table-row elements", so it's mostly assumed that
+                    // they won't apply on inline elements and we'll never meet them - but as
+                    // it doesn't say we should not, let's ensure them if provided - and
+                    // only "avoid" as it may have some purpose to stick a full-width image
+                    // or inline-block to the previous or next line).
+                    ldomNode * node = (ldomNode *) lastSrc->object;
+                    if ( node && lastSrc->flags & LTEXT_SRC_IS_INLINE_BOX ) {
+                        // We have not propagated page_break styles from the original
+                        // inline-block to its inlineBox wrapper
+                        node = node->getChildNode(0);
+                    }
+                    if ( node ) {
+                        css_style_ref_t style = node->getStyle();
+                        if ( style->page_break_before == css_pb_avoid )
+                            frmline->flags |= LTEXT_LINE_SPLIT_AVOID_BEFORE;
+                        if ( style->page_break_after == css_pb_avoid )
+                            frmline->flags |= LTEXT_LINE_SPLIT_AVOID_AFTER;
+                    }
                 }
                 else {
                     // word

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -384,16 +384,19 @@ public:
     lUInt16 * m_flags;
     src_text_fragment_t * * m_srcs;
     lUInt16 * m_charindex;
-    int *     m_widths;
-    int m_y;
-    int m_max_img_height;
+    int  *     m_widths;
+    int  m_y;
+    int  m_max_img_height;
     bool m_has_images;
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
     bool m_allow_strut_confinning;
     bool m_has_multiple_scripts;
-    int m_specified_para_dir;
+    bool m_indent_first_line_done;
+    int  m_indent_after_first_line;
+    int  m_indent_current;
+    int  m_specified_para_dir;
     #if (USE_FRIBIDI==1)
         // Bidi/RTL support
         FriBidiCharType *    m_bidi_ctypes;
@@ -2901,14 +2904,6 @@ public:
         // split paragraph into lines, export lines
         int pos = 0;
         int upSkipPos = -1;
-        int indent = m_srcs[0]->indent;
-
-        /* We'd rather not have this final node text just dropped if there
-         * is not enough width for the indent !
-        if (indent > maxWidth) {
-            return;
-        }
-        */
 
         // int minWidth = 0;
         // Not per-specs, but when floats reduce the available width, skip y until
@@ -2917,11 +2912,13 @@ public:
         int minWidth = 3 * m_pbuffer->strut_height;
 
         for (;pos<m_length;) { // each loop makes a line
-            // x is the initial line indent: it's set to text-indent value for the
-            // first line (when pos=0), or to the others when it is negative.
-            // (We use it like a x coordinates below, but we'll use it on the
-            // right in addLine() if para is RTL.)
-            int x = indent >=0 ? (pos==0 ? indent : 0) : (pos==0 ? 0 : -indent);
+            // x is this line indent. We use it like a x coordinates below, but
+            // we'll use it on the right in addLine() if para is RTL.
+            int x = m_indent_current;
+            if ( !m_indent_first_line_done ) {
+                m_indent_first_line_done = true;
+                m_indent_current = m_indent_after_first_line;
+            }
             int w0 = pos>0 ? m_widths[pos-1] : 0;
             int i;
             int lastNormalWrap = -1;
@@ -3472,6 +3469,22 @@ lUInt32 LFormattedText::Format(lUInt16 width, lUInt16 page_height, int para_dire
     m_pbuffer->page_height = page_height;
     // format text
     LVFormatter formatter( m_pbuffer );
+
+    // Set (as properties of the whole final block) the text-indent computed
+    // values for the first line and for the next lines, by taking it
+    // from the first src_text_fragment_t added (see comment in lvrend.cpp
+    // renderFinalBlock() why we do it that way - while it might be better
+    // if it were provided as a parameter to LFormattedText::Format()).
+    int indent = m_pbuffer->srctextlen > 0 ? m_pbuffer->srctext[0].indent : 0;
+    formatter.m_indent_first_line_done = false;
+    if ( indent >= 0 ) { // positive indent affects only first line
+        formatter.m_indent_current = indent;
+        formatter.m_indent_after_first_line = 0;
+    }
+    else { // negative indent affects all but first lines
+        formatter.m_indent_current = 0;
+        formatter.m_indent_after_first_line = -indent;
+    }
 
     // Set specified para direction (can be REND_DIRECTION_UNSET, in which case
     // it will be detected by fribidi)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2533,18 +2533,36 @@ public:
                         word->flags |= LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER;
                     }
                     if ( m_flags[i-1] & LCHAR_IS_SPACE) { // Current word ends with a space
-                        // condition for "- " at beginning of paragraph
-                        if ( wstart!=0 || word->t.len!=2 || !(lGetCharProps(m_text[wstart]) & CH_PROP_DASH) ) {
+                        // Each word ending with a space (except in some conditions) can
+                        // have its width reduced by a fraction of this space width or
+                        // increased if needed (for text justification), so actually
+                        // making that space larger or smaller.
+                        bool can_adjust_width = true;
+                        if ( wstart == 0 && word->t.len == 2 && isLeftPunctuation(m_text[0]) ) {
+                            // Single char (with space) at start of line is one of the
+                            // common opening quotation marks or dashes used to introduce
+                            // a quotation or a part of a dialog:
+                            //   https://en.wikipedia.org/wiki/Quotation_mark
+                            // Don't allow the following space to change width, so other
+                            // similar lines get their real first word similarly aligned.
+                            can_adjust_width = false;
+                        }
+                        else if ( word->t.len>=2 && i>=2 && m_text[i-1]==UNICODE_NO_BREAK_SPACE
+                                                         && m_text[i-2]==UNICODE_NO_BREAK_SPACE ) {
                             // condition for double nbsp after run-in footnote title
-                            if ( !(word->t.len>=2 && m_text[i-1]==UNICODE_NO_BREAK_SPACE && m_text[i-2]==UNICODE_NO_BREAK_SPACE)
-                                    && !( m_text[i]==UNICODE_NO_BREAK_SPACE && m_text[i+1]==UNICODE_NO_BREAK_SPACE) ) {
-                                // Each word ending with a space (except for the 2 conditions above)
-                                // can have its width reduced by a fraction of this space width.
-                                word->flags |= LTEXT_WORD_CAN_ADD_SPACE_AFTER;
-                                int dw = getMaxCondensedSpaceTruncation(i-1);
-                                if (dw>0) {
-                                    word->min_width = word->width - dw;
-                                }
+                            can_adjust_width = false;
+                            // (not sure what this one and the next are about)
+                        }
+                        else if ( i < m_length-1 && m_text[i]==UNICODE_NO_BREAK_SPACE
+                                                 && m_text[i+1]==UNICODE_NO_BREAK_SPACE ) {
+                            // condition for double nbsp after run-in footnote title
+                            can_adjust_width = false;
+                        }
+                        if ( can_adjust_width ) {
+                            word->flags |= LTEXT_WORD_CAN_ADD_SPACE_AFTER;
+                            int dw = getMaxCondensedSpaceTruncation(i-1);
+                            if (dw>0) {
+                                word->min_width = word->width - dw;
                             }
                         }
                         if ( !visualAlignmentEnabled && lastWord ) {
@@ -2832,6 +2850,17 @@ public:
         return c==0x2018 || c==0x201c || // ‘ “ left single and double quotation marks
                c==0x3008 || c==0x300a || c==0x300c || c==0x300e || c==0x3010 || // 〈 《 「 『 【 CJK left brackets
                c==0xff08; // （ fullwidth left parenthesis
+    }
+
+    bool isLeftPunctuation(lChar16 c) {
+        // Opening quotation marks and dashes that we don't want a followup space to
+        // have its width changed
+        return ( c >= 0x2010 && c <= 0x2027 ) || // Hyphens, dashes, quotation marks, bullets...
+               ( c >= 0x2032 && c <= 0x205E ) || // Primes, bullets...
+               ( c >= 0x002A && c <= 0x002F ) || // Ascii * + , - . /
+                 c == 0x00AB || c == 0x00BB   || // Quotation marks (including right pointing, for german text)
+                 c == 0x0022 || c == 0x0027 || c == 0x0023; // Ascii " ' #
+
     }
 
     /// Split paragraph into lines

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8353,7 +8353,7 @@ void ldomXRangeList::getRanges( ldomMarkedRangeList &dst )
         return;
     for ( int i=0; i<length(); i++ ) {
         ldomXRange * range = get(i);
-        if (range->getFlags() < 2) {
+        if (range->getFlags() < 0x10) {
             // Legacy marks drawing: make a single ldomMarkedRange spanning
             // multiple lines, assuming full width LTR paragraphs)
             // (Updated to use toPoint(extended=true) to have them shifted
@@ -8751,7 +8751,7 @@ bool ldomXRange::getWordRange( ldomXRange & range, ldomXPointer & p )
 /// returns true if intersects specified line rectangle
 bool ldomMarkedRange::intersects( lvRect & rc, lvRect & intersection )
 {
-    if ( flags < 2 ) {
+    if ( flags < 0x10 ) {
         // This assumes lines (rc) are from full-width LTR paragraphs, and
         // takes some shortcuts when checking intersection (it can be wrong
         // when floats, table cells, or RTL/BiDi text are involved).

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13690,6 +13690,31 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
     if ( rm == erm_invisible ) {
         return NULL;
     }
+
+    if ( rm == erm_inline ) {
+        // We shouldn't meet erm_inline here, as our purpose is to return
+        // a final node (so, the container of inlines), and not look further
+        // (it's ldomDocument::createXPointer(pt) job to look at this final
+        // node rendered content to find the exact text node and char at pt).
+        // Except in the "pt.y is inside the box bottom overflow" case below,
+        // and that box is erm_final (see there for more comments).
+        // We should navigate all the erm_inline nodes, looking for
+        // non-erm_inline ones that may be in that overflow and containt pt.
+        // erm_inline nodes don't have a RenderRectAccessor(), so their x/y
+        // shifts are 0, and any inner block node had its RenderRectAccessor
+        // x/y offsets positionned related to the final block. So, no need
+        // to shift pt: just recursively call elementFromPoint() as-is,
+        // and we'll be recursively navigating inline nodes here.
+        int count = getChildCount();
+        for ( int i=0; i<count; i++ ) {
+            ldomNode * p = getChildNode( i );
+            ldomNode * e = p->elementFromPoint( pt, direction );
+            if ( e ) // found it!
+                return e;
+        }
+        return NULL; // nothing found
+    }
+
     RenderRectAccessor fmt( this );
 
     if ( BLOCK_RENDERING_G(ENHANCED) ) {
@@ -13722,6 +13747,15 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
                 // Check each of this element's children if pt is inside it (so, we'll
                 // go by here for each of them that has some overflow too, and that
                 // contributed to making this element's overflow.)
+                // Note that if this node is erm_final, its bottom overflow must have
+                // been set by some inner embedded float. But this final block's children
+                // are erm_inline, and the float might be deep among inlines' children.
+                // erm_inline nodes don't have their RenderRectAccessor set, so the
+                // bottom overflow is not propagated thru them, and we would be in
+                // the above case ("Box (with overflow) fully before pt.y"), not
+                // looking at inlines' children. We handle this case above (at the
+                // start of this function) by looking at erm_inline's children for
+                // non-erm_inline nodes before checking any x/y or bottom overflow.
                 int count = getChildCount();
                 for ( int i=0; i<count; i++ ) {
                     ldomNode * p = getChildNode( i );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.33k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.34k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001D
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -69,7 +69,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.34k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x001D
+#define FORMATTING_VERSION_ID 0x001E
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6790,9 +6790,74 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             continue;
         // CRLog::debug("  point (%d, %d) line found [%d]: (%d..%d)",
         //      pt.x, pt.y, l, frmline->y, frmline->y+frmline->height);
-
-        // Found line, searching for word
+        bool line_is_bidi = frmline->flags & LTEXT_LINE_IS_BIDI;
         int wc = (int)frmline->word_count;
+
+        if ( direction >= PT_DIR_SCAN_FORWARD_LOGICAL_FIRST || direction <= PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST ) {
+            // Only used by LVDocView::getBookmark(), LVDocView::getPageDocumentRange()
+            // and ldomDocument::findText(), to not miss any content or text from
+            // the page.
+            // The SCAN_ part has been done done: a line has been found, and we want
+            // to find node/chars from it in the logical (HTML) order, and not in the
+            // visual order (that PT_DIR_SCAN_FORWARD/PT_DIR_SCAN_BACKWARD do), which
+            // might not be the same in bidi lines:
+            bool find_first = direction == PT_DIR_SCAN_FORWARD_LOGICAL_FIRST ||
+                              direction == PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST;
+                         // so, false when PT_DIR_SCAN_FORWARD_LOGICAL_LAST
+                         //             or PT_DIR_SCAN_BACKWARD_LOGICAL_LAST
+
+            const formatted_word_t * word = NULL;
+            for ( int w=0; w<wc; w++ ) {
+                const formatted_word_t * tmpword = &frmline->words[w];
+                const src_text_fragment_t * src = txtform->GetSrcInfo(tmpword->src_text_index);
+                ldomNode * node = (ldomNode *)src->object;
+                if ( !node ) // ignore crengine added text (spacing, list item bullets...)
+                    continue;
+                if ( !line_is_bidi ) {
+                    word = tmpword;
+                    if ( find_first )
+                        break; // found logical first real word
+                    // otherwise, go to the end, word will be logical last real word
+                }
+                else {
+                    if (!word) { // first word seen: first candidate
+                        word = tmpword;
+                    }
+                    else { // compare current word to the current candidate
+                        if ( find_first && tmpword->src_text_index < word->src_text_index ) {
+                            word = tmpword;
+                        }
+                        else if ( !find_first && tmpword->src_text_index > word->src_text_index ) {
+                            word = tmpword;
+                        }
+                        else if (tmpword->src_text_index == word->src_text_index ) {
+                            // (Same src_text_fragment_t, same src->t.offset, skip in when comparing)
+                            if ( find_first && tmpword->t.start < word->t.start ) {
+                                word = tmpword;
+                            }
+                            else if ( !find_first && tmpword->t.start > word->t.start ) {
+                                word = tmpword;
+                            }
+                        }
+                    }
+                }
+            }
+            if ( !word ) // no word: no xpointer (should not happen?)
+                return ptr;
+            // Found right word/image
+            const src_text_fragment_t * src = txtform->GetSrcInfo(word->src_text_index);
+            ldomNode * node = (ldomNode *)src->object;
+            if ( word->flags & LTEXT_WORD_IS_INLINE_BOX || word->flags & LTEXT_WORD_IS_OBJECT ) {
+                return ldomXPointer(node, 0);
+            }
+            // It is a word
+            if ( find_first ) // return xpointer to logical start of word
+                return ldomXPointer( node, src->t.offset + word->t.start );
+            else // return xpointer to logical end of word
+                return ldomXPointer( node, src->t.offset + word->t.start + word->t.len );
+        }
+
+        // Found line, searching for word (words are in visual order)
         int x = pt.x - frmline->x;
         // frmline->x is text indentation (+ possibly leading space if text
         // centered or right aligned)
@@ -6801,7 +6866,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 return ptr;
             }
         }
-        bool line_is_bidi = frmline->flags & LTEXT_LINE_IS_BIDI;
+
         for ( int w=0; w<wc; w++ ) {
             const formatted_word_t * word = &frmline->words[w];
             if ( ( !line_is_bidi && x < word->x + word->width ) ||
@@ -8147,15 +8212,19 @@ bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool rever
     // If we're provided with minY or maxY in some empty space (margins, empty
     // elements...), they may not resolve to a XPointer.
     // Find a valid y near each of them that does resolve to a XPointer:
+    // We also want to get start/end point to logical-order HTML nodes,
+    // which might be different from visual-order in bidi text.
     ldomXPointer start;
     ldomXPointer end;
     for (int y = minY; y >= 0; y--) {
-        start = createXPointer( lvPoint(0, y), reverse?-1:1 );
+        start = createXPointer( lvPoint(0, y), reverse ? PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST
+                                                       : PT_DIR_SCAN_FORWARD_LOGICAL_FIRST );
         if (!start.isNull())
             break;
     }
     for (int y = maxY; y <= fh; y++) {
-        end = createXPointer( lvPoint(10000, y), reverse?-1:1 );
+        end = createXPointer( lvPoint(10000, y), reverse ? PT_DIR_SCAN_BACKWARD_LOGICAL_LAST
+                                                         : PT_DIR_SCAN_FORWARD_LOGICAL_LAST );
         if (!end.isNull())
             break;
     }
@@ -13725,10 +13794,10 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         // So, if we ignore the margins, there can be holes along the vertical
         // axis (these holes are the collapsed margins). But the content boxes
         // (without margins) don't overlap.
-        if ( direction>=0 ) {
+        if ( direction >= PT_DIR_EXACT ) { // PT_DIR_EXACT or PT_DIR_SCAN_FORWARD*
             // We get the parent node's children in ascending order
             // It could just be:
-            //   if ( pt.y >= fmt.getY() + fmt.getHeight() ) {
+            //   if ( pt.y >= fmt.getY() + fmt.getHeight() )
             //       // Box fully before pt.y: not a candidate, next one may be
             //       return NULL;
             // but, because of possible floats overflowing their container element,
@@ -13760,8 +13829,8 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
                 for ( int i=0; i<count; i++ ) {
                     ldomNode * p = getChildNode( i );
                     // Find an inner erm_final element that has pt in it: for now, it can
-                    // only be a float. Use direction=0 to really check for x boundaries.
-                    ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), 0 );
+                    // only be a float. Use PT_DIR_EXACT to really check for x boundaries.
+                    ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), PT_DIR_EXACT );
                     if ( e ) {
                         // Just to be sure, as elementFromPoint() may be a bit fuzzy in its
                         // checks, double check that pt is really inside that e rect.
@@ -13780,7 +13849,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
             // more twisted here, and it's less common that floats overflow
             // their container's top (they need to have negative margins).
         }
-        else {
+        else { // PT_DIR_SCAN_BACKWARD*
             // We get the parent node's children in descending order
             if ( pt.y < fmt.getY() ) {
                 // Box fully before pt.y: not a candidate, next one may be
@@ -13800,27 +13869,22 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 
         int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y < fmt.getY() - top_margin) {
-            if ( direction>0 && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
+            if ( direction >= PT_DIR_SCAN_FORWARD && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
                 return this;
             return NULL;
         }
         int bottom_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
-            if ( direction<0 && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
+            if ( direction <= PT_DIR_SCAN_BACKWARD && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
                 return this;
             return NULL;
         }
     }
 
-    if ( !direction ) {
-        // We shouldn't do the following if we are given a direction
-        // (full text search) as we may get locked on some page.
-        // When interested only in finding the slice of a page
-        // at y (to get the current page top or range xpointers),
-        // use direction=1 or -1.
-        // Use direction=0 to exactly find the final node at y AND x,
-        // which is necessary when selecting text or finding links
-        // in table cells or floats.
+    if ( direction == PT_DIR_EXACT ) {
+        // (We shouldn't check for pt.x when we are given PT_DIR_SCAN_*.
+        // In full text search, we might not find any and get locked
+        // on some page.)
         if ( pt.x >= fmt.getX() + fmt.getWidth() ) {
             return NULL;
         }
@@ -13858,19 +13922,17 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
     // Not a final node, but a block container node that must contain
     // the final node we look for: check its children.
     int count = getChildCount();
-    if ( direction>=0 ) {
+    if ( direction >= PT_DIR_EXACT ) { // PT_DIR_EXACT or PT_DIR_SCAN_FORWARD*
         for ( int i=0; i<count; i++ ) {
             ldomNode * p = getChildNode( i );
-            ldomNode * e = p->elementFromPoint( lvPoint( pt.x - fmt.getX(),
-                    pt.y - fmt.getY() ), direction );
+            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction );
             if ( e )
                 return e;
         }
     } else {
         for ( int i=count-1; i>=0; i-- ) {
             ldomNode * p = getChildNode( i );
-            ldomNode * e = p->elementFromPoint( lvPoint( pt.x - fmt.getX(),
-                    pt.y - fmt.getY() ), direction );
+            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction );
             if ( e )
                 return e;
         }
@@ -13882,7 +13944,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 ldomNode * ldomNode::finalBlockFromPoint( lvPoint pt )
 {
     ASSERT_NODE_NOT_NULL;
-    ldomNode * elem = elementFromPoint( pt, 0 );
+    ldomNode * elem = elementFromPoint( pt, PT_DIR_EXACT );
     if ( elem && elem->getRendMethod() == erm_final )
         return elem;
     return NULL;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -14716,8 +14716,9 @@ void ldomDocument::registerEmbeddedFonts()
                 if (!tmp.empty()) {face=tmp;break;}
             }
         }
-        if ((!x.empty() and x.pos(face)!=-1) or url.empty())
-        {continue;}
+        if ((!x.empty() && x.pos(face)!=-1) || url.empty()) {
+            continue;
+        }
         if (url.startsWithNoCase(lString16("res://")) || url.startsWithNoCase(lString16("file://"))) {
             if (!fontMan->RegisterExternalFont(item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register external font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
@@ -14727,7 +14728,7 @@ void ldomDocument::registerEmbeddedFonts()
         else {
             if (!fontMan->RegisterDocumentFont(getDocIndex(), _container, item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register document font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
-            lString16 fontface = lString16("");
+                lString16 fontface = lString16("");
                 for (int j = 0; j < cnt; j = j + 1) {
                 fontface = flist[j];
                 do { (fontface.replace(lString16(" "), lString16("\0"))); }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10401,6 +10401,7 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
     //CRLog::trace("convertHref(%s, codeBase=%s, filePathName=%s)", LCSTR(href), LCSTR(codeBase), LCSTR(filePathName));
 
     if (href[0] == '#') {
+        // Link to anchor in the same docFragment
         lString16 replacement = pathSubstitutions.get(filePathName);
         if (replacement.empty())
             return href;
@@ -10409,24 +10410,38 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
         return p;
     }
 
-    href = LVCombinePaths(codeBase, href);
+    // href = LVCombinePaths(codeBase, href);
+
+    // Depending on what's calling us, href may or may not have
+    // gone thru DecodeHTMLUrlString() to decode %-encoded bits.
+    // We'll need to try again with DecodeHTMLUrlString() if not
+    // initially found in "pathSubstitutions" (whose filenames went
+    // thru DecodeHTMLUrlString(), and so did 'codeBase').
 
     // resolve relative links
-    lString16 p, id;
+    lString16 p, id; // path, id
     if ( !href.split2(cs16("#"), p, id) )
         p = href;
     if ( p.empty() ) {
         //CRLog::trace("codebase = %s -> href = %s", LCSTR(codeBase), LCSTR(href));
         if ( codeBasePrefix.empty() )
-            return href;
+            return LVCombinePaths(codeBase, href);
         p = codeBasePrefix;
-    } else {
-        lString16 replacement = pathSubstitutions.get(p);
+    }
+    else {
+        lString16 replacement = pathSubstitutions.get(LVCombinePaths(codeBase, p));
         //CRLog::trace("href %s -> %s", LCSTR(p), LCSTR(replacement));
         if ( !replacement.empty() )
             p = replacement;
-        else
-            return href;
+        else {
+            // Try again after DecodeHTMLUrlString()
+            p = DecodeHTMLUrlString(p);
+            replacement = pathSubstitutions.get(LVCombinePaths(codeBase, p));
+            if ( !replacement.empty() )
+                p = replacement;
+            else
+                return LVCombinePaths(codeBase, href);
+        }
         //else
         //    p = codeBasePrefix;
         //p = LVCombinePaths( codeBase, p ); // relative to absolute path

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -69,7 +69,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.34k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x001E
+#define FORMATTING_VERSION_ID 0x001F
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6575,7 +6575,7 @@ xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & inde
             pos++;
             while (s[pos]>='0' && s[pos]<='9')
                 pos++;
-            if (s[pos] && s[pos!='/'] && s[pos]!='.')
+            if (s[pos] && s[pos]!='/' && s[pos]!='.')
                 return xpath_step_error;
             lString16 sindex( path+nstart, pos-nstart );
             index = sindex.atoi();


### PR DESCRIPTION
See individual commit messages for details.
Some additional notes:
- `CSS: ensure selectors are applied in the order met` discussed in https://github.com/koreader/crengine/pull/170#issuecomment-573414720.
- `Fix getPageDocumentRange() on bidi text` issue explained in https://github.com/koreader/crengine/pull/313#issuecomment-573356486
- `text-indent: some fixes, handle negative & hanging indent` Issues detailed at https://github.com/koreader/koreader/issues/2857#issuecomment-576319227 . Closes https://github.com/koreader/koreader/issues/2857
- `Text: fix: allow wrap on space around images` Sample case:
Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72917777-c0352400-3d44-11ea-9c05-6ee504a0b427.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72917534-4dc44400-3d44-11ea-8221-08d57eb1752b.png)</kbd>

- `(Upstream) Minor cleanup and ifdef wraps` minor stuff picked from upstream in-progress merge of our changes https://github.com/buggins/coolreader/pull/125, mostly related to what I added.

- `CSS/Text: adds "-cr-hint: strut-confined"` Will allow us to have a one-stop solution to publisher footnote links badly styled, and variable size inline images, that causes line-height oscillation in a paragraph: 
```lua
        {
            id = "lineheight_all_normal_strut_confined";
            title = _("Enforce steady line heights"),
            description = _("Prevent inline content like sub- and superscript from changing their paragraph line height."),
            priority = -5, -- so other -cr-hint can override (this one has effect only on inline content)
            css = [[* { -cr-hint: strut-confined; }]],
        },
```

Before style tweak applied:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72918373-d68faf80-3d45-11ea-93cc-e0e0e2484999.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72918108-63863900-3d45-11ea-9d7f-2c4572257a89.png)</kbd>
(An inline image standalone on a line is not confined, as noticed at the bottom - the two other are reduced because they have a comma or a period after them.)

The main benefit (for me) is getting rid of badly styled footnote links (not even wrapped in `<SUP>`, that even the `Ignore publisher line-height` and the radical `Ignore publisher font-size` couldn't get rid of because of excessive vertical-align (one would have needed to look at the code and create a custom style tweak to get rid of that).
Before style tweak applied:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72919240-68e48300-3d47-11ea-8f08-0a3c94bef817.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/72919308-87e31500-3d47-11ea-8e11-70141d474c6b.png)</kbd>

- `lvtextfm: avoid spurious spaces when hyphenating` fixes this:
<kbd>![image](https://user-images.githubusercontent.com/24273478/73158222-81f08980-40e3-11ea-906e-1d4d02076b11.png)</kbd>
when
<kbd>![image](https://user-images.githubusercontent.com/24273478/73158256-9896e080-40e3-11ea-903b-632ef4b98954.png)</kbd>
so we get the correct:
<kbd>![image](https://user-images.githubusercontent.com/24273478/73158293-b3695500-40e3-11ea-8b87-a552febc8f77.png)</kbd>

- `lvtextfm: dont adjust space after initial quotation mark/dash` Fixes this too wide space:
<kbd>![image](https://user-images.githubusercontent.com/24273478/73158578-86697200-40e4-11ea-8601-0d373fd5e438.png)</kbd>

- `lvtextfm: ensure page-break:avoid on inline-block and images` is not required by specs, but will allow us to finally get nice gallery in Wikipedia EPUBs by having all the items inline-block, including a 100% caption, ensuring the captions is stuck on the same page as the first items:
<kbd>![image](https://user-images.githubusercontent.com/24273478/73159361-a1d57c80-40e6-11ea-89e7-69ac40298675.png)</kbd>
instead of the messy stuff we got with floats, screenshot in #299.

- `Fix internal/footnote links not working on some books` fixed internal link not working when internal file names are percent-encoded (`<a href="Author%20Title.html#fnt1">[1]</a>`) - I sometimes had footnotes links not working, and always assumed it was the book that was badly made :|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/326)
<!-- Reviewable:end -->
