### PR TITLE
Normalized xpointers fix, some FB2 footnotes tweaks

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5911,6 +5911,14 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     //   content in the other bodies should be accessible by hyperlinks. Name
     //   attribute should describe the meaning of this body, this is optional
     //   for the main body.
+    /* Don't do that anymore in this hardcoded / not disable'able way (but
+     * let's have it still be done that way in legacy mode, as FB2 readers
+     * may expect it): one can enable in-page footnotes in fb2.css or
+     * a style tweak by just using:
+     *     body[name="notes"] section    { -cr-hint: footnote-inpage; }
+     *     body[name="comments"] section { -cr-hint: footnote-inpage; }
+     * which will be hanbled by previous check.
+     *
     if ( enode->getNodeId()==el_section && enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES) ) {
         ldomNode * body = enode->getParentNode();
         while ( body != NULL && body->getNodeId()!=el_body )
@@ -5922,6 +5930,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     isFootNoteBody = true;
         }
     }
+    */
 
     // is this a floating float container (floatBox)?
     bool is_floating = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES) && enode->isFloatingBox();

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2529,7 +2529,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
             line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
 
-        if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline) {
+        if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline && rm != erm_runin) {
             // Non-inline node in a final block: this is the top and single 'final' node:
             // get text-indent and line-height that will apply to the full final block
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1483,9 +1483,11 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         }
                         strValue = joinPropertyValueList( list );
                     }
-                    // default to serif generic font-family
+                    // default to sans-serif generic font-family (the default
+                    // in lvfntman.cpp, as FreeType can't know the family of
+                    // a font)
                     if (n == -1)
-                        n = 1;
+                        n = css_ff_sans_serif;
                 }
                 break;
             case cssd_font_style:

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3865,7 +3865,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             // rendering method, which gives us a visual hint of it.
             lvdom_element_render_method rm = node->getRendMethod();
             // Text and inline nodes stay stuck together, but not all others
-            if (rm != erm_inline || node->isBoxingInlineBox()) {
+            if ( (rm != erm_inline && rm != erm_runin) || node->isBoxingInlineBox()) {
                 doNewLineBeforeStartTag = true;
                 doNewLineAfterStartTag = true;
                 // doNewLineBeforeEndTag = false; // done by child elements
@@ -5788,16 +5788,60 @@ void ldomNode::initNodeRendMethod()
                             if ( !this->getDocument()->hasCacheFile() )
                                 autoboxChildren( j, i, handleFloating );
                         i = j;
-                    } else if ( i>0 ) {
+                    }
+                    else if ( i>0 ) {
+                        // This node is not inline, but might be preceeded by a css_d_run_in node:
+                        // https://css-tricks.com/run-in/
+                        // https://developer.mozilla.org/en-US/docs/Web/CSS/display
+                        //   "If the adjacent sibling of the element defined as "display: run-in" box
+                        //   is a block box, the run-in box becomes the first inline box of the block
+                        //   box that follows it. "
+                        // Hopefully only used for footnotes in fb2 where the footnote number
+                        // is in a block element, and the footnote text in another.
+                        // fb2.css sets the first block to be "display: run-in" as an
+                        // attempt to render both on the same line:
+                        //   <section id="n1">
+                        //     <title style="display: run-in; font-weight: bold;">
+                        //       <p>1</p>
+                        //     </title>
+                        //     <p>Text footnote</p>
+                        //   </section>
+                        //
+                        // This node might be that second block: look if preceeding node
+                        // is "run-in", and if it is, bring them both in an autoBoxing.
                         ldomNode * prev = getChildNode(i-1);
-                        if ( prev->isElement() && prev->getRendMethod()==erm_runin ) {
-                            // autobox run-in
-                            if ( getChildCount()!=2 ) {
-                                CRLog::debug("Autoboxing run-in items");
-                                if ( !this->getDocument()->hasCacheFile() )
-                                    autoboxChildren( i-1, i, handleFloating );
+                        ldomNode * inBetweenTextNode = NULL;
+                        if ( prev->isText() && i-1>0 ) { // some possible empty text in between
+                            inBetweenTextNode = prev;
+                            prev = getChildNode(i-2);
+                        }
+                        if ( prev->isElement() && prev->getRendMethod()==erm_runin && !this->getDocument()->hasCacheFile() ) {
+                            bool do_autoboxing = true;
+                            int run_in_idx = inBetweenTextNode ? i-2 : i-1;
+                            int block_idx = i;
+                            if ( inBetweenTextNode ) {
+                                lString16 text = inBetweenTextNode->getText();
+                                if ( IsEmptySpace(text.c_str(), text.length() ) ) {
+                                    removeChildren(i-1, i-1);
+                                    block_idx = i-1;
+                                }
+                                else {
+                                    do_autoboxing = false;
+                                }
                             }
-                            i--;
+                            if ( do_autoboxing ) {
+                                CRLog::debug("Autoboxing run-in items");
+                                // Sadly, to avoid having an erm_final inside another erm_final,
+                                // we need to reset the block node to be inline (but that second
+                                // erm_final would have been handled as inline anyway, except
+                                // for possibly updating the strut height/baseline).
+                                node->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
+                                // No need to autobox if there are only 2 children (the run-in and this box)
+                                if ( getChildCount()!=2 ) { // autobox run-in
+                                    autoboxChildren( run_in_idx, block_idx, handleFloating );
+                                }
+                            }
+                            i = run_in_idx;
                         }
                     }
                 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8458,10 +8458,18 @@ lString16 ldomXPointer::toStringV2()
         return path;
     ldomNode * node = getNode();
     int offset = getOffset();
-    if ( offset >= 0 ) {
-        path << "." << fmt::decimal(offset);
-    }
     ldomNode * p = node;
+    if ( !node->isBoxingNode() ) {
+        if ( offset >= 0 ) {
+            path << "." << fmt::decimal(offset);
+        }
+    }
+    else {
+        if ( offset < p->getChildCount() )
+            p = p->getChildNode(offset);
+        else
+            p = p->getParentNode();
+    }
     ldomNode * mainNode = node->getDocument()->getRootNode();
     while (p && p!=mainNode) {
         ldomNode * parent = p->getParentNode();


### PR DESCRIPTION
Fix issue with toStringV2() when the node is itself a boxing node. See https://github.com/koreader/crengine/pull/328#issuecomment-591070225.

Also a few commits related to FB2 footnotes (that I don't use, I just have 1 single FB2 file with footnotes...), which may help the user that posted at https://www.mobileread.com/forums/showthread.php?p=3956818#post3956818 on his 2 issues:

`FB2 footnotes: fix spurious newline ("display: run-in")`
I might have discovered why there was this strange support for that obscure/obsolete `display: run-in`:
https://css-tricks.com/run-in/ https://developer.mozilla.org/en-US/docs/Web/CSS/display
It might have been seen as a good and not-hackish solution to solve the fact that FB2 footnotes have a strange structure, and appears in the HTML as:
```html
   <body>
    <section>
      <p>Text before<a l:href="#n1" type="note">[1]</a></p>
    </section>
    [...]
   </body>
   <body name="notes">
    <title><p>blah</p></title>
    <section id="n1">
      <title>
        <p>1</p>
      </title>
      <p>Text footnote</p>
    </section>
    <section id="n3">
      <title>
        <p>3</p>
      </title>
      <p>Table fntext2</p>
      <p>Table fntext2 2nd para</p>
      <p>Table fntext2 3nd para</p>
    </section>
  </body>
</FictionBook>
```
and so the footnote number and the footnote text being each in a block element, which would be rendered as:
<kbd>![image](https://user-images.githubusercontent.com/24273478/75367806-27ed0a80-58c1-11ea-8da9-e828ef5c5c62.png)</kbd>
By setting the `title `to be `display: run-in`, it merges as inline in the following block element:
<kbd>![image](https://user-images.githubusercontent.com/24273478/75367927-54088b80-58c1-11ea-9570-e939b2b8e02a.png)</kbd>

I'm not sure support for `display: run-in` is really complete as per-specs (it should become block in many cases), but I guess its implementation in crengine was enough to solve this footnote rendering problem.
But it didn't work on the above sample - but it did if I removed all newlines and spaces...
I don't know if I broke that with my other changes over the last year - but I just tried to fix this case :) by just skipping the empty text node if there is one in between.

(I thought about just dropping support for "run-in", and use `section > title { float: left; }` - but there are so many `section` & `title` (chapter names) in FB2, with their own styling (centering) in fb2.css - that it would have need quite many fixes in there ... and I don't really much care about restyling FB2...)

`FB2 footnotes: disable hardcoded handling as in-page`
`FB2 footnotes: allow them to be shown in popup`
will allow FB2 footnotes to be shown as popups, or enabled back as in-page via a style tweak, just like EPUBs foonotes. For consistency.

----
For this FB2 user's other question at https://www.mobileread.com/forums/showthread.php?t=327670, we have in fb2.css:
```css
cite p, epigraph p { text-align: left; text-indent: 0px }
cite { display: block; font-style: italic; margin-left: 5%; margin-right: 5%; text-align: justify; margin-top: 20px; margin-bottom: 20px }
```
so, I guess a style tweak with one of these (not sure what's wished) would work:
`cite { display: inline !important }`
or
```css
cite p, epigraph p { text-indent: 1.2em !important; }
cite { margin-top: 0 !important; margin-bottom: 0 !important; }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/329)
<!-- Reviewable:end -->
