### PR TITLE
Adds support for "display: ruby" and <ruby> elements

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -146,6 +146,22 @@ u, ins                  { text-decoration: underline; }
 del, s, strike          { text-decoration: line-through; }
 a                       { text-decoration: underline; color: gray; }
 
+/* Ruby support */
+ruby {
+    /* These will have no effect when ruby is reset to display: inline */
+    text-align: center;
+    text-indent: 0;
+}
+rb, rubyBox[T=rb] {
+    line-height: 1;
+}
+rt, rubyBox[T=rt] {
+    line-height: 1.2;
+    font-size: 50%;
+    font-variant-east-asian: ruby;
+    -cr-hint: text-selection-skip;
+}
+
 /* No support for the "quotes:" property, these will use default quote chars */
 q::before               { content: open-quote; }
 q::after                { content: close-quote; }

--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -112,7 +112,6 @@ sub, sup {
   font-size: smaller;
 }
 
-/* crengine? : these display: ruby* would fallback to 'inline', should it be 'none' ? */
 ruby {
   display: ruby;
 }
@@ -140,6 +139,22 @@ rtc {
 
 ruby, rb, rt, rbc, rtc {
   unicode-bidi: isolate;
+}
+
+/* crengine+: additionally needed for prettier Ruby support */
+ruby {
+    /* These will have no effect when ruby is reset to display: inline */
+    text-align: center;
+    text-indent: 0;
+}
+rb, rubyBox[T=rb] {
+    line-height: 1;
+}
+rt, rubyBox[T=rt] {
+    line-height: 1.2;
+    font-size: 50%;
+    font-variant-east-asian: ruby;
+    -cr-hint: text-selection-skip;
 }
 
 /* crengine-: not supported
@@ -254,7 +269,7 @@ pre[dir=auto i] {
 */
 
 /* Quotes */
-/* crengine-: not supported
+/* crengine-: not supported, but proper quote by language ensured by textlang.cpp
 :root {
   quotes: '\201c' '\201d' '\2018' '\2019';
 }

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -30,7 +30,7 @@ enum css_display_t {
     css_d_inline,  // All elements starts being css_d_inline, unless otherwise specified in fb2def.h
     // Above are those that define a mostly inline container, below those that define a mostly block container
     css_d_block,
-    css_d_list_item,        // display: -cr-list-item-final (was used before 20180524 for display: list-item)
+    css_d_list_item_legacy, // display: -cr-list-item-final (was used before 20180524 for display: list-item)
     css_d_list_item_block,  // display: list-item
     css_d_inline_block,
     css_d_inline_table, // (needs to be before css_d_table, as we use tests like if: (style->display > css_d_table))

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -26,6 +26,7 @@
 // Especially don't change the order of these ones, as we use "style->display > css_d_something" like tests
 enum css_display_t {
     css_d_inherit, // Inheritance not implemented: should not be seen, unless specified in CSS, which then behave as inline
+    css_d_ruby,    // Behave as inline, but inner content might be wrapped in a table like structure
     css_d_run_in,  // Rarely used display type (but used as a solution to inline FB2 footnotes)
     css_d_inline,  // All elements starts being css_d_inline, unless otherwise specified in fb2def.h
     // Above are those that define a mostly inline container, below those that define a mostly block container

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -22,17 +22,18 @@
 
 // The order of items in following enums should match the order in the tables in src/lvstsheet.cpp
 /// display property values
+
+// Especially don't change the order of these ones, as we use "style->display > css_d_something" like tests
 enum css_display_t {
-    css_d_inherit,
-    css_d_inline,
+    css_d_inherit, // Inheritance not implemented: should not be seen, unless specified in CSS, which then behave as inline
+    css_d_run_in,  // Rarely used display type (but used as a solution to inline FB2 footnotes)
+    css_d_inline,  // All elements starts being css_d_inline, unless otherwise specified in fb2def.h
+    // Above are those that define a mostly inline container, below those that define a mostly block container
     css_d_block,
     css_d_list_item,        // display: -cr-list-item-final (was used before 20180524 for display: list-item)
     css_d_list_item_block,  // display: list-item
     css_d_inline_block,
     css_d_inline_table, // (needs to be before css_d_table, as we use tests like if: (style->display > css_d_table))
-    css_d_run_in, 
-    css_d_compact, 
-    css_d_marker, 
     css_d_table, 
     css_d_table_row_group, 
     css_d_table_header_group, 

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -266,6 +266,11 @@ XS_ATTR( role )
 XS_ATTR( dir )
 XS_ATTR( lang )
 XS_ATTR( recindex ) // used with mobi images
+// Note that attributes parsed in the HTML are lowercased, unlike the ones
+// we explicitely set while building the DOM. So, for our internal elements
+// needs, let's use some uppercase to avoid conflicts with HTML content
+// and the risk to have them matched by publishers CSS selectors.
+XS_ATTR( T )      // to flag subtype of boxing internal elements if needed
 XS_ATTR( Before ) // for pseudoElem internal element
 XS_ATTR( After )  // for pseudoElem internal element
 // Other classic attributes present in html5.css

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -36,6 +36,8 @@ XS_BEGIN_TAGS
 XS_TAG1T( autoBoxing )
 // Internal element for tabular elements added to complete incomplete tables
 XS_TAG1T( tabularBox )
+// Internal element for ruby wrapping completion (so we can render them as inline-table with tweaks)
+XS_TAG1I( rubyBox )
 // Internal element for float rendering
 XS_TAG1T( floatBox )
 // Internal element for inline-block and inline-table rendering
@@ -165,6 +167,14 @@ XS_TAG1I( tt )
 XS_TAG1I( u )
 XS_TAG1I( var )
 
+// Ruby elements (defaults to inline)
+XS_TAG1D( ruby, true, css_d_ruby, css_ws_normal )
+XS_TAG1I( rbc ) // no more in HTML5, but in 2001's https://www.w3.org/TR/ruby/
+XS_TAG1I( rtc )
+XS_TAG1I( rb )
+XS_TAG1I( rt )
+XS_TAG1I( rp )
+
 // EPUB3 elements (in ns_epub - otherwise set to inline like any unknown element)
 XS_TAG1I( switch )  // <epub:switch>
 XS_TAG1I( case )    // <epub:case required-namespace="...">
@@ -242,6 +252,7 @@ XS_ATTR( width )
 XS_ATTR( height )
 XS_ATTR( colspan )
 XS_ATTR( rowspan )
+XS_ATTR( rbspan )
 XS_ATTR( align )
 XS_ATTR( valign )
 XS_ATTR( currency )

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -119,7 +119,7 @@ void initFormatData( ldomNode * node );
 /// initializes rendering method for node
 int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing );
 /// converts style to text formatting API flags
-lUInt32 styleToTextFmtFlags( const css_style_ref_t & style, lUInt32 oldflags, int direction=REND_DIRECTION_UNSET );
+lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction=REND_DIRECTION_UNSET );
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
                        int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL );

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -36,10 +36,12 @@
 #define RENDER_RECT_FLAG_NO_CLEAR_OWN_FLOATS                0x0020
 #define RENDER_RECT_FLAG_FINAL_FOOTPRINT_AS_SAVED_FLOAT_IDS 0x0040
 #define RENDER_RECT_FLAG_FLOATBOX_IS_RIGHT                  0x0080
+#define RENDER_RECT_FLAG_NO_INTERLINE_SCALE_UP              0x0100 // for ruby elements to not scale up
 
-#define RENDER_RECT_SET_FLAG(r, f)   ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )
-#define RENDER_RECT_UNSET_FLAG(r, f) ( r.setFlags( r.getFlags() & ~RENDER_RECT_FLAG_##f ) )
-#define RENDER_RECT_HAS_FLAG(r, f)   ( (bool)(r.getFlags() & RENDER_RECT_FLAG_##f) )
+#define RENDER_RECT_SET_FLAG(r, f)     ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )
+#define RENDER_RECT_UNSET_FLAG(r, f)   ( r.setFlags( r.getFlags() & ~RENDER_RECT_FLAG_##f ) )
+#define RENDER_RECT_HAS_FLAG(r, f)     ( (bool)(r.getFlags() & RENDER_RECT_FLAG_##f) )
+#define RENDER_RECT_PTR_HAS_FLAG(r, f) ( (bool)(r->getFlags() & RENDER_RECT_FLAG_##f) )
 
 #define RENDER_RECT_FLAG_DIRECTION_MASK                     0x0007
 #define RENDER_RECT_SET_DIRECTION(r, d)   ( r.setFlags( r.getFlags() | d ) )
@@ -130,7 +132,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
 /// renders table element
 int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
                  bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,
-                 bool pb_inside_avoid=false, bool enhanced_rendering=false );
+                 bool pb_inside_avoid=false, bool enhanced_rendering=false, bool is_ruby_table=false );
 /// sets node style
 void setNodeStyle( ldomNode * node, css_style_ref_t parent_style, LVFontRef parent_font );
 /// copy style

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -279,7 +279,6 @@ enum lvdom_element_render_method
     erm_final,         ///< final element: render the whole it's content as single render block
     erm_inline,        ///< inline element
     erm_runin,         ///< run-in (used as a solution to inline FB2 footnotes)
-    erm_list_item,     ///< obsolete/legacy: render as block element as list item
     erm_table,         ///< table element: render as table
     erm_table_row_group,    ///< table row group
     erm_table_header_group, ///< table header group

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -278,18 +278,17 @@ enum lvdom_element_render_method
     erm_block,         ///< render as block element (render as containing other elements)
     erm_final,         ///< final element: render the whole it's content as single render block
     erm_inline,        ///< inline element
-    erm_mixed,         ///< block and inline elements are mixed: autobox inline portions of nodes; TODO
-    erm_list_item,     ///< render as block element as list item
+    erm_runin,         ///< run-in (used as a solution to inline FB2 footnotes)
+    erm_list_item,     ///< obsolete/legacy: render as block element as list item
     erm_table,         ///< table element: render as table
-    erm_table_row_group, ///< table row group
+    erm_table_row_group,    ///< table row group
     erm_table_header_group, ///< table header group
     erm_table_footer_group, ///< table footer group
-    erm_table_row,  ///< table row
+    erm_table_row,          ///< table row
     erm_table_column_group, ///< table column group
-    erm_table_column, ///< table column
-    erm_table_cell, ///< table cell
-    erm_table_caption, ///< table caption
-    erm_runin          ///< run-in
+    erm_table_column,       ///< table column
+    erm_table_caption,      ///< table caption // XXX = erm_final
+    // Note that table cells always become either erm_block or erm_final depending on their content
 };
 
 /// node format record

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -287,8 +287,8 @@ enum lvdom_element_render_method
     erm_table_row,          ///< table row
     erm_table_column_group, ///< table column group
     erm_table_column,       ///< table column
-    erm_table_caption,      ///< table caption // XXX = erm_final
     // Note that table cells always become either erm_block or erm_final depending on their content
+    // and that table captions are set erm_final.
 };
 
 /// node format record

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1130,7 +1130,7 @@ public:
                 printf("TABLE WIDTHS step3: cols[%d]: %d%% %dpx (min:%d / max:%d)\n",
                     x, cols[x]->percent, cols[x]->width, cols[x]->min_width, cols[x]->max_width);
         #endif
-        bool canFitMinWidths = (sumMinWidths > 0 && sumMinWidths < assignable_width);
+        bool canFitMinWidths = (sumMinWidths > 0 && sumMinWidths <= assignable_width);
         // new pass: resize columns with originally unspecified widths
         int rw=0;
         int dist_nb_cols = 0;
@@ -9099,6 +9099,10 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
     // we only handle list-style-position/text-align combinations vs direction,
     // which have different rendering methods.)
 
+    #ifdef DEBUG_GETRENDEREDWIDTHS
+        printf("GRW node: %s\n", UnicodeToLocal(ldomXPointer(node, 0).toString()).c_str());
+    #endif
+
     if ( node->isElement() && !processNodeAsText ) {
         int m = node->getRendMethod();
         if (m == erm_invisible)
@@ -9384,15 +9388,161 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     _minWidth = curWordWidth;
             }
         }
-        // if (m == erm_block) // Block node that contains other stacked block or final nodes
-        // Not dealing with other rendering methods may return widths of 0 (and
-        // on a nested inner table with erm_table, would ask to render this inner
-        // table in a width of 0).
-        // So, we treat all other erm_* as erm_block (which will obviously be
-        // wrong for erm_table* with more than 1 column, but it should give a
-        // positive enough width to draw something).
-        //   Update: we use a trick when erm_table_row below.
-        else {
+        else if (m == erm_table) {
+            // Table: a bit hard to estimate a table min/max widths without going
+            // at rendering it, but let's do our best.
+            // We can't just add, for each row, the widths of the cells, as:
+            //   |  AB  | CD |     would get sized to contain "EFGHK", while
+            //   | EFGH | K  |     it should have been sized to contain "EFGHCD"
+            //   |   LMNOP   |
+            // So, we need to gather cells min and max widths to compute accurate
+            // columns min and max widths.
+            // We won't handle well cells with colspan, as that would be too complicated
+            // here (we'll still put into columns cells before the first with a colspan).
+            // So, we'll still compute the addition of each row's cells (which might
+            // give the right min/max width of a row with colspan): we'll take the
+            // largest widths from these 2 computations.
+            typedef struct CellWidths {
+                int min_w;
+                int max_w;
+                bool colspan_involved;
+                CellWidths() : min_w(0), max_w(0), colspan_involved(false) {};
+                CellWidths(int min, int max, bool csi=false)
+                    : min_w(min), max_w(max), colspan_involved(csi) {};
+            } CellWidths;
+            typedef LVArray<CellWidths> RowCells;
+            LVArray<RowCells> table;
+            int seen_nb_cells = 2; // for RowCells() initial allocation, to avoid realloc
+
+            // Non-recursive sub tree walker, to find erm_table_row nodes
+            ldomNode * n = node;
+            if ( n && n->getChildCount() > 0 ) {
+                int index = 0;
+                n = n->getChildNode(index);
+                while ( true ) {
+                    // Check the node only the first time we meet it (index == 0) and
+                    // not when we get back to it from a child to process next sibling
+                    if ( index == 0 ) {
+                        if ( n->getRendMethod() == erm_table_row ) {
+                            // Non-recursive sub tree walker found what we are looking for
+                            //
+                            // Measures cells in that row
+                            RowCells row;
+                            row.reserve(seen_nb_cells);
+                            bool colspan_involved = false;
+                            for (int i = 0; i < n->getChildCount(); i++) {
+                                ldomNode * child = n->getChildNode(i);
+                                if ( child->isText() ) {
+                                    // Ignore text nodes among table elements (they are usually
+                                    // dropped when parsing the HTML, but for <ruby>, parsed as
+                                    // inline but later acquiring erm_table* rendering methods,
+                                    // we might find some text nodes here.
+                                    continue;
+                                }
+                                int _maxw = 0;
+                                int _minw = 0;
+                                int _curMaxWidth = 0;
+                                int _curWordWidth = 0;
+                                bool _collapseNextSpace = true;
+                                int _lastSpaceWidth = 0;
+                                getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
+                                    _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, lang_cfg);
+                                int cs = StrToIntPercent( child->getAttributeValue(attr_colspan).c_str() );
+                                if ( cs > 1 ) { // 0 if no attribute
+                                    // Keep flagging next cells, as their mapping to columns is now messed up
+                                    colspan_involved = true;
+                                }
+                                else { // also check obsolete rbspan attribute for <ruby> tables
+                                    cs = StrToIntPercent( child->getAttributeValue(attr_rbspan).c_str() );
+                                    if ( cs > 1 ) {
+                                        colspan_involved = true;
+                                    }
+                                }
+                                row.add( CellWidths(_minw, _maxw, colspan_involved) );
+                            }
+                            if ( row.length() > seen_nb_cells )
+                                seen_nb_cells = row.length();
+                            table.add(row);
+                            //
+                            // Non-recursive sub tree walker (continued)
+                            index = n->getChildCount(); // Skip walking/entering that row
+                        }
+                    }
+                    // Process next child
+                    if ( index < n->getChildCount() ) {
+                        n = n->getChildNode(index);
+                        index = 0;
+                        continue;
+                    }
+                    // No more child, get back to parent and have it process our sibling
+                    index = n->getNodeIndex() + 1;
+                    n = n->getParentNode();
+                    if ( n == node && index >= n->getChildCount() )
+                        break; // back to top node and all its children visited
+                }
+            } // Done with non-recursive sub tree walker
+
+            // nb_columns is the largest nb of cells in a row
+            int nb_columns = 0;
+            for (int r=0; r<table.length(); r++) {
+                int row_len = table[r].length();
+                if ( row_len > nb_columns ) {
+                    nb_columns = row_len;
+                }
+            }
+            // We still compute cumulative cells widths (might be right when colspan involved)
+            int cumulative_min_width = 0;
+            int cumulative_max_width = 0;
+            //
+            RowCells columns(nb_columns, CellWidths()); // Columns widths
+            for (int r=0; r<table.length(); r++) {
+                bool giveup_columns = false;
+                int row_cumul_min_w = 0;
+                int row_cumul_max_w = 0;
+                int row_len = table[r].length();
+                for (int c=0; c<row_len; c++) {
+                    if ( table[r][c].colspan_involved ) {
+                        // cells from now on do not map to columns anymore
+                        giveup_columns = true;
+                    }
+                    if ( !giveup_columns ) {
+                        if ( columns[c].min_w < table[r][c].min_w )
+                             columns[c].min_w = table[r][c].min_w;
+                        if ( columns[c].max_w < table[r][c].max_w )
+                             columns[c].max_w = table[r][c].max_w;
+                    }
+                    row_cumul_min_w += table[r][c].min_w;
+                    row_cumul_max_w += table[r][c].max_w;
+                }
+                if ( cumulative_min_width < row_cumul_min_w )
+                     cumulative_min_width = row_cumul_min_w;
+                if ( cumulative_max_width < row_cumul_max_w )
+                     cumulative_max_width = row_cumul_max_w;
+            }
+            // Compute sum of columns widths
+            int columns_min_width = 0;
+            int columns_max_width = 0;
+            for (int c=0; c<nb_columns; c++) {
+                columns_min_width += columns[c].min_w;
+                columns_max_width += columns[c].max_w;
+            }
+            // _minWidth is the max of columns_min_width and cumulative_min_width
+            if ( _minWidth < columns_min_width )
+                 _minWidth = columns_min_width;
+            if ( _minWidth < cumulative_min_width )
+                 _minWidth = cumulative_min_width;
+            // _maxWidth is the max of columns_max_width and cumulative_max_width
+            if ( _maxWidth < columns_max_width )
+                 _maxWidth = columns_max_width;
+            if ( _maxWidth < cumulative_max_width )
+                 _maxWidth = cumulative_max_width;
+            #ifdef DEBUG_GETRENDEREDWIDTHS
+                printf("GRW table: min %d %d > %d    max %d %d > %d\n", columns_min_width, cumulative_min_width,
+                         _minWidth, columns_max_width, cumulative_max_width, _maxWidth);
+            #endif
+        }
+        else { // m == erm_block (or any other we didn't handle specifically)
+            // Block node that contains other stacked block or final nodes
             // Process children, which are all block-like nodes:
             // our *Width are the max of our children *Width
             for (int i = 0; i < node->getChildCount(); i++) {
@@ -9400,21 +9550,17 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 int _maxw = 0;
                 int _minw = 0;
                 ldomNode * child = node->getChildNode(i);
+                if ( child->isText() ) {
+                    // Ignore text nodes between block nodes
+                    // (we shouldn't find any, but well)
+                    continue;
+                }
                 getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
                     curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg);
-                if (m == erm_table_row) {
-                    // For table rows, adding the min/max widths of each children
-                    // (the table cells), instead of taking the largest, gives
-                    // a better estimate of what the table width should be.
-                    _maxWidth += _maxw;
-                    _minWidth += _minw;
-                }
-                else {
-                    if (_maxw > _maxWidth)
-                        _maxWidth = _maxw;
-                    if (_minw > _minWidth)
-                        _minWidth = _minw;
-                }
+                if (_maxw > _maxWidth)
+                    _maxWidth = _maxw;
+                if (_minw > _minWidth)
+                    _minWidth = _minw;
             }
         }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -471,9 +471,12 @@ public:
                 case erm_list_item:     // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
                 case erm_block:         // render as block element (as containing other elements)
                 case erm_final:         // final element: render the whole of its content as single text block
-                    // Table cells became either erm_block or erm_final depending on their content
-                    {
-                        // <th> or <td> inside <tr>
+                    if ( style->display == css_d_table_caption ) {
+                        caption = item;
+                        caption_direction = item_direction;
+                    }
+                    else { // <th> or <td> inside <tr>
+                        // Table cells became either erm_block or erm_final depending on their content
 
                         if ( rows.length()==0 ) {
                             CCRTableRow * row = new CCRTableRow;
@@ -572,12 +575,6 @@ public:
                         cell->row->cells.add( cell );
                         cell->row->numcols += cell->colspan;
                         ExtendCols( cell->row->numcols ); // update col count
-                    }
-                    break;
-                case erm_table_caption: // table caption
-                    {
-                        caption = item;
-                        caption_direction = item_direction;
                     }
                     break;
                 case erm_inline:
@@ -3001,8 +2998,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // Don't handle dir= for the erm_final (<p dir="auto"), as it would "isolate"
             // the whole content from the bidi algorithm and we would get a default paragraph
             // direction of LTR. It is handled directly in lvtextfm.cpp.
-            bool hasDirAttribute = enode->hasAttribute( attr_dir ) && rm != erm_final
-                                                && rm != erm_table_caption && rm != erm_list_item;
+            bool hasDirAttribute = enode->hasAttribute( attr_dir ) && rm != erm_final && rm != erm_list_item;
             bool addGeneratedContent = hasDirAttribute ||
                                        nodeElementId == el_bdi ||
                                        nodeElementId == el_bdo ||
@@ -6538,7 +6534,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     RENDER_RECT_SET_DIRECTION(fmt, direction);
     // Store lang node index if it's an erm_final like node (it's only needed for these,
     // as the starting lang for renderFinalBlock())
-    if ( m == erm_final || m == erm_table_caption || m == erm_list_item ) {
+    if ( m == erm_final || m == erm_list_item ) {
         if ( has_lang_attribute )
             fmt.setLangNodeIndex( enode->getDataIndex() );
         else
@@ -8257,7 +8253,6 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
             break;
         case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
         case erm_final:
-        case erm_table_caption:
             {
                 // No sub-background drawing for erm_final (its background was
                 // drawn above, before the switch())
@@ -9326,7 +9321,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             _maxWidth = lengthToPx( style_width, 0, em );
             _minWidth = _maxWidth;
         }
-        else if (m == erm_final || m == erm_table_caption) {
+        else if (m == erm_final) {
             // Block node that contains only inline or text nodes
             if ( is_img ) { // img with display: block always become erm_final (never erm_block)
                 if (img_width > 0) { // block img with a fixed width

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -469,10 +469,9 @@ public:
                     }
                     break;
                 case erm_list_item:     // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
-                case erm_block:         // render as block element (render as containing other elements)
-                case erm_final:         // final element: render the whole it's content as single render block
-                case erm_mixed:         // block and inline elements are mixed: autobox inline portions of nodes; TODO
-                case erm_table_cell:    // table cell
+                case erm_block:         // render as block element (as containing other elements)
+                case erm_final:         // final element: render the whole of its content as single text block
+                    // Table cells became either erm_block or erm_final depending on their content
                     {
                         // <th> or <td> inside <tr>
 
@@ -3884,13 +3883,6 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                     return fmt.getHeight();
                 }
                 break;
-            case erm_mixed:
-                {
-                    // TODO: autoboxing not supported yet
-                    // (actually, erm_mixed is never used, and autoboxing
-                    // IS supported and done when needed)
-                }
-                break;
             case erm_table:
                 {
                     // ??? not sure
@@ -4099,7 +4091,6 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                 break;
             case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
             case erm_final:
-            case erm_table_cell:
                 {
 
                     if ( style->display == css_d_list_item_block ) {
@@ -6971,7 +6962,6 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             break;
         case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
         case erm_final:
-        case erm_table_cell:
             {
                 // Deal with list item marker
                 int list_marker_padding = 0;;
@@ -7965,8 +7955,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         doc_y += fmt.getY();
         lvdom_element_render_method rm = enode->getRendMethod();
         // A few things differ when done for TR, THEAD, TBODY and TFOOT
-        bool isTableRowLike = rm == erm_table_row || rm == erm_table_row_group ||
-                              rm == erm_table_header_group || rm == erm_table_footer_group;
+        // (erm_table_row_group, erm_table_header_group, erm_table_footer_group, erm_table_row)
+        bool isTableRowLike = rm >= erm_table_row_group && rm <= erm_table_row;
 
         // Check if this node has content to be shown on viewport
         int height = fmt.getHeight();

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -325,6 +325,7 @@ public:
     bool shrink_to_fit;
     bool avoid_pb_inside;
     bool enhanced_rendering;
+    bool is_ruby_table;
     ldomNode * elem;
     ldomNode * caption;
     int caption_h;
@@ -496,6 +497,14 @@ public:
                             cell->colspan=cs;
                         } else {
                             cs=1;
+                        }
+                        if ( is_ruby_table ) { // rbspan works just as colspan
+                            int cs=StrToIntPercent(item->getAttributeValue(attr_rbspan).c_str());
+                            if (cs>0 && cs<100) {
+                                cell->colspan=cs;
+                            } else {
+                                cs=1;
+                            }
                         }
                         int rs=StrToIntPercent(item->getAttributeValue(attr_rowspan).c_str());
                         if (rs>0 && rs<100) {
@@ -1468,6 +1477,8 @@ public:
                         int padding_bottom = lengthToPx( elem_style->padding[3], cell->width, em ) + measureBorder(cell->elem,2);
                         RenderRectAccessor fmt( cell->elem );
                         fmt.setWidth( cell->width ); // needed before calling elem->renderFinalBlock
+                        if ( is_ruby_table )
+                            RENDER_RECT_SET_FLAG(fmt, NO_INTERLINE_SCALE_UP);
                         if ( enhanced_rendering ) {
                             // As done in renderBlockElementEnhanced when erm_final
                             fmt.setInnerX( padding_left );
@@ -2023,7 +2034,7 @@ public:
     }
 
     CCRTable(ldomNode * tbl_elem, int tbl_width, bool tbl_shrink_to_fit, int tbl_direction, bool tbl_avoid_pb_inside,
-                                bool tbl_enhanced_rendering, int dwidth) : digitwidth(dwidth) {
+                                bool tbl_enhanced_rendering, int dwidth, bool tbl_is_ruby_table) : digitwidth(dwidth) {
         currentRowGroup = NULL;
         caption = NULL;
         caption_h = 0;
@@ -2035,20 +2046,26 @@ public:
         is_rtl = direction == REND_DIRECTION_RTL;
         avoid_pb_inside = tbl_avoid_pb_inside;
         enhanced_rendering = tbl_enhanced_rendering;
+        is_ruby_table = tbl_is_ruby_table;
         #ifdef DEBUG_TABLE_RENDERING
             printf("TABLE: ============ parsing new table %s\n",
                 UnicodeToLocal(ldomXPointer(elem, 0).toString()).c_str());
         #endif
         LookupElem( tbl_elem, direction, 0 );
+        if ( is_ruby_table && rows.length() >= 2 ) {
+            // Move 2nd row (first ruby annotation) to 1st position,
+            // so base ruby text (initially 1st row) becomes 2nd
+            rows.move(0, 1);
+        }
         PlaceCells();
     }
 };
 
 int renderTable( LVRendPageContext & context, ldomNode * node, int x, int y, int width, bool shrink_to_fit,
-                 int & fitted_width, int direction, bool avoid_pb_inside, bool enhanced_rendering )
+                 int & fitted_width, int direction, bool avoid_pb_inside, bool enhanced_rendering, bool is_ruby_table )
 {
     CR_UNUSED2(x, y);
-    CCRTable table( node, width, shrink_to_fit, direction, avoid_pb_inside, enhanced_rendering, 10 );
+    CCRTable table( node, width, shrink_to_fit, direction, avoid_pb_inside, enhanced_rendering, 10, is_ruby_table );
     int h = table.renderCells( context );
     if (shrink_to_fit)
         fitted_width = table.table_width;
@@ -2543,8 +2560,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // Scale line_h according to gInterlineScaleFactor, but not if
         // it was already in screen_px, which means it has already been
         // scaled (in setNodeStyle() when inherited).
-        if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
-            line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+        if ( style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+            if ( RENDER_RECT_PTR_HAS_FLAG(fmt, NO_INTERLINE_SCALE_UP)
+                    && gInterlineScaleFactor > INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+                // Don't scale up (for <ruby> content, so we can increase interline to make
+                // the text breath without spreading ruby annotations on the space gained)
+            }
+            else {
+                line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            }
+        }
 
         if ((flags & LTEXT_FLAG_NEWLINE) && rm == erm_final) {
             // Top and single 'final' node (unless in the degenarate case
@@ -4536,6 +4561,12 @@ public:
             //
             // Try to find the first table row, looking at descendants of the
             // provided node (which must be the top node of this FlowState).
+            //
+            // Note: this is still valid with ruby internal wrapping in
+            // a table: even if we switched the 2 first rows in the internal
+            // structures used when rendering the table, we look here at the
+            // DOM, where the base text is still the first erm_table_row.
+            //
             // Walk the tree up and down (avoid the need for recursion):
             ldomNode * n = node;
             ldomNode * rowNode = NULL;
@@ -6622,10 +6653,15 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 //   table {width: auto !important} to have tables shrink to their content
                 int table_width = width;
                 int fitted_width = -1;
+                bool is_ruby_table = false;
+                if ( enode->getParentNode()->isBoxingInlineBox() && enode->getParentNode()->getParentNode()
+                        && enode->getParentNode()->getParentNode()->getStyle()->display == css_d_ruby ) {
+                    is_ruby_table = true;
+                }
                 // renderTable has not been updated to use 'flow', and it looks
                 // like it does not really need to.
                 int h = renderTable( *(flow->getPageContext()), enode, 0, flow->getCurrentRelativeY(),
-                            table_width, table_shrink_to_fit, fitted_width, direction, avoid_pb_inside, true );
+                            table_width, table_shrink_to_fit, fitted_width, direction, avoid_pb_inside, true, is_ruby_table );
                 // (It feels like we don't need to ensure a table specified height.)
                 fmt.setHeight( h );
                 // Update table width if it was fitted/shrunk
@@ -8756,6 +8792,16 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             else {
                 pstyle->display = orig_elem_display;
             }
+        }
+    }
+
+    // Avoid some new features when migration to normalized xpointers has not yet been done
+    if ( gDOMVersionRequested < DOM_VERSION_WITH_NORMALIZED_XPOINTERS ) {
+        // display: ruby may wrap the element content in many inlineBox/rubyBox.
+        // Avoid that until migrated to normalized xpointers by handling
+        // them as css_d_inline like before ruby support.
+        if ( pstyle->display == css_d_ruby ) {
+            pstyle->display = css_d_inline;
         }
     }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -468,7 +468,6 @@ public:
                         colindex++;
                     }
                     break;
-                case erm_list_item:     // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
                 case erm_block:         // render as block element (as containing other elements)
                 case erm_final:         // final element: render the whole of its content as single text block
                     if ( style->display == css_d_table_caption ) {
@@ -2359,7 +2358,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
                 flags |= LTEXT_STRUT_CONFINED;
         }
         marker += "\t";
-        // That "\t" had some purpose in legacy rendering (erm_list_item) to mark the end
+        // That "\t" had some purpose in css_d_list_item_legacy rendering to mark the end
         // of the marker, and by providing the marker_width as negative indent, so that
         // the following text can have some constant indent by rendering it just like
         // negative/hanging text-indent. It has no real use if we provide a 0-indent
@@ -2519,7 +2518,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         else {
             // Let's fallback to the previous (wrong) behaviour when gRenderDPI=0
             // Only do it for the top and single final node
-            if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline) {
+            if ((flags & LTEXT_FLAG_NEWLINE) && rm == erm_final) {
                 int fh = enode->getFont()->getHeight(); // former code used font height for everything
                 switch( style->line_height.type ) {
                     case css_val_percent:
@@ -2546,9 +2545,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
             line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
 
-        if ((flags & LTEXT_FLAG_NEWLINE) && rm != erm_inline && rm != erm_runin) {
-            // Non-inline node in a final block: this is the top and single 'final' node:
-            // get text-indent and line-height that will apply to the full final block
+        if ((flags & LTEXT_FLAG_NEWLINE) && rm == erm_final) {
+            // Top and single 'final' node (unless in the degenarate case
+            // of obsolete css_d_list_item_legacy):
+            // Get text-indent and line-height that will apply to the full final block
 
             // text-indent should really not have to be handled here: it would be
             // better handled in ldomNode::renderFinalBlock(), grabbing it from the
@@ -2560,7 +2560,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // like we do here. (It is never updated, and as it is not passed by reference,
             // updates/reset would not apply to sibling or parent nodes.)
             // There is just one case that sets it to a different value: in the
-            // legacy/obsolete erm_list_item rendering method with lsp_outside, where
+            // obsolete css_d_list_item_legacy rendering with lsp_outside, where
             // it is set to a negative value (the width of the marker), so to handle text
             // indentation from the outside marker just like regular negative text-indent.
             // So, sadly, let's keep it that way to not break legacy rendering.
@@ -2804,7 +2804,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // (Looks like nothing special to do with indent or line_h)
         }
 
-        if ( rm==erm_list_item ) { // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
+        if ( style->display == css_d_list_item_legacy ) { // obsolete (used only when gDOMVersionRequested < 20180524)
             // put item number/marker to list
             lString16 marker;
             int marker_width = 0;
@@ -2998,7 +2998,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // Don't handle dir= for the erm_final (<p dir="auto"), as it would "isolate"
             // the whole content from the bidi algorithm and we would get a default paragraph
             // direction of LTR. It is handled directly in lvtextfm.cpp.
-            bool hasDirAttribute = enode->hasAttribute( attr_dir ) && rm != erm_final && rm != erm_list_item;
+            bool hasDirAttribute = rm != erm_final && enode->hasAttribute( attr_dir );
             bool addGeneratedContent = hasDirAttribute ||
                                        nodeElementId == el_bdi ||
                                        nodeElementId == el_bdo ||
@@ -3235,7 +3235,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
         //baseflags &= ~LTEXT_RUNIN_FLAG;
-        if ( rm != erm_inline && (baseflags & LTEXT_SRC_IS_CLEAR_BOTH) ) {
+        if ( rm == erm_final && (baseflags & LTEXT_SRC_IS_CLEAR_BOTH) ) {
             // We're leaving the top final node with a clear: not consumed
             // (set by a last or single <br clear=>), with no follow-up
             // txform->AddSourceLine() that would have carried it.
@@ -4085,7 +4085,6 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                     return y + margin_top + margin_bottom + padding_bottom; // return block height
                 }
                 break;
-            case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
             case erm_final:
                 {
 
@@ -6532,9 +6531,9 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // Set direction for all blocks (needed for text in erm_final, but also for list item
     // markers in erm_block, so that DrawDocument can draw it on the right if rtl).
     RENDER_RECT_SET_DIRECTION(fmt, direction);
-    // Store lang node index if it's an erm_final like node (it's only needed for these,
+    // Store lang node index if it's an erm_final node (it's only needed for these,
     // as the starting lang for renderFinalBlock())
-    if ( m == erm_final || m == erm_list_item ) {
+    if ( m == erm_final ) {
         if ( has_lang_attribute )
             fmt.setLangNodeIndex( enode->getDataIndex() );
         else
@@ -6956,7 +6955,6 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 return;
             }
             break;
-        case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
         case erm_final:
             {
                 // Deal with list item marker
@@ -8251,7 +8249,6 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // Border was previously drawn here, but has been moved above for earlier drawing.
             	}
             break;
-        case erm_list_item: // obsolete rendering method (used only when gDOMVersionRequested < 20180524)
         case erm_final:
             {
                 // No sub-background drawing for erm_final (its background was
@@ -8276,8 +8273,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 int padding_left;
                 int padding_top;
                 if ( RENDER_RECT_HAS_FLAG(fmt, INNER_FIELDS_SET) ) { // enhanced rendering for erm_final nodes
-                    // This flag is set only when in enhanced rendering mode, and
-                    // only on erm_final-like nodes.
+                    // This flag is set only when in enhanced rendering mode, and only on erm_final nodes.
                     padding_left = fmt.getInnerX();
                     padding_top = fmt.getInnerY();
                     inner_width = fmt.getInnerWidth();
@@ -8499,7 +8495,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                     pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
                 }
                 if (nodeElementId == el_li) {
-                    pstyle->display = css_d_list_item; // otherwise correctly set to css_d_list_item_block
+                    pstyle->display = css_d_list_item_legacy; // otherwise correctly set to css_d_list_item_block
                 }
                 if (nodeElementId == el_style) {
                     pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2135,10 +2135,7 @@ LVFontRef getFont(css_style_rec_t * style, int documentId)
 lUInt32 styleToTextFmtFlags( const css_style_ref_t & style, lUInt32 oldflags, int direction )
 {
     lUInt32 flg = oldflags;
-    if ( style->display == css_d_run_in ) {
-        flg |= LTEXT_RUNIN_FLAG;
-    } //else
-    if (style->display != css_d_inline) {
+    if (style->display > css_d_inline) {
         // text alignment flags
         flg = oldflags & ~LTEXT_FLAG_NEWLINE;
         if ( !(oldflags & LTEXT_RUNIN_FLAG) ) {
@@ -2191,6 +2188,9 @@ lUInt32 styleToTextFmtFlags( const css_style_ref_t & style, lUInt32 oldflags, in
                 break;
             }
         }
+    }
+    else if ( style->display == css_d_run_in ) {
+        flg |= LTEXT_RUNIN_FLAG;
     }
     // We should clean these flags that we got from the parent node via baseFlags:
     // CSS white-space inheritance is correctly handled via styles (so, no need
@@ -8670,7 +8670,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         // not yet got its float_ from its child. So the ->display of the floatBox
         // element will have to be updated too elsewhere.
         if ( pstyle->float_ == css_f_left || pstyle->float_ == css_f_right ) {
-            if ( pstyle->display == css_d_inline ) {
+            if ( pstyle->display <= css_d_inline ) {
                 pstyle->display = css_d_block;
             }
         }
@@ -8698,7 +8698,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                     // We do as in ldomNode::initNodeRendMethod() when the floatBox
                     // is already there (on re-renderings):
                     pstyle->float_ = child_style->float_;
-                    if (child_style->display == css_d_inline) { // when !PREPARE_FLOATBOXES
+                    if (child_style->display <= css_d_inline) { // when !PREPARE_FLOATBOXES
                         pstyle->display = css_d_inline; // become an inline wrapper
                     }
                     else if (child_style->display == css_d_none) {
@@ -8744,7 +8744,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                                             // (no other possible value yet, no need to compare strings)
                         pstyle->display = css_d_inline; // wrap bogus "block among inlines" in inline
                     }
-                    else if (child_style->display == css_d_inline) {
+                    else if (child_style->display <= css_d_inline) {
                         pstyle->display = css_d_inline; // wrap inline in inline
                     }
                     else if (child_style->display == css_d_none) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4574,8 +4574,8 @@ public:
                     // No more child, get back to parent and have it process our sibling
                     nextChildIndex = n->getNodeIndex() + 1;
                     n = n->getParentNode();
-                    if ( n == node ) // all children done and back to top node
-                        break;
+                    if ( n == node && nextChildIndex >= n->getChildCount() )
+                        break; // back to top node and all its children visited
                 }
             }
             if ( rowNode ) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2127,10 +2127,10 @@ LVFontRef getFont(css_style_rec_t * style, int documentId)
     return fnt;
 }
 
-lUInt32 styleToTextFmtFlags( const css_style_ref_t & style, lUInt32 oldflags, int direction )
+lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction )
 {
     lUInt32 flg = oldflags;
-    if (style->display > css_d_inline) {
+    if ( is_block ) {
         // text alignment flags
         flg = oldflags & ~LTEXT_FLAG_NEWLINE;
         if ( !(oldflags & LTEXT_RUNIN_FLAG) ) {
@@ -2470,7 +2470,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // - with block nodes (so, only with the first "final" node, and not
         //   when recursing its children which are inline), it will also set
         //   horitontal alignment flags.
-        lUInt32 flags = styleToTextFmtFlags( enode->getStyle(), baseflags, direction );
+        bool is_block = rm == erm_final;
+        lUInt32 flags = styleToTextFmtFlags( is_block, enode->getStyle(), baseflags, direction );
         // Note:
         // - baseflags (passed by reference) is shared and re-used by this node's siblings
         //   (all inline); it should carry newline/horizontal aligment flag, which should
@@ -2885,7 +2886,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             bool isBlock = style->display == css_d_block;
             if ( isBlock ) {
                 // If block image, forget any current flags and start from baseflags (?)
-                lUInt32 flags = styleToTextFmtFlags( enode->getStyle(), baseflags, direction );
+                lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
                 //txform->AddSourceLine(L"title", 5, 0x000000, 0xffffff, font, baseflags, interval, margin, NULL, 0, 0);
                 LVFont * font = enode->getFont().get();
                 lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -6061,7 +6061,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool is_inline_box_child = enode->getParentNode() && enode->getParentNode()->isBoxingInlineBox();
 
     // In the business of computing width and height, we should handle a bogus
-    // embedded block (<inlineBox type="EmbeddedBlock">) (and its child) just
+    // embedded block (<inlineBox T="EmbeddedBlock">) (and its child) just
     // like any normal block element (taking the full width of its container
     // if no specified width, without the need to get its rendered width).
     if ( is_inline_box && enode->isEmbeddedBlockBoxingInlineBox(true) ) {
@@ -8734,13 +8734,13 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                     // is already there (on re-renderings):
                     // (If this is an inlineBox in the initial XML loading phase,
                     // child is necessarily css_d_inline_block or css_d_inline_table,
-                    // or this node is <inlineBox type=EmbeddedBlock>.
+                    // or this node is <inlineBox T=EmbeddedBlock>.
                     // The following 'else's should never trigger.
                     if (child_style->display == css_d_inline_block || child_style->display == css_d_inline_table) {
                         pstyle->display = css_d_inline; // become an inline wrapper
                         pstyle->vertical_align = child_style->vertical_align;
                     }
-                    else if ( enode->hasAttribute( attr_type ) ) { // type="EmbeddedBlock"
+                    else if ( enode->hasAttribute( attr_T ) ) { // T="EmbeddedBlock"
                                             // (no other possible value yet, no need to compare strings)
                         pstyle->display = css_d_inline; // wrap bogus "block among inlines" in inline
                     }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1268,15 +1268,13 @@ static void resolve_url_path( lString8 & str, lString16 codeBase ) {
 static const char * css_d_names[] = 
 {
     "inherit",
+    "run-in",
     "inline",
     "block",
     "-cr-list-item-final", // non-standard, legacy crengine rendering of list items as final: css_d_list_item
     "list-item",           // correct rendering of list items as block: css_d_list_item_block
     "inline-block",
     "inline-table",
-    "run-in", 
-    "compact", 
-    "marker", 
     "table", 
     "table-row-group", 
     "table-header-group", 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1271,7 +1271,7 @@ static const char * css_d_names[] =
     "run-in",
     "inline",
     "block",
-    "-cr-list-item-final", // non-standard, legacy crengine rendering of list items as final: css_d_list_item
+    "-cr-list-item-final", // non-standard, legacy crengine rendering of list items as final: css_d_list_item_legacy
     "list-item",           // correct rendering of list items as block: css_d_list_item_block
     "inline-block",
     "inline-table",
@@ -1770,7 +1770,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
                 if (gDOMVersionRequested < 20180524 && n == css_d_list_item_block) {
-                    n = css_d_list_item; // legacy rendering of list-item
+                    n = css_d_list_item_legacy; // legacy rendering of list-item
                 }
                 break;
             case cssd_white_space:

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1268,6 +1268,7 @@ static void resolve_url_path( lString8 & str, lString16 codeBase ) {
 static const char * css_d_names[] = 
 {
     "inherit",
+    "ruby",
     "run-in",
     "inline",
     "block",
@@ -3766,14 +3767,14 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
             // a few ones that are added explicitely by crengine): we need
             // to lowercase them here too to expect a match.
             lString16 element(ident);
-            if ( element.length() < 8 ) {
+            if ( element.length() < 7 ) {
                 // Avoid following string comparisons if element name string
-                // is shorter than the shortest of them (floatBox)
+                // is shorter than the shortest of them (rubyBox)
                 element = element.lowercase();
             }
             else if ( element != "DocFragment" && element != "autoBoxing" && element != "tabularBox" &&
-                      element != "floatBox"    && element != "inlineBox"  && element != "pseudoElem" &&
-                      element != "FictionBook" ) {
+                      element != "rubyBox"     && element != "floatBox"   && element != "inlineBox"  &&
+                      element != "pseudoElem"  && element != "FictionBook" ) {
                 element = element.lowercase();
             }
             _id = doc->getElementNameIndex( element.c_str() );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3750,6 +3750,10 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
         {
             _id = 0;
         }
+        else if ( *str == '[' ) // attribute selector follows
+        {
+            _id = 0;
+        }
         else if ( *str == '#' ) // node Id follows
         {
             _id = 0; // (elementName internal id)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4364,7 +4364,7 @@ static void getAbsMarksFromMarks(ldomMarkedRangeList * marks, ldomMarkedRangeLis
     ldomNode * final_node = node->getParentNode();
     for ( ; final_node; final_node = final_node->getParentNode() ) {
         int rm = final_node->getRendMethod();
-        if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption )
+        if ( rm == erm_final || rm == erm_list_item )
             break;
     }
     lvRect final_node_rect = lvRect();

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3288,11 +3288,14 @@ public:
         }
 
         // Fix up words position and width to ensure requested alignment and indent
-        // (no need to do that if light formatting, as this won't affect the
+        // No need to do that if light formatting, as this won't affect the
         // block height and floats positionning - is_reusable will be unset,
         // and any attempt at reusing this formatting for drawing will cause
-        // a non-light re-formatting)
-        if ( !m_pbuffer->light_formatting ) {
+        // a non-light re-formatting. Except when there are inlineBoxes in the
+        // text: we need to correctly position them to have their x/y saved
+        // in their RenderRectAccessor (so getRect() can work accurately before
+        // the page is drawn).
+        if ( !m_pbuffer->light_formatting || has_inline_boxes ) {
             alignLine( frmline, align, rightIndent, has_inline_boxes );
         }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1980,7 +1980,7 @@ public:
             #endif
         }
         if ( tabIndex >= 0 && m_srcs[0]->indent < 0) {
-            // Used by obsolete rendering method erm_list_item when css_lsp_outside,
+            // Used by obsolete rendering of css_d_list_item_legacy when css_lsp_outside,
             // where the marker width is provided as negative/hanging indent.
             int tabPosition = -m_srcs[0]->indent; // has been set to marker_width
             if ( tabPosition>0 && tabPosition > m_widths[tabIndex] ) {
@@ -4364,7 +4364,7 @@ static void getAbsMarksFromMarks(ldomMarkedRangeList * marks, ldomMarkedRangeLis
     ldomNode * final_node = node->getParentNode();
     for ( ; final_node; final_node = final_node->getParentNode() ) {
         int rm = final_node->getRendMethod();
-        if ( rm == erm_final || rm == erm_list_item )
+        if ( rm == erm_final )
             break;
     }
     lvRect final_node_rect = lvRect();

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1868,8 +1868,17 @@ public:
                             // inline-block and inline-table have a baseline, that renderBlockElement()
                             // will compute and give us back.
                             int baseline = REQ_BASELINE_FOR_INLINE_BLOCK;
-                            if ( node->getChildNode(0)->getStyle()->display == css_d_inline_table )
+                            if ( node->getChildNode(0)->getStyle()->display == css_d_inline_table ) {
                                 baseline = REQ_BASELINE_FOR_TABLE;
+                            }
+                            else if ( node->getParentNode()->getStyle()->display == css_d_ruby
+                                        && node->getChildNode(0)->getRendMethod() == erm_table ) {
+                                // Ruby sub-tables don't carry css_d_inline_table, so check rend method;
+                                // (a table could be in a "display: inline-block" container, and it
+                                // would be erm_table - but we should still use REQ_BASELINE_FOR_INLINE_BLOCK,
+                                // so check that the parent is really css_d_ruby)
+                                baseline = REQ_BASELINE_FOR_TABLE;
+                            }
                             // We render the inlineBox with the specified direction (from upper dir=), even
                             // if UNSET (and not with the direction determined by fribidi from the text).
                             renderBlockElement( alt_context, node, 0, 0, m_pbuffer->width, m_specified_para_dir, &baseline );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4071,7 +4071,6 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 case erm_table_row:          *stream << "TR";    break;
                 case erm_table_column_group: *stream << "TCG";   break;
                 case erm_table_column:       *stream << "TC";    break;
-                case erm_table_caption:      *stream << "tcap";  break;
                 case erm_runin:              *stream << "R";     break;
                 default:                     *stream << "?";     break;
             }
@@ -5386,8 +5385,7 @@ static void detectChildTypes( ldomNode * parent, bool & hasBlockItems, bool & ha
                 hasBlockItems = true;
                 // (Table internal elements are all block items in the context
                 // where hasBlockItems is used, so account for them in both)
-                if ( ( d > css_d_table && d <= css_d_table_caption ) ||
-                     ( m > erm_table   && m <= erm_table_caption ) ) {
+                if ( ( d > css_d_table && d <= css_d_table_caption ) || ( m > erm_table ) ) {
                     hasInternalTableItems = true;
                 }
             }
@@ -5513,7 +5511,7 @@ int initTableRendMethods( ldomNode * enode, int state )
                 is_proper = true;
             }
             else if ( d==css_d_table_caption ) {
-                child->setRendMethod( erm_table_caption );
+                child->setRendMethod( erm_final );
                 is_proper = true;
             }
             else if ( d==css_d_none ) {
@@ -7618,7 +7616,7 @@ ldomNode * ldomXPointer::getFinalNode() const
     for (;;) {
         if ( !node )
             return NULL;
-        if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item || node->getRendMethod() == erm_table_caption )
+        if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item )
             return node;
         node = node->getParentNode();
     }
@@ -7630,7 +7628,7 @@ bool ldomXPointer::isFinalNode() const
     ldomNode * node = getNode();
     if ( !node )
         return false;
-    if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item || node->getRendMethod() == erm_table_caption )
+    if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item )
         return true;
     return false;
 }
@@ -7688,7 +7686,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
     // printf("finalNode %s\n", UnicodeToLocal(ldomXPointer(finalNode, 0).toString()).c_str());
 
     lvdom_element_render_method rm = finalNode->getRendMethod();
-    if ( rm != erm_final && rm != erm_list_item && rm != erm_table_caption ) {
+    if ( rm != erm_final && rm != erm_list_item ) {
         // Not final, return XPointer to first or last child
         lvRect rc;
         finalNode->getAbsRect( rc );
@@ -7973,7 +7971,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
     ldomNode * mainNode = p->getDocument()->getRootNode();
     for ( ; p; p = p->getParentNode() ) {
         int rm = p->getRendMethod();
-        if ( rm == erm_final || rm == erm_table_caption ) {
+        if ( rm == erm_final ) {
             // With floats, we may get multiple erm_final when walking up
             // to root node: keep the first one met (but go on up to the
             // root node in case we're in some upper erm_invisible).
@@ -11033,7 +11031,6 @@ ldomNode * ldomXPointerEx::getThisBlockNode()
         case erm_table:
         case erm_table_row_group:
         case erm_table_row:
-        case erm_table_caption:
             return node;
         default:
             break; // ignore
@@ -15402,13 +15399,13 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 
         int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y < fmt.getY() - top_margin) {
-            if ( direction >= PT_DIR_SCAN_FORWARD && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
+            if ( direction >= PT_DIR_SCAN_FORWARD && (rm == erm_final || rm == erm_list_item) )
                 return this;
             return NULL;
         }
         int bottom_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
-            if ( direction <= PT_DIR_SCAN_BACKWARD && (rm == erm_final || rm == erm_list_item || rm == erm_table_caption) )
+            if ( direction <= PT_DIR_SCAN_BACKWARD && (rm == erm_final || rm == erm_list_item) )
                 return this;
             return NULL;
         }
@@ -15448,7 +15445,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         // We could add more conditions (like parentNode->getRendMethod()>=erm_table),
         // but let's just check this in all cases when direction=0.
     }
-    if ( rm == erm_final || rm == erm_list_item || rm == erm_table_caption ) {
+    if ( rm == erm_final || rm == erm_list_item ) {
         // Final node, that's what we looked for
         return this;
     }
@@ -16581,7 +16578,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     if ( cache.get( this, f ) ) {
         if ( f->isReusable() ) {
             frmtext = f;
-            if ( rm != erm_final && rm != erm_list_item && rm != erm_table_caption )
+            if ( rm != erm_final && rm != erm_list_item )
                 return 0;
             //RenderRectAccessor fmt( this );
             //CRLog::trace("Found existing formatted object for node #%08X", (lUInt32)this);
@@ -16591,7 +16588,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
         cache.remove( this );
     }
     f = getDocument()->createFormattedText();
-    if ( (rm != erm_final && rm != erm_list_item && rm != erm_table_caption) )
+    if ( rm != erm_final && rm != erm_list_item )
         return 0;
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -16592,7 +16592,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object
     int direction = RENDER_RECT_PTR_GET_DIRECTION(fmt);
-    lUInt32 flags = styleToTextFmtFlags( getStyle(), 0, direction );
+    lUInt32 flags = styleToTextFmtFlags( true, getStyle(), 0, direction );
     int lang_node_idx = fmt->getLangNodeIndex();
     TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg(lang_node_idx>0 ? getDocument()->getTinyNode(lang_node_idx) : NULL);
     ::renderFinalBlock( this, f.get(), fmt, flags, 0, -1, lang_cfg );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5764,7 +5764,7 @@ bool ldomNode::isEmbeddedBlockBoxingInlineBox(bool inline_box_checks_done) const
             return false; // regular boxing inlineBox
         }
     }
-    if ( hasAttribute( attr_type ) ) { // type="EmbeddedBlock"
+    if ( hasAttribute( attr_T ) ) { // T="EmbeddedBlock"
             // (no other possible value yet, no need to compare strings)
         int cm = getChildNode(0)->getRendMethod();
         if ( cm == erm_inline || cm == erm_runin || cm == erm_invisible || cm == erm_killed )
@@ -5852,7 +5852,7 @@ void ldomNode::initNodeRendMethod()
         }
         else if ( !isNotBoxWrappingNode(this) ) {
             // If this node is already a box wrapping node (active floatBox or inlineBox,
-            // possibly a <inlineBox type="EmbeddedBlock"> created here in a previous
+            // possibly a <inlineBox T="EmbeddedBlock"> created here in a previous
             // rendering), just set it to erm_inline.
             setRendMethod(erm_inline);
         }
@@ -5905,7 +5905,7 @@ void ldomNode::initNodeRendMethod()
                 }
                 if ( do_wrap_blocks ) {
                     // We have a mix of inline nodes or non-empty text, and block elements:
-                    // wrap each block element in a <inlineBox type="EmbeddedBlock">.
+                    // wrap each block element in a <inlineBox T="EmbeddedBlock">.
                     for ( int i=getChildCount()-1; i >=0; i-- ) {
                         ldomNode * child = getChildNode( i );
                         if ( !child->isElement() ) // text node
@@ -5949,7 +5949,7 @@ void ldomNode::initNodeRendMethod()
                             ldomNode * ibox = insertChildElement( i, LXML_NS_NONE, el_inlineBox );
                             moveItemsTo( ibox, i+1, i+1 ); // move this child from 'this' into ibox
                             // Mark this inlineBox so we can handle its pecularities
-                            ibox->setAttributeValue(LXML_NS_NONE, getDocument()->getAttrNameIndex(L"type"), L"EmbeddedBlock");
+                            ibox->setAttributeValue(LXML_NS_NONE, attr_T, L"EmbeddedBlock");
                             setNodeStyle( ibox, getStyle(), getFont() );
                             ibox->setRendMethod( erm_inline );
                         }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.41k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0023
+#define FORMATTING_VERSION_ID 0x0024
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -4906,33 +4906,10 @@ static bool isBlockNode( ldomNode * node )
     if ( !node->isElement() )
         return false;
 #if BUILD_LITE!=1
-    switch ( node->getStyle()->display )
-    {
-    case css_d_block:
-    case css_d_inline_block:
-    case css_d_inline_table:
-    case css_d_list_item:
-    case css_d_list_item_block:
-    case css_d_table:
-    case css_d_table_row:
-    case css_d_table_row_group:
-    case css_d_table_header_group:
-    case css_d_table_footer_group:
-    case css_d_table_column_group:
-    case css_d_table_column:
-    case css_d_table_cell:
-    case css_d_table_caption:
-        return true;
-
-    case css_d_inherit:
-    case css_d_inline:
-    case css_d_run_in:
-    case css_d_compact:
-    case css_d_marker:
-    case css_d_none:
-        break;
+    if ( node->getStyle()->display <= css_d_inline || node->getStyle()->display == css_d_none ) {
+        return false;
     }
-    return false;
+    return true;
 #else
     return true;
 #endif
@@ -5648,7 +5625,7 @@ int initTableRendMethods( ldomNode * enode, int state )
                     // be rendered and drawn quite correctly be. But we'll
                     // have the others drawn as erm_killed, showing a small
                     // symbol so users know some content is missing.
-                    if ( d > css_d_table || d == css_d_inline ) {
+                    if ( d > css_d_table || d <= css_d_inline ) {
                         child->setRendMethod( erm_killed );
                     }
                     // Note that there are other situations where some content
@@ -6521,7 +6498,7 @@ void ldomNode::initNodeRendMethod()
                 css_style_ref_t my_new_style( new css_style_rec_t );
                 copystyle(my_style, my_new_style);
                 my_new_style->float_ = child_style->float_;
-                if (child_style->display == css_d_inline) { // when !PREPARE_FLOATBOXES
+                if (child_style->display <= css_d_inline) { // when !PREPARE_FLOATBOXES
                     my_new_style->display = css_d_inline; // become an inline wrapper
                 }
                 else if (child_style->display == css_d_none) {
@@ -6672,7 +6649,7 @@ void ldomNode::initNodeRendMethod()
                     my_new_style->display = css_d_inline; // wrap bogus "block among inlines" in inline
                     setRendMethod( erm_inline );
                 }
-                else if (child_style->display == css_d_inline) {
+                else if (child_style->display <= css_d_inline) {
                     my_new_style->display = css_d_inline; // wrap inline in inline
                     setRendMethod( erm_inline );
                 }
@@ -11718,34 +11695,18 @@ public:
             return true;
         }
         switch ( elem->getStyle()->display ) {
-        /*
-        case css_d_inherit:
-        case css_d_block:
-        case css_d_list_item:
-        case css_d_list_item_block:
-        case css_d_compact:
-        case css_d_marker:
-        case css_d_table:
-        case css_d_table_row_group:
-        case css_d_table_header_group:
-        case css_d_table_footer_group:
-        case css_d_table_row:
-        case css_d_table_column_group:
-        case css_d_table_column:
-        case css_d_table_cell:
-        case css_d_table_caption:
-        */
-        default:
-            newBlock = true;
-            return true;
-        case css_d_none:
-            return false;
-        case css_d_inline:
-        case css_d_run_in:
-        case css_d_inline_block: // Make these behave as inline, in case they don't contain much
-        case css_d_inline_table: // (if they do, some inner block element will give newBlock=true)
-            newBlock = false;
-            return true;
+            case css_d_none:
+                return false;
+            case css_d_inherit:
+            case css_d_run_in:
+            case css_d_inline:
+            case css_d_inline_block: // Make these behave as inline, in case they don't contain much
+            case css_d_inline_table: // (if they do, some inner block element will give newBlock=true)
+                newBlock = false;
+                return true;
+            default:
+                newBlock = true;
+                return true;
         }
 #else
         newBlock = true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4063,7 +4063,6 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 case erm_block:              *stream << "B";     break;
                 case erm_final:              *stream << "F";     break;
                 case erm_inline:             *stream << "i";     break;
-                case erm_mixed:              *stream << "M";     break; // not implemented
                 case erm_list_item:          *stream << "L";     break; // no more used
                 case erm_table:              *stream << "T";     break;
                 case erm_table_row_group:    *stream << "TRG";   break;
@@ -4072,7 +4071,6 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 case erm_table_row:          *stream << "TR";    break;
                 case erm_table_column_group: *stream << "TCG";   break;
                 case erm_table_column:       *stream << "TC";    break;
-                case erm_table_cell:         *stream << "tcell"; break; // never stays erm_table_cell (becomes block or final)
                 case erm_table_caption:      *stream << "tcap";  break;
                 case erm_runin:              *stream << "R";     break;
                 default:                     *stream << "?";     break;
@@ -5554,13 +5552,11 @@ int initTableRendMethods( ldomNode * enode, int state )
         }
         else if ( state==3 ) { // in row
             if ( d==css_d_table_cell ) {
-                child->setRendMethod( erm_table_cell );
+                // This will set the rend method of the cell to either erm_block
+                // or erm_final, depending on its content.
+                child->initNodeRendMethodRecursive();
                 cellCount++;
                 is_proper = true;
-                // This will reset the rend method we just set (erm_table_cell)
-                // to the most appropriate one (erm_final or erm_block) for
-                // rendering, depending on the cell content:
-                child->initNodeRendMethodRecursive();
             }
             else if ( d==css_d_none ) {
                 child->setRendMethod( erm_invisible );
@@ -5571,9 +5567,10 @@ int initTableRendMethods( ldomNode * enode, int state )
                 #ifdef DEBUG_INCOMPLETE_TABLE_COMPLETION
                     printf("initTableRendMethods(3): (reused)wrapping unproper > cell\n");
                 #endif
-                child->setRendMethod( erm_table_cell );
-                cellCount++;
+                // This will set the rend method of the cell to either erm_block
+                // or erm_final, depending on its content.
                 child->initNodeRendMethodRecursive();
+                cellCount++;
                 is_proper = true;
             }
         }
@@ -5662,9 +5659,10 @@ int initTableRendMethods( ldomNode * enode, int state )
                 }
                 else if ( state==3 ) {
                     tbox->initNodeStyle();
-                    tbox->setRendMethod( erm_table_cell );
+                    // This will set the rend method of the cell to either erm_block
+                    // or erm_final, depending on its content.
+                    tbox->initNodeRendMethodRecursive();
                     cellCount++;
-                    tbox->initNodeRendMethodRecursive(); // will reset rend method
                 }
                 else if ( state==1 ) { // should not happen, see above
                     tbox->initNodeStyle();
@@ -11031,7 +11029,6 @@ ldomNode * ldomXPointerEx::getThisBlockNode()
         case erm_runin: // treat as separate block
         case erm_block:
         case erm_final:
-        case erm_mixed:
         case erm_list_item: // no more used (obsolete rendering method)
         case erm_table:
         case erm_table_row_group:
@@ -12354,7 +12351,7 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     // we translate these deprecated attributes to their style equivalents:
     //
     // HTML valign= => CSS vertical-align: only for TH & TD (as lvrend.cpp
-    // only uses it with erm_table_cell)
+    // only uses it with table cells (erm_final or erm_block))
     if (id == el_th || id == el_td) {
         // Default rendering for cells is valign=top
         // There is no support for valign=baseline.
@@ -12368,7 +12365,7 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
         }
     }
     // HTML width= => CSS width: only for TH, TD and COL (as lvrend.cpp
-    // only uses it with erm_table_cell and erm_table_column)
+    // only uses it with erm_table_column and table cells)
     // Note: with IMG, lvtextfm LFormattedText::AddSourceObject() only uses
     // style, and not attributes: <img width=100 height=50> would not be used.
     if (id == el_th || id == el_td || id == el_col) {
@@ -15400,8 +15397,8 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 
         // Styles margins set on <TR>, <THEAD> and the like are ignored
         // by table layout algorithm (as per CSS specs)
-        bool ignore_margins = ( rm == erm_table_row || rm == erm_table_row_group ||
-                                rm == erm_table_header_group || rm == erm_table_footer_group );
+        // (erm_table_row_group, erm_table_header_group, erm_table_footer_group, erm_table_row)
+        bool ignore_margins = rm >= erm_table_row_group && rm <= erm_table_row;
 
         int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y < fmt.getY() - top_margin) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11178,12 +11178,14 @@ bool ldomXPointerEx::prevVisibleWordStart( bool thisBlockOnly )
         }
         bool foundNonSpace = false;
         while ( _data->getOffset() > 0 && IsWordSeparator(text[_data->getOffset()-1]) )
-            _data->addOffset(-1);
+            _data->addOffset(-1); // skip preceeding space if any (we were on a visible word start)
         while ( _data->getOffset()>0 ) {
             if ( IsWordSeparator(text[ _data->getOffset()-1 ]) )
                 break;
             foundNonSpace = true;
             _data->addOffset(-1);
+            if ( canWrapWordBefore( text[_data->getOffset()] ) ) // CJK char
+                break;
         }
         if ( foundNonSpace )
             return true;
@@ -11225,6 +11227,9 @@ bool ldomXPointerEx::prevVisibleWordEnd( bool thisBlockOnly )
         while ( _data->getOffset()>0 ) {
             if ( IsWordSeparator(text[ _data->getOffset()-1 ]) )
                 break;
+            if ( moved && canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
+            moved = true;
             _data->addOffset(-1);
         }
         // skip spaces
@@ -11280,6 +11285,8 @@ bool ldomXPointerEx::nextVisibleWordStart( bool thisBlockOnly )
         while ( _data->getOffset()<textLen ) {
             if ( IsWordSeparator(text[ _data->getOffset() ]) )
                 break;
+            if ( moved && canWrapWordBefore( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
             moved = true;
             _data->addOffset(1);
         }
@@ -11363,6 +11370,8 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
                 break;
             nonSpaceFound = true;
             _data->addOffset(1);
+            if ( canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
         }
         if ( nonSpaceFound )
             return true;
@@ -11377,6 +11386,8 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
                 break;
             nonSpaceFound = true;
             _data->addOffset(1);
+            if ( canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
         }
         if ( nonSpaceFound )
             return true;
@@ -11394,10 +11405,21 @@ bool ldomXPointerEx::isVisibleWordStart()
     lString16 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
+    // We're actually testing the boundary between the char at i-1 and
+    // the char at i. So, we return true when [i] is the first letter
+    // of a word.
     lChar16 currCh = i<textLen ? text[i] : 0;
-    lChar16 prevCh = i<textLen && i>0 ? text[i-1] : 0;
-    if (canWrapWordBefore(currCh) || (IsWordSeparatorOrNull(prevCh) && !IsWordSeparator(currCh)))
+    lChar16 prevCh = i<=textLen && i>0 ? text[i-1] : 0;
+    if (canWrapWordBefore(currCh)) {
+        // If [i] is a CJK char (that's what canWrapWordBefore()
+        // checks), this is a visible word start.
         return true;
+    }
+    if (IsWordSeparatorOrNull(prevCh) && !IsWordSeparator(currCh)) {
+        // If [i-1] is a space or punctuation (or [i] is the start of the text
+        // node) and [i] is a letter: this is a visible word start.
+        return true;
+    }
     return false;
  }
 
@@ -11412,10 +11434,21 @@ bool ldomXPointerEx::isVisibleWordEnd()
     lString16 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
+    // We're actually testing the boundary between the char at i-1 and
+    // the char at i. So, we return true when [i-1] is the last letter
+    // of a word.
     lChar16 currCh = i>0 ? text[i-1] : 0;
     lChar16 nextCh = i<textLen ? text[i] : 0;
-    if (canWrapWordAfter(currCh) || (!IsWordSeparator(currCh) && IsWordSeparatorOrNull(nextCh)))
+    if (canWrapWordAfter(currCh)) {
+        // If [i-1] is a CJK char (that's what canWrapWordAfter()
+        // checks), this is a visible word end.
         return true;
+    }
+    if (!IsWordSeparator(currCh) && IsWordSeparatorOrNull(nextCh)) {
+        // If [i-1] is a letter and [i] is a space or punctuation (or [i-1] is
+        // the last letter of a text node): this is a visible word end.
+        return true;
+    }
     return false;
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -15769,8 +15769,8 @@ ldomNode * ldomNode::getUnboxedLastChild( bool skip_text_nodes ) const
             // No more child, get back to parent and have it process our sibling
             index = n->getNodeIndex() + 1;
             n = n->getParentNode();
-            if ( n == topNode ) // all children done and back to top node
-                break;
+            if ( n == topNode && index >= n->getChildCount() )
+                break; // back to top node and all its children visited
         }
     }
 */

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.41k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.42k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0024
 
@@ -5715,6 +5715,12 @@ bool ldomNode::isBoxingInlineBox() const
             if (d == css_d_inline_block || d == css_d_inline_table) {
                 return true;
             }
+            // Also if this box parent is <ruby> and if what this inlineBox
+            // contains (probably a rubyBox) is being rendered as erm_table
+            if ( getChildNode(0)->getRendMethod() == erm_table && getParentNode()
+                        && getParentNode()->getStyle()->display == css_d_ruby ) {
+                return true;
+            }
             return isEmbeddedBlockBoxingInlineBox(true); // avoid rechecking what we just checked
         }
     }
@@ -5734,6 +5740,10 @@ bool ldomNode::isEmbeddedBlockBoxingInlineBox(bool inline_box_checks_done) const
         css_display_t d = getChildNode(0)->getStyle()->display;
         if (d == css_d_inline_block || d == css_d_inline_table) {
             return false; // regular boxing inlineBox
+        }
+        if ( getChildNode(0)->getRendMethod() == erm_table && getParentNode()
+                    && getParentNode()->getStyle()->display == css_d_ruby ) {
+            return false; // inlineBox wrapping a rubyBox as a child of <ruby>
         }
     }
     if ( hasAttribute( attr_T ) ) { // T="EmbeddedBlock"
@@ -5929,6 +5939,18 @@ void ldomNode::initNodeRendMethod()
                 }
             }
         }
+    } else if ( d==css_d_ruby ) {
+        // This will be dealt in a big section below. For now, reset everything
+        // to inline as ruby is only allowed to contain inline content.
+        // We don't support the newer display: values like ruby-base, ruby-text...,
+        // but only "display: ruby" which is just set on the <ruby> element
+        // (which allows us to have it reset back to "display: inline" if we
+        // don't wan't ruby support).
+        //   recurseElements( resetRendMethodToInline );
+        // Or may be not: looks like we can support <ruby> inside <ruby>,
+        // so allow that; and probably anything nested, as we'll handle
+        // that just like a table cell content.
+        setRendMethod(erm_inline);
     } else if ( d==css_d_run_in ) {
         // runin
         //CRLog::trace("switch all children elements of <%s> to inline", LCSTR(getNodeName()));
@@ -6437,6 +6459,392 @@ void ldomNode::initNodeRendMethod()
                 // and everything will be reset to erm_inline. The parent DIV
                 // will just see that it contains a single erm_inline SPAN,
                 // and won't do any boxing.
+            }
+        }
+    }
+
+    if ( d == css_d_ruby && BLOCK_RENDERING_G(ENHANCED) ) {
+        // Ruby input can be quite loose and have various tag strategies (mono/group,
+        // interleaved/tabular, double sided). Moreover, the specs have evolved between
+        // 2001 and 2020 (<rbc> tag no more mentionned in 2020; <rtc> being just another
+        // semantic container for Mozilla, and can be preceded by a bunch of <rt> which
+        // are pronunciation containers, that don't have to be in an <rtc>...)
+        // Moreover, various samples on the following pages don't close tags, and expect
+        // the HTML parser to do that. We do that only when parsing .html files, but
+        // we don't when parsing .epub files as they are expected to be balanced XHTML.
+        //
+        // References:
+        //  https://www.w3.org/International/articles/ruby/markup
+        //  https://www.w3.org/TR/ruby-use-cases/ differences between XHTML, HTML5 & HTML Extensions
+        //  https://www.w3.org/TR/ruby/ Ruby Annotation, 2001
+        //  http://darobin.github.io/html-ruby/ HTML Ruby Markup Extensions, 2015
+        //  https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element HTML Living standard
+        //  https://drafts.csswg.org/css-ruby/ CSS Ruby Layout, 2020
+        //  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rtc
+        //  https://chenhuijing.com/blog/html-ruby/ All about the HTML <ruby> element (in 2016)
+        //  https://github.com/w3c/html/issues/291 How to handle legacy Ruby content that may use <rbc>?
+        //  https://w3c.github.io/i18n-tests/results/ruby-html Browsers support
+        //
+        // We can handle quite a few of these variations with the following strategy.
+        //
+        // We want a <ruby> (which will stay inline) to only contain inlineBox>rubyBox elements
+        // that will be set up to be rendered just as an inline-table:
+        //   <ruby, "display: ruby", erm_inline>
+        //     <inlineBox, erm_inline>  [1 or more, 1 per ruby segment]
+        //       <rubyBox, erm_table>   [1]
+        //         <rbc or rubyBox, erm_table_row>  [1]
+        //           <rb or rubyBox, erm_final> base text </rb or /rubyBox>  [1 or more]
+        //         </rbc or /rubyBox>
+        //         <rtc or rubyBox, erm_table_row>  [1 or more, usually 1 or 2]
+        //           <rt or rubyBox, erm_final> annotation text </rt or /rubyBox>  [1 or more]
+        //         </rtc or /rubyBox>
+        //       </rubyBox>
+        //     </inlineBox>
+        //     [some possible empty space text nodes between ruby segments]
+        //   </ruby>
+        //
+        // (The re-ordering of the table rows, putting the first "rtc" above the "rbc",
+        // will be done in renderTable(), as it is just needed there in its own internal
+        // table data structures. The DOM will stay in its original order: the "rbc"
+        // staying before followup "rtc", which will give us the correct baseline to use
+        // for the whole structure: the baseline of the "rbc".
+        //
+        // We need to build all this when we meet a simple:
+        //   <ruby>text1<rt>annot1</rt>text2<rt>annot2</rt> </ruby>
+        // The only element we'll nearly always find inside a <ruby> is <rt>,
+        // (but we can find sometimes a single <rtc> with no <rt>).
+        //
+        // One thing we might not handle well is white-space, which, depending on where
+        // it happens, should be dropped or not. We drop some by putting it between table
+        // elements, we keep some by putting it between the inlineBoxes, but not really
+        // according to the complex rules in https://drafts.csswg.org/css-ruby/#box-fixup
+        //
+        // Some other notes:
+        // - We can style some ruby elements, including some of the rubyBox we add, with:
+        //     rt, rubyBox[T=rt] { font-size: 50%; font-variant-east-asian: ruby; }
+        //     rubyBox { border: 1px solid green; }
+        // - Note that on initial loading (HTML parsing, and this boxing here happening,
+        //   the real ruby sub-elements present in the HTML will already be there in the
+        //   DOM and have their style set, possibly inherited from their parent (the <ruby>
+        //   element) *before* this boxing is happening. If we add a rubyBox, and it
+        //   becomes the parent of a rb or rt, these rb or rt won't inherite from the
+        //   rubyBox (that we may style). They also won't get styled by CSS selectors
+        //   like "rubyBox > rt".
+        //   But on a next re-renderings, as the DOM is kept, all this will happen.
+        //   So: avoid such rules, and avoid setting inherit'able properties to
+        //   the rubyBox elements; otherwise we may get different look on initial
+        //   loading and on subsequent re-renderings.
+        // - With some ruby constructs, the behaviour and rendering might be different
+        //   whether we're parsing a HTML file or an EPUB file:
+        //   - the HTML parser is able to auto-close tags, which is needed with most
+        //     of the samples in the above URLs (but may fail on nested ruby with
+        //     unbalanced tags, as auto-closing in one ruby might kill the other).
+        //   - the EPUB XHTML parser expects balanced tags, and may work with nested
+        //     ruby, but will not process ruby with unbalanced tags.
+
+        // To make things easier to follow below (with the amount of nested rubyBoxes...),
+        // we name the variables used to hold each of them:
+        //   ibox1 : the inlineBox wrapping the 1st level rubyBox that will be erm_table (inline-table)
+        //   rbox1 : the 1st level rubyBox that will be erm_table
+        //   rbox2 : the 2nd level rubyBox that will be erm_table_row, like existing <rbc> and <rtc>
+        //   rbox3 : the 3rd level rubyBox that will be a table cell (erm_final or erm_block), like existing <rb> and <rt>
+
+        // Check if we have already wrapped: we should contain only <inlineBox>'ed <rubyBox>es
+        // Note that <ruby style="display: ruby"> is all that is required to trigger this. When
+        // wanting to disable ruby support, it's enough to just set <ruby> to "display: inline":
+        // a change in "display:" value will cause a nodeDisplayStyleHash mismatch, and propose
+        // a full reload with DOM rebuild, which will forget all the rubyBox we added.
+        bool needs_wrapping = true;
+        int len = getChildCount();
+        for ( int i=0; i<len; i++ ) {
+            ldomNode * child = getChildNode(i);
+            if ( child->isElement() && child->getNodeId() == el_inlineBox
+                    && child->getChildCount() > 0 && child->getChildNode(0)->getNodeId() == el_rubyBox ) {
+                // If we find one <inlineBox><rubyBox>, we created that previously and we ensured
+                // there are only rubyBoxes, empty text nodes, or some trailing inline nodes
+                // not followed by a <rt>: no need for more checks and work.
+                needs_wrapping = false;
+                break;
+            }
+        }
+        if ( needs_wrapping ) {
+            // 1) Wrap everything up to (and including consecutive ones) <rt> <rtc> <rp>
+            // into <inlineBox><rubyBox>, and continue doing it after that.
+            int first_to_wrap = -1;
+            int last_to_wrap = -1;
+            for ( int i=0; i<=len; i++ ) {
+                ldomNode * child;
+                lInt16 elemId;
+                bool eoc = i == len; // end of children
+                if ( !eoc ) {
+                    child = getChildNode(i);
+                    if ( child->isElement() ) {
+                        elemId = child->getNodeId();
+                    }
+                    else {
+                        lString16 s = child->getText();
+                        elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
+                        // When meeting an empty space (elemId==-2), we'll delay wrapping
+                        // decision to when we process the next node.
+                        // We'll also not start a wrap with it.
+                    }
+                }
+                if ( last_to_wrap >= 0 && (eoc || (elemId != el_rt && elemId != el_rtc && elemId != el_rp && elemId != -2) ) ) {
+                    if ( getDocument()->hasCacheFile() ) {
+                        // (We can only move/add nodes while we don't yet have a cache file)
+                        getDocument()->setBoxingWishedButPreventedByCache();
+                    }
+                    else {
+                        if ( first_to_wrap < 0 )
+                            first_to_wrap = 0;
+                        ldomNode * rbox1 = boxWrapChildren(first_to_wrap, last_to_wrap, el_rubyBox);
+                        if ( rbox1 && !rbox1->isNull() ) {
+                            // Set an attribute for the kind of container we made (Ruby Segment)
+                            // so we can style it via CSS.
+                            rbox1->setAttributeValue(LXML_NS_NONE, attr_T, L"rseg");
+                            rbox1->initNodeStyle();
+                            // Update loop index and end
+                            int removed = last_to_wrap - first_to_wrap;
+                            i = i - removed;
+                            len = len - removed;
+                            // And wrap this rubyBox in an inlineBox
+                            ldomNode * ibox1 = insertChildElement( first_to_wrap, LXML_NS_NONE, el_inlineBox );
+                            moveItemsTo( ibox1, first_to_wrap+1, first_to_wrap+1 );
+                            ibox1->initNodeStyle();
+                        }
+                        first_to_wrap = -1;
+                        last_to_wrap = -1;
+                    }
+                    if (eoc)
+                        break;
+                }
+                if ( elemId == -1 ) { // isText(), non empty
+                    if ( first_to_wrap < 0 ) {
+                        first_to_wrap = i;
+                    }
+                }
+                else if ( elemId == -2 ) { // isText(), empty
+                    // Don't start a wrap on it
+                }
+                else {
+                    if ( first_to_wrap < 0 ) {
+                        first_to_wrap = i;
+                    }
+                    if ( elemId == el_rt || elemId == el_rtc || elemId == el_rp ) {
+                        last_to_wrap = i;
+                        // Don't wrap yet: there can be followup other RT/RTC
+                    }
+                }
+            }
+            // 2) Enter each rubyBox we have created (they will be inline-table),
+            // and wrap its content as needed to make rows (of rubyBox, rbc and rtc)
+            // and cells (of rubyBox, rb and rt).
+            len = getChildCount();
+            for ( int i=0; i<len; i++ ) {
+                ldomNode * ibox1 = getChildNode(i);
+                if ( !ibox1->isElement() || ibox1->getNodeId() != el_inlineBox )
+                    continue;
+                ldomNode * rbox1 = ibox1->getChildCount() > 0 ? ibox1->getChildNode(0) : NULL;
+                if ( !rbox1 || !rbox1->isElement() || rbox1->getNodeId() != el_rubyBox )
+                    continue;
+                // (Each rbox1 will be set erm_table)
+                int len1 = rbox1->getChildCount();
+                int first_to_wrap = -1;
+                bool ruby_base_wrap_done = false;
+                bool ruby_base_present = false;
+                for ( int i1=0; i1<=len1; i1++ ) {
+                    ldomNode * child;
+                    lInt16 elemId;
+                    bool eoc = i1 == len1; // end of children
+                    if ( !eoc ) {
+                        child = rbox1->getChildNode(i1);
+                        if ( child->isElement() ) {
+                            elemId = child->getNodeId();
+                        }
+                        else {
+                            lString16 s = child->getText();
+                            elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
+                            // When meeting an empty space (elemId==-2), we'll delay wrapping
+                            // decision to when we process the next node.
+                            // We'll also not start a wrap with it.
+                        }
+                    }
+                    if ( first_to_wrap >= 0 && (
+                                    eoc
+                                 || ( !ruby_base_wrap_done && (elemId == el_rtc || elemId == el_rt || elemId == el_rp) )
+                                 || (  ruby_base_wrap_done && elemId == el_rtc )
+                                ) ) {
+                        if ( getDocument()->hasCacheFile() ) {
+                            // (We can only move/add nodes while we don't yet have a cache file)
+                            getDocument()->setBoxingWishedButPreventedByCache();
+                        }
+                        else {
+                            ldomNode * rbox2 = rbox1->boxWrapChildren(first_to_wrap, i1-1, el_rubyBox);
+                            if ( rbox2 && !rbox2->isNull() ) {
+                                // Set an attribute for the kind of container we made (<rbc> or <rtc>-like),
+                                // so we can style it like real <rbc> and <rtc> via CSS.
+                                rbox2->setAttributeValue(LXML_NS_NONE, attr_T, ruby_base_wrap_done ? L"rtc" : L"rbc");
+                                rbox2->initNodeStyle();
+                                // Update loop index and end
+                                int removed = i1-1 - first_to_wrap;
+                                i1 = i1 - removed;
+                                len1 = len1 - removed;
+                            }
+                            first_to_wrap = -1;
+                        }
+                        if ( !eoc && !ruby_base_wrap_done ) {
+                            ruby_base_present = true; // We did create it
+                        }
+                        if (eoc)
+                            break;
+                    }
+                    if ( elemId == -1 ) { // isText(), non empty
+                        if ( first_to_wrap < 0 ) {
+                            first_to_wrap = i1;
+                        }
+                    }
+                    else if ( elemId == -2 ) { // isText(), empty
+                        // Don't start a wrap on it
+                    }
+                    else {
+                        if ( elemId == el_rbc || elemId == el_rtc ) {
+                            // These are fine containers at this level.
+                            // (If el_rbc, we shouldn't have found anything before
+                            // it; if we did, just ignore it.)
+                            first_to_wrap = -1;
+                            ruby_base_wrap_done = true;
+                            if ( elemId == el_rbc )
+                                ruby_base_present = true;
+                        }
+                        else if ( first_to_wrap < 0 ) {
+                            first_to_wrap = i1;
+                            if ( elemId == el_rt || elemId == el_rp ) {
+                                ruby_base_wrap_done = true;
+                            }
+                        }
+                    }
+                }
+                if ( !ruby_base_present ) {
+                    // <ruby><rt>annotation</rt></ruby> : add rubyBox for empty base text
+                    if ( getDocument()->hasCacheFile() ) {
+                        getDocument()->setBoxingWishedButPreventedByCache();
+                    }
+                    else {
+                        ldomNode * rbox2 = rbox1->insertChildElement( 0, LXML_NS_NONE, el_rubyBox );
+                        rbox2->setAttributeValue(LXML_NS_NONE, attr_T, L"rbc");
+                        rbox2->initNodeStyle();
+                    }
+                }
+                // rbox1 now contains only <rbc>, <rtc> or <rubyBox> (which will be set erm_table_row)
+                // 3) for each, ensure its content is <rb>, <rt>, and if not, wrap it in
+                // a <rubyBox> (these will be all like table cells, set erm_final)
+                len1 = rbox1->getChildCount();
+                bool ruby_base_seen = false;
+                for ( int i1=0; i1<len1; i1++ ) {
+                    ldomNode * rbox2 = rbox1->getChildNode(i1);
+                    if ( !rbox2->isElement() )
+                        continue;
+                    lInt16 elemId = rbox2->getNodeId();
+                    lInt16 expected_child_elem_id;
+                    if ( elemId == el_rbc ) {
+                        expected_child_elem_id = el_rb;
+                    }
+                    else if ( elemId == el_rtc ) {
+                        expected_child_elem_id = el_rt;
+                    }
+                    else if ( elemId == el_rubyBox ) {
+                        expected_child_elem_id = ruby_base_seen ? el_rt : el_rb;
+                    }
+                    else { // unexpected
+                        continue;
+                    }
+                    ruby_base_seen = true; // We're passing by a container, the first one being the base
+                    bool has_expected = false;
+                    int len2 = rbox2->getChildCount();
+                    for ( int i2=0; i2<len2; i2++ ) {
+                        ldomNode * child = rbox2->getChildNode(i2);
+                        lInt16 childElemId = child->isElement() ? child->getNodeId() : -1;
+                        if ( childElemId == expected_child_elem_id ) {
+                            // If a single expected is found, assume everything is fine
+                            // (other badly wrapped elements will just be ignored and invisible)
+                            has_expected = true;
+                            break;
+                        }
+                    }
+                    if ( !has_expected ) {
+                        // Wrap everything into a rubyBox
+                        if ( getDocument()->hasCacheFile() ) {
+                            getDocument()->setBoxingWishedButPreventedByCache();
+                        }
+                        else {
+                            if ( len2 > 0 ) { // some children to wrap
+                                ldomNode * rbox3 = rbox2->boxWrapChildren(0, len2-1, el_rubyBox);
+                                if ( rbox3 && !rbox3->isNull() ) {
+                                    rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? L"rb" : L"rt");
+                                    if ( elemId == el_rtc ) {
+                                        // Firefox makes a <rtc>text</rtc> (without any <rt>) span the whole involved base
+                                        rbox3->setAttributeValue(LXML_NS_NONE, attr_rbspan, L"99"); // (our max supported)
+                                    }
+                                    rbox3->initNodeStyle();
+                                }
+                            }
+                            else { // no child to wrap
+                                // We need to insert an empty element to play the role of a <td> for
+                                // the table rendering code to work correctly.
+                                ldomNode * rbox3 = rbox2->insertChildElement( 0, LXML_NS_NONE, el_rubyBox );
+                                rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? L"rb" : L"rt");
+                                rbox3->initNodeStyle();
+                                // We need to add some text for the cell to ensure its height.
+                                // We add a ZERO WIDTH SPACE, which will not collapse into nothing
+                                rbox3->insertChildText(L"\x200B");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // All wrapping done, or assumed to have already been done correctly.
+        // We can set the rendering methods to make all this a table.
+        // All unexpected elements will be erm_invisible
+        len = getChildCount();
+        for ( int i=0; i<len; i++ ) {
+            ldomNode * ibox1 = getChildNode(i);
+            if ( !ibox1->isElement() || ibox1->getNodeId() != el_inlineBox )
+                continue;
+            ibox1->setRendMethod( erm_inline );
+            ldomNode * rbox1 = ibox1->getChildCount() > 0 ? ibox1->getChildNode(0) : NULL;
+            if ( rbox1 && rbox1->isElement() && rbox1->getNodeId() == el_rubyBox ) {
+                // First level rubyBox: each will be an inline table
+                rbox1->setRendMethod( erm_table );
+                int len1 = rbox1->getChildCount();
+                for ( int i1=0; i1<len1; i1++ ) {
+                    ldomNode * rbox2 = rbox1->getChildNode(i1);
+                    if ( rbox2->isElement() ) {
+                        rbox2->setRendMethod( erm_invisible );
+                        lInt16 rb2elemId = rbox2->getNodeId();
+                        if ( rb2elemId == el_rubyBox || rb2elemId == el_rbc || rb2elemId == el_rtc ) {
+                            // Second level rubyBox: each will be a table row
+                            rbox2->setRendMethod( erm_table_row );
+                            int len2 = rbox2->getChildCount();
+                            for ( int i2=0; i2<len2; i2++ ) {
+                                ldomNode * rbox3 = rbox2->getChildNode(i2);
+                                if ( rbox3->isElement() ) {
+                                    rbox3->setRendMethod( erm_invisible );
+                                    lInt16 rb3elemId = rbox3->getNodeId();
+                                    if ( rb3elemId == el_rubyBox || rb3elemId == el_rb || rb3elemId == el_rt ) {
+                                        // Third level rubyBox: each will be a table cell.
+                                        // (As all it content has previously been reset to erm_inline)
+                                        //  /\ This is no more true, but we expect to find inline
+                                        //  content, with possibly some nested ruby.
+                                        // We can have the cell erm_final.
+                                        rbox3->setRendMethod( erm_final );
+                                    }
+                                    // We let <rp> be invisible like other unexpected elements
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -11691,6 +12099,7 @@ public:
             case css_d_none:
                 return false;
             case css_d_inherit:
+            case css_d_ruby:
             case css_d_run_in:
             case css_d_inline:
             case css_d_inline_block: // Make these behave as inline, in case they don't contain much

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -34,7 +34,7 @@
 // be applied after a <BR>.
 //
 // 20180524: changed default rendering of:
-//   <li> (and css 'display:list-item') from css_d_list_item to css_d_list_item_block
+//   <li> (and css 'display:list-item') from css_d_list_item_legacy to css_d_list_item_block
 //   <cite> from css_d_block to css_d_inline (inline in HTML, block in FB2, ensured by fb2.css)
 //   <style> from css_d_inline to css_d_none (invisible in HTML)
 // Changed also the default display: value for base elements (and so
@@ -4063,7 +4063,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 case erm_block:              *stream << "B";     break;
                 case erm_final:              *stream << "F";     break;
                 case erm_inline:             *stream << "i";     break;
-                case erm_list_item:          *stream << "L";     break; // no more used
+                case erm_runin:              *stream << "r";     break;
                 case erm_table:              *stream << "T";     break;
                 case erm_table_row_group:    *stream << "TRG";   break;
                 case erm_table_header_group: *stream << "THG";   break;
@@ -4071,7 +4071,6 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 case erm_table_row:          *stream << "TR";    break;
                 case erm_table_column_group: *stream << "TCG";   break;
                 case erm_table_column:       *stream << "TC";    break;
-                case erm_runin:              *stream << "R";     break;
                 default:                     *stream << "?";     break;
             }
         }
@@ -5935,9 +5934,9 @@ void ldomNode::initNodeRendMethod()
         //CRLog::trace("switch all children elements of <%s> to inline", LCSTR(getNodeName()));
         recurseElements( resetRendMethodToInline );
         setRendMethod(erm_runin);
-    } else if ( d==css_d_list_item ) {
+    } else if ( d==css_d_list_item_legacy ) {
         // list item (no more used, obsolete rendering method)
-        setRendMethod(erm_list_item);
+        setRendMethod(erm_final);
     } else if ( d==css_d_table ) {
         // table: this will "Generate missing child wrappers" if needed
         initTableRendMethods( this, 0 );
@@ -7616,7 +7615,7 @@ ldomNode * ldomXPointer::getFinalNode() const
     for (;;) {
         if ( !node )
             return NULL;
-        if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item )
+        if ( node->getRendMethod()==erm_final )
             return node;
         node = node->getParentNode();
     }
@@ -7628,7 +7627,7 @@ bool ldomXPointer::isFinalNode() const
     ldomNode * node = getNode();
     if ( !node )
         return false;
-    if ( node->getRendMethod()==erm_final || node->getRendMethod()==erm_list_item )
+    if ( node->getRendMethod()==erm_final )
         return true;
     return false;
 }
@@ -7686,7 +7685,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
     // printf("finalNode %s\n", UnicodeToLocal(ldomXPointer(finalNode, 0).toString()).c_str());
 
     lvdom_element_render_method rm = finalNode->getRendMethod();
-    if ( rm != erm_final && rm != erm_list_item ) {
+    if ( rm != erm_final ) {
         // Not final, return XPointer to first or last child
         lvRect rc;
         finalNode->getAbsRect( rc );
@@ -7972,20 +7971,22 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
     for ( ; p; p = p->getParentNode() ) {
         int rm = p->getRendMethod();
         if ( rm == erm_final ) {
-            // With floats, we may get multiple erm_final when walking up
-            // to root node: keep the first one met (but go on up to the
-            // root node in case we're in some upper erm_invisible).
-            if (!finalNode)
-                finalNode = p; // found final block
-        }
-        else if (rm == erm_list_item) {
-            // This obsolete rendering method is considered just like erm_final
-            // for many purposes, but can contain real erm_final nodes.
-            // So, if we found an erm_final, and if we find an erm_list_item
-            // when going up, we should use it (unlike in previous case).
-            // (This is needed to correctly display highlights on books opened
-            // with some older DOM_VERSION.)
-            finalNode = p;
+            if ( gDOMVersionRequested < 20180524 && p->getStyle()->display == css_d_list_item_legacy ) {
+                // This legacy rendering of list item is now erm_final, but
+                // can contain other real erm_final nodes.
+                // So, if we found an erm_final, and if we find this erm_final
+                // when going up, we should use it (unlike in next case).
+                // (This is needed to correctly display highlights on books opened
+                // with some older DOM_VERSION.)
+                finalNode = p;
+            }
+            else {
+                // With floats, we may get multiple erm_final when walking up
+                // to root node: keep the first one met (but go on up to the
+                // root node in case we're in some upper erm_invisible).
+                if (!finalNode)
+                    finalNode = p; // found final block
+            }
         }
         else if ( p->getRendMethod() == erm_invisible ) {
             return false; // invisible !!!
@@ -9968,8 +9969,7 @@ bool ldomXRange::getRectEx( lvRect & rect, bool & isSingleLine )
     ldomNode * finalNode2 = getEnd().getFinalNode();
     if ( !finalNode1 || !finalNode2 ) {
         // Shouldn't happen, but prevent a segfault in case some other bug
-        // in initNodeRendMethod made some text not having a erm_final-like
-        // ancestor.
+        // in initNodeRendMethod made some text not having an erm_final ancestor.
         if ( !finalNode1 )
             printf("CRE WARNING: no final parent for range start %s\n", UnicodeToLocal(getStart().toString()).c_str());
         if ( !finalNode2 )
@@ -11027,7 +11027,6 @@ ldomNode * ldomXPointerEx::getThisBlockNode()
         case erm_runin: // treat as separate block
         case erm_block:
         case erm_final:
-        case erm_list_item: // no more used (obsolete rendering method)
         case erm_table:
         case erm_table_row_group:
         case erm_table_row:
@@ -15015,7 +15014,7 @@ void ldomNode::getAbsRect( lvRect & rect, bool inner )
     rect.bottom = fmt.getHeight();
     if ( inner && RENDER_RECT_HAS_FLAG(fmt, INNER_FIELDS_SET) ) {
         // This flag is set only when in enhanced rendering mode, and
-        // only on erm_final-like nodes.
+        // only on erm_final nodes.
         rect.left += fmt.getInnerX();     // add padding left
         rect.top += fmt.getInnerY();      // add padding top
         rect.right = fmt.getInnerWidth(); // replace by inner width
@@ -15399,13 +15398,13 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
 
         int top_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[2], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y < fmt.getY() - top_margin) {
-            if ( direction >= PT_DIR_SCAN_FORWARD && (rm == erm_final || rm == erm_list_item) )
+            if ( direction >= PT_DIR_SCAN_FORWARD && rm == erm_final )
                 return this;
             return NULL;
         }
         int bottom_margin = ignore_margins ? 0 : lengthToPx(enode->getStyle()->margin[3], fmt.getWidth(), enode->getFont()->getSize());
         if ( pt.y >= fmt.getY() + fmt.getHeight() + bottom_margin ) {
-            if ( direction <= PT_DIR_SCAN_BACKWARD && (rm == erm_final || rm == erm_list_item) )
+            if ( direction <= PT_DIR_SCAN_BACKWARD && rm == erm_final )
                 return this;
             return NULL;
         }
@@ -15445,7 +15444,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         // We could add more conditions (like parentNode->getRendMethod()>=erm_table),
         // but let's just check this in all cases when direction=0.
     }
-    if ( rm == erm_final || rm == erm_list_item ) {
+    if ( rm == erm_final ) {
         // Final node, that's what we looked for
         return this;
     }
@@ -15875,7 +15874,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                     sibling = sibling->getUnboxedNextSibling(true);
                     continue;
                 }
-                if ( cs->display != css_d_list_item_block && cs->display != css_d_list_item) {
+                if ( cs->display != css_d_list_item_block && cs->display != css_d_list_item_legacy) {
                     // Alien element among list item nodes, skip it to not mess numbering
                     if ( sibling == this ) // Should not happen, but let's be sure
                         break;
@@ -16578,7 +16577,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     if ( cache.get( this, f ) ) {
         if ( f->isReusable() ) {
             frmtext = f;
-            if ( rm != erm_final && rm != erm_list_item )
+            if ( rm != erm_final )
                 return 0;
             //RenderRectAccessor fmt( this );
             //CRLog::trace("Found existing formatted object for node #%08X", (lUInt32)this);
@@ -16588,7 +16587,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
         cache.remove( this );
     }
     f = getDocument()->createFormattedText();
-    if ( rm != erm_final && rm != erm_list_item )
+    if ( rm != erm_final )
         return 0;
     //RenderRectAccessor fmt( this );
     /// render whole node content as single formatted object

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5863,7 +5863,25 @@ lString16 LVReadTextFile( LVStreamRef stream )
     return buf;
 }
 
-
+// In the following list of autoclose definitions, there are 2 forms:
+// Either: {"hr", NULL}
+//    meaning this element auto-closes itself
+// Or: {"ul", "li", "p", NULL}
+//    meaning that when "ul" is about to be inserted in the DOM as a child of
+//    the current node, we check the current node and up its parent until we
+//    find one that is listed among the followup list of tags: ["li", "p"] (we
+//    stop at the first one found).
+//    If none found: fine, nothing special to do, go on inserting it here.
+//    If one found, autoclose current node, and its parent nodes up to the found
+//    node, found node included. And then insert the new element as a child of that
+//    found node's parent (so the new element becomes a sibling of that found node).
+//    i.e:
+//    {"li", "li", "p", NULL}: a new <li> appearing inside (even deep inside)
+//        another <li> or <p> will close it to become a sibling of this <li> or <p>
+//    {"ul", "li", "p", NULL}: a new <ul> appearing inside (even deep inside)
+//        another <li> or <p> will close it to become a sibling of this <li> or <p>,
+//        so possibly a child of the <ul> that is the parent of the <li>, or
+//        a child of the <div> that is the parent of the <p>.
 static const char * AC_P[]  = {"p", "p", "hr", NULL};
 static const char * AC_COL[] = {"col", NULL};
 static const char * AC_LI[] = {"li", "li", "p", NULL};
@@ -5887,6 +5905,11 @@ static const char * AC_TFOOT[] = {"tfoot", "tr", "thead", "tfoot", "tbody", NULL
 static const char * AC_TBODY[] = {"tbody", "tr", "thead", "tfoot", "tbody", NULL};
 static const char * AC_OPTION[] = {"option", "option", NULL};
 static const char * AC_PRE[] = {"pre", "pre", NULL};
+static const char * AC_RBC[] = {"rbc", "rbc", "rb", "rtc", "rt", NULL};
+static const char * AC_RTC[] = {"rtc", "rtc", "rt", "rbc", "rb", NULL};
+static const char * AC_RB[] = {"rb", "rb", "rt", "rtc", NULL};
+static const char * AC_RT[] = {"rt", "rt", "rb", "rbc", NULL};
+static const char * AC_RP[] = {"rp", "rp", "rb", "rt", NULL};
 static const char * AC_INPUT[] = {"input", NULL};
 static const char * AC_AREA[] = {"area", NULL};
 static const char * AC_BASE[] = {"base", NULL};
@@ -5928,6 +5951,11 @@ HTML_AUTOCLOSE_TABLE[] = {
     AC_TFOOT,
     AC_TBODY,
     AC_TABLE,
+    AC_RBC,
+    AC_RTC,
+    AC_RB,
+    AC_RT,
+    AC_RP,
     NULL
 };
 // Note: AC_TD and AC_TR may kill a table nested inside an other table,


### PR DESCRIPTION
`Fix some non-recursive subtree walkers`
`Text: skip formatting optimisations when inlineBoxes`
`CSS parsing: parse selectors starting with [attrib]`
`Use T="" for internal elements attributes`
`CSS: re-order css_d_* (display) enum for easier checking`
`Rendering methods: remove erm_table_cell`
`Rendering methods: remove erm_table_caption`
`Rendering methods: remove erm_list_item`
`getRenderedWidths(): better estimate table width`
`styleToTextFmtFlags(): adds is_block parameter`
Some fixes and needed cleanups noticed while making the ruby stuff - but unrelated to the ruby support itself.
See individual commit messages for details.

#### `Adds support for "display: ruby" and <ruby> elements`
See previous discussion and early attempts at supporting ruby via style tweaks in https://github.com/koreader/koreader/issues/6223.
Some final results screenshot with real japanese ruby in https://github.com/koreader/koreader/issues/6223#issuecomment-644110399 .

See the big comment in lvtinydom.cpp for details. Just cut and pasting its beginning:

Ruby input can be quite loose and have various tag strategies (mono/group, interleaved/tabular, double sided). Moreover, the specs have evolved between 2001 and 2020 (`<rbc>` tag no more mentionned 2020; `<rtc>` being just another semantic container for Mozilla, and can be preceded by a bunch of `<rt>` which are pronunciation containers, that don't have to be in an `<rtc>`...)
Moreover, various samples on the following pages don't close tags, and expect the HTML parser to do that. We do that only when parsing .html files, but we don't when parsing .epub files as they  expected to be balanced XHTML.

References:
https://www.w3.org/International/articles/ruby/markup
https://www.w3.org/TR/ruby-use-cases/ differences between XHTML, HTML5 & HTML Extensions
https://www.w3.org/TR/ruby/ Ruby Annotation, 2001
http://darobin.github.io/html-ruby/ HTML Ruby Markup Extensions, 2015
https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element HTML 2020
https://drafts.csswg.org/css-ruby/ CSS Ruby Layout, 2020
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rtc
https://chenhuijing.com/blog/html-ruby/ All about the HTML `<ruby>` element (in 2016)
`https://github.com/w3c/html/issues/291` How to handle legacy Ruby content that may use `<rbc>`?
https://w3c.github.io/i18n-tests/results/ruby-html Browsers support

The idea is that for this simple ruby fragment: `<ruby>紫檀<rt>したん</rt></ruby>`

We'll build this in the DOM (and give them appropriate table rendering methods):
<kbd>![image](https://user-images.githubusercontent.com/24273478/84677581-34a87380-af2f-11ea-831c-1e68c4f9f1c8.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/84679278-66223e80-af31-11ea-8c95-dabfe0e9a6c7.png)</kbd> 

so it can be rendered as an inline table like:
<kbd>![image](https://user-images.githubusercontent.com/24273478/84678032-d16b1100-af2f-11ea-8c2b-06b70057f98d.png)</kbd> and become <kbd>![image](https://user-images.githubusercontent.com/24273478/84677805-881ac180-af2f-11ea-99b7-8dc77b7d3945.png)</kbd>

(I have no idea how much of an overhead this adds when rendering/drawing books with thousands of such ruby :)

Random screenshots of stuff (working or not) used while testing:

<kbd>![image](https://user-images.githubusercontent.com/24273478/84678719-a59c5b00-af30-11ea-9bbf-89071f854a77.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/84678753-acc36900-af30-11ea-9d07-acfb555f0a11.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/84678780-b6e56780-af30-11ea-95b7-91927d657cc1.png)</kbd>
<kbd>![image](https://user-images.githubusercontent.com/24273478/84678800-be0c7580-af30-11ea-8e71-0f5d4fdafa57.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/347)
<!-- Reviewable:end -->
