### PR TITLE
Text: fix possible bad widths after collapsed spaces

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1688,8 +1688,9 @@ public:
                                 int scaled_width = char_width * m_pbuffer->space_width_scale_percent / 100;
                                 // We can just account for the space reduction (or increase) in cumulative_width_removed
                                 cumulative_width_removed += char_width - scaled_width;
-                                widths[k] -= cumulative_width_removed;
                             }
+                            // remove, from the measured cumulative width, what we just, and previously, removed
+                            widths[k] -= cumulative_width_removed;
                             if ( first_word_len >= 0 ) { // This is the space (or nbsp) after first word
                                 if ( first_word_len == 1 ) { // Previous word is a single char
                                     if ( isLeftPunctuation(m_text[k-1]) ) {


### PR DESCRIPTION
Fix Issue noticed at https://github.com/koreader/koreader/pull/6112#issuecomment-623679395 and introduced by previous commit (2504a403, #341), witnessed only with `space_width_scale_percent=100`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/342)
<!-- Reviewable:end -->
