### PR TITLE
FB2: fix various issues

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -18,7 +18,7 @@ ul { display: block; list-style-type: disc; margin-left: 1em }
 ol { display: block; list-style-type: decimal; margin-left: 1em }
 
 cite p, epigraph p { text-align: left; text-indent: 0px }
-v { text-align: left; text-align-last: right; text-indent: 1em hanging }
+v { text-align: left; text-align-last: -cr-right-if-not-first; text-indent: 1em hanging; hyphenate: none }
 
 stanza + stanza { margin-top: 1em; }
 stanza { margin-left: 15%; text-align: left; font-style: italic  }
@@ -80,11 +80,11 @@ th {  font-weight: bold; text-align: center; background-color: #DDD  }
 /* #808080; */
 table caption { text-indent: 0px; padding: 4px; background-color: #EEE }
 
-tt, samp, kbd, code, pre { font-family: "Courier New", "Courier", monospace; }
+tt, samp, kbd { font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", "Courier New", "Courier", monospace; }
 code, pre {
    white-space: pre;
    text-align: left;
-   font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", monospace;
+   font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", "Courier New", "Courier", monospace;
    }
 code {
    display: inline;
@@ -109,10 +109,6 @@ body[name="comments"] section title {
     page-break-inside: auto;
     page-break-after: auto;
 }
-body[name="notes"] section title p,
-body[name="comments"] section title p {
-    display: inline; /* counteract default of block, so it can be inline with the preceeding number */
-}
 
 description { display: block; }
 title-info { display: block; }
@@ -132,7 +128,7 @@ coverpage { display: none }
 
 head, form, script { display: none; }
 
-b,strong,i,em,dfn,var,q,u,underline,del,s,strike,spacing,small,big,sub,sup,acronym,tt,sa mp,kbd,code {
+b,strong,i,em,dfn,var,q,u,underline,del,s,strike,spacing,small,big,sub,sup,acronym,tt,samp,kbd {
    display: inline;
 }
 

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -104,7 +104,14 @@ enum css_text_align_t {
     css_ta_justify,
     css_ta_start, // = left if LTR, right if RTL
     css_ta_end,   // = right if LTR, left if LTR
-    css_ta_auto   // only accepted with text-align-last
+    // Next ones are only accepted with text-align-last
+    css_ta_auto,
+    css_ta_left_if_not_first,    // These non standard keywords allow text-align-last
+    css_ta_right_if_not_first,   // to not apply to a single line. The previous normal
+    css_ta_center_if_not_first,  // keywords apply to a single line (which is alone,
+    css_ta_justify_if_not_first, // so the last) according to the specs.
+    css_ta_start_if_not_first,
+    css_ta_end_if_not_first
 };
 
 /// vertical-align property values

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -67,8 +67,8 @@ extern "C" {
 // Text white-space and hyphenation handling
 #define LTEXT_FLAG_PREFORMATTED      0x00010000  // text is preformatted (white-space: pre, pre-wrap, break-spaces)
 #define LTEXT_FLAG_NOWRAP            0x00020000  // text does not allow wrap (white-space: nowrap)
-#define LTEXT_HYPHENATE              0x00040000  // allow hyphenation
-#define LTEXT__AVAILABLE_BIT_20__    0x00080000
+#define LTEXT_LOCKED_SPACING         0x00040000  // regular spaces should not change width with text justification
+#define LTEXT_HYPHENATE              0x00080000  // allow hyphenation
 
 // Source object type (when source is not a text node)
 #define LTEXT_SRC_IS_OBJECT          0x00100000  // object (image)

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -39,6 +39,7 @@ extern "C" {
 #define LTEXT_LAST_LINE_ALIGN_RIGHT  0x0020  // last line of justified paragraph should be right-aligned
 #define LTEXT_LAST_LINE_ALIGN_CENTER 0x0030  // last line of justified paragraph should be centered
 #define LTEXT_LAST_LINE_ALIGN_WIDTH  0x0040  // last line of justified paragraph should be justified
+#define LTEXT_LAST_LINE_IF_NOT_FIRST 0x0080  // previous flag doesn't apply if last line is also the first (standalone line)
 
 // Text vertical alignment
 #define LTEXT_VALIGN_MASK            0x0700  // vertical align flags mask
@@ -61,8 +62,7 @@ extern "C" {
 
 // (Don't waste the 4th bit not used in the 4-bits sets above)
 #define LTEXT_FLAG_OWNTEXT           0x0008  // store local copy of text instead of pointer
-#define LTEXT_IS_LINK                0x0080  // source text is a link (to gather in-page footnotes)
-#define LTEXT__AVAILABLE_BIT_16__    0x8000
+#define LTEXT_IS_LINK                0x8000  // source text is a link (to gather in-page footnotes)
 
 // Text white-space and hyphenation handling
 #define LTEXT_FLAG_PREFORMATTED      0x00010000  // text is preformatted (white-space: pre, pre-wrap, break-spaces)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2139,7 +2139,7 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
     lUInt32 flg = oldflags;
     if ( is_block ) {
         // text alignment flags
-        flg = oldflags & ~LTEXT_FLAG_NEWLINE;
+        flg = oldflags & ~(LTEXT_FLAG_NEWLINE | (LTEXT_FLAG_NEWLINE<<LTEXT_LAST_LINE_ALIGN_SHIFT) | LTEXT_LAST_LINE_IF_NOT_FIRST);
         switch (style->text_align)
         {
             case css_ta_left:
@@ -2160,8 +2160,8 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
             case css_ta_end:
                 flg |= (direction == REND_DIRECTION_RTL ? LTEXT_ALIGN_LEFT : LTEXT_ALIGN_RIGHT);
                 break;
-            case css_ta_auto: // shouldn't happen (only accepted with text-align-last)
             case css_ta_inherit:
+            default: // others values shouldn't happen (only accepted with text-align-last)
                 break;
         }
         switch (style->text_align_last)
@@ -2186,6 +2186,30 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
                 break;
             case css_ta_auto: // let flg have none of the above set, which will mean "auto"
             case css_ta_inherit:
+                break;
+            case css_ta_left_if_not_first:     // Private text-align-last keywords
+                flg |= LTEXT_LAST_LINE_ALIGN_LEFT;
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
+                break;
+            case css_ta_right_if_not_first:
+                flg |= LTEXT_LAST_LINE_ALIGN_RIGHT;
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
+                break;
+            case css_ta_center_if_not_first:
+                flg |= LTEXT_LAST_LINE_ALIGN_CENTER;
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
+                break;
+            case css_ta_justify_if_not_first:
+                flg |= LTEXT_LAST_LINE_ALIGN_WIDTH;
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
+                break;
+            case css_ta_start_if_not_first:
+                flg |= (direction == REND_DIRECTION_RTL ? LTEXT_LAST_LINE_ALIGN_RIGHT : LTEXT_LAST_LINE_ALIGN_LEFT);
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
+                break;
+            case css_ta_end_if_not_first:
+                flg |= (direction == REND_DIRECTION_RTL ? LTEXT_LAST_LINE_ALIGN_LEFT : LTEXT_LAST_LINE_ALIGN_RIGHT);
+                flg |= LTEXT_LAST_LINE_IF_NOT_FIRST;
                 break;
         }
     }
@@ -2504,7 +2528,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         // be prepended with the run-in node content.
                         lUInt32 next_sibling_flags = styleToTextFmtFlags( true, next_sibling->getStyle(), baseflags, direction );
                         // Grab only the alignment flags
-                        lUInt32 align_flags_mask = LTEXT_FLAG_NEWLINE | (LTEXT_FLAG_NEWLINE<<LTEXT_LAST_LINE_ALIGN_SHIFT);
+                        lUInt32 align_flags_mask = LTEXT_FLAG_NEWLINE | (LTEXT_FLAG_NEWLINE<<LTEXT_LAST_LINE_ALIGN_SHIFT) | LTEXT_LAST_LINE_IF_NOT_FIRST;
                         next_sibling_flags &= align_flags_mask;
                         // Update both flags and baseflags with the grabbed alignments
                         flags &= ~align_flags_mask;
@@ -2995,7 +3019,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         flags |= (is_rtl ? LTEXT_ALIGN_LEFT : LTEXT_ALIGN_RIGHT);
                         break;
                     case css_ta_inherit:
-                    case css_ta_auto:
+                    default: // others values shouldn't happen (only accepted with text-align-last)
                         break;
                     }
                 }
@@ -3246,7 +3270,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 baseflags |= (is_rtl ? LTEXT_ALIGN_LEFT : LTEXT_ALIGN_RIGHT);
                 break;
             case css_ta_inherit:
-            case css_ta_auto:
+            default: // others values shouldn't happen (only accepted with text-align-last)
                 break;
             }
             // Among inline nodes, only <BR> can carry a "clear: left/right/both".

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3197,14 +3197,31 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
 
             if ( isRunIn ) {
-                // append space to run-in object
+                // Append space to run-in object: both the run-in text node and
+                // the following paragraph first text node might not end or start
+                // with a space. But they might also both do, and we want all spaces
+                // to collapse into one - so, we don't set LTEXT_FLAG_PREFORMATTED,
+                // and we don't use UNICODE_NO_BREAK_SPACE.
                 LVFontRef font = enode->getFont();
                 css_style_ref_t style = enode->getStyle();
                 lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                txform->AddSourceLine( L" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
+                /*
+                // We used to specify two UNICODE_NO_BREAK_SPACE (that would not collapse)
+                // mostly so we were able to detect them in lvtextfm.cpp and avoid this
+                // spacing to change width with text justification.
                 lChar16 delimiter[] = {UNICODE_NO_BREAK_SPACE, UNICODE_NO_BREAK_SPACE}; //160
                 txform->AddSourceLine( delimiter, sizeof(delimiter)/sizeof(lChar16), cl, bgcl, font.get(), lang_cfg,
                                             LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                // Users who would like more spacing can use:
+                //   body[name="notes"] section title:after,
+                //   body[name="comments"] section title:after {
+                //       content: '\A0'
+                //   }
+                // But the text nodes spaces will then not collapse, and constant spacing
+                // won't be ensured (spacing may vary from one document to another).
+                */
             }
         }
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1445,6 +1445,12 @@ static const char * css_ta_names[] =
     "start",
     "end",
     "auto",
+    "-cr-left-if-not-first",
+    "-cr-right-if-not-first",
+    "-cr-center-if-not-first",
+    "-cr-justify-if-not-first",
+    "-cr-start-if-not-first",
+    "-cr-end-if-not-first",
     NULL
 };
 
@@ -1913,7 +1919,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 break;
             case cssd_text_align:
                 n = parse_name( decl, css_ta_names, -1 );
-                if ( n == css_ta_auto ) // only accepted with text-align-last
+                if ( n >= css_ta_auto ) // only accepted with text-align-last
                     n = -1;
                 break;
             case cssd_text_align_last:

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1780,6 +1780,7 @@ static const char * css_cr_only_if_names[]={
         "allow-style-w-h-absolute-units",
         "full-featured",
         "epub-document",
+        "fb2-document",
         NULL
 };
 enum cr_only_if_t {
@@ -1795,6 +1796,7 @@ enum cr_only_if_t {
     cr_only_if_allow_style_w_h_absolute_units,
     cr_only_if_full_featured,
     cr_only_if_epub_document,
+    cr_only_if_fb2_document, // fb2 or fb3
 };
 
 bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
@@ -1888,6 +1890,15 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             // but we don't expect to see -cr-only-if: in them.
                             if (doc) {
                                 match = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none) == doc_format_epub;
+                                if (invert) {
+                                    match = !match;
+                                }
+                            }
+                        }
+                        else if ( name == cr_only_if_fb2_document ) {
+                            if (doc) {
+                                int doc_format = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none);
+                                match = (doc_format == doc_format_fb2) || (doc_format == doc_format_fb3);
                                 if (invert) {
                                     match = !match;
                                 }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -968,6 +968,8 @@ public:
         int pos = 0;
         int i;
         bool prev_was_space = true; // start with true, to get rid of all leading spaces
+        bool is_locked_spacing = false;
+        int last_non_collapsed_space_pos = 0; // reset to -1 if first char is not a space
         int last_non_space_pos = -1; // to get rid of all trailing spaces
         src_text_fragment_t * prev_src = NULL;
 
@@ -1087,7 +1089,9 @@ public:
                     m_flags[pos] |= LCHAR_ALLOW_WRAP_AFTER;
                 #endif
                 last_non_space_pos = pos;
+                last_non_collapsed_space_pos = -1;
                 prev_was_space = false;
+                is_locked_spacing = false;
                 pos++;
             }
             else if ( src->flags & LTEXT_SRC_IS_OBJECT ) {
@@ -1106,7 +1110,9 @@ public:
                     m_flags[pos] |= LCHAR_ALLOW_WRAP_AFTER;
                 #endif
                 last_non_space_pos = pos;
+                last_non_collapsed_space_pos = -1;
                 prev_was_space = false;
+                is_locked_spacing = false;
                 pos++;
             }
             else {
@@ -1180,25 +1186,62 @@ public:
                 for ( int k=0; k<len; k++ ) {
                     lChar16 c = m_text[pos];
 
+                    // If not on a 'pre' text node, we should strip trailing
+                    // spaces and collapse consecutive spaces (other spaces
+                    // like UNICODE_NO_BREAK_SPACE should not collapse).
                     bool is_space = (c == ' ');
-                    if ( is_space && prev_was_space && !preformatted ) {
-                        // On non-pre paragraphs, flag spaces following a space
-                        // so we can discard them later.
-                        // Note: for the empty lines or indentation we might add
-                        // with 'txform->AddSourceLine(L" "...)', we need to
-                        // provide LTEXT_FLAG_PREFORMATTED if we don't want them
-                        // to be collapsed.
-                        m_flags[pos] = LCHAR_IS_COLLAPSED_SPACE | LCHAR_ALLOW_WRAP_AFTER;
-                        // m_text[pos] = '_'; // uncomment when debugging
-                        // (We can replace the char to see it in printf() (m_text is not the
-                        // text that is drawn, it's measured but we correct the measure
-                        // by setting a zero width, it's just used here for analysis.
-                        // But best to let it as-is except for debugging)
+                    if ( is_space && !preformatted ) {
+                        if ( prev_was_space ) {
+                            // On non-pre text nodes, flag spaces following a space
+                            // so we can discard them later.
+                            // Note: the behaviour with consecutive spaces in a mix
+                            // of pre and non-pre text nodes has not been tested,
+                            // and what we do here might be wrong.
+                            // Note: with a mix of normal spaces and non-break-spaces,
+                            // we seem to behave just as Firefox.
+                            // Note: for the empty lines or indentation we might add
+                            // with 'txform->AddSourceLine(L" "...)', we need to
+                            // provide LTEXT_FLAG_PREFORMATTED if we don't want them
+                            // to be collapsed.
+                            m_flags[pos] = LCHAR_IS_COLLAPSED_SPACE | LCHAR_ALLOW_WRAP_AFTER;
+                            // m_text[pos] = '_'; // uncomment when debugging
+                            // (We can replace the char to see it in printf() (m_text is not the
+                            // text that is drawn, it's measured but we correct the measure
+                            // by setting a zero width, it's just used here for analysis.
+                            // But best to let it as-is except for debugging)
+                        }
+                        else {
+                            last_non_collapsed_space_pos = pos;
+                        }
+                        // Locked spacing can be set on any space among contiguous spaces,
+                        // but will be useful only on the non-collapsed one. We propagate
+                        // it on all previous and following spaces so we don't have to
+                        // redo-it after any BiDi re-ordering (not sure thus this will
+                        // be alright...)
+                        // (This is for now only used with FB2 run-in footnotes to ensure
+                        // a constant width between the footnote number and its following
+                        // text, but could be used with list item markers/numbers.)
+                        if ( src->flags & LTEXT_LOCKED_SPACING )
+                            is_locked_spacing = true;
+                        if ( is_locked_spacing ) {
+                            m_flags[pos] |= LCHAR_LOCKED_SPACING;
+                            if ( last_non_collapsed_space_pos >= 0 ) { // update previous spaces
+                                for ( int j=last_non_collapsed_space_pos; j<pos; j++ ) {
+                                    m_flags[j] |= LCHAR_LOCKED_SPACING;
+                                }
+                            }
+                        }
                     }
-                    if ( !is_space || preformatted ) // don't strip traling spaces if pre
+                    else {
+                        // don't strip traling spaces if pre
                         last_non_space_pos = pos;
-                    if ( !is_space )
-                        m_allow_strut_confinning = true;
+                        last_non_collapsed_space_pos = -1;
+                        is_locked_spacing = false;
+                        if ( !is_space ) {
+                            // Non empty text, we can do strut confinning
+                            m_allow_strut_confinning = true;
+                        }
+                    }
                     prev_was_space = is_space || (c == '\n');
                         // We might meet '\n' in PRE text, which shouldn't make any space
                         // collapsed - except when "white-space: pre-line". So, have
@@ -3043,26 +3086,11 @@ public:
                         // have its width reduced by a fraction of this space width or
                         // increased if needed (for text justification), so actually
                         // making that space larger or smaller.
-                        bool can_adjust_width = true;
                         // Note: checking if the first word of first line is one of the
                         // common opening quotation marks or dashes is done in measureText(),
                         // to have it work also with BiDi/RTL text (checking that here
                         // would be too late, as reordering has been done).
-                        if ( m_flags[i-1] & LCHAR_LOCKED_SPACING ) {
-                            can_adjust_width = false;
-                        }
-                        else if ( word->t.len>=2 && i>=2 && m_text[i-1]==UNICODE_NO_BREAK_SPACE
-                                                         && m_text[i-2]==UNICODE_NO_BREAK_SPACE ) {
-                            // condition for double nbsp after run-in footnote title
-                            can_adjust_width = false;
-                            // (not sure what this one and the next are about)
-                        }
-                        else if ( i < m_length-1 && m_text[i]==UNICODE_NO_BREAK_SPACE
-                                                 && m_text[i+1]==UNICODE_NO_BREAK_SPACE ) {
-                            // condition for double nbsp after run-in footnote title
-                            can_adjust_width = false;
-                        }
-                        if ( can_adjust_width ) {
+                        if ( !(m_flags[i-1] & LCHAR_LOCKED_SPACING) ) {
                             word->flags |= LTEXT_WORD_CAN_ADD_SPACE_AFTER;
                             int dw = getMaxCondensedSpaceTruncation(i-1);
                             if (dw>0) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2254,7 +2254,9 @@ public:
         // it is also the last (so, it is used for a single line paragraph).
         // Also, when "text-align-last: justify", Firefox does justify the last
         // (or single) line.
-        if ( last ) { // Last line of paragraph, or single line paragraph
+        // We support private keywords to not behave like that for standalone lines.
+        bool if_not_first = para->flags & LTEXT_LAST_LINE_IF_NOT_FIRST;
+        if ( last && ( if_not_first ? !first : true ) ) { // Last line of paragraph (it is also first when standalone)
             // https://drafts.csswg.org/css-text-3/#text-align-last-property
             //  "If 'auto' is specified, content on the affected line is aligned
             //  per text-align-all unless text-align-all is set to justify,

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1081,10 +1081,12 @@ public:
                     // (it will allow wrap before and after an object, unless it's near
                     // some punctuation/quote/paren, whose rules will be ensured it seems).
                     int brk = lb_process_next_char(&lbCtx, (utf32_t)0xFFFC); // OBJECT REPLACEMENT CHARACTER
-                    if (brk == LINEBREAK_ALLOWBREAK)
-                        m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
-                    else
-                        m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
+                    if (pos > 0) {
+                        if (brk == LINEBREAK_ALLOWBREAK)
+                            m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
+                        else
+                            m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
+                    }
                 #else
                     m_flags[pos] |= LCHAR_ALLOW_WRAP_AFTER;
                 #endif
@@ -1102,10 +1104,12 @@ public:
                 #if (USE_LIBUNIBREAK==1)
                     // Let libunibreak know there was an object
                     int brk = lb_process_next_char(&lbCtx, (utf32_t)0xFFFC); // OBJECT REPLACEMENT CHARACTER
-                    if (brk == LINEBREAK_ALLOWBREAK)
-                        m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
-                    else
-                        m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
+                    if (pos > 0) {
+                        if (brk == LINEBREAK_ALLOWBREAK)
+                            m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
+                        else
+                            m_flags[pos-1] &= ~LCHAR_ALLOW_WRAP_AFTER;
+                    }
                 #else
                     m_flags[pos] |= LCHAR_ALLOW_WRAP_AFTER;
                 #endif

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12172,8 +12172,6 @@ public:
     {
 #if BUILD_LITE!=1
         ldomNode * elem = (ldomNode *)ptr->getNode();
-        if ( elem->getRendMethod() == erm_invisible )
-            return false;
         // Allow tweaking that with hints
         css_cr_hint_t hint = elem->getStyle()->cr_hint;
         if ( hint == css_cr_hint_text_selection_skip ) {
@@ -12187,21 +12185,28 @@ public:
             newBlock = true;
             return true;
         }
-        switch ( elem->getStyle()->display ) {
-            case css_d_none:
-                return false;
-            case css_d_inherit:
-            case css_d_ruby:
-            case css_d_run_in:
-            case css_d_inline:
-            case css_d_inline_block: // Make these behave as inline, in case they don't contain much
-            case css_d_inline_table: // (if they do, some inner block element will give newBlock=true)
-                newBlock = false;
-                return true;
-            default:
-                newBlock = true;
-                return true;
+        lvdom_element_render_method rm = elem->getRendMethod();
+        if ( rm == erm_invisible )
+            return false;
+        if ( rm == erm_inline ) {
+            // Don't set newBlock if rendering method is erm_inline,
+            // no matter the original CSS display.
+            // (Don't reset any previously set and not consumed newBlock)
+            return true;
         }
+        // For other rendering methods (that would bring newBlock=true),
+        // look at the initial CSS display, as we might have boxed some
+        // inline-like elements for rendering purpose.
+        css_display_t d = elem->getStyle()->display;
+        if ( d <= css_d_inline || d == css_d_inline_block || d == css_d_inline_table ) {
+            // inline, ruby; consider inline-block/-table as inline, in case
+            // they don't contain much (if they do, some inner block element
+            // will set newBlock=true).
+            return true;
+        }
+        // Otherwise, it's a block like node, and we want a \n before the next text
+        newBlock = true;
+        return true;
 #else
         newBlock = true;
         return true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.43k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0024
+#define FORMATTING_VERSION_ID 0x0025
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4168,6 +4168,16 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 for ( int i=indentBaseLevel; i<level; i++ )
                     *stream << "  ";
             *stream << "</" << elemName << ">";
+            if ( WNEFLAG(TEXT_HYPHENATE) ) {
+                // Additional minor formatting tweaks for when this is going to be fed
+                // to some other renderer, which is usually when we request HYPHENATE.
+                if ( node->getStyle()->display == css_d_run_in ) {
+                    // For FB2 footnotes, add a space between the number and text,
+                    // as none might be present in the source. If there were some,
+                    // the other renderer will probably collapse them.
+                    *stream << " ";
+                }
+            }
         }
         if (doNewLineAfterEndTag)
             *stream << "\n";


### PR DESCRIPTION
Fix most issues with FB2 noticed from https://github.com/koreader/koreader/issues/6344#issuecomment-655936850 and later comments.

`CSS: adds text-align-last: -cr-right-if-not-first private keywords` 
To be used with FB2 `<v>` https://github.com/koreader/koreader/issues/6344#issuecomment-657347443

`CSS: adds "-cr-only-if: fb2-document"`
Might allow to target some style tweaks to only EPUB or FB2, and avoid some conflicts. https://github.com/koreader/koreader/issues/6344#issuecomment-658273890

`FB2 footnotes: fix spacing between number and text`
Have consistent (1 space, fixed width) spacing between FB2 footnote number and text.

`ldomTextCollector: guess block boundaries better`
Avoid spurious newlines in text selection in various context (FB2 footnotes, ruby...)

(Changes not super tested with formats other than FB2, so bumping this might wait till after next release.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/357)
<!-- Reviewable:end -->
