### PR TITLE
New HTML parser, libRu and FB2 tweaks

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -106,6 +106,7 @@ body[name="comments"] section title {
     display: run-in;   /* technical trick to have the footnote number inline with the followup text */
     font-weight: bold;
     font-size: 100%; /* counteract default of 110% with regular title */
+    font-variant: tabular-nums; /* get fixed width digits for nicer text alignment */
     text-align: start; /* counteract default of center with regular title */
     page-break-before: auto; /* counteract default of always with regular title */
     page-break-inside: auto;

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -285,6 +285,7 @@ XS_ATTR( recindex ) // used with mobi images
 XS_ATTR( T )      // to flag subtype of boxing internal elements if needed
 XS_ATTR( Before ) // for pseudoElem internal element
 XS_ATTR( After )  // for pseudoElem internal element
+XS_ATTR( ParserHint )   // HTML parser hints (used for Lib.ru support)
 // Other classic attributes present in html5.css
 XS_ATTR2( accept_charset, "accept-charset" )
 XS_ATTR( alt )

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -63,10 +63,20 @@ XS_TAG1D( title, true, css_d_block, css_ws_inherit )
 XS_TAG1D( style, true, css_d_none, css_ws_inherit )
 XS_TAG1D( script, true, css_d_none, css_ws_inherit )
 XS_TAG1D( base, false, css_d_none, css_ws_inherit ) // among crengine autoclose elements
+XS_TAG1D( basefont, false, css_d_none, css_ws_inherit )
+XS_TAG1D( bgsound, false, css_d_none, css_ws_inherit )
+XS_TAG1D( meta, false, css_d_none, css_ws_inherit )
 XS_TAG1D( link, false, css_d_none, css_ws_inherit )
 XS_TAG1T( body )
-XS_TAG1( param ) /* quite obsolete, child of <object>... was there, let's keep it */
 
+// Limits for head handling by our HTML Parser (ldomDocumentWriterFilter)
+// (if met before any HEAD or BODY, HTML/HEAD might be auto-inserted)
+#define EL_IN_HEAD_START el_head
+#define EL_IN_HEAD_END   el_link
+#define EL_IN_BODY_START el_body
+
+                // HTML5: start of special tags, closing all
+                // the way, and closing any <P>
 // Block elements
 XS_TAG1T( hr )
 XS_TAG1T( svg )
@@ -84,6 +94,29 @@ XS_TAG1T( p )
 XS_TAG1T( output )
 XS_TAG1T( section )
 
+// Lists
+XS_TAG1T( ol )
+XS_TAG1T( ul )
+XS_TAG1D( li, true, css_d_list_item_block, css_ws_inherit )
+
+// Definitions
+XS_TAG1T( dl )
+XS_TAG1T( dt )
+XS_TAG1T( dd )
+
+// Tables
+XS_TAG1D( table, false, css_d_table, css_ws_inherit )
+XS_TAG1D( caption, true, css_d_table_caption, css_ws_inherit )
+XS_TAG1D( colgroup, false, css_d_table_column_group, css_ws_inherit )
+XS_TAG1D( col, false, css_d_table_column, css_ws_inherit )
+XS_TAG1D( thead, false, css_d_table_header_group, css_ws_inherit )
+XS_TAG1D( tbody, false, css_d_table_row_group, css_ws_inherit )
+XS_TAG1D( tfoot, false, css_d_table_footer_group, css_ws_inherit )
+XS_TAG1D( tr, false, css_d_table_row, css_ws_inherit )
+XS_TAG1D( th, true, css_d_table_cell, css_ws_inherit )
+XS_TAG1D( td, true, css_d_table_cell, css_ws_inherit )
+
+// Added 20180528
 // Keep this block starting with "address" and ending with "xmp" as we
 // are using: if (id >= el_address && id <= el_xmp) in lvrend.cpp
 // Additional semantic block elements
@@ -113,66 +146,101 @@ XS_TAG1D( textarea, true, css_d_block, css_ws_pre ) // similar to "pre"
 XS_TAG1D( plaintext, true, css_d_block, css_ws_pre ) // start of raw text (no end tag), not supported
 XS_TAG1D( xmp, true, css_d_block, css_ws_pre ) // similar to "pre"
 
-// Lists
-XS_TAG1T( ol )
-XS_TAG1T( ul )
-XS_TAG1D( li, true, css_d_list_item_block, css_ws_inherit )
+// Added 20200824
+// Keep this block starting with "details" and ending with "wbr" as we
+// are using: if (id >= el_details && id <= el_wbr) in lvrend.cpp
+// Additional semantic block elements
+XS_TAG1T( details )
+XS_TAG1T( dialog )
+XS_TAG1T( summary )
+// Additional "special" elements mentionned in the HTML standard,
+// not supposed to close any P, but let's consider them similarly,
+// and be block elements, so their content is shown.
+XS_TAG1T( frame )
+XS_TAG1T( frameset )
+XS_TAG1T( iframe )
+XS_TAG1T( noembed )
+XS_TAG1T( template )
+XS_TAG1T( select )
+// BUTTON should not close a P, so we could have P > BUTTON > P,
+// and other elements close a P "in button scope" - but we want to
+// avoid nested Ps - so for our HTML parser, a BUTTON closes a P)
+XS_TAG1T( button )
+// HTML5: these 3 are special tags, that should not close any <P>,
+// but they start a new "scope" that should not be crossed when
+// other special tags are closing a P. As they are rare, we make
+// them close a P too, just so that we'll never have nested Ps.
+XS_TAG1T( marquee )
+XS_TAG1( applet )
+XS_TAG1( object )
+                // HTML5: end of special tags, closing all
+                // the way, and closing any <P>
+// Other HTML elements with usually no content or no usable content
+XS_TAG1T( optgroup ) // shown as block
+XS_TAG1I( option )   // shown as inline
+XS_TAG1T( map )
+XS_TAG1( area )
+XS_TAG1( track )
+XS_TAG1( embed )
+XS_TAG1( input )
+XS_TAG1( keygen )
+XS_TAG1( param )
+XS_TAG1( audio )
+XS_TAG1( source )
+XS_TAG1I( picture ) // may contain one <img>, and multiple <source>
+XS_TAG1I( wbr )
 
-// Definitions
-XS_TAG1T( dl )
-XS_TAG1T( dt )
-XS_TAG1T( dd )
-
-// Tables
-XS_TAG1D( table, false, css_d_table, css_ws_inherit )
-XS_TAG1D( caption, true, css_d_table_caption, css_ws_inherit )
-XS_TAG1D( col, false, css_d_table_column, css_ws_inherit )
-XS_TAG1D( colgroup, false, css_d_table_column_group, css_ws_inherit )
-XS_TAG1D( tr, false, css_d_table_row, css_ws_inherit )
-XS_TAG1D( tbody, false, css_d_table_row_group, css_ws_inherit )
-XS_TAG1D( thead, false, css_d_table_header_group, css_ws_inherit )
-XS_TAG1D( tfoot, false, css_d_table_footer_group, css_ws_inherit )
-XS_TAG1D( th, true, css_d_table_cell, css_ws_inherit )
-XS_TAG1D( td, true, css_d_table_cell, css_ws_inherit )
+// Limits for special handling by our HTML Parser (ldomDocumentWriterFilter)
+#define EL_SPECIAL_START           el_html
+#define EL_SPECIAL_END             el_wbr
+#define EL_SPECIAL_CLOSING_P_START el_hr
+#define EL_SPECIAL_CLOSING_P_END   el_object
 
 // Inline elements
 XS_TAG1OBJ( img ) /* inline and specific handling as 'object' */
+
+                // HTML5: start of "active formatting elements"
 XS_TAG1I( a )
-XS_TAG1I( acronym )
 XS_TAG1I( b )
-XS_TAG1I( bdi )
-XS_TAG1I( bdo )
 XS_TAG1I( big )
-XS_TAG1I( br )
-XS_TAG1I( cite ) // conflict between HTML (inline) and FB2 (block): default here to inline (fb2.css puts it back to block)
 XS_TAG1I( code ) // should not be css_ws_pre according to specs
-XS_TAG1I( del )
-XS_TAG1I( dfn )
 XS_TAG1I( em )
-XS_TAG1I( emphasis )
 XS_TAG1I( font )
 XS_TAG1I( i )
-XS_TAG1I( ins )
-XS_TAG1I( kbd )
 XS_TAG1I( nobr )
-XS_TAG1I( q )
-XS_TAG1I( samp )
-XS_TAG1I( small )
-XS_TAG1I( span )
 XS_TAG1I( s )
+XS_TAG1I( small )
 XS_TAG1I( strike )
 XS_TAG1I( strong )
-XS_TAG1I( sub )
-XS_TAG1I( sup )
 XS_TAG1I( tt )
 XS_TAG1I( u )
+                // HTML5: end of "active formatting elements"
+                // This is just for refence: we don't handle them specifically
+                // (in HTML5, when mis-nested tags would close one of these,
+                // they are re-opened when leaving the mis-nested tag container)
+
+XS_TAG1I( acronym )
+XS_TAG1I( bdi )
+XS_TAG1I( bdo )
+XS_TAG1I( br )
+XS_TAG1I( cite ) // conflict between HTML (inline) and FB2 (block): default here to inline (fb2.css puts it back to block)
+XS_TAG1I( del )
+XS_TAG1I( dfn )
+XS_TAG1I( emphasis )
+XS_TAG1I( ins )
+XS_TAG1I( kbd )
+XS_TAG1I( q )
+XS_TAG1I( samp )
+XS_TAG1I( span )
+XS_TAG1I( sub )
+XS_TAG1I( sup )
 XS_TAG1I( var )
 
 // Ruby elements (defaults to inline)
 XS_TAG1D( ruby, true, css_d_ruby, css_ws_inherit )
 XS_TAG1I( rbc ) // no more in HTML5, but in 2001's https://www.w3.org/TR/ruby/
-XS_TAG1I( rtc )
 XS_TAG1I( rb )
+XS_TAG1I( rtc )
 XS_TAG1I( rt )
 XS_TAG1I( rp )
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2649,7 +2649,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
     /// close tags
@@ -2702,7 +2702,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on text
     virtual void OnText( const lChar16 * text, int len, lUInt32 flags );
     /// constructor
@@ -2790,7 +2790,7 @@ public:
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     /// called on attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
     /// called on text

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1054,7 +1054,7 @@ public:
     /// inserts child text
     ldomNode * insertChildText( const lString16 & value );
     /// inserts child text
-    ldomNode * insertChildText(const lString8 & value);
+    ldomNode * insertChildText(const lString8 & value, bool before_last_child=false);
     /// remove child
     ldomNode * removeChild( lUInt32 index );
 
@@ -2597,11 +2597,11 @@ class ldomElementWriter
         return _element;
     }
     lString16 getPath();
-    void onText( const lChar16 * text, int len, lUInt32 flags );
+    void onText( const lChar16 * text, int len, lUInt32 flags, bool insert_before_last_child=false );
     void addAttribute( lUInt16 nsid, lUInt16 id, const wchar_t * value );
     //lxmlElementWriter * pop( lUInt16 id );
 
-    ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent);
+    ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent, bool insert_before_last_child=false);
     ~ldomElementWriter();
 
     friend class ldomDocumentWriter;
@@ -2698,10 +2698,13 @@ protected:
     bool _bodyTagSeen;
     bool _curNodeIsSelfClosing;
     bool _curTagIsIgnored;
+    ldomElementWriter * _curNodeBeforeFostering;
+    ldomElementWriter * _curFosteredNode;
     ldomElementWriter * _lastP;
     virtual void AutoClose( lUInt16 tag_id, bool open );
     virtual bool AutoOpenClosePop( int step, lUInt16 tag_id );
     virtual lUInt16 popUpTo( ldomElementWriter * target, lUInt16 target_id=0, int scope=0 );
+    virtual bool CheckAndEnsureFosterParenting(lUInt16 tag_id);
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2692,7 +2692,16 @@ protected:
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
+    // Some states used when gDOMVersionRequested >= 20200824
+    bool _htmlTagSeen;
+    bool _headTagSeen;
+    bool _bodyTagSeen;
+    bool _curNodeIsSelfClosing;
+    bool _curTagIsIgnored;
+    ldomElementWriter * _lastP;
     virtual void AutoClose( lUInt16 tag_id, bool open );
+    virtual bool AutoOpenClosePop( int step, lUInt16 tag_id );
+    virtual lUInt16 popUpTo( ldomElementWriter * target, lUInt16 target_id=0, int scope=0 );
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2684,14 +2684,16 @@ public:
 class ldomDocumentWriterFilter : public ldomDocumentWriter
 {
 protected:
+    bool _libRuDocumentToDetect;
     bool _libRuDocumentDetected;
     bool _libRuParagraphStart;
+    bool _libRuParseAsPre;
     lUInt16 _styleAttrId;
     lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
     virtual void AutoClose( lUInt16 tag_id, bool open );
-    virtual void ElementCloseHandler( ldomNode * elem );
+    virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
     virtual void appendStyle( const lChar16 * style );
     virtual void setClass( const lChar16 * className, bool overrideExisting=false );
 public:

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -61,10 +61,10 @@ public:
     {
         OnTagOpen( nsname, tagname );
         OnTagBody();
-        OnTagClose( nsname, tagname );
+        OnTagClose( nsname, tagname, true );
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname ) = 0;
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) = 0;
     /// called on element attribute
     virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue ) = 0;
     /// called on text

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -731,7 +731,7 @@ public:
     void OnTagBody();
 
     /// called on tag close
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
 
     /// called on element attribute
     void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
@@ -1325,7 +1325,7 @@ void docXMLreader::OnTagBody()
         m_handler->handleTagBody();
 }
 
-void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
 {
     CR_UNUSED(nsname);
 
@@ -2788,7 +2788,7 @@ void docx_drawingHandler::handleAttribute(const lChar16 *attrname, const lChar16
             m_writer->OnTagOpen(L"", L"img");
             m_writer->OnAttribute(L"", L"src",  imgPath.c_str());
             m_writer->OnTagBody();
-            m_writer->OnTagClose(L"", L"img");
+            m_writer->OnTagClose(L"", L"img", true);
         }
     }
 }

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -387,7 +387,7 @@ public:
         return NULL;
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname ) {
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) {
         CR_UNUSED(nsname);
         if (!lStr_cmp(tagname, "encryption"))
             insideEncryption = false;

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -60,7 +60,7 @@ public:
 public:
     ldomNode *OnTagOpen(const lChar16 *nsname, const lChar16 *tagname);
     /// called on closing tag
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
     void OnTagBody();
     void OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue);
 
@@ -165,7 +165,7 @@ void fb3DomWriter::writeDescription()
         m_parent->OnTagOpenNoAttr( NULL, L"coverpage" );
         m_parent->OnTagOpen(NULL, L"image");
         m_parent->OnAttribute(L"l", L"href", m_context->m_coverImage.c_str());
-        m_parent->OnTagClose( NULL, L"image" );
+        m_parent->OnTagClose( NULL, L"image", true );
         m_parent->OnTagClose( NULL, L"coverpage" );
     }
     m_parent->OnTagClose( NULL, L"title-info" );
@@ -193,7 +193,7 @@ ldomNode *fb3DomWriter::OnTagOpen(const lChar16 *nsname, const lChar16 *tagname)
     return m_parent->OnTagOpen(nsname, tagname);
 }
 
-void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname, bool self_closing_tag)
 {
     if ( !lStr_cmp(tagname, "fb3-body") ) {
         m_parent->OnTagClose(NULL, L"body");
@@ -205,7 +205,7 @@ void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname)
     } else if ( !lStr_cmp(tagname, "notes" )) {
         tagname = L"body";
     }
-    m_parent->OnTagClose(nsname, tagname);
+    m_parent->OnTagClose(nsname, tagname, self_closing_tag);
 }
 
 void fb3DomWriter::OnTagBody()

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -114,7 +114,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBookMarks")==0 && state==in_fbm ) {
             state = in_xml;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -668,7 +668,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         CR_UNUSED2(nsname, tagname);
         insidePatternTag = false;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4546,6 +4546,13 @@ bool LVDocView::ParseDocument() {
         ldomDocumentWriter writer(m_doc);
         ldomDocumentWriterFilter writerFilter(m_doc, false,
                 HTML_AUTOCLOSE_TABLE);
+        // Note: creating these 2 writers here, and using only one,
+        // will still have both their destructors called when
+        // leaving this scope. Each destructor call will have
+        // ldomDocumentWriter::~ldomDocumentWriter() called, and
+        // both will do the same work on m_doc. So, beware there
+        // that this causes no issue.
+        // We might want to refactor this section to avoid any issue.
 
         LVFileFormatParser * parser = NULL;
         if (m_stream->GetSize() >= 5) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2330,12 +2330,9 @@ void LVDocView::Draw(LVDrawBuf & drawbuf, int position, int page, bool rotate, b
 		return;
 	if (isScrollMode()) {
 		drawbuf.SetClipRect(NULL);
-		drawbuf.setHidePartialGlyphs(false);
-		drawPageBackground(drawbuf, 0, position);
-		/* Don't draw FB2 cover in scroll mode, as having it not part of the document
-		   height and having to shift the document start and adjust y/pos in many
-		   places is quite complicated
-		int cover_height = 0;
+        drawbuf.setHidePartialGlyphs(false);
+        drawPageBackground(drawbuf, 0, position);
+        int cover_height = 0;
 		if (m_pages.length() > 0 && (m_pages[0]->flags & RN_PAGE_TYPE_COVER))
 			cover_height = m_pages[0]->height;
 		if (position < cover_height) {
@@ -2349,7 +2346,6 @@ void LVDocView::Draw(LVDrawBuf & drawbuf, int position, int page, bool rotate, b
 			rc.right -= m_pageMargins.right;
 			drawCoverTo(&drawbuf, rc);
 		}
-		*/
 		DrawDocument(drawbuf, m_doc->getRootNode(), m_pageMargins.left, 0, drawbuf.GetWidth()
 				- m_pageMargins.left - m_pageMargins.right, drawbuf.GetHeight(), 0, -position,
 				drawbuf.GetHeight(), &m_markRanges, &m_bmkRanges);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4735,6 +4735,23 @@ public:
         }
         return false;
     }
+    void getFloatsCurrentShifts( int & dx_left, int & dx_right, int h=0 ) {
+        // Initial work in absolute coordinates
+        int left_x = 0;
+        int right_x = o_width;
+        for (int i=0; i<_floats.length(); i++) {
+            BlockFloat * flt = _floats[i];
+            if (flt->top < c_y+h && flt->bottom > c_y) {
+                if ( flt->is_right && flt->left < right_x )
+                    right_x = flt->left;
+                if ( !flt->is_right && flt->right > left_x )
+                    left_x = flt->right;
+            }
+        }
+        // And adjust to current container's width
+        dx_left = left_x - x_min;
+        dx_right = x_max - right_x;
+    }
 
     void addSpaceToContext( int starty, int endy, int line_h,
             bool split_avoid_before, bool split_avoid_inside, bool split_avoid_after ) {
@@ -6565,8 +6582,39 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // is... margin_left
     int dx = margin_left;
 
+    // Strangely, when floats are involved, a HR behaves differently than
+    // a regular DIV (observed with Firefox): a DIV is sized as if there
+    // was no float, and only its text will adjust to be in-between floats,
+    // while a HR box does adjust to fit between the floats. Couldn't find
+    // any mention of that in the CSS specs...
+    // Let's try to handle that, even if it feels hackish and might not be right.
+    int adjusted_container_width = container_width;
+    int adjusted_forced_x_shift = 0;
+    if ( is_hr && flow->hasActiveFloats() ) {
+        // <HR> should not be drawn over floats (except if negative
+        // margins or larger specified width - its width in % is to
+        // stay computed as a % of its container width)
+        int dx_left;
+        int dx_right;
+        flow->getFloatsCurrentShifts(dx_left, dx_right);
+        if ( dx_right > 0 ) {
+            adjusted_container_width -= dx_right;
+        }
+        if ( dx_left > 0 ) {
+            adjusted_container_width -= dx_left;
+            adjusted_forced_x_shift = dx_left;
+        }
+        if ( style->width.type == css_val_unspecified ) {
+            // When no specified width, it is to become the constrained width
+            width = adjusted_container_width;
+        }
+        // And go again at adjusting this HR position
+        auto_width = false;
+    }
     if ( !auto_width ) { // We have a width that may not fill all available space
         // printf("fixed width: %d\n", width);
+        // For these initial overflow checks, we use the original container_width
+        // and not the adjusted one
         if ( width + margin_left + margin_right > container_width ) {
             if ( is_rtl ) {
                 margin_left = 0; // drop margin_left if RTL
@@ -6593,26 +6641,33 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 //
                 // (if margin_left_auto, we have until now: dx = margin_left = 0)
                 if ( margin_left_auto && margin_right_auto ) {
-                    dx = (container_width - width) / 2;
+                    dx = (adjusted_container_width - width) / 2;
                     margin_auto_ensured = true;
                 }
                 else if ( margin_left_auto ) {
-                    dx = container_width - width;
+                    dx = adjusted_container_width - width - margin_right;
                     margin_auto_ensured = true;
                 }
                 else if ( margin_right_auto ) {
                     // No dx tweak needed
                     margin_auto_ensured = true;
                 }
+                if ( is_hr && dx < 0 && margin_auto_ensured ) {
+                    // With Firefox, when any margin is auto and the HR width
+                    // doesn't fit, it is fitted left.
+                    dx = 0;
+                }
             }
             if ( !margin_auto_ensured ) {
                 // Nothing else needed for LTR: stay stuck to the left
                 // For RTL: stick it to the right
                 if (is_rtl) {
-                    dx = container_width - width;
+                    dx = adjusted_container_width - width;
                 }
             }
         }
+        // Add left shift imposed by left floats to HR
+        dx += adjusted_forced_x_shift;
     }
 
     // Prevent overflows if not allowed

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5669,8 +5669,8 @@ public:
         RenderRectAccessor fmt( node );
         int width = fmt.getWidth();
         int height = fmt.getHeight();
-        int x = fmt.getX();   // a floatBox has no margin and no padding, but these
-        int y = fmt.getY();   // x/y carries the container's padding left/top
+        int x = fmt.getX();   // a floatBox has no margin and no padding, but x carries the container's padding left
+        int y = fmt.getY();   // (but y must be =0, as padding_top has already been accounted in c_y
         // printf("  block addFloat w=%d h=%d x=%d y=%d\n", width, height, x, y);
         int shift_x = 0;
         int shift_y = 0;
@@ -6969,9 +6969,11 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // and if !DO_NOT_CLEAR_OWN_FLOATS, we'll fill the remaining
                         // height taken by floats if any.
                         LVRendPageContext alt_context( NULL, flow->getPageHeight(), false );
-                        // For floats too, the provided x/y must be the padding-left/top of the
+                        // For floats too, the provided x must be the padding-left of the
                         // parent container of the float (and width must exclude the parent's
-                        // padding-left/right) for the flow to correctly position inner floats:
+                        // padding-left/right) for the flow to correctly position inner floats
+                        // (but we don't provide padding_top, as if non-zero, we already
+                        // flow->addContentLine() it above, so the flow is already aware of it):
                         // flow->addFloat() will additionally shift its positionning by the
                         // child x/y set by this renderBlockElement().
                         // We provide 0,0 as the usable left/right overflows, so no glyph/hanging
@@ -6979,7 +6981,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // the initial float element's margins, which can then be used if it has
                         // no border (if borders, only the padding can be used).
                         renderBlockElement( alt_context, child, (is_rtl ? 0 : list_marker_padding) + padding_left,
-                                    padding_top, width - list_marker_padding - padding_left - padding_right, 0, 0, direction );
+                                    0, width - list_marker_padding - padding_left - padding_right, 0, 0, direction );
                         flow->addFloat(child, child_clear, is_right, flt_vertical_margin);
                         // Gather footnotes links accumulated by alt_context
                         lString16Collection * link_ids = alt_context.getLinkIds();
@@ -7517,6 +7519,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         // in a float, etc...)
         FlowState flow( context, width, usable_left_overflow, usable_right_overflow, rend_flags,
                                 direction, TextLangMan::getLangNodeIndex(enode) );
+        flow.moveDown(y);
         if (baseline != NULL) {
             flow.setRequestedBaselineType(*baseline);
         }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8830,28 +8830,36 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->white_space = type_ptr->white_space;
 
         // Account for backward incompatible changes in fb2def.h
-        if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
-            if (nodeElementId == el_form) {
-                pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
-            }
-            if (nodeElementId == el_code) {
-                pstyle->white_space = css_ws_pre; // otherwise white-space: normal, as browsers do
-            }
-            if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
+        if (gDOMVersionRequested < 20200824) { // revert what was changed 20200824
+            if (nodeElementId >= el_details && nodeElementId <= el_wbr) { // newly added block elements
                 pstyle->display = css_d_inline; // previously unknown and shown as inline
                 if (gDOMVersionRequested < 20180524) {
                     pstyle->display = css_d_inherit; // previously unknown and display: inherit
                 }
             }
-            if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
-                if (nodeElementId == el_cite) {
-                    pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
+            if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
+                if (nodeElementId == el_form) {
+                    pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
                 }
-                if (nodeElementId == el_li) {
-                    pstyle->display = css_d_list_item_legacy; // otherwise correctly set to css_d_list_item_block
+                if (nodeElementId == el_code) {
+                    pstyle->white_space = css_ws_pre; // otherwise white-space: normal, as browsers do
                 }
-                if (nodeElementId == el_style) {
-                    pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)
+                if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
+                    pstyle->display = css_d_inline; // previously unknown and shown as inline
+                    if (gDOMVersionRequested < 20180524) {
+                        pstyle->display = css_d_inherit; // previously unknown and display: inherit
+                    }
+                }
+                if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
+                    if (nodeElementId == el_cite) {
+                        pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
+                    }
+                    if (nodeElementId == el_li) {
+                        pstyle->display = css_d_list_item_legacy; // otherwise correctly set to css_d_list_item_block
+                    }
+                    if (nodeElementId == el_style) {
+                        pstyle->display = css_d_inline; // otherwise correctly set to css_d_none (hidden)
+                    }
                 }
             }
         }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1369,6 +1369,21 @@ public:
                             else if ( c >= 0x2066 ) m_flags[pos] = LCHAR_IS_TO_IGNORE; // 2066>2069
                         }
                     }
+                    else if ( c <= 0x009F ) {
+                        // Also ignore some ASCII and Unicode control chars
+                        // in the ranges 00>1F and 7F>9F, except a few.
+                        // (Some of these can be found in old documents or
+                        // badly converted ones)
+                        if ( c <= 0x001F ) {
+                            // Let \t \n \r be (they might have already been
+                            // expanded to spaces, converted or skipped)
+                            if ( c != 0x000A && c!= 0x000D && c!= 0x0009 )
+                                m_flags[pos] = LCHAR_IS_TO_IGNORE; // 0000>001F except those above
+                        }
+                        else if ( c >= 0x007F ) {
+                            m_flags[pos] = LCHAR_IS_TO_IGNORE;     // 007F>009F
+                        }
+                    }
                     // We might want to add some others when we happen to meet them.
                     // todo: see harfbuzz hb-unicode.hh is_default_ignorable() for how
                     // to do this kind of check fast

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12996,46 +12996,134 @@ void ldomDocumentWriterFilter::AutoClose( lUInt16 tag_id, bool open )
 
 ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
 {
+    //logfile << "lxmlDocumentWriter::OnTagOpen() [" << nsname << ":" << tagname << "]";
+    //lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
     //CRLog::trace("OnTagOpen(%s, %s)", LCSTR(lString16(nsname)), LCSTR(lString16(tagname)));
+
+    // We expect from the parser to always have OnTagBody called
+    // after OnTagOpen before any other OnTagOpen
     if ( !_tagBodyCalled ) {
         CRLog::error("OnTagOpen w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));
         crFatalError();
     }
     _tagBodyCalled = false;
-    //logfile << "lxmlDocumentWriter::OnTagOpen() [" << nsname << ":" << tagname << "]";
-//    if ( nsname && nsname[0] )
-//        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
-//    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
 
     lUInt16 id = _document->getElementNameIndex(tagname);
     lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
+
+    // http://lib.ru/ books detection (a bit ugly to have this hacked
+    // into ldomDocumentWriterFilter, but well, it's been there for ages
+    // and it seems quite popular and expected to have crengine handle
+    // Lib.ru books without any conversion needed).
+    // Detection has been reworked to be done here (in OnTagOpen). It
+    // was previously done in ElementCloseHandler/OnTagClose when closing
+    // the elements, and as it removed the FORM node from the DOM, it
+    // caused a display hash mismatch which made the cache invalid.
+    // So, do it here and don't remove any node but make then hidden.
+    // Lib.ru books (in the 2 formats that are supported, "Lib.ru html"
+    // and "Fine HTML"), have this early in the document:
+    //   <div align=right><form action=/INPROZ/ASTURIAS/asturias1_1.txt><select name=format><OPTION...>
+    // Having a FORM child of a DIV with align=right is assumed to be
+    // quite rare, so check for that.
+    bool setDisplayNone = false;
+    bool setParseAsPre = false;
+    if ( _libRuDocumentToDetect && id == el_form ) {
+        // At this point _currNode is still the parent of the FORM that is opening
+        if ( _currNode && _currNode->_element->getNodeId() == el_div ) {
+            ldomNode * node = _currNode->_element;
+            lString16 style = node->getAttributeValue(attr_style);
+            // align=right would have been translated to style="text-align: right"
+            if ( !style.empty() && style.pos("text-align: right", 0) >= 0 ) {
+                _libRuDocumentDetected = true;
+                // We can't set this DIV to be display:none as the element
+                // has already had setNodeStyle() called and applied, so
+                // it would take effect only on re-renderings (and would
+                // cause a display hash mismatch).
+                // So, we'll set it on the FORM just after it's created below
+                setDisplayNone = true;
+            }
+        }
+        // If the first FORM met doesn't match, no need keep detecting
+        _libRuDocumentToDetect = false;
+    }
+    // Fixed 20180503: this was done previously in any case, but now only
+    // if _libRuDocumentDetected. We still allow the old behaviour if
+    // requested to keep previously recorded XPATHs valid.
+    if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
+        // Patch for bad LIB.RU books - BR delimited paragraphs
+        // in "Fine HTML" format, that appears as:
+        //   <br>&nbsp; &nbsp; &nbsp; Viento fuerte, 1950
+        //   <br>&nbsp; &nbsp; &nbsp; Spellcheck [..., with \n every 76 chars]
+        if ( id == el_br || id == el_dd ) {
+            // Replace such BR with P
+            id = el_p;
+            _libRuParagraphStart = true; // to trim leading &nbsp;
+        } else {
+            _libRuParagraphStart = false;
+        }
+        if ( _libRuDocumentDetected && id == el_pre ) {
+            // "Lib.ru html" format is actually minimal HTML with
+            // the text wrapped in <PRE>. We will parse this text
+            // to build proper HTML with each paragraph wrapped
+            // in a <P> (this is done by the XMLParser when we give
+            // it TXTFLG_PRE_PARA_SPLITTING).
+            // Once that is detected, we don't want it to be PRE
+            // anymore (so that on re-renderings, it's not handled
+            // as white-space: pre), so we're swapping this PRE with
+            // a DIV element. But we need to still parse the text
+            // when building the DOM as PRE.
+            id = el_div;
+            ldomNode * n = _currNode ? _currNode->getElement() : NULL;
+            if ( n && n->getNodeId() == el_pre ) {
+                // Also close any previous PRE that would have been
+                // auto-closed if we kept PRE as PRE (from now on,
+                // we'll convert PRE to DIV), as this unclosed PRE
+                // would apply to all the text.
+                _currNode = pop( _currNode, el_pre);
+            }
+            else if ( n && n->getNodeId() == el_div && n->hasAttribute( attr_ParserHint ) &&
+                        n->getAttributeValue( attr_ParserHint ) == L"ParseAsPre" ) {
+                // Also close any previous PRE we already masqueraded
+                // as <DIV ParserHint="ParseAsPre">
+                _currNode = pop( _currNode, el_div);
+            }
+            // Below, we'll then be inserting a DIV, which won't be TXTFLG_PRE.
+            // We'll need to re-set _flags to be TXTFLG_PRE in our OnTagBody(),
+            // after it has called the superclass's OnTagBody(),
+            // as ldomDocumentWriter::OnTagBody() will call onBodyEnter() which
+            // will have set default styles (so, not TXTFLG_PRE for DIV as its
+            // normal style is "white-space: normal").
+            // We'll add the attribute ParserHint="ParseAsPre" below so
+            // we know it was a PRE and do various tweaks.
+            setParseAsPre = true;
+        }
+    }
 
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
     if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
-    // Fixed 20180503: this was done previously in any case, but now only
-    // if _libRuDocumentDetected. We still allow the old behaviour if
-    // requested to keep previously recorded XPATHs valid.
-    if ( _libRuDocumentDetected || gDOMVersionRequested < 20180503) {
-        // Patch for bad LIB.RU books - BR delimited paragraphs in "Fine HTML" format
-        if ( id == el_br || id == el_dd ) {
-            // substitute to P
-            id = el_p;
-            _libRuParagraphStart = true; // to trim leading &nbsp;
-        } else {
-            _libRuParagraphStart = false;
-        }
-    }
-
     AutoClose( id, true );
     _currNode = new ldomElementWriter( _document, nsid, id, _currNode );
     _flags = _currNode->getFlags();
-    if ( _libRuDocumentDetected && (_flags & TXTFLG_PRE) )
-        _flags |= TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM; // convert preformatted text into paragraphs
+
+    // Some libRu tweaks:
+    if ( setParseAsPre ) {
+        // Set an attribute on the DIV we just added
+        _currNode->getElement()->setAttributeValue(LXML_NS_NONE, attr_ParserHint, L"ParseAsPre");
+        // And set this global flag as we'll need to re-enable PRE (as it
+        // will be reset by ldomDocumentWriter::OnTagBody() as we won't have
+        // proper CSS white-space:pre inheritance) and XMLParser flags.
+        _libRuParseAsPre = true;
+    }
+    if ( setDisplayNone ) {
+        // Hide the FORM that was used to detect libRu,
+        // now that currNode is the FORM element
+        appendStyle( L"display: none" );
+    }
+
     //logfile << " !o!\n";
-    //return _currNode->getElement();
     return _currNode->getElement();
 }
 
@@ -13049,63 +13137,20 @@ void ldomDocumentWriterFilter::OnTagBody()
     // Some specific handling for the <BODY> tag to deal with HEAD STYLE and
     // LINK is done in super class (ldomDocumentWriter)
     ldomDocumentWriter::OnTagBody();
-}
 
-bool isRightAligned(ldomNode * node) {
-    lString16 style = node->getAttributeValue(attr_style);
-    if (style.empty())
-        return false;
-    int p = style.pos("text-align: right", 0);
-    return (p >= 0);
-}
-
-void ldomDocumentWriterFilter::ElementCloseHandler( ldomNode * node )
-{
-    ldomNode * parent = node->getParentNode();
-    lUInt16 id = node->getNodeId();
-    if ( parent ) {
-        if ( parent->getLastChild() != node )
-            return;
-        if ( id==el_table ) {
-            if (isRightAligned(node) && node->getAttributeValue(attr_width) == "30%") {
-                // LIB.RU TOC detected: remove it
-                //parent = parent->modify();
-
-                //parent->removeLastChild();
-            }
-        } else if ( id==el_pre && _libRuDocumentDetected ) {
-            // for LIB.ru - replace PRE element with DIV (section?)
-            if ( node->getChildCount()==0 ) {
-                //parent = parent->modify();
-
-                //parent->removeLastChild(); // remove empty PRE element
-            }
-            //else if ( node->getLastChild()->getNodeId()==el_div && node->getLastChild()->getChildCount() &&
-            //          ((ldomElement*)node->getLastChild())->getLastChild()->getNodeId()==el_form )
-            //    parent->removeLastChild(); // remove lib.ru final section
-            else
-                node->setNodeId( el_div );
-        } else if ( id==el_div ) {
-//            CRLog::trace("DIV attr align = %s", LCSTR(node->getAttributeValue(attr_align)));
-//            CRLog::trace("DIV attr count = %d", node->getAttrCount());
-//            int alignId = node->getDocument()->getAttrNameIndex("align");
-//            CRLog::trace("align= %d %d", alignId, attr_align);
-//            for (int i = 0; i < node->getAttrCount(); i++)
-//                CRLog::trace("DIV attr %s", LCSTR(node->getAttributeName(i)));
-            if (isRightAligned(node)) {
-                ldomNode * child = node->getLastChild();
-                if ( child && child->getNodeId()==el_form )  {
-                    // LIB.RU form detected: remove it
-                    //parent = parent->modify();
-
-                    parent->removeLastChild();
-                    _libRuDocumentDetected = true;
-                }
-            }
+    if ( _libRuDocumentDetected ) {
+        if ( _libRuParseAsPre ) {
+            // The OnTagBody() above might have cancelled TXTFLG_PRE
+            // (that the ldomElementWriter inherited from its parent)
+            // when ensuring proper CSS white-space inheritance.
+            // Re-enable it
+            _currNode->_flags |= TXTFLG_PRE;
+            // Also set specific XMLParser flags so it spits out
+            // <P>... for each paragraph of plain text, so that
+            // we get some nice HTML instead
+            _flags = TXTFLG_PRE | TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM;
         }
     }
-    if (!_libRuDocumentDetected)
-        node->persist();
 }
 
 void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
@@ -13229,6 +13274,23 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
     // below might handle. So, here below, we check that both id and curNodeId match
     // the element id we check for.
 
+    if ( _libRuDocumentToDetect && id == el_div ) {
+        // No need to try detecting after we see a closing </DIV>,
+        // as the FORM we look for is in the first DIV
+        _libRuDocumentToDetect = false;
+    }
+    if ( _libRuDocumentDetected && id == el_pre ) {
+        // Also, if we're about to close the original PRE that we masqueraded
+        // as DIV and that has enabled _libRuParseAsPre, reset it.
+        // (In Lib.ru books, it seems a PRE is never closed, or only at
+        // the end by another PRE where it doesn't matter if we keep that flag.)
+        ldomNode * n = _currNode->getElement();
+        if ( n->getNodeId() == el_div && n->hasAttribute( attr_ParserHint ) &&
+                    n->getAttributeValue( attr_ParserHint ) == L"ParseAsPre" ) {
+            _libRuParseAsPre = false;
+        }
+    }
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks,
     // they will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriter::OnTagClose)
@@ -13268,14 +13330,11 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
 
     if ( _currNode ) {
         _flags = _currNode->getFlags();
-        if ( _libRuDocumentDetected && (_flags & TXTFLG_PRE) )
-            _flags |= TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM; // convert preformatted text into paragraphs
+        if ( _libRuParseAsPre ) {
+            // Re-set specific parser flags
+            _flags |= TXTFLG_PRE | TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM;
+        }
     }
-
-    //=============================================================
-    // LIB.RU patch: remove table of contents
-    //ElementCloseHandler( closedElement );
-    //=============================================================
 
     if ( id==_stopTagId ) {
         //CRLog::trace("stop tag found, stopping...");
@@ -13301,12 +13360,15 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
         if ( (_flags & XML_FLAG_NO_SPACE_TEXT)
              && IsEmptySpace(text, len) && !(flags & TXTFLG_PRE))
              return;
-        bool autoPara = _libRuDocumentDetected && (flags & TXTFLG_PRE);
-        if (_currNode->_allowText) {
+        if ( !_currNode->_allowText )
+            return;
+        if ( !_libRuDocumentDetected ) {
+            _currNode->onText( text, len, flags );
+        }
+        else { // Lib.ru text cleanup
             if ( _libRuParagraphStart ) {
-                bool cleaned = false;
+                // Cleanup "Fine HTML": "<br>&nbsp; &nbsp; &nbsp; Viento fuerte, 1950"
                 while ( *text==160 && len > 0 ) {
-                    cleaned = true;
                     text++;
                     len--;
                     while ( *text==' ' && len > 0 ) {
@@ -13314,12 +13376,11 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
                         len--;
                     }
                 }
-                if ( cleaned ) {
-                    setClass(L"justindent");
-                    //appendStyle(L"text-indent: 1.3em; text-align: justify");
-                }
                 _libRuParagraphStart = false;
             }
+            // Handle "Lib.ru html" paragraph, parsed from the nearly plaintext
+            // by XMLParser with TXTFLG_PRE | TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM
+            bool autoPara = flags & TXTFLG_PRE;
             int leftSpace = 0;
             const lChar16 * paraTag = NULL;
             bool isHr = false;
@@ -13335,6 +13396,15 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
                 for ( int i=0; i<len; i++ ) {
                     if ( !ch )
                         ch = text[i];
+                    // We would need this to have HR work:
+                    //   else if ( i == len-1 && text[i] == ' ' ) {
+                    //      // Ignore a trailing space we may get
+                    //      // Note that some HR might be missed when the
+                    //      // "----" directly follows some indented text.
+                    //   }
+                    // but by fixing it, we'd remove a P and have XPointers
+                    // like /html/body/div/p[14]/text().113 reference the wrong P,
+                    // so keep doing bad to not mess past highlights...
                     else if ( ch != text[i] ) {
                         sameCh = false;
                         break;
@@ -13365,8 +13435,10 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
 
 ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool headerOnly, const char *** rules )
 : ldomDocumentWriter( document, headerOnly )
+, _libRuDocumentToDetect(true)
 , _libRuDocumentDetected(false)
 , _libRuParagraphStart(false)
+, _libRuParseAsPre(false)
 , _styleAttrId(0)
 , _classAttrId(0)
 , _tagBodyCalled(true)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19,7 +19,7 @@
 // Users of this library can request the old behaviour by setting
 // gDOMVersionRequested to an older version to request the old (possibly
 // buggy) behaviour.
-#define DOM_VERSION_CURRENT 20200223
+#define DOM_VERSION_CURRENT 20200824
 
 // Also defined in include/lvtinydom.h
 #define DOM_VERSION_WITH_NORMALIZED_XPOINTERS 20200223
@@ -77,6 +77,9 @@
 // and toStringV1() to have non-normalized XPointers still working.)
 // (20200223: added toggable auto completion of incomplete tables by
 // wrapping some elements in a new <tabularBox>.)
+//
+// 20200824: added more HTML5 elements, and HTML parser changes
+// to be (only a little bit) more HTML5 conformant
 
 extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 int gDOMVersionRequested     = DOM_VERSION_CURRENT;
@@ -84,7 +87,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.47k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.48k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 
@@ -5118,7 +5121,7 @@ void ldomElementWriter::onBodyEnter()
     _bodyEnterCalled = true;
 #if BUILD_LITE!=1
     //CRLog::trace("onBodyEnter() for node %04x %s", _element->getDataIndex(), LCSTR(_element->getNodeName()));
-    if ( _document->isDefStyleSet() ) {
+    if ( _document->isDefStyleSet() && _element ) {
         _element->initNodeStyle();
 //        if ( _element->getStyle().isNull() ) {
 //            CRLog::error("error while style initialization of element %x %s", _element->getNodeIndex(), LCSTR(_element->getNodeName()) );
@@ -7388,6 +7391,7 @@ void ldomElementWriter::addAttribute( lUInt16 nsid, lUInt16 id, const wchar_t * 
 
 ldomElementWriter * ldomDocumentWriter::pop( ldomElementWriter * obj, lUInt16 id )
 {
+    // First check if there's an element with provided id in the stack
     //logfile << "{p";
     ldomElementWriter * tmp = obj;
     for ( ; tmp; tmp = tmp->_parent )
@@ -7399,6 +7403,7 @@ ldomElementWriter * ldomDocumentWriter::pop( ldomElementWriter * obj, lUInt16 id
     //logfile << "1";
     if (!tmp)
     {
+        // No element in the stack with provided id: nothing to close, stay at current element
         //logfile << "-err}";
         return obj; // error!!!
     }
@@ -12959,6 +12964,7 @@ void ldomDocumentWriterFilter::appendStyle( const lChar16 * style )
     node->setAttributeValue(LXML_NS_NONE, _styleAttrId, oldStyle.c_str());
 }
 
+// Legacy auto close handler (gDOMVersionRequested < 20200824)
 void ldomDocumentWriterFilter::AutoClose( lUInt16 tag_id, bool open )
 {
     lUInt16 * rule = _rules[tag_id];
@@ -12994,19 +13000,516 @@ void ldomDocumentWriterFilter::AutoClose( lUInt16 tag_id, bool open )
     }
 }
 
+// With gDOMVersionRequested >= 20200824, we use hardcoded rules
+// for opening and closing tags, trying to follow what's relevant
+// in the HTML Living Standard (=HTML5):
+//   https://html.spec.whatwg.org/multipage/parsing.html
+// A less frightening introduction is available at:
+//   https://htmlparser.info/parser/
+//
+// Note that a lot of rules and checks in the algorithm are for
+// noticing "parser errors", with usually a fallback of ignoring
+// it and going on.
+// It feels that we can simplify it to the following implementation,
+// with possibly some cases not handled related to:
+// - FORM and form elements (SELECT, INPUT, OPTION...)
+// - TEMPLATE, APPLET, OBJECT, MARQUEE
+// - Mis-nested HTML/BODY/HEAD
+// - Foster parenting of non-table elements inside a table
+// - Reconstructing the active formatting elements (B, I...) when
+//   mis-nested or "on hold" when entering block or table elements.
+// - The "adoption agency algorithm" for mis-nested formatting
+//   elements (and nested <A>)
+// - We may not ignore some opening tag that we normally should
+//   (like HEAD or FRAME when in BODY) (but we ignore a standalone
+//   sub-table element when not inside a TABLE) as this would
+//   complicate the internal parser state.
+//
+// Of interest:
+// https://html.spec.whatwg.org/multipage/parsing.html#parse-state
+//   List of "special" elements
+//   List of elements for rules "have a particular element in X scope"
+// https://html.spec.whatwg.org/multipage/parsing.html#tree-construction
+//   Specific rules when start or end tag of specific elements is met
+
+// Scope are for limiting ancestor search when looking for a previous
+// element to close (a closing tag may be ignored if no opening tag is
+// found in the specified scope)
+enum ScopeType {
+HTML_SCOPE_NONE = 0,       // no stop tag
+HTML_SCOPE_MAIN,           // HTML, TABLE, TD, TH, CAPTION, APPLET, MARQUEE, OBJECT, TEMPLATE
+HTML_SCOPE_LIST_ITEM,      // = SCOPE_MAIN + OL, UL
+HTML_SCOPE_BUTTON,         // = SCOPE_MAIN + BUTTON (not used, only used with P that we handle specifically)
+HTML_SCOPE_TABLE,          // HTML, TABLE, TEMPLATE
+HTML_SCOPE_SELECT,         // All elements stop, except OPTGROUP, OPTION
+HTML_SCOPE_SPECIALS,       // All specials elements (inline don't close across block/specials elements)
+// Next ones are scopes with specific behaviours that may ignore target_id
+HTML_SCOPE_OPENING_LI,     // = SCOPE_SPECIALS, minus ADDRESS, DIV, P: close any LI
+HTML_SCOPE_OPENING_DT_DD,  // = SCOPE_SPECIALS, minus ADDRESS, DIV, P: close any DT/DD
+HTML_SCOPE_OPENING_H1_H6,  // = close current node if H1, H2, H3, H4, H5, H6
+HTML_SCOPE_CLOSING_H1_H6,  // = SCOPE_MAIN: close any of H1..H6
+HTML_SCOPE_TABLE_TO_TOP,   // = SCOPE_TABLE: close all table sub-elements to end up being TABLE
+HTML_SCOPE_TABLE_OPENING_TD_TH, // = SCOPE_TABLE: close any TD/TH
+};
+// Note: as many elements close a P, we don't handle checking and closing them
+// via popUpTo(NULL, el_p, HTML_SCOPE_BUTTON), but we keep the last P as _lastP
+// so we can just popUpTo(_lastP) if set when meeting a "close a P" element.
+
+// Boxing elements (id < el_DocFragment) (and DocFragment itself,
+// not used with the HTMLParser) are normally added by crengine
+// after "delete ldomElementWriter" (which calls onBodyExit()
+// which calls initNodeRendMethod()), so after we have closed
+// and pass by the element.
+// So, we shouldn't meet any in popUpTo() and don't have to wonder
+// if we should stop at them, or pass by them.
+
+lUInt16 ldomDocumentWriterFilter::popUpTo( ldomElementWriter * target, lUInt16 target_id, int scope )
+{
+    if ( !target ) {
+        // Check if there's an element with provided target_id in the stack inside this scope
+        ldomElementWriter * tmp = _currNode;
+        while ( tmp ) {
+            lUInt16 tmpId = tmp->getElement()->getNodeId();
+            if ( tmpId < el_DocFragment && tmpId > el_NULL) {
+                // We shouldn't meet any (see comment above)
+                // (but we can meet the root node when poping </html>)
+                crFatalError( 127, "Unexpected boxing element met in ldomDocumentWriterFilter::popUpTo()" );
+            }
+            if ( target_id && tmpId == target_id )
+                break;
+            // Check scope stop tags
+            bool stop = false;
+            switch (scope) {
+                case HTML_SCOPE_MAIN: // stop at HTML/TABLE/TD...
+                    if ( tmpId == el_html || tmpId == el_table || tmpId == el_td || tmpId == el_th || tmpId == el_caption ||
+                         tmpId == el_applet || tmpId == el_marquee || tmpId == el_object || tmpId == el_template ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_LIST_ITEM: // stop at SCOPE_MAIN + OL, UL
+                    if ( tmpId == el_html || tmpId == el_table || tmpId == el_td || tmpId == el_th || tmpId == el_caption ||
+                         tmpId == el_applet || tmpId == el_marquee || tmpId == el_object || tmpId == el_template ||
+                         tmpId == el_ol || tmpId == el_ul ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_BUTTON: // stop at SCOPE_MAIN + BUTTON
+                    if ( tmpId == el_html || tmpId == el_table || tmpId == el_td || tmpId == el_th || tmpId == el_caption ||
+                         tmpId == el_applet || tmpId == el_marquee || tmpId == el_object || tmpId == el_template ||
+                         tmpId == el_button ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_TABLE: // stop at HTML and TABLE
+                    if ( tmpId == el_html || tmpId == el_table || tmpId == el_template ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_SELECT:
+                    // This one is different: all elements stop it, except optgroup and option
+                    if ( tmpId != el_optgroup && tmpId != el_option ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_SPECIALS: // stop at any "special" element
+                    if ( tmpId >= EL_SPECIAL_START && tmpId <= EL_SPECIAL_END ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_OPENING_LI:
+                    if ( tmpId == el_li ) {
+                        stop = true;
+                    }
+                    else if ( tmpId >= EL_SPECIAL_START && tmpId <= EL_SPECIAL_END &&
+                         tmpId != el_div && tmpId != el_p && tmpId != el_address ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_OPENING_DT_DD:
+                    if ( tmpId == el_dt || tmpId == el_dd ) {
+                        stop = true;
+                    }
+                    else if ( tmpId >= EL_SPECIAL_START && tmpId <= EL_SPECIAL_END &&
+                         tmpId != el_div && tmpId != el_p && tmpId != el_address ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_OPENING_H1_H6:
+                    // Close immediate parent H1...H6, but don't walk up
+                    // <H3> ... <H4> : H4 will close H3
+                    // <H3> ... <B> ... <H4> : H4 will not close H3
+                    if ( tmpId < el_h1 || tmpId > el_h6 ) {
+                        tmp = NULL; // Nothing to close
+                    }
+                    stop = true; // Don't check upper
+                    break;
+                case HTML_SCOPE_CLOSING_H1_H6:
+                    if ( tmpId >= el_h1 && tmpId <= el_h6 ) {
+                        stop = true;
+                    }
+                    else if ( tmpId == el_html || tmpId == el_table || tmpId == el_td || tmpId == el_th || tmpId == el_caption ||
+                         tmpId == el_applet || tmpId == el_marquee || tmpId == el_object || tmpId == el_template ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_TABLE_TO_TOP:
+                    if ( tmp->_parent && tmp->_parent->getElement()->getNodeId() == el_table ) {
+                        stop = true;
+                    }
+                    else if ( tmpId == el_html || tmpId == el_table || tmpId == el_template ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_TABLE_OPENING_TD_TH:
+                    if ( tmpId == el_td || tmpId == el_th ) {
+                        stop = true;
+                    }
+                    else if ( tmpId == el_html || tmpId == el_table || tmpId == el_template ) {
+                        tmp = NULL;
+                        stop = true;
+                    }
+                    break;
+                case HTML_SCOPE_NONE:
+                default:
+                    // Never stop, continue up to root node
+                    break;
+            }
+            if ( stop )
+                break;
+            tmp = tmp->_parent;
+        }
+        target = tmp; // (NULL if not found, NULL or not if stopped)
+    }
+    if ( target ) {
+        // Assume target is valid and will be found
+        while ( _currNode ) {
+            // Update state for after this node is closed
+            lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+            // Reset these flags if we see again these tags (so to
+            // at least reconstruct </html><html><body><hr> when
+            // meeting </html><hr> and have el_html as the catch all
+            // element in SCOPEs working.
+            if ( curNodeId == el_body ) {
+                _bodyTagSeen = false;
+            }
+            else if ( curNodeId == el_html ) {
+                _headTagSeen = false;
+                _htmlTagSeen = false;
+            }
+            if ( _lastP && _currNode == _lastP )
+                _lastP = NULL;
+            bool done = _currNode == target;
+            ldomElementWriter * tmp = _currNode;
+            _currNode = _currNode->_parent;
+            ElementCloseHandler( tmp->getElement() );
+            delete tmp;
+            if ( done )
+                break;
+        }
+    }
+    return _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
+}
+
+// To give as first parameter to AutoOpenClosePop()
+enum ParserStepType {
+    PARSER_STEP_TAG_OPENING = 1,
+    PARSER_STEP_TAG_CLOSING,
+    PARSER_STEP_TAG_SELF_CLOSING,
+    PARSER_STEP_TEXT
+};
+
+// More HTML5 conforming auto close handler (gDOMVersionRequested >= 20200824)
+bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
+{
+    lUInt16 curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
+    if ( !_bodyTagSeen && ( step == PARSER_STEP_TAG_OPENING || step == PARSER_STEP_TEXT) ) {
+        // Create some expected containing elements if not yet seen
+        if ( !_headTagSeen ) {
+            if ( !_htmlTagSeen ) {
+                _htmlTagSeen = true;
+                if ( tag_id != el_html ) {
+                    OnTagOpen(L"", L"html");
+                    OnTagBody();
+                }
+            }
+            if ( (tag_id >= EL_IN_HEAD_START && tag_id <= EL_IN_HEAD_END) || tag_id == el_noscript ) {
+                if ( tag_id != el_head ) {
+                    OnTagOpen(L"", L"head");
+                    OnTagBody();
+                }
+                _headTagSeen = true;
+            }
+            curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
+        }
+        if ( tag_id >= EL_IN_BODY_START || (step == PARSER_STEP_TEXT && (curNodeId == el_html || curNodeId == el_head)) ) {
+            // Tag usually found inside <body>, or text while being <HTML> or <HEAD>
+            // (text while being in <HTML><HEAD><TITLE> should not trigger this):
+            // end of <head> and start of <body>
+            if ( _headTagSeen )
+                OnTagClose(L"", L"head");
+            if ( tag_id != el_body ) {
+                OnTagOpen(L"", L"body");
+                OnTagBody();
+            }
+            curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
+            _bodyTagSeen = true;
+            _headTagSeen = true; // We won't open any <head> anymore
+        }
+    }
+    if ( step == PARSER_STEP_TEXT ) // new text: nothing more to do
+        return true;
+
+    bool is_self_closing_tag = false;
+    switch (tag_id) {
+        // These are scaterred among different ranges, so we sadly
+        // can't use any range comparisons
+        case el_area:
+        case el_base:
+        case el_br:
+        case el_col:
+        case el_embed:
+        case el_hr:
+        case el_img:
+        case el_input:
+        case el_link:
+        case el_meta:
+        case el_param:
+        case el_source:
+        case el_track:
+        case el_wbr:
+            is_self_closing_tag = true;
+            break;
+        default:
+            break;
+    }
+
+    if ( step == PARSER_STEP_TAG_OPENING ) {
+        // A new element with tag_id will be created after we return
+        // We should
+        // - create implicit parent elements for tag_id if not present (partially
+        //   done for HTML/HEAD/BODY elements above)
+        // - close elements that should be closed by this tag_id (some with optional
+        //   end tags and others that the spec says so)
+        // - keep a note if it's self-closing so we can close it when appropriate
+        // - ignore this opening tag in some cases
+
+        // Table elements can be ignored, create missing elements
+        // and/or close some others
+        if ( tag_id == el_th || tag_id == el_td ) {
+            // Close any previous TD/TH in table scope if any
+            curNodeId = popUpTo(NULL, 0, HTML_SCOPE_TABLE_OPENING_TD_TH);
+            // We should be in a table or sub-table element
+            // (a standalone TD is ignored)
+            if ( curNodeId < el_table || curNodeId > el_tr )
+                return false; // Not in a table context: ignore this TD/TH
+            // We must be in a TR. If we're not, have missing elements created
+            if ( curNodeId != el_tr ) {
+                // This will create all the other missing elements if needed
+                OnTagOpen(L"", L"tr");
+                OnTagBody();
+            }
+        }
+        else if ( tag_id == el_tr ) {
+            // Close any previous TR in table scope if any
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_TABLE);
+            // We should be in a table or sub-table element
+            // (a standalone TR is ignored)
+            if ( curNodeId < el_table || curNodeId > el_tfoot )
+                return false; // Not in a table context: ignore this TR
+            // We must be in a THEAD/TBODY/TFOOT. If we're not, have missing elements created
+            if ( curNodeId < el_thead || curNodeId > el_tfoot ) {
+                // This will create all the other missing elements if needed
+                OnTagOpen(L"", L"tbody");
+                OnTagBody();
+            }
+        }
+        else if ( tag_id == el_col ) {
+            // Close any previous COL in table scope if any
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_TABLE);
+            // We should be in a table or sub-table element
+            if ( curNodeId < el_table || curNodeId > el_td )
+                return false; // Not in a table context: ignore this TR
+            // We must be in a COLGROUP. If we're not, have missing elements created
+            if ( curNodeId != el_colgroup ) {
+                // This will create all the other missing elements if needed
+                OnTagOpen(L"", L"colgroup");
+                OnTagBody();
+            }
+        }
+        else if ( (tag_id >= el_thead && tag_id <= el_tfoot) ||
+                   tag_id == el_caption ||
+                   tag_id == el_colgroup ) {
+            // Close any previous THEAD/TBODY/TFOOT/CAPTION/COLGROUP/COL in table scope if any
+            curNodeId = popUpTo(NULL, 0, HTML_SCOPE_TABLE_TO_TOP);
+            // We should be in a table element
+            if ( curNodeId != el_table )
+                return false; // Not in a table context
+        }
+
+        if ( tag_id == el_li ) {
+            // A LI should close any previous LI, but should stop at specials
+            // except ADDRESS, DIV and P (they will so stop at UL/OL and won't
+            // close any upper LI that had another level of list opened).
+            // Once that LI close, they should also close any P, which will
+            // be taken care by followup check.
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_OPENING_LI);
+        }
+        else if ( tag_id == el_dt || tag_id == el_dd ) {
+            curNodeId = popUpTo(NULL, 0, HTML_SCOPE_OPENING_DT_DD);
+        }
+        else if ( tag_id == el_select ) {
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_SELECT);
+        }
+        if ( _lastP && tag_id >= EL_SPECIAL_CLOSING_P_START && tag_id <= EL_SPECIAL_CLOSING_P_END ) {
+            // All these should close a P "in button scope", meaning until a parent
+            // with these tag names is met:
+            //   html, table, td, th, caption, applet, marquee, object, template
+            // These should all have closed any previous P when opened, except
+            // applet, marquee, object, template - but to simplify things, we
+            // made them close a P too. So, _lastP is always "in button scope".
+            curNodeId = popUpTo(_lastP); // will set _lastP = NULL
+            // Note: in "quirks mode", a TABLE should not close a P (should
+            // we force this behaviour on old CHM files ? Having the table
+            // close a P when it shouldn't will make the following text out
+            // of P and possibly not styled as P).
+        }
+        if ( tag_id >= el_h1 && tag_id <= el_h6 ) {
+            // After possibly closing a P, H1...H6 close any H1...H6 direct ancestor
+            curNodeId = popUpTo(NULL, 0, HTML_SCOPE_OPENING_H1_H6);
+        }
+        else if ( curNodeId == el_option && (tag_id == el_optgroup || tag_id == el_option) ) {
+            // Close previous option
+            curNodeId = popUpTo(_currNode);
+        }
+        else if ( tag_id >= el_rbc && tag_id <= el_rp ) { // ruby sub-elements
+            // The HTML5 specs says that:
+            // - we should do that only if there is a RUBY in scope (but we don't check that)
+            // - RB and RTC should close implied end tags, meaning: RB RP RT RTC
+            // - RP and RT should close implied end tags except RTC, meaning: RB RP RT
+            // But they don't mention the old <RBC> that we want to support
+            // If we do, we end up with these rules (x for HTML specs, o for our added RBC support)
+            //               tags to close
+            //     tag_id   RBC RB RTC RT RP
+            //     RBC       o  o   o  o  o
+            //     RB           x   x  x  x
+            //     RTC       o  x   x  x  x
+            //     RT        o  x      x  x
+            //     RP        o  x      x  x
+            if ( tag_id == el_rbc || tag_id == el_rtc ) {
+                while ( curNodeId >= el_rbc && curNodeId <= el_rp ) {
+                    curNodeId = popUpTo(_currNode);
+                }
+            }
+            else if ( tag_id == el_rb ) {
+                while ( curNodeId >= el_rb && curNodeId <= el_rp ) {
+                    curNodeId = popUpTo(_currNode);
+                }
+            }
+            else { // el_rt || el_rp
+                while ( curNodeId >= el_rbc && curNodeId <= el_rp && curNodeId != el_rtc) {
+                    curNodeId = popUpTo(_currNode);
+                }
+            }
+        }
+
+        // Self closing will be handled in OnTagBody
+        _curNodeIsSelfClosing = is_self_closing_tag;
+    }
+    else if ( step == PARSER_STEP_TAG_CLOSING || step == PARSER_STEP_TAG_SELF_CLOSING ) { // Closing, </tag_id> or <tag_id/>
+        // We are responsible for poping up to and closing the provided tag_id,
+        // or ignoring it if stopped or not found.
+        if ( is_self_closing_tag ) {
+            // We can ignore this closing tag, except in one case:
+            // a standalone closing </BR> (so, not self closing)
+            // Specs say we should insert a new/another one
+            if ( tag_id == el_br && step == PARSER_STEP_TAG_CLOSING ) {
+                OnTagOpen(L"", L"br");
+                OnTagBody();
+                OnTagClose(L"", L"br", true);
+                return true;
+            }
+            return false; // ignored
+        }
+        if ( tag_id == curNodeId ) {
+            // If closing current node, no need for more checks
+            popUpTo(_currNode);
+            return true;
+        }
+        if ( tag_id == el_p && !_lastP ) {
+            // </P> without any previous <P> should emit <P></P>
+            // Insert new one and pop it
+            OnTagOpen(L"", L"p");
+            OnTagBody();
+            popUpTo(_currNode);
+            return true;
+        }
+        if ( tag_id > EL_SPECIAL_END ) {
+            // Inline elements don't close across specials
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_SPECIALS);
+        }
+        else if ( tag_id >= el_h1 && tag_id <= el_h6 ) {
+            // A closing Hn closes any other Hp
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_CLOSING_H1_H6);
+        }
+        else if ( tag_id == el_li ) {
+            // </li> shouldn't close across OL/UL
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_LIST_ITEM);
+            // Note: dt/dd (which have the same kind of auto-close previous
+            // as LI for the opening tag) do not have any restriction, and
+            // will use HTML_SCOPE_MAIN below
+        }
+        else if ( tag_id >= el_table && tag_id <= el_td ) {
+            // Table sub-element: don't cross TABLE
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_TABLE);
+        }
+        else if ( tag_id >= EL_SPECIAL_START ) {
+            // All other "specials" close across nearly everything
+            // except TABLE/TH/TD/CAPTION
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_MAIN);
+        }
+        else {
+            // Boxing elements are normally added by crengine after
+            // "delete ldomElementWriter" (which calls onBodyExit()
+            // which calls initNodeRendMethod()), so after we have
+            // closed and pass by the element.
+            // So, we shouldn't meet any.
+            // But logically, they shouldn't have any limitation
+            curNodeId = popUpTo(NULL, tag_id, HTML_SCOPE_NONE);
+        }
+        // SELECT should close any previous SELECT in HTML_SCOPE_SELECT,
+        // which should contain only OPTGROUP and OPTION, but we don't
+        // ensure that. So, we don't ensure this closing restriction.
+    }
+
+    // (Silences clang warning about 'curNodeId' is never read, if we
+    // happen to not had the need to re-check it - but better to keep
+    // updating it if we later add stuff that does use it)
+    (void)curNodeId;
+
+    return true;
+}
+
 ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
 {
-    //logfile << "lxmlDocumentWriter::OnTagOpen() [" << nsname << ":" << tagname << "]";
-    //lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
-    //CRLog::trace("OnTagOpen(%s, %s)", LCSTR(lString16(nsname)), LCSTR(lString16(tagname)));
-
     // We expect from the parser to always have OnTagBody called
     // after OnTagOpen before any other OnTagOpen
     if ( !_tagBodyCalled ) {
         CRLog::error("OnTagOpen w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));
         crFatalError();
     }
-    _tagBodyCalled = false;
+    // _tagBodyCalled = false;
+    // We delay setting _tagBodyCalled=false to below as we may create
+    // additional wrappers before inserting this new element
 
     lUInt16 id = _document->getElementNameIndex(tagname);
     lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
@@ -13099,14 +13602,42 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         }
     }
 
+    bool tag_accepted = true;
+    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+        if ( id == el_image )
+            id = el_img;
+        tag_accepted = AutoOpenClosePop( PARSER_STEP_TAG_OPENING, id );
+    }
+    else {
+        AutoClose( id, true );
+    }
+
     // Set a flag for OnText to accumulate the content of any <HEAD><STYLE>
+    // (We do that after the autoclose above, so that with <HEAD><META><STYLE>,
+    // the META is properly closed and we find HEAD as the current node.)
     if ( id == el_style && _currNode && _currNode->getElement()->getNodeId() == el_head ) {
         _inHeadStyle = true;
     }
 
-    AutoClose( id, true );
+    // From now on, we don't create/close any elements, so expect
+    // the next event to be OnTagBody (except OnTagAttribute)
+    _tagBodyCalled = false;
+
+    if ( !tag_accepted ) {
+        // Don't create the element
+        // If not accepted, the HTML parser will still call OnTagBody, and might
+        // call OnTagAttribute before that. We should ignore them until OnTagBody.
+        // No issue with OnTagClose, that can usually ignore stuff.
+        _curTagIsIgnored = true;
+        return _currNode ? _currNode->getElement() : NULL;
+    }
+
     _currNode = new ldomElementWriter( _document, nsid, id, _currNode );
     _flags = _currNode->getFlags();
+    if (gDOMVersionRequested >= 20200824 && id == el_p) {
+        // To avoid checking DOM ancestors with the numerous tags that close a P
+        _lastP = _currNode;
+    }
 
     // Some libRu tweaks:
     if ( setParseAsPre ) {
@@ -13133,10 +13664,26 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
 void ldomDocumentWriterFilter::OnTagBody()
 {
     _tagBodyCalled = true;
+    if ( _curTagIsIgnored ) {
+        _curTagIsIgnored = false; // Done with this ignored tag
+        // We don't want ldomDocumentWriter::OnTagBody() to re-init
+        // the current node styles (as we ignored this element,
+        // _currNode is the previous node, already initNodeStyle()'d)
+        return;
+    }
 
-    // Some specific handling for the <BODY> tag to deal with HEAD STYLE and
-    // LINK is done in super class (ldomDocumentWriter)
+    // This superclass OnTagBody() will initNodeStyle() on this node.
+    // Some specific handling for the <BODY> tag to deal with HEAD STYLE
+    // and LINK is also done there.
     ldomDocumentWriter::OnTagBody();
+
+    if ( _curNodeIsSelfClosing ) {
+        // Now that styles are set, we can close the element
+        // Let's have it closed properly with flags correctly re set, and so
+        // that specific handling in OnTagClose() is done (ex. for <LINK>)
+        OnTagClose(NULL, NULL, true);
+        return;
+    }
 
     if ( _libRuDocumentDetected ) {
         if ( _libRuParseAsPre ) {
@@ -13161,6 +13708,10 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     //lStr_lowercase( const_cast<lChar16 *>(attrname), lStr_len(attrname) );
 
     //CRLog::trace("OnAttribute(%s, %s)", LCSTR(lString16(attrname)), LCSTR(lString16(attrvalue)));
+
+    if ( _curTagIsIgnored ) { // Ignore attributes if tag was ignored
+        return;
+    }
 
     // ldomDocumentWriterFilter is used for HTML/CHM/PDB (not with EPUBs).
     // We translate some attributes (now possibly deprecated) to their
@@ -13254,20 +13805,14 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         CRLog::error("OnTagClose w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));
         crFatalError();
     }
-    //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
-//    if ( nsname && nsname[0] )
-//        lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
-//    lStr_lowercase( const_cast<lChar16 *>(tagname), lStr_len(tagname) );
-    if (!_currNode || !_currNode->getElement())
-    {
+    if ( !_currNode || !_currNode->getElement() ) {
         _errFlag = true;
-        //logfile << " !c-err!\n";
         return;
     }
 
     //lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
     lUInt16 curNodeId = _currNode->getElement()->getNodeId();
-    lUInt16 id = _document->getElementNameIndex(tagname);
+    lUInt16 id = tagname ? _document->getElementNameIndex(tagname) : curNodeId;
     _errFlag |= (id != curNodeId); // (we seem to not do anything with _errFlag)
     // We should expect the tagname we got to be the same as curNode's element name,
     // but it looks like we may get an upper closing tag, that pop() or AutoClose()
@@ -13319,14 +13864,27 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
             _document->getProps()->setString( DOC_PROP_TITLE, s );
         }
     }
-    //======== START FILTER CODE ============
-    AutoClose( curNodeId, false );
-    //======== END FILTER CODE ==============
-    // save closed element
-    // ldomNode * closedElement = _currNode->getElement();
 
-    _currNode = pop( _currNode, id );
-        // _currNode is now the parent
+    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+        if ( _curNodeIsSelfClosing ) { // Internal call (not from XMLParser)
+            _currNode = pop( _currNode, id );
+            _curNodeIsSelfClosing = false;
+        }
+        else {
+            if ( id == el_image )
+                id = el_img;
+            AutoOpenClosePop( self_closing_tag ? PARSER_STEP_TAG_SELF_CLOSING : PARSER_STEP_TAG_CLOSING, id );
+        }
+    }
+    else {
+        //======== START FILTER CODE ============
+        AutoClose( curNodeId, false );
+        //======== END FILTER CODE ==============
+        // save closed element
+        // ldomNode * closedElement = _currNode->getElement();
+        _currNode = pop( _currNode, id );
+            // _currNode is now the parent
+    }
 
     if ( _currNode ) {
         _flags = _currNode->getFlags();
@@ -13353,10 +13911,29 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
         return;
     }
 
+    if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
+        // We can get text before any node (it should then have <html><body> emited before it),
+        // but we might get spaces between " <html> <head> <title>The title <br>The content".
+        // Try to handle that correctly.
+        if ( !_bodyTagSeen ) {
+            // While not yet in BODY, when in HTML or HEAD, ignore empty
+            // text (as non empty text will create BODY)
+            if ( !_currNode || _currNode->getElement()->isRoot() ||
+                               _currNode->getElement()->getNodeId() == el_html ||
+                               _currNode->getElement()->getNodeId() == el_head ) {
+                if ( !IsEmptySpace(text, len) ) {
+                    // Non-empty text: have implicit HTML or BODY tags created and HEAD closed
+                    AutoOpenClosePop( PARSER_STEP_TEXT, 0 );
+                }
+            }
+        }
+    }
     //logfile << "lxmlDocumentWriter::OnText() fpos=" << fpos;
     if (_currNode)
     {
-        AutoClose( _currNode->_element->getNodeId(), false );
+        if (gDOMVersionRequested < 20200824) {
+            AutoClose( _currNode->_element->getNodeId(), false );
+        }
         if ( (_flags & XML_FLAG_NO_SPACE_TEXT)
              && IsEmptySpace(text, len) && !(flags & TXTFLG_PRE))
              return;
@@ -13442,7 +14019,17 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
 , _styleAttrId(0)
 , _classAttrId(0)
 , _tagBodyCalled(true)
+, _htmlTagSeen(false)
+, _headTagSeen(false)
+, _bodyTagSeen(false)
+, _curNodeIsSelfClosing(false)
+, _curTagIsIgnored(false)
+, _lastP(NULL)
 {
+    if (gDOMVersionRequested >= 20200824) {
+        // We're not using the provided rules, but hardcoded ones in AutoOpenClosePop()
+        return;
+    }
     lUInt16 i;
     for ( i=0; i<MAX_ELEMENT_TYPE_ID; i++ )
         _rules[i] = NULL;
@@ -13467,6 +14054,9 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
 ldomDocumentWriterFilter::~ldomDocumentWriterFilter()
 {
 
+    if (gDOMVersionRequested >= 20200824) {
+        return;
+    }
     for ( int i=0; i<MAX_ELEMENT_TYPE_ID; i++ ) {
         if ( _rules[i] )
             delete[] _rules[i];

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7602,7 +7602,7 @@ ldomDocumentWriter::~ldomDocumentWriter()
 #endif
 }
 
-void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname )
+void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname, bool self_closing_tag )
 {
     //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
     if (!_currNode || !_currNode->getElement())
@@ -12875,7 +12875,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
 }
 
 /// called on closing tag
-void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
 {
     styleDetectionState = headStyleState = 0;
     if ( insideTag && baseTag==tagname ) {
@@ -12888,7 +12888,7 @@ void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar
         return;
     }
     if ( insideTag )
-        parent->OnTagClose(nsname, tagname);
+        parent->OnTagClose(nsname, tagname, self_closing_tag);
 }
 
 /// called after > of opening tag (when entering tag body) or just before /> closing tag for empty tags
@@ -13203,7 +13203,7 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
 }
 
 /// called on closing tag
-void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lChar16 * tagname )
+void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lChar16 * tagname, bool self_closing_tag )
 {
     if ( !_tagBodyCalled ) {
         CRLog::error("OnTagClose w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3995,6 +3995,11 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
         if ( ! toWrite )
             return;
 
+        // In case we're called (when debugging) while styles have been reset,
+        // avoid crash on stuff like isBoxingInlineBox()/isFloatingBox() that
+        // do check styles
+        bool has_styles_set = !node->getStyle().isNull();
+
         bool doNewLineBeforeStartTag = false;
         bool doNewLineAfterStartTag = false;
         bool doNewLineBeforeEndTag = false; // always stays false, newline done by child elements
@@ -4031,7 +4036,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                         rm = erm_final;
                 }
             }
-            if ( rm != erm_inline || node->isBoxingInlineBox()) {
+            if ( rm != erm_inline || (has_styles_set && node->isBoxingInlineBox()) ) {
                 doNewLineBeforeStartTag = true;
                 doNewLineAfterStartTag = true;
                 // doNewLineBeforeEndTag = false; // done by child elements
@@ -4044,7 +4049,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     doNewLineAfterStartTag = false;
                     doIndentBeforeEndTag = false;
                 }
-                else if (node->isFloatingBox()) {
+                else if (has_styles_set && node->isFloatingBox()) {
                     lvdom_element_render_method prm = node->getParentNode()->getRendMethod();
                     if (prm == erm_final || prm == erm_inline) {
                         doNewlineBeforeIndentBeforeStartTag = true;
@@ -4070,7 +4075,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                         }
                     }
                 }
-                else if (node->isBoxingInlineBox()) {
+                else if (has_styles_set && node->isBoxingInlineBox()) {
                     doNewlineBeforeIndentBeforeStartTag = true;
                     doIndentAfterNewLineAfterEndTag = WNEFLAG(INDENT_NEWLINE);
                     // Same as above
@@ -4115,8 +4120,10 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
         if (doIndentBeforeStartTag)
             for ( int i=indentBaseLevel; i<level; i++ )
                 *stream << "  ";
-        if ( elemName.empty() ) // should not happen (except for the root node, that we hopefully skipped)
-            elemName = elemNsName + "???";
+        if ( elemName.empty() ) {
+            // should not happen (except for the root node, that we might have skipped)
+            elemName = node->isRoot() ? lString8("?RootNode?") : (elemNsName + "???");
+        }
         if ( !elemNsName.empty() )
             elemName = elemNsName + ":" + elemName;
         *stream << "<" << elemName;
@@ -4135,7 +4142,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 lString8 attrName( UnicodeToUtf8(node->getDocument()->getAttrName(attr->id)) );
                 lString8 nsName( UnicodeToUtf8(node->getDocument()->getNsName(attr->nsid)) );
                 lString8 attrValue( UnicodeToUtf8(node->getDocument()->getAttrValue(attr->index)) );
-                if ( WNEFLAG(SHOW_MISC_INFO) ) {
+                if ( WNEFLAG(SHOW_MISC_INFO) && has_styles_set ) {
                     if ( node->getNodeId() == el_pseudoElem && (attr->id == attr_Before || attr->id == attr_After) ) {
                         // Show the rendered content as the otherwise empty Before/After attribute value
                         if ( WNEFLAG(TEXT_SHOW_UNICODE_CODEPOINT) ) {
@@ -4227,7 +4234,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             if ( WNEFLAG(TEXT_HYPHENATE) ) {
                 // Additional minor formatting tweaks for when this is going to be fed
                 // to some other renderer, which is usually when we request HYPHENATE.
-                if ( node->getStyle()->display == css_d_run_in ) {
+                if ( has_styles_set && node->getStyle()->display == css_d_run_in ) {
                     // For FB2 footnotes, add a space between the number and text,
                     // as none might be present in the source. If there were some,
                     // the other renderer will probably collapse them.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4993,7 +4993,7 @@ bool IsEmptySpace( const lChar16 * text, int len )
 
 static bool IS_FIRST_BODY = false;
 
-ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent)
+ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent, bool insert_before_last_child)
     : _parent(parent), _document(document), _tocItem(NULL), _isBlock(true), _isSection(false),
       _stylesheetIsSet(false), _bodyEnterCalled(false), _pseudoElementAfterChildIndex(-1)
 {
@@ -5022,8 +5022,12 @@ ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUIn
         }
     }
 
-    if (_parent)
-        _element = _parent->getElement()->insertChildElement( (lUInt32)-1, nsid, id );
+    if (_parent) {
+        lUInt32 index = _parent->getElement()->getChildCount();
+        if ( insert_before_last_child )
+            index--;
+        _element = _parent->getElement()->insertChildElement( index, nsid, id );
+    }
     else
         _element = _document->getRootNode(); //->insertChildElement( (lUInt32)-1, nsid, id );
     if ( IS_FIRST_BODY && id==el_body ) {
@@ -7300,7 +7304,7 @@ void ldomElementWriter::onBodyExit()
 #endif
 }
 
-void ldomElementWriter::onText( const lChar16 * text, int len, lUInt32 )
+void ldomElementWriter::onText( const lChar16 * text, int len, lUInt32, bool insert_before_last_child )
 {
     //logfile << "{t";
     {
@@ -7308,7 +7312,7 @@ void ldomElementWriter::onText( const lChar16 * text, int len, lUInt32 )
         // add text node, if not first empty space string of block node
         if ( !_isBlock || _element->getChildCount()!=0 || !IsEmptySpace( text, len ) || (_flags&TXTFLG_PRE) ) {
             lString8 s8 = UnicodeToUtf8(text, len);
-            _element->insertChildText(s8);
+            _element->insertChildText(s8, insert_before_last_child);
         } else {
             //CRLog::trace("ldomElementWriter::onText: Ignoring first empty space of block item");
         }
@@ -7591,7 +7595,9 @@ ldomDocumentWriter::~ldomDocumentWriter()
         _document->dumpStatistics();
         if ( _document->_nodeStylesInvalidIfLoading ) {
             // Some pseudoclass like :last-child has been met which has set this flag
+            // (or, with the HTML parser, foster parenting of invalid element in tables)
             printf("CRE: document loaded, but styles re-init needed (cause: peculiar CSS pseudoclasses met)\n");
+            _document->_nodeStylesInvalidIfLoading = false; // show this message only once
             _document->forceReinitStyles();
         }
         if ( _document->hasRenderData() ) {
@@ -13010,12 +13016,17 @@ void ldomDocumentWriterFilter::AutoClose( lUInt16 tag_id, bool open )
 // Note that a lot of rules and checks in the algorithm are for
 // noticing "parser errors", with usually a fallback of ignoring
 // it and going on.
+// We ensure one tedious requirement: foster parenting of non-table
+// elements met while building a table, mostly to not have mis-nested
+// content simply ignored and not shown to the user.
+// Other tedious requirements not ensured might just have some impact
+// on the styling of the content, which should be a minor issue.
+//
 // It feels that we can simplify it to the following implementation,
 // with possibly some cases not handled related to:
 // - FORM and form elements (SELECT, INPUT, OPTION...)
 // - TEMPLATE, APPLET, OBJECT, MARQUEE
 // - Mis-nested HTML/BODY/HEAD
-// - Foster parenting of non-table elements inside a table
 // - Reconstructing the active formatting elements (B, I...) when
 //   mis-nested or "on hold" when entering block or table elements.
 // - The "adoption agency algorithm" for mis-nested formatting
@@ -13077,6 +13088,12 @@ lUInt16 ldomDocumentWriterFilter::popUpTo( ldomElementWriter * target, lUInt16 t
             }
             if ( target_id && tmpId == target_id )
                 break;
+            if ( _curFosteredNode && tmp == _curFosteredNode ) {
+                // If fostering and we're not closing the fostered node itself,
+                // don't go at closing stuff above the fostered node
+                tmp = NULL;
+                break;
+            }
             // Check scope stop tags
             bool stop = false;
             switch (scope) {
@@ -13208,9 +13225,19 @@ lUInt16 ldomDocumentWriterFilter::popUpTo( ldomElementWriter * target, lUInt16 t
             }
             if ( _lastP && _currNode == _lastP )
                 _lastP = NULL;
-            bool done = _currNode == target;
             ldomElementWriter * tmp = _currNode;
-            _currNode = _currNode->_parent;
+            bool done = _currNode == target;
+            if ( _curFosteredNode && _currNode == _curFosteredNode ) {
+                // If we meet the fostered node, have it closed but don't
+                // go at closing above it
+                done = true;
+                _currNode = _curNodeBeforeFostering;
+                _curNodeBeforeFostering = NULL;
+                _curFosteredNode = NULL;
+            }
+            else {
+                _currNode = _currNode->_parent;
+            }
             ElementCloseHandler( tmp->getElement() );
             delete tmp;
             if ( done )
@@ -13498,6 +13525,46 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
 
     return true;
 }
+bool ldomDocumentWriterFilter::CheckAndEnsureFosterParenting(lUInt16 tag_id)
+{
+    if ( !_currNode )
+        return false;
+    lUInt16 curNodeId = _currNode->getElement()->getNodeId();
+    if ( curNodeId >= el_table && curNodeId <= el_tr && curNodeId != el_caption ) {
+        if ( tag_id < el_table || tag_id > el_td ) {
+            // Non table sub-element met as we expect only a table sub-element.
+            // Ensure foster parenting: this node (and its content) is to be
+            // inserted as a previous sibling of the table element we are in
+            _curNodeBeforeFostering = NULL;
+            // Look for the containing table element
+            ldomElementWriter * elem = _currNode;
+            while ( elem ) {
+                if ( elem->getElement()->getNodeId() == el_table ) {
+                    break;
+                }
+                elem = elem->_parent;
+            }
+            if ( elem ) { // found it
+                _curNodeBeforeFostering = _currNode;
+                _currNode = elem->_parent; // parent of table
+                return true; // Insert the new element in _currNode (the parent of this
+                             // table), before its last child (which is this table)
+            }
+        }
+        // We're in a table, and we see an expected sub-table element: all is fine
+        return false;
+    }
+    else if ( _curFosteredNode ) {
+        // We've been foster parenting: if we see a table sub-element,
+        // stop foster parenting and restore the original noce
+        if ( tag_id >= el_table && tag_id <= el_td ) {
+            popUpTo(_curFosteredNode);
+            // popUpTo() has restored _currNode to _curNodeBeforeFostering and
+            // reset _curFosteredNode and _curNodeBeforeFostering to NULL
+        }
+    }
+    return false;
+}
 
 ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
 {
@@ -13603,10 +13670,29 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     }
 
     bool tag_accepted = true;
+    bool insert_before_last_child = false;
     if (gDOMVersionRequested >= 20200824) { // A little bit more HTML5 conformance
         if ( id == el_image )
             id = el_img;
-        tag_accepted = AutoOpenClosePop( PARSER_STEP_TAG_OPENING, id );
+        // If non-sub-table element opening while we're still
+        // inside sub-table non-TD/TH elements, we should
+        // do foster parenting: insert the node as the previous
+        // sibling of the TABLE element we're dealing with
+        // https://html.spec.whatwg.org/multipage/parsing.html#foster-parent
+        if ( CheckAndEnsureFosterParenting(id) ) {
+            insert_before_last_child = true;
+            // As we'll be inserting a node before the TABLE, which
+            // already had its style applied, some CSS selectors matches
+            // might no more be valid (i.e. :first-child, DIV + TABLE),
+            // so styles could change on the next re-rendering.
+            // We don't check if we actually had such selectors as that
+            // is complicated from here: we just set styles to be invalid
+            // so they are re-computed once the DOM is fully built.
+            _document->setNodeStylesInvalidIfLoading();
+        }
+        else {
+            tag_accepted = AutoOpenClosePop( PARSER_STEP_TAG_OPENING, id );
+        }
     }
     else {
         AutoClose( id, true );
@@ -13632,8 +13718,13 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         return _currNode ? _currNode->getElement() : NULL;
     }
 
-    _currNode = new ldomElementWriter( _document, nsid, id, _currNode );
+    _currNode = new ldomElementWriter( _document, nsid, id, _currNode, insert_before_last_child );
     _flags = _currNode->getFlags();
+
+    if ( insert_before_last_child ) {
+        _curFosteredNode = _currNode;
+    }
+
     if (gDOMVersionRequested >= 20200824 && id == el_p) {
         // To avoid checking DOM ancestors with the numerous tags that close a P
         _lastP = _currNode;
@@ -13931,16 +14022,35 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
     //logfile << "lxmlDocumentWriter::OnText() fpos=" << fpos;
     if (_currNode)
     {
+        lUInt16 curNodeId = _currNode->getElement()->getNodeId();
         if (gDOMVersionRequested < 20200824) {
-            AutoClose( _currNode->_element->getNodeId(), false );
+            AutoClose( curNodeId, false );
         }
         if ( (_flags & XML_FLAG_NO_SPACE_TEXT)
              && IsEmptySpace(text, len) && !(flags & TXTFLG_PRE))
              return;
-        if ( !_currNode->_allowText )
-            return;
+        bool insert_before_last_child = false;
+        if (gDOMVersionRequested >= 20200824) {
+            // If we're inserting text while in table sub-elements that
+            // don't accept text, have it foster parented
+            if ( curNodeId >= el_table && curNodeId <= el_tr && curNodeId != el_caption ) {
+                if ( !IsEmptySpace(text, len) ) {
+                    if ( CheckAndEnsureFosterParenting(el_NULL) ) {
+                        insert_before_last_child = true;
+                    }
+                }
+            }
+        }
+        else {
+            // Previously, text in table sub-elements (only table elements and
+            // self-closing elements have _allowText=false) had any text in between
+            // table elements dropped (but not elements! with "<table>abc<div>def",
+            // "abc" was dropped, but not "def")
+            if ( !_currNode->_allowText )
+                return;
+        }
         if ( !_libRuDocumentDetected ) {
-            _currNode->onText( text, len, flags );
+            _currNode->onText( text, len, flags, insert_before_last_child );
         }
         else { // Lib.ru text cleanup
             if ( _libRuParagraphStart ) {
@@ -14001,10 +14111,17 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
                     OnTagOpen( NULL, paraTag );
                     OnTagBody();
                 }
-                _currNode->onText( text, len, flags );
+                _currNode->onText( text, len, flags, insert_before_last_child );
                 if ( autoPara )
                     OnTagClose( NULL, paraTag );
             }
+        }
+        if ( insert_before_last_child ) {
+            // We have no _curFosteredNode to pop, so just restore
+            // the previous table node
+            _currNode = _curNodeBeforeFostering;
+            _curNodeBeforeFostering = NULL;
+            _curFosteredNode = NULL;
         }
     }
     //logfile << " !t!\n";
@@ -14024,6 +14141,8 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
 , _bodyTagSeen(false)
 , _curNodeIsSelfClosing(false)
 , _curTagIsIgnored(false)
+, _curNodeBeforeFostering(NULL)
+, _curFosteredNode(NULL)
 , _lastP(NULL)
 {
     if (gDOMVersionRequested >= 20200824) {
@@ -17701,7 +17820,7 @@ ldomNode * ldomNode::insertChildText( const lString16 & value )
 }
 
 /// inserts child text
-ldomNode * ldomNode::insertChildText(const lString8 & s8)
+ldomNode * ldomNode::insertChildText(const lString8 & s8, bool before_last_child)
 {
     ASSERT_NODE_NOT_NULL;
     if  ( isElement() ) {
@@ -17715,7 +17834,10 @@ ldomNode * ldomNode::insertChildText(const lString8 & s8)
         ldomNode * node = getDocument()->allocTinyNode( NT_PTEXT );
         node->_data._ptext_addr = getDocument()->_textStorage.allocText( node->_handle._dataIndex, _handle._dataIndex, s8 );
 #endif
-        me->_children.insert( me->_children.length(), node->getDataIndex() );
+        int index = me->_children.length();
+        if ( before_last_child && index > 0 )
+            index--;
+        me->_children.insert( index, node->getDataIndex() );
         return node;
     }
     readOnlyError();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6269,7 +6269,10 @@ void ldomNode::initNodeRendMethod()
                         }
                         i = j;
                     }
-                    else if ( i>0 ) {
+                    else if ( i>0 && node->getRendMethod() == erm_final ) {
+                        // (We skip the following if the current node is not erm_final, as
+                        // if it is erm_block, we would break the block layout by making
+                        // it all inline in an erm_final autoBoxing.)
                         // This node is not inline, but might be preceeded by a css_d_run_in node:
                         // https://css-tricks.com/run-in/
                         // https://developer.mozilla.org/en-US/docs/Web/CSS/display

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5843,16 +5843,24 @@ bool LVHTMLParser::CheckFormat()
     if ( charsDecoded > 30 ) {
         lString16 s( chbuf, charsDecoded );
         s.lowercase();
-        if ( s.pos("<html") >=0 && ( s.pos("<head") >= 0 || s.pos("<body") >=0 ) ) //&& s.pos("<FictionBook") >= 0
+        if ( s.pos("<html") >=0 && ( s.pos("<head") >= 0 || s.pos("<body") >=0 ) ) {
             res = true;
-        lString16 name=m_stream->GetName();
-        name.lowercase();
-        bool html_ext = name.endsWith(".htm") || name.endsWith(".html")
-                        || name.endsWith(".hhc")
-                        || name.endsWith(".xhtml");
-        if ( html_ext && (s.pos("<!--")>=0 || s.pos("UL")>=0
-                           || s.pos("<p>")>=0 || s.pos("ul")>=0) )
-            res = true;
+        }
+        if ( !res ) { // check <!doctype html> (and others) which may have no/implicit <html/head/body>
+            int doctype_pos = s.pos("<!doctype ");
+            if ( doctype_pos >= 0 ) {
+                int html_pos = s.pos("html", doctype_pos);
+                if ( html_pos >= 0 && html_pos < 32 )
+                    res = true;
+            }
+        }
+        if ( !res ) { // check filename extension and present of common HTML tags
+            lString16 name=m_stream->GetName();
+            name.lowercase();
+            bool html_ext = name.endsWith(".htm") || name.endsWith(".html") || name.endsWith(".hhc") || name.endsWith(".xhtml");
+            if ( html_ext && (s.pos("<!--")>=0 || s.pos("ul")>=0 || s.pos("<p>")>=0) )
+                res = true;
+        }
         lString16 enc = htmlCharset( s );
         if ( !enc.empty() )
             SetCharset( enc.c_str() );

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -1829,7 +1829,7 @@ public:
             callback->OnTagOpen(L"", L"img");
             callback->OnAttribute(L"", L"src", url.c_str());
             callback->OnTagBody();
-            callback->OnTagClose(L"", L"img");
+            callback->OnTagClose(L"", L"img", true);
         }
 
         void startParagraph() {
@@ -3053,8 +3053,8 @@ bool LVXMLParser::Parse()
                 {
                     m_callback->OnTagBody();
                     // end of tag
-                    if ( ch!='>' )
-                        m_callback->OnTagClose(tagns.c_str(), tagname.c_str());
+                    if ( ch!='>' ) // '/' in '<hr/>' : self closing tag
+                        m_callback->OnTagClose(tagns.c_str(), tagname.c_str(), true);
                     if ( ch=='>' )
                         PeekNextCharFromBuffer();
                     else
@@ -6286,7 +6286,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBook")==0) {
             insideFictionBook = false;

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -169,7 +169,7 @@ public:
         len = s.length();
         if ( !len ) {
             m_callback->OnTagOpenNoAttr(NULL, L"empty-line");
-            m_callback->OnTagClose(NULL, L"empty-line");
+            m_callback->OnTagClose(NULL, L"empty-line", true);
             return;
         }
         bool intbl = m_stack.getInt( pi_intbl )>0;
@@ -370,7 +370,7 @@ public:
 #endif
         m_callback->OnTagOpen(LXML_NS_NONE, L"img");
         m_callback->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-        m_callback->OnTagClose(LXML_NS_NONE, L"img");
+        m_callback->OnTagClose(LXML_NS_NONE, L"img", true);
     }
 };
 

--- a/crengine/src/wordfmt.cpp
+++ b/crengine/src/wordfmt.cpp
@@ -711,7 +711,7 @@ bTranslateImage(diagram_type *pDiag, FILE *pFile, BOOL bMinimalInformation,
             writer->OnBlob(name, pucJpeg, len);
             writer->OnTagOpen(LXML_NS_NONE, L"img");
             writer->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-            writer->OnTagClose(LXML_NS_NONE, L"img");
+            writer->OnTagClose(LXML_NS_NONE, L"img", true);
 
             free(pucJpeg);
             return TRUE;


### PR DESCRIPTION
`Revert "FB2: don't draw cover in scroll mode"` (revert lazy workaround from #366)
`(Upstream) FB2: fix coverpage drawing in scroll mode`
Proper solution by @virxkane to this issue, https://github.com/koreader/koreader/issues/6490#issuecomment-678612146 , and fixing a bug of mine.

`FB2 footnotes: only merge run-in when next is erm_final` https://github.com/koreader/koreader/issues/6344#issuecomment-678635145
`fb2.css: use OTF tabular-nums for footnote numbers` https://github.com/koreader/koreader/issues/6344#issuecomment-678637131

`Text: ignore ascii and unicode control chars`
https://www.mobileread.com/forums/showthread.php?p=4025496#post4025496
I'm not sure it's really preferable, I'd like to set the crap I get :) but I guess if we find these control chars, it's usually crap left by puslisher or conversion that a real reader is not interested in.
https://www.aivosto.com/articles/control-characters.html
Please have a quick look that I didn't ignore other valuable code (I kept `\t \r \n`)

`Fix HR positionning when floats involved`
Both the DIV in blue and the HR in grey are styled similarly with {width: 30%; height: 100px; margin: 0 auto 0 auto; } but shouldn't be positionned similarly.
Before:
<kbd>![image](https://user-images.githubusercontent.com/24273478/91015382-5c7d1d00-e5eb-11ea-949d-706cd54e37b4.png)</kbd>
After:
<kbd>![image](https://user-images.githubusercontent.com/24273478/91015076-d8c33080-e5ea-11ea-97e0-a344efe8000f.png)</kbd>

`writeNodeEx(): minor tweaks`
`OnTagClose(): add self_closing_tag parameter` to all XML writers, even if most don't use it
`HTML format detection: accept HTML5 doctype` Closes #141

`HTML parser: rework Lib.ru specific handling` https://github.com/koreader/koreader/issues/6480#issuecomment-676128803
I don't like much having some little non-standard book format specific hacks in there, but well...
Rewrote it to have it a bit more "normal", and solve the display hash mismatch after first load.
The DOM built should hopefully be similar to the old CoolReader one (but may be not to the one got from a few months ago witk KOReader, so KOReader users reading Lib.Ru books may have highlights made recently messed up).

`HTML parser: new more conforming implementation`
`HTML parser: ensure foster parenting inside tables`
Try to conform to the HTML specs, even if not implementing the exact algorithm:
https://html.spec.whatwg.org/multipage/parsing.html
https://htmlparser.info/parser/
Limitations:
```
- FORM and form elements (SELECT, INPUT, OPTION...)
- TEMPLATE, APPLET, OBJECT, MARQUEE
- Mis-nested HTML/BODY/HEAD
- Reconstructing the active formatting elements (B, I...) when
  mis-nested or "on hold" when entering block or table elements.
- The "adoption agency algorithm" for mis-nested formatting
  elements (and nested <A>)
- We may not ignore some opening tag that we normally should
  (like HEAD or FRAME when in BODY) (but we ignore a standalone
  sub-table element when not inside a TABLE) as this would
  complicate the internal parser state.
```

Done after trying to fix the autoclose stuff, but what the existing code allowed wasn't right. Some discussion and discoveries at:
https://github.com/koreader/koreader/issues/6482#issuecomment-670920639 https://github.com/koreader/crengine/pull/243#issuecomment-670371069

https://hsivonen.fi/doctype/ (about doctypes, that I didn't really investigate it we'd need to parse that and act differently)

So, that new HTML parser will only be used with HTML and CHM files.
I wonder how much of this and the specs should apply when parsing XHTML from EPUBs.
Should it also correct autoclosing tags (`<hr><div>toto</div></hr>`, `<br></br>` should output 2 BRs), misnested tags, non table stuff inside tables... ? When having a balanced XHTML file will map directly to a DOM... (I don't plan to do anything on that front, just curious :)

Not sure this won't crash on twisted HTML documents :/
Also, it will make my life harder when testing stuff, as now what I usually test with a test.html file (because building a .epub is tedious) won't be handled the same as if it were in a .epub...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/370)
<!-- Reviewable:end -->
