### PR TITLE
More generic cleanup of RenderRect used for CSS caching

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -104,6 +104,7 @@ body[name="notes"] section title,
 body[name="comments"] section title {
     display: run-in;   /* technical trick to have the footnote number inline with the followup text */
     font-weight: bold;
+    font-size: 100%; /* counteract default of 110% with regular title */
     text-align: start; /* counteract default of center with regular title */
     page-break-before: auto; /* counteract default of always with regular title */
     page-break-inside: auto;

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1554,6 +1554,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc->registerEmbeddedFonts();
         printf("CRE: document loaded, but styles re-init needed (cause: embedded fonts)\n");
         m_doc->forceReinitStyles();
+        // todo: we could avoid forceReinitStyles() when embedded fonts are disabled
+        // (but being here is quite rare - and having embedded font disabled even more)
     }
 
     if ( fragmentCount==0 )

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4447,10 +4447,10 @@ void LVDocView::createEmptyDocument() {
 			PROP_EMBEDDED_STYLES, true));
     m_doc->setDocFlag(DOC_FLAG_ENABLE_DOC_FONTS, m_props->getBoolDef(
             PROP_EMBEDDED_FONTS, true));
-    m_doc->setSpaceWidthScalePercent(m_props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, 100));
-    m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, 50));
-    m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, 5));
-    m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, 0));
+    m_doc->setSpaceWidthScalePercent(m_props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, DEF_SPACE_WIDTH_SCALE_PERCENT));
+    m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
+    m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
+    m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6147,10 +6147,10 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
     props->setInt(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, p);
 
     p = props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT);
-    if (p<0)
-        p = 0;
-    if (p>20)
-        p = 20;
+    if (p<25)
+        p = 25;
+    if (p>100)
+        p = 100;
     props->setInt(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, p);
 
     p = props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT);
@@ -6161,10 +6161,10 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
     props->setInt(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, p);
 
     p = props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT);
-    if (p<25)
-        p = 25;
-    if (p>100)
-        p = 100;
+    if (p<0)
+        p = 0;
+    if (p>20)
+        p = 20;
     props->setInt(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, p);
 
     props->setIntDef(PROP_RENDER_DPI, DEF_RENDER_DPI); // 96 dpi

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2672,7 +2672,7 @@ void ldomDataStorageManager::setStyleData( lUInt32 elemDataIndex, const ldomNode
     // assume storage has raw data chunks
     int index = elemDataIndex>>4; // element sequential index
     int chunkIndex = index >> STYLE_DATA_CHUNK_ITEMS_SHIFT;
-    while ( _chunks.length() < chunkIndex ) {
+    while ( _chunks.length() <= chunkIndex ) {
         //if ( _chunks.length()>0 )
         //    _chunks[_chunks.length()-1]->compact();
         _chunks.add( new ldomTextStorageChunk(STYLE_DATA_CHUNK_SIZE, this, _chunks.length()) );
@@ -2709,7 +2709,7 @@ void ldomDataStorageManager::setRendRectData( lUInt32 elemDataIndex, const lvdom
     // assume storage has raw data chunks
     int index = elemDataIndex>>4; // element sequential index
     int chunkIndex = index >> RECT_DATA_CHUNK_ITEMS_SHIFT;
-    while ( _chunks.length() < chunkIndex ) {
+    while ( _chunks.length() <= chunkIndex ) {
         //if ( _chunks.length()>0 )
         //    _chunks[_chunks.length()-1]->compact();
         _chunks.add( new ldomTextStorageChunk(RECT_DATA_CHUNK_SIZE, this, _chunks.length()) );
@@ -4548,14 +4548,6 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
             // is invalid (should happen now only when EPUB has embedded fonts
             // or some pseudoclass like :last-child has been met).
             printf("CRE: styles re-init needed after load, re-rendering\n");
-            // We should clear RenderRectAccessor, that may have been used for
-            // caching CSS checks results (i.e. :nth-child(), :last-of-type...)
-            if ( hasRenderData() ) {
-                // (We would crash in the following if no RenderRectAccessor has
-                // been created, which may happen if we're here not because of
-                // CSS checks but because of embedded fonts.)
-                getRootNode()->clearRenderDataRecursive();
-            }
         }
         CRLog::info("rendering context is changed - full render required...");
         // Clear LFormattedTextRef cache
@@ -7526,6 +7518,14 @@ ldomDocumentWriter::~ldomDocumentWriter()
             // Some pseudoclass like :last-child has been met which has set this flag
             printf("CRE: document loaded, but styles re-init needed (cause: peculiar CSS pseudoclasses met)\n");
             _document->forceReinitStyles();
+        }
+        if ( _document->hasRenderData() ) {
+            // We have created some RenderRectAccessors, to cache some CSS check results
+            // (i.e. :nth-child(), :last-of-type...): we should clean them.
+            // (We do that here for after the initial loading phase - on re-renderings,
+            // this is done in updateRendMethod() called by initNodeRendMethodRecursive()
+            // on all nodes.)
+            _document->getRootNode()->clearRenderDataRecursive();
         }
     }
 


### PR DESCRIPTION
getRenderRectData() is doing that right, but setRendRectData() was possibly not allocating the chunk we're about to use.
Follow up to 0b7cc16e (#358), to fix possible crash when loading some books with embedded fonts.
Investigation in https://github.com/koreader/crengine/pull/358#issuecomment-662544553 and followup comments - thanks @virxkane .
Will allow closing https://github.com/koreader/koreader/issues/6413 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/361)
<!-- Reviewable:end -->
