### PR TITLE
Don't mangle source pixel when alpha-blending to 8bpp

### DIFF
--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -673,6 +673,8 @@ public:
                         } else if ( bpp == 4 ) {
                             origColor = origColor & 0xF0;
                             origColor = origColor | (origColor>>4);
+                        } else {
+                            origColor = origColor & 0xFF;
                         }
                         // Expand to RGB32 (i.e., duplicate, R = G = B = Y)
                         origColor = origColor | (origColor<<8) | (origColor<<16);

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -666,15 +666,16 @@ public:
                         }
                     } else if ( alpha != 0 ) {
                         lUInt32 origColor = row[x];
+                        // Expand to Gray8
                         if ( bpp == 3 ) {
                             origColor = origColor & 0xE0;
                             origColor = origColor | (origColor>>3) | (origColor>>6);
-                            origColor = origColor | (origColor<<8) | (origColor<<16);
                         } else if ( bpp == 4 ) {
                             origColor = origColor & 0xF0;
                             origColor = origColor | (origColor>>4);
-                            origColor = origColor | (origColor<<8) | (origColor<<16);
                         }
+                        // Expand to RGB32 (i.e., duplicate, R = G = B = Y)
+                        origColor = origColor | (origColor<<8) | (origColor<<16);
                         ApplyAlphaRGB( origColor, cl, alpha );
                         cl = origColor;
                     }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -665,21 +665,19 @@ public:
                             continue;
                         }
                     } else if ( alpha != 0 ) {
-                        lUInt32 origColor = row[x];
-                        // Expand to Gray8
+                        lUInt8 origColor = row[x];
+                        // Expand lower bitdepths to Y8
                         if ( bpp == 3 ) {
                             origColor = origColor & 0xE0;
                             origColor = origColor | (origColor>>3) | (origColor>>6);
                         } else if ( bpp == 4 ) {
                             origColor = origColor & 0xF0;
                             origColor = origColor | (origColor>>4);
-                        } else {
-                            origColor = origColor & 0xFF;
                         }
-                        // Expand to RGB32 (i.e., duplicate, R = G = B = Y)
-                        origColor = origColor | (origColor<<8) | (origColor<<16);
-                        ApplyAlphaRGB( origColor, cl, alpha );
-                        cl = origColor;
+                        // Expand Y8 to RGB32 (i.e., duplicate, R = G = B = Y)
+                        lUInt32 bufColor = origColor | (origColor<<8) | (origColor<<16);
+                        ApplyAlphaRGB( bufColor, cl, alpha );
+                        cl = bufColor;
                     }
 
                     lUInt8 dcl;

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -726,12 +726,12 @@ public:
                             continue;
                         }
                     } else if ( alpha != 0 ) {
-                        lUInt32 origColor = (row[ byteindex ] & mask)>>bitindex;
-                        origColor = origColor | (origColor<<2);
-                        origColor = origColor | (origColor<<4);
-                        origColor = origColor | (origColor<<8) | (origColor<<16);
-                        ApplyAlphaRGB( origColor, cl, alpha );
-                        cl = origColor;
+                        lUInt8 origLuma = (row[ byteindex ] & mask)>>bitindex;
+                        origLuma = origLuma | (origLuma<<2);
+                        origLuma = origLuma | (origLuma<<4);
+                        lUInt32 bufColor = origLuma | (origLuma<<8) | (origLuma<<16);
+                        ApplyAlphaRGB( bufColor, cl, alpha );
+                        cl = bufColor;
                     }
 
                     lUInt32 dcl = 0;

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -670,7 +670,7 @@ public:
                             origColor = origColor & 0xE0;
                             origColor = origColor | (origColor>>3) | (origColor>>6);
                             origColor = origColor | (origColor<<8) | (origColor<<16);
-                        } else if ( bpp = 4 ) {
+                        } else if ( bpp == 4 ) {
                             origColor = origColor & 0xF0;
                             origColor = origColor | (origColor>>4);
                             origColor = origColor | (origColor<<8) | (origColor<<16);

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -665,17 +665,17 @@ public:
                             continue;
                         }
                     } else if ( alpha != 0 ) {
-                        lUInt8 origColor = row[x];
+                        lUInt8 origLuma = row[x];
                         // Expand lower bitdepths to Y8
                         if ( bpp == 3 ) {
-                            origColor = origColor & 0xE0;
-                            origColor = origColor | (origColor>>3) | (origColor>>6);
+                            origLuma = origLuma & 0xE0;
+                            origLuma = origLuma | (origLuma>>3) | (origLuma>>6);
                         } else if ( bpp == 4 ) {
-                            origColor = origColor & 0xF0;
-                            origColor = origColor | (origColor>>4);
+                            origLuma = origLuma & 0xF0;
+                            origLuma = origLuma | (origLuma>>4);
                         }
                         // Expand Y8 to RGB32 (i.e., duplicate, R = G = B = Y)
-                        lUInt32 bufColor = origColor | (origColor<<8) | (origColor<<16);
+                        lUInt32 bufColor = origLuma | (origLuma<<8) | (origLuma<<16);
                         ApplyAlphaRGB( bufColor, cl, alpha );
                         cl = bufColor;
                     }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -669,11 +669,12 @@ public:
                         if ( bpp == 3 ) {
                             origColor = origColor & 0xE0;
                             origColor = origColor | (origColor>>3) | (origColor>>6);
-                        } else {
+                            origColor = origColor | (origColor<<8) | (origColor<<16);
+                        } else if ( bpp = 4 ) {
                             origColor = origColor & 0xF0;
                             origColor = origColor | (origColor>>4);
+                            origColor = origColor | (origColor<<8) | (origColor<<16);
                         }
-                        origColor = origColor | (origColor<<8) | (origColor<<16);
                         ApplyAlphaRGB( origColor, cl, alpha );
                         cl = origColor;
                     }


### PR DESCRIPTION
I'm not quite sure what the bit twiddling was attempting to do, because
I'm not familiar with those low bitdepths, but it's almost definitely
wrong for 8bpp targets, where we do *NOT* want/need *any* quantization.

Dates back to 4c9e894b23a5af82ba5b8b7d0678d37a9da11cad

Re https://github.com/koreader/koreader/issues/6345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/352)
<!-- Reviewable:end -->
