### PR TITLE
Add libCURL's CA bundle to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ cr3gui/data/cr3.ini
 cr3gui/data/dict/
 cr3gui/data/dict_ext
 cr3gui/data/tessdata/
+cr3gui/data/ca-bundle.crt
 thirdparty


### PR DESCRIPTION
We use CRe's data folder as-is for our own data symlink ;).

Fix #331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/332)
<!-- Reviewable:end -->
