### PR TITLE
(Upstream) Adds ODT (ODF) format support

### DIFF
--- a/crengine/include/bookformats.h
+++ b/crengine/include/bookformats.h
@@ -17,7 +17,8 @@ typedef enum {
     doc_format_doc,
     doc_format_docx,
     doc_format_pdb,
-    doc_format_max = doc_format_pdb
+    doc_format_odt,
+    doc_format_max = doc_format_odt
     // don't forget update getDocFormatName() when changing this enum
 } doc_format_t;
 

--- a/crengine/include/odtfmt.h
+++ b/crengine/include/odtfmt.h
@@ -1,0 +1,11 @@
+#ifndef ODTFMT_H
+#define ODTFMT_H
+
+#include "../include/crsetup.h"
+#include "../include/lvtinydom.h"
+
+
+bool DetectOpenDocumentFormat( LVStreamRef stream );
+bool ImportOpenDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback );
+
+#endif // DOCXFMT_H

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -15,13 +15,6 @@
 //If true <title class="hx"><p>...</p></title> else <title><hx>..</hx></title>
 #define DOCX_USE_CLASS_FOR_HEADING true
 
-// Upstream made things ready for us: we just have to undef
-// the above to have a HTML DOM with classic headings, that
-// can be tweaked with style tweaks, and popup and in-page
-// footnotes also toggable with style tweaks.
-#undef DOCX_CRENGINE_IN_PAGE_FOOTNOTES
-#undef DOCX_FB2_DOM_STRUCTURE
-
 /// known docx items name and identifier
 struct item_def_t {
     int      id;
@@ -2334,11 +2327,14 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     writer.OnTagClose(NULL, L"description");
 #else
     writer.OnStart(NULL);
+    writer.OnTagOpen(NULL, L"?xml");
+    writer.OnAttribute(NULL, L"version", L"1.0");
+    writer.OnAttribute(NULL, L"encoding", L"utf-8");
+    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagBody();
+    writer.OnTagClose(NULL, L"?xml");
     writer.OnTagOpenNoAttr(NULL, L"html");
 #endif
-// Note: the code in-here will forward attributes from the docx
-// document.xml '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-// to the <FictionBook> or <html> tags.
 
 #ifdef DOCX_FB2_DOM_STRUCTURE
     //Two options when dealing with titles: (FB2|HTML)
@@ -2366,14 +2362,6 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     writer.OnTagClose(NULL, L"html");
 #endif
     writer.OnStop();
-
-#ifndef DOCX_FB2_DOM_STRUCTURE
-    // With DOCX_FB2_DOM_STRUCTURE, headings are wrapped in <section><title>
-    // and benefit from crengine internal TOC building.
-    // When using plain HTML, we don't and have to build it here instead,
-    // from the headings we made.
-    doc->buildTocFromHeadings();
-#endif
 
     if ( progressCallback ) {
         progressCallback->OnLoadFileEnd( );

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -2,24 +2,12 @@
 #include "../include/lvtinydom.h"
 #include "../include/fb2def.h"
 #include "../include/lvopc.h"
+#include "odxutil.h"
 
 #define DOCX_TAG_NAME(itm) docx_el_##itm##_name
 #define DOCX_TAG_ID(itm) docx_el_##itm
 #define DOCX_TAG_CHILD(itm) { DOCX_TAG_ID(itm), DOCX_TAG_NAME(itm) }
 #define DOCX_LAST_ITEM { -1, NULL }
-
-// comment this out to disable in-page footnotes
-#define DOCX_CRENGINE_IN_PAGE_FOOTNOTES 1
-// build FB2 DOM, comment out to build HTML DOM
-#define DOCX_FB2_DOM_STRUCTURE 1
-//If true <title class="hx"><p>...</p></title> else <title><hx>..</hx></title>
-#define DOCX_USE_CLASS_FOR_HEADING true
-
-/// known docx items name and identifier
-struct item_def_t {
-    int      id;
-    const lChar16 * name;
-};
 
 static const lChar16* const docx_DocumentContentType   = L"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
 static const lChar16* const docx_NumberingContentType  = L"application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml";
@@ -46,20 +34,6 @@ const struct item_def_t styles_elements[] = {
     DOCX_TAG_CHILD(style),
     DOCX_TAG_CHILD(docDefaults),
     DOCX_LAST_ITEM
-};
-
-
-enum docx_lineRule_type {
-    docx_lineRule_atLeast,
-    docx_lineRule_auto,
-    docx_lineRule_exact
-};
-
-enum docx_style_type {
-    docx_paragraph_style,
-    docx_character_style,
-    docx_table_style,
-    docx_numbering_style
 };
 
 enum docx_multilevel_type {
@@ -269,17 +243,17 @@ const struct item_def_t textAlignment_attr_values[] = {
 };
 
 const struct item_def_t lineRule_attr_values[] = {
-    { docx_lineRule_atLeast, L"atLeast" },
-    { docx_lineRule_auto, L"auto"},
-    { docx_lineRule_exact, L"exact"},
+    { odx_lineRule_atLeast, L"atLeast" },
+    { odx_lineRule_auto, L"auto"},
+    { odx_lineRule_exact, L"exact"},
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t styleType_attr_values[] = {
-    { docx_paragraph_style, L"paragraph" },
-    { docx_character_style, L"character"},
-    { docx_numbering_style, L"numbering"},
-    { docx_table_style, L"table"},
+    { odx_paragraph_style, L"paragraph" },
+    { odx_character_style, L"character"},
+    { odx_numbering_style, L"numbering"},
+    { odx_table_style, L"table"},
     DOCX_LAST_ITEM
 };
 
@@ -309,191 +283,6 @@ bool DetectDocXFormat( LVStreamRef stream )
 }
 
 class docxImportContext;
-class docxStyle;
-
-template <int N>
-class docx_PropertiesContainer
-{
-public:
-    static const int PROP_COUNT = N;
-
-    virtual void reset() {
-        init();
-    }
-
-    virtual ~docx_PropertiesContainer() {}
-
-    docx_PropertiesContainer() {
-        init();
-    }
-
-    css_length_t get(int index) const {
-        if( index < N ) {
-            return m_properties[index];
-        }
-        return css_length_t(css_val_unspecified, 0);
-    }
-
-    void set(int index, int value) {
-        if ( index < N ) {
-            m_properties[index].type = css_val_pt;
-            m_properties[index].value = value;
-        }
-    }
-
-    void set(int index, css_length_t& value) {
-        if ( index < N ) {
-            m_properties[index] = value;
-        }
-    }
-
-    template<class T, typename U = void>
-    T getValue(int index, T defaultValue) const {
-        css_length_t property = get(index);
-        if(property.type != css_val_unspecified)
-            return (T)property.value;
-        return defaultValue;
-    }
-
-    template<typename U>
-    bool getValue(int index, bool defaultValue) const {
-        css_length_t property = get(index);
-        if(property.type != css_val_unspecified)
-            return (property.value != 0);
-        return defaultValue;
-    }
-
-    void combineWith(const docx_PropertiesContainer* other)
-    {
-        for(int i = 0; i < PROP_COUNT; i++) {
-            css_length_t baseValue = other->get(i);
-            if( get(i).type == css_val_unspecified &&
-                baseValue.type != css_val_unspecified)
-                set(i, baseValue);
-        }
-    }
-
-protected:
-    css_length_t m_properties[N];
-private:
-    void init() {
-        for(int i = 0; i < N; i++) {
-            m_properties[i].type = css_val_unspecified;
-            m_properties[i].value = 0;
-        }
-    }
-};
-
-enum docx_run_properties
-{
-    docx_run_italic_prop,
-    docx_run_bold_prop,
-    docx_run_underline_prop,
-    docx_run_strikethrough_prop,
-    docx_run_hidden_prop,
-    docx_run_halign_prop,
-    docx_run_valign_prop,
-    docx_run_font_size_prop,
-    docx_run_max_prop
-};
-
-class docx_rPr : public docx_PropertiesContainer<docx_run_max_prop>
-{
-    friend class docx_rPrHandler;
-private:
-    lString16 m_rStyle;
-public:
-    docx_rPr();
-    void reset() { m_rStyle.clear(); docx_PropertiesContainer::reset(); }
-    ///properties
-    inline bool isBold() const { return getValue(docx_run_bold_prop, false); }
-    inline void setBold(bool value) { set(docx_run_bold_prop, value); }
-    inline bool isItalic() const { return getValue(docx_run_italic_prop, false); }
-    inline void setItalic(bool value) { set(docx_run_italic_prop, value); }
-    inline bool isUnderline() const { return getValue(docx_run_underline_prop, false); }
-    inline void setUnderline(bool value) { set(docx_run_underline_prop, value); }
-    inline bool isStrikeThrough() const { return getValue(docx_run_strikethrough_prop, false); }
-    inline void setStrikeThrough(bool value) { set(docx_run_strikethrough_prop, value); }
-    inline bool isSubScript() const { return (getVertAlign() == css_va_sub);  }
-    inline bool isSuperScript() const { return (getVertAlign() == css_va_super); }
-    inline bool isHidden() const { return getValue(docx_run_hidden_prop, false); }
-    inline void setHidden(bool value) { set(docx_run_hidden_prop, value); }
-    inline css_text_align_t getTextAlign() const {
-        return getValue(docx_run_halign_prop, css_ta_inherit);
-    }
-    inline void setTextAlign( css_text_align_t value ) { set(docx_run_halign_prop, value); }
-    inline css_vertical_align_t getVertAlign() const {
-        return getValue(docx_run_valign_prop, css_va_inherit);
-    }
-    inline void setVertAlign(css_vertical_align_t value) { set(docx_run_valign_prop,value); }
-    lString16 getCss();
-};
-
-enum docx_p_properties {
-    docx_p_page_break_before_prop,
-    docx_p_keep_next_prop,
-    docx_p_mirror_indents_prop,
-    docx_p_halign_prop,
-    docx_p_valign_prop,
-    docx_p_line_rule_prop,
-    docx_p_hyphenate_prop,
-    docx_p_before_spacing_prop,
-    docx_p_after_spacing_prop,
-    docx_p_before_auto_spacing_prop,
-    docx_p_after_auto_spacing_prop,
-    docx_p_line_spacing_prop,
-    docx_p_line_height_prop,
-    docx_p_left_margin_prop,
-    docx_p_right_margin_prop,
-    docx_p_indent_prop,
-    docx_p_hanging_prop,
-    docx_p_outline_level_prop,
-    docx_p_num_id_prop,
-    docx_p_ilvl_prop,
-    docx_p_max_prop
-};
-
-class docx_pPr : public docx_PropertiesContainer<docx_p_max_prop>
-{
-    friend class docx_pPrHandler;
-private:
-    lString16 m_pStyleId;
-public:
-    docx_pPr();
-
-    void reset() {
-        m_pStyleId.clear();
-        docx_PropertiesContainer::reset();
-    }
-    ///properties
-    inline css_text_align_t getTextAlign() const {
-        return getValue(docx_p_halign_prop, css_ta_inherit);
-    }
-    inline void setTextAlign( css_text_align_t value ) { set(docx_p_halign_prop, value); }
-    inline css_vertical_align_t getVertAlign() const {
-        return getValue(docx_p_valign_prop, css_va_inherit);
-    }
-    inline void setVertAlign(css_vertical_align_t value) { set(docx_p_valign_prop, value); }
-    inline css_hyphenate_t getHyphenate() const {
-        return getValue(docx_p_hyphenate_prop, css_hyph_inherit);
-    }
-    inline void setHyphenate( css_hyphenate_t value ) { set(docx_p_hyphenate_prop, value); }
-    // page-break-before:always
-    inline bool isPageBreakBefore() const { return getValue(docx_p_page_break_before_prop, false); }
-    inline void setPageBreakBefore(bool value) { set(docx_p_page_break_before_prop, value); }
-    // page-break-after:avoid
-    inline bool isKeepNext() const { return getValue(docx_p_keep_next_prop, false); }
-    inline void setKeepNext(bool value) { set(docx_p_keep_next_prop, value); }
-    inline bool isMirrorIndents() const { return getValue(docx_p_mirror_indents_prop, false); }
-    inline void setMirrorIndents(bool value) { set(docx_p_mirror_indents_prop, value); }
-    inline docx_lineRule_type getLineRule() const { return getValue(docx_p_line_rule_prop, docx_lineRule_auto); }
-    inline void setLineRule(docx_lineRule_type value) { set(docx_p_line_rule_prop, value); }
-    inline int getNumberingId() { return getValue(docx_p_num_id_prop, 0); }
-    css_length_t getOutlineLvl() { return get(docx_p_outline_level_prop); }
-    inline int getNumberingLevel() { return get(docx_p_ilvl_prop).value; }
-    docxStyle* getStyle(docxImportContext* context);
-    lString16 getCss();
-};
 
 class docxNumLevel : public LVRefCounter
 {
@@ -505,8 +294,8 @@ private:
     lString16 m_lvlText;
     bool m_lvlTextNull;
     docx_numFormat_type m_lvlNumFormat;
-    docx_pPr m_pPr;
-    docx_rPr m_rPr;
+    odx_pPr m_pPr;
+    odx_rPr m_rPr;
     lString16 m_pStyle;
     css_length_t m_lvlStart;
     docx_LevelSuffix_type m_suffix;
@@ -536,8 +325,8 @@ public:
     inline void setLevelStart(const css_length_t &value) { m_lvlStart = value; }
     inline docx_LevelSuffix_type getLevelSuffix() const { return m_suffix; }
     inline void setLevelSuffix(const docx_LevelSuffix_type value) { m_suffix = value; }
-    inline docx_rPr * get_rPr() { return &m_rPr; }
-    inline docx_pPr * get_pPr() { return &m_pPr; }
+    inline odx_rPr * get_rPr() { return &m_rPr; }
+    inline odx_pPr * get_pPr() { return &m_pPr; }
     css_list_style_type_t getListType() const;
 };
 
@@ -584,58 +373,18 @@ public:
 
 typedef LVFastRef< docxNum > docxNumRef;
 
-class docxStyle : public LVRefCounter
-{
-    friend class docx_styleHandler;
-private:
-    lString16 m_Name;
-    lString16 m_Id;
-    lString16 m_basedOn;
-    docx_style_type m_type;
-    docx_pPr m_pPr;
-    docx_rPr m_rPr;
-    bool m_pPrMerged;
-    bool m_rPrMerged;
-public:
-    docxStyle();
-
-    inline lString16 getName() const { return m_Name; }
-    inline void setName(const lChar16 * value) { m_Name = value; }
-
-    inline lString16 getId() const { return m_Id; }
-    inline void setId(const lChar16 * value) { m_Id = value; }
-
-    inline lString16 getBasedOn() const { return m_basedOn; }
-    inline void setBasedOn(const lChar16 * value) { m_basedOn = value; }
-    bool isValid() const;
-
-    inline docx_style_type getStyleType() const { return m_type; }
-    inline void setStyleType(docx_style_type value) { m_type = value; }
-    docxStyle* getBaseStyle(docxImportContext* context);
-    inline docx_pPr * get_pPr(docxImportContext* context);
-    inline docx_rPr * get_rPr(docxImportContext* context);
-};
-
-typedef LVFastRef< docxStyle > docxStyleRef;
-
-class docxImportContext
+class docxImportContext : public odx_ImportContext
 {
 private:
-    LVHashTable<lString16, docxStyleRef> m_styles;
     LVHashTable<lUInt32, docxAbstractNumRef> m_abstractNumbers;
     LVHashTable<lUInt32, docxNumRef> m_Numbers;
     LVArray<css_list_style_type_t> m_ListLevels;
-    docx_rPr m_rPrDefault;
-    docx_pPr m_pPrDefault;
     OpcPartRef m_docPart;
     OpcPartRef m_relatedPart;
     OpcPackage* m_package;
-    ldomDocument* m_doc;
 public:
     docxImportContext(OpcPackage *package, ldomDocument * doc);
     virtual ~docxImportContext();
-    docxStyle * getStyle( lString16 id );
-    void addStyle( docxStyleRef style );
     void addNum( docxNumRef num );
     void addAbstractNum(docxAbstractNumRef abstractNum );
     docxNumRef getNum(lUInt32 id) { return m_Numbers.get(id); }
@@ -656,169 +405,35 @@ public:
     void closeRelatedPart();
     void openList(int level, int numid, ldomDocumentWriter *writer);
     void closeList(int level, ldomDocumentWriter *writer);
-    inline docx_rPr * get_rPrDefault() { return &m_rPrDefault; }
-    inline docx_pPr * get_pPrDefault() { return &m_pPrDefault; }
     inline int getListLevel() { return m_ListLevels.length(); }
     inline bool isInList() { return m_ListLevels.length() != 0; }
-    void setLanguage(const lChar16 *lang);
     lString16 m_footNoteId;
     int m_footNoteCount;
     int m_endNoteCount;
     bool m_inField;
     ldomNode *m_linkNode;
-    docxStyle* m_pStyle;
-private:
-    lString16 getListStyle(css_list_style_type_t listType);
+    odx_Style* m_pStyle;
 };
 
-class docx_ElementHandler;
-
-class docXMLreader : public LVXMLParserCallback
-{
-private:
-    enum docx_reader_state {
-        docx_in_start,
-        docx_in_xml_declaration,
-        docx_in_body,
-        docx_in_document
-    };
-    int m_skipTag;
-    docx_reader_state m_state;
-protected:
-    docx_ElementHandler *m_handler;
-    ldomDocumentWriter *m_writer;
-
-    inline bool isSkipping()
-    {
-        return (m_skipTag != 0);
-    }
-
-    inline void skipped()
-    {
-        m_skipTag--;
-    }
-
-public:
-    /// constructor
-    docXMLreader(ldomDocumentWriter *writer) : m_skipTag(0), m_state(docx_in_start),
-        m_handler(NULL), m_writer(writer)
-    {
-    }
-
-    /// destructor
-    virtual ~docXMLreader() { }
-    /// called on parsing start
-    virtual void OnStart(LVFileFormatParser *);
-    /// called on parsing end
-    virtual void OnStop() {  }
-
-    inline void skip()
-    {
-        m_skipTag++;
-    }
-
-    /// called on opening tag <
-    ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname);
-
-    /// called after > of opening tag (when entering tag body)
-    void OnTagBody();
-
-    /// called on tag close
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
-
-    /// called on element attribute
-    void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
-
-    /// called on text
-    void OnText( const lChar16 * text, int len, lUInt32 flags );
-
-    /// add named BLOB data to document
-    bool OnBlob(lString16 name, const lUInt8 * data, int size);
-
-    docx_ElementHandler * getHandler()
-    {
-        return m_handler;
-    }
-
-    void setHandler(docx_ElementHandler *a_handler)
-    {
-        m_handler = a_handler;
-    }
-
-    void setWriter(ldomDocumentWriter *writer)
-    {
-        m_writer = writer;
-    }
-};
-
-class docx_ElementHandler
+class docx_ElementHandler : public xml_ElementHandler
 {
 protected:
-    docXMLreader * m_reader;
-    ldomDocumentWriter *m_writer;
-    docx_ElementHandler *m_savedHandler;
     docxImportContext *m_importContext;
-    const item_def_t *m_children;
-    int m_element;
-    int m_state;
 protected:
     static bool parse_OnOff_attribute(const lChar16 * attrValue);
-    static int parse_name(const struct item_def_t *tags, const lChar16 * nameValue);
-    static void parse_int(const lChar16 * attrValue, css_length_t & result);
     void generateLink(const lChar16 * target, const lChar16 * type, const lChar16 *text);
-    void setChildrenInfo(const struct item_def_t *tags);
     docx_ElementHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context,
-                        int element, const struct item_def_t *children) :
-        m_reader(reader), m_writer(writer), m_importContext(context), m_children(children),
-        m_element(element), m_state(element)
+                        int element, const struct item_def_t *children) : xml_ElementHandler(reader, writer, element, children),
+        m_importContext(context)
     {
     }
     virtual ~docx_ElementHandler() {}
-public:
-    ldomNode * handleTagOpen(const lChar16 * nsname, const lChar16 * tagname);
-    virtual ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue)
-    {
-        CR_UNUSED(nsname);
-
-        handleAttribute(attrname, attrvalue);
-    }
-    virtual void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue) {
-        CR_UNUSED2(attrname, attrvalue);
-    }
-    virtual void handleTagBody() {}
-    virtual void handleText( const lChar16 * text, int len, lUInt32 flags ) {
-        CR_UNUSED3(text,len,flags);
-    }
-    virtual void handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
-    {
-        CR_UNUSED2(nsname, tagname);
-
-        if(m_state == m_element)
-            stop();
-        else
-            m_state = m_element;
-    }
-    virtual void start();
-    virtual void stop();
-    virtual void reset();
-};
-
-class docx_SkipElementHandler : public docx_ElementHandler
-{
-public:
-    docx_SkipElementHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context,
-                            int element) : docx_ElementHandler(reader, writer, context, element, no_elements) {}
-    void skipElement(int element) {
-        m_state = element;
-        start();
-    }
 };
 
 class docx_rPrHandler : public docx_ElementHandler
 {
 private:
-    docx_rPr *m_rPr;
+    odx_rPr *m_rPr;
 public:
     docx_rPrHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context) :
         docx_ElementHandler(reader, writer, context, docx_el_rPr, rPr_elements), m_rPr(NULL)
@@ -826,7 +441,7 @@ public:
     }
     ldomNode * handleTagOpen(int tagId);
     void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void start(docx_rPr *rPr);
+    void start(odx_rPr *rPr);
     void reset();
 };
 
@@ -849,7 +464,7 @@ class docx_pHandler;
 class docx_rHandler : public docx_ElementHandler
 {
 private:
-    docx_rPr m_rPr;
+    odx_rPr m_rPr;
     docx_pHandler* m_pHandler;
     docx_rPrHandler m_rPrHandler;
     lString16 m_footnoteId;
@@ -876,7 +491,7 @@ public:
 class docx_pPrHandler : public docx_ElementHandler
 {
 private:
-    docx_pPr *m_pPr;
+    odx_pPr *m_pPr;
 public:
     docx_pPrHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context) :
         docx_ElementHandler(reader, writer, context, docx_el_pPr, pPr_elements), m_pPr(NULL)
@@ -885,44 +500,8 @@ public:
     ldomNode * handleTagOpen(int tagId);
     void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
     void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
-    void start(docx_pPr *pPr);
+    void start(odx_pPr *pPr);
     void reset();
-};
-
-class docx_titleHandler
-{
-public:
-    docx_titleHandler(ldomDocumentWriter *writer, docxImportContext *context, bool useClassName=false) :
-        m_writer(writer), m_importContext(context), m_titleLevel(), m_useClassName(useClassName) {}
-    virtual ~docx_titleHandler() {}
-    virtual void onBodyStart();
-    virtual void onTitleStart(int level, bool noSection = false);
-    virtual void onTitleEnd();
-    virtual void onBodyEnd() {}
-    bool useClassForTitle() { return m_useClassName; }
-protected:
-    ldomDocumentWriter *m_writer;
-    docxImportContext *m_importContext;
-    int m_titleLevel;
-    bool m_useClassName;
-};
-
-class docx_fb2TitleHandler : public docx_titleHandler
-{
-public:
-    docx_fb2TitleHandler(ldomDocumentWriter *writer, docxImportContext *context, bool useClassName) :
-        docx_titleHandler(writer, context, useClassName)
-    {}
-    void onBodyStart();
-    void onTitleStart(int level, bool noSection = false);
-    void onTitleEnd();
-private:
-    void makeSection(int startIndex);
-    void openSection(int level);
-    void closeSection(int level);
-private:
-    ldomNode *m_section;
-    bool m_hasTitle;
 };
 
 class docx_hyperlinkHandler  : public docx_ElementHandler
@@ -944,44 +523,29 @@ public:
 
 class docx_documentHandler;
 
-class docx_pHandler : public docx_ElementHandler
+class docx_pHandler : public docx_ElementHandler, public odx_styleTagsHandler
 {
 private:
     docx_pPrHandler m_pPrHandler;
-    docx_pPr m_pPr;
+    odx_pPr m_pPr;
     docx_rHandler m_rHandler;
-    docx_titleHandler* m_titleHandler;
+    odx_titleHandler* m_titleHandler;
     docx_hyperlinkHandler m_hyperlinkHandler;
     int m_runCount;
-    lString16 m_styleTags;
     bool m_inTitle;
-private:
-    int styleTagPos(lChar16 ch)
-    {
-        for (int i=0; i < m_styleTags.length(); i++)
-            if (m_styleTags[i] == ch)
-                return i;
-        return -1;
-    }
-    const lChar16 * getStyleTagName( lChar16 ch );
-    void closeStyleTag( lChar16 ch);
-    void openStyleTag( lChar16 ch);
 public:
-    docx_pHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_titleHandler* p_documentHandler) :
+    docx_pHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, odx_titleHandler* p_documentHandler) :
         docx_ElementHandler(reader, writer, context, docx_el_p, p_elements),
         m_pPrHandler(reader, writer, context),
         m_rHandler(reader, writer, context, this),
         m_titleHandler(p_documentHandler),
-        m_hyperlinkHandler(reader, writer, context, this), m_inTitle(false)
+        m_hyperlinkHandler(reader, writer, context, this), m_runCount(0), m_inTitle(false)
     {
     }
     ldomNode * handleTagOpen(int tagId);
     void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
     void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
     void reset();
-    void openStyleTags(docx_rPr* runProps);
-    void closeStyleTags(docx_rPr* runProps);
-    void closeStyleTags();
 };
 
 struct docx_row_span_info {
@@ -997,10 +561,10 @@ private:
     LVArray<int> m_levels;
     LVArray<docx_row_span_info> m_rowSpaninfo;
     int m_rowCount;
-    docx_titleHandler m_titleHandler;
+    odx_titleHandler m_titleHandler;
     docx_pHandler m_pHandler;
-    docx_SkipElementHandler m_skipHandler;
-    docx_ElementHandler* m_pHandler_;
+    xml_SkipElementHandler m_skipHandler;
+    xml_ElementHandler* m_pHandler_;
     int m_colSpan;
     int m_column;
     int m_columnCount;
@@ -1012,11 +576,11 @@ private:
     int m_vMergeState;
     void endRowSpan(int column);
 public:
-    docx_tblHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_titleHandler* titleHandler) :
+    docx_tblHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, odx_titleHandler* titleHandler) :
         docx_ElementHandler(reader, writer, context, docx_el_tbl, tbl_elements),
-        m_rowCount(0), m_titleHandler(writer, context, titleHandler->useClassForTitle()),
+        m_rowCount(0), m_titleHandler(writer, titleHandler->useClassForTitle()),
         m_pHandler(reader, writer, context, &m_titleHandler),
-        m_skipHandler(reader, writer, context, docx_el_p), m_colSpan(1),
+        m_skipHandler(reader, writer, docx_el_p), m_pHandler_(NULL), m_colSpan(1),
         m_column(0), m_columnCount(0), m_vMergeState(VMERGE_NONE)
     {
     }
@@ -1051,9 +615,9 @@ private:
     docx_pHandler paragraphHandler;
     docx_tblHandler m_tableHandler;
 protected:
-    docx_titleHandler* m_titleHandler;
+    odx_titleHandler* m_titleHandler;
 public:
-    docx_documentHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_titleHandler* titleHandler) :
+    docx_documentHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, odx_titleHandler* titleHandler) :
         docx_ElementHandler(reader, writer, context, docx_el_document, document_elements),
         paragraphHandler(reader, writer, context, titleHandler),
         m_tableHandler(reader, writer, context, titleHandler), m_titleHandler(titleHandler)
@@ -1069,8 +633,8 @@ class docx_styleHandler : public docx_ElementHandler
 private:
     docx_pPrHandler m_pPrHandler;
     docx_rPrHandler m_rPrHandler;
-    docxStyleRef m_styleRef;
-    docxStyle *m_style;
+    odx_StyleRef m_styleRef;
+    odx_Style *m_style;
 public:
     /// constructor
     docx_styleHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context) :
@@ -1180,70 +744,6 @@ public:
     void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
 };
 
-docx_rPr::docx_rPr()
-{
-}
-
-lString16 docx_rPr::getCss()
-{
-    lString16 style;
-
-    if( isBold() )
-        style << " font-weight: bold;";
-    if( isItalic() )
-        style << " font-style: italic;";
-    if( isUnderline() )
-        style << " text-decoration: underline;";
-    if( isStrikeThrough() )
-        style << " text-decoration: line-through;";
-    return style;
-}
-
-docx_pPr::docx_pPr()
-{
-}
-
-docxStyle *docx_pPr::getStyle(docxImportContext *context)
-{
-    docxStyle* ret = NULL;
-
-    if (!m_pStyleId.empty() ) {
-        ret = context->getStyle(m_pStyleId);
-    }
-    return ret;
-}
-
-lString16 docx_pPr::getCss()
-{
-    lString16 style;
-
-    css_text_align_t align = getTextAlign();
-    if(align != css_ta_inherit)
-    {
-        style << "text-align: ";
-        switch(align)
-        {
-        case css_ta_left:
-            style << "left;";
-            break;
-        case css_ta_right:
-            style << "right";
-            break;
-        case css_ta_center:
-            style << "center;";
-            break;
-        case css_ta_justify:
-        default:
-            style << "justify";
-            break;
-        }
-    }
-    if( isPageBreakBefore() )
-        style << "page-break-before: always;";
-    else if ( isKeepNext() )
-        style << "page-break-before: avoid;";
-    return style;
-}
 
 docxNumLevel::docxNumLevel() :
     m_isLgl(false), m_lvlJc(css_ta_inherit), m_ilvl(css_val_unspecified, 0),
@@ -1292,123 +792,11 @@ css_list_style_type_t docxNumLevel::getListType() const
     }
 }
 
-
-ldomNode * docXMLreader::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname)
-{
-    if ( m_state == docx_in_start && !lStr_cmp(tagname, "?xml") )
-        m_state = docx_in_xml_declaration;
-    else if( !isSkipping() ) {
-        if ( m_handler )
-            return m_handler->handleTagOpen(nsname, tagname);
-    } else
-        // skip nested tag
-        skip();
-    return NULL;
-}
-
-void docXMLreader::OnStart(LVFileFormatParser *)
-{
-    m_skipTag = 0;
-    m_state = docx_in_start;
-}
-
-void docXMLreader::OnTagBody()
-{
-    if( m_state != docx_in_xml_declaration && !isSkipping() && m_handler )
-        m_handler->handleTagBody();
-}
-
-void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
-{
-    CR_UNUSED(nsname);
-
-    switch(m_state) {
-    case docx_in_xml_declaration:
-        m_state = docx_in_document;
-        break;
-    case docx_in_document:
-        if( isSkipping() )
-            skipped();
-        else if ( m_handler )
-            m_handler->handleTagClose(L"", tagname);
-        break;
-    default:
-        CRLog::error("Unexpected state");
-        break;
-    }
-}
-
-void docXMLreader::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
-{
-    switch(m_state) {
-    case docx_in_xml_declaration:
-        if ( m_writer )
-            m_writer->OnAttribute(nsname, attrname, attrvalue);
-        break;
-    case docx_in_document:
-        if ( !isSkipping() && m_handler )
-            m_handler->handleAttribute(nsname, attrname, attrvalue);
-        break;
-    default:
-        CRLog::error("Unexpected state");
-    }
-}
-
-void docXMLreader::OnText( const lChar16 * text, int len, lUInt32 flags )
-{
-    if( !isSkipping() && m_handler )
-        m_handler->handleText(text, len, flags);
-}
-
-bool docXMLreader::OnBlob(lString16 name, const lUInt8 * data, int size)
-{
-    if ( !isSkipping() && m_writer )
-        return m_writer->OnBlob(name, data, size);
-    return false;
-}
-
-void docx_ElementHandler::start()
-{
-    m_savedHandler = m_reader->getHandler();
-    reset();
-    m_reader->setHandler(this);
-}
-
-void docx_ElementHandler::reset()
-{
-}
-
-void docx_ElementHandler::stop()
-{
-    m_reader->setHandler(m_savedHandler);
-    m_savedHandler = NULL;
-}
-
 bool docx_ElementHandler::parse_OnOff_attribute(const lChar16 * attrValue)
 {
     if ( !lStr_cmp(attrValue, "1") || !lStr_cmp(attrValue, "on") || !lStr_cmp(attrValue, "true") )
         return true;
     return false;
-}
-
-int docx_ElementHandler::parse_name(const struct item_def_t *tags, const lChar16 * nameValue)
-{
-    for (int i=0; tags[i].name; i++) {
-        if ( !lStr_cmp( tags[i].name, nameValue )) {
-            // found!
-            return tags[i].id;
-        }
-    }
-    return -1;
-}
-
-void docx_ElementHandler::parse_int(const lChar16 * attrValue, css_length_t & result)
-{
-    lString16 value = attrValue;
-
-    result.type = css_val_unspecified;
-    if ( value.atoi(result.value) )
-        result.type = css_val_pt; //just to distinguish with unspecified value
 }
 
 void docx_ElementHandler::generateLink(const lChar16 *target, const lChar16 *type, const lChar16 *text)
@@ -1420,7 +808,7 @@ void docx_ElementHandler::generateLink(const lChar16 *target, const lChar16 *typ
     // Add classic role=doc-noteref attribute to allow popup/in-page footnotes
     m_writer->OnAttribute(L"", L"role", L"doc-noteref");
     m_writer->OnTagBody();
-#ifndef DOCX_CRENGINE_IN_PAGE_FOOTNOTES
+#ifndef ODX_CRENGINE_IN_PAGE_FOOTNOTES
     if( !lStr_cmp(type, "note") ) {
         // For footnotes (but not endnotes), wrap in <sup> (to get the
         // same effect as the following in docx.css:
@@ -1431,36 +819,12 @@ void docx_ElementHandler::generateLink(const lChar16 *target, const lChar16 *typ
 #endif
     lString16 t(text);
     m_writer->OnText(t.c_str(), t.length(), 0);
-#ifndef DOCX_CRENGINE_IN_PAGE_FOOTNOTES
+#ifndef ODX_CRENGINE_IN_PAGE_FOOTNOTES
     if( !lStr_cmp(type, "note") ) {
         m_writer->OnTagClose(L"", L"sup");
     }
 #endif
     m_writer->OnTagClose(L"", L"a");
-}
-
-void docx_ElementHandler::setChildrenInfo(const struct item_def_t *tags)
-{
-    m_children = tags;
-}
-
-ldomNode * docx_ElementHandler::handleTagOpen(int tagId)
-{
-    m_state = tagId;
-    return NULL;
-}
-
-ldomNode * docx_ElementHandler::handleTagOpen(const lChar16 * nsname, const lChar16 * tagname)
-{
-    int tag = parse_name(m_children, tagname);
-
-    CR_UNUSED(nsname);
-    if( -1 == tag) {
-        // skip the tag we are not interested in
-        m_reader->skip();
-        return NULL;
-    }
-    return handleTagOpen(tag);
 }
 
 ldomNode * docx_rPrHandler::handleTagOpen(int tagId)
@@ -1525,13 +889,7 @@ void docx_rPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * 
         //todo
         break;
     case docx_el_rStyle:
-        m_rPr->m_rStyle = attrvalue;
-        if ( !m_rPr->m_rStyle.empty() ) {
-            docxStyle *style = m_importContext->getStyle(m_rPr->m_rStyle);
-            if( style && (docx_character_style == style->getStyleType()) ) {
-                m_rPr->combineWith(style->get_rPr(m_importContext));
-            }
-        }
+        m_rPr->setStyleId(m_importContext, attrvalue);
         break;
     case docx_el_strike:
         if( !lStr_cmp(attrname, "val") )
@@ -1563,7 +921,7 @@ void docx_rPrHandler::reset()
         m_rPr->reset();
 }
 
-void docx_rPrHandler::start(docx_rPr * const rPr)
+void docx_rPrHandler::start(odx_rPr * const rPr)
 {
     m_rPr = rPr;
     docx_ElementHandler::start();
@@ -1594,8 +952,8 @@ ldomNode *docx_rHandler::handleTagOpen(int tagId)
             if( m_importContext->m_pStyle )
                 m_rPr.combineWith(m_importContext->m_pStyle->get_rPr(m_importContext));
             m_rPr.combineWith(m_importContext->get_rPrDefault());
-            m_pHandler->closeStyleTags(&m_rPr);
-            m_pHandler->openStyleTags(&m_rPr);
+            m_pHandler->closeStyleTags(&m_rPr, m_writer);
+            m_pHandler->openStyleTags(&m_rPr, m_writer);
             m_content = true;
         }
         m_state = tagId;
@@ -1755,13 +1113,7 @@ void docx_pPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * 
     switch(m_state) {
     case docx_el_pStyle:
         if( !lStr_cmp(attrname, "val") ) {
-             m_pPr->m_pStyleId = attrvalue;
-             if ( !m_pPr->m_pStyleId.empty() ) {
-                 docxStyle* style = m_importContext->getStyle(m_pPr->m_pStyleId);
-                 if( style && (docx_paragraph_style == style->getStyleType()) ) {
-                    m_pPr->combineWith(style->get_pPr(m_importContext));
-                 }
-             }
+             m_pPr->setStyleId(m_importContext, attrvalue);
         }
         break;
     case docx_el_jc:
@@ -1775,15 +1127,15 @@ void docx_pPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * 
         if( !lStr_cmp(attrname, "line") ) {
             css_length_t val;
             parse_int(attrvalue, val);
-            m_pPr->set(docx_p_line_spacing_prop, val);
+            m_pPr->set(odx_p_line_spacing_prop, val);
         } else if( !lStr_cmp(attrname, "lineRule") ) {
             int attr_value = parse_name(lineRule_attr_values, attrvalue);
             if( -1 != attr_value )
-                m_pPr->setLineRule((docx_lineRule_type)attr_value);
+                m_pPr->setLineRule((odx_lineRule_type)attr_value);
         } else if ( !lStr_cmp(attrname, "afterAutospacing") ) {
-            m_pPr->set(docx_p_after_auto_spacing_prop, parse_OnOff_attribute(attrvalue));
+            m_pPr->set(odx_p_after_auto_spacing_prop, parse_OnOff_attribute(attrvalue));
         } else if ( !lStr_cmp(attrname, "beforeAutospacing") ) {
-            m_pPr->set(docx_p_before_auto_spacing_prop, parse_OnOff_attribute(attrvalue));
+            m_pPr->set(odx_p_before_auto_spacing_prop, parse_OnOff_attribute(attrvalue));
         } else {
             //todo
         }
@@ -1802,21 +1154,21 @@ void docx_pPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * 
         if( !lStr_cmp(attrname, "val") ) {
             css_length_t val;
             parse_int(attrvalue, val);
-            m_pPr->set(docx_p_ilvl_prop, val.value);
+            m_pPr->set(odx_p_ilvl_prop, val.value);
         }
         break;
     case docx_el_numId:
         if( !lStr_cmp(attrname, "val") ) {
             css_length_t val;
             parse_int(attrvalue, val);
-            m_pPr->set(docx_p_num_id_prop, val);
+            m_pPr->set(odx_p_num_id_prop, val);
         }
         break;
     case docx_el_outlineLvl:
         if( !lStr_cmp(attrname, "val") ) {
             css_length_t val;
             parse_int(attrvalue, val);
-            m_pPr->set(docx_p_outline_level_prop, val);
+            m_pPr->set(odx_p_outline_level_prop, val);
         }
         break;
     case docx_el_pageBreakBefore:
@@ -1862,56 +1214,10 @@ void docx_pPrHandler::reset()
         m_pPr->reset();
 }
 
-void docx_pPrHandler::start(docx_pPr *pPr)
+void docx_pPrHandler::start(odx_pPr *pPr)
 {
     m_pPr = pPr;
     docx_ElementHandler::start();
-}
-
-const lChar16 *docx_pHandler::getStyleTagName(lChar16 ch)
-{
-    switch ( ch ) {
-    case 'b':
-        return L"strong";
-    case 'i':
-        return L"em";
-    case 'u':
-        return L"u";
-    case 's':
-        return L"s";
-    case 't':
-        return L"sup";
-    case 'd':
-        return L"sub";
-    default:
-        return NULL;
-    }
-}
-
-void docx_pHandler::closeStyleTag(lChar16 ch)
-{
-    int pos = styleTagPos( ch );
-    if (pos >= 0) {
-        for (int i = m_styleTags.length() - 1; i >= pos; i--) {
-            const lChar16 * tag = getStyleTagName(m_styleTags[i]);
-            m_styleTags.erase(m_styleTags.length() - 1, 1);
-            if ( tag ) {
-                m_writer->OnTagClose(L"", tag);
-            }
-        }
-    }
-}
-
-void docx_pHandler::openStyleTag(lChar16 ch)
-{
-    int pos = styleTagPos( ch );
-    if (pos < 0) {
-        const lChar16 * tag = getStyleTagName(ch);
-        if ( tag ) {
-            m_writer->OnTagOpenNoAttr(L"", tag);
-            m_styleTags.append( 1,  ch );
-        }
-    }
 }
 
 ldomNode * docx_pHandler::handleTagOpen(int tagId)
@@ -1985,7 +1291,7 @@ void docx_pHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagn
 
     switch(m_state) {
     case docx_el_p:
-        closeStyleTags();
+        closeStyleTags(m_writer);
         if( m_pPr.getNumberingId() == 0 ) {
             if( !m_inTitle ) {
                 m_writer->OnTagClose(L"", L"p");
@@ -2009,46 +1315,6 @@ void docx_pHandler::reset()
     m_rHandler.reset();
     m_state = docx_el_p;
     m_runCount = 0;
-}
-
-void docx_pHandler::openStyleTags(docx_rPr *runProps)
-{
-    if(runProps->isBold())
-        openStyleTag('b');
-    if(runProps->isItalic())
-        openStyleTag('i');
-    if(runProps->isUnderline())
-        openStyleTag('u');
-    if(runProps->isStrikeThrough())
-        openStyleTag('s');
-    if(runProps->isSubScript())
-        openStyleTag('d');
-    if(runProps->isSuperScript())
-        openStyleTag('t');
-}
-
-void docx_pHandler::closeStyleTags(docx_rPr *runProps)
-{
-    if(!runProps->isBold())
-        closeStyleTag('b');
-    if(!runProps->isItalic())
-        closeStyleTag('i');
-    if(!runProps->isUnderline())
-        closeStyleTag('u');
-    if(!runProps->isStrikeThrough())
-        closeStyleTag('s');
-    if(!runProps->isSubScript())
-        closeStyleTag('d');
-    if(!runProps->isSuperScript())
-        closeStyleTag('t');
-
-}
-
-void docx_pHandler::closeStyleTags()
-{
-    for(int i = m_styleTags.length() - 1; i >= 0; i--)
-        closeStyleTag(m_styleTags[i]);
-    m_styleTags.clear();
 }
 
 ldomNode * docx_documentHandler::handleTagOpen(int tagId)
@@ -2095,10 +1361,10 @@ ldomNode * docx_styleHandler::handleTagOpen(int tagId)
 {
     switch(tagId) {
     case docx_el_pPr:
-        m_pPrHandler.start(&m_style->m_pPr);
+        m_pPrHandler.start(m_style->get_pPrPointer());
         break;
     case docx_el_rPr:
-        m_rPrHandler.start(&m_style->m_rPr);
+        m_rPrHandler.start(m_style->get_rPrPointer());
         break;
     case docx_el_tblPr:
     case docx_el_trPr:
@@ -2119,7 +1385,7 @@ void docx_styleHandler::handleAttribute(const lChar16 * attrname, const lChar16 
         if ( !lStr_cmp(attrname, "type") ) {
             int attr_value = parse_name(styleType_attr_values, attrvalue);
             if( -1 != attr_value )
-                m_style->setStyleType((docx_style_type)attr_value);
+                m_style->setStyleType((odx_style_type)attr_value);
         } else if ( !lStr_cmp(attrname, "styleId") ) {
             m_style->setId(attrvalue);
         }
@@ -2158,7 +1424,7 @@ void docx_styleHandler::handleTagClose( const lChar16 * nsname, const lChar16 * 
 void docx_styleHandler::start()
 {
     docx_ElementHandler::start();
-    m_styleRef = docxStyleRef( new docxStyle );
+    m_styleRef = odx_StyleRef( new odx_Style );
     m_style = m_styleRef.get();
     m_state = docx_el_style;
 }
@@ -2264,7 +1530,7 @@ void parseFootnotes(ldomDocumentWriter& writer, docxImportContext& context, int 
         LVXMLParser parser(m_stream, &docReader);
 
         if(parser.Parse())
-#ifdef DOCX_CRENGINE_IN_PAGE_FOOTNOTES
+#ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
             writer.OnTagClose(L"", docx_el_body_name);
 #else
             // We didn't add <body name=notes> to not trigger crengine auto-in-page-foonotes
@@ -2309,38 +1575,13 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     ldomDocumentWriter writer(doc);
     docXMLreader docReader(&writer);
 
-#ifdef DOCX_FB2_DOM_STRUCTURE
-    writer.OnStart(NULL);
-    writer.OnTagOpen(NULL, L"?xml");
-    writer.OnAttribute(NULL, L"version", L"1.0");
-    writer.OnAttribute(NULL, L"encoding", L"utf-8");
-    writer.OnEncoding(L"utf-8", NULL);
-    writer.OnTagBody();
-    writer.OnTagClose(NULL, L"?xml");
-    writer.OnTagOpenNoAttr(NULL, L"FictionBook");
-    // DESCRIPTION
-    writer.OnTagOpenNoAttr(NULL, L"description");
-    writer.OnTagOpenNoAttr(NULL, L"title-info");
-    writer.OnTagOpenNoAttr(NULL, L"book-title");
-    writer.OnTagClose(NULL, L"book-title");
-    writer.OnTagClose(NULL, L"title-info");
-    writer.OnTagClose(NULL, L"description");
-#else
-    writer.OnStart(NULL);
-    writer.OnTagOpen(NULL, L"?xml");
-    writer.OnAttribute(NULL, L"version", L"1.0");
-    writer.OnAttribute(NULL, L"encoding", L"utf-8");
-    writer.OnEncoding(L"utf-8", NULL);
-    writer.OnTagBody();
-    writer.OnTagClose(NULL, L"?xml");
-    writer.OnTagOpenNoAttr(NULL, L"html");
-#endif
+    importContext.startDocument(writer);
 
 #ifdef DOCX_FB2_DOM_STRUCTURE
     //Two options when dealing with titles: (FB2|HTML)
-    docx_fb2TitleHandler titleHandler(&writer, &importContext, DOCX_USE_CLASS_FOR_HEADING); //<section><title>..</title></section>
+    odx_fb2TitleHandler titleHandler(&writer, DOCX_USE_CLASS_FOR_HEADING); //<section><title>..</title></section>
 #else
-    docx_titleHandler titleHandler(&writer, &importContext);  //<hx>..</hx>
+    odx_titleHandler titleHandler(&writer);  //<hx>..</hx>
 #endif
     docx_documentHandler documentHandler(&docReader, &writer, &importContext, &titleHandler);
     docReader.setHandler(&documentHandler);
@@ -2356,11 +1597,8 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     if(importContext.m_endNoteCount > 0) {
         parseFootnotes(writer, importContext, docx_el_endnotes);
     }
-#ifdef DOCX_FB2_DOM_STRUCTURE
-    writer.OnTagClose(NULL, L"FictionBook");
-#else
-    writer.OnTagClose(NULL, L"html");
-#endif
+
+    importContext.endDocument(writer);
     writer.OnStop();
 
     if ( progressCallback ) {
@@ -2371,74 +1609,16 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     return true;
 }
 
-docxStyle::docxStyle() : m_type(docx_paragraph_style),
-    m_pPrMerged(false), m_rPrMerged(false)
-{
-}
-
-bool docxStyle::isValid() const
-{
-    return ( !(m_Name.empty() || m_Id.empty()) );
-}
-
-docxStyle *docxStyle::getBaseStyle(docxImportContext *context)
-{
-    lString16 basedOn = getBasedOn();
-    if ( !basedOn.empty() ) {
-        docxStyle *pStyle = context->getStyle(basedOn);
-        if( pStyle && pStyle->getStyleType() == getStyleType() )
-            return pStyle;
-    }
-    return NULL;
-}
-
-docx_pPr *docxStyle::get_pPr(docxImportContext *context)
-{
-    if( !m_pPrMerged ) {
-        docxStyle* pStyle = getBaseStyle(context);
-        if (pStyle ) {
-            m_pPr.combineWith(pStyle->get_pPr(context));
-        }
-        m_pPrMerged = true;
-    }
-    return &m_pPr;
-}
-
-docx_rPr *docxStyle::get_rPr(docxImportContext *context)
-{
-    if( !m_rPrMerged ) {
-        docxStyle* pStyle = getBaseStyle(context);
-        if (pStyle ) {
-            m_rPr.combineWith(pStyle->get_rPr(context));
-        }
-        m_rPrMerged = true;
-    }
-    return &m_rPr;
-}
-
-docxImportContext::docxImportContext(OpcPackage *package, ldomDocument *doc) : m_styles(64), m_abstractNumbers(16),
+docxImportContext::docxImportContext(OpcPackage *package, ldomDocument *doc) :
+    odx_ImportContext(doc), m_abstractNumbers(16),
     m_Numbers(16), m_footNoteCount(0), m_endNoteCount(0),
     m_inField(false), m_linkNode(NULL), m_pStyle(NULL),
-    m_package(package), m_doc(doc)
+    m_package(package)
 {
 }
 
 docxImportContext::~docxImportContext()
 {
-}
-
-docxStyle * docxImportContext::getStyle( lString16 id )
-{
-    return m_styles.get(id).get();
-}
-
-void docxImportContext::addStyle( docxStyleRef style )
-{
-    docxStyle *referenced = style.get();
-    if ( NULL != referenced)
-    {
-        m_styles.set(referenced->getId(), style);
-    }
 }
 
 void docxImportContext::addNum(docxNumRef num)
@@ -2493,10 +1673,8 @@ void docxImportContext::openList(int level, int numid, ldomDocumentWriter *write
         if (listLevel)
             listType = listLevel->getListType();
         writer->OnTagOpen(L"", L"ol");
-        lString16 listStyle = getListStyle(listType);
-         m_ListLevels.add(listType);
-        if ( !listStyle.empty() )
-            writer->OnAttribute(L"", L"style", listStyle.c_str());
+        m_ListLevels.add(listType);
+        writer->OnAttribute(L"", L"style", getListStyleCss(listType).c_str());
         writer->OnTagBody();
         if ( i != level - 1 )
             writer->OnTagOpenNoAttr(L"", L"li");
@@ -2509,41 +1687,6 @@ void docxImportContext::closeList(int level, ldomDocumentWriter *writer)
         writer->OnTagClose(L"", L"li");
         writer->OnTagClose(L"", L"ol");
         m_ListLevels.remove(getListLevel() - 1);
-    }
-}
-
-void docxImportContext::setLanguage(const lChar16 *lang)
-{
-    lString16 language(lang);
-
-    int p = language.pos(cs16("-"));
-    if ( p > 0  ) {
-        language = language.substr(0, p);
-    }
-    m_doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
-}
-
-lString16 docxImportContext::getListStyle(css_list_style_type_t listType)
-{
-    switch(listType) {
-    case css_lst_disc:
-        return lString16("list-style-type: disc;");
-    case css_lst_circle:
-        return lString16("list-style-type: circle;");
-    case css_lst_square:
-        return lString16("list-style-type: square;");
-    case css_lst_decimal:
-        return lString16("list-style-type: decimal;");
-    case css_lst_lower_roman:
-        return lString16("list-style-type: lower-roman;");
-    case css_lst_upper_roman:
-        return lString16("list-style-type: upper-roman;");
-    case css_lst_lower_alpha:
-        return lString16("list-style-type: lower-alpha;");
-    case css_lst_upper_alpha:
-        return lString16("list-style-type: upper-alpha;");
-    default:
-        return lString16();
     }
 }
 
@@ -2659,7 +1802,7 @@ ldomNode *docx_footnotesHandler::handleTagOpen(int tagId)
         break;
     case docx_el_footnotes:
     case docx_el_endnotes:
-#ifdef DOCX_CRENGINE_IN_PAGE_FOOTNOTES
+#ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
         m_writer->OnTagOpen(L"", docx_el_body_name);
         if(isEndNote()) {
             m_writer->OnAttribute(L"", L"name", L"comments");
@@ -3106,102 +2249,4 @@ docxNumLevel *docxAbstractNum::getLevel(int level)
 void docxAbstractNum::reset()
 {
     m_levels.clear();
-}
-
-void docx_titleHandler::onBodyStart()
-{
-    m_writer->OnTagOpen(L"", docx_el_body_name);
-}
-
-void docx_titleHandler::onTitleStart(int level, bool noSection)
-{
-    CR_UNUSED(noSection);
-
-    m_titleLevel = level;
-    lString16 name = cs16("h") +  lString16::itoa(m_titleLevel);
-    if( m_useClassName ) {
-        m_writer->OnTagOpen(L"", L"p");
-        m_writer->OnAttribute(L"", L"class", name.c_str());
-    } else
-        m_writer->OnTagOpen(L"", name.c_str());
-}
-
-void docx_titleHandler::onTitleEnd()
-{
-    if( !m_useClassName ) {
-        lString16 tagName = cs16("h") +  lString16::itoa(m_titleLevel);
-        m_writer->OnTagClose(L"", tagName.c_str());
-    } else
-        m_writer->OnTagClose(L"", L"p");
-}
-
-void docx_fb2TitleHandler::onBodyStart()
-{
-    m_section = m_writer->OnTagOpen(L"", docx_el_body_name);
-}
-
-void docx_fb2TitleHandler::onTitleStart(int level, bool noSection)
-{
-    if( noSection )
-        docx_titleHandler::onTitleStart(level, true);
-    else {
-        if( m_titleLevel < level ) {
-            int startIndex = m_hasTitle ? 1 : 0;
-            int contentCount = m_section->getChildCount();
-            if(contentCount > startIndex)
-                makeSection(startIndex);
-        } else
-            closeSection(m_titleLevel - level + 1);
-        openSection(level);
-        m_writer->OnTagOpen(L"", L"title");
-        lString16 headingName = cs16("h") +  lString16::itoa(level);
-        if( m_useClassName ) {
-            m_writer->OnTagBody();
-            m_writer->OnTagOpen(L"", L"p");
-            m_writer->OnAttribute(L"", L"class", headingName.c_str());
-        } else {
-            m_writer->OnTagBody();
-            m_writer->OnTagOpen(L"", headingName.c_str());
-        }
-    }
-}
-
-void docx_fb2TitleHandler::onTitleEnd()
-{
-    if( !m_useClassName ) {
-        lString16 headingName = cs16("h") +  lString16::itoa(m_titleLevel);
-        m_writer->OnTagClose(L"", headingName.c_str());
-    } else
-        m_writer->OnTagClose(L"", L"p");
-
-    m_writer->OnTagClose(L"", L"title");
-    m_hasTitle = true;
-}
-
-void docx_fb2TitleHandler::makeSection(int startIndex)
-{
-    ldomNode *newSection = m_section->insertChildElement(startIndex, LXML_NS_NONE, el_section);
-    newSection->initNodeStyle();
-    m_section->moveItemsTo(newSection, startIndex + 1, m_section->getChildCount() - 1);
-    newSection->initNodeRendMethod( );
-    m_section = newSection;
-}
-
-void docx_fb2TitleHandler::openSection(int level)
-{
-    for(int i = m_titleLevel; i < level; i++) {
-        m_section = m_writer->OnTagOpen(L"", L"section");
-        m_writer->OnTagBody();
-    }
-    m_titleLevel = level;
-    m_hasTitle = false;
-}
-
-void docx_fb2TitleHandler::closeSection(int level)
-{
-    for(int i = 0; i < level; i++) {
-        m_writer->OnTagClose(L"", L"section");
-        m_titleLevel--;
-    }
-    m_hasTitle = false;
 }

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -1601,6 +1601,14 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     importContext.endDocument(writer);
     writer.OnStop();
 
+#ifndef DOCX_FB2_DOM_STRUCTURE
+    // With DOCX_FB2_DOM_STRUCTURE, headings are wrapped in <section><title>
+    // and benefit from crengine internal TOC building.
+    // When using plain HTML, we don't and we have to build it here instead,
+    // from the headings we made.
+    doc->buildTocFromHeadings();
+#endif
+
     if ( progressCallback ) {
         progressCallback->OnLoadFileEnd( );
         doc->compact();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -30,6 +30,7 @@
 #include "../include/pdbfmt.h"
 #include "../include/fb3fmt.h"
 #include "../include/docxfmt.h"
+#include "../include/odtfmt.h"
 
 /// to show page bounds rectangles
 //#define SHOW_PAGE_RECT
@@ -4171,6 +4172,38 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             }
         }
 
+        if( DetectOpenDocumentFormat(m_stream) ) {
+            CRLog::info("ODT format detected");
+            createEmptyDocument();
+            m_doc->setProps( m_doc_props );
+            setRenderProps( 0, 0 );
+            setDocFormat( doc_format_odt );
+            if ( m_callback )
+                m_callback->OnLoadFileFormatDetected(doc_format_odt);
+            updateDocStyleSheet();
+            bool res = ImportOpenDocument(m_stream, m_doc, m_callback, this );
+            if ( !res ) {
+                setDocFormat( doc_format_none );
+                createDefaultDocument( cs16("ERROR: Error reading DOCX format"), cs16("Cannot open document") );
+                if ( m_callback ) {
+                    m_callback->OnLoadFileError( cs16("Error reading DOCX document") );
+                }
+                return false;
+            } else {
+                m_container = m_doc->getContainer();
+                m_doc_props = m_doc->getProps();
+                setRenderProps( 0, 0 );
+                REQUEST_RENDER("loadDocument")
+                if ( m_callback ) {
+                    m_callback->OnLoadFileEnd( );
+                    //m_doc->compact();
+                    m_doc->dumpStatistics();
+                }
+                m_arc = m_doc->getContainer();
+                return true;
+            }
+        }
+
 #if CHM_SUPPORT_ENABLED==1
         if ( DetectCHMFormat( m_stream ) ) {
 			// CHM
@@ -4410,6 +4443,8 @@ const lChar16 * getDocFormatName(doc_format_t fmt) {
 		return L"DOC";
 	case doc_format_docx:
 		return L"DOCX";
+    case doc_format_odt:
+        return L"OpenDocument (ODT)";
 	default:
 		return L"Unknown format";
 	}

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -1,0 +1,1017 @@
+#include "../include/odtfmt.h"
+#include "../include/lvtinydom.h"
+#include "../include/fb2def.h"
+#include "../include/lvopc.h"
+#include "odxutil.h"
+
+// If you add new element - update odt_elements_mapping table below
+#define ODT_TAGS \
+    ODT_TAG(a)\
+    ODT_TAG2(automaticStyles, "automatic-styles")\
+    ODT_TAG(body)\
+    ODT_TAG(bookmark)\
+    ODT_TAG2(bookmarkRef, "bookmark-ref")\
+    ODT_TAG2(bookmarkStart, "bookmark-start")\
+    ODT_TAG2(defaultStyle, "default-style")\
+    ODT_TAG2(documentContent, "document-content")\
+    ODT_TAG2(documentStyles, "document-styles")\
+    ODT_TAG(frame)\
+    ODT_TAG(h)\
+    ODT_TAG(image)\
+    ODT_TAG2(indexBody, "index-body")\
+    ODT_TAG2(lineBreak, "line-break")\
+    ODT_TAG(list)\
+    ODT_TAG2(listStyle, "list-style")\
+    ODT_TAG2(listLevelStyleBullet, "list-level-style-bullet")\
+    ODT_TAG2(listLevelStyleNumber, "list-level-style-number")\
+    ODT_TAG2(listItem, "list-item")\
+    ODT_TAG(note)\
+    ODT_TAG2(noteBody, "note-body")\
+    ODT_TAG2(noteCitation, "note-citation")\
+    ODT_TAG2(noteRef, "note-ref")\
+    ODT_TAG(p)\
+    ODT_TAG2(paragraphProperties, "paragraph-properties")\
+    ODT_TAG2(referenceMark, "reference-mark")\
+    ODT_TAG2(referenceMarkStart, "reference-mark-start")\
+    ODT_TAG2(referenceRef, "reference-ref")\
+    ODT_TAG(s)\
+    ODT_TAG(span)\
+    ODT_TAG(style)\
+    ODT_TAG(styles)\
+    ODT_TAG(tab)\
+    ODT_TAG(table)\
+    ODT_TAG2(tableHeaderRows, "table-header-rows")\
+    ODT_TAG2(tableOfContent, "table-of-content")\
+    ODT_TAG2(tableRow, "table-row")\
+    ODT_TAG2(tableCell, "table-cell")\
+    ODT_TAG(text)\
+    ODT_TAG2(textBox, "text-box")\
+    ODT_TAG2(textProperties, "text-properties")
+
+#define ODT_TAG_NAME(itm) odt_el_##itm##_name
+#define ODT_TAG_ID(itm) odt_el_##itm
+#define ODT_TAG_CHILD(itm) { ODT_TAG_ID(itm), ODT_TAG_NAME(itm) }
+#define ODT_TAG_CHILD2(itm, name) { ODT_TAG_ID(itm), L ## name }
+#define ODT_LAST_ITEM { -1, NULL }
+
+enum {
+#define ODT_TAG(itm) ODT_TAG_ID(itm),
+#define ODT_TAG2(itm, name) ODT_TAG_ID(itm),
+    odt_el_NULL = 0,
+    ODT_TAGS
+    odt_el_MAX_ID
+};
+
+#undef ODT_TAG
+#undef ODT_TAG2
+#define ODT_TAG(itm) static const lChar16 * const ODT_TAG_NAME(itm) = L ## #itm;
+#define ODT_TAG2(itm, name) static const lChar16 * const ODT_TAG_NAME(itm) = L ## name;
+    ODT_TAGS
+
+#undef ODT_TAG
+#undef ODT_TAG2
+#define ODT_TAG(itm) ODT_TAG_CHILD(itm),
+#define ODT_TAG2(itm, name) ODT_TAG_CHILD2(itm, name),
+
+const struct item_def_t odt_elements_mapping[] = {
+    { odt_el_NULL, NULL },
+    { odt_el_a, L"a" },
+    { odt_el_automaticStyles, NULL },
+    { odt_el_body, L"body" },
+    { odt_el_bookmark, L"a" },
+    { odt_el_bookmarkRef, L"a" },
+    { odt_el_bookmarkStart, L"a" },
+    { odt_el_defaultStyle, NULL },
+    { odt_el_documentContent, NULL },
+    { odt_el_documentStyles, NULL },
+    { odt_el_frame, NULL },
+    { odt_el_h, NULL /*Special processing*/},
+    { odt_el_image, L"img" },
+    { odt_el_indexBody, NULL },
+    { odt_el_lineBreak, L"br" },
+    { odt_el_list, L"ol" },
+    { odt_el_listStyle, NULL },
+    { odt_el_listLevelStyleBullet, NULL },
+    { odt_el_listLevelStyleNumber, NULL },
+    { odt_el_listItem, L"li" },
+    { odt_el_note, NULL },
+    { odt_el_noteBody, NULL /*Special Processing */ },
+    { odt_el_noteCitation, NULL /*Special Processing */ },
+    { odt_el_noteRef, L"a" },
+    { odt_el_p, L"p" },
+    { odt_el_paragraphProperties, NULL },
+    { odt_el_referenceMark, L"a" },
+    { odt_el_referenceMarkStart, L"a" },
+    { odt_el_referenceRef, L"a" },
+    { odt_el_s, NULL },
+    { odt_el_span, NULL },
+    { odt_el_style, NULL },
+    { odt_el_styles, NULL },
+    { odt_el_tab, NULL },
+    { odt_el_table, L"table" },
+    { odt_el_tableHeaderRows, L"thead" },
+    { odt_el_tableOfContent, NULL },
+    { odt_el_tableRow, L"tr" },
+    { odt_el_tableCell, L"td" },
+    { odt_el_text, NULL },
+    { odt_el_textBox, NULL },
+    { odt_el_textProperties, NULL }
+};
+
+const struct item_def_t odt_elements[] = {
+    ODT_TAG_CHILD(a),
+    ODT_TAG_CHILD(automaticStyles),
+    ODT_TAG_CHILD(body),
+    ODT_TAG_CHILD(bookmark),
+    ODT_TAG_CHILD(bookmarkRef),
+    ODT_TAG_CHILD(bookmarkStart),
+    ODT_TAG_CHILD(documentContent),
+    ODT_TAG_CHILD(frame),
+    ODT_TAG_CHILD(h),
+    ODT_TAG_CHILD(image),
+    ODT_TAG_CHILD(indexBody),
+    ODT_TAG_CHILD(lineBreak),
+    ODT_TAG_CHILD(list),
+    ODT_TAG_CHILD(listItem),
+    ODT_TAG_CHILD(note),
+    ODT_TAG_CHILD(noteBody),
+    ODT_TAG_CHILD(noteCitation),
+    ODT_TAG_CHILD(noteRef),
+    ODT_TAG_CHILD(p),
+    ODT_TAG_CHILD(referenceMark),
+    ODT_TAG_CHILD(referenceMarkStart),
+    ODT_TAG_CHILD(referenceRef),
+    ODT_TAG_CHILD(s),
+    ODT_TAG_CHILD(span),
+    ODT_TAG_CHILD(tab),
+    ODT_TAG_CHILD(table),
+    ODT_TAG_CHILD(tableHeaderRows),
+    ODT_TAG_CHILD(tableOfContent),
+    ODT_TAG_CHILD(tableRow),
+    ODT_TAG_CHILD(tableCell),
+    ODT_TAG_CHILD(text),
+    ODT_TAG_CHILD(textBox),
+    ODT_LAST_ITEM
+};
+
+const struct item_def_t odt_style_elements[] = {
+    ODT_TAG_CHILD(automaticStyles),
+    ODT_TAG_CHILD(defaultStyle),
+    ODT_TAG_CHILD(documentStyles),
+    ODT_TAG_CHILD(listStyle),
+    ODT_TAG_CHILD(listLevelStyleBullet),
+    ODT_TAG_CHILD(listLevelStyleNumber),
+    ODT_TAG_CHILD(paragraphProperties),
+    ODT_TAG_CHILD(style),
+    ODT_TAG_CHILD(styles),
+    ODT_TAG_CHILD(textProperties),
+    ODT_LAST_ITEM
+};
+
+static const struct item_def_t styleFamily_attr_values[] = {
+    { odx_paragraph_style, L"paragraph" },
+    { odx_character_style, L"text"},
+    ODT_LAST_ITEM
+};
+
+const struct item_def_t odt_fontWeigth_attr_values[] = {
+    { 400, L"normal" },
+    { 600, L"bold" },
+    { 100, L"100" },
+    { 200, L"200" },
+    { 300, L"300" },
+    { 400, L"400" },
+    { 500, L"500" },
+    { 600, L"600" },
+    { 700, L"700" },
+    { 800, L"800" },
+    { 900, L"900" },
+    ODT_LAST_ITEM
+};
+
+static const struct item_def_t odt_textAlign_attr_values[] =
+{
+    { css_ta_left, L"left" },
+    { css_ta_right, L"right" },
+    { css_ta_center, L"center" },
+    { css_ta_justify, L"justify" },
+    { css_ta_start, L"start" },
+    { css_ta_end, L"end" },
+    ODT_LAST_ITEM
+};
+
+bool DetectOpenDocumentFormat( LVStreamRef stream )
+{
+    LVContainerRef arc = LVOpenArchieve( stream );
+    if ( arc.isNull() )
+        return false; // not a ZIP archive
+    lString16 mimeType;
+    {
+        LVStreamRef mtStream = arc->OpenStream(L"mimetype", LVOM_READ );
+        if ( !mtStream.isNull() ) {
+            lvsize_t size = mtStream->GetSize();
+            if ( size>4 && size<100 ) {
+                LVArray<char> buf( size+1, '\0' );
+                if ( mtStream->Read( buf.get(), size, NULL )==LVERR_OK ) {
+                    for ( lvsize_t i=0; i<size; i++ )
+                        if ( buf[i]<32 || ((unsigned char)buf[i])>127 )
+                            buf[i] = 0;
+                    buf[size] = 0;
+                    if ( buf[0] )
+                        mimeType = Utf8ToUnicode( lString8( buf.get() ) );
+                }
+            }
+        }
+    }
+    return ( mimeType == L"application/vnd.oasis.opendocument.text" );
+}
+
+class odt_ListLevelStyle : public LVRefCounter
+{
+    css_length_t m_lvlStart;
+    css_list_style_type_t m_levelType;
+    int m_level;
+public:
+    odt_ListLevelStyle() :
+        m_lvlStart(css_val_unspecified, 0), m_levelType(css_lst_disc), m_level(0) { }
+    virtual ~odt_ListLevelStyle() {}
+    inline css_length_t getLevelStart() const { return m_lvlStart; }
+    inline void setLevelStart( int value) {
+        m_lvlStart.type = css_val_pt;
+        m_lvlStart.value = value;
+    }
+    inline int getLevel() { return m_level; }
+    inline void setLevel( const lChar16* value) { m_level = lString16(value).atoi(); }
+    inline css_list_style_type_t getLevelType() { return m_levelType; }
+    inline void setLevelType(css_list_style_type_t levelType) { m_levelType = levelType; }
+    void reset() {}
+};
+
+typedef LVFastRef< odt_ListLevelStyle > odt_ListLevelStyleRef;
+
+class odt_ListStyle : public LVRefCounter
+{
+    LVHashTable<lUInt32, odt_ListLevelStyleRef> m_levels;
+    bool m_consecutiveNumbering;
+    lString16 m_Id;
+public:
+    odt_ListStyle() : m_levels(10), m_consecutiveNumbering(false) {}
+    virtual ~odt_ListStyle() {}
+    odt_ListLevelStyle* getLevel(int level) {
+        return m_levels.get(level).get();
+    }
+    inline lString16 getId() const { return m_Id; }
+    inline void setId(const lChar16 * value) { m_Id = value; }
+    bool getConsecutiveNumbering() { return m_consecutiveNumbering; }
+    void setConsecutiveNumbering(bool value) {
+        m_consecutiveNumbering = value;
+    }
+    void addLevel(odt_ListLevelStyleRef listLevel);
+    void reset() { m_levels.clear(); }
+};
+
+typedef LVFastRef< odt_ListStyle > odt_ListStyleRef;
+
+class odtImportContext : public odx_ImportContext
+{
+    LVHashTable<lString16, odt_ListStyleRef> m_ListStyles;
+public:
+    explicit odtImportContext(ldomDocument* doc) : odx_ImportContext(doc), m_ListStyles(64) { }
+    void addListStyle(odt_ListStyleRef listStyle);
+    odt_ListStyle* getListStyle(lString16 id) {
+        if( !id.empty() )
+            return m_ListStyles.get(id).get();
+        return NULL;
+    }
+    LVStreamRef openFile(const lChar16 * const fileName);
+};
+
+class odt_stylesHandler : public xml_ElementHandler
+{
+private:
+    LVArray<int> m_levels;
+    odx_StyleRef m_styleRef;
+    odx_Style *m_style;
+    odt_ListStyleRef m_ListStyleRef;
+    odt_ListStyle *m_ListStyle;
+    odt_ListLevelStyleRef m_ListLevelStyleRef;
+    odt_ListLevelStyle *m_ListLevelStyle;
+    odx_pPr* m_pPr;
+    odx_rPr* m_rPr;
+    odtImportContext *m_context;
+public:
+    /// constructor
+    odt_stylesHandler(docXMLreader * reader, ldomDocumentWriter *writer, int element,
+                      odtImportContext *context) :
+        xml_ElementHandler(reader, writer, element, odt_style_elements),
+            m_style(NULL), m_ListStyle(NULL), m_pPr(NULL), m_rPr(NULL), m_context(context)
+    {
+    }
+    ldomNode * handleTagOpen(int tagId);
+    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
+    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+};
+
+class odt_documentHandler : public xml_ElementHandler, odx_styleTagsHandler
+{
+    LVArray<int> m_levels;
+    LVArray<bool> m_listItems;
+    LVArray<odt_ListStyle*> m_ListLevels;
+    ldomDocumentWriter m_footNotesWriter;
+    ldomDocumentWriter m_endNotesWriter;
+    ldomDocumentWriter *m_saveWriter;
+    odtImportContext * m_context;
+    ldomNode *m_footNotes;
+    ldomNode *m_endNotes;
+    ldomNode *m_body;
+    lString16 m_noteId;
+    lString16 m_noteRefText;
+    lString16 m_StyleName;
+    lString16 m_spanStyleName;
+    bool m_isEndNote;
+    bool m_paragraphStarted;
+    odt_stylesHandler m_stylesHandler;
+private:
+    ldomNode* startNotes(const lChar16 * notesKind) {
+        m_writer->OnStart(NULL);
+#ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
+        ldomNode* notes = m_writer->OnTagOpen(L"", L"body");
+        m_writer->OnAttribute(L"", L"name", notesKind);
+#else
+        ldomNode* notes = m_writer->OnTagOpen(L"", L"div");
+        m_writer->OnAttribute(L"", L"style", L"page-break-before: always");
+#endif
+        m_writer->OnTagBody();
+        return notes;
+    }
+    void finishNotes(ldomNode* notes, ldomDocumentWriter& writer) {
+        ldomNode* parent = notes->getParentNode();
+        int index = notes->getNodeIndex();
+#ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
+        writer.OnTagClose(L"", L"body");
+#else
+        writer.OnTagClose(L"", L"div");
+#endif
+        writer.OnStop();
+        parent->moveItemsTo(m_body->getParentNode(), index, index);
+    }
+    inline void checkParagraphStart() {
+        if( !m_paragraphStarted ) {
+            startParagraph();
+        }
+    }
+    void startParagraph();
+protected:
+    odx_titleHandler* m_titleHandler;
+    int m_outlineLevel;
+    bool m_inTable;
+    bool m_inListItem;
+    bool m_listItemHadContent;
+public:
+    odt_documentHandler(ldomDocument * doc, docXMLreader * reader,
+                        ldomDocumentWriter * writer, odx_titleHandler* titleHandler,
+                        odtImportContext * context) :
+        xml_ElementHandler(reader, writer, odt_el_NULL, odt_elements),
+        m_footNotesWriter(doc), m_endNotesWriter(doc), m_saveWriter(NULL),
+        m_context(context), m_footNotes(NULL), m_endNotes(NULL), m_body(NULL),
+        m_isEndNote(false), m_titleHandler(titleHandler),
+        m_outlineLevel(0), m_inTable(false), m_inListItem(false),
+        m_stylesHandler(reader, NULL, odt_el_automaticStyles, context),
+        m_listItemHadContent(false), m_paragraphStarted(false) {
+    }
+    inline bool isInList() { return m_ListLevels.length() != 0; }
+    ldomNode *handleTagOpen(int tagId);
+    void handleAttribute(const lChar16 *attrname, const lChar16 *attrValue);
+    void handleTagBody();
+    void handleTagClose(const lChar16 *nsname, const lChar16 *tagname);
+    void handleText(const lChar16 *text, int len, lUInt32 flags);
+    void reset();
+};
+
+static bool parseStyles(odtImportContext *context)
+{
+    LVStreamRef stream = context->openFile(L"styles.xml");
+    if ( stream.isNull() )
+        return false;
+
+    docXMLreader docReader(NULL);
+    odt_stylesHandler stylesHandler(&docReader, NULL, odt_el_documentStyles, context);
+    docReader.setHandler(&stylesHandler);
+
+    LVXMLParser parser(stream, &docReader);
+
+    if ( !parser.Parse() )
+        return false;
+    return true;
+}
+
+bool ImportOpenDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback )
+{
+    LVContainerRef arc = LVOpenArchieve( stream );
+    if ( arc.isNull() )
+        return false; // not a ZIP archive
+
+    doc->setContainer(arc);
+
+    //Read document metadata
+    LVStreamRef meta_stream = arc->OpenStream(L"meta.xml", LVOM_READ);
+    if ( meta_stream.isNull() )
+        return false;
+    ldomDocument * metaDoc = LVParseXMLStream( meta_stream );
+    if ( metaDoc ) {
+        CRPropRef doc_props = doc->getProps();
+
+        lString16 author = metaDoc->textFromXPath( cs16("document-meta/meta/creator") );
+        lString16 title = metaDoc->textFromXPath( cs16("document-meta/meta/title") );
+        lString16 description = metaDoc->textFromXPath( cs16("document-meta/meta/description") );
+        doc_props->setString(DOC_PROP_TITLE, title);
+        doc_props->setString(DOC_PROP_AUTHORS, author );
+        doc_props->setString(DOC_PROP_DESCRIPTION, description );
+        delete metaDoc;
+    } else {
+        CRLog::error("Couldn't parse document meta data");
+    }
+
+#if BUILD_LITE!=1
+    if ( doc->openFromCache(formatCallback) ) {
+        if ( progressCallback ) {
+            progressCallback->OnLoadFileEnd( );
+        }
+        return true;
+    }
+#endif
+
+    ldomDocumentWriter writer(doc);
+    docXMLreader docReader(&writer);
+
+    odtImportContext importContext(doc);
+    if( !parseStyles(&importContext) )
+        return false;
+
+    LVStreamRef m_stream = arc->OpenStream(L"content.xml", LVOM_READ);
+    if ( m_stream.isNull() )
+        return false;
+
+    importContext.startDocument(writer);
+
+#ifdef DOCX_FB2_DOM_STRUCTURE
+    //Two options when dealing with titles: (FB2|HTML)
+    odx_fb2TitleHandler titleHandler(&writer, DOCX_USE_CLASS_FOR_HEADING); //<section><title>..</title></section>
+#else
+    odx_titleHandler titleHandler(&writer);  //<hx>..</hx>
+#endif
+
+    odt_documentHandler documentHandler(doc, &docReader, &writer, &titleHandler, &importContext);
+    docReader.setHandler(&documentHandler);
+
+    LVXMLParser parser(m_stream, &docReader);
+
+    if ( !parser.Parse() )
+        return false;
+
+    importContext.endDocument(writer);
+    writer.OnStop();
+
+    if ( progressCallback ) {
+        progressCallback->OnLoadFileEnd( );
+        doc->compact();
+        doc->dumpStatistics();
+    }
+
+    return true;
+}
+
+void odt_documentHandler::startParagraph()
+{
+    if(m_inListItem) {
+        m_listItemHadContent = true;
+        m_writer->OnTagOpenNoAttr(L"", L"li");
+    }
+    m_writer->OnTagOpen(L"", L"p");
+    odx_Style* style = m_context->getStyle(m_StyleName);
+    if( style ) {
+        odx_pPr pPr;
+
+        pPr.combineWith(style->get_pPr(m_context));
+        pPr.combineWith(m_context->get_pPrDefault());
+        lString16 css = pPr.getCss();
+        if( !css.empty() )
+            m_writer->OnAttribute(L"", L"style", css.c_str());
+    }
+    m_writer->OnTagBody();
+#ifndef DOCX_FB2_DOM_STRUCTURE
+    if(m_state == odt_el_noteBody) {
+        m_writer->OnTagOpen(L"", L"sup");
+        m_writer->OnTagBody();
+        m_writer->OnText(m_noteRefText.c_str(), m_noteRefText.length(), 0);
+        m_writer->OnTagClose(L"", L"sup");
+    }
+#endif
+    m_paragraphStarted = true;
+}
+
+ldomNode *odt_documentHandler::handleTagOpen(int tagId)
+{
+    bool elementHandled = false;
+    switch(tagId) {
+    case odt_el_automaticStyles:
+        m_stylesHandler.start();
+        elementHandled = true;
+        break;
+    case odt_el_note:
+        m_isEndNote = false;
+        m_writer->OnTagOpen(L"", L"a");
+        break;
+    case odt_el_body:
+        m_body = m_titleHandler->onBodyStart();
+        m_writer->OnTagBody();
+        break;
+    case odt_el_h:
+        if( odt_el_p == m_state)
+            checkParagraphStart();
+        m_StyleName.clear();
+        m_outlineLevel = 0;
+        break;
+    case odt_el_p:
+#ifndef DOCX_FB2_DOM_STRUCTURE
+        if( odt_el_p == m_state || odt_el_noteBody == m_state)
+            checkParagraphStart();
+        m_paragraphStarted = odt_el_noteBody == m_state;
+#else
+        if( odt_el_p == m_state)
+            checkParagraphStart();
+        m_paragraphStarted = false;
+#endif
+        m_StyleName.clear();
+        break;
+    case odt_el_span:
+        m_spanStyleName.clear();
+        break;
+    case odt_el_list:
+        if( odt_el_p == m_state)
+            checkParagraphStart();
+        m_StyleName.clear();
+        m_writer->OnTagOpen(L"", L"ol");
+        if (isInList())
+            m_listItems.add(m_listItemHadContent);
+        break;
+    case odt_el_listItem:
+        m_inListItem = true;
+        m_listItemHadContent = false;
+        break;
+    case odt_el_tab:
+    case odt_el_s:
+        if( odt_el_p == m_state)
+            checkParagraphStart();
+        m_writer->OnText(L" ", 1, TXTFLG_PRE);
+        break;
+    case odt_el_noteBody:
+        m_saveWriter = m_writer;
+        if(m_isEndNote) {
+            m_writer = &m_endNotesWriter;
+            if(!m_endNotes)
+                m_endNotes = startNotes(L"comments");
+        } else {
+            m_writer = &m_footNotesWriter;
+            if(!m_footNotes)
+                m_footNotes = startNotes(L"notes");;
+        }
+        m_writer->OnTagOpen(L"", L"section");
+        m_writer->OnAttribute(L"", L"id", m_noteId.c_str());
+        m_writer->OnAttribute(L"", L"role", m_isEndNote ? L"doc-rearnote" : L"doc-footnote");
+        m_writer->OnTagBody();
+#ifdef DOCX_FB2_DOM_STRUCTURE
+        m_writer->OnTagOpenNoAttr(L"", L"title");
+        m_writer->OnTagOpenNoAttr(L"", L"p");
+        m_writer->OnText(m_noteRefText.c_str(), m_noteRefText.length(), 0);
+        m_writer->OnTagClose(L"", L"p");
+        m_writer->OnTagClose(L"", L"title");
+#else
+        m_paragraphStarted = false;
+#endif
+        break;
+    case odt_el_table:
+        m_inTable = true;
+    default:
+        if( odt_elements_mapping[tagId].name ) {
+            if( odt_el_p == m_state)
+                checkParagraphStart();
+            m_writer->OnTagOpen(L"", odt_elements_mapping[tagId].name);
+        }
+        break;
+    }
+    if( !elementHandled ) {
+        m_state = tagId;
+        m_levels.add(tagId);
+    }
+    return NULL;
+}
+
+void odt_documentHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrValue)
+{
+    switch (m_state) {
+    case odt_el_bookmark:
+    case odt_el_bookmarkStart:
+    case odt_el_referenceMark:
+    case odt_el_referenceMarkStart:
+        if(!lStr_cmp(attrname, "name") ) {
+            m_writer->OnAttribute(L"", L"id", attrValue);
+        }
+        break;
+    case odt_el_bookmarkRef:
+    case odt_el_noteRef:
+    case odt_el_referenceRef:
+        if(!lStr_cmp(attrname, "ref-name") ) {
+            lString16 target = cs16("#") + lString16(attrValue);
+            m_writer->OnAttribute(L"", L"href", target.c_str());
+        }
+        break;
+    case odt_el_h:
+        if(!lStr_cmp(attrname, "outline-level") ) {
+            lString16 value = attrValue;
+            int tmp;
+
+            if(value.atoi(tmp))
+                m_outlineLevel = tmp - 1;
+            break;
+        }
+        if( !lStr_cmp(attrname, "style-name") ) {
+            m_StyleName = attrValue;
+        }
+        break;
+    case odt_el_note:
+        if(!lStr_cmp(attrname, "note-class")) {
+            if(!lStr_cmp(attrValue, "endnote")) {
+                m_writer->OnAttribute(L"", L"type", L"comment");
+                m_isEndNote = true;
+            } else if(!lStr_cmp(attrValue, "footnote")) {
+                m_writer->OnAttribute(L"", L"type", L"note");
+            }
+            m_writer->OnAttribute(L"", L"role", L"doc-noteref");
+        } else if(!lStr_cmp(attrname, "id")) {
+            m_noteId = lString16(attrValue);
+            lString16 target = cs16("#") + m_noteId;
+            m_writer->OnAttribute(L"", L"href", target.c_str());
+        }
+        break;
+    case odt_el_tableCell:
+        if(!lStr_cmp(attrname, "number-columns-spanned"))
+            m_writer->OnAttribute(L"", L"colspan", attrValue);
+        else if(!lStr_cmp(attrname, "number-rows-spanned"))
+            m_writer->OnAttribute(L"", L"rowspan", attrValue);
+        break;
+    case odt_el_a:
+    case odt_el_image:
+        if( !lStr_cmp(attrname, "href") )
+            m_writer->OnAttribute(L"", attrname, attrValue);
+        break;
+    case odt_el_p:
+    case odt_el_list:
+    case odt_el_span:
+        if( !lStr_cmp(attrname, "style-name") ) {
+            if( m_state == odt_el_span)
+                m_spanStyleName = attrValue;
+            else
+                m_StyleName = attrValue;
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void odt_documentHandler::handleTagBody()
+{
+    switch(m_state) {
+    case odt_el_span:
+    case odt_el_p:
+        break;
+    case odt_el_list:
+        {
+            css_list_style_type_t listType = css_lst_none;
+            css_length_t levelStart(css_val_unspecified, 0);
+            odt_ListStyle* listStyle = m_context->getListStyle(m_StyleName);
+            if( !listStyle && !m_ListLevels.empty() ) {
+                listStyle = m_ListLevels.get( m_ListLevels.length() -1);
+            }
+            m_ListLevels.add(listStyle);
+            if(listStyle) {
+                odt_ListLevelStyle* levelStyle = listStyle->getLevel(m_ListLevels.length());
+                if(levelStyle) {
+                    listType = levelStyle->getLevelType();
+                    levelStart = levelStyle->getLevelStart();
+                }
+            }
+            m_writer->OnAttribute(L"", L"style", m_context->getListStyleCss(listType).c_str());
+            if(levelStart.type != css_val_unspecified)
+                m_writer->OnAttribute(L"", L"start", lString16::itoa(levelStart.value).c_str());
+            m_writer->OnTagBody();
+        }
+        break;
+    case odt_el_h:
+        if(m_inListItem) {
+            m_listItemHadContent = true;
+            m_writer->OnTagOpenNoAttr(L"", L"li");
+        }
+        m_titleHandler->onTitleStart(m_outlineLevel + 1, m_inTable || m_inListItem);
+        m_writer->OnTagBody();
+        break;
+    default:
+        if( odt_elements_mapping[m_state].name )
+            m_writer->OnTagBody();
+        break;
+    }
+}
+
+void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+{
+    switch(m_state) {
+    case odt_el_body:
+        m_titleHandler->onBodyEnd();
+        m_writer->OnTagClose(nsname, tagname);
+        if(m_footNotes)
+            finishNotes(m_footNotes, m_footNotesWriter);
+        if(m_endNotes)
+            finishNotes(m_endNotes, m_endNotesWriter);
+        break;
+    case odt_el_h:
+        closeStyleTags(m_writer);
+        m_titleHandler->onTitleEnd();
+        break;
+    case odt_el_p:
+        if( !m_paragraphStarted ) {
+            if( m_inListItem) {
+                m_writer->OnTagOpen(L"", L"li");
+                m_writer->OnAttribute(L"", L"style", L"display:none");
+                m_writer->OnTagBody();
+                m_writer->OnTagClose(L"", L"li");
+            } else
+                m_writer->OnTagOpenNoAttr(L"", L"p");
+            m_paragraphStarted = true;
+        } else
+            closeStyleTags(m_writer);
+        m_writer->OnTagClose(nsname, tagname);
+        break;
+    case odt_el_list:
+        m_ListLevels.remove(m_ListLevels.length() - 1);
+        m_writer->OnTagClose(L"", L"ol");
+        break;
+    case odt_el_listItem:
+        if(m_listItemHadContent)
+            m_writer->OnTagClose(L"", L"li");
+        if(!m_listItems.empty()) {
+            m_listItemHadContent = m_listItems[m_listItems.length() - 1];
+            m_listItems.erase(m_listItems.length() - 1, 1);
+        }
+        m_inListItem = false;
+        break;
+    case odt_el_noteBody:
+        m_writer->OnTagClose(L"", L"section");
+        m_writer = m_saveWriter;
+        break;
+    case odt_el_noteCitation:
+        m_writer->OnTagClose(L"", L"a");
+        break;
+    case odt_el_table:
+        m_inTable = false;
+    default:
+        if( odt_elements_mapping[m_state].name )
+            m_writer->OnTagClose(L"", odt_elements_mapping[m_state].name);
+        break;
+    }
+    m_levels.erase(m_levels.length() - 1, 1);
+    if( !m_levels.empty() )
+        m_state = m_levels[m_levels.length() - 1];
+    else
+        m_state = odt_el_NULL;
+}
+
+void odt_documentHandler::handleText(const lChar16 *text, int len, lUInt32 flags)
+{
+    odx_Style* style;
+
+    switch(m_state) {
+    case odt_el_h:
+    case odt_el_p:
+    case odt_el_span:
+        style = m_context->getStyle(m_state == odt_el_span ? m_spanStyleName : m_StyleName);
+        if(style) {
+            odx_rPr rPr;
+
+            rPr.combineWith(style->get_rPr(m_context));
+            rPr.combineWith(m_context->get_rPrDefault());
+            if( rPr.isHidden() )
+                break;
+            checkParagraphStart();
+            closeStyleTags(&rPr, m_writer);
+            openStyleTags(&rPr, m_writer);
+        } else
+            checkParagraphStart();
+        m_writer->OnText(text, len, flags);
+        break;
+    case odt_el_noteCitation:
+        m_noteRefText = text;
+        m_writer->OnTagBody();
+    case odt_el_bookmarkRef:
+    case odt_el_noteRef:
+    case odt_el_referenceRef:
+    case odt_el_a:
+        m_writer->OnText(text, len, flags);
+        break;
+    default:
+        break;
+    }
+}
+
+void odt_documentHandler::reset()
+{
+    m_levels.clear();
+    m_ListLevels.clear();
+    m_listItems.clear();
+    m_state = odt_el_NULL;
+    m_outlineLevel = 0;
+    m_inTable = false;
+    m_inListItem = false;
+    m_listItemHadContent = false;
+    m_paragraphStarted = false;
+}
+
+void odtImportContext::addListStyle(odt_ListStyleRef listStyle)
+{
+    if( !listStyle.isNull())
+        m_ListStyles.set(listStyle->getId(), listStyle);
+}
+
+LVStreamRef odtImportContext::openFile(const lChar16 * const fileName)
+{
+    LVContainerRef container = m_doc->getContainer();
+    if( !container.isNull() )
+        return container->OpenStream(fileName, LVOM_READ);
+    return LVStreamRef();
+}
+
+ldomNode *odt_stylesHandler::handleTagOpen(int tagId)
+{
+    switch(tagId) {
+    case odt_el_defaultStyle:
+        m_style = NULL;
+        break;
+    case odt_el_paragraphProperties:
+        m_pPr = m_style ? m_style->get_pPrPointer() : m_context->get_pPrDefault();
+        break;
+    case odt_el_textProperties:
+        m_rPr = m_style ? m_style->get_rPrPointer() : m_context->get_rPrDefault();
+        break;
+    case odt_el_style:
+        m_styleRef = odx_StyleRef( new odx_Style );
+        m_style = m_styleRef.get();
+    case odt_el_listStyle:
+        m_ListStyleRef = odt_ListStyleRef( new odt_ListStyle );
+        m_ListStyle = m_ListStyleRef.get();
+        break;
+    case odt_el_listLevelStyleBullet:
+    case odt_el_listLevelStyleNumber:
+        m_ListLevelStyleRef = odt_ListLevelStyleRef( new odt_ListLevelStyle );
+        m_ListLevelStyle = m_ListLevelStyleRef.get();
+        break;
+    default:
+        break;
+    }
+    m_state = tagId;
+    m_levels.add(tagId);
+    return NULL;
+}
+
+void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+{
+    switch(m_state) {
+    case odt_el_style:
+        if( !lStr_cmp(attrname, "name") ) {
+            m_style->setId(attrvalue);
+        } else if( !lStr_cmp(attrname, "display-name") ) {
+            m_style->setName(attrvalue);
+        } else if( !lStr_cmp(attrname, "family") ) {
+            int n = parse_name(styleFamily_attr_values, attrvalue);
+            if(n != -1)
+                m_style->setStyleType((odx_style_type)n);
+        } else if( !lStr_cmp(attrname, "parent-style-name") ) {
+            m_style->setBasedOn(attrvalue);
+        }
+        break;
+    case odt_el_listStyle:
+        if( !lStr_cmp(attrname, "name") )
+            m_ListStyle->setId(attrvalue);
+        break;
+    case odt_el_listLevelStyleNumber:
+        if( !lStr_cmp(attrname, "num-format") ) {
+            lString16 format(attrvalue);
+
+            if( format.length() == 1) {
+                switch(attrvalue[0]) {
+                case '1':
+                    m_ListLevelStyle->setLevelType(css_lst_decimal);
+                    break;
+                case 'a':
+                    m_ListLevelStyle->setLevelType(css_lst_lower_alpha);
+                    break;
+                case 'A':
+                    m_ListLevelStyle->setLevelType(css_lst_upper_alpha);
+                    break;
+                case 'i':
+                    m_ListLevelStyle->setLevelType(css_lst_lower_roman);
+                    break;
+                case 'I':
+                    m_ListLevelStyle->setLevelType(css_lst_upper_roman);
+                    break;
+                default:
+                    m_ListLevelStyle->setLevelType(css_lst_none);
+                    break;
+                }
+            } else if( format.empty() )
+                m_ListLevelStyle->setLevelType(css_lst_none);
+            break;
+        }
+        if( !lStr_cmp(attrname, "start-value") ) {
+            int startValue;
+
+            if( lString16(attrvalue).atoi( startValue) )
+                m_ListLevelStyle->setLevelStart( startValue );
+            break;
+        }
+    case odt_el_listLevelStyleBullet:
+        if( !lStr_cmp(attrname, "level") )
+            m_ListLevelStyle->setLevel(attrvalue);
+        break;
+    case odt_el_paragraphProperties:
+        if( !lStr_cmp(attrname, "break-before") ) {
+            m_pPr->setPageBreakBefore( !lStr_cmp(attrvalue, "page") );
+        } else if( !lStr_cmp(attrname, "text-align") ) {
+            int n = parse_name(odt_textAlign_attr_values, attrvalue);
+            if(n != -1)
+                m_pPr->setTextAlign((css_text_align_t)n);
+        } else if( !lStr_cmp(attrname, "keep-with-next") ) {
+            m_pPr->setKeepNext( !lStr_cmp(attrvalue, "always") );
+        }
+        break;
+    case odt_el_textProperties:
+        if( NULL == m_style && !lStr_cmp(attrname, "language") ) {
+            m_context->setLanguage(attrvalue);
+        } else if( !lStr_cmp(attrname, "font-style") ) {
+            m_rPr->setItalic( lStr_cmp(attrvalue, "normal") !=0 );
+        } else if( !lStr_cmp(attrname, "font-weight") ) {
+            int n = parse_name(odt_fontWeigth_attr_values, attrvalue);
+            if( n != -1 )
+                m_rPr->setBold( n >= 600 );
+        } else if( !lStr_cmp(attrname, "text-underline-style") ) {
+            m_rPr->setUnderline( lStr_cmp( attrvalue, "none") !=0 );
+        } else if( !lStr_cmp(attrname, "text-line-through-type") ) {
+            m_rPr->setStrikeThrough( lStr_cmp( attrvalue, "none") !=0 );
+        } else if( !lStr_cmp(attrname, "text-position") ) {
+            lString16 val = attrvalue;
+
+            if( val.startsWith(L"super") ) {
+                m_rPr->setVertAlign(css_va_super);
+            } else if( val.startsWith(L"sub") ) {
+                m_rPr->setVertAlign(css_va_sub);
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void odt_stylesHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+{
+    CR_UNUSED2(nsname, tagname);
+
+    switch(m_state) {
+    case odt_el_listStyle:
+        m_context->addListStyle(m_ListStyleRef);
+        break;
+    case odt_el_listLevelStyleBullet:
+    case odt_el_listLevelStyleNumber:
+        m_ListStyle->addLevel(m_ListLevelStyleRef);
+        break;
+    case odt_el_style:
+        if(m_style && m_style->isValid()) {
+            m_context->addStyle(m_styleRef);
+        }
+    default:
+        break;
+    }
+    if( !m_levels.empty() ) {
+        m_levels.erase(m_levels.length() - 1, 1);
+        if(! m_levels.empty() )
+            m_state = m_levels[m_levels.length() - 1];
+        else
+            m_state = m_element;
+    } else
+        stop();
+}
+
+void odt_ListStyle::addLevel(odt_ListLevelStyleRef listLevel)
+{
+    if( !listLevel.isNull() )
+        m_levels.set( listLevel->getLevel(), listLevel );
+}

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -472,6 +472,14 @@ bool ImportOpenDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     importContext.endDocument(writer);
     writer.OnStop();
 
+#ifndef DOCX_FB2_DOM_STRUCTURE
+    // With DOCX_FB2_DOM_STRUCTURE, headings are wrapped in <section><title>
+    // and benefit from crengine internal TOC building.
+    // When using plain HTML, we don't and we have to build it here instead,
+    // from the headings we made.
+    doc->buildTocFromHeadings();
+#endif
+
     if ( progressCallback ) {
         progressCallback->OnLoadFileEnd( );
         doc->compact();

--- a/crengine/src/odxutil.cpp
+++ b/crengine/src/odxutil.cpp
@@ -421,12 +421,18 @@ void odx_ImportContext::startDocument(ldomDocumentWriter &writer)
     writer.OnTagClose(NULL, L"description");
 #else
     writer.OnStart(NULL);
+    // Note: the following is not needed:
+    // docXMLreader::OnAttribute() will forward attributes from the docx
+    // document.xml '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    // to the <FictionBook> or <html> tags.
+    /*
     writer.OnTagOpen(NULL, L"?xml");
     writer.OnAttribute(NULL, L"version", L"1.0");
     writer.OnAttribute(NULL, L"encoding", L"utf-8");
     writer.OnEncoding(L"utf-8", NULL);
     writer.OnTagBody();
     writer.OnTagClose(NULL, L"?xml");
+    */
     writer.OnTagOpenNoAttr(NULL, L"html");
 #endif
 }

--- a/crengine/src/odxutil.cpp
+++ b/crengine/src/odxutil.cpp
@@ -1,0 +1,534 @@
+#include "../include/fb2def.h"
+#include "odxutil.h"
+
+ldomNode * docXMLreader::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname)
+{
+    if ( m_state == xml_doc_in_start && !lStr_cmp(tagname, "?xml") )
+        m_state = xml_doc_in_xml_declaration;
+    else if( !isSkipping() ) {
+        if ( m_handler )
+            return m_handler->handleTagOpen(nsname, tagname);
+    } else
+        // skip nested tag
+        skip();
+    return NULL;
+}
+
+void docXMLreader::OnStart(LVFileFormatParser *)
+{
+    m_skipTag = 0;
+    m_state = xml_doc_in_start;
+}
+
+void docXMLreader::OnTagBody()
+{
+    if( m_state != xml_doc_in_xml_declaration && !isSkipping() && m_handler )
+        m_handler->handleTagBody();
+}
+
+void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
+{
+    CR_UNUSED(nsname);
+
+    switch(m_state) {
+    case xml_doc_in_xml_declaration:
+        m_state = xml_doc_in_document;
+        break;
+    case xml_doc_in_document:
+        if( isSkipping() )
+            skipped();
+        else if ( m_handler )
+            m_handler->handleTagClose(L"", tagname);
+        break;
+    default:
+        CRLog::error("Unexpected state");
+        break;
+    }
+}
+
+void docXMLreader::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+{
+    switch(m_state) {
+    case xml_doc_in_xml_declaration:
+        if ( m_writer )
+            m_writer->OnAttribute(nsname, attrname, attrvalue);
+        break;
+    case xml_doc_in_document:
+        if ( !isSkipping() && m_handler )
+            m_handler->handleAttribute(nsname, attrname, attrvalue);
+        break;
+    default:
+        CRLog::error("Unexpected state");
+    }
+}
+
+void docXMLreader::OnText( const lChar16 * text, int len, lUInt32 flags )
+{
+    if( !isSkipping() && m_handler )
+        m_handler->handleText(text, len, flags);
+}
+
+bool docXMLreader::OnBlob(lString16 name, const lUInt8 * data, int size)
+{
+    if ( !isSkipping() && m_writer )
+        return m_writer->OnBlob(name, data, size);
+    return false;
+}
+
+void xml_ElementHandler::setChildrenInfo(const struct item_def_t *tags)
+{
+    m_children = tags;
+}
+
+int xml_ElementHandler::parse_name(const struct item_def_t *tags, const lChar16 * nameValue)
+{
+    for (int i=0; tags[i].name; i++) {
+        if ( !lStr_cmp( tags[i].name, nameValue )) {
+            // found!
+            return tags[i].id;
+        }
+    }
+    return -1;
+}
+
+void xml_ElementHandler::parse_int(const lChar16 * attrValue, css_length_t & result)
+{
+    lString16 value = attrValue;
+
+    result.type = css_val_unspecified;
+    if ( value.atoi(result.value) )
+        result.type = css_val_pt; //just to distinguish with unspecified value
+}
+
+ldomNode *xml_ElementHandler::handleTagOpen(const lChar16 *nsname, const lChar16 *tagname)
+{
+    int tag = parseTagName(tagname);
+
+    CR_UNUSED(nsname);
+    if( -1 == tag) {
+        // skip the tag we are not interested in
+        m_reader->skip();
+        return NULL;
+    }
+    return handleTagOpen(tag);
+}
+
+ldomNode *xml_ElementHandler::handleTagOpen(int tagId)
+{
+    m_state = tagId;
+    return NULL;
+}
+
+void xml_ElementHandler::start()
+{
+    m_savedHandler = m_reader->getHandler();
+    reset();
+    m_reader->setHandler(this);
+}
+
+void xml_ElementHandler::stop()
+{
+    m_reader->setHandler(m_savedHandler);
+    m_savedHandler = NULL;
+}
+
+void xml_ElementHandler::reset()
+{
+}
+
+ldomNode *odx_titleHandler::onBodyStart()
+{
+    return m_writer->OnTagOpen(L"", L"body");
+}
+
+void odx_titleHandler::onTitleStart(int level, bool noSection)
+{
+    CR_UNUSED(noSection);
+
+    m_titleLevel = level;
+    lString16 name = cs16("h") +  lString16::itoa(m_titleLevel);
+    if( m_useClassName ) {
+        m_writer->OnTagOpen(L"", L"p");
+        m_writer->OnAttribute(L"", L"class", name.c_str());
+    } else
+        m_writer->OnTagOpen(L"", name.c_str());
+}
+
+void odx_titleHandler::onTitleEnd()
+{
+    if( !m_useClassName ) {
+        lString16 tagName = cs16("h") +  lString16::itoa(m_titleLevel);
+        m_writer->OnTagClose(L"", tagName.c_str());
+    } else
+        m_writer->OnTagClose(L"", L"p");
+}
+
+ldomNode* odx_fb2TitleHandler::onBodyStart()
+{
+    m_section = m_writer->OnTagOpen(L"", L"body");
+    return m_section;
+}
+
+void odx_fb2TitleHandler::onTitleStart(int level, bool noSection)
+{
+    if( noSection )
+        odx_titleHandler::onTitleStart(level, true);
+    else {
+        if( m_titleLevel < level ) {
+            int startIndex = m_hasTitle ? 1 : 0;
+            int contentCount = m_section->getChildCount();
+            if(contentCount > startIndex)
+                makeSection(startIndex);
+        } else
+            closeSection(m_titleLevel - level + 1);
+        openSection(level);
+        m_writer->OnTagOpen(L"", L"title");
+        lString16 headingName = cs16("h") +  lString16::itoa(level);
+        if( m_useClassName ) {
+            m_writer->OnTagBody();
+            m_writer->OnTagOpen(L"", L"p");
+            m_writer->OnAttribute(L"", L"class", headingName.c_str());
+        } else {
+            m_writer->OnTagBody();
+            m_writer->OnTagOpen(L"", headingName.c_str());
+        }
+    }
+}
+
+void odx_fb2TitleHandler::onTitleEnd()
+{
+    if( !m_useClassName ) {
+        lString16 headingName = cs16("h") +  lString16::itoa(m_titleLevel);
+        m_writer->OnTagClose(L"", headingName.c_str());
+    } else
+        m_writer->OnTagClose(L"", L"p");
+
+    m_writer->OnTagClose(L"", L"title");
+    m_hasTitle = true;
+}
+
+void odx_fb2TitleHandler::makeSection(int startIndex)
+{
+    ldomNode *newSection = m_section->insertChildElement(startIndex, LXML_NS_NONE, el_section);
+    newSection->initNodeStyle();
+    m_section->moveItemsTo(newSection, startIndex + 1, m_section->getChildCount() - 1);
+    newSection->initNodeRendMethod( );
+    m_section = newSection;
+}
+
+void odx_fb2TitleHandler::openSection(int level)
+{
+    for(int i = m_titleLevel; i < level; i++) {
+        m_section = m_writer->OnTagOpen(L"", L"section");
+        m_writer->OnTagBody();
+    }
+    m_titleLevel = level;
+    m_hasTitle = false;
+}
+
+void odx_fb2TitleHandler::closeSection(int level)
+{
+    for(int i = 0; i < level; i++) {
+        m_writer->OnTagClose(L"", L"section");
+        m_titleLevel--;
+    }
+    m_hasTitle = false;
+}
+
+odx_rPr::odx_rPr() : odx_StylePropertiesContainer(odx_character_style)
+{
+}
+
+lString16 odx_rPr::getCss()
+{
+    lString16 style;
+
+    if( isBold() )
+        style << " font-weight: bold;";
+    if( isItalic() )
+        style << " font-style: italic;";
+    if( isUnderline() )
+        style << " text-decoration: underline;";
+    if( isStrikeThrough() )
+        style << " text-decoration: line-through;";
+    return style;
+}
+
+odx_pPr::odx_pPr() : odx_StylePropertiesContainer(odx_paragraph_style)
+{
+}
+
+lString16 odx_pPr::getCss()
+{
+    lString16 style;
+
+    css_text_align_t align = getTextAlign();
+    if(align != css_ta_inherit)
+    {
+        style << "text-align: ";
+        switch(align)
+        {
+        case css_ta_left:
+            style << "left;";
+            break;
+        case css_ta_right:
+            style << "right;";
+            break;
+        case css_ta_center:
+            style << "center;";
+            break;
+        case css_ta_justify:
+            style << "justify;";
+            break;
+        case css_ta_end:
+            style << "end;";
+            break;
+        case css_ta_start:
+            style << "start;";
+            break;
+        default:
+            style << "inherited;";
+            break;
+        }
+    }
+    if( isPageBreakBefore() )
+        style << "page-break-before: always;";
+    else if ( isKeepNext() )
+        style << "page-break-before: avoid;";
+    return style;
+}
+
+odx_Style::odx_Style() : m_type(odx_paragraph_style),
+    m_pPrMerged(false), m_rPrMerged(false)
+{
+}
+
+bool odx_Style::isValid() const
+{
+    return ( odx_invalid_style != m_type && !m_Id.empty() );
+}
+
+odx_Style *odx_Style::getBaseStyle(odx_ImportContext *context)
+{
+    lString16 basedOn = getBasedOn();
+    if ( !basedOn.empty() ) {
+        odx_Style *pStyle = context->getStyle(basedOn);
+        if( pStyle && pStyle->getStyleType() == getStyleType() )
+            return pStyle;
+    }
+    return NULL;
+}
+
+odx_pPr *odx_Style::get_pPr(odx_ImportContext *context)
+{
+    if( !m_pPrMerged ) {
+        odx_Style* pStyle = getBaseStyle(context);
+        if (pStyle ) {
+            m_pPr.combineWith(pStyle->get_pPr(context));
+        }
+        m_pPrMerged = true;
+    }
+    return &m_pPr;
+}
+
+odx_rPr *odx_Style::get_rPr(odx_ImportContext *context)
+{
+    if( !m_rPrMerged ) {
+        odx_Style* pStyle = getBaseStyle(context);
+        if (pStyle ) {
+            m_rPr.combineWith(pStyle->get_rPr(context));
+        }
+        m_rPrMerged = true;
+    }
+    return &m_rPr;
+}
+
+odx_StylePropertiesGetter *odx_Style::getStyleProperties(odx_ImportContext *context, odx_style_type styleType)
+{
+    switch(styleType) {
+    case odx_paragraph_style:
+        return get_pPr(context);
+    case odx_character_style:
+        return get_rPr(context);
+    default:
+        break;
+    }
+    return NULL;
+}
+
+void odx_ImportContext::addStyle(odx_StyleRef style)
+{
+    odx_Style *referenced = style.get();
+    if ( NULL != referenced)
+    {
+        m_styles.set(referenced->getId(), style);
+    }
+}
+
+void odx_ImportContext::setLanguage(const lChar16 *lang)
+{
+    lString16 language(lang);
+
+    int p = language.pos(cs16("-"));
+    if ( p > 0  ) {
+        language = language.substr(0, p);
+    }
+    m_doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
+}
+
+lString16 odx_ImportContext::getListStyleCss(css_list_style_type_t listType)
+{
+    switch(listType) {
+    case css_lst_disc:
+        return cs16("list-style-type: disc;");
+    case css_lst_circle:
+        return cs16("list-style-type: circle;");
+    case css_lst_square:
+        return cs16("list-style-type: square;");
+    case css_lst_decimal:
+        return cs16("list-style-type: decimal;");
+    case css_lst_lower_roman:
+        return cs16("list-style-type: lower-roman;");
+    case css_lst_upper_roman:
+        return cs16("list-style-type: upper-roman;");
+    case css_lst_lower_alpha:
+        return cs16("list-style-type: lower-alpha;");
+    case css_lst_upper_alpha:
+        return cs16("list-style-type: upper-alpha;");
+    default:
+        break;
+    }
+    return cs16("list-style-type: none;");
+}
+
+void odx_ImportContext::startDocument(ldomDocumentWriter &writer)
+{
+#ifdef DOCX_FB2_DOM_STRUCTURE
+    writer.OnStart(NULL);
+    writer.OnTagOpen(NULL, L"?xml");
+    writer.OnAttribute(NULL, L"version", L"1.0");
+    writer.OnAttribute(NULL, L"encoding", L"utf-8");
+    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagBody();
+    writer.OnTagClose(NULL, L"?xml");
+    writer.OnTagOpenNoAttr(NULL, L"FictionBook");
+    // DESCRIPTION
+    writer.OnTagOpenNoAttr(NULL, L"description");
+    writer.OnTagOpenNoAttr(NULL, L"title-info");
+    writer.OnTagOpenNoAttr(NULL, L"book-title");
+    writer.OnTagClose(NULL, L"book-title");
+    writer.OnTagClose(NULL, L"title-info");
+    writer.OnTagClose(NULL, L"description");
+#else
+    writer.OnStart(NULL);
+    writer.OnTagOpen(NULL, L"?xml");
+    writer.OnAttribute(NULL, L"version", L"1.0");
+    writer.OnAttribute(NULL, L"encoding", L"utf-8");
+    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagBody();
+    writer.OnTagClose(NULL, L"?xml");
+    writer.OnTagOpenNoAttr(NULL, L"html");
+#endif
+}
+
+void odx_ImportContext::endDocument(ldomDocumentWriter &writer)
+{
+#ifdef DOCX_FB2_DOM_STRUCTURE
+    writer.OnTagClose(NULL, L"FictionBook");
+#else
+    writer.OnTagClose(NULL, L"html");
+#endif
+}
+
+int odx_styleTagsHandler::styleTagPos(lChar16 ch)
+{
+    for (int i=0; i < m_styleTags.length(); i++)
+        if (m_styleTags[i] == ch)
+            return i;
+    return -1;
+}
+
+const lChar16 *odx_styleTagsHandler::getStyleTagName(lChar16 ch)
+{
+    switch ( ch ) {
+    case 'b':
+        return L"strong";
+    case 'i':
+        return L"em";
+    case 'u':
+        return L"u";
+    case 's':
+        return L"s";
+    case 't':
+        return L"sup";
+    case 'd':
+        return L"sub";
+    default:
+        return NULL;
+    }
+}
+
+void odx_styleTagsHandler::closeStyleTag(lChar16 ch, ldomDocumentWriter *writer)
+{
+    int pos = styleTagPos( ch );
+    if (pos >= 0) {
+        for (int i = m_styleTags.length() - 1; i >= pos; i--) {
+            const lChar16 * tag = getStyleTagName(m_styleTags[i]);
+            m_styleTags.erase(m_styleTags.length() - 1, 1);
+            if ( tag ) {
+                writer->OnTagClose(L"", tag);
+            }
+        }
+    }
+}
+
+void odx_styleTagsHandler::openStyleTag(lChar16 ch, ldomDocumentWriter *writer)
+{
+    int pos = styleTagPos( ch );
+    if (pos < 0) {
+        const lChar16 * tag = getStyleTagName(ch);
+        if ( tag ) {
+            writer->OnTagOpenNoAttr(L"", tag);
+            m_styleTags.append( 1,  ch );
+        }
+    }
+}
+
+void odx_styleTagsHandler::openStyleTags(odx_rPr *runProps, ldomDocumentWriter *writer)
+{
+    if(runProps->isBold())
+        openStyleTag('b', writer);
+    if(runProps->isItalic())
+        openStyleTag('i', writer);
+    if(runProps->isUnderline())
+        openStyleTag('u', writer);
+    if(runProps->isStrikeThrough())
+        openStyleTag('s', writer);
+    if(runProps->isSubScript())
+        openStyleTag('d', writer);
+    if(runProps->isSuperScript())
+        openStyleTag('t', writer);
+}
+
+void odx_styleTagsHandler::closeStyleTags(odx_rPr *runProps, ldomDocumentWriter *writer)
+{
+    if(!runProps->isBold())
+        closeStyleTag('b', writer);
+    if(!runProps->isItalic())
+        closeStyleTag('i', writer);
+    if(!runProps->isUnderline())
+        closeStyleTag('u', writer);
+    if(!runProps->isStrikeThrough())
+        closeStyleTag('s', writer);
+    if(!runProps->isSubScript())
+        closeStyleTag('d', writer);
+    if(!runProps->isSuperScript())
+        closeStyleTag('t', writer);
+}
+
+void odx_styleTagsHandler::closeStyleTags(ldomDocumentWriter *writer)
+{
+    for(int i = m_styleTags.length() - 1; i >= 0; i--)
+        closeStyleTag(m_styleTags[i], writer);
+    m_styleTags.clear();
+}

--- a/crengine/src/odxutil.h
+++ b/crengine/src/odxutil.h
@@ -1,0 +1,490 @@
+#include <lvxml.h>
+#include <lvtinydom.h>
+
+// build FB2 DOM, comment out to build HTML DOM
+#define DOCX_FB2_DOM_STRUCTURE 1
+//If true <title class="hx"><p>...</p></title> else <title><hx>..</hx></title>
+#define DOCX_USE_CLASS_FOR_HEADING true
+// comment this out to disable in-page footnotes
+#define ODX_CRENGINE_IN_PAGE_FOOTNOTES 1
+
+enum odx_style_type {
+    odx_invalid_style,
+    odx_paragraph_style,
+    odx_character_style,
+    odx_table_style,
+    odx_numbering_style
+};
+
+enum odx_lineRule_type {
+    odx_lineRule_atLeast,
+    odx_lineRule_auto,
+    odx_lineRule_exact
+};
+
+class odx_StylePropertiesGetter
+{
+public:
+    virtual css_length_t get(int index) const = 0;
+};
+
+class odx_Style;
+typedef LVFastRef< odx_Style > odx_StyleRef;
+
+class odx_ImportContext;
+
+template <int N>
+class odx_StylePropertiesContainer : public odx_StylePropertiesGetter
+{
+    odx_style_type m_styleType;
+    lString16 m_styleId;
+public:
+    static const int PROP_COUNT = N;
+
+    virtual void reset() {
+        init();
+        m_styleId.clear();
+    }
+
+    virtual ~odx_StylePropertiesContainer() {}
+
+    odx_StylePropertiesContainer(odx_style_type styleType) : m_styleType(styleType) {
+        init();
+    }
+
+    css_length_t get(int index) const {
+        if( index < N ) {
+            return m_properties[index];
+        }
+        return css_length_t(css_val_unspecified, 0);
+    }
+
+    void set(int index, int value) {
+        if ( index < N ) {
+            m_properties[index].type = css_val_pt;
+            m_properties[index].value = value;
+        }
+    }
+
+    void set(int index, css_length_t& value) {
+        if ( index < N ) {
+            m_properties[index] = value;
+        }
+    }
+
+    template<class T, typename U = void>
+    T getValue(int index, T defaultValue) const {
+        css_length_t property = get(index);
+        if(property.type != css_val_unspecified)
+            return (T)property.value;
+        return defaultValue;
+    }
+
+    template<typename U>
+    bool getValue(int index, bool defaultValue) const {
+        css_length_t property = get(index);
+        if(property.type != css_val_unspecified)
+            return (property.value != 0);
+        return defaultValue;
+    }
+
+    void combineWith(const odx_StylePropertiesGetter* other)
+    {
+        for(int i = 0; other && i < PROP_COUNT; i++) {
+            css_length_t baseValue = other->get(i);
+            if( get(i).type == css_val_unspecified &&
+                baseValue.type != css_val_unspecified)
+                set(i, baseValue);
+        }
+    }
+    void setStyleId(odx_ImportContext* context, const lChar16* styleId);
+    odx_Style* getStyle(odx_ImportContext* context);
+protected:
+    css_length_t m_properties[N];
+private:
+    void init() {
+        for(int i = 0; i < N; i++) {
+            m_properties[i].type = css_val_unspecified;
+            m_properties[i].value = 0;
+        }
+    }
+};
+
+
+enum odx_run_properties
+{
+    odx_run_italic_prop,
+    odx_run_bold_prop,
+    odx_run_underline_prop,
+    odx_run_strikethrough_prop,
+    odx_run_hidden_prop,
+    odx_run_halign_prop,
+    odx_run_valign_prop,
+    odx_run_font_size_prop,
+    odx_run_max_prop
+};
+
+class odx_rPr : public odx_StylePropertiesContainer<odx_run_max_prop>
+{
+public:
+    odx_rPr();
+    ///properties
+    inline bool isBold() const { return getValue(odx_run_bold_prop, false); }
+    inline void setBold(bool value) { set(odx_run_bold_prop, value); }
+    inline bool isItalic() const { return getValue(odx_run_italic_prop, false); }
+    inline void setItalic(bool value) { set(odx_run_italic_prop, value); }
+    inline bool isUnderline() const { return getValue(odx_run_underline_prop, false); }
+    inline void setUnderline(bool value) { set(odx_run_underline_prop, value); }
+    inline bool isStrikeThrough() const { return getValue(odx_run_strikethrough_prop, false); }
+    inline void setStrikeThrough(bool value) { set(odx_run_strikethrough_prop, value); }
+    inline bool isSubScript() const { return (getVertAlign() == css_va_sub);  }
+    inline bool isSuperScript() const { return (getVertAlign() == css_va_super); }
+    inline bool isHidden() const { return getValue(odx_run_hidden_prop, false); }
+    inline void setHidden(bool value) { set(odx_run_hidden_prop, value); }
+    inline css_text_align_t getTextAlign() const {
+        return getValue(odx_run_halign_prop, css_ta_inherit);
+    }
+    inline void setTextAlign( css_text_align_t value ) { set(odx_run_halign_prop, value); }
+    inline css_vertical_align_t getVertAlign() const {
+        return getValue(odx_run_valign_prop, css_va_inherit);
+    }
+    inline void setVertAlign(css_vertical_align_t value) { set(odx_run_valign_prop,value); }
+    lString16 getCss();
+};
+
+enum odx_p_properties {
+    odx_p_page_break_before_prop,
+    odx_p_keep_next_prop,
+    odx_p_mirror_indents_prop,
+    odx_p_halign_prop,
+    odx_p_valign_prop,
+    odx_p_line_rule_prop,
+    odx_p_hyphenate_prop,
+    odx_p_before_spacing_prop,
+    odx_p_after_spacing_prop,
+    odx_p_before_auto_spacing_prop,
+    odx_p_after_auto_spacing_prop,
+    odx_p_line_spacing_prop,
+    odx_p_line_height_prop,
+    odx_p_left_margin_prop,
+    odx_p_right_margin_prop,
+    odx_p_indent_prop,
+    odx_p_hanging_prop,
+    odx_p_outline_level_prop,
+    odx_p_num_id_prop,
+    odx_p_ilvl_prop,
+    odx_p_max_prop
+};
+
+class odx_pPr : public odx_StylePropertiesContainer<odx_p_max_prop>
+{
+public:
+    odx_pPr();
+
+    ///properties
+    inline css_text_align_t getTextAlign() const {
+        return getValue(odx_p_halign_prop, css_ta_inherit);
+    }
+    inline void setTextAlign( css_text_align_t value ) { set(odx_p_halign_prop, value); }
+    inline css_vertical_align_t getVertAlign() const {
+        return getValue(odx_p_valign_prop, css_va_inherit);
+    }
+    inline void setVertAlign(css_vertical_align_t value) { set(odx_p_valign_prop, value); }
+    inline css_hyphenate_t getHyphenate() const {
+        return getValue(odx_p_hyphenate_prop, css_hyph_inherit);
+    }
+    inline void setHyphenate( css_hyphenate_t value ) { set(odx_p_hyphenate_prop, value); }
+    // page-break-before:always
+    inline bool isPageBreakBefore() const { return getValue(odx_p_page_break_before_prop, false); }
+    inline void setPageBreakBefore(bool value) { set(odx_p_page_break_before_prop, value); }
+    // page-break-after:avoid
+    inline bool isKeepNext() const { return getValue(odx_p_keep_next_prop, false); }
+    inline void setKeepNext(bool value) { set(odx_p_keep_next_prop, value); }
+    inline bool isMirrorIndents() const { return getValue(odx_p_mirror_indents_prop, false); }
+    inline void setMirrorIndents(bool value) { set(odx_p_mirror_indents_prop, value); }
+    inline odx_lineRule_type getLineRule() const { return getValue(odx_p_line_rule_prop, odx_lineRule_auto); }
+    inline void setLineRule(odx_lineRule_type value) { set(odx_p_line_rule_prop, value); }
+    inline int getNumberingId() { return getValue(odx_p_num_id_prop, 0); }
+    css_length_t getOutlineLvl() { return get(odx_p_outline_level_prop); }
+    inline int getNumberingLevel() { return get(odx_p_ilvl_prop).value; }
+    lString16 getCss();
+};
+
+class odx_ImportContext
+{
+    LVHashTable<lString16, odx_StyleRef> m_styles;
+    odx_rPr m_rPrDefault;
+    odx_pPr m_pPrDefault;
+protected:
+    ldomDocument* m_doc;
+public:
+    odx_ImportContext(ldomDocument* doc) : m_styles(64), m_doc(doc) { }
+    virtual ~odx_ImportContext() {}
+    void addStyle( odx_StyleRef style );
+    odx_Style * getStyle( lString16 id ) {
+        return m_styles.get(id).get();
+    }
+    inline odx_rPr * get_rPrDefault() { return &m_rPrDefault; }
+    inline odx_pPr * get_pPrDefault() { return &m_pPrDefault; }
+    void setLanguage(const lChar16 *lang);
+    lString16 getListStyleCss(css_list_style_type_t listType);
+    void startDocument(ldomDocumentWriter& writer);
+    void endDocument(ldomDocumentWriter& writer);
+};
+
+class odx_Style : public LVRefCounter
+{
+    lString16 m_Name;
+    lString16 m_Id;
+    lString16 m_basedOn;
+    odx_style_type m_type;
+    odx_pPr m_pPr;
+    odx_rPr m_rPr;
+    bool m_pPrMerged;
+    bool m_rPrMerged;
+public:
+    odx_Style();
+
+    inline lString16 getName() const { return m_Name; }
+    inline void setName(const lChar16 * value) { m_Name = value; }
+
+    inline lString16 getId() const { return m_Id; }
+    inline void setId(const lChar16 * value) { m_Id = value; }
+
+    inline lString16 getBasedOn() const { return m_basedOn; }
+    inline void setBasedOn(const lChar16 * value) { m_basedOn = value; }
+    bool isValid() const;
+
+    inline odx_style_type getStyleType() const { return m_type; }
+    inline void setStyleType(odx_style_type value) { m_type = value; }
+    odx_Style* getBaseStyle(odx_ImportContext* context);
+    odx_pPr * get_pPr(odx_ImportContext* context);
+    odx_rPr * get_rPr(odx_ImportContext* context);
+    inline odx_pPr * get_pPrPointer() { return &m_pPr; }
+    inline odx_rPr * get_rPrPointer() { return &m_rPr; }
+    odx_StylePropertiesGetter* getStyleProperties(odx_ImportContext* context,
+                                                  odx_style_type styleType);
+};
+
+template<int N>
+void odx_StylePropertiesContainer<N>::setStyleId(odx_ImportContext *context, const lChar16 *styleId) {
+    m_styleId = styleId;
+    if ( !m_styleId.empty() ) {
+        odx_Style *style = context->getStyle(m_styleId);
+        if( style && (m_styleType == style->getStyleType()) ) {
+            combineWith(style->getStyleProperties(context, m_styleType));
+        }
+    }
+}
+
+template<int N>
+odx_Style *odx_StylePropertiesContainer<N>::getStyle(odx_ImportContext *context) {
+    odx_Style* ret = NULL;
+
+    if (!m_styleId.empty() ) {
+        ret = context->getStyle(m_styleId);
+    }
+    return ret;
+}
+
+/// known docx items name and identifier
+struct item_def_t {
+    int      id;
+    const lChar16 * name;
+};
+
+class xml_ElementHandler;
+
+class docXMLreader : public LVXMLParserCallback
+{
+private:
+    enum xml_doc_reader_state {
+        xml_doc_in_start,
+        xml_doc_in_xml_declaration,
+        xml_doc_in_body,
+        xml_doc_in_document
+    };
+    int m_skipTag;
+    xml_doc_reader_state m_state;
+protected:
+    xml_ElementHandler *m_handler;
+    ldomDocumentWriter *m_writer;
+
+    inline bool isSkipping()
+    {
+        return (m_skipTag != 0);
+    }
+
+    inline void skipped()
+    {
+        m_skipTag--;
+    }
+
+public:
+    /// constructor
+    docXMLreader(ldomDocumentWriter *writer) : m_skipTag(0), m_state(xml_doc_in_start),
+        m_handler(NULL), m_writer(writer)
+    {
+    }
+
+    /// destructor
+    virtual ~docXMLreader() { }
+    /// called on parsing start
+    virtual void OnStart(LVFileFormatParser *);
+    /// called on parsing end
+    virtual void OnStop() {  }
+
+    inline void skip()
+    {
+        m_skipTag++;
+    }
+
+    /// called on opening tag <
+    ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname);
+
+    /// called after > of opening tag (when entering tag body)
+    void OnTagBody();
+
+    /// called on tag close
+    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+
+    /// called on element attribute
+    void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
+
+    /// called on text
+    void OnText( const lChar16 * text, int len, lUInt32 flags );
+
+    /// add named BLOB data to document
+    bool OnBlob(lString16 name, const lUInt8 * data, int size);
+
+    xml_ElementHandler * getHandler()
+    {
+        return m_handler;
+    }
+
+    void setHandler(xml_ElementHandler *a_handler)
+    {
+        m_handler = a_handler;
+    }
+
+    void setWriter(ldomDocumentWriter *writer)
+    {
+        m_writer = writer;
+    }
+};
+
+class xml_ElementHandler
+{
+protected:
+    docXMLreader * m_reader;
+    ldomDocumentWriter *m_writer;
+    xml_ElementHandler *m_savedHandler;
+    const item_def_t *m_children;
+    int m_element;
+    int m_state;
+protected:
+    xml_ElementHandler(docXMLreader * reader, ldomDocumentWriter *writer,
+                       int element, const struct item_def_t *children) :
+        m_reader(reader), m_writer(writer), m_children(children), m_element(element),
+        m_state(element)
+    {
+    }
+    virtual ~xml_ElementHandler() {}
+    virtual int parseTagName(const lChar16 *tagname) {
+        if(m_children)
+            return parse_name(m_children, tagname);
+        return -1;
+    }
+public:
+    static int parse_name(const struct item_def_t *tags, const lChar16 * nameValue);
+    static void parse_int(const lChar16 * attrValue, css_length_t & result);
+    void setChildrenInfo(const struct item_def_t *tags);
+    ldomNode * handleTagOpen(const lChar16 * nsname, const lChar16 * tagname);
+    virtual ldomNode * handleTagOpen(int tagId);
+    void handleAttribute(const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue)
+    {
+        CR_UNUSED(nsname);
+
+        handleAttribute(attrname, attrvalue);
+    }
+    virtual void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue) {
+        CR_UNUSED2(attrname, attrvalue);
+    }
+    virtual void handleTagBody() {}
+    virtual void handleText( const lChar16 * text, int len, lUInt32 flags ) {
+        CR_UNUSED3(text,len,flags);
+    }
+    virtual void handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    {
+        CR_UNUSED2(nsname, tagname);
+
+        if(m_state == m_element)
+            stop();
+        else
+            m_state = m_element;
+    }
+    virtual void start();
+    virtual void stop();
+    virtual void reset();
+};
+
+class xml_SkipElementHandler : public xml_ElementHandler
+{
+public:
+    xml_SkipElementHandler(docXMLreader * reader, ldomDocumentWriter *writer,
+                           int element) : xml_ElementHandler(reader, writer, element, NULL) {}
+    void skipElement(int element) {
+        m_state = element;
+        start();
+    }
+};
+
+class odx_styleTagsHandler
+{
+    lString16 m_styleTags;
+    int styleTagPos(lChar16 ch);
+protected:
+    const lChar16 * getStyleTagName( lChar16 ch );
+    void closeStyleTag( lChar16 ch, ldomDocumentWriter *writer);
+    void openStyleTag(lChar16 ch, ldomDocumentWriter *writer);
+public:
+    odx_styleTagsHandler() {}
+    void openStyleTags(odx_rPr* runProps, ldomDocumentWriter *writer);
+    void closeStyleTags(odx_rPr* runProps, ldomDocumentWriter *writer);
+    void closeStyleTags(ldomDocumentWriter *writer);
+};
+
+class odx_titleHandler
+{
+public:
+    odx_titleHandler(ldomDocumentWriter *writer, bool useClassName=false) :
+        m_writer(writer), m_titleLevel(), m_useClassName(useClassName) {}
+    virtual ~odx_titleHandler() {}
+    virtual ldomNode* onBodyStart();
+    virtual void onTitleStart(int level, bool noSection = false);
+    virtual void onTitleEnd();
+    virtual void onBodyEnd() {}
+    bool useClassForTitle() { return m_useClassName; }
+protected:
+    ldomDocumentWriter *m_writer;
+    int m_titleLevel;
+    bool m_useClassName;
+};
+
+class odx_fb2TitleHandler : public odx_titleHandler
+{
+public:
+    odx_fb2TitleHandler(ldomDocumentWriter *writer, bool useClassName) :
+        odx_titleHandler(writer, useClassName), m_hasTitle(false)
+    {}
+    ldomNode* onBodyStart();
+    void onTitleStart(int level, bool noSection = false);
+    void onTitleEnd();
+private:
+    void makeSection(int startIndex);
+    void openSection(int level);
+    void closeSection(int level);
+private:
+    ldomNode *m_section;
+    bool m_hasTitle;
+};

--- a/crengine/src/odxutil.h
+++ b/crengine/src/odxutil.h
@@ -8,6 +8,13 @@
 // comment this out to disable in-page footnotes
 #define ODX_CRENGINE_IN_PAGE_FOOTNOTES 1
 
+// Upstream made things ready for us: we just have to undef
+// the above to have a HTML DOM with classic headings, that
+// can be tweaked with style tweaks, and popup and in-page
+// footnotes also toggable with style tweaks.
+#undef DOCX_FB2_DOM_STRUCTURE
+#undef ODX_CRENGINE_IN_PAGE_FOOTNOTES
+
 enum odx_style_type {
     odx_invalid_style,
     odx_paragraph_style,


### PR DESCRIPTION
Adds support for ODT documents (OpenDocument Format), by @pkb, from:
https://github.com/buggins/coolreader/pull/164
https://github.com/buggins/coolreader/pull/165
https://github.com/buggins/coolreader/pull/168 (5th commit)

(I haven't digged into the code :/ I have just checked it works quite well :)

Closes #367.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/377)
<!-- Reviewable:end -->
