### PR TITLE
Fix possible crash with duplicated hyphens

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1373,6 +1373,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         }
     }
 
+    // Clear any toc items possibly added while parsing the HTML
+    m_doc->getToc()->clear();
     bool has_toc = false;
     bool has_pagemap = false;
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4280,6 +4280,7 @@ public:
             int height = fmt.getHeight();
             formatted_line_t * frmline = lvtextAddFormattedLine( m_pbuffer );
             frmline->x = block_x;
+            frmline->width = width; // single word width
             frmline->y = cur_y;
             frmline->height = height;
             frmline->flags = 0; // no flags needed once page split has been done

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4189,6 +4189,11 @@ public:
                     pos--; // Have that last hyphen also at the start of next line
                            // (small caveat: the duplicated hyphen at start of next
                            // line won't be part of the highlighted text)
+                    // And forbid a break after this duplicated hyphen (this avoids
+                    // a possible infinite loop and out of memory when no allowed
+                    // wrap is found on next line, as we would continuously AddLine()
+                    // lines with only this hyphen)
+                    m_flags[pos] &= ~LCHAR_ALLOW_WRAP_AFTER;
                 }
             }
             #endif

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -87,7 +87,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.49k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.50k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 
@@ -5030,10 +5030,20 @@ ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUIn
     }
     else
         _element = _document->getRootNode(); //->insertChildElement( (lUInt32)-1, nsid, id );
-    if ( IS_FIRST_BODY && id==el_body ) {
-        _tocItem = _document->getToc();
-        //_tocItem->clear();
-        IS_FIRST_BODY = false;
+    if ( id==el_body ) {
+        if ( IS_FIRST_BODY ) {
+            _tocItem = _document->getToc();
+            //_tocItem->clear();
+            IS_FIRST_BODY = false;
+        }
+        else {
+            int fmt = _document->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none);
+            if ( fmt == doc_format_fb2 || fmt == doc_format_fb3 ) {
+                // Add FB2 2nd++ BODYs' titles (footnotes and endnotes) in the TOC
+                // (but not their own children that are <section>)
+                _isSection = true; // this is just to have updateTocItem() called
+            }
+        }
     }
     //logfile << "}";
 }
@@ -5111,11 +5121,16 @@ void ldomElementWriter::updateTocItem()
 {
     if ( !_isSection )
         return;
-    // TODO: update item
-    if ( _parent && _parent->_tocItem ) {
+    if ( !_parent )
+        return;
+    if ( _parent->_tocItem ) { // <section> in the first <body>
         lString16 title = getSectionHeader( _element );
         //CRLog::trace("TOC ITEM: %s", LCSTR(title));
         _tocItem = _parent->_tocItem->addChild(title, ldomXPointer(_element,0), getPath() );
+    }
+    else if ( getElement()->getNodeId() == el_body ) { // 2nd, 3rd... <body>, in FB2 documents
+        lString16 title = getSectionHeader( _element );
+        _document->getToc()->addChild(title, ldomXPointer(_element,0), getPath() );
     }
     _isSection = false;
 }


### PR DESCRIPTION
`Text: fix possible crash with duplicated hyphens`
Fix possible crash (infinite loop until an out of memory) with languages having `_duplicate_real_hyphen_on_next_line=true` when text is rendered in a small width (floats, table cells...)
Noticed with, in a small float at 48 dpi, with typography lang set to Serbian (with hyph) or Polish (no hyph), `famille de Valois-Angouleme en haut` that would end up being rendered as:
```
famille
de Valois-
-
-
-
-
-
[infinitely]
Angouleme
en haut
```
when `-Angouleme` happens to not be breakable, except after the initial duplicated hyphen...

`EmbeddedBlock inlineBox: fix createXPointer()/toPoint()`
Tap on links and xpointers highlighting was not working in such embedded blocks (from #330).

`FB2: include footnotes and endnotes start page in TOC`
https://github.com/koreader/koreader/issues/5961#issuecomment-683412410

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/374)
<!-- Reviewable:end -->
