### PR TITLE
Various small FB2 and other fixes

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -74,11 +74,12 @@ h3 { font-size: 130% }
 h4 { font-size: 120% }
 h5 { font-size: 110% }
 
-table { font-size: 80% }
+table { font-size: 80%; width: 100%;  }
 td, th { text-indent: 0px; padding: 3px }
 th {  font-weight: bold; text-align: center; background-color: #DDD  }
 /* #808080; */
 table caption { text-indent: 0px; padding: 4px; background-color: #EEE }
+table, th, td { border-width: 1px; border-style: solid; border-color: black; border-collapse: collapse; }
 
 tt, samp, kbd { font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", "Courier New", "Courier", monospace; }
 code, pre {

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -63,6 +63,7 @@ XS_TAG1D( title, true, css_d_block, css_ws_inherit )
 XS_TAG1D( style, true, css_d_none, css_ws_inherit )
 XS_TAG1D( script, true, css_d_none, css_ws_inherit )
 XS_TAG1D( base, false, css_d_none, css_ws_inherit ) // among crengine autoclose elements
+XS_TAG1D( link, false, css_d_none, css_ws_inherit )
 XS_TAG1T( body )
 XS_TAG1( param ) /* quite obsolete, child of <object>... was there, let's keep it */
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1741,6 +1741,15 @@ public:
     /// move to next visible word end
     bool nextVisibleWordEnd( bool thisBlockOnly = false );
 
+    /// move to previous visible word beginning (in sentence)
+    bool prevVisibleWordStartInSentence();
+    /// move to previous visible word end (in sentence)
+    bool prevVisibleWordEndInSentence();
+    /// move to next visible word beginning (in sentence)
+    bool nextVisibleWordStartInSentence();
+    /// move to next visible word end (in sentence)
+    bool nextVisibleWordEndInSentence();
+
     /// move to beginning of current visible text sentence
     bool thisSentenceStart();
     /// move to end of current visible text sentence

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2530,7 +2530,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             if ( baseflags & LTEXT_FLAG_NEWLINE ) {
                 if ( enode->getNodeIndex() == 0 && parent && parent->getChildCount() > 1 ) {
                     ldomNode * next_sibling = parent->getChildNode(1);
-                    if ( next_sibling && !next_sibling->isNull() ) {
+                    if ( next_sibling && !next_sibling->isNull() && !next_sibling->isElement() ) {
+                        // The next sibling might be a text node, so get the next one
+                        if ( parent->getChildCount() > 2 ) {
+                            next_sibling = parent->getChildNode(2);
+                        }
+                    }
+                    if ( next_sibling && !next_sibling->isNull() && next_sibling->isElement() ) {
                         // next_sibling is an original block node that should have
                         // been erm_final, but has been made erm_inline so it can
                         // be prepended with the run-in node content.

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3769,11 +3769,11 @@ int pagebreakhelper(ldomNode *enode,int width)
 // int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int direction, int rend_flags );
 
 // Prototypes of the 2 alternative block rendering recursive functions
-int  renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int x, int y, int width );
+int  renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int usable_right_overflow );
 void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int width, int flags );
 
 // Legacy/original CRE block rendering
-int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int x, int y, int width )
+int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int x, int y, int width, int usable_right_overflow )
 {
     if ( enode->isElement() )
     {
@@ -4125,8 +4125,10 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                             crFatalError(144, "Attempting to render non-empty Text node");
                         }
                         //fmt.push();
-                        int h = renderBlockElementLegacy( context, child, padding_left + list_marker_padding, y,
-                            width - padding_left - padding_right - list_marker_padding );
+                        int h = renderBlockElementLegacy( context, child,
+                                                          padding_left + list_marker_padding, y,
+                                                          width - padding_left - padding_right - list_marker_padding,
+                                                          usable_right_overflow );
                         y += h;
                         block_height += h;
                     }
@@ -4194,7 +4196,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                     fmt.setX( fmt.getX() );
                     fmt.setY( fmt.getY() );
                     fmt.setLangNodeIndex( 0 ); // No support for lang in legacy rendering
-                    // (No support for overflows and hanging punctuation in legacy mode)
+                    fmt.setUsableRightOverflow(usable_right_overflow);  // Partially support of hanging punctuation in legacy mode
                     fmt.push();
                     //if ( CRLog::isTraceEnabled() )
                     //    CRLog::trace("rendering final node: %s %d %s", LCSTR(enode->getNodeName()), enode->getDataIndex(), LCSTR(ldomXPointer(enode,0).toString()) );
@@ -7523,7 +7525,8 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
     }
     else {
         // (Legacy rendering does not support direction)
-        return renderBlockElementLegacy( context, enode, x, y, width);
+        // (Partial support for hanging punctuation by just propagating the page right margin)
+        return renderBlockElementLegacy( context, enode, x, y, width, usable_right_overflow);
     }
 }
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.45k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.46k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 
@@ -7531,7 +7531,7 @@ ldomNode * ldomDocumentWriter::OnTagOpen( const lChar16 * nsname, const lChar16 
     lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
 
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
-    if ( tagname[0] == 's' && !lStr_cmp(tagname, "style") && _currNode && _currNode->getElement()->isNodeName("head") ) {
+    if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
@@ -7595,23 +7595,31 @@ ldomDocumentWriter::~ldomDocumentWriter()
 void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
 {
     //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
-    if (!_currNode)
+    if (!_currNode || !_currNode->getElement())
     {
         _errFlag = true;
         //logfile << " !c-err!\n";
         return;
     }
 
+    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+    lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    _errFlag |= (id != curNodeId); // (we seem to not do anything with _errFlag)
+    // We should expect the tagname we got to be the same as curNode's element name,
+    // but it looks like we may get an upper closing tag, that pop() below might
+    // handle. So, here below, we check that both id and curNodeId match the
+    // element id we check for.
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks.
     // They will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriterFilter::OnTagClose)
-    if (tagname[0] == 'l' && _currNode && !lStr_cmp(tagname, "link")) {
-        // link node
-        if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
-             _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = _currNode->getElement()->getAttributeValue("href");
+    if ( id == el_link && curNodeId == el_link ) { // link node
+        ldomNode * n = _currNode->getElement();
+        if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
+                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
+            lString16 href = n->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
@@ -7621,23 +7629,8 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         }
     }
 
-    /* This is now dealt with in :OnTagBody(), just before creating this <stylesheet> tag
-    bool isStyleSheetTag = !lStr_cmp(tagname, "stylesheet");
-    if ( isStyleSheetTag ) {
-        ldomNode *parentNode = _currNode->getElement()->getParentNode();
-        if (parentNode && parentNode->isNodeName("DocFragment")) {
-            _document->parseStyleSheet(_currNode->getElement()->getAttributeValue(attr_href),
-                                       _currNode->getElement()->getText());
-            isStyleSheetTag = false;
-        }
-    }
-    */
-    bool isStyleSheetTag = tagname[0] == 's' && !lStr_cmp(tagname, "stylesheet");
-
-    lUInt16 id = _document->getElementNameIndex(tagname);
-    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
-    _errFlag |= (id != _currNode->getElement()->getNodeId());
     _currNode = pop( _currNode, id );
+        // _currNode is now the parent
 
     if ( _currNode )
         _flags = _currNode->getFlags();
@@ -7662,7 +7655,7 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
     // Caveat: any style set on the <FictionBook> element itself won't be applied now
     // in this loading phase (as we have already set its style) - but it will apply
     // on re-renderings.
-    if ( isStyleSheetTag && _currNode && _currNode->getElement()->getNodeId() == el_FictionBook ) {
+    if ( id == el_stylesheet && _currNode && _currNode->getElement()->getNodeId() == el_FictionBook ) {
         //CRLog::trace("</stylesheet> found");
 #if BUILD_LITE!=1
         if ( !_popStyleOnFinish && _document->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
@@ -13004,8 +12997,11 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
 //        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
 //    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
 
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
-    if ( tagname[0] == 's' && !lStr_cmp(tagname, "style") && _currNode && _currNode->getElement()->isNodeName("head") ) {
+    if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
@@ -13014,18 +13010,15 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     // requested to keep previously recorded XPATHs valid.
     if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
         // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
-        if ((tagname[0] == 'b' && tagname[1] == 'r' && tagname[2] == 0)
-            || (tagname[0] == 'd' && tagname[1] == 'd' && tagname[2] == 0)) {
+        if ( id == el_br || id == el_dd ) {
             // substitute to P
-            tagname = L"p";
+            id = el_p;
             _libRuParagraphStart = true; // to trim leading &nbsp;
         } else {
             _libRuParagraphStart = false;
         }
     }
 
-    lUInt16 id = _document->getElementNameIndex(tagname);
-    lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
     AutoClose( id, true );
     _currNode = new ldomElementWriter( _document, nsid, id, _currNode );
     _flags = _currNode->getFlags();
@@ -13210,23 +13203,31 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
 //    if ( nsname && nsname[0] )
 //        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
 //    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
-    if (!_currNode)
+    if (!_currNode || !_currNode->getElement())
     {
         _errFlag = true;
         //logfile << " !c-err!\n";
         return;
     }
 
+    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+    lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+    lUInt16 id = _document->getElementNameIndex(tagname);
+    _errFlag |= (id != curNodeId); // (we seem to not do anything with _errFlag)
+    // We should expect the tagname we got to be the same as curNode's element name,
+    // but it looks like we may get an upper closing tag, that pop() or AutoClose()
+    // below might handle. So, here below, we check that both id and curNodeId match
+    // the element id we check for.
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks,
     // they will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriter::OnTagClose)
-    if (tagname[0] == 'l' && _currNode && !lStr_cmp(tagname, "link")) {
-        // link node
-        if ( _currNode && _currNode->getElement() && _currNode->getElement()->isNodeName("link") &&
-             _currNode->getElement()->getParentNode() && _currNode->getElement()->getParentNode()->isNodeName("head") &&
-             lString16(_currNode->getElement()->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-             lString16(_currNode->getElement()->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = _currNode->getElement()->getAttributeValue("href");
+    if ( id == el_link && curNodeId == el_link ) { // link node
+        ldomNode * n = _currNode->getElement();
+        if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
+                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
+                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
+            lString16 href = n->getAttributeValue("href");
             lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
@@ -13236,11 +13237,9 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         }
     }
 
-    lUInt16 id = _document->getElementNameIndex(tagname);
-
     // HTML title detection
-    if ( id==el_title && _currNode && _currNode->_element && _currNode->_element->getParentNode() != NULL
-                                   && _currNode->_element->getParentNode()->getNodeId() == el_head ) {
+    if ( id == el_title && curNodeId == el_title && _currNode->_element->getParentNode() &&
+                           _currNode->_element->getParentNode()->getNodeId() == el_head ) {
         lString16 s = _currNode->_element->getText();
         s.trim();
         if ( !s.empty() ) {
@@ -13249,15 +13248,13 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         }
     }
     //======== START FILTER CODE ============
-    if ( _currNode->_element ) // (should always be true, but avoid clang warning)
-        AutoClose( _currNode->_element->getNodeId(), false );
+    AutoClose( curNodeId, false );
     //======== END FILTER CODE ==============
-    //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
     // save closed element
-    ldomNode * closedElement = _currNode->getElement();
-    _errFlag |= (!closedElement || id != closedElement->getNodeId());
-    _currNode = pop( _currNode, id );
+    // ldomNode * closedElement = _currNode->getElement();
 
+    _currNode = pop( _currNode, id );
+        // _currNode is now the parent
 
     if ( _currNode ) {
         _flags = _currNode->getFlags();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4351,13 +4351,16 @@ public:
 
         lString16 codeBase = cssFile;
         LVExtractLastPathElement(codeBase);
-        LVStreamRef cssStream = _document->getContainer()->OpenStream(cssFile.c_str(), LVOM_READ);
-        if ( !cssStream.isNull() ) {
-            lString16 css;
-            css << LVReadTextFile( cssStream );
-            int offset = _inProgress.add(cssFile);
-            ret = Parse(codeBase, css) || ret;
-            _inProgress.erase(offset, 1);
+        LVContainerRef container = _document->getContainer();
+        if (!container.isNull()) {
+            LVStreamRef cssStream = container->OpenStream(cssFile.c_str(), LVOM_READ);
+            if (!cssStream.isNull()) {
+                lString16 css;
+                css << LVReadTextFile(cssStream);
+                int offset = _inProgress.add(cssFile);
+                ret = Parse(codeBase, css) || ret;
+                _inProgress.erase(offset, 1);
+            }
         }
         return ret;
     }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7632,6 +7632,7 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         }
     }
     */
+    bool isStyleSheetTag = tagname[0] == 's' && !lStr_cmp(tagname, "stylesheet");
 
     lUInt16 id = _document->getElementNameIndex(tagname);
     //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
@@ -7646,11 +7647,25 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         _parser->Stop();
     }
 
-    /* This is now dealt with in :OnTagBody(), just before creating this <stylesheet> tag
-    if ( isStyleSheetTag ) {
+    // For EPUB/HTML, this is now dealt with in :OnTagBody(), just before creating this <stylesheet> tag.
+    // But for FB2, where we have:
+    //   <FictionBook>
+    //     <stylesheet type="text/css">
+    //       some css
+    //     </stylesheet>
+    //     <p>...
+    //     other content
+    //   </FictionBook>
+    // we need to apply the <stylesheet> content we have just left, so it applies
+    // to the coming up content.
+    // We check the parent we have just pop'ed is a <FictionBook>.
+    // Caveat: any style set on the <FictionBook> element itself won't be applied now
+    // in this loading phase (as we have already set its style) - but it will apply
+    // on re-renderings.
+    if ( isStyleSheetTag && _currNode && _currNode->getElement()->getNodeId() == el_FictionBook ) {
         //CRLog::trace("</stylesheet> found");
 #if BUILD_LITE!=1
-        if ( !_popStyleOnFinish ) {
+        if ( !_popStyleOnFinish && _document->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
             //CRLog::trace("saving current stylesheet before applying of document stylesheet");
             _document->getStyleSheet()->push();
             _popStyleOnFinish = true;
@@ -7658,7 +7673,6 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
         }
 #endif
     }
-    */
 
     //logfile << " !c!\n";
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11328,18 +11328,18 @@ bool ldomXPointerEx::prevVisibleWordStart( bool thisBlockOnly )
             node = getNode();
             text = node->getText();
         }
-        bool foundNonSpace = false;
+        bool foundNonSeparator = false;
         while ( _data->getOffset() > 0 && IsWordSeparator(text[_data->getOffset()-1]) )
             _data->addOffset(-1); // skip preceeding space if any (we were on a visible word start)
         while ( _data->getOffset()>0 ) {
             if ( IsWordSeparator(text[ _data->getOffset()-1 ]) )
                 break;
-            foundNonSpace = true;
+            foundNonSeparator = true;
             _data->addOffset(-1);
             if ( canWrapWordBefore( text[_data->getOffset()] ) ) // CJK char
                 break;
         }
-        if ( foundNonSpace )
+        if ( foundNonSeparator )
             return true;
     }
 }
@@ -11366,14 +11366,14 @@ bool ldomXPointerEx::prevVisibleWordEnd( bool thisBlockOnly )
             node = getNode();
             text = node->getText();
         }
-        // skip spaces
+        // skip separators
         while ( _data->getOffset() > 0 && IsWordSeparator(text[_data->getOffset()-1]) ) {
             _data->addOffset(-1);
             moved = true;
         }
         if ( moved && _data->getOffset()>0 )
             return true; // found!
-        // skip non-spaces
+        // skip non-separators
         while ( _data->getOffset()>0 ) {
             if ( IsWordSeparator(text[ _data->getOffset()-1 ]) )
                 break;
@@ -11382,7 +11382,7 @@ bool ldomXPointerEx::prevVisibleWordEnd( bool thisBlockOnly )
             moved = true;
             _data->addOffset(-1);
         }
-        // skip spaces
+        // skip separators
         while ( _data->getOffset() > 0 && IsWordSeparator(text[_data->getOffset()-1]) ) {
             _data->addOffset(-1);
             moved = true;
@@ -11424,14 +11424,14 @@ bool ldomXPointerEx::nextVisibleWordStart( bool thisBlockOnly )
                 moved = true;
             }
         }
-        // skip spaces
+        // skip separators
         while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
             _data->addOffset(1);
             moved = true;
         }
         if ( moved && _data->getOffset()<textLen )
             return true;
-        // skip non-spaces
+        // skip non-separators
         while ( _data->getOffset()<textLen ) {
             if ( IsWordSeparator(text[ _data->getOffset() ]) )
                 break;
@@ -11440,7 +11440,7 @@ bool ldomXPointerEx::nextVisibleWordStart( bool thisBlockOnly )
             moved = true;
             _data->addOffset(1);
         }
-        // skip spaces
+        // skip separators
         while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
             _data->addOffset(1);
             moved = true;
@@ -11467,12 +11467,12 @@ bool ldomXPointerEx::thisVisibleWordEnd(bool thisBlockOnly)
     textLen = text.length();
     if ( _data->getOffset() >= textLen )
         return false;
-    // skip spaces
+    // skip separators
     while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
         _data->addOffset(1);
         //moved = true;
     }
-    // skip non-spaces
+    // skip non-separators
     while ( _data->getOffset()<textLen ) {
         if ( IsWordSeparator(text[ _data->getOffset() ]) )
             break;
@@ -11513,10 +11513,166 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
                 _data->setOffset( 0 );
             }
         }
+        bool nonSeparatorFound = false;
+        // skip non-separators
+        while ( _data->getOffset()<textLen ) {
+            if ( IsWordSeparator(text[ _data->getOffset() ]) )
+                break;
+            nonSeparatorFound = true;
+            _data->addOffset(1);
+            if ( canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
+        }
+        if ( nonSeparatorFound )
+            return true;
+        // skip separators
+        while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
+            _data->addOffset(1);
+            //moved = true;
+        }
+        // skip non-separators
+        while ( _data->getOffset()<textLen ) {
+            if ( IsWordSeparator(text[ _data->getOffset() ]) )
+                break;
+            nonSeparatorFound = true;
+            _data->addOffset(1);
+            if ( canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
+        }
+        if ( nonSeparatorFound )
+            return true;
+    }
+}
+
+/// move to previous visible word beginning (in sentence)
+bool ldomXPointerEx::prevVisibleWordStartInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    for ( ;; ) {
+        if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
+            // move to previous text
+            if ( !prevVisibleText(true) )
+                return false;
+            node = getNode();
+            text = node->getText();
+            int textLen = text.length();
+            _data->setOffset( textLen );
+        } else {
+            node = getNode();
+            text = node->getText();
+        }
+        bool foundNonSpace = false;
+        while ( _data->getOffset() > 0 && IsUnicodeSpace(text[_data->getOffset()-1]) )
+            _data->addOffset(-1); // skip preceeding space if any (we were on a visible word start)
+        while ( _data->getOffset()>0 ) {
+            if ( IsUnicodeSpace(text[ _data->getOffset()-1 ]) )
+                break;
+            foundNonSpace = true;
+            _data->addOffset(-1);
+            if ( canWrapWordBefore( text[_data->getOffset()] ) ) // CJK char
+                break;
+        }
+        if ( foundNonSpace )
+            return true;
+    }
+}
+
+/// move to next visible word beginning (in sentence)
+bool ldomXPointerEx::nextVisibleWordStartInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    int textLen = 0;
+    bool moved = false;
+    for ( ;; ) {
+        if ( !isText() || !isVisible() ) {
+            // move to previous text
+            if ( !nextVisibleText(false) )
+                return false;
+            node = getNode();
+            text = node->getText();
+            textLen = text.length();
+            _data->setOffset( 0 );
+            moved = true;
+        } else {
+            for (;;) {
+                node = getNode();
+                text = node->getText();
+                textLen = text.length();
+                if ( _data->getOffset() < textLen )
+                    break;
+                if ( !nextVisibleText(false) )
+                    return false;
+                _data->setOffset( 0 );
+                moved = true;
+            }
+        }
+        // skip spaces
+        while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
+            _data->addOffset(1);
+            moved = true;
+        }
+        if ( moved && _data->getOffset()<textLen )
+            return true;
+        // skip non-spaces
+        while ( _data->getOffset()<textLen ) {
+            if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
+                break;
+            if ( moved && canWrapWordBefore( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
+            moved = true;
+            _data->addOffset(1);
+        }
+        // skip spaces
+        while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
+            _data->addOffset(1);
+            moved = true;
+        }
+        if ( moved && _data->getOffset()<textLen )
+            return true;
+    }
+}
+
+/// move to next visible word end (in sentence)
+bool ldomXPointerEx::nextVisibleWordEndInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    int textLen = 0;
+    //bool moved = false;
+    for ( ;; ) {
+        if ( !isText() || !isVisible() ) {
+            // move to previous text
+            if ( !nextVisibleText(true) )
+                return false;
+            node = getNode();
+            text = node->getText();
+            textLen = text.length();
+            _data->setOffset( 0 );
+            //moved = true;
+        } else {
+            for (;;) {
+                node = getNode();
+                text = node->getText();
+                textLen = text.length();
+                if ( _data->getOffset() < textLen )
+                    break;
+                if ( !nextVisibleText(true) )
+                    return false;
+                _data->setOffset( 0 );
+            }
+        }
         bool nonSpaceFound = false;
         // skip non-spaces
         while ( _data->getOffset()<textLen ) {
-            if ( IsWordSeparator(text[ _data->getOffset() ]) )
+            if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
                 break;
             nonSpaceFound = true;
             _data->addOffset(1);
@@ -11526,13 +11682,13 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
         if ( nonSpaceFound )
             return true;
         // skip spaces
-        while ( _data->getOffset()<textLen && IsWordSeparator(text[ _data->getOffset() ]) ) {
+        while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
             _data->addOffset(1);
             //moved = true;
         }
         // skip non-spaces
         while ( _data->getOffset()<textLen ) {
-            if ( IsWordSeparator(text[ _data->getOffset() ]) )
+            if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
                 break;
             nonSpaceFound = true;
             _data->addOffset(1);
@@ -11541,6 +11697,54 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
         }
         if ( nonSpaceFound )
             return true;
+    }
+}
+
+/// move to previous visible word end (in sentence)
+bool ldomXPointerEx::prevVisibleWordEndInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    bool moved = false;
+    for ( ;; ) {
+        if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
+            // move to previous text
+            if ( !prevVisibleText(false) )
+                return false;
+            node = getNode();
+            text = node->getText();
+            int textLen = text.length();
+            _data->setOffset( textLen );
+            moved = true;
+        } else {
+            node = getNode();
+            text = node->getText();
+        }
+        // skip spaces
+        while ( _data->getOffset() > 0 && IsUnicodeSpace(text[_data->getOffset()-1]) ) {
+            _data->addOffset(-1);
+            moved = true;
+        }
+        if ( moved && _data->getOffset()>0 )
+            return true; // found!
+        // skip non-spaces
+        while ( _data->getOffset()>0 ) {
+            if ( IsUnicodeSpace(text[ _data->getOffset()-1 ]) )
+                break;
+            if ( moved && canWrapWordAfter( text[_data->getOffset()] ) ) // We moved to a CJK char
+                return true;
+            moved = true;
+            _data->addOffset(-1);
+        }
+        // skip spaces
+        while ( _data->getOffset() > 0 && IsUnicodeSpace(text[_data->getOffset()-1]) ) {
+            _data->addOffset(-1);
+            moved = true;
+        }
+        if ( moved && _data->getOffset()>0 )
+            return true; // found!
     }
 }
 
@@ -11754,7 +11958,7 @@ bool ldomXPointerEx::thisSentenceStart()
     for (;;) {
         if ( isSentenceStart() )
             return true;
-        if ( !prevVisibleWordStart(true) )
+        if ( !prevVisibleWordStartInSentence() )
             return false;
     }
 }
@@ -11769,7 +11973,7 @@ bool ldomXPointerEx::thisSentenceEnd()
     for (;;) {
         if ( isSentenceEnd() )
             return true;
-        if ( !nextVisibleWordEnd(true) )
+        if ( !nextVisibleWordEndInSentence() )
             return false;
     }
 }
@@ -11780,7 +11984,7 @@ bool ldomXPointerEx::nextSentenceStart()
     if ( !isSentenceStart() && !thisSentenceEnd() )
         return false;
     for (;;) {
-        if ( !nextVisibleWordStart() )
+        if ( !nextVisibleWordStartInSentence() )
             return false;
         if ( isSentenceStart() )
             return true;
@@ -11814,7 +12018,7 @@ bool ldomXPointerEx::prevSentenceEnd()
     if ( !thisSentenceStart() )
         return false;
     for (;;) {
-        if ( !prevVisibleWordEnd() )
+        if ( !prevVisibleWordEndInSentence() )
             return false;
         if ( isSentenceEnd() )
             return true;

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -739,16 +739,18 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
     // In French, there's usually a space before and after guillemets,
     // or before a quotation mark. Having them hanging, and then a
     // space, looks like there's a hole in the margin.
-    // So, avoid hanging if the next/prev char is a space char.
+    // So, for some chars, we'll avoid hanging or reduce the hanging
+    // ratio if the next/prev char is a space char.
     // This might not happen in other languages, so let's do that
     // prevention generically. If needed, make that dependant on
     // a boolean member, set to true if LANG_STARTS_WITH(("fr")).
+    bool space_alongside = false;
     if ( right_hanging ) {
         if ( pos > 0 ) {
             lChar16 prev_ch = text[pos-1];
             if ( prev_ch == 0x0020 || prev_ch == 0x00A0 || (prev_ch >= 0x2000 && prev_ch <= 0x200A ) ) {
                 // Normal space, no-break space, and other unicode spaces (except zero-width ones)
-                return 0;
+                space_alongside = true;
             }
         }
     }
@@ -757,7 +759,7 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
             lChar16 next_ch = text[pos+1];
             if ( next_ch == 0x0020 || next_ch == 0x00A0 || (next_ch >= 0x2000 && next_ch <= 0x200A ) ) {
                 // Normal space, no-break space, and other unicode spaces (except zero-width ones)
-                return 0;
+                space_alongside = true;
             }
         }
     }
@@ -793,15 +795,17 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
         case 0x2019: // ’ right single quotation mark
         case 0x201A: // ‚ single low-9 quotation mark
         case 0x201B: // ‛ single high-reversed-9 quotation mark
+            ratio = 70;
+            break;
         case 0x2039: // ‹ left single guillemet
         case 0x203A: // › right single guillemet
-            ratio = 70;
+            // These are wider than the previous ones, and hanging by 70% with a space
+            // alongside can give a feeling of bad justification. So, hang less.
+            ratio = space_alongside ? 20 : 70;
             break;
         case 0x0022: // " double quote
         case 0x003A: // : colon
         case 0x003B: // ; semicolon
-        case 0x00AB: // « left guillemet
-        case 0x00BB: // » right guillemet
         case 0x061B: // ؛ arabic semicolon
         case 0x201C: // “ left double quotation mark
         case 0x201D: // ” right double quotation mark
@@ -809,7 +813,14 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
         case 0x201F: // ‟ double high-reversed-9 quotation mark
             ratio = 50;
             break;
+        case 0x00AB: // « left guillemet
+        case 0x00BB: // » right guillemet
+            // These are wider than the previous ones, and hanging by 50% with a space
+            // alongside can give a feeling of bad justification. So, hang less.
+            ratio = space_alongside ? 20 : 50;
+            break;
         case 0x2013: // – endash
+            // Should have enough body inside (with only 30% hanging)
             ratio = 30;
             break;
         case 0x0021: // !
@@ -819,6 +830,8 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
         case 0x061F: // ؟
         case 0x2014: // — emdash
         case 0x2026: // … ellipsis
+            // These will have enough body inside (with only 20% hanging),
+            // so they shouldn't hurt when space_alongside.
             ratio = 20;
             break;
         case 0x0028: // (
@@ -839,6 +852,7 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
     // Other are non punctuation but slight adjustment for some letters,
     // that might be ignored if the font already include some negative
     // left side bearing.
+    // The hanging ratio is small, so no need to correct if space_alongside.
     check_font = true;
     if ( right_hanging ) {
         switch (ch) {


### PR DESCRIPTION
Various fixes discussed with @virxkane these last days:

`(Upstream) LVImportStylesheetParser: avoid possible segfault`
(seems to not happen with KOReader, but this simple check looks sane https://github.com/koreader/crengine/pull/355#issuecomment-667652503 )

`(Upstream) FB2: fix <stylesheet> not being applied on first load`
https://github.com/buggins/coolreader/pull/142#discussion_r463956126

`(Upstream) Legacy rendering: partial support of new hanging punctuation`
https://github.com/koreader/crengine/pull/355#issuecomment-667645818

`(Upstream) Fix sentence selection in TTS`
https://github.com/koreader/crengine/pull/69#issuecomment-668175384

`Fix possible crash with 'display: run-in'`
https://github.com/koreader/crengine/pull/355#issuecomment-667689433

`fb2.css: have tables full-width with some border`
https://github.com/koreader/koreader/issues/6344#issuecomment-667516025

`OnTagOpen/Close(): compare ids instead of strings`
Just a bit of cleanup in these, should be logically equivalent to previous code.

`Hanging punctuation: tweak hanging ratios`
https://github.com/koreader/crengine/pull/355#issuecomment-668540278

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/363)
<!-- Reviewable:end -->
