### PR TITLE
Allow providing and using multiple fallback fonts

### DIFF
--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -18,6 +18,7 @@
 #define PROP_LOG_AUTOFLUSH           "crengine.log.autoflush"
 #define PROP_FONT_SIZE               "crengine.font.size"
 #define PROP_FALLBACK_FONT_FACE      "crengine.font.fallback.face"
+    // multiple fallback font faces allowed, separated by '|' (name kept singular for compatibility)
 #define PROP_STATUS_FONT_COLOR       "crengine.page.header.font.color"
 #define PROP_STATUS_FONT_FACE        "crengine.page.header.font.face"
 #define PROP_STATUS_FONT_SIZE        "crengine.page.header.font.size"

--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -7,13 +7,10 @@
 #endif
 
 #if USE_LIBUNIBREAK==1
-#include <linebreak.h>
-    // linebreakdef.h is not wrapped by this, unlike linebreak.h
-    // (not wrapping results in "undefined symbol" with the original
-    // function name kinda obfuscated)
     #ifdef __cplusplus
     extern "C" {
     #endif
+#include <linebreak.h>
 #include <linebreakdef.h>
     #ifdef __cplusplus
     }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6307,12 +6307,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_FONT_FACE) {
             setDefaultFontFace(UnicodeToUtf8(value));
         } else if (name == PROP_FALLBACK_FONT_FACE) {
-            lString8 oldFace = fontMan->GetFallbackFontFace();
-            if ( UnicodeToUtf8(value)!=oldFace )
-                fontMan->SetFallbackFontFace(UnicodeToUtf8(value));
-            value = Utf8ToUnicode(fontMan->GetFallbackFontFace());
-            if ( UnicodeToUtf8(value) != oldFace ) {
-                REQUEST_RENDER("propsApply  fallback font face")
+            lString8 oldFaces = fontMan->GetFallbackFontFaces();
+            if ( UnicodeToUtf8(value)!=oldFaces )
+                fontMan->SetFallbackFontFaces(UnicodeToUtf8(value));
+            value = Utf8ToUnicode(fontMan->GetFallbackFontFaces());
+            if ( UnicodeToUtf8(value) != oldFaces ) {
+                REQUEST_RENDER("propsApply  fallback font faces")
             }
         } else if (name == PROP_STATUS_FONT_FACE) {
             setStatusFontFace(UnicodeToUtf8(value));

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -924,13 +924,13 @@ public:
     {
         #if (USE_LIBUNIBREAK==1)
         struct LineBreakContext lbCtx;
-        // Let's init it before the first char, by adding a leading space which
-        // will be treated as WJ (Word Joiner, non-breakable) and should not
-        // change the behaviour with the real first char coming up. We then
-        // can just use lb_process_next_char() with the real text.
+        // Let's init it before the first char, by adding a leading Zero-Width Joiner
+        // (Word Joiner, non-breakable) which should not change the behaviour with
+        // the real first char coming up. We then can just use lb_process_next_char()
+        // with the real text.
         // The lang lb_props will be plugged in from the TextLangCfg of the
-        // coming up text node.
-        lb_init_break_context(&lbCtx, 0x0020, NULL);
+        // coming up text node. We provide NULL in the meantime.
+        lb_init_break_context(&lbCtx, 0x200D, NULL); // ZERO WIDTH JOINER
         #endif
 
         m_has_bidi = false; // will be set if fribidi detects it is bidirectionnal text
@@ -1171,45 +1171,48 @@ public:
                         ch = src->lang_cfg->getLBCharSubFunc()(m_text, pos, len-1 - k);
                     }
                     int brk = lb_process_next_char(&lbCtx, (utf32_t)ch);
-                    // printf("between <%c%c>: brk %d\n", m_text[pos-1], m_text[pos], brk);
-                    if (brk != LINEBREAK_ALLOWBREAK) {
-                        m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
-                    }
-                    else {
-                        m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
-                        // brk is set on the last space in a sequence of multiple spaces.
-                        //   between <ne>: brk 2
-                        //   between <ed>: brk 2
-                        //   between <d.>: brk 2
-                        //   between <. >: brk 2
-                        //   between <  >: brk 2
-                        //   between <  >: brk 2
-                        //   between < T>: brk 1
-                        //   between <Th>: brk 2
-                        //   between <he>: brk 2
-                        //   between <ey>: brk 2
-                        //   between <y >: brk 2
-                        //   between <  >: brk 2
-                        //   between < h>: brk 1
-                        //   between <ha>: brk 2
-                        //   between <av>: brk 2
-                        //   between <ve>: brk 2
-                        //   between <e >: brk 2
-                        //   between < a>: brk 1
-                        //   between <as>: brk 2
-                        // Given the algorithm described in addLine(), we want the break
-                        // after the first space, so the following collapsed spaces can
-                        // be at start of next line where they will be ignored.
-                        // (Not certain this is really needed, but let's do it, as the
-                        // code expecting that has been quite well tested and fixed over
-                        // the months, so let's avoid adding uncertainty.)
-                        if ( m_flags[pos-1] & LCHAR_IS_COLLAPSED_SPACE ) {
-                            // We have spaces before, and if we are allowed to break,
-                            // the break is allowed on all preceeding spaces.
-                            int j = pos-2;
-                            while ( j >= 0 && ( (m_flags[j] & LCHAR_IS_COLLAPSED_SPACE) || m_text[j] == ' ' ) ) {
-                                m_flags[j] |= LCHAR_ALLOW_WRAP_AFTER;
-                                j--;
+                    if ( pos > 0 ) {
+                        // printf("between <%c%c>: brk %d\n", m_text[pos-1], m_text[pos], brk);
+                        // printf("between <%x.%x>: brk %d\n", m_text[pos-1], m_text[pos], brk);
+                        if (brk != LINEBREAK_ALLOWBREAK) {
+                            m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
+                        }
+                        else {
+                            m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
+                            // brk is set on the last space in a sequence of multiple spaces.
+                            //   between <ne>: brk 2
+                            //   between <ed>: brk 2
+                            //   between <d.>: brk 2
+                            //   between <. >: brk 2
+                            //   between <  >: brk 2
+                            //   between <  >: brk 2
+                            //   between < T>: brk 1
+                            //   between <Th>: brk 2
+                            //   between <he>: brk 2
+                            //   between <ey>: brk 2
+                            //   between <y >: brk 2
+                            //   between <  >: brk 2
+                            //   between < h>: brk 1
+                            //   between <ha>: brk 2
+                            //   between <av>: brk 2
+                            //   between <ve>: brk 2
+                            //   between <e >: brk 2
+                            //   between < a>: brk 1
+                            //   between <as>: brk 2
+                            // Given the algorithm described in addLine(), we want the break
+                            // after the first space, so the following collapsed spaces can
+                            // be at start of next line where they will be ignored.
+                            // (Not certain this is really needed, but let's do it, as the
+                            // code expecting that has been quite well tested and fixed over
+                            // the months, so let's avoid adding uncertainty.)
+                            if ( m_flags[pos-1] & LCHAR_IS_COLLAPSED_SPACE ) {
+                                // We have spaces before, and if we are allowed to break,
+                                // the break is allowed on all preceeding spaces.
+                                int j = pos-2;
+                                while ( j >= 0 && ( (m_flags[j] & LCHAR_IS_COLLAPSED_SPACE) || m_text[j] == ' ' ) ) {
+                                    m_flags[j] |= LCHAR_ALLOW_WRAP_AFTER;
+                                    j--;
+                                }
                             }
                         }
                     }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1500,6 +1500,8 @@ public:
             lUInt32 prevScript = HB_SCRIPT_COMMON;
             hb_unicode_funcs_t* _hb_unicode_funcs = hb_unicode_funcs_get_default();
         #endif
+        int first_word_len = 0; // set to -1 when done with it (only used to check
+                                // for single char first word, see below)
         for ( i=0; i<=m_length; i++ ) {
             LVFont * newFont = NULL;
             lInt16 newLetterSpacing = 0;
@@ -1672,10 +1674,32 @@ public:
                             // We can just account for the space reduction (or increase) in cumulative_width_removed
                             cumulative_width_removed += char_width - scaled_width;
                             widths[k] -= cumulative_width_removed;
+                            if ( first_word_len >= 0 ) { // This is the space (or nbsp) after first word
+                                if ( first_word_len == 1 ) { // Previous word is a single char
+                                    if ( isLeftPunctuation(m_text[k-1]) ) {
+                                        // This space follows one of the common opening quotation marks or
+                                        // dashes used to introduce a quotation or a part of a dialog:
+                                        // https://en.wikipedia.org/wiki/Quotation_mark
+                                        // Don't allow this space to change width, so text justification
+                                        // doesn't move away next word, so that other similar paragraphs
+                                        // get their real first words vertically aligned.
+                                        flags[k] &= ~LCHAR_IS_SPACE;
+                                        // Note: we do this check here, with the text still in logical
+                                        // order, so we get that working with RTL text too (where, in
+                                        // visual order, we'll have lost track of which word is the
+                                        // first word).
+                                    }
+                                }
+                                first_word_len = -1; // We don't need to deal with this anymore
+                            }
                         }
                         else {
                             // remove, from the measured cumulative width, what we previously removed
                             widths[k] -= cumulative_width_removed;
+                            if ( first_word_len >= 0 ) {
+                                // Not a collapsed space and not a space: this will be part of first word
+                                first_word_len++;
+                            }
                         }
                         m_widths[start + k] = lastWidth + widths[k];
                         #if (USE_LIBUNIBREAK==1)
@@ -2702,16 +2726,11 @@ public:
                         // increased if needed (for text justification), so actually
                         // making that space larger or smaller.
                         bool can_adjust_width = true;
-                        if ( wstart == 0 && word->t.len == 2 && isLeftPunctuation(m_text[0]) ) {
-                            // Single char (with space) at start of line is one of the
-                            // common opening quotation marks or dashes used to introduce
-                            // a quotation or a part of a dialog:
-                            //   https://en.wikipedia.org/wiki/Quotation_mark
-                            // Don't allow the following space to change width, so other
-                            // similar lines get their real first word similarly aligned.
-                            can_adjust_width = false;
-                        }
-                        else if ( word->t.len>=2 && i>=2 && m_text[i-1]==UNICODE_NO_BREAK_SPACE
+                        // Note: checking if the first word of first line is one of the
+                        // common opening quotation marks or dashes is done in measureText(),
+                        // to have it work also with BiDi/RTL text (checking that here
+                        // would be too late, as reordering has been done).
+                        if ( word->t.len>=2 && i>=2 && m_text[i-1]==UNICODE_NO_BREAK_SPACE
                                                          && m_text[i-2]==UNICODE_NO_BREAK_SPACE ) {
                             // condition for double nbsp after run-in footnote title
                             can_adjust_width = false;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.39k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0022
+#define FORMATTING_VERSION_ID 0x0023
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
`Simplify libunibreak includes`
See https://github.com/koreader/crengine/pull/337#discussion_r410838779

`Text: fix read/write outside array bounds`
Fix crash that could happen (in rare situations) since #337.
(The large diff is just wrapping that section with `if ( pos > 0 ) {`).
Witnessed with an embedded float (so, malloc'ed dynamic buffers), being a `<bdi>` which made text start with U+2068 (FIRST STRONG ISOLATE, which happens to be breakable after a leading space), leading to `|= LCHAR_ALLOW_WRAP_AFTER` modifying byte at -1, causing a double free (while
`&= ~LCHAR_ALLOW_WRAP_AFTER`, done when no break allowed, did not cause any harm.)
Also switch to using a Zero-Width Joiner instead of a space as the initial libunibreak char.

`lvtextfm: dont adjust space after initial quotation mark/dash (rework)`
Rework f41517d so it works even when there are leading collapsed spaces, and probably too on BiDi/RTL text (not tested).
Didn't work when there were a collapsed space at start before the dash, like with the 2nd line here (before | after):
<kbd>![space_dash_space](https://user-images.githubusercontent.com/24273478/80213032-d949bb80-8638-11ea-89ca-d99e8c89ae16.png)</kbd>

`Fonts: allow providing and using multiple fallback fonts`
As our use of the fallback font was a recursive calls, we can provide chained fallback fonts.
As one of the fallback font could be the main font, we need to use first getFallbackFont() (to get the first fallback font, even on a font among these fallback fonts), and getNextFallbackFont() to get the chained fallback font.
Caveat: we might try rendering/drawing with the main font twice if it is among the fallback fonts (but avoiding that wouldn't make this change as simple).
Wished for in #307.

We'll have in frontend something like that (can be discussed, we already had a first round of discussion for the UI fallback fonts in https://github.com/koreader/koreader/pull/3942):
```lua
    -- Reasons for the fallback font ordering:
    -- - Noto Sans CJK SC before FreeSans/Serif, as it has nice and larger symbol for Wikipedia EPUB headings)
    -- - FreeSerif after most, has it has good coverage but smaller glyphs (and most other fonts are better looking)
    -- - FreeSans has some coverage that FreeSerif has not - and is usually fine along other fonts (even serif fonts)
    -- - Noto Serif & Sans at the end (just in case). A user can select them as fallback to move them at front
    --   (depending whether his main font is serif or sans). Moving them before FreeSans would need one to set
    --   FreeSans as fallback to get its nice glyphes, which would override Noto Sans CJK good symbol glyphs
    --   with smaller ones.
    fallback_fonts = {
        "Noto Sans CJK SC",
        "Noto Sans Arabic UI",
        "Noto Sans Devanagari UI",
        "FreeSans",
        "FreeSerif",
        "Noto Serif",
        "Noto Sans",
    },
```
Users will still be able to only set one fallback font, which will be put at start of this list. If the font is already in that list, it will be moved first. This allows some bit of customisation, while always providing large coverage.
Might allow closing https://github.com/koreader/koreader/issues/5277.

We get complete coverage for https://r12a.github.io/scripts/tutorial/summaries/wrapping :
<kbd>![image](https://user-images.githubusercontent.com/24273478/80214932-f3d16400-863b-11ea-9ad7-2c140552e305.png)</kbd>
and quite a bit more for https://r12a.github.io/scripts/phrases, except:
Balinese, Khmer, Mongolian, Myanmar, Telugu, Tibetan (and hyeroglyphs for Ancient egyptian :)
And possibly Urdu which should be a bit tilted arabic and expects a "nastaliq" font we don't provide - and that it seems we/HB wouldn't render very well if provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/339)
<!-- Reviewable:end -->
