### PR TITLE
CSS: adds support for font-variant - More FB2 metadata

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -215,6 +215,77 @@ enum kerning_mode_t {
 #define LFNT_DRAW_BLINK                  0x0800 /// blinking text (implemented as underline)
 #define LFNT_DRAW_DECORATION_MASK        0x0F00
 
+
+// CSS font-variant and font-feature-settings properties:
+//   https://drafts.csswg.org/css-fonts-3/#propdef-font-variant
+//   https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant
+// OpenType feature tags (to be provided to HarfBuzz)
+//   https://en.wikipedia.org/wiki/List_of_typographic_features
+//   https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+// See https://github.com/koreader/koreader/issues/5821#issuecomment-596243758
+// Random notes:
+// - common-ligatures : 'liga' + 'clig'  (the keyword 'normal' activates these ligatures)
+//   and 'rlig' ("required ligatures, e.g. for arabic) are enabled by default by Harfbuzz
+// - discretionary-ligatures : 'dlig'   (type designer choices) is not enabled by default
+// - diagonal-fractions : 'frac' (enabling also 'numr' + 'dnom' seems not needed,
+//   numr or dnom standalone just make the / more oblique)
+// - stacked-fractions: "/" becomes horizontal
+// - jis90 'jp90' is said to be the default in fonts. Other jp* replace this one.
+// - Not supported (because no room and because they require some args, which
+//   would complicate parsing and storing):
+//   CSS font-variant-alternates:
+//       stylistic()
+//       styleset()
+//       character-variant()
+//       swash()
+//       ornaments()
+//       annotation()
+
+// OpenType features to request
+// Max 31 bits. We need "signed int features" to have -1 for non-instantiated fonts)
+#define LFNT_OT_FEATURES_NORMAL 0x00000000
+
+// #define LFNT_OT_FEATURES_P_LIGA 0x000000XX // +liga +clig enabled by default  (font-variant-ligatures: common-ligatures)
+// #define LFNT_OT_FEATURES_P_CALT 0x000000XX // +calt       enabled by default  (font-variant-ligatures: contextual)
+#define LFNT_OT_FEATURES_M_LIGA 0x00000001 // -liga -clig   (font-variant-ligatures: no-common-ligatures)
+#define LFNT_OT_FEATURES_M_CALT 0x00000002 // -calt         (font-variant-ligatures: no-contextual)
+#define LFNT_OT_FEATURES_P_DLIG 0x00000004 // +dlig         (font-variant-ligatures: discretionary-ligatures)
+#define LFNT_OT_FEATURES_M_DLIG 0x00000008 // -dlig         (font-variant-ligatures: no-discretionary-ligatures)
+#define LFNT_OT_FEATURES_P_HLIG 0x00000010 // +hlig         (font-variant-ligatures: historical-ligatures)
+#define LFNT_OT_FEATURES_M_HLIG 0x00000020 // -hlig         (font-variant-ligatures: no-historical-ligatures)
+
+#define LFNT_OT_FEATURES_P_HIST 0x00000040 // +hist         (font-variant-alternates: historical-forms)
+#define LFNT_OT_FEATURES_P_RUBY 0x00000080 // +ruby         (font-variant-east-asian: ruby)
+
+#define LFNT_OT_FEATURES_P_SMCP 0x00000100 // +smcp         (font-variant-caps: small-caps)
+#define LFNT_OT_FEATURES_P_C2SC 0x00000200 // +c2sc +smcp   (font-variant-caps: all-small-caps)
+#define LFNT_OT_FEATURES_P_PCAP 0x00000400 // +pcap         (font-variant-caps: petite-caps)
+#define LFNT_OT_FEATURES_P_C2PC 0x00000800 // +c2pc +pcap   (font-variant-caps: all-petite-caps)
+#define LFNT_OT_FEATURES_P_UNIC 0x00001000 // +unic         (font-variant-caps: unicase)
+#define LFNT_OT_FEATURES_P_TITL 0x00002000 // +titl         (font-variant-caps: titling-caps)
+#define LFNT_OT_FEATURES_P_SUPS 0x00004000 // +sups         (font-variant-position: super)
+#define LFNT_OT_FEATURES_P_SUBS 0x00008000 // +subs         (font-variant-position: sub)
+
+#define LFNT_OT_FEATURES_P_LNUM 0x00010000 // +lnum         (font-variant-numeric: lining-nums)
+#define LFNT_OT_FEATURES_P_ONUM 0x00020000 // +onum         (font-variant-numeric: oldstyle-nums)
+#define LFNT_OT_FEATURES_P_PNUM 0x00040000 // +pnum         (font-variant-numeric: proportional-nums)
+#define LFNT_OT_FEATURES_P_TNUM 0x00080000 // +tnum         (font-variant-numeric: tabular-nums)
+#define LFNT_OT_FEATURES_P_ZERO 0x00100000 // +zero         (font-variant-numeric: slashed-zero)
+#define LFNT_OT_FEATURES_P_ORDN 0x00200000 // +ordn         (font-variant-numeric: ordinal)
+#define LFNT_OT_FEATURES_P_FRAC 0x00400000 // +frac         (font-variant-numeric: diagonal-fractions)
+#define LFNT_OT_FEATURES_P_AFRC 0x00800000 // +afrc         (font-variant-numeric: stacked-fractions)
+
+#define LFNT_OT_FEATURES_P_SMPL 0x01000000 // +smpl         (font-variant-east-asian: simplified)
+#define LFNT_OT_FEATURES_P_TRAD 0x02000000 // +trad         (font-variant-east-asian: traditional)
+#define LFNT_OT_FEATURES_P_FWID 0x04000000 // +fwid         (font-variant-east-asian: full-width)
+#define LFNT_OT_FEATURES_P_PWID 0x08000000 // +pwid         (font-variant-east-asian: proportional-width)
+#define LFNT_OT_FEATURES_P_JP78 0x10000000 // +jp78         (font-variant-east-asian: jis78)
+#define LFNT_OT_FEATURES_P_JP83 0x20000000 // +jp83         (font-variant-east-asian: jis83)
+#define LFNT_OT_FEATURES_P_JP04 0x40000000 // +jp04         (font-variant-east-asian: jis04)
+// No more room for: (let's hope it's really the default in fonts)
+// #define LFNT_OT_FEATURES_P_JP90 0x80000000 // +jp90      (font-variant-east-asian: jis90)
+
+
 class LVDrawBuf;
 
 /** \brief base class for fonts
@@ -330,6 +401,11 @@ public:
     /// set bitmap mode (true=monochrome bitmap, false=antialiased)
     virtual void setBitmapMode( bool ) { }
 
+    /// get OpenType features (bitmap)
+    virtual int getFeatures() const { return 0; }
+    /// set OpenType features (bitmap)
+    virtual void setFeatures( int features ) { }
+
     /// sets current kerning mode
     virtual void setKerningMode( kerning_mode_t /*mode*/ ) { }
     /// returns current kerning mode
@@ -415,7 +491,8 @@ public:
     /// garbage collector frees unused fonts
     virtual void gc() = 0;
     /// returns most similar font
-    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface, int documentId = -1, bool useBias=false) = 0;
+    virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
+                                int features=0, int documentId = -1, bool useBias=false) = 0;
     /// set fallback font face (returns true if specified font is found)
     virtual bool SetFallbackFontFace( lString8 face ) { CR_UNUSED(face); return false; }
     /// get fallback font face (returns empty string if no fallback font is set)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -36,52 +36,53 @@ enum css_style_rec_important_bit {
     imp_bit_font_size             = 1ULL << 9,
     imp_bit_font_style            = 1ULL << 10,
     imp_bit_font_weight           = 1ULL << 11,
-    imp_bit_text_indent           = 1ULL << 12,
-    imp_bit_line_height           = 1ULL << 13,
-    imp_bit_width                 = 1ULL << 14,
-    imp_bit_height                = 1ULL << 15,
-    imp_bit_margin_left           = 1ULL << 16,
-    imp_bit_margin_right          = 1ULL << 17,
-    imp_bit_margin_top            = 1ULL << 18,
-    imp_bit_margin_bottom         = 1ULL << 19,
-    imp_bit_padding_left          = 1ULL << 20,
-    imp_bit_padding_right         = 1ULL << 21,
-    imp_bit_padding_top           = 1ULL << 22,
-    imp_bit_padding_bottom        = 1ULL << 23,
-    imp_bit_color                 = 1ULL << 24,
-    imp_bit_background_color      = 1ULL << 25,
-    imp_bit_letter_spacing        = 1ULL << 26,
-    imp_bit_page_break_before     = 1ULL << 27,
-    imp_bit_page_break_after      = 1ULL << 28,
-    imp_bit_page_break_inside     = 1ULL << 29,
-    imp_bit_hyphenate             = 1ULL << 30,
-    imp_bit_list_style_type       = 1ULL << 31,
-    imp_bit_list_style_position   = 1ULL << 32,
-    imp_bit_border_style_top      = 1ULL << 33,
-    imp_bit_border_style_bottom   = 1ULL << 34,
-    imp_bit_border_style_right    = 1ULL << 35,
-    imp_bit_border_style_left     = 1ULL << 36,
-    imp_bit_border_width_top      = 1ULL << 37,
-    imp_bit_border_width_right    = 1ULL << 38,
-    imp_bit_border_width_bottom   = 1ULL << 39,
-    imp_bit_border_width_left     = 1ULL << 40,
-    imp_bit_border_color_top      = 1ULL << 41,
-    imp_bit_border_color_right    = 1ULL << 42,
-    imp_bit_border_color_bottom   = 1ULL << 43,
-    imp_bit_border_color_left     = 1ULL << 44,
-    imp_bit_background_image      = 1ULL << 45,
-    imp_bit_background_repeat     = 1ULL << 46,
-    imp_bit_background_attachment = 1ULL << 47,
-    imp_bit_background_position   = 1ULL << 48,
-    imp_bit_border_collapse       = 1ULL << 49,
-    imp_bit_border_spacing_h      = 1ULL << 50,
-    imp_bit_border_spacing_v      = 1ULL << 51,
-    imp_bit_orphans               = 1ULL << 52,
-    imp_bit_widows                = 1ULL << 53,
-    imp_bit_float                 = 1ULL << 54,
-    imp_bit_clear                 = 1ULL << 55,
-    imp_bit_direction             = 1ULL << 56,
-    imp_bit_cr_hint               = 1ULL << 57
+    imp_bit_font_features         = 1ULL << 12,
+    imp_bit_text_indent           = 1ULL << 13,
+    imp_bit_line_height           = 1ULL << 14,
+    imp_bit_width                 = 1ULL << 15,
+    imp_bit_height                = 1ULL << 16,
+    imp_bit_margin_left           = 1ULL << 17,
+    imp_bit_margin_right          = 1ULL << 18,
+    imp_bit_margin_top            = 1ULL << 19,
+    imp_bit_margin_bottom         = 1ULL << 20,
+    imp_bit_padding_left          = 1ULL << 21,
+    imp_bit_padding_right         = 1ULL << 22,
+    imp_bit_padding_top           = 1ULL << 23,
+    imp_bit_padding_bottom        = 1ULL << 24,
+    imp_bit_color                 = 1ULL << 25,
+    imp_bit_background_color      = 1ULL << 26,
+    imp_bit_letter_spacing        = 1ULL << 27,
+    imp_bit_page_break_before     = 1ULL << 28,
+    imp_bit_page_break_after      = 1ULL << 29,
+    imp_bit_page_break_inside     = 1ULL << 30,
+    imp_bit_hyphenate             = 1ULL << 31,
+    imp_bit_list_style_type       = 1ULL << 32,
+    imp_bit_list_style_position   = 1ULL << 33,
+    imp_bit_border_style_top      = 1ULL << 34,
+    imp_bit_border_style_bottom   = 1ULL << 35,
+    imp_bit_border_style_right    = 1ULL << 36,
+    imp_bit_border_style_left     = 1ULL << 37,
+    imp_bit_border_width_top      = 1ULL << 38,
+    imp_bit_border_width_right    = 1ULL << 39,
+    imp_bit_border_width_bottom   = 1ULL << 40,
+    imp_bit_border_width_left     = 1ULL << 41,
+    imp_bit_border_color_top      = 1ULL << 42,
+    imp_bit_border_color_right    = 1ULL << 43,
+    imp_bit_border_color_bottom   = 1ULL << 44,
+    imp_bit_border_color_left     = 1ULL << 45,
+    imp_bit_background_image      = 1ULL << 46,
+    imp_bit_background_repeat     = 1ULL << 47,
+    imp_bit_background_attachment = 1ULL << 48,
+    imp_bit_background_position   = 1ULL << 49,
+    imp_bit_border_collapse       = 1ULL << 50,
+    imp_bit_border_spacing_h      = 1ULL << 51,
+    imp_bit_border_spacing_v      = 1ULL << 52,
+    imp_bit_orphans               = 1ULL << 53,
+    imp_bit_widows                = 1ULL << 54,
+    imp_bit_float                 = 1ULL << 55,
+    imp_bit_clear                 = 1ULL << 56,
+    imp_bit_direction             = 1ULL << 57,
+    imp_bit_cr_hint               = 1ULL << 58
 };
 
 /**
@@ -93,8 +94,8 @@ typedef struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
     lUInt64              important;  // bitmap for !important (used only by LVCssDeclaration)
-                                     // we have currently below 58 css properties
-                                     // lvstsheet knows about 73, which are mapped to these 58
+                                     // we have currently below 59 css properties
+                                     // lvstsheet knows about 81, which are mapped to these 59
                                      // update bits above if you add new properties below
     lUInt64              importance; // bitmap for important bit's importance/origin
                                      // (allows for 2 level of !important importance)
@@ -110,6 +111,7 @@ typedef struct css_style_rec_tag {
     css_length_t         font_size;
     css_font_style_t     font_style;
     css_font_weight_t    font_weight;
+    css_length_t         font_features;
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -159,6 +161,7 @@ typedef struct css_style_rec_tag {
     , font_size(css_val_inherited, 0)
     , font_style(css_fs_inherit)
     , font_weight(css_fw_inherit)
+    , font_features(css_val_inherited, 0)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, 0)
@@ -216,6 +219,18 @@ typedef struct css_style_rec_tag {
             *field = value; // apply
             if (is_important & 0x1) important |= bit;   // update important flag
             if (is_important == 0x3) importance |= bit; // update importance flag (!important comes from higher_importance CSS)
+        }
+    };
+    // Similar to previous one, but logical-OR'ing values, for bitmaps (currently, only style->font_features)
+    inline void ApplyAsBitmapOr( css_length_t value, css_length_t *field, css_style_rec_important_bit bit, lUInt8 is_important ) {
+        if (     !(important & bit)
+              || (is_important == 0x3)
+              || (is_important == 0x1 && !(importance & bit) )
+           ) {
+            field->value |= value.value; // logical-or values
+            field->type = value.type;    // use the one from value (always css_val_unspecified for font_features)
+            if (is_important & 0x1) important |= bit;
+            if (is_important == 0x3) importance |= bit;
         }
     };
 } css_style_rec_t;

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2679,6 +2679,8 @@ lString16 extractDocTitle( ldomDocument * doc );
 lString16 extractDocLanguage( ldomDocument * doc );
 /// returns "(Series Name #number)" if pSeriesNumber is NULL, separate name and number otherwise
 lString16 extractDocSeries( ldomDocument * doc, int * pSeriesNumber=NULL );
+lString16 extractDocKeywords( ldomDocument * doc );
+lString16 extractDocDescription( ldomDocument * doc );
 
 bool IsEmptySpace( const lChar16 * text, int len );
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6550,7 +6550,7 @@ bool SimpleTitleFormatter::splitLines(const char * delimiter) {
     return measure();
 }
 bool SimpleTitleFormatter::format(int fontSize) {
-    _font = fontMan->GetFont(fontSize, _bold ? 800 : 400, _italic, css_ff_sans_serif, _fontFace, -1);
+    _font = fontMan->GetFont(fontSize, _bold ? 800 : 400, _italic, css_ff_sans_serif, _fontFace, 0, -1);
     _lineHeight = _font->getHeight() * 120 / 100;
     _lines.clear();
     int singleLineWidth = _font->getTextWidth(_text.c_str(), _text.length());
@@ -6703,7 +6703,7 @@ void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace,
     buf.FillRect(rc3, palette->vline);
 
 
-	LVFontRef fnt = fontMan->GetFont(16, 400, false, css_ff_sans_serif, fontFace, -1); // = fontMan
+	LVFontRef fnt = fontMan->GetFont(16, 400, false, css_ff_sans_serif, fontFace, 0, -1); // = fontMan
 	if (!fnt.isNull()) {
 
 		rc.left += rc.width() / 10;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4629,6 +4629,8 @@ bool LVDocView::ParseDocument() {
 			m_doc_props->setString(DOC_PROP_AUTHORS, extractDocAuthors(m_doc));
 			m_doc_props->setString(DOC_PROP_TITLE, extractDocTitle(m_doc));
 			m_doc_props->setString(DOC_PROP_LANGUAGE, extractDocLanguage(m_doc));
+			m_doc_props->setString(DOC_PROP_KEYWORDS, extractDocKeywords(m_doc));
+			m_doc_props->setString(DOC_PROP_DESCRIPTION, extractDocDescription(m_doc));
             int seriesNumber = -1;
             lString16 seriesName = extractDocSeries(m_doc, &seriesNumber);
             m_doc_props->setString(DOC_PROP_SERIES_NAME, seriesName);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2124,6 +2124,7 @@ LVFontRef getFont(css_style_rec_t * style, int documentId)
         style->font_style==css_fs_italic,
         style->font_family,
         lString8(style->font_name.c_str()),
+        style->font_features.value, // (.type is always css_val_unspecified after setNodeStyle())
         documentId, true); // useBias=true, so that our preferred font gets used
     //fnt = LVCreateFontTransform( fnt, LVFONT_TRANSFORM_EMBOLDEN );
     return fnt;
@@ -3389,6 +3390,8 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->font_size.value = source->font_size.value ;
     dest->font_style = source->font_style ;
     dest->font_weight = source->font_weight ;
+    dest->font_features.type = source->font_features.type ;
+    dest->font_features.value = source->font_features.value ;
     dest->text_indent = source->text_indent ;
     dest->line_height = source->line_height ;
     dest->width = source->width ;
@@ -8720,6 +8723,25 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     }
     UPDATE_STYLE_FIELD( font_family, css_ff_inherit );
     //UPDATE_LEN_FIELD( font_size ); // this is done below
+
+    // font_features (font-variant/font-feature-settings)
+    // The specs say a font-variant resets the ones that would be
+    // inherited (as inheritance always does).
+    // But, as we store in a single bitmap the values from multiple
+    // properties (font-variant, font-variant-caps...), we drift from
+    // the specs by OR'ing the ones sets by style on this node with
+    // the ones inherited from parents (so we can use style-tweaks
+    // like body { font-variant: oldstyle-nums; } without that being
+    // reset by a lower H1 { font-variant: small-caps; }.
+    // Note that we don't handle the !important bit whether it's set
+    // for this node or the parent (if it's set on the parent, we
+    // could decide to = instead of |=), as it's not clear whether
+    // it's better or not: we'll see.
+    // (Note that we can use * { font-variant: normal !important; } to
+    // stop any font-variant without !important from being applied.)
+    pstyle->font_features.value |= parent_style->font_features.value;
+    pstyle->font_features.type = css_val_unspecified;
+
     //UPDATE_LEN_FIELD( text_indent );
     spreadParent( pstyle->text_indent, parent_style->text_indent );
     switch( pstyle->font_weight )

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -29,6 +29,7 @@ lUInt32 calcHash(font_ref_t & f)
     v = v * 31 + (lUInt32)f->getSize();
     v = v * 31 + (lUInt32)f->getWeight();
     v = v * 31 + (lUInt32)f->getItalic();
+    v = v * 31 + (lUInt32)f->getFeatures();
     v = v * 31 + (lUInt32)f->getKerningMode();
     v = v * 31 + (lUInt32)f->getHintingMode();
     v = v * 31 + (lUInt32)f->getBitmapMode();
@@ -42,7 +43,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
            (lUInt32)(rec.important >> 32)) * 31
          + (lUInt32)(rec.important & 0xFFFFFFFFULL)) * 31
          + (lUInt32)(rec.importance >> 32)) * 31
@@ -63,6 +64,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_size.value) * 31
          + (lUInt32)rec.font_style) * 31
          + (lUInt32)rec.font_weight) * 31
+         + (lUInt32)rec.font_features.pack()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -142,6 +144,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_weight == r2.font_weight &&
            r1.font_name == r2.font_name &&
            r1.font_family == r2.font_family&&
+           r1.font_features == r2.font_features&&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -319,6 +322,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_LEN(font_size);          //    css_length_t         font_size;
     ST_PUT_ENUM(font_style);        //    css_font_style_t     font_style;
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
+    ST_PUT_LEN(font_features);      //    css_length_t         font_features;
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -377,6 +381,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_LEN(font_size);                                  //    css_length_t         font_size;
     ST_GET_ENUM(css_font_style_t, font_style);              //    css_font_style_t     font_style;
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
+    ST_GET_LEN(font_features);                              //    css_length_t         font_features;
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8856,6 +8856,204 @@ lString16 extractDocSeries( ldomDocument * doc, int * pSeriesNumber )
     return res;
 }
 
+lString16 extractDocKeywords( ldomDocument * doc )
+{
+    lString16 res;
+    // Year
+    res << doc->createXPointer(L"/FictionBook/description/title-info/date").getText().trim();
+    // Genres
+    for ( int i=0; i<16; i++) {
+        lString16 path = cs16("/FictionBook/description/title-info/genre[") + fmt::decimal(i+1) + "]";
+        ldomXPointer genre = doc->createXPointer(path);
+        if ( !genre ) {
+            break;
+        }
+        if ( !res.empty() )
+            res << "\n";
+        res << genre.getText().trim();
+    }
+    return res;
+}
+
+lString16 extractDocDescription( ldomDocument * doc )
+{
+    // We put all other FB2 meta info in this description
+    lString16 res;
+
+    // Annotation (description)
+    res << doc->createXPointer(L"/FictionBook/description/title-info/annotation").getText().trim();
+
+    // Translators
+    lString16 translators;
+    int nbTranslators = 0;
+    for ( int i=0; i<16; i++) {
+        lString16 path = cs16("/FictionBook/description/title-info/translator[") + fmt::decimal(i+1) + "]";
+        ldomXPointer ptranslator = doc->createXPointer(path);
+        if ( !ptranslator ) {
+            break;
+        }
+        lString16 firstName = ptranslator.relative( L"/first-name" ).getText().trim();
+        lString16 lastName = ptranslator.relative( L"/last-name" ).getText().trim();
+        lString16 middleName = ptranslator.relative( L"/middle-name" ).getText().trim();
+        lString16 translator = firstName;
+        if ( !translator.empty() )
+            translator += " ";
+        if ( !middleName.empty() )
+            translator += middleName;
+        if ( !lastName.empty() && !translator.empty() )
+            translator += " ";
+        translator += lastName;
+        if ( !translators.empty() )
+            translators << "\n";
+        translators << translator;
+        nbTranslators++;
+    }
+    if ( !translators.empty() ) {
+        if ( !res.empty() )
+            res << "\n\n";
+        if ( nbTranslators > 1 )
+            res << "Translators:\n" << translators;
+        else
+            res << "Translator: " << translators;
+    }
+
+    // Publication info & publisher
+    ldomXPointer publishInfo = doc->createXPointer(L"/FictionBook/description/publish-info");
+    if ( !publishInfo.isNull() ) {
+        lString16 publisher = publishInfo.relative( L"/publisher" ).getText().trim();
+        lString16 pubcity = publishInfo.relative( L"/city" ).getText().trim();
+        lString16 pubyear = publishInfo.relative( L"/year" ).getText().trim();
+        lString16 isbn = publishInfo.relative( L"/isbn" ).getText().trim();
+        lString16 bookName = publishInfo.relative( L"/book-name" ).getText().trim();
+        lString16 publication;
+        if ( !publisher.empty() || !pubcity.empty() ) {
+            if ( !publisher.empty() ) {
+                publication << publisher;
+            }
+            if ( !pubcity.empty() ) {
+                if ( !!publisher.empty() ) {
+                    publication << ", ";
+                }
+                publication << pubcity;
+            }
+        }
+        if ( !pubyear.empty() || !isbn.empty() ) {
+            if ( !publication.empty() )
+                publication << "\n";
+            if ( !pubyear.empty() ) {
+                publication << pubyear;
+            }
+            if ( !isbn.empty() ) {
+                if ( !pubyear.empty() ) {
+                    publication << ", ";
+                }
+                publication << isbn;
+            }
+        }
+        if ( !bookName.empty() ) {
+            if ( !publication.empty() )
+                publication << "\n";
+            publication << bookName;
+        }
+        if ( !publication.empty() ) {
+            if ( !res.empty() )
+                res << "\n\n";
+            res << "Publication:\n" << publication;
+        }
+    }
+
+    // Document info
+    ldomXPointer pDocInfo = doc->createXPointer(L"/FictionBook/description/document-info");
+    if ( !pDocInfo.isNull() ) {
+        lString16 docInfo;
+        lString16 docAuthors;
+        int nbAuthors = 0;
+        for ( int i=0; i<16; i++) {
+            lString16 path = cs16("/FictionBook/description/document-info/author[") + fmt::decimal(i+1) + "]";
+            ldomXPointer pdocAuthor = doc->createXPointer(path);
+            if ( !pdocAuthor ) {
+                break;
+            }
+            lString16 firstName = pdocAuthor.relative( L"/first-name" ).getText().trim();
+            lString16 lastName = pdocAuthor.relative( L"/last-name" ).getText().trim();
+            lString16 middleName = pdocAuthor.relative( L"/middle-name" ).getText().trim();
+            lString16 docAuthor = firstName;
+            if ( !docAuthor.empty() )
+                docAuthor += " ";
+            if ( !middleName.empty() )
+                docAuthor += middleName;
+            if ( !lastName.empty() && !docAuthor.empty() )
+                docAuthor += " ";
+            docAuthor += lastName;
+            if ( !docAuthors.empty() )
+                docAuthors << "\n";
+            docAuthors << docAuthor;
+            nbAuthors++;
+        }
+        if ( !docAuthors.empty() ) {
+            if ( nbAuthors > 1 )
+                docInfo << "Authors:\n" << docAuthors;
+            else
+                docInfo << "Author: " << docAuthors;
+        }
+        lString16 docPublisher = pDocInfo.relative( L"/publisher" ).getText().trim();
+        lString16 docId = pDocInfo.relative( L"/id" ).getText().trim();
+        lString16 docVersion = pDocInfo.relative( L"/version" ).getText().trim();
+        lString16 docDate = pDocInfo.relative( L"/date" ).getText().trim();
+        lString16 docHistory = pDocInfo.relative( L"/history" ).getText().trim();
+        lString16 docSrcUrl = pDocInfo.relative( L"/src-url" ).getText().trim();
+        lString16 docSrcOcr = pDocInfo.relative( L"/src-ocr" ).getText().trim();
+        lString16 docProgramUsed = pDocInfo.relative( L"/program-used" ).getText().trim();
+        if ( !docPublisher.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "Publisher: " << docPublisher;
+        }
+        if ( !docId.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "Id: " << docId;
+        }
+        if ( !docVersion.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "Version: " << docVersion;
+        }
+        if ( !docDate.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "Date: " << docDate;
+        }
+        if ( !docHistory.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "History: " << docHistory;
+        }
+        if ( !docSrcUrl.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "URL: " << docSrcUrl;
+        }
+        if ( !docSrcOcr.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "OCR: " << docSrcOcr;
+        }
+        if ( !docProgramUsed.empty() ) {
+            if ( !docInfo.empty() )
+                docInfo << "\n";
+            docInfo << "Application: " << docProgramUsed;
+        }
+        if ( !docInfo.empty() ) {
+            if ( !res.empty() )
+                res << "\n\n";
+            res << "Document:\n" << docInfo;
+        }
+    }
+
+    return res;
+}
+
 void ldomXPointerEx::initIndex()
 {
     int m[MAX_DOM_LEVEL];

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.37k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0020
+#define FORMATTING_VERSION_ID 0x0021
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -4235,6 +4235,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_name = def_font->getTypeFace();
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
+    s->font_features.type = css_val_unspecified;
+    s->font_features.value = 0;
     s->text_indent.type = css_val_px;
     s->text_indent.value = 0;
     // s->line_height.type = css_val_percent;
@@ -16931,6 +16933,8 @@ void runBasicTinyDomUnitTests()
         style1->font_name = cs8("Arial");
         style1->font_weight = css_fw_400;
         style1->font_style = css_fs_normal;
+        style1->font_features.type = css_val_unspecified;
+        style1->font_features.value = 0;
         style1->text_indent.type = css_val_px;
         style1->text_indent.value = 0;
         style1->line_height.type = css_val_unspecified;
@@ -16961,6 +16965,8 @@ void runBasicTinyDomUnitTests()
         style2->font_name = cs8("Arial");
         style2->font_weight = css_fw_400;
         style2->font_style = css_fs_normal;
+        style2->font_features.type = css_val_unspecified;
+        style2->font_features.value = 0;
         style2->text_indent.type = css_val_px;
         style2->text_indent.value = 0;
         style2->line_height.type = css_val_unspecified;
@@ -16991,6 +16997,8 @@ void runBasicTinyDomUnitTests()
         style3->font_name = cs8("Arial");
         style3->font_weight = css_fw_400;
         style3->font_style = css_fs_normal;
+        style3->font_features.type = css_val_unspecified;
+        style3->font_features.value = 0;
         style3->text_indent.type = css_val_px;
         style3->text_indent.value = 0;
         style3->line_height.type = css_val_unspecified;


### PR DESCRIPTION
`CSS: adds support for font-variant`
Details around https://github.com/koreader/koreader/issues/5821#issuecomment-600225376
Most values from CSS-FONTS-3 (31 named-values) are supported, see the code for the list.
Only `font-variant` and its buddies (`font-variant-caps`, `font-variant-ligatures`...) are parsed, but it could be extended to also support `font-feature-settings`.
https://drafts.csswg.org/css-fonts-3/#propdef-font-variant
https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant
https://en.wikipedia.org/wiki/List_of_typographic_features
https://docs.microsoft.com/en-us/typography/opentype/spec/features_ko#tag-onum

Note that I haven't thought about how font-variant should be handled when we need to use the fallback font - so, the fallback font should have currently no OT feature enabled.

@virxkane @pkb: when/if you pick up this one, you'll have a bit of merging work as it touches lvfntman.cpp, that you have splitted on your side (thought about easing that for you and making it 2 commits, but the split wasn't obvious, and it feels better as a single commit here).

`FB2: merge other metadata in returned keywords and description`
FB2 has a lot more metadata than other formats, so try to merge and fit them in the 2 available returned metadata slots that weren't used by FB2: Description & Keywords.
Details around https://github.com/koreader/koreader/issues/5956#issuecomment-599515032

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/334)
<!-- Reviewable:end -->
