### PR TITLE
Support vertical-align: baseline in tables, various other fixes

### DIFF
--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -225,7 +225,7 @@ br[clear=all i], br[clear=both i] {
 }
 
 /* Bidirectional text */
-/* crengine-: not supported
+/* crengine-: handled internally (unicode-bidi not supported, but bdo handled)
 [dir]:dir(ltr), bdi:dir(ltr), input[type=tel]:dir(ltr) {
   direction: ltr;
 }

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -80,6 +80,7 @@ XS_TAG1T( figure )
 XS_TAG1T( footer )
 XS_TAG1T( header )
 XS_TAG1T( hgroup )
+XS_TAG1T( legend ) // child of fieldset, rendered as block by most browsers
 XS_TAG1T( main )
 XS_TAG1T( nav )
 XS_TAG1T( noscript )

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -280,6 +280,7 @@ public:
     inline int getEnd() const { return start + height; }
     inline int getStart() const { return start; }
     inline int getHeight() const { return height; }
+    inline lUInt16 getFlags() const { return flags; }
 
     LVRendLineInfo() : links(NULL), start(-1), height(0), flags(0) { }
     LVRendLineInfo( int line_start, int line_end, lUInt16 line_flags )
@@ -327,6 +328,7 @@ public:
     CompactArray<LVRendLineInfo*, 2, 4> & getLines() { return lines; }
     bool empty() { return lines.empty(); }
     void clear() { lines.clear(); }
+    lString16 getId() { return id; }
 };
 
 class LVDocViewCallback;
@@ -354,8 +356,10 @@ class LVRendPageContext
     // page list to fill
     LVRendPageList * page_list;
     // page height
-    int          page_h;
-    // Links gathered when no page_list
+    int page_h;
+    // Whether to gather lines or not (only footnote links will be gathered if not)
+    bool gather_lines;
+    // Links gathered when !gather_lines
     lString16Collection link_ids;
 
     LVHashTable<lString16, LVFootNoteRef> footNotes;
@@ -382,14 +386,16 @@ public:
     }
     bool updateRenderProgress( int numFinalBlocksRendered );
 
+    bool wantsLines() { return gather_lines; }
+
     /// Get the number of links in the current line links list, or
-    // in link_ids when no page_list
+    // in link_ids when !gather_lines
     int getCurrentLinksCount();
 
     /// append or insert footnote link to last added line
     void addLink( lString16 id, int pos=-1 );
 
-    /// get gathered links when no page_list
+    /// get gathered links when !gather_lines
     // (returns a reference to avoid lString16Collection destructor from
     // being called twice and a double free crash)
     lString16Collection * getLinkIds() { return &link_ids; }
@@ -406,11 +412,14 @@ public:
     /// returns page list pointer
     LVRendPageList * getPageList() { return page_list; }
 
-    LVRendPageContext(LVRendPageList * pageList, int pageHeight);
+    LVRendPageContext(LVRendPageList * pageList, int pageHeight, bool gatherLines=true);
 
     /// add source line
     void AddLine( int starty, int endy, int flags );
 
+    LVPtrVector<LVRendLineInfo> * getLines() {
+        return &lines;
+    };
     void Finalize();
 };
 

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -51,8 +51,8 @@
 // To be provided via the initial value to renderBlockElement(... int *baseline ...) to
 // have FlowState compute baseline (different rules whether inline-block or inline-table).
 #define REQ_BASELINE_NOT_NEEDED       0
-#define REQ_BASELINE_FOR_INLINE_BLOCK 1
-#define REQ_BASELINE_FOR_INLINE_TABLE 2
+#define REQ_BASELINE_FOR_INLINE_BLOCK 1    // use last baseline fed
+#define REQ_BASELINE_FOR_TABLE        2    // keep first baseline fed
 
 class FlowState;
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2322,6 +2322,8 @@ public:
     int getFullHeight();
     /// returns page height setting
     int getPageHeight() { return _page_height; }
+    /// returns page width setting
+    int getPageWidth() { return _page_width; }
 #endif
     /// saves document contents as XML to stream with specified encoding
     bool saveToStream( LVStreamRef stream, const char * codepage, bool treeLayout=false );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2271,6 +2271,7 @@ void LVDocView::Draw(LVDrawBuf & drawbuf, int position, int page, bool rotate, b
 		return;
 	if (isScrollMode()) {
 		drawbuf.SetClipRect(NULL);
+        drawbuf.setHidePartialGlyphs(false);
         drawPageBackground(drawbuf, 0, position);
         int cover_height = 0;
 		if (m_pages.length() > 0 && (m_pages[0]->flags & RN_PAGE_TYPE_COVER))

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -43,9 +43,10 @@ int LVRendPageList::FindNearestPage( int y, int direction )
     return length()-1;
 }
 
-LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight)
+LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, bool gatherLines)
     : callback(NULL), totalFinalBlocks(0)
-    , renderedFinalBlocks(0), lastPercent(-1), page_list(pageList), page_h(pageHeight), footNotes(64), curr_note(NULL)
+    , renderedFinalBlocks(0), lastPercent(-1), page_list(pageList), page_h(pageHeight)
+    , gather_lines(gatherLines), footNotes(64), curr_note(NULL)
 {
     if ( callback ) {
         callback->OnFormatStart();
@@ -72,10 +73,10 @@ bool LVRendPageContext::updateRenderProgress( int numFinalBlocksRendered )
 }
 
 /// Get the number of links in the current line links list, or
-// in link_ids when no page_list
+// in link_ids when !gather_lines
 int LVRendPageContext::getCurrentLinksCount()
 {
-    if ( !page_list ) {
+    if ( !gather_lines ) {
         return link_ids.length();
     }
     if ( lines.empty() )
@@ -86,8 +87,7 @@ int LVRendPageContext::getCurrentLinksCount()
 /// append or insert footnote link to last added line
 void LVRendPageContext::addLink( lString16 id, int pos )
 {
-    if ( !page_list ) {
-        // gather links even if no page_list
+    if ( !gather_lines ) {
         if ( pos >= 0 ) // insert at pos
             link_ids.insert( pos, id );
         else // append

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -420,6 +420,16 @@ public:
                     AddToList(); //create a page with only the footnotes
                 }
             }
+            if ( line->flags & RN_SPLIT_DISCARD_AT_START ) {
+                // Don't put this line at start of new page (this flag
+                // is set on a margin line when page split auto, as it should
+                // be seen when inside page, but should not be seen on top of
+                // page - and can be kept if it fits at the end of previous page)
+                #ifdef DEBUG_PAGESPLIT
+                    printf("PS:   discarded discardable line at start of page %d\n", page_list->length());
+                #endif
+                return;
+            }
             #ifdef DEBUG_PAGESPLIT
                 printf("   starting page with it\n");
             #endif
@@ -519,7 +529,7 @@ public:
                 pageend = last;
                 AddToList();
                 if ( flgSplit==RN_SPLIT_AUTO && (line->flags & RN_SPLIT_DISCARD_AT_START) ) {
-                    // Don't put this line at start of first page (this flag
+                    // Don't put this line at start of new page (this flag
                     // is set on a margin line when page split auto, as it should
                     // be seen when inside page, but should not be seen on top of
                     // page - and can be kept if it fits at the end of previous page)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8731,6 +8731,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         // So, we treat all other erm_* as erm_block (which will obviously be
         // wrong for erm_table* with more than 1 column, but it should give a
         // positive enough width to draw something).
+        //   Update: we use a trick when erm_table_row below.
         else {
             // Process children, which are all block-like nodes:
             // our *Width are the max of our children *Width
@@ -8741,10 +8742,19 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 ldomNode * child = node->getChildNode(i);
                 getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
                     curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent);
-                if (_maxw > _maxWidth)
-                    _maxWidth = _maxw;
-                if (_minw > _minWidth)
-                    _minWidth = _minw;
+                if (m == erm_table_row) {
+                    // For table rows, adding the min/max widths of each children
+                    // (the table cells), instead of taking the largest, gives
+                    // a better estimate of what the table width should be.
+                    _maxWidth += _maxw;
+                    _minWidth += _minw;
+                }
+                else {
+                    if (_maxw > _maxWidth)
+                        _maxWidth = _maxw;
+                    if (_minw > _minWidth)
+                        _minWidth = _minw;
+                }
             }
         }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7756,7 +7756,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         int height = fmt.getHeight();
         int top_overflow = fmt.getTopOverflow();
         int bottom_overflow = fmt.getBottomOverflow();
-        if ( (doc_y + height + bottom_overflow <= 0 || doc_y - top_overflow > 0 + dy) ) {
+        if ( (doc_y + height + bottom_overflow <= 0 || doc_y - top_overflow >= 0 + dy) ) {
             // We don't have to draw this node.
             // Except TR which may have cells with rowspan>1, and even though
             // this TR is out of range, it must draw a rowspan>1 cell, so it

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2054,7 +2054,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             lString16 marker;
             int markerWidth = 0;
             ldomNode * child = parent->getChildElementNode(i);
-            if ( child->getNodeId() == el_floatBox || child->getNodeId() == el_inlineBox ) {
+            if ( child && ( child->getNodeId() == el_floatBox || child->getNodeId() == el_inlineBox ) ) {
                 child = child->getChildNode(0);
             }
             if ( child && child->getNodeListMarker( counterValue, marker, markerWidth ) ) {
@@ -5547,7 +5547,7 @@ void BlockFloatFootprint::store(ldomNode * node)
         RENDER_RECT_UNSET_FLAG(fmt, NO_CLEAR_OWN_FLOATS);
     }
     fmt.push();
-};
+}
 
 void BlockFloatFootprint::restore(ldomNode * node, int final_width)
 {
@@ -5563,7 +5563,7 @@ void BlockFloatFootprint::restore(ldomNode * node, int final_width)
         generateEmbeddedFloatsFromFootprints( final_width );
     }
     no_clear_own_floats = RENDER_RECT_HAS_FLAG(fmt, NO_CLEAR_OWN_FLOATS);
-};
+}
 
 // Enhanced block rendering
 void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int container_width, int flags )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -159,6 +159,7 @@ public:
     int direction;
     int width;
     int height;
+    int baseline;
     int percent;
     int max_content_width;
     int min_content_width;
@@ -171,13 +172,14 @@ public:
     , direction(REND_DIRECTION_UNSET)
     , width(0)
     , height(0)
+    , baseline(0)
     , percent(0)
     , max_content_width(0)
     , min_content_width(0)
     , colspan(1)
     , rowspan(1)
-    , halign(0)
-    , valign(0)
+    , halign(0) // default to text-align: left
+    , valign(0) // default to vertical-align: baseline
     , elem(NULL)
     { }
 };
@@ -188,6 +190,7 @@ class CCRTableRow {
 public:
     int index;
     int height;
+    int baseline;
     int bottom_overflow; // extra height from row with rowspan>1
     int y;
     int numcols; // sum of colspan
@@ -198,6 +201,7 @@ public:
     CCRTableRowGroup * rowgroup;
     CCRTableRow() : index(0)
     , height(0)
+    , baseline(0)
     , bottom_overflow(0)
     , y(0)
     , numcols(0) // sum of colspan
@@ -503,9 +507,9 @@ public:
                         // "valign"
                         lString16 valign = item->getAttributeValue(attr_valign);
                         if (valign == "center")
-                            cell->valign = 1; // center
+                            cell->valign = 2; // middle
                         else if (valign == "bottom")
-                            cell->valign = 2; // bottom
+                            cell->valign = 3; // bottom
                         */
                         // These commented above attributes have been translated to
                         // CSS properties by ldomDocumentWriterFilter::OnAttribute():
@@ -536,12 +540,18 @@ public:
                         else if ( ta == css_ta_right )
                             cell->halign = 2; // right
 
+                        // https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
+                        // The default for vertical_align is baseline (cell->valign=0,
+                        // set at CCRTableCell init time), and all other named values
+                        // than top/middle/bottom act as baseline.
                         css_length_t va = style->vertical_align;
                         if ( va.type == css_val_unspecified ) {
-                            if ( va.value == css_va_middle )
-                                cell->valign = 1; // middle
+                            if ( va.value == css_va_top )
+                                cell->valign = 1; // top
+                            else if ( va.value == css_va_middle )
+                                cell->valign = 2; // middle
                             else if ( va.value == css_va_bottom )
-                                cell->valign = 2; // bottom
+                                cell->valign = 3; // bottom
                         }
 
                         cell->direction = item_direction;
@@ -1386,6 +1396,7 @@ public:
         // Calc individual cells dimensions
         for (i=0; i<rows.length(); i++) {
             CCRTableRow * row = rows[i];
+            bool row_has_baseline_aligned_cells = false;
             for (j=0; j<rows[i]->cells.length(); j++) {
                 CCRTableCell * cell = rows[i]->cells[j];
                 //int x = cell->col->index;
@@ -1413,7 +1424,23 @@ public:
                         }
                         fmt.push();
                         int h = cell->elem->renderFinalBlock( txform, &fmt, cell->width - padding_left - padding_right);
-                        cell->height = h + padding_top + padding_bottom;
+                        cell->height = padding_top + h + padding_bottom;
+
+                        // A cell baseline is the baseline of its first line of text (or
+                        // the bottom of content edge of the cell if no line)
+                        if ( cell->valign == 0 ) { // vertical-align: baseline
+                            if ( txform->GetLineCount() > 0 ) // we have a line
+                                cell->baseline = padding_top + txform->GetLineInfo(0)->baseline;
+                            else // no line, no image: bottom of content edge is at padding_top
+                                cell->baseline = padding_top;
+                        }
+                        else { // all other vertical-align: values
+                            // "If a row has no cell box aligned to its baseline,
+                            // the baseline of that row is the bottom content edge
+                            // of the lowest cell in the row."
+                            // So, store that bottom content edge in cell->baseline
+                            cell->baseline += h;
+                        }
 
                         // Gather footnotes links, as done in renderBlockElement() when erm_final/flgSplit:
                         if ( elem->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) {
@@ -1451,8 +1478,26 @@ public:
                         // main context. Their heights will already be accounted
                         // in their row's height (added to main context below).
                         LVRendPageContext emptycontext( NULL, context.getPageHeight() );
-                        int h = renderBlockElement( emptycontext, cell->elem, 0, 0, cell->width, cell->direction);
+                        // See above about what we'll store in cell->baseline
+                        int baseline = REQ_BASELINE_NOT_NEEDED;
+                        if ( cell->valign == 0 ) { // vertical-align: baseline
+                            baseline = REQ_BASELINE_FOR_TABLE;
+                        }
+                        int h = renderBlockElement( emptycontext, cell->elem, 0, 0, cell->width,
+                                                    cell->direction, &baseline );
                         cell->height = h;
+                        if ( cell->valign == 0 ) { // vertical-align: baseline
+                            cell->baseline = baseline;
+                        }
+                        else {
+                            // We'd need the bottom content edge of what's been rendered.
+                            // We just need to remove this cell bottom padding (we should
+                            // not remove the inner content bottom margins or paddings).
+                            int em = cell->elem->getFont()->getSize();
+                            css_style_ref_t elem_style = cell->elem->getStyle();
+                            int padding_bottom = lengthToPx( elem_style->padding[3], cell->width, em ) + measureBorder(cell->elem,2);
+                            cell->baseline = h - padding_bottom;
+                        }
                         // Gather footnotes links accumulated by emptycontext
                         lString16Collection * link_ids = emptycontext.getLinkIds();
                         if (link_ids->length() > 0) {
@@ -1483,6 +1528,45 @@ public:
                         if ( row->height < cell->height )
                             row->height = cell->height;
                     }
+                    // Set the row baseline from baseline-aligned cells' baselines.
+                    // https://www.w3.org/TR/CSS22/tables.html#height-layout
+                    //   "First the cells that are aligned on their baseline are positioned.
+                    //   This will establish the baseline of the row"
+                    if ( cell->valign == 0 ) { // only cells with vertical-align: baseline
+                        row_has_baseline_aligned_cells = true;
+                        if ( row->baseline < cell->baseline )
+                            row->baseline = cell->baseline;
+                    }
+                }
+            }
+            // Fixup row height and baseline
+            for (j=0; j<rows[i]->cells.length(); j++) {
+                CCRTableCell * cell = rows[i]->cells[j];
+                int y = cell->row->index;
+                if ( i==y ) { // upper left corner of cell
+                    if ( !row_has_baseline_aligned_cells ) {
+                        // "If a row has no cell box aligned to its baseline,
+                        // the baseline of that row is the bottom content edge
+                        // of the lowest cell in the row."
+                        // We have computed cell->baseline that way
+                        // when cell->valign != 0, so just use it:
+                        if ( row->baseline < cell->baseline )
+                            row->baseline = cell->baseline;
+                        // cell->baseline = 0; // (not needed, as not used)
+                    }
+                    else if ( cell->valign == 0 ) {
+                        // Cells with vertical-align: baseline must align with
+                        // the row baseline: this can increase the height of
+                        // a cell, and so the height of the row.
+                        // As we don't need the real cell->baseline after this,
+                        // we store in it the shift-down frop top for this cell,
+                        // that we'll use below when handling cell->valign==0.
+                        int shift_down = row->baseline - cell->baseline;
+                        if ( row->height < cell->height + shift_down )
+                            row->height = cell->height + shift_down;
+                        cell->baseline = shift_down;
+                    }
+                    // else cell->baseline = 0; // (not needed, as not used)
                 }
             }
         }
@@ -1586,6 +1670,9 @@ public:
                 fmt.setY(row->y);
                 fmt.setWidth( table_width - table_border_left - table_padding_left - table_padding_right - table_border_right );
                 fmt.setHeight( row->height );
+                // This baseline will only be useful if we're part of
+                // some flow rendered with REQ_BASELINE_FOR_TABLE
+                fmt.setBaseline( row->baseline );
                 if ( enhanced_rendering ) {
                     fmt.setBottomOverflow( row->bottom_overflow );
                 }
@@ -1678,12 +1765,16 @@ public:
                     // We have to shift down the cell content itself
                     int cell_h = fmt.getHeight(); // original height that fit cell content
                     fmt.setHeight( row_h );
-                    if ( cell->valign && cell_h < row_h ) {
-                        int pad = 0;
-                        if (cell->valign == 1) // center
+                    if ( cell_h < row_h ) {
+                        int pad = 0; // default when cell->valign=1 / top
+                        if (cell->valign == 0) // baseline
+                            pad = cell->baseline; // contains the shift-down to align cell and row baselines
+                        else if (cell->valign == 2) // center
                             pad = (row_h - cell_h)/2;
-                        else if (cell->valign == 2) // bottom
+                        else if (cell->valign == 3) // bottom
                             pad = (row_h - cell_h);
+                        if ( pad == 0 ) // No need to update this cell
+                            continue;
                         if ( cell->elem->getRendMethod() == erm_final ) {
                             if ( enhanced_rendering ) {
                                 // Just shift down the content box
@@ -4050,7 +4141,7 @@ private:
     int  in_y_max;    //   that overflow this level height)
     int  x_min;       // current left min x
     int  x_max;       // current right max x
-    int  baseline_req; // baseline type requested (REQ_BASELINE_FOR_INLINE_BLOCK or REQ_BASELINE_FOR_INLINE_TABLE)
+    int  baseline_req; // baseline type requested (REQ_BASELINE_FOR_INLINE_BLOCK or REQ_BASELINE_FOR_TABLE)
     int  baseline_y;   // baseline y relative to formatting context top (computed when rendering inline-block/table)
     bool baseline_set; // (set to true on first baseline met)
     bool is_main_flow;
@@ -4164,7 +4255,7 @@ public:
         // Quotes from https://www.w3.org/TR/CSS21/visudet.html#propdef-vertical-align
         // Note that our table rendering code has not been updated to use FlowState,
         // so, if top element is a table, we haven't got any baseline.
-        if ( baseline_req == REQ_BASELINE_FOR_INLINE_TABLE ) {
+        if ( baseline_req == REQ_BASELINE_FOR_TABLE ) {
             // "The baseline of an 'inline-table' is the baseline of the first
             //  row of the table.
             // Tests show that this is true even if the element with
@@ -4207,23 +4298,17 @@ public:
                 }
             }
             if ( rowNode ) {
-                // Get this row bottom y related to the top node y
+                // Get this row baseline y related to the top node y
                 RenderRectAccessor fmt( rowNode );
-                int row_bottom = fmt.getY() + fmt.getHeight();
+                int row_baseline = fmt.getY() + fmt.getBaseline();
                 ldomNode * n = rowNode->getParentNode();
                 for (; n && n!=node; n=n->getParentNode()) {
                     RenderRectAccessor fmt(n);
-                    row_bottom += fmt.getY();
+                    row_baseline += fmt.getY();
                 }
-                if ( !baseline_set || (row_bottom < baseline_y) ) {
-                    baseline_y = row_bottom;
+                if ( !baseline_set || (row_baseline < baseline_y) ) {
+                    baseline_y = row_baseline;
                 }
-                // Not implemented: it seems that if any of this row cell has
-                // "vertical-align: baseline", it's no more the bottom of the
-                // row that should be the baseline, but this cell baseline...
-                // See (which has a hidden "#cell-of-first-row {vertical-align: baseline;}"
-                // which makes it behave as advertised:
-                // http://www.gtalbot.org/BrowserBugsSection/Safari3Bugs/baseline-inline-table-vertical-align.html
                 baseline_set = true;
             }
         }
@@ -4376,15 +4461,15 @@ public:
                 // https://stackoverflow.com/questions/19352072/what-is-the-difference-between-inline-block-and-inline-table/56305302#56305302
                 // A tricky thing with inline-table is that the baseline is different if
                 // there is a table of if there's not
-                // - if the first content line is a table row, it should be the bottom
-                //   margin of the row (and not the baseline of the first or last line
+                // - if the first content is a table row, it should be the baseline of
+                //   the row (which might not be the baseline of the first or last line
                 //   of any table cell of that row).
-                // - if the first content line is not a table row (we can have inline-table
+                // - if the first content is not a table row (we can have inline-table
                 //   containing no table-like elements), it is the real baseline of the
-                //   first line.
+                //   first line in that content.
                 // As the rendering table code does not use FlowState, we manage the
                 // first case in getBaselineAbsoluteY() when we're done.
-                if ( baseline_req == REQ_BASELINE_FOR_INLINE_TABLE && baseline_set ) {
+                if ( baseline_req == REQ_BASELINE_FOR_TABLE && baseline_set ) {
                     // inline-table: first baseline already met, it will stay the final baseline
                 }
                 else { // inline-block
@@ -8257,9 +8342,17 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( page_break_after, css_pb_inherit );
     UPDATE_STYLE_FIELD( page_break_inside, css_pb_inherit );
 
-    // vertical_align is not inherited per CSS specs: we fixed its propagation
-    // to children with the use of 'valign_dy'
-    // UPDATE_STYLE_FIELD( vertical_align, css_va_inherit );
+    // vertical_align
+    // Should not be inherited per CSS specs: we fixed its propagation
+    // to children with the use of 'valign_dy'.
+    // But our default value for each node is not "inherit" but "baseline",
+    // so we should be fine allowing an explicite "inherit" to get its parent
+    // value. This is actually required with html5.css where TR,TD,TH are
+    // explicitely set to "vertical-align: inherit", so they can inherit
+    // from "thead, tbody, tfoot, table > tr { vertical-align: middle}"
+    if ( pstyle->vertical_align.type == css_val_unspecified && pstyle->vertical_align.value == css_va_inherit)
+        pstyle->vertical_align = parent_style->vertical_align;
+
     UPDATE_STYLE_FIELD( font_style, css_fs_inherit );
     UPDATE_STYLE_FIELD( font_weight, css_fw_inherit );
     if ( pstyle->font_family == css_ff_inherit ) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -199,6 +199,7 @@ public:
     ldomNode * elem;
     LVPtrVector<CCRTableCell> cells;
     CCRTableRowGroup * rowgroup;
+    LVRendPageContext * single_col_context; // we can add cells' lines instead of full rows
     CCRTableRow() : index(0)
     , height(0)
     , baseline(0)
@@ -208,6 +209,7 @@ public:
     , linkindex(-1)
     , elem(NULL)
     , rowgroup(NULL)
+    , single_col_context(NULL)
     { }
 };
 
@@ -1316,7 +1318,6 @@ public:
         const int table_y0 = rect.top; // absolute y in document for top of table
         int last_y = table_y0; // used as y0 to AddLine(y0, table_y0+table_h)
         int line_flags = 0;
-        bool splitPages = context.getPageList() != NULL;
 
         // Final table height will be added to as we meet table content
         int table_h = 0;
@@ -1372,7 +1373,7 @@ public:
             // Includes half of it here, and the other half when adding the row
             table_h += borderspacing_v_bottom;
         }
-        if (splitPages) {
+        if ( context.wantsLines() ) {
             // Includes table border top + full caption if any + table padding
             // top + half of borderspacing_v.
             // We ask for a split between these and the first row to be avoided,
@@ -1390,6 +1391,51 @@ public:
                 line_flags |= RN_LINE_IS_RTL;
             context.AddLine(last_y, table_y0 + table_h, line_flags);
             last_y = table_y0 + table_h;
+        }
+
+        // If table is a single column, we can add to main context
+        // the lines of each cell, instead of full table rows, which
+        // will avoid cell lines to possibly be cut in the middle.
+        // (When multi-columns, because same-row cells' lines may
+        // not align, and because it's easier for the reader to
+        // not have to go back one page to read next cell (from
+        // same row) content, each row is considered a single
+        // line in the matter of page splitting.)
+        bool is_single_column = false;
+        int min_row_height_for_split_by_line;
+        if ( context.wantsLines() && cols.length() == 1 && enhanced_rendering ) {
+            is_single_column = true;
+            // We actually don't know if splitting by line is better
+            // than splitting by row. By-row might be better if it's
+            // a real table where rows really list items, while by-lines
+            // is preferable where the table is just used as a content
+            // wrapper. So, let's follow this simple rule from:
+            // https://www.w3.org/TR/css-tables-3/#fragmentation
+            //   "must attempt to preserve the table rows unfragmented if
+            //   the cells spanning the row do not span any subsequent row,
+            //   and their height is at least twice smaller than both the
+            //   fragmentainer height and width. Other rows are said
+            //   freely fragmentable."
+            // which looks like it applies to multi-columns tables too
+            // (but our lvpagesplitter will manage this as fine) - but
+            // let's just use that rule for single-columns tables.
+            int page_height = elem->getDocument()->getPageHeight();
+            int page_width = elem->getDocument()->getPageWidth();
+            if ( page_width < page_height )
+                min_row_height_for_split_by_line = page_width / 2;
+            else
+                min_row_height_for_split_by_line = page_height / 2;
+            // Looks like cells having rowspan > 1 (which makes no sense
+            // if only own column) shouldn't need any specific tweaks.
+            // Also, as we don't apply cells and row style height, and
+            // vertical-align shouldn't change anything if there are no
+            // other cell that would increase the row height, this too
+            // shouldn't need any check.
+            // (Note that a TD style height will still be applied if rendered
+            // as erm_block (but not if erm_final), but vertical-align won't
+            // be ensured. todo: make that consistent.)
+            // todo: we could also try to do that even if multi columns,
+            // by merging multiple cells' LVRendPageContext.
         }
 
         int i, j;
@@ -1442,11 +1488,47 @@ public:
                             cell->baseline += h;
                         }
 
-                        // Gather footnotes links, as done in renderBlockElement() when erm_final/flgSplit:
-                        if ( elem->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) {
+                        // Gather footnotes links, as done in renderBlockElement() when erm_final/flgSplit
+                        // and cell lines when is_single_column:
+                        if ( elem->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) || is_single_column ) {
+                            int orphans;
+                            int widows;
+                            if ( is_single_column ) {
+                                orphans = (int)(elem_style->orphans) - (int)(css_orphans_widows_1) + 1;
+                                widows = (int)(elem_style->widows) - (int)(css_orphans_widows_1) + 1;
+                                // We use a LVRendPageContext that gathers links by line,
+                                // so we can transfer them line by line to the upper/main context
+                                row->single_col_context = new LVRendPageContext(NULL, context.getPageHeight());
+                                row->single_col_context->AddLine(0, padding_top, RN_SPLIT_AFTER_AVOID);
+                            }
                             int count = txform->GetLineCount();
                             for (int i=0; i<count; i++) {
                                 const formatted_line_t * line = txform->GetLineInfo(i);
+                                int link_insert_pos; // used if is_single_column
+                                if ( is_single_column ) {
+                                    int line_flags = 0;
+                                    // Honor widows and orphans
+                                    if (orphans > 1 && i > 0 && i < orphans)
+                                        line_flags |= RN_SPLIT_BEFORE_AVOID;
+                                    if (widows > 1 && i < count-1 && count-1 - i < widows)
+                                        line_flags |= RN_SPLIT_AFTER_AVOID;
+                                    // Honor line's own flags
+                                    if (line->flags & LTEXT_LINE_SPLIT_AVOID_BEFORE)
+                                        line_flags |= RN_SPLIT_BEFORE_AVOID;
+                                    if (line->flags & LTEXT_LINE_SPLIT_AVOID_AFTER)
+                                        line_flags |= RN_SPLIT_AFTER_AVOID;
+                                    row->single_col_context->AddLine(padding_top + line->y,
+                                                        padding_top + line->y + line->height, line_flags);
+                                    if (i == count-1) // add bottom padding
+                                        row->single_col_context->AddLine(padding_top + line->y + line->height,
+                                            padding_top + line->y + line->height + padding_bottom, RN_SPLIT_BEFORE_AVOID);
+                                    if ( !elem->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) )
+                                        continue;
+                                    if ( line->flags & LTEXT_LINE_PARA_IS_RTL )
+                                        link_insert_pos = row->single_col_context->getCurrentLinksCount();
+                                    else
+                                        link_insert_pos = -1; // append
+                                }
                                 for ( int w=0; w<line->word_count; w++ ) { // check link start flag for every word
                                     if ( line->words[w].flags & LTEXT_WORD_IS_LINK_START ) {
                                         const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
@@ -1459,7 +1541,10 @@ public:
                                                 lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                                 if ( href.length()>0 && href.at(0)=='#' ) {
                                                     href.erase(0,1);
-                                                    row->links.add( href );
+                                                    if ( is_single_column )
+                                                        row->single_col_context->addLink( href, link_insert_pos );
+                                                    else
+                                                        row->links.add( href );
                                                 }
                                             }
                                         }
@@ -1477,14 +1562,28 @@ public:
                         // sub-renderings (of cells' content) do not add to our
                         // main context. Their heights will already be accounted
                         // in their row's height (added to main context below).
-                        LVRendPageContext emptycontext( NULL, context.getPageHeight() );
+                        // Except when table is a single column, and we can just
+                        // transfer lines to the upper context.
+                        LVRendPageContext * cell_context;
+                        int rend_flags = gRenderBlockRenderingFlags; // global flags
+                        if ( is_single_column ) {
+                            row->single_col_context = new LVRendPageContext(NULL, context.getPageHeight());
+                            cell_context = row->single_col_context;
+                            // We want to avoid negative margins (if allowed in global flags) and
+                            // going back the flow y, as the transfered lines would not reflect
+                            // that, and we could get some small mismatches and glitches.
+                            rend_flags &= ~BLOCK_RENDERING_ALLOW_NEGATIVE_COLLAPSED_MARGINS;
+                        }
+                        else {
+                            cell_context = new LVRendPageContext( NULL, context.getPageHeight(), false );
+                        }
                         // See above about what we'll store in cell->baseline
                         int baseline = REQ_BASELINE_NOT_NEEDED;
                         if ( cell->valign == 0 ) { // vertical-align: baseline
                             baseline = REQ_BASELINE_FOR_TABLE;
                         }
-                        int h = renderBlockElement( emptycontext, cell->elem, 0, 0, cell->width,
-                                                    cell->direction, &baseline );
+                        int h = renderBlockElement( *cell_context, cell->elem, 0, 0, cell->width,
+                                                    cell->direction, &baseline, rend_flags);
                         cell->height = h;
                         if ( cell->valign == 0 ) { // vertical-align: baseline
                             cell->baseline = baseline;
@@ -1498,12 +1597,15 @@ public:
                             int padding_bottom = lengthToPx( elem_style->padding[3], cell->width, em ) + measureBorder(cell->elem,2);
                             cell->baseline = h - padding_bottom;
                         }
-                        // Gather footnotes links accumulated by emptycontext
-                        lString16Collection * link_ids = emptycontext.getLinkIds();
-                        if (link_ids->length() > 0) {
-                            for ( int n=0; n<link_ids->length(); n++ ) {
-                                row->links.add( link_ids->at(n) );
+                        if ( !is_single_column ) {
+                            // Gather footnotes links accumulated by cell_context
+                            lString16Collection * link_ids = cell_context->getLinkIds();
+                            if (link_ids->length() > 0) {
+                                for ( int n=0; n<link_ids->length(); n++ ) {
+                                    row->links.add( link_ids->at(n) );
+                                }
                             }
+                            delete cell_context;
                         }
                     }
                     // RenderRectAccessor needs to be updated after the call
@@ -1677,9 +1779,58 @@ public:
                     fmt.setBottomOverflow( row->bottom_overflow );
                 }
             }
+            if ( context.wantsLines() && is_single_column ) {
+                // Transfer lines from each row->single_col_context to main context
+                // (This has to be done before we update table_h)
+                int cur_y = table_y0 + table_h;
+                int line_flags = 0;
+                if (avoid_pb_inside) {
+                    line_flags = RN_SPLIT_BEFORE_AVOID | RN_SPLIT_AFTER_AVOID;
+                }
+                if (is_rtl)
+                    line_flags |= RN_LINE_IS_RTL;
+                int content_line_flags = line_flags;
+                if ( row->height < min_row_height_for_split_by_line ) {
+                    // Too small row height: stick all line together to prevent split
+                    // inside this row
+                    content_line_flags = RN_SPLIT_BEFORE_AVOID | RN_SPLIT_AFTER_AVOID;
+                }
+                // Add border spacing top
+                int top_line_flags = line_flags | RN_SPLIT_AFTER_AVOID;
+                if (i == 0) // first row (or single row): stick to table top padding/border
+                    top_line_flags |= RN_SPLIT_BEFORE_AVOID;
+                context.AddLine(last_y, cur_y, top_line_flags);
+                // Add cell lines
+                if ( row->single_col_context && row->single_col_context->getLines() ) {
+                    // (It could happen no context was created or no line were added, if
+                    // cell was erm_invisible)
+                    LVPtrVector<LVRendLineInfo> * lines = row->single_col_context->getLines();
+                    for ( int i=0; i < lines->length(); i++ ) {
+                        LVRendLineInfo * line = lines->get(i);
+                        context.AddLine(cur_y, cur_y+line->getHeight(), line->getFlags()|content_line_flags);
+                        LVFootNoteList * links = line->getLinks();
+                        if ( links ) {
+                            for ( int j=0; j < links->length(); j++ ) {
+                                context.addLink( links->get(j)->getId() );
+                            }
+                        }
+                        cur_y += line->getHeight();
+                    }
+                }
+                // Add border spacing bottom
+                int bottom_line_flags = line_flags | RN_SPLIT_BEFORE_AVOID;
+                if (i == nb_rows-1) // last row (or single row): stick to table bottom padding/border
+                    bottom_line_flags |= RN_SPLIT_AFTER_AVOID;
+                context.AddLine(cur_y, cur_y+borderspacing_v_bottom, bottom_line_flags|RN_SPLIT_BEFORE_AVOID);
+                last_y = cur_y + borderspacing_v_bottom;
+                if (last_y != table_y0 + table_h + row->height + borderspacing_v_bottom) {
+                    printf("CRE WARNING: single column table row height error %d =! %d\n",
+                                last_y, table_y0 + table_h + row->height + borderspacing_v_bottom);
+                }
+            }
             table_h += row->height;
             table_h += borderspacing_v_bottom;
-            if (splitPages) {
+            if ( context.wantsLines() && !is_single_column ) {
                 // Includes the row and half of its border_spacing above and half below.
                 if (avoid_pb_inside) {
                     // Avoid any split between rows
@@ -1716,7 +1867,7 @@ public:
                 context.AddLine(last_y, table_y0 + table_h, line_flags);
                 last_y = table_y0 + table_h;
             }
-            // Add links gathered from this row's cells (even if !splitPages
+            // Add links gathered from this row's cells (even if ! context.wantsLines())
             // in case of imbricated tables)
             if (row->links.length() > 0) {
                 for ( int n=0; n<row->links.length(); n++ ) {
@@ -1731,7 +1882,7 @@ public:
             table_h += borderspacing_v_top;
         }
         table_h += table_padding_bottom + table_border_bottom;
-        if (splitPages) {
+        if ( context.wantsLines() ) {
             // Any table->style->page-break-after AVOID or ALWAYS will be taken
             // care of by renderBlockElement(), so we can use AVOID here.
             if ( !enhanced_rendering )
@@ -1846,6 +1997,15 @@ public:
                     if ( max_row_bottom_overflow_y > fmt.getHeight() ) {
                         fmt.setBottomOverflow( max_row_bottom_overflow_y - fmt.getHeight() );
                     }
+                }
+            }
+        }
+
+        if ( is_single_column ) {
+            // Cleanup rows' LVRendPageContext
+            for ( i=0; i<rows.length(); i++ ) {
+                if ( rows[i]->single_col_context ) {
+                    delete rows[i]->single_col_context;
                 }
             }
         }
@@ -3881,7 +4041,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
             lvRect rect;
             enode->getAbsRect(rect);
             // split pages
-            if ( context.getPageList() != NULL ) { // not to be done if erm_table_cell
+            if ( context.wantsLines() ) {
                 if (margin_top>0) {
                     pb_flag = pagebreakhelper(enode,width);
                     context.AddLine(rect.top - margin_top, rect.top, pb_flag);
@@ -3974,9 +4134,9 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                         }
                     }
                 }
-            } // has page list
+            } // wantsLines()
             else {
-                // we still need to gather links when an emptycontext is used
+                // we still need to gather links when an alternative context is used
                 // (duplicated part of the code above, as we don't want to consume any page-break)
                 int count = txform->GetLineCount();
                 for (int i=0; i<count; i++) {
@@ -4196,6 +4356,13 @@ public:
         vm_active_pb_flag(RN_SPLIT_AUTO)
         {
             is_main_flow = context.getPageList() != NULL;
+            if ( context.wantsLines() ) {
+                // Also behave as is_main_flow when context wants lines (which,
+                // if it is not the main flow, it should want lines only for
+                // transfering them to the real main flow; the only use case
+                // for now is when rendering cells in single-column tables).
+                is_main_flow = true;
+            }
             top_clear_level = is_main_flow ? 1 : 2; // see resetFloatsLevelToTopLevel()
             page_height = context.getPageHeight();
         }
@@ -6426,17 +6593,17 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // to the page splitting context. The non-floating nodes will,
                         // and if !DO_NOT_CLEAR_OWN_FLOATS, we'll fill the remaining
                         // height taken by floats if any.
-                        LVRendPageContext emptycontext( NULL, flow->getPageHeight() );
+                        LVRendPageContext alt_context( NULL, flow->getPageHeight(), false );
                         // For floats too, the provided x/y must be the padding-left/top of the
                         // parent container of the float (and width must exclude the parent's
                         // padding-left/right) for the flow to correctly position inner floats:
                         // flow->addFloat() will additionally shift its positionning by the
                         // child x/y set by this renderBlockElement().
-                        renderBlockElement( emptycontext, child, (is_rtl ? 0 : list_marker_padding) + padding_left,
+                        renderBlockElement( alt_context, child, (is_rtl ? 0 : list_marker_padding) + padding_left,
                                     padding_top, width - list_marker_padding - padding_left - padding_right, direction );
                         flow->addFloat(child, child_clear, is_right, flt_vertical_margin);
-                        // Gather footnotes links accumulated by emptycontext
-                        lString16Collection * link_ids = emptycontext.getLinkIds();
+                        // Gather footnotes links accumulated by alt_context
+                        lString16Collection * link_ids = alt_context.getLinkIds();
                         if (link_ids->length() > 0) {
                             for ( int n=0; n<link_ids->length(); n++ ) {
                                 flow->getPageContext()->addLink( link_ids->at(n) );

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1599,7 +1599,7 @@ public:
                             // will compute and give us back.
                             int baseline = REQ_BASELINE_FOR_INLINE_BLOCK;
                             if ( node->getChildNode(0)->getStyle()->display == css_d_inline_table )
-                                baseline = REQ_BASELINE_FOR_INLINE_TABLE;
+                                baseline = REQ_BASELINE_FOR_TABLE;
                             // We render the inlineBox with the specified direction (from upper dir=), even
                             // if UNSET (and not with the direction determined by fribidi from the text).
                             renderBlockElement( emptycontext, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -582,15 +582,15 @@ public:
             // But let's be fully deterministic with that, and redo it.
         }
         if ( !already_rendered ) {
-            LVRendPageContext emptycontext( NULL, m_pbuffer->page_height );
+            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, false );
             // We render the float with the specified direction (from upper dir=), even
             // if UNSET (and not with the direction determined by fribidi from the text).
-            renderBlockElement( emptycontext, node, 0, 0, m_pbuffer->width, m_specified_para_dir );
+            renderBlockElement( alt_context, node, 0, 0, m_pbuffer->width, m_specified_para_dir );
             // (renderBlockElement will ensure style->height if requested.)
-            // Gather footnotes links accumulated by emptycontext
+            // Gather footnotes links accumulated by alt_context
             // (We only need to gather links in the rendering phase, for
             // page splitting, so no worry if we don't when already_rendered)
-            lString16Collection * link_ids = emptycontext.getLinkIds();
+            lString16Collection * link_ids = alt_context.getLinkIds();
             if (link_ids->length() > 0) {
                 flt->links = new lString16Collection();
                 for ( int n=0; n<link_ids->length(); n++ ) {
@@ -1594,7 +1594,7 @@ public:
                             }
                         }
                         if ( !already_rendered ) {
-                            LVRendPageContext emptycontext( NULL, m_pbuffer->page_height );
+                            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, false );
                             // inline-block and inline-table have a baseline, that renderBlockElement()
                             // will compute and give us back.
                             int baseline = REQ_BASELINE_FOR_INLINE_BLOCK;
@@ -1602,7 +1602,7 @@ public:
                                 baseline = REQ_BASELINE_FOR_TABLE;
                             // We render the inlineBox with the specified direction (from upper dir=), even
                             // if UNSET (and not with the direction determined by fribidi from the text).
-                            renderBlockElement( emptycontext, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );
+                            renderBlockElement( alt_context, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );
                             // (renderBlockElement will ensure style->height if requested.)
 
                             // Note: this inline box we just rendered can have some overflow
@@ -1621,7 +1621,7 @@ public:
                             RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
                             // We'll have alignLine() do the fmt.setX/Y once it is fully positionned
 
-                            // We'd like to gather footnote links accumulated by emptycontext
+                            // We'd like to gather footnote links accumulated by alt_context
                             // (we do that for floats), but it's quite more complicated:
                             // we have them here too early, and we would need to associate
                             // the links to this "char" index, so needing in LVFormatter

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3761,10 +3761,10 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
 
     for (i=0; i<m_pbuffer->frmlinecount; i++)
     {
-        if (line_y>=clip.bottom)
+        if (line_y >= clip.bottom)
             break;
         frmline = m_pbuffer->frmlines[i];
-        if (line_y + frmline->height>=clip.top)
+        if (line_y + frmline->height > clip.top)
         {
             // process background
 
@@ -4019,7 +4019,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
         // because of the checks with _hidePartialGlyphs in lvdrawbuf.cpp
         // (todo: get rid of these _hidePartialGlyphs checks ?)
 
-        if (y + flt->y - top_overflow < clip.bottom && y + flt->y + flt->height + bottom_overflow >= clip.top) {
+        if (y + flt->y - top_overflow < clip.bottom && y + flt->y + flt->height + bottom_overflow > clip.top) {
             // DrawDocument() parameters (y0 + doc_y must be equal to our y,
             // doc_y just shift the viewport, so anything outside is not drawn).
             int x0 = x + flt->x;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2537,7 +2537,7 @@ public:
                             word->min_width = word->width;
                         }
                     }
-                    if ( lastWord && m_flags[i-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
+                    if ( m_flags[i-1] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
                         if ( m_flags[i] & LCHAR_IS_CLUSTER_TAIL ) {
                             // The end of this word is part of a ligature that, because
                             // of hyphenation, has been splitted onto next word.
@@ -3271,16 +3271,27 @@ public:
                         }
                     }
                     if ( HyphMan::hyphenate(m_text+wstart, len, widths, flags, _hyphen_width, max_width, 2) ) {
+                        // We need to reset the flag for the multiple hyphenation
+                        // opportunities we will not be using (or they could cause
+                        // spurious spaces, as a word here may be multiple words
+                        // in AddLine() if parts from different text nodes).
                         for ( int i=0; i<len; i++ ) {
                             if ( m_flags[wstart+i] & LCHAR_ALLOW_HYPH_WRAP_AFTER ) {
                                 if ( widths[i] + _hyphen_width > max_width ) {
                                     TR("hyphen found, but max width reached at char %d", i);
-                                    break; // hyph is too late
+                                    m_flags[wstart+i] &= ~LCHAR_ALLOW_HYPH_WRAP_AFTER; // reset flag
                                 }
-                                if ( wstart + i > pos+1 ) {
+                                else if ( wstart + i > pos+1 ) {
+                                    if ( lastHyphWrap >= 0 ) { // reset flag on previous candidate
+                                        m_flags[lastHyphWrap] &= ~LCHAR_ALLOW_HYPH_WRAP_AFTER;
+                                    }
                                     lastHyphWrap = wstart + i;
                                     // Keep looking for some other candidates in that word
                                 }
+                                else if ( wstart + i >= pos ) {
+                                    m_flags[wstart+i] &= ~LCHAR_ALLOW_HYPH_WRAP_AFTER; // reset flag
+                                }
+                                // Don't reset those < pos as they are part of previous line
                             }
                         }
                         if ( lastHyphWrap >= 0 ) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1605,6 +1605,17 @@ public:
                             renderBlockElement( emptycontext, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );
                             // (renderBlockElement will ensure style->height if requested.)
 
+                            // Note: this inline box we just rendered can have some overflow
+                            // (i.e. if it has some negative margins). As these overflows are
+                            // usually small, we'll handle that in LFormattedText::Draw() by
+                            // just dropping the page rect clip when drawing it, so that the
+                            // overflowing content might be drawn in the page margins.
+                            // (Otherwise, we'd need to upgrade our frmline to store a line
+                            // top and bottom overflows, use LTEXT_LINE_SPLIT_AVOID_BEFORE/AFTER
+                            // to stick that line to previous or next, with the risk of bringing
+                            // a large top margin to top of page just to display that small
+                            // overflow in it...)
+
                             RenderRectAccessor fmt( node );
                             fmt.setBaseline(baseline);
                             RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
@@ -3883,7 +3894,19 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         getAbsMarksFromMarks(marks, absmarks, node);
                         absmarks_update_needed = false;
                     }
+                    // inline-block boxes with negative margins can overflow the
+                    // line height, and so possibly the page when that line is
+                    // at top or bottom of page.
+                    // When witnessed, that overflow was very small, and probably
+                    // aimed at vertically aligning the box vs the text, but enough
+                    // to have their glyphs truncated when clipped to the page rect.
+                    // So, to avoid that, we just drop that clip when drawing the
+                    // box, and restore it when done.
+                    lvRect curclip;
+                    buf->GetClipRect( &curclip ); // backup clip
+                    buf->SetClipRect(NULL); // no clipping
                     DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );
+                    buf->SetClipRect(&curclip); // restore original page clip
                 }
                 else
                 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5415,6 +5415,8 @@ void ldomNode::initNodeRendMethod()
             case css_d_block:
             case css_d_list_item_block:
             case css_d_inline:
+            case css_d_inline_block:
+            case css_d_inline_table:
             case css_d_run_in:
                 setRendMethod( erm_final );
                 break;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8563,6 +8563,16 @@ bool ldomXRange::getRectEx( lvRect & rect, bool & isSingleLine )
         return false;
     ldomNode * finalNode1 = getStart().getFinalNode();
     ldomNode * finalNode2 = getEnd().getFinalNode();
+    if ( !finalNode1 || !finalNode2 ) {
+        // Shouldn't happen, but prevent a segfault in case some other bug
+        // in initNodeRendMethod made some text not having a erm_final-like
+        // ancestor.
+        if ( !finalNode1 )
+            printf("CRE WARNING: no final parent for range start %s\n", UnicodeToLocal(getStart().toString()).c_str());
+        if ( !finalNode2 )
+            printf("CRE WARNING: no final parent for range end %s\n", UnicodeToLocal(getEnd().toString()).c_str());
+        return false;
+    }
     RenderRectAccessor fmt1(finalNode1);
     RenderRectAccessor fmt2(finalNode2);
     // In legacy mode, we just got the erm_final coordinates, and we must

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3823,8 +3823,11 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
         bool doNewLineAfterEndTag = false;
         bool doIndentBeforeStartTag = false;
         bool doIndentBeforeEndTag = false;
-        bool doNewlineBeforeIndentBeforeStartTag = false; // specific for floats among inlines inside final
-        bool doIndentAfterNewLineAfterEndTag = false;     // specific for floats among inlines inside final
+        // Specific for floats and inline-blocks among inlines inside final, that
+        // we want to show on their own lines:
+        bool doNewlineBeforeIndentBeforeStartTag = false;
+        bool doIndentAfterNewLineAfterEndTag = false;
+        bool doIndentOneLevelLessAfterNewLineAfterEndTag = false;
         if ( WNEFLAG(NEWLINE_ALL_NODES) ) {
             doNewLineBeforeStartTag = true;
             doNewLineAfterStartTag = true;
@@ -3855,12 +3858,47 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     lvdom_element_render_method prm = node->getParentNode()->getRendMethod();
                     if (prm == erm_final || prm == erm_inline) {
                         doNewlineBeforeIndentBeforeStartTag = true;
-                        doIndentAfterNewLineAfterEndTag = true;
+                        doIndentAfterNewLineAfterEndTag = WNEFLAG(INDENT_NEWLINE);
+                        // If we're the last node in parent collection, indent one level less,
+                        // so that next node (the parent) is not at this node level
+                        ldomNode * parent = node->getParentNode();
+                        if ( parent && (node->getNodeIndex() == parent->getChildCount()-1) )
+                            doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                        else if ( parent && (node->getNodeIndex() == parent->getChildCount()-2)
+                                         && parent->getChildNode(parent->getChildCount()-1)->isText() )
+                            doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                        else if ( containsEnd ) // same if next siblings won't be shown
+                            doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                        // But if previous sibling node is a floating or boxing inline node
+                        // that have done what we just did, cancel some of what we did
+                        if ( node->getNodeIndex() > 0 ) {
+                            ldomNode * prevsibling = parent->getChildNode(node->getNodeIndex()-1);
+                            if ( prevsibling->isFloatingBox() || prevsibling->isBoxingInlineBox() ) {
+                                doNewlineBeforeIndentBeforeStartTag = false;
+                                doIndentBeforeStartTag = false;
+                            }
+                        }
                     }
                 }
                 else if (node->isBoxingInlineBox()) {
                     doNewlineBeforeIndentBeforeStartTag = true;
-                    doIndentAfterNewLineAfterEndTag = true;
+                    doIndentAfterNewLineAfterEndTag = WNEFLAG(INDENT_NEWLINE);
+                    // Same as above
+                    ldomNode * parent = node->getParentNode();
+                    if ( parent && (node->getNodeIndex() == parent->getChildCount()-1) )
+                        doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                    else if ( parent && (node->getNodeIndex() == parent->getChildCount()-2)
+                                     && parent->getChildNode(parent->getChildCount()-1)->isText() )
+                        doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                    else if ( containsEnd )
+                        doIndentOneLevelLessAfterNewLineAfterEndTag = true;
+                    if ( node->getNodeIndex() > 0 ) {
+                        ldomNode * prevsibling = parent->getChildNode(node->getNodeIndex()-1);
+                        if ( prevsibling->isFloatingBox() || prevsibling->isBoxingInlineBox() ) {
+                            doNewlineBeforeIndentBeforeStartTag = false;
+                            doIndentBeforeStartTag = false;
+                        }
+                    }
                 }
             }
             // Do something specific when erm_invisible ?
@@ -3990,9 +4028,11 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
         }
         if (doNewLineAfterEndTag)
             *stream << "\n";
-        if (doIndentAfterNewLineAfterEndTag)
-            for ( int i=indentBaseLevel; i<level; i++ )
+        if (doIndentAfterNewLineAfterEndTag) {
+            int ilevel = doIndentOneLevelLessAfterNewLineAfterEndTag ? level-1 : level;
+            for ( int i=indentBaseLevel; i<ilevel; i++ )
                 *stream << "  ";
+        }
         if ( containsEnd && WNEFLAG(NB_SKIPPED_NODES) ) {
             // Next siblings will not contain endXP and won't be written: show how many they are
             ldomNode * parent = node->getParentNode();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4900,6 +4900,24 @@ void ldomElementWriter::onBodyEnter()
 #endif
 }
 
+#if BUILD_LITE!=1
+static void resetRendMethodToInline( ldomNode * node )
+{
+    // we shouldn't reset to inline (visible) if display: none
+    // (using node->getRendMethod() != erm_invisible seems too greedy and may
+    // hide other nodes)
+    if (node->getStyle()->display != css_d_none)
+        node->setRendMethod(erm_inline);
+    else if (gDOMVersionRequested < 20180528) // do that in all cases
+        node->setRendMethod(erm_inline);
+}
+
+static void resetRendMethodToInvisible( ldomNode * node )
+{
+    node->setRendMethod(erm_invisible);
+}
+#endif
+
 void ldomNode::removeChildren( int startIndex, int endIndex )
 {
     for ( int i=endIndex; i>=startIndex; i-- ) {
@@ -5032,11 +5050,16 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
 
         // inner inline
         ldomNode * abox = insertChildElement( firstNonEmpty, LXML_NS_NONE, el_autoBoxing );
-        abox->initNodeStyle();
-        abox->setRendMethod( erm_final );
         moveItemsTo( abox, firstNonEmpty+1, lastNonEmpty+1 );
         // remove starting empty
         removeChildren(startIndex, firstNonEmpty-1);
+        abox->initNodeStyle();
+        if ( !BLOCK_RENDERING_G(FLOAT_FLOATBOXES) ) {
+            // If we don't want floatBoxes floating, reset them to be
+            // rendered inline among inlines
+            abox->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
+        }
+        abox->setRendMethod( erm_final );
     }
     else if ( hasFloating) {
         // only floats, don't autobox them (otherwise the autobox wouldn't be floating)
@@ -5126,22 +5149,6 @@ bool ldomNode::hasNonEmptyInlineContent( bool ignoreFloats )
 }
 
 #if BUILD_LITE!=1
-static void resetRendMethodToInline( ldomNode * node )
-{
-    // we shouldn't reset to inline (visible) if display: none
-    // (using node->getRendMethod() != erm_invisible seems too greedy and may
-    // hide other nodes)
-    if (node->getStyle()->display != css_d_none)
-        node->setRendMethod(erm_inline);
-    else if (gDOMVersionRequested < 20180528) // do that in all cases
-        node->setRendMethod(erm_inline);
-}
-
-static void resetRendMethodToInvisible( ldomNode * node )
-{
-    node->setRendMethod(erm_invisible);
-}
-
 static void detectChildTypes( ldomNode * parent, bool & hasBlockItems, bool & hasInline, bool & hasFloating, bool detectFloating=false )
 {
     hasBlockItems = false;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -67,7 +67,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.34k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.35k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x001F
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13565,7 +13565,7 @@ void ldomNode::getAbsRect( lvRect & rect, bool inner )
             // getAbsRect() is mostly used on erm_final nodes. So,
             // if we meet another erm_final node in our parent, we are
             // probably an embedded floatBox or inlineBox. Embedded
-            // floatBoxes or inlineBoxes are positionned according
+            // floatBoxes or inlineBoxes are positioned according
             // to the inner LFormattedText, so we need to account
             // for these padding shifts.
             rect.left += fmt.getInnerX();     // add padding left
@@ -13828,7 +13828,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         // non-erm_inline ones that may be in that overflow and containt pt.
         // erm_inline nodes don't have a RenderRectAccessor(), so their x/y
         // shifts are 0, and any inner block node had its RenderRectAccessor
-        // x/y offsets positionned related to the final block. So, no need
+        // x/y offsets positioned related to the final block. So, no need
         // to shift pt: just recursively call elementFromPoint() as-is,
         // and we'll be recursively navigating inline nodes here.
         int count = getChildCount();
@@ -13899,6 +13899,14 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
                     }
                 }
                 return NULL; // Nothing found in the overflow
+            }
+            // There is one special case to skip: floats that may have been
+            // positioned after their normal y (because of clear:, or because
+            // of not enough width). Their following non-float siblings (after
+            // in the HTML/DOM tree) may have a lower fmt.getY().
+            if ( isFloatingBox() && pt.y < fmt.getY() ) {
+                // Float starts after pt.y: next non-float siblings may contain pt.y
+                return NULL;
             }
             // pt.y is inside the box (without overflows), go on with it.
             // Note: we don't check for next elements which may have a top


### PR DESCRIPTION
See individual commit messages for details.

This does not include any of the xpointers and complete incomplete tables/inline-tables dicussed alongside https://github.com/koreader/crengine/pull/325#issuecomment-580413175, which is more risky and will be in another PR.
The bits in this PR are rather safe. So, they could be bumped for 2020.02 if we let it a few days - but as it seems ready :), they can as well wait and be bumped after.

Not much screenshots this time. Just some for the support of `vertical-align: baseline` in tables:
Before => After
<kbd>![image](https://user-images.githubusercontent.com/24273478/74107166-b2b5d180-4b6d-11ea-8e69-018aff2fd63b.png)</kbd>=><kbd>![image](https://user-images.githubusercontent.com/24273478/74107154-987bf380-4b6d-11ea-803b-853703954d3e.png)</kbd>
(When the baseline is not near the top, it's because there is some padding-top for one of the cell, or because I added some othe vertical-align in the cells on the right without changing the wording.)

Also, about `Fix images with "display: inline-block" not shown`: images (and any replaced elements) are not allowed to be inline-table or table-xyz. I'll fix that according to the specs in another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/327)
<!-- Reviewable:end -->
