### PR TITLE
Font: fix wrong usage of Harfbuzz y_offset

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2869,7 +2869,7 @@ public:
                                         item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), w);
                             #endif
                             buf->Draw(x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
-                                      y + _baseline - item->origin_y + FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
+                                      y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
                                       item->bmp,
                                       item->bmp_width,
                                       item->bmp_height,


### PR DESCRIPTION
Shows up when using an Arabic nastaliq font, see https://github.com/koreader/koreader/pull/6090#issuecomment-619418198 (and above).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/340)
<!-- Reviewable:end -->
