### PR TITLE
CSS: switch cr-hint from enum to bitmap

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -89,62 +89,6 @@ public:
 
 typedef LVRef<LVCssDeclaration> LVCssDeclRef;
 
-// See https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
-enum LVCssSelectorPseudoClass
-{
-    csspc_root,             // :root
-    csspc_dir,              // :dir(rtl), :dir(ltr)
-    csspc_first_child,      // :first-child
-    csspc_first_of_type,    // :first-of-type
-    csspc_nth_child,        // :nth-child(even), :nth-child(3n+4)
-    csspc_nth_of_type,      // :nth-of-type()
-    // Those after this won't be valid when checked in the initial
-    // document loading phase when the XML is being parsed, as at
-    // this point, the checked node is always the last node as we
-    // haven't yet parsed its following siblings. When meeting one,
-    // we'll need to re-render and re-check styles after load with
-    // a fully built DOM.
-    csspc_last_child,       // :last-child
-    csspc_last_of_type,     // :last-of-type
-    csspc_nth_last_child,   // :nth-last-child()
-    csspc_nth_last_of_type, // :nth-last-of-type()
-    csspc_only_child,       // :only-child
-    csspc_only_of_type,     // :only-of-type
-    csspc_empty,            // :empty
-};
-
-static const char * css_pseudo_classes[] =
-{
-    "root",
-    "dir",
-    "first-child",
-    "first-of-type",
-    "nth-child",
-    "nth-of-type",
-    "last-child",
-    "last-of-type",
-    "nth-last-child",
-    "nth-last-of-type",
-    "only-child",
-    "only-of-type",
-    "empty",
-    NULL
-};
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
-enum LVCssSelectorPseudoElement
-{
-    csspe_before = 1,   // ::before
-    csspe_after  = 2,   // ::after
-};
-
-static const char * css_pseudo_elements[] =
-{
-    "before",
-    "after",
-    NULL
-};
-
 enum LVCssSelectorRuleType
 {
     cssrt_universal,         // *

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -153,7 +153,7 @@ struct css_style_rec_tag {
     css_clear_t            clear;
     css_direction_t        direction;
     lString16              content;
-    css_cr_hint_t          cr_hint;
+    css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
     // and cleaned up there, before the style is cached and shared. They are not serialized.
     lInt8                flags; // bitmap of STYLE_REC_FLAG_*
@@ -202,7 +202,7 @@ struct css_style_rec_tag {
     , float_(css_f_none)
     , clear(css_c_none)
     , direction(css_dir_inherit)
-    , cr_hint(css_cr_hint_none)
+    , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)
     , pseudo_elem_after_style(NULL)
@@ -240,7 +240,7 @@ struct css_style_rec_tag {
             if (is_important == 0x3) importance |= bit; // update importance flag (!important comes from higher_importance CSS)
         }
     }
-    // Similar to previous one, but logical-OR'ing values, for bitmaps (currently, only style->font_features)
+    // Similar to previous one, but logical-OR'ing values, for bitmaps (currently, only style->font_features and style->cr_hint)
     inline void ApplyAsBitmapOr( css_length_t value, css_length_t *field, css_style_rec_important_bit bit, lUInt8 is_important ) {
         if (     !(important & bit)
               || (is_important == 0x3)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2380,7 +2380,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             // Scale it according to gInterlineScaleFactor
             if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
                 line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
-            if ( style->cr_hint == css_cr_hint_strut_confined )
+            if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) )
                 flags |= LTEXT_STRUT_CONFINED;
         }
         marker += "\t";
@@ -2657,7 +2657,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             int f_half_leading = (line_h - fh) / 2;
             txform->setStrut(line_h, fb + f_half_leading);
         }
-        else if ( style->cr_hint == css_cr_hint_strut_confined ) {
+        else if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) ) {
             // Previous branch for the top final node has set the strut.
             // Inline nodes having "-cr-hint: strut-confined" will be confined
             // inside that strut.
@@ -3533,7 +3533,8 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->clear = source->clear;
     dest->direction = source->direction;
     dest->content = source->content ;
-    dest->cr_hint = source->cr_hint;
+    dest->cr_hint.type = source->cr_hint.type ;
+    dest->cr_hint.value = source->cr_hint.value ;
 }
 
 // Only used by renderBlockElementLegacy()
@@ -3771,7 +3772,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
         lString16 footnoteId;
         // Allow displaying footnote content at the bottom of all pages that contain a link
         // to it, when -cr-hint: footnote-inpage is set on the footnote block container.
-        if ( style->cr_hint == css_cr_hint_footnote_inpage &&
+        if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) &&
                     enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES)) {
             footnoteId = enode->getFirstInnerAttributeValue(attr_id);
             if ( !footnoteId.empty() )
@@ -6080,7 +6081,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     lString16 footnoteId;
     // Allow displaying footnote content at the bottom of all pages that contain a link
     // to it, when -cr-hint: footnote-inpage is set on the footnote block container.
-    if ( style->cr_hint == css_cr_hint_footnote_inpage &&
+    if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) &&
                 enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES)) {
         footnoteId = enode->getFirstInnerAttributeValue(attr_id);
         if ( !footnoteId.empty() )
@@ -9035,6 +9036,18 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // stop any font-variant without !important from being applied.)
     pstyle->font_features.value |= parent_style->font_features.value;
     pstyle->font_features.type = css_val_unspecified;
+
+    // cr_hint is also a bitmap, and only some bits are inherited.
+    // A node starts with (css_val_inherited, 0), but if some
+    // stylesheet has applied some -cr-hint to it, we meet it
+    // here with (css_val_unspecified, bitmap) and we report the
+    // inheritable bits from the parent.
+    // Unless "-cr-hint: none" has been applied to the node, which
+    // prevents inheritance
+    if ( !STYLE_HAS_CR_HINT(pstyle, NONE_NO_INHERIT) ) {
+        pstyle->cr_hint.value |= (parent_style->cr_hint.value & CSS_CR_HINT_INHERITABLE_MASK);
+        pstyle->cr_hint.type = css_val_unspecified;
+    }
 
     //UPDATE_LEN_FIELD( text_indent );
     spreadParent( pstyle->text_indent, parent_style->text_indent );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -213,6 +213,62 @@ static const char * css_decl_name[] = {
     NULL
 };
 
+// See https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
+enum LVCssSelectorPseudoClass
+{
+    csspc_root,             // :root
+    csspc_dir,              // :dir(rtl), :dir(ltr)
+    csspc_first_child,      // :first-child
+    csspc_first_of_type,    // :first-of-type
+    csspc_nth_child,        // :nth-child(even), :nth-child(3n+4)
+    csspc_nth_of_type,      // :nth-of-type()
+    // Those after this won't be valid when checked in the initial
+    // document loading phase when the XML is being parsed, as at
+    // this point, the checked node is always the last node as we
+    // haven't yet parsed its following siblings. When meeting one,
+    // we'll need to re-render and re-check styles after load with
+    // a fully built DOM.
+    csspc_last_child,       // :last-child
+    csspc_last_of_type,     // :last-of-type
+    csspc_nth_last_child,   // :nth-last-child()
+    csspc_nth_last_of_type, // :nth-last-of-type()
+    csspc_only_child,       // :only-child
+    csspc_only_of_type,     // :only-of-type
+    csspc_empty,            // :empty
+};
+
+static const char * css_pseudo_classes[] =
+{
+    "root",
+    "dir",
+    "first-child",
+    "first-of-type",
+    "nth-child",
+    "nth-of-type",
+    "last-child",
+    "last-of-type",
+    "nth-last-child",
+    "nth-last-of-type",
+    "only-child",
+    "only-of-type",
+    "empty",
+    NULL
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements
+enum LVCssSelectorPseudoElement
+{
+    csspe_before = 1,   // ::before
+    csspe_after  = 2,   // ::after
+};
+
+static const char * css_pseudo_elements[] =
+{
+    "before",
+    "after",
+    NULL
+};
+
 inline bool css_is_alpha( char ch )
 {
     return ( (ch>='A' && ch<='Z') || ( ch>='a' && ch<='z' ) || (ch=='-') || (ch=='_') );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -105,7 +105,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.float_) * 31
          + (lUInt32)rec.clear) * 31
          + (lUInt32)rec.direction) * 31
-         + (lUInt32)rec.cr_hint) * 31
+         + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
          + (lUInt32)rec.content.getHash());
@@ -363,7 +363,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(clear);
     ST_PUT_ENUM(direction);
     buf << content;
-    ST_PUT_ENUM(cr_hint);
+    ST_PUT_LEN(cr_hint);
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -424,7 +424,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_clear_t, clear);
     ST_GET_ENUM(css_direction_t, direction);
     buf>>content;
-    ST_GET_ENUM(css_cr_hint_t, cr_hint);
+    ST_GET_LEN(cr_hint);
     lUInt32 hash = 0;
     buf >> hash;
     // printf("imp: %llx oldhash: %lx ", important, hash);

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -415,7 +415,7 @@ public:
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
-    bool m_allow_strut_confinning;
+    bool m_allow_strut_confining;
     bool m_has_multiple_scripts;
     bool m_indent_first_line_done;
     int  m_indent_after_first_line;
@@ -960,10 +960,7 @@ public:
         }
         #endif
 
-        // Whether any "-cr-hint: strut-confined" should be applied: only when
-        // we have non-space-only text in the paragraph - standalone images
-        // possibly separated by spaces don't need to be reduced in size.
-        m_allow_strut_confinning = false;
+        bool has_non_space = false; // If we have non-empty text, we can do strut confining
 
         int pos = 0;
         int i;
@@ -1242,8 +1239,7 @@ public:
                         last_non_collapsed_space_pos = -1;
                         is_locked_spacing = false;
                         if ( !is_space ) {
-                            // Non empty text, we can do strut confinning
-                            m_allow_strut_confinning = true;
+                            has_non_space = true;
                         }
                     }
                     prev_was_space = is_space || (c == '\n');
@@ -1424,6 +1420,13 @@ public:
             }
         }
         TR("%s", LCSTR(lString16(m_text, m_length)));
+
+        // Whether any "-cr-hint: strut-confined" should be applied: only when
+        // we have non-space-only text in the paragraph - standalone images
+        // possibly separated by spaces don't need to be reduced in size.
+        // And only when we actually have a strut set (list item markers
+        // with "list-style-position: outside" don't have any set).
+        m_allow_strut_confining = has_non_space && m_pbuffer->strut_height > 0;
 
         #if (USE_FRIBIDI==1)
         if ( has_rtl ) {
@@ -2000,7 +2003,7 @@ public:
                             UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
                         */
                         resizeImage(width, height, m_pbuffer->width, m_max_img_height, m_length>1);
-                        if ( (m_srcs[start]->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confinning ) {
+                        if ( (m_srcs[start]->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confining ) {
                             // Text with "-cr-hint: strut-confined" might just be vertically shifted,
                             // but won't change widths. But images who will change height must also
                             // have their width reduced to keep their aspect ratio.
@@ -2807,7 +2810,7 @@ public:
                 bool adjust_line_box = true;
                 // We will make sure elements with "-cr-hint: strut-confined"
                 // do not change the strut baseline and height
-                bool strut_confined = (srcline->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confinning;
+                bool strut_confined = (srcline->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confining;
 
                 if ( srcline->flags & LTEXT_SRC_IS_OBJECT ) {
                     // object: image or inline-block box (floats have been skipped above)
@@ -2830,7 +2833,7 @@ public:
                     else { // image
                         word->flags = LTEXT_WORD_IS_OBJECT;
                         // The image dimensions have already been resized to fit
-                        // into m_pbuffer->width (and strut confinning if requested.
+                        // into m_pbuffer->width (and strut confining if requested.
                         // Note: it can happen when there is some text-indent than
                         // the image width exceeds the available width: it might be
                         // shown overflowing or overrideing other content.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.43k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.44k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 
@@ -4372,7 +4372,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->float_ = css_f_none;
     s->clear = css_c_none;
     s->direction = css_dir_inherit;
-    s->cr_hint = css_cr_hint_none;
+    s->cr_hint.type = css_val_unspecified;
+    s->cr_hint.value = CSS_CR_HINT_NONE;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();
     if ( _last_docflags != getDocFlags() ) {
@@ -12173,15 +12174,15 @@ public:
 #if BUILD_LITE!=1
         ldomNode * elem = (ldomNode *)ptr->getNode();
         // Allow tweaking that with hints
-        css_cr_hint_t hint = elem->getStyle()->cr_hint;
-        if ( hint == css_cr_hint_text_selection_skip ) {
+        css_style_ref_t style = elem->getStyle();
+        if ( STYLE_HAS_CR_HINT(style, TEXT_SELECTION_SKIP) ) {
             return false;
         }
-        else if ( hint == css_cr_hint_text_selection_inline ) {
+        else if ( STYLE_HAS_CR_HINT(style, TEXT_SELECTION_INLINE) ) {
             newBlock = false;
             return true;
         }
-        else if ( hint == css_cr_hint_text_selection_block ) {
+        else if ( STYLE_HAS_CR_HINT(style, TEXT_SELECTION_BLOCK) ) {
             newBlock = true;
             return true;
         }
@@ -12197,7 +12198,7 @@ public:
         // For other rendering methods (that would bring newBlock=true),
         // look at the initial CSS display, as we might have boxed some
         // inline-like elements for rendering purpose.
-        css_display_t d = elem->getStyle()->display;
+        css_display_t d = style->display;
         if ( d <= css_d_inline || d == css_d_inline_block || d == css_d_inline_table ) {
             // inline, ruby; consider inline-block/-table as inline, in case
             // they don't contain much (if they do, some inner block element
@@ -17416,11 +17417,18 @@ static inline void makeTocFromCrHintsOrHeadings( ldomNode * node, bool ensure_cr
 {
     int level;
     if ( ensure_cr_hints ) {
-        css_cr_hint_t hint = node->getStyle()->cr_hint;
-        if ( hint == css_cr_hint_toc_ignore )
+        css_style_ref_t style = node->getStyle();
+        if ( STYLE_HAS_CR_HINT(style, TOC_IGNORE) )
             return; // requested to be ignored via style tweaks
-        if ( hint >= css_cr_hint_toc_level1 && hint <= css_cr_hint_toc_level6 )
-            level = hint - css_cr_hint_toc_level1 + 1;
+        if ( STYLE_HAS_CR_HINT(style, TOC_LEVELS_MASK) ) {
+            if      ( STYLE_HAS_CR_HINT(style, TOC_LEVEL1) ) level = 1;
+            else if ( STYLE_HAS_CR_HINT(style, TOC_LEVEL2) ) level = 2;
+            else if ( STYLE_HAS_CR_HINT(style, TOC_LEVEL3) ) level = 3;
+            else if ( STYLE_HAS_CR_HINT(style, TOC_LEVEL4) ) level = 4;
+            else if ( STYLE_HAS_CR_HINT(style, TOC_LEVEL5) ) level = 5;
+            else if ( STYLE_HAS_CR_HINT(style, TOC_LEVEL6) ) level = 6;
+            else level = 7; // should not be reached
+        }
         else if ( node->getNodeId() >= el_h1 && node->getNodeId() <= el_h6 )
             // el_h1 .. el_h6 are consecutive and ordered in include/fb2def.h
             level = node->getNodeId() - el_h1 + 1;
@@ -17854,7 +17862,8 @@ void runBasicTinyDomUnitTests()
         style1->text_indent.value = 0;
         style1->line_height.type = css_val_unspecified;
         style1->line_height.value = css_generic_normal; // line-height: normal
-        style1->cr_hint = css_cr_hint_none;
+        style1->cr_hint.type = css_val_unspecified;
+        style1->cr_hint.value = CSS_CR_HINT_NONE;
 
         css_style_ref_t style2;
         style2 = css_style_ref_t( new css_style_rec_t );
@@ -17886,7 +17895,8 @@ void runBasicTinyDomUnitTests()
         style2->text_indent.value = 0;
         style2->line_height.type = css_val_unspecified;
         style2->line_height.value = css_generic_normal; // line-height: normal
-        style2->cr_hint = css_cr_hint_none;
+        style2->cr_hint.type = css_val_unspecified;
+        style2->cr_hint.value = CSS_CR_HINT_NONE;
 
         css_style_ref_t style3;
         style3 = css_style_ref_t( new css_style_rec_t );
@@ -17918,7 +17928,8 @@ void runBasicTinyDomUnitTests()
         style3->text_indent.value = 0;
         style3->line_height.type = css_val_unspecified;
         style3->line_height.value = css_generic_normal; // line-height: normal
-        style3->cr_hint = css_cr_hint_none;
+        style3->cr_hint.type = css_val_unspecified;
+        style3->cr_hint.value = CSS_CR_HINT_NONE;
 
         el1->setStyle(style1);
         css_style_ref_t s1 = el1->getStyle();


### PR DESCRIPTION
`(Upstream) lvstsheet: avoid compilation warnings`
Fix some issue affecting upstream only, See https://github.com/koreader/crengine/pull/339#issuecomment-660298773

`Strut confinning: don't when there is no strut`
Fix list item markers not showing in in-page footnotes (when `-cr-hint: footnote-inpage strut-confined`, allowed with next commit).

`CSS: switch cr-hint from enum to bitmap`
Allows specifying multiple hints on a same node. Might help with #355 if we allow glyph overflows by default, and want to get previous behaviour by specifying it via `-cr-hint:` (on all elements, on only some like tables).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/359)
<!-- Reviewable:end -->
