### PR TITLE
TextLang: increase _lb_props static array size

### DIFF
--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -91,7 +91,7 @@ public:
     ~TextLangMan();
 };
 
-#define MAX_NB_LB_PROPS_ITEMS 10 // for our statically sized array (increase if needed)
+#define MAX_NB_LB_PROPS_ITEMS 20 // for our statically sized array (increase if needed)
 
 #if USE_LIBUNIBREAK==1
 typedef lChar16 (*lb_char_sub_func_t)(struct LineBreakContext *lbpCtx, const lChar16 * text, int pos, int next_usable);

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -737,6 +737,9 @@ TextLangCfg::TextLangCfg( lString16 lang_tag ) {
     if ( has_em_dash_alphabetic )                        _lb_props[n++] = { 0x2E3A, 0x2E3B, LBP_AL };
     // End of list
     _lb_props[n++] = { 0, 0, LBP_Undefined };
+        // When adding properties, be sure combinations for all languages
+        // do fit in _lb_props[MAX_NB_LB_PROPS_ITEMS] (MAX_NB_LB_PROPS_ITEMS
+        // is defined in textlang.h, currently at 20).
     // Done with libunibreak per-language LineBreakProperties extensions
 
     // Other line breaking and text layout tweaks


### PR DESCRIPTION
Fix possible crash with #365 where we could add 2 more slots in the statically sized array `_lb_props[10]`. Use 20 to be safe for the future.
Noticed at https://github.com/koreader/koreader-base/pull/1160#issuecomment-675045553.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/368)
<!-- Reviewable:end -->
