### PR TITLE
Various upstream and FB2 fixes

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1104,7 +1104,9 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
         if (dst_dy > rc.height() * 6 / 8)
 			dst_dy = imgrc.height();
 		//CRLog::trace("drawCoverTo() - drawing image");
-        LVColorDrawBuf buf2(src_dx, src_dy, 32);
+        // It's best to use a 16bpp LVColorDrawBuf as the intermediate buffer,
+        // as using 32bpp would mess colors up when drawBuf is itself 32bpp.
+        LVColorDrawBuf buf2(src_dx, src_dy, 16);
         buf2.Draw(imgsrc, 0, 0, src_dx, src_dy, true);
         drawBuf->DrawRescaled(&buf2, imgrc.left + (imgrc.width() - dst_dx) / 2,
                 imgrc.top + (imgrc.height() - dst_dy) / 2, dst_dx, dst_dy, 0);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2330,9 +2330,12 @@ void LVDocView::Draw(LVDrawBuf & drawbuf, int position, int page, bool rotate, b
 		return;
 	if (isScrollMode()) {
 		drawbuf.SetClipRect(NULL);
-        drawbuf.setHidePartialGlyphs(false);
-        drawPageBackground(drawbuf, 0, position);
-        int cover_height = 0;
+		drawbuf.setHidePartialGlyphs(false);
+		drawPageBackground(drawbuf, 0, position);
+		/* Don't draw FB2 cover in scroll mode, as having it not part of the document
+		   height and having to shift the document start and adjust y/pos in many
+		   places is quite complicated
+		int cover_height = 0;
 		if (m_pages.length() > 0 && (m_pages[0]->flags & RN_PAGE_TYPE_COVER))
 			cover_height = m_pages[0]->height;
 		if (position < cover_height) {
@@ -2346,6 +2349,7 @@ void LVDocView::Draw(LVDrawBuf & drawbuf, int position, int page, bool rotate, b
 			rc.right -= m_pageMargins.right;
 			drawCoverTo(&drawbuf, rc);
 		}
+		*/
 		DrawDocument(drawbuf, m_doc->getRootNode(), m_pageMargins.left, 0, drawbuf.GetWidth()
 				- m_pageMargins.left - m_pageMargins.right, drawbuf.GetHeight(), 0, -position,
 				drawbuf.GetHeight(), &m_markRanges, &m_bmkRanges);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -982,15 +982,17 @@ LVStreamRef LVDocView::getCoverPageImageStream() {
     // FB2 coverpage
 	//CRLog::trace("LVDocView::getCoverPageImage()");
 	//m_doc->dumpStatistics();
-	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
-			el_coverpage, 0 };
+	lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
 	ldomNode * rootNode = m_doc->getRootNode();
 	ldomNode * cover_el = 0;
-	if (rootNode)
+	if (rootNode) {
 		cover_el = rootNode->findChildElement(path);
-	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
-
+		if (!cover_el) { // might otherwise be found inside <src-title-info>
+			lUInt16 path2[] = { el_FictionBook, el_description, el_src_title_info, el_coverpage, 0 };
+			cover_el = rootNode->findChildElement(path2);
+		}
+	}
 	if (cover_el) {
 		ldomNode * cover_img_el = cover_el->findChildElement(LXML_NS_ANY,
 				el_image, 0);
@@ -1009,15 +1011,17 @@ LVImageSourceRef LVDocView::getCoverPageImage() {
 	//        CRLog::trace("Image stream size is %d", (int)stream->GetSize() );
 	//CRLog::trace("LVDocView::getCoverPageImage()");
 	//m_doc->dumpStatistics();
-	lUInt16 path[] = { el_FictionBook, el_description, el_title_info,
-			el_coverpage, 0 };
+	lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, 0 };
 	//lUInt16 path[] = { el_FictionBook, el_description, el_title_info, el_coverpage, el_image, 0 };
 	ldomNode * cover_el = 0;
 	ldomNode * rootNode = m_doc->getRootNode();
-	if (rootNode)
+	if (rootNode) {
 		cover_el = rootNode->findChildElement(path);
-	//ldomNode * cover_img_el = m_doc->getRootNode()->findChildElement( path );
-
+		if (!cover_el) { // might otherwise be found inside <src-title-info>
+			lUInt16 path2[] = { el_FictionBook, el_description, el_src_title_info, el_coverpage, 0 };
+			cover_el = rootNode->findChildElement(path2);
+		}
+	}
 	if (cover_el) {
 		ldomNode * cover_img_el = cover_el->findChildElement(LXML_NS_ANY,
 				el_image, 0);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7903,7 +7903,7 @@ private:
 public:
     virtual ~LVBase64NodeStream() { }
     LVBase64NodeStream( ldomNode * element )
-        : m_elem(element), m_curr_node(element), m_size(0), m_pos(0)
+        : m_elem(element), m_curr_node(element), m_text_pos(0), m_size(0), m_pos(0)
     {
         // calculate size
         rewind();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -84,7 +84,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.46k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.47k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 


### PR DESCRIPTION
`(Upstream) LVBase64NodeStream: fix possible segfault`
`(Upstream) Fix getting encoding from HTML META tags`
by @virxkane from https://github.com/buggins/coolreader/pull/150.

`FB2: also look for cover in <src-title-info>` https://github.com/koreader/koreader/issues/6493#issuecomment-671357506
`FB2: fix cover image colors` https://github.com/koreader/koreader/issues/6490#issuecomment-671768171

`FB2: don't draw cover in scroll mode` https://github.com/koreader/koreader/issues/6490#issuecomment-671317973
So it does not cover the text (and because correctly drawing the cover in scroll mode looks complicated and feels like it would need some frontend changes - so let's not. we'll revert that if upstream comes up with a solution and see how much change it would require to our frontend).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/366)
<!-- Reviewable:end -->
