### PR TITLE
More FB2 footnotes tweaks

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -96,9 +96,23 @@ pre {
    text-align: left
 }
 
-body[name="notes"] { font-size: 70%; }
-body[name="notes"] section title { display: run-in; text-align: left; font-size: 110%; font-weight: bold; page-break-before: auto; page-break-inside: auto; page-break-after: auto; }
-body[name="notes"] section title p { display: inline }
+/* FB2 may have multiple BODY tags, with different "name=" attributes:
+   - name="notes" is for regular footnotes
+   - name="comments" is for additional notes that can be considered end notes */
+/* body[name="notes"], body[name="comments"] { font-size: 80%; } delegated to style tweaks */
+body[name="notes"] section title,
+body[name="comments"] section title {
+    display: run-in;   /* technical trick to have the footnote number inline with the followup text */
+    font-weight: bold;
+    text-align: start; /* counteract default of center with regular title */
+    page-break-before: auto; /* counteract default of always with regular title */
+    page-break-inside: auto;
+    page-break-after: auto;
+}
+body[name="notes"] section title p,
+body[name="comments"] section title p {
+    display: inline; /* counteract default of block, so it can be inline with the preceeding number */
+}
 
 description { display: block; }
 title-info { display: block; }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5968,37 +5968,35 @@ void ldomNode::initNodeRendMethod()
                             prev = getChildNode(i-2);
                         }
                         if ( prev->isElement() && prev->getRendMethod()==erm_runin ) {
-                            if ( getDocument()->hasCacheFile() ) {
-                                getDocument()->setBoxingWishedButPreventedByCache();
-                            }
-                            else {
-                                bool do_autoboxing = true;
-                                int run_in_idx = inBetweenTextNode ? i-2 : i-1;
-                                int block_idx = i;
-                                if ( inBetweenTextNode ) {
-                                    lString16 text = inBetweenTextNode->getText();
-                                    if ( IsEmptySpace(text.c_str(), text.length() ) ) {
-                                        removeChildren(i-1, i-1);
-                                        block_idx = i-1;
-                                    }
-                                    else {
-                                        do_autoboxing = false;
-                                    }
+                            bool do_autoboxing = true;
+                            int run_in_idx = inBetweenTextNode ? i-2 : i-1;
+                            int block_idx = i;
+                            if ( inBetweenTextNode ) {
+                                lString16 text = inBetweenTextNode->getText();
+                                if ( IsEmptySpace(text.c_str(), text.length() ) ) {
+                                    removeChildren(i-1, i-1);
+                                    block_idx = i-1;
                                 }
-                                if ( do_autoboxing ) {
-                                    CRLog::debug("Autoboxing run-in items");
-                                    // Sadly, to avoid having an erm_final inside another erm_final,
-                                    // we need to reset the block node to be inline (but that second
-                                    // erm_final would have been handled as inline anyway, except
-                                    // for possibly updating the strut height/baseline).
-                                    node->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
-                                    // No need to autobox if there are only 2 children (the run-in and this box)
-                                    if ( getChildCount()!=2 ) { // autobox run-in
+                                else {
+                                    do_autoboxing = false;
+                                }
+                            }
+                            if ( do_autoboxing ) {
+                                CRLog::debug("Autoboxing run-in items");
+                                // Sadly, to avoid having an erm_final inside another erm_final,
+                                // we need to reset the block node to be inline (but that second
+                                // erm_final would have been handled as inline anyway, except
+                                // for possibly updating the strut height/baseline).
+                                node->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
+                                // No need to autobox if there are only 2 children (the run-in and this box)
+                                if ( getChildCount()!=2 ) { // autobox run-in
+                                    if ( getDocument()->hasCacheFile() )
+                                        getDocument()->setBoxingWishedButPreventedByCache();
+                                    else
                                         autoboxChildren( run_in_idx, block_idx, handleFloating );
-                                    }
                                 }
-                                i = run_in_idx;
                             }
+                            i = run_in_idx;
                         }
                     }
                 }


### PR DESCRIPTION
`FB2 footnotes: fix setBoxingWishedButPreventedByCache()` when handling `display: run-in`.
It was called too early (so, even if we were not to need any autoboxing), causing some invalid display
hash mismatch messages.

`fb2.css: handle body[name="comments"] as footnotes`
`body[name="comments"]` contains another set of notes that can be considered as end notes.
They can be shown in-page too with style tweaks, and need to be wrapped just as "notes" to be properly shown as popup footnotes.
Also remove any hardcoded `font-size`: `font-size` can be fed via style tweaks too if a smaller one is preferred.

Both discussed around https://github.com/koreader/crengine/pull/329#issuecomment-599064384

Will come with updated FB2 footnotes style tweaks.

Note: first commit, if we ignore the indentation shifts, is really just this:
```diff
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5968,10 +5968,6 @@ void ldomNode::initNodeRendMethod()
                             prev = getChildNode(i-2);
                         }
                         if ( prev->isElement() && prev->getRendMethod()==erm_runin ) {
-                            if ( getDocument()->hasCacheFile() ) {
-                                getDocument()->setBoxingWishedButPreventedByCache();
-                            }
-                            else {
                             bool do_autoboxing = true;
                             int run_in_idx = inBetweenTextNode ? i-2 : i-1;
                             int block_idx = i;
@@ -5994,6 +5990,9 @@ void ldomNode::initNodeRendMethod()
                                 node->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
                                 // No need to autobox if there are only 2 children (the run-in and this box)
                                 if ( getChildCount()!=2 ) { // autobox run-in
+                                    if ( getDocument()->hasCacheFile() )
+                                        getDocument()->setBoxingWishedButPreventedByCache();
+                                    else
                                         autoboxChildren( run_in_idx, block_idx, handleFloating );
                                 }
                             }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/333)
<!-- Reviewable:end -->
