### PR TITLE
Add support for EPUB3 nav toc and various hardcopy page maps/lists

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -166,6 +166,10 @@ img[align=right i]   { float: right; }
 table[align=left i]  { float: left; }
 table[align=right i] { float: right; }
 
+/* EPUB3 epub:type="pagebreak" may sometimes have the page number
+ * as content: hide it. (Usually, its content is empty and the
+ * page number is in a title= attribute.) */
+span[type=pagebreak] { display: none; }
 
 /* Old element or className based selectors involving display: that
  * we need to support for older gDOMVersionRequested

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -648,6 +648,11 @@ public:
     bool getFlatToc( LVPtrVector<LVTocItem, false> & items );
     /// update page numbers for items
     void updatePageNumbers( LVTocItem * item );
+    /// returns pointer to LVPageMapItems container
+    LVPageMap * getPageMap();
+    /// update PageMap items page infos
+    void updatePageMapInfo( LVPageMap * pagemap );
+
     /// set view mode (pages/scroll) - DVM_SCROLL/DVM_PAGES
     void setViewMode( LVDocViewMode view_mode, int visiblePageCount=-1 );
     /// get view mode (pages/scroll)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2170,6 +2170,86 @@ public:
     void invalidatePageNumbers() { if (_level==0) _percent = 0; }
 };
 
+/// PageMapItem
+class LVPageMapItem
+{
+    friend class LVDocView;
+    friend class LVPageMap;
+private:
+    ldomDocument *  _doc;
+    lInt32          _index;
+    lInt32          _page;
+    lInt32          _doc_y;
+    lString16       _label;
+    lString16       _path;
+    ldomXPointer    _position;
+    LVPageMapItem( ldomXPointer pos, lString16 path, const lString16 & label )
+        : _index(0), _page(0), _doc_y(-1), _label(label), _path(path), _position(pos)
+        { }
+    void setPage( int n ) { _page = n; }
+    void setDocY( int y ) { _doc_y = y; }
+public:
+    /// serialize to byte array (pointer will be incremented by number of bytes written)
+    bool serialize( SerialBuf & buf );
+    /// deserialize from byte array (pointer will be incremented by number of bytes read)
+    bool deserialize( ldomDocument * doc, SerialBuf & buf );
+    /// get rendered page number
+    int getPage() { return _page; }
+    /// returns node index
+    int getIndex() const { return _index; }
+    /// returns page label
+    lString16 getLabel() const { return _label; }
+    /// returns position pointer
+    ldomXPointer getXPointer();
+    /// returns position path
+    lString16 getPath();
+    /// returns Y position
+    int getDocY(bool refresh=false);
+    LVPageMapItem( ldomDocument * doc ) : _doc(doc), _index(0), _page(0), _doc_y(-1) { }
+};
+
+/// PageMapItems container
+class LVPageMap
+{
+    friend class LVDocView;
+private:
+    ldomDocument *  _doc;
+    bool            _page_info_valid;
+    lString16       _source;
+    LVPtrVector<LVPageMapItem> _children;
+    void addPage( LVPageMapItem * item ) {
+        item->_doc = _doc;
+        item->_index = _children.length();
+        _children.add(item);
+    }
+public:
+    /// serialize to byte array (pointer will be incremented by number of bytes written)
+    bool serialize( SerialBuf & buf );
+    /// deserialize from byte array (pointer will be incremented by number of bytes read)
+    bool deserialize( ldomDocument * doc, SerialBuf & buf );
+    /// returns child node count
+    int getChildCount() const { return _children.length(); }
+    /// returns child node by index
+    LVPageMapItem * getChild( int index ) const { return _children[index]; }
+    /// add page item
+    LVPageMapItem * addPage( const lString16 & label, ldomXPointer ptr, lString16 path )
+    {
+        LVPageMapItem * item = new LVPageMapItem( ptr, path, label );
+        addPage( item );
+        return item;
+    }
+    void clear() { _children.clear(); }
+    bool hasValidPageInfo() { return _page_info_valid; }
+    void invalidatePageInfo() { _page_info_valid = false; }
+    // Page source (info about the book paper version the page labels reference)
+    void setSource( lString16 source ) { _source = source; }
+    lString16 getSource() const { return _source; }
+    // root node constructor
+    LVPageMap( ldomDocument * doc )
+        : _doc(doc), _page_info_valid(false) { }
+    ~LVPageMap() { clear(); }
+};
+
 
 class ldomNavigationHistory
 {
@@ -2242,6 +2322,7 @@ class ldomDocument : public lxmlDocBase
     friend class ldomDocumentWriterFilter;
 private:
     LVTocItem m_toc;
+    LVPageMap m_pagemap;
 #if BUILD_LITE!=1
     font_ref_t _def_font; // default font
     css_style_ref_t _def_style;
@@ -2323,6 +2404,9 @@ public:
     bool isTocAlternativeToc() { return m_toc.hasAlternativeTocFlag(); }
     /// build TOC from headings
     void buildTocFromHeadings();
+
+    /// returns pointer to PageMapItems container
+    LVPageMap * getPageMap() { return &m_pagemap; }
 
 #if BUILD_LITE!=1
     bool isTocFromCacheValid() { return _toc_from_cache_valid; }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2135,6 +2135,9 @@ public:
     lString16 getName() const { return _name; }
     /// returns position pointer
     ldomXPointer getXPointer();
+    /// set position pointer (for cases where we need to create a LVTocItem as a container, but
+    /// we'll know the xpointer only later, mostly always the same xpointer as its first child)
+    void setXPointer(ldomXPointer xp) { _position = xp; }
     /// returns position path
     lString16 getPath();
     /// returns Y position

--- a/crengine/include/lvtypes.h
+++ b/crengine/include/lvtypes.h
@@ -143,8 +143,9 @@ public:
     /// returns true if specified rectangle is fully covered by this rectangle
     bool isRectInside( lvRect rc ) const
     {
-        if ( rc.isEmpty() || isEmpty() )
-            return false;
+        // This was wrong: a 0-height or 0-width rect can be inside another rect
+        // if ( rc.isEmpty() || isEmpty() )
+        //    return false;
         if ( rc.left < left || rc.right > right || rc.top < top || rc.bottom > bottom )
             return false;
         return true;

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -90,7 +90,7 @@ bool DetectEpubFormat( LVStreamRef stream )
     return true;
 }
 
-void ReadEpubToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, ldomDocumentFragmentWriter & appender ) {
+void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, ldomDocumentFragmentWriter & appender ) {
     if ( !mapRoot || !baseToc)
         return;
     lUInt16 navPoint_id = mapRoot->getDocument()->getElementNameIndex(L"navPoint");
@@ -126,7 +126,53 @@ void ReadEpubToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, l
             continue;
         ldomXPointer ptr(target, 0);
         LVTocItem * tocItem = baseToc->addChild(title, ptr, lString16::empty_str);
-        ReadEpubToc( doc, navPoint, tocItem, appender );
+        ReadEpubNcxToc( doc, navPoint, tocItem, appender );
+    }
+}
+
+void ReadEpubNcxPageList( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pageMap, ldomDocumentFragmentWriter & appender ) {
+    // http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2
+    // http://idpf.org/epub/a11y/techniques/techniques-20160711.html#refPackagesLatest
+    //    <pageTarget id="p4" playOrder="6" type="normal" value="2">
+    //      <navLabel><text>Page 8</text></navLabel>
+    //      <content src="OEBPS/PL12.xhtml#page_8"/>
+    //    </pageTarget>
+    // http://blog.epubbooks.com/346/marking-up-page-numbers-in-the-epub-ncx/
+    // type:value must be unique, and value can not be used as a short version of text...
+    // Also see http://kb.daisy.org/publishing/docs/navigation/pagelist.html
+    if ( !mapRoot || !pageMap)
+        return;
+    lUInt16 pageTarget_id = mapRoot->getDocument()->getElementNameIndex(L"pageTarget");
+    lUInt16 navLabel_id = mapRoot->getDocument()->getElementNameIndex(L"navLabel");
+    lUInt16 content_id = mapRoot->getDocument()->getElementNameIndex(L"content");
+    lUInt16 text_id = mapRoot->getDocument()->getElementNameIndex(L"text");
+    for ( int i=0; i<50000; i++ ) {
+        ldomNode * pageTarget = mapRoot->findChildElement(LXML_NS_ANY, pageTarget_id, i);
+        if ( !pageTarget )
+            break;
+        ldomNode * navLabel = pageTarget->findChildElement(LXML_NS_ANY, navLabel_id, -1);
+        if ( !navLabel )
+            continue;
+        ldomNode * text = navLabel->findChildElement(LXML_NS_ANY, text_id, -1);
+        if ( !text )
+            continue;
+        ldomNode * content = pageTarget->findChildElement(LXML_NS_ANY, content_id, -1);
+        if ( !content )
+            continue;
+        lString16 href = content->getAttributeValue("src");
+        lString16 title = text->getText(' ');
+        title.trimDoubleSpaces(false, false, false);
+        if ( href.empty() || title.empty() )
+            continue;
+        href = DecodeHTMLUrlString(href);
+        href = appender.convertHref(href);
+        if ( href.empty() || href[0]!='#' )
+            continue;
+        ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
+        if ( !target )
+            continue;
+        ldomXPointer ptr(target, 0);
+        pageMap->addPage(title, ptr, lString16::empty_str);
     }
 }
 
@@ -196,6 +242,65 @@ void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
     }
 }
 
+void ReadEpubNavPageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pageMap, ldomDocumentFragmentWriter & appender ) {
+    // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
+    if ( !mapRoot || !pageMap)
+        return;
+    lUInt16 ol_id = mapRoot->getDocument()->getElementNameIndex(L"ol");
+    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(L"li");
+    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(L"a");
+    for ( int i=0; i<50000; i++ ) {
+        ldomNode * li = mapRoot->findChildElement(LXML_NS_ANY, li_id, i);
+        if ( !li )
+            break;
+        ldomNode * a = li->findChildElement(LXML_NS_ANY, a_id, -1);
+        if ( a ) {
+            lString16 href = a->getAttributeValue("href");
+            lString16 title = a->getText(' ');
+            if ( title.empty() ) {
+                title = a->getAttributeValue("title");
+            }
+            title.trimDoubleSpaces(false, false, false);
+            if ( !href.empty() ) {
+                href = DecodeHTMLUrlString(href);
+                href = appender.convertHref(href);
+                if ( !href.empty() && href[0]=='#' ) {
+                    ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
+                    if ( target ) {
+                        ldomXPointer ptr(target, 0);
+                        pageMap->addPage(title, ptr, lString16::empty_str);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void ReadEpubAdobePageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pageMap, ldomDocumentFragmentWriter & appender ) {
+    // https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page-map
+    if ( !mapRoot || !pageMap)
+        return;
+    lUInt16 page_id = mapRoot->getDocument()->getElementNameIndex(L"page");
+    for ( int i=0; i<50000; i++ ) {
+        ldomNode * page = mapRoot->findChildElement(LXML_NS_ANY, page_id, i);
+        if ( !page )
+            break;
+        lString16 href = page->getAttributeValue("href");
+        lString16 title = page->getAttributeValue("name");
+        title.trimDoubleSpaces(false, false, false);
+        if ( href.empty() || title.empty() )
+            continue;
+        href = DecodeHTMLUrlString(href);
+        href = appender.convertHref(href);
+        if ( href.empty() || href[0]!='#' )
+            continue;
+        ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
+        if ( !target )
+            continue;
+        ldomXPointer ptr(target, 0);
+        pageMap->addPage(title, ptr, lString16::empty_str);
+    }
+}
 
 lString16 EpubGetRootFilePath(LVContainerRef m_arc)
 {
@@ -828,8 +933,10 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 
     bool isEpub3 = false;
     lString16 epubVersion;
-    lString16 ncxHref; // epub2 TOC
     lString16 navHref; // epub3 TOC
+    lString16 ncxHref; // epub2 TOC
+    lString16 pageMapHref; // epub2 Adobe page-map
+    lString16 pageMapSource;
     lString16 coverId;
 
     LVEmbeddedFontList fontList;
@@ -860,6 +967,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         lString16 title = doc->textFromXPath( cs16("package/metadata/title"));
         lString16 language = doc->textFromXPath( cs16("package/metadata/language"));
         lString16 description = doc->textFromXPath( cs16("package/metadata/description"));
+        pageMapSource = doc->textFromXPath( cs16("package/metadata/source"));
         // m_doc_props->setString(DOC_PROP_AUTHORS, authors);
         m_doc_props->setString(DOC_PROP_TITLE, title);
         m_doc_props->setString(DOC_PROP_LANGUAGE, language);
@@ -1043,10 +1151,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             ldomNode * spine = doc->nodeFromXPath( cs16("package/spine") );
             if ( spine ) {
 
+                // <spine toc="ncx" page-map="page-map">
                 EpubItem * ncx = epubItems.findById( spine->getAttributeValue("toc") ); //TODO
-                //EpubItem * ncx = epubItems.findById(cs16("ncx"));
                 if ( ncx!=NULL )
                     ncxHref = LVCombinePaths(codeBase, ncx->href);
+                EpubItem * page_map = epubItems.findById( spine->getAttributeValue("page-map") );
+                if ( page_map!=NULL )
+                    pageMapHref = LVCombinePaths(codeBase, page_map->href);
 
                 for ( int i=1; i<50000; i++ ) {
                     ldomNode * item = doc->nodeFromXPath(lString16("package/spine/itemref[") << fmt::decimal(i) << "]");
@@ -1141,6 +1252,9 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         }
     }
 
+    bool has_toc = false;
+    bool has_pagemap = false;
+
     // EPUB3 documents may contain both a toc.ncx and a nav xhtml toc.
     // We would have preferred to read first a toc.ncx if present, as it
     // is more structured than nav toc (all items have a href), but it
@@ -1178,7 +1292,6 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                                 lString16 type = n->getAttributeValue("type");
                                 if ( type == L"toc") {
                                     n_toc = n;
-                                    break;
                                 }
                                 else if ( type == L"landmarks") {
                                     n_landmarks = n;
@@ -1223,12 +1336,22 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     if ( ol_root )
                         ReadEpubNavToc( m_doc, ol_root, m_doc->getToc(), appender );
                 }
+                if ( n_page_list ) {
+                    ldomNode * ol_root = n_page_list->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(L"ol"), -1 );
+                    if ( ol_root )
+                        ReadEpubNavPageMap( m_doc, ol_root, m_doc->getPageMap(), appender );
+                }
                 delete navDoc;
             }
         }
     }
+
+    has_toc = m_doc->getToc()->getChildCount() > 0;
+    has_pagemap = m_doc->getPageMap()->getChildCount() > 0;
+
     // For EPUB2 (or EPUB3 where no nav toc was found): read ncx toc
-    if ( m_doc->getToc()->getChildCount() == 0 && !ncxHref.empty() ) {
+    // We may also find in the ncx a <pageList> list
+    if ( ( !has_toc || !has_pagemap ) && !ncxHref.empty() ) {
         LVStreamRef stream = m_arc->OpenStream(ncxHref.c_str(), LVOM_READ);
         lString16 codeBase = LVExtractPath( ncxHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
@@ -1237,15 +1360,27 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         if ( !stream.isNull() ) {
             ldomDocument * ncxdoc = LVParseXMLStream( stream );
             if ( ncxdoc!=NULL ) {
-                ldomNode * navMap = ncxdoc->nodeFromXPath( cs16("ncx/navMap"));
-                if ( navMap!=NULL )
-                    ReadEpubToc( m_doc, navMap, m_doc->getToc(), appender );
+                if ( !has_toc ) {
+                    ldomNode * navMap = ncxdoc->nodeFromXPath( cs16("ncx/navMap"));
+                    if ( navMap!=NULL )
+                        ReadEpubNcxToc( m_doc, navMap, m_doc->getToc(), appender );
+                }
+                // http://blog.epubbooks.com/346/marking-up-page-numbers-in-the-epub-ncx/
+                if ( !has_pagemap ) {
+                    ldomNode * pageList = ncxdoc->nodeFromXPath( cs16("ncx/pageList"));
+                    if ( pageList!=NULL )
+                        ReadEpubNcxPageList( m_doc, pageList, m_doc->getPageMap(), appender );
+                }
                 delete ncxdoc;
             }
         }
     }
+
+    has_toc = m_doc->getToc()->getChildCount() > 0;
+    has_pagemap = m_doc->getPageMap()->getChildCount() > 0;
+
     // If still no TOC, fallback to using the spine, as Kobo does.
-    if ( m_doc->getToc()->getChildCount() == 0 ) {
+    if ( !has_toc ) {
         LVTocItem * baseToc = m_doc->getToc();
         for ( int i=0; i<spineItemsNb; i++ ) {
             if (spineItems[i]->mediaType == "application/xhtml+xml") {
@@ -1261,6 +1396,30 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             }
         }
     }
+
+    // If no pagemap, parse Adobe page-map if there is one
+    // https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page-map
+    if ( !has_pagemap && !pageMapHref.empty() ) {
+        LVStreamRef stream = m_arc->OpenStream(pageMapHref.c_str(), LVOM_READ);
+        lString16 codeBase = LVExtractPath( pageMapHref );
+        if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
+            codeBase.append(1, L'/');
+        appender.setCodeBase(codeBase);
+        if ( !stream.isNull() ) {
+            ldomDocument * pagemapdoc = LVParseXMLStream( stream );
+            if ( pagemapdoc!=NULL ) {
+                if ( !has_pagemap ) {
+                    ldomNode * pageMap = pagemapdoc->nodeFromXPath( cs16("page-map"));
+                    if ( pageMap!=NULL )
+                        ReadEpubAdobePageMap( m_doc, pageMap, m_doc->getPageMap(), appender );
+                }
+                delete pagemapdoc;
+            }
+        }
+    }
+
+    if ( m_doc->getPageMap()->getChildCount() > 0 && !pageMapSource.empty() )
+        m_doc->getPageMap()->setSource(pageMapSource);
 
     writer.OnTagClose(L"", L"body");
     writer.OnStop();

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -130,6 +130,73 @@ void ReadEpubToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, l
     }
 }
 
+void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, ldomDocumentFragmentWriter & appender ) {
+    // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
+    if ( !mapRoot || !baseToc)
+        return;
+    lUInt16 ol_id = mapRoot->getDocument()->getElementNameIndex(L"ol");
+    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(L"li");
+    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(L"a");
+    lUInt16 span_id = mapRoot->getDocument()->getElementNameIndex(L"span");
+    for ( int i=0; i<5000; i++ ) {
+        ldomNode * li = mapRoot->findChildElement(LXML_NS_ANY, li_id, i);
+        if ( !li )
+            break;
+        LVTocItem * tocItem = NULL;
+        ldomNode * a = li->findChildElement(LXML_NS_ANY, a_id, -1);
+        if ( a ) {
+            lString16 href = a->getAttributeValue("href");
+            lString16 title = a->getText(' ');
+            if ( title.empty() ) {
+                // "If the a element contains [...] that do not provide intrinsic text alternatives,
+                // it must also include a title attribute with an alternate text rendition of the
+                // link label."
+                title = a->getAttributeValue("title");
+            }
+            title.trimDoubleSpaces(false, false, false);
+            if ( !href.empty() ) {
+                href = DecodeHTMLUrlString(href);
+                href = appender.convertHref(href);
+                if ( !href.empty() && href[0]=='#' ) {
+                    ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
+                    if ( target ) {
+                        ldomXPointer ptr(target, 0);
+                        tocItem = baseToc->addChild(title, ptr, lString16::empty_str);
+                        // Report xpointer to upper parent(s) that didn't have
+                        // one (no <a>) - but stop before the root node
+                        LVTocItem * tmp = baseToc;
+                        while ( tmp && tmp->getLevel() > 0 && tmp->getXPointer().isNull() ) {
+                            tmp->setXPointer(ptr);
+                            tmp = tmp->getParent();
+                        }
+                    }
+                }
+            }
+        }
+        // "The a element may optionally be followed by an ol ordered list representing
+        // a subsidiary content level below that heading (e.g., all the subsection
+        // headings of a section). The span element must be followed by an ol ordered
+        // list: it cannot be used in "leaf" li elements."
+        ldomNode * ol = li->findChildElement( LXML_NS_ANY, ol_id, -1 );
+        if ( ol ) { // there are sub items
+            if ( !tocItem ) {
+                // Make a LVTocItem to contain sub items
+                // There can be a <span>, with no href: children will set it to its own xpointer
+                lString16 title;
+                ldomNode * span = li->findChildElement(LXML_NS_ANY, span_id, -1);
+                if ( span ) {
+                    title = span->getText(' ');
+                    title.trimDoubleSpaces(false, false, false);
+                }
+                // If none, let title empty
+                tocItem = baseToc->addChild(title, ldomXPointer(), lString16::empty_str);
+            }
+            ReadEpubNavToc( doc, ol, tocItem, appender );
+        }
+    }
+}
+
+
 lString16 EpubGetRootFilePath(LVContainerRef m_arc)
 {
     // check root media type
@@ -759,7 +826,10 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         return false;
 
 
-    lString16 ncxHref;
+    bool isEpub3 = false;
+    lString16 epubVersion;
+    lString16 ncxHref; // epub2 TOC
+    lString16 navHref; // epub3 TOC
     lString16 coverId;
 
     LVEmbeddedFontList fontList;
@@ -777,6 +847,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 //            LVStreamRef out = LVOpenFileStream("/tmp/content.xml", LVOM_WRITE);
 //            doc->saveToStream(out, NULL, true);
 //        }
+
+        ldomNode * package = doc->nodeFromXPath(lString16("package"));
+        if ( package ) {
+            epubVersion = package->getAttributeValue("version");
+            if ( !epubVersion.empty() && epubVersion[0] >= '3' )
+                isEpub3 = true;
+        }
 
         CRPropRef m_doc_props = m_doc->getProps();
         // lString16 authors = doc->textFromXPath( cs16("package/metadata/creator"));
@@ -922,6 +999,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 epubItem->mediaType = mediaType;
                 epubItems.add( epubItem );
 
+                if ( isEpub3 && navHref.empty() ) {
+                    lString16 properties = item->getAttributeValue("properties");
+                    // We met properties="nav scripted"...
+                    if ( properties == L"nav" || properties.startsWith(L"nav ")
+                            || properties.endsWith(L" nav") || properties.pos(L" nav ") >= 0 ) {
+                        navHref = href;
+                    }
+                }
+
 //                // register embedded document fonts
 //                if (mediaType == L"application/vnd.ms-opentype"
 //                        || mediaType == L"application/x-font-otf"
@@ -1055,7 +1141,94 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         }
     }
 
-    if ( !ncxHref.empty() ) {
+    // EPUB3 documents may contain both a toc.ncx and a nav xhtml toc.
+    // We would have preferred to read first a toc.ncx if present, as it
+    // is more structured than nav toc (all items have a href), but it
+    // seems Sigil includes a toc.ncx for EPUB3, but does not keep it
+    // up-to-date, while it does for the nav toc.
+    if ( isEpub3 && !navHref.empty() ) {
+        // Parse toc nav if epub3
+        // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
+        navHref = LVCombinePaths(codeBase, navHref);
+        LVStreamRef stream = m_arc->OpenStream(navHref.c_str(), LVOM_READ);
+        lString16 codeBase = LVExtractPath( navHref );
+        if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
+            codeBase.append(1, L'/');
+        appender.setCodeBase(codeBase);
+        if ( !stream.isNull() ) {
+            ldomDocument * navDoc = LVParseXMLStream( stream );
+            if ( navDoc!=NULL ) {
+                // Find <nav epub:type="toc">
+                lUInt16 nav_id = navDoc->getElementNameIndex(L"nav");
+                ldomNode * navDocRoot = navDoc->getRootNode();
+                ldomNode * n = navDocRoot;
+                // Kobo falls back to other <nav type=> when no <nav type=toc> is found,
+                // let's do the same.
+                ldomNode * n_toc = NULL;
+                ldomNode * n_landmarks = NULL;
+                ldomNode * n_page_list = NULL;
+                if (n->isElement() && n->getChildCount() > 0) {
+                    int nextChildIndex = 0;
+                    n = n->getChildNode(nextChildIndex);
+                    while (true) {
+                        // Check only the first time we met a node (nextChildIndex == 0)
+                        // and not when we get back to it from a child to process next sibling
+                        if (nextChildIndex == 0) {
+                            if ( n->isElement() && n->getNodeId() == nav_id ) {
+                                lString16 type = n->getAttributeValue("type");
+                                if ( type == L"toc") {
+                                    n_toc = n;
+                                    break;
+                                }
+                                else if ( type == L"landmarks") {
+                                    n_landmarks = n;
+                                }
+                                else if ( type == L"page-list") {
+                                    n_page_list = n;
+                                }
+                            }
+                        }
+                        // Process next child
+                        if (n->isElement() && nextChildIndex < n->getChildCount()) {
+                            n = n->getChildNode(nextChildIndex);
+                            nextChildIndex = 0;
+                            continue;
+                        }
+                        // No more child, get back to parent and have it process our sibling
+                        nextChildIndex = n->getNodeIndex() + 1;
+                        n = n->getParentNode();
+                        if (!n) // back to root node
+                            break;
+                        if (n == navDocRoot && nextChildIndex >= n->getChildCount())
+                            // back to this node, and done with its children
+                            break;
+                    }
+                }
+                if ( !n_toc ) {
+                    if ( n_landmarks ) {
+                        n_toc = n_landmarks;
+                    }
+                    else if ( n_page_list ) {
+                        n_toc = n_page_list;
+                    }
+                }
+                if ( n_toc ) {
+                    // "Each nav element may contain an optional heading indicating the title
+                    // of the navigation list. The heading must be one of H1...H6."
+                    // We can't do much with this heading (that would not resolve to anything),
+                    // we could just add it as a top container item for the others, which will
+                    // be useless (and bothering), so let's just ignore it.
+                    // Get its first and single <OL> child
+                    ldomNode * ol_root = n_toc->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(L"ol"), -1 );
+                    if ( ol_root )
+                        ReadEpubNavToc( m_doc, ol_root, m_doc->getToc(), appender );
+                }
+                delete navDoc;
+            }
+        }
+    }
+    // For EPUB2 (or EPUB3 where no nav toc was found): read ncx toc
+    if ( m_doc->getToc()->getChildCount() == 0 && !ncxHref.empty() ) {
         LVStreamRef stream = m_arc->OpenStream(ncxHref.c_str(), LVOM_READ);
         lString16 codeBase = LVExtractPath( ncxHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
@@ -1068,6 +1241,23 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 if ( navMap!=NULL )
                     ReadEpubToc( m_doc, navMap, m_doc->getToc(), appender );
                 delete ncxdoc;
+            }
+        }
+    }
+    // If still no TOC, fallback to using the spine, as Kobo does.
+    if ( m_doc->getToc()->getChildCount() == 0 ) {
+        LVTocItem * baseToc = m_doc->getToc();
+        for ( int i=0; i<spineItemsNb; i++ ) {
+            if (spineItems[i]->mediaType == "application/xhtml+xml") {
+                lString16 title = spineItems[i]->id; // nothing much else to use
+                lString16 href = appender.convertHref(spineItems[i]->id);
+                if ( href.empty() || href[0]!='#' )
+                    continue;
+                ldomNode * target = m_doc->getNodeById(m_doc->getAttrValueIndex(href.substr(1).c_str()));
+                if ( !target )
+                    continue;
+                ldomXPointer ptr(target, 0);
+                LVTocItem * tocItem = baseToc->addChild(title, ptr, lString16::empty_str);
             }
         }
     }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -894,6 +894,49 @@ void LVDocView::updatePageNumbers(LVTocItem * item) {
 	}
 }
 
+LVPageMap * LVDocView::getPageMap() {
+    if (!m_doc)
+        return NULL;
+    if ( !m_doc->getPageMap()->hasValidPageInfo() ) {
+        updatePageMapInfo(m_doc->getPageMap());
+    }
+    return m_doc->getPageMap();
+}
+
+/// update page info for LVPageMapItems
+void LVDocView::updatePageMapInfo(LVPageMap * pagemap) {
+    // Ensure page and doc_y never go backward
+    int prev_page = 0;
+    int prev_doc_y = 0;
+    for (int i = 0; i < pagemap->getChildCount(); i++) {
+        LVPageMapItem * item = pagemap->getChild(i);
+        if (!item->getXPointer().isNull()) {
+            int doc_y = item->getDocY(true); // refresh
+            int page = -1;
+            if (doc_y >= 0) {
+                page = m_pages.FindNearestPage(doc_y, 0);
+                if (page < 0 && page >= getPageCount())
+                    page = -1;
+            }
+            item->_page = page;
+            if ( item->_page < prev_page )
+                item->_page = prev_page;
+            else
+                prev_page = item->_page;
+            if ( item->_doc_y < prev_doc_y )
+                item->_doc_y = prev_doc_y;
+            else
+                prev_doc_y = item->_doc_y;
+        }
+        else {
+            item->_page = prev_page;
+            item->_doc_y = prev_doc_y;
+        }
+    }
+    pagemap->_page_info_valid = true;
+}
+
+
 /// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
 /// path relative to document directory for non-container documents like HTML)
 LVStreamRef LVDocView::getDocumentFileStream( lString16 filePath ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.37k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.38k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0021
 
@@ -135,6 +135,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 #define COMPRESS_MISC_DATA          true
 #define COMPRESS_PAGES_DATA         true
 #define COMPRESS_TOC_DATA           true
+#define COMPRESS_PAGEMAP_DATA       true
 #define COMPRESS_STYLE_DATA         true
 
 //#define CACHE_FILE_SECTOR_SIZE 4096
@@ -202,10 +203,11 @@ enum CacheFileBlockType {
     CBT_TEXT_NODE,
     CBT_REND_PARAMS, //12
     CBT_TOC_DATA,
+    CBT_PAGEMAP_DATA,
     CBT_STYLE_DATA,
-    CBT_BLOB_INDEX, //15
+    CBT_BLOB_INDEX, //16
     CBT_BLOB_DATA,
-    CBT_FONT_DATA  //17
+    CBT_FONT_DATA  //18
 };
 
 
@@ -3419,6 +3421,7 @@ ldomNode * lxmlDocBase::getRootNode()
 
 ldomDocument::ldomDocument()
 : m_toc(this)
+, m_pagemap(this)
 #if BUILD_LITE!=1
 , _last_docflags(0)
 , _page_height(0)
@@ -3467,6 +3470,7 @@ lxmlDocBase::lxmlDocBase( lxmlDocBase & doc )
 ldomDocument::ldomDocument( ldomDocument & doc )
 : lxmlDocBase(doc)
 , m_toc(this)
+, m_pagemap(this)
 #if BUILD_LITE!=1
 , _def_font(doc._def_font) // default font
 , _def_style(doc._def_style)
@@ -4474,6 +4478,7 @@ int ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback, 
         // force recalculation of page numbers (even if not computed in this
         // session, they will be when loaded from cache next session)
         m_toc.invalidatePageNumbers();
+        m_pagemap.invalidatePageInfo();
         pages->clear();
         if ( showCover )
             pages->add( new LVRendPageInfo( _page_height ) );
@@ -12637,6 +12642,19 @@ bool ldomDocument::loadCacheFileContent(CacheLoadingCallback * formatCallback, L
             return false;
         }
     }
+    if (progressCallback) progressCallback->OnLoadFileProgress(85);
+    CRLog::trace("ldomDocument::loadCacheFileContent() - PageMap");
+    {
+        SerialBuf pagemapbuf(0,true);
+        if ( !_cacheFile->read( CBT_PAGEMAP_DATA, pagemapbuf ) ) {
+            CRLog::error("Error while reading PageMap data");
+            return false;
+        } else if ( !m_pagemap.deserialize(this, pagemapbuf) ) {
+            CRLog::error("PageMap data deserialization is failed");
+            return false;
+        }
+    }
+
 
     if (progressCallback) progressCallback->OnLoadFileProgress(90);
     if ( loadStylesData() ) {
@@ -12830,8 +12848,7 @@ ContinuousOperationResult ldomDocument::saveChanges( CRTimerUtil & maxTime, LVDo
         }
         CRLog::info("Saving render properties: styleHash=%x, stylesheetHash=%x, docflags=%x, width=%x, height=%x, nodeDisplayStyleHash=%x",
                     _hdr.render_style_hash, _hdr.stylesheet_hash, _hdr.render_docflags, _hdr.render_dx, _hdr.render_dy, _hdr.node_displaystyle_hash);
-
-        if (progressCallback) progressCallback->OnSaveCacheFileProgress(75);
+        if (progressCallback) progressCallback->OnSaveCacheFileProgress(73);
 
         CRLog::trace("ldomDocument::saveChanges() - TOC");
         {
@@ -12841,6 +12858,19 @@ ContinuousOperationResult ldomDocument::saveChanges( CRTimerUtil & maxTime, LVDo
                 return CR_ERROR;
             } else if ( !_cacheFile->write( CBT_TOC_DATA, tocbuf, COMPRESS_TOC_DATA ) ) {
                 CRLog::error("Error while writing TOC data");
+                return CR_ERROR;
+            }
+        }
+        if (progressCallback) progressCallback->OnSaveCacheFileProgress(76);
+
+        CRLog::trace("ldomDocument::saveChanges() - PageMap");
+        {
+            SerialBuf pagemapbuf(0,true);
+            if ( !m_pagemap.serialize(pagemapbuf) ) {
+                CRLog::error("PageMap data serialization is failed");
+                return CR_ERROR;
+            } else if ( !_cacheFile->write( CBT_PAGEMAP_DATA, pagemapbuf, COMPRESS_PAGEMAP_DATA ) ) {
+                CRLog::error("Error while writing PageMap data");
                 return CR_ERROR;
             }
         }
@@ -16690,6 +16720,112 @@ void ldomDocument::buildAlternativeToc()
     // cache file will have to be updated with the alt TOC
     setCacheFileStale(true);
     _toc_from_cache_valid = false; // to force update of page numbers
+}
+
+/// returns position pointer
+ldomXPointer LVPageMapItem::getXPointer()
+{
+    if ( _position.isNull() && !_path.empty() ) {
+        _position = _doc->createXPointer( _path );
+        if ( _position.isNull() ) {
+            CRLog::trace("LVPageMapItem node is not found for path %s", LCSTR(_path) );
+        } else {
+            CRLog::trace("LVPageMapItem node is found for path %s", LCSTR(_path) );
+        }
+    }
+    return _position;
+}
+
+/// returns position path
+lString16 LVPageMapItem::getPath()
+{
+    if ( _path.empty() && !_position.isNull())
+        _path = _position.toString();
+    return _path;
+}
+
+/// returns Y position
+int LVPageMapItem::getDocY(bool refresh)
+{
+#if BUILD_LITE!=1
+    if ( _doc_y < 0 || refresh )
+        _doc_y = getXPointer().toPoint().y;
+    if ( _doc_y < 0 && !_position.isNull() ) {
+        // We got a xpointer, that did not resolve to a point.
+        // It may be because the node it points to is invisible,
+        // which may happen with pagebreak spans (that may not
+        // be empty, and were set to "display: none").
+        ldomXPointerEx xp = _position;
+        if ( !xp.isVisible() ) {
+            if ( xp.nextVisibleText() ) {
+                _doc_y = xp.toPoint().y;
+            }
+            else {
+                xp = _position;
+                if ( xp.prevVisibleText() ) {
+                    _doc_y = xp.toPoint().y;
+                }
+            }
+        }
+    }
+    return _doc_y;
+#else
+    return 0;
+#endif
+}
+
+/// serialize to byte array (pointer will be incremented by number of bytes written)
+bool LVPageMapItem::serialize( SerialBuf & buf )
+{
+    buf << (lUInt32)_index << (lUInt32)_page << (lUInt32)_doc_y << _label << getPath();
+    return !buf.error();
+}
+
+/// deserialize from byte array (pointer will be incremented by number of bytes read)
+bool LVPageMapItem::deserialize( ldomDocument * doc, SerialBuf & buf )
+{
+    if ( buf.error() )
+        return false;
+    buf >> _index >> _page >> _doc_y >> _label >> _path;
+    return !buf.error();
+
+}
+/// serialize to byte array (pointer will be incremented by number of bytes written)
+bool LVPageMap::serialize( SerialBuf & buf )
+{
+    buf << (lUInt32)_page_info_valid << (lUInt32)_children.length() << _source;
+    if ( buf.error() )
+        return false;
+    for ( int i=0; i<_children.length(); i++ ) {
+        _children[i]->serialize( buf );
+        if ( buf.error() )
+            return false;
+    }
+    return !buf.error();
+}
+
+/// deserialize from byte array (pointer will be incremented by number of bytes read)
+bool LVPageMap::deserialize( ldomDocument * doc, SerialBuf & buf )
+{
+    if ( buf.error() )
+        return false;
+    lUInt32 childCount = 0;
+    lUInt32 pageInfoValid = 0;
+    buf >> pageInfoValid >> childCount >> _source;
+    if ( buf.error() )
+        return false;
+    _page_info_valid = (bool)pageInfoValid;
+    for ( int i=0; i<childCount; i++ ) {
+        LVPageMapItem * item = new LVPageMapItem(doc);
+        if ( !item->deserialize( doc, buf ) ) {
+            delete item;
+            return false;
+        }
+        _children.add( item );
+        if ( buf.error() )
+            return false;
+    }
+    return true;
 }
 
 


### PR DESCRIPTION
`Fix lvRect:isRectInside(rc) with 0-width or 0-height rect`
will allow closing https://github.com/koreader/koreader/issues/5991

`TOC: parse EPUB3 nav toc, fallback to spine when no toc`
will allow closing https://github.com/koreader/koreader/issues/4915.
EPUB3 nav toc, although less strict that EPUB2 ncx TOC (because some items may not have xpointers, and we require one for each TOC element), will have precedence if both are present, because Sigil may include both, and keep its nav TOC up-to-date, while neglecting to update the ncx TOC.
Also fallback to showing each element of the spine as a TOC item if no TOC is present (as Kobo does as described in https://github.com/kobolabs/epub-spec#table-of-contents-toc).

`Parse and cache various hardcopy page list maps`
will allow closing https://github.com/koreader/koreader/issues/4521.

Supported sources of page map/list (reference URLs in the code), checked in this order:
- EPUB3 `<nav epub:type="page-list">` in nav document
- EPUB2 `<pageList><pageTarget>` in ncx document
- Adobe page-map document referenced as `<spine page-map="page-map">`
(some samples in https://github.com/koreader/koreader/issues/4521#issuecomment-466057309)

The mapping xpointer > page label is stored in an object and in the cache, resolved to doc_y when needed, and is just made available to frontend code for it to handle them (no drawing of page labels is done by crengine - and it continues to work only with its own internal rendered page numbers).
So, this will need some helpers to do much of the work in base/cre.cpp, and I'll add a `reader/modules/readerpagemap.lua` new module.
(I named all that "PageMap" internally, because there is already the notion of "PageList" used in the page splitting code.)

It will not be often used (less than 5% of my publishers' EPUB have a page map/list), and most people will probably disable it when it appears, as it's rarely useful. It's just nice to have (for when you see in a book "See note page 48" and that references the hardcopy book, with no internal link to that note in the EPUB).

We'll then have this in KOReader (only when there is a pagemap in the book):
<kbd>![image](https://user-images.githubusercontent.com/24273478/77579273-53700e80-6eda-11ea-886e-ea912c356612.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/77579310-62ef5780-6eda-11ea-9809-d28ba70fc7ba.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/77579377-82868000-6eda-11ea-80c0-9397ea5ecddf.png)</kbd>
An option to use the source/hardcopy page number in the footer, TOC, Bookmark names, Goto and SkimTo widgets:
<kbd>![image](https://user-images.githubusercontent.com/24273478/77579495-b5c90f00-6eda-11ea-8367-e91771f3b819.png)</kbd>
and one to show the page labels in the margin:
<kbd>![image](https://user-images.githubusercontent.com/24273478/77579550-cd07fc80-6eda-11ea-858e-e0b2365f488c.png)</kbd>

I'll need some help with the wording of the frontend name for this feature and these page maps/lists I used "Source pages" because I'm not sure it's always reference to hardcopy paper book pages, but I dunno...
Opinions and suggestions welcome (here or later in the frontend PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/336)
<!-- Reviewable:end -->
