### PR TITLE
Various small fixes: rendered widths, table head/foot re-orderning

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -56,8 +56,7 @@ blockquote:dir(rtl) {
     margin-right: 2em;
 }
 hr {
-    height: 2px;
-    background-color: #808080;
+    border: 1px solid #808080;
     margin: 0.5em auto;
 }
 center {

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -24,6 +24,7 @@ stanza + stanza { margin-top: 1em; }
 stanza { margin-left: 15%; text-align: left; font-style: italic  }
 poem { margin-top: 1em; margin-bottom: 1em; text-indent: 0px }
 text-author { font-weight: bold; font-style: italic; margin-left: 5%}
+date { font-style: italic; margin-left: 5% }
 epigraph { margin-left: 15%; margin-right: 1em; text-align: left; text-indent: 1em; font-style: italic; margin-top: 15px; margin-bottom: 25px }
 cite { display: block; font-style: italic; margin-left: 5%; margin-right: 5%; text-align: justify; margin-top: 20px; margin-bottom: 20px }
 style { display: inline; }
@@ -116,7 +117,7 @@ body[name="comments"] section title {
 description { display: block; }
 title-info { display: block; }
 annotation { margin-left: 5%; margin-right: 5%; font-size: 80%; font-style: italic; text-align: justify; text-indent: 1em }
-date { display: block; font-size: 80%; font-style: italic; text-align: center }
+description date  { font-size: 80%; text-align: center }
 genre { display: none; }
 author { display: none; }
 book-title { display: none; }

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -37,6 +37,7 @@
 #define RENDER_RECT_FLAG_FINAL_FOOTPRINT_AS_SAVED_FLOAT_IDS 0x0040
 #define RENDER_RECT_FLAG_FLOATBOX_IS_RIGHT                  0x0080
 #define RENDER_RECT_FLAG_NO_INTERLINE_SCALE_UP              0x0100 // for ruby elements to not scale up
+#define RENDER_RECT_FLAG_CHILDREN_RENDERING_REORDERED       0x0200 // for table rows/thead/tfoot reordering
 #define RENDER_RECT_FLAG_TEMP_USED_AS_CSS_CHECK_CACHE       0x8000 // has been cleared and is used as a CSS checks cache
 
 #define RENDER_RECT_SET_FLAG(r, f)     ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1013,7 +1013,7 @@ public:
 
 #if BUILD_LITE!=1
     /// find node by coordinates of point in formatted document
-    ldomNode * elementFromPoint( lvPoint pt, int direction );
+    ldomNode * elementFromPoint( lvPoint pt, int direction, bool strict_bounds_checking=false );
     /// find final node by coordinates of point in formatted document
     ldomNode * finalBlockFromPoint( lvPoint pt );
 #endif

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9616,7 +9616,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 int _maxw = 0;
                 int _minw = 0;
                 getRenderedWidths(node, _maxw, _minw, direction, false, rendFlags);
-                maxWidth += _maxw;
+                curMaxWidth += _maxw;
                 if (_minw > minWidth)
                     minWidth = _minw;
                 return;
@@ -9820,6 +9820,10 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                                     // we might find some text nodes here.
                                     continue;
                                 }
+                                if ( child->getRendMethod() == erm_invisible ) {
+                                    // Ignore invisible nodes (like "<rp>(</rp>" inside <ruby>)
+                                    continue;
+                                }
                                 int _maxw = 0;
                                 int _minw = 0;
                                 int _curMaxWidth = 0;
@@ -9917,6 +9921,13 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                  _maxWidth = columns_max_width;
             if ( _maxWidth < cumulative_max_width )
                  _maxWidth = cumulative_max_width;
+            // add horizontal border_spacing if "border-collapse: separate"
+            if ( style->border_collapse != css_border_collapse ) {
+                int em = node->getFont()->getSize();
+                int extra_width = lengthToPx(style->border_spacing[0], 0, em) * (nb_columns+1);
+                _minWidth += extra_width;
+                _maxWidth += extra_width;
+            }
             #ifdef DEBUG_GETRENDEREDWIDTHS
                 printf("GRW table: min %d %d > %d    max %d %d > %d\n", columns_min_width, cumulative_min_width,
                          _minWidth, columns_max_width, cumulative_max_width, _maxWidth);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -218,6 +218,7 @@ public:
 class CCRTableRowGroup {
 public:
     int index;
+    int kind; // erm_table_header_group, erm_table_row_group or erm_table_footer_group
     int height;
     int y;
     ldomNode * elem;
@@ -328,6 +329,7 @@ public:
     bool avoid_pb_inside;
     bool enhanced_rendering;
     bool is_ruby_table;
+    bool rows_rendering_reordered;
     ldomNode * elem;
     ldomNode * caption;
     int caption_h;
@@ -408,6 +410,7 @@ public:
                         currentRowGroup = new CCRTableRowGroup();
                         currentRowGroup->elem = item;
                         currentRowGroup->index = rowgroups.length();
+                        currentRowGroup->kind = rendMethod;
                         rowgroups.add( currentRowGroup );
                         LookupElem( item, item_direction, 0 );
                         currentRowGroup = NULL;
@@ -588,6 +591,104 @@ public:
             }
         }
         return 0;
+    }
+
+    void FixRowGroupsOrder() {
+        if ( !enhanced_rendering )
+            return;
+        if ( rowgroups.length() == 0 )
+            return;
+
+        // THEAD TBODY/TR TFOOT usually comes in this logical order,
+        // but with CSS, "display:table-header-group" might be used
+        // to render some element above others even if it is after
+        // them in the DOM.
+        // (This is done by the MathML CSS profile, for example with
+        // <msup>, to render the superscript in a top table row).
+        //
+        // Note that Firefox only moves the *first* table-header-group and
+        // the *first* table-footer-group met.
+        // https://www.w3.org/TR/CSS2/tables.html#table-display says the same:
+        //   "If a table contains multiple elements with 'display: table-header-group',
+        //    only the first is rendered as a header; the others are treated as if they
+        //    had 'display: table-row-group'. "
+        // So, we will handle only the first ones met.
+        //
+        // (At this point, row->index have not yet been set, so
+        // we have just 'rowgroups' and 'rows' arrays, that we
+        // can just re-order without any other fix.)
+        //
+        // This might cause some issues if the reordered things contain
+        // some rowspan/colspan crossing row groups... Firefox limits
+        // the rowspan effect to inside each table group, but we don't
+        // do that. Hopefully, this kind of HTML error must be rare.
+
+        // Look for the first erm_table_header_group
+        for ( int i=0; i < rowgroups.length(); i++ ) {
+            if ( rowgroups[i]->kind == erm_table_header_group ) {
+                CCRTableRowGroup * first_header_group = rowgroups[i];
+                if ( i > 0 ) {
+                    // It is not first in rowgroups: move it at start
+                    rowgroups.move(0, i); // move(indexTo, indexFrom)
+                    rows_rendering_reordered = true;
+                }
+                // Even if this group was first among groups, we may have
+                // before its rows other table-rows not part of any group:
+                // we need to move the rows part of this rowgroup before
+                // all other rows.
+                bool group_met = false;
+                int dest_idx = 0;
+                for ( int j=0; j < rows.length(); j++ ) {
+                    if ( rows[j]->rowgroup == first_header_group ) {
+                        if ( j != dest_idx ) {
+                            rows.move(dest_idx, j); // move(indexTo, indexFrom)
+                            rows_rendering_reordered = true;
+                            dest_idx++;
+                        }
+                        group_met = true;
+                    }
+                    else if ( group_met ) {
+                        // Not a row part of first_header_group: we moved
+                        // all its rows, we're done.
+                        break;
+                    }
+                }
+                break; // Only deal with the first one met
+            }
+        }
+        // Look for the first erm_table_footer_group
+        for ( int i=0; i < rowgroups.length(); i++ ) {
+            if ( rowgroups[i]->kind == erm_table_footer_group ) {
+                CCRTableRowGroup * first_footer_group = rowgroups[i];
+                if ( i < rowgroups.length()-1 ) {
+                    // It is not last in rowgroups: move it at end
+                    rowgroups.move(rowgroups.length()-1, i); // move(indexTo, indexFrom)
+                    rows_rendering_reordered = true;
+                }
+                // Even if this group was last among groups, we may have
+                // after its rows other table-rows not part of any group:
+                // we need to move the rows part of this rowgroup after
+                // all other rows.
+                bool group_met = false;
+                int dest_idx = rows.length()-1;
+                for ( int j=rows.length()-1; j >= 0; j-- ) {
+                    if ( rows[j]->rowgroup == first_footer_group ) {
+                        if ( j != dest_idx ) {
+                            rows.move(dest_idx, j); // move(indexTo, indexFrom)
+                            rows_rendering_reordered = true;
+                        }
+                        dest_idx--;
+                        group_met = true;
+                    }
+                    else if ( group_met ) {
+                        // Not a row part of first_footer_group: we moved
+                        // all its rows, we're done.
+                        break;
+                    }
+                }
+                break; // Only deal with the first one met
+            }
+        }
     }
 
     // More or less complex algorithms to calculate column widths are described at:
@@ -2044,17 +2145,28 @@ public:
         avoid_pb_inside = tbl_avoid_pb_inside;
         enhanced_rendering = tbl_enhanced_rendering;
         is_ruby_table = tbl_is_ruby_table;
+        rows_rendering_reordered = false;
         #ifdef DEBUG_TABLE_RENDERING
             printf("TABLE: ============ parsing new table %s\n",
                 UnicodeToLocal(ldomXPointer(elem, 0).toString()).c_str());
         #endif
         LookupElem( tbl_elem, direction, 0 );
+        FixRowGroupsOrder();
         if ( is_ruby_table && rows.length() >= 2 ) {
             // Move 2nd row (first ruby annotation) to 1st position,
             // so base ruby text (initially 1st row) becomes 2nd
             rows.move(0, 1);
+            rows_rendering_reordered = true;
         }
         PlaceCells();
+        if ( enhanced_rendering && rows_rendering_reordered ) {
+            // printf("table rows re-ordered: %s\n", UnicodeToLocal(ldomXPointer(elem, 0).toString()).c_str());
+            RenderRectAccessor fmt( elem );
+            RENDER_RECT_SET_FLAG(fmt, CHILDREN_RENDERING_REORDERED);
+            if ( !is_ruby_table ) { // don't show this warning as it's expected with ruby
+                elem->getDocument()->printWarning("table rows/thead/tfoot re-ordered", 2);
+            }
+        }
     }
 };
 
@@ -6845,6 +6957,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // like it does not really need to.
                 int h = renderTable( *(flow->getPageContext()), enode, 0, flow->getCurrentRelativeY(),
                             table_width, table_shrink_to_fit, fitted_width, direction, avoid_pb_inside, true, is_ruby_table );
+                // Reload fmt, as renderTable() may have set some flags
+                fmt = RenderRectAccessor( enode );
                 // (It feels like we don't need to ensure a table specified height.)
                 fmt.setHeight( h );
                 // Update table width if it was fitted/shrunk

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1072,8 +1072,8 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
     // declaration, but, as we don't support all those from the
     // specs, we'll just ignore the tokens we don't support.
     // We parse the original content into a "parsed content" string,
-    // consisting of a first letter, indicating its type, and if
-    // some data: its length and that data.
+    // consisting of a first letter, indicating its type, and if some
+    // data: its length (+1 to avoid NULLs in strings) and that data.
     // parsed_content may contain multiple values, in the format
     //   'X' for 'none' (or 'normal', = none with pseudo elements)
     //   's' + <len> + string16 (string content) for ""
@@ -1139,7 +1139,7 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
                     lString16 attr = Utf8ToUnicode(attr8);
                     attr.trim();
                     parsed_content << L'a';
-                    parsed_content << lChar16(attr.length());
+                    parsed_content << lChar16(attr.length() + 1); // (+1 to avoid storing \x00)
                     parsed_content << attr;
                     continue;
                 }
@@ -1228,7 +1228,7 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
             if ( *str == quote_ch ) {
                 lString16 str16 = Utf8ToUnicode(str8);
                 parsed_content << L's';
-                parsed_content << lChar16(str16.length());
+                parsed_content << lChar16(str16.length() + 1); // (+1 to avoid storing \x00)
                 parsed_content << str16;
                 str++;
                 continue;
@@ -1317,12 +1317,12 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
     while ( i < parsed_content_len ) {
         lChar16 ctype = parsed_content[i];
         if ( ctype == 's' ) { // literal string: copy as-is
-            lChar16 len = parsed_content[i];
+            lChar16 len = parsed_content[i] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }
         else if ( ctype == 'a' ) { // attribute value: copy as-is
-            lChar16 len = parsed_content[i];
+            lChar16 len = parsed_content[i] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }
@@ -1368,12 +1368,12 @@ lString16 get_applied_content_property( ldomNode * node ) {
     while ( i < parsed_content_len ) {
         lChar16 ctype = parsed_content[i++];
         if ( ctype == 's' ) { // literal string
-            lChar16 len = parsed_content[i++];
+            lChar16 len = parsed_content[i++] - 1; // (remove added +1)
             res << parsed_content.substr(i, len);
             i += len;
         }
         else if ( ctype == 'a' ) { // attribute value
-            lChar16 len = parsed_content[i++];
+            lChar16 len = parsed_content[i++] - 1; // (remove added +1)
             lString16 attr_name = parsed_content.substr(i, len);
             i += len;
             ldomNode * attrNode = node;
@@ -3189,9 +3189,11 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             {
                 int l = *p++;
                 lString16 content;
-                content.reserve(l);
-                for (int i=0; i<l; i++)
-                    content << (lChar16)(*p++);
+                if ( l > 0 ) {
+                    content.reserve(l);
+                    for (int i=0; i<l; i++)
+                        content << (lChar16)(*p++);
+                }
                 style->Apply( content, &style->content, imp_bit_content, is_important );
             }
             break;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13285,11 +13285,11 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
                 }
             }
             if ( (tag_id >= EL_IN_HEAD_START && tag_id <= EL_IN_HEAD_END) || tag_id == el_noscript ) {
+                _headTagSeen = true;
                 if ( tag_id != el_head ) {
                     OnTagOpen(L"", L"head");
                     OnTagBody();
                 }
-                _headTagSeen = true;
             }
             curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
         }
@@ -13299,13 +13299,14 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // end of <head> and start of <body>
             if ( _headTagSeen )
                 OnTagClose(L"", L"head");
+            else
+                _headTagSeen = true; // We won't open any <head> anymore
+            _bodyTagSeen = true;
             if ( tag_id != el_body ) {
                 OnTagOpen(L"", L"body");
                 OnTagBody();
             }
             curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
-            _bodyTagSeen = true;
-            _headTagSeen = true; // We won't open any <head> anymore
         }
     }
     if ( step == PARSER_STEP_TEXT ) // new text: nothing more to do

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10268,11 +10268,31 @@ bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool rever
         if (!start.isNull())
             break;
     }
+    if (start.isNull()) {
+        // If none found (can happen when minY=0 and blank content at start
+        // of document like a <br/>), scan forward from document start
+        for (int y = 0; y <= fh; y++) {
+            start = createXPointer( lvPoint(0, y), reverse ? PT_DIR_SCAN_BACKWARD_LOGICAL_FIRST
+                                                           : PT_DIR_SCAN_FORWARD_LOGICAL_FIRST );
+            if (!start.isNull())
+                break;
+        }
+    }
     for (int y = maxY; y <= fh; y++) {
         end = createXPointer( lvPoint(10000, y), reverse ? PT_DIR_SCAN_BACKWARD_LOGICAL_LAST
                                                          : PT_DIR_SCAN_FORWARD_LOGICAL_LAST );
         if (!end.isNull())
             break;
+    }
+    if (end.isNull()) {
+        // If none found (can happen when maxY=fh and blank content at end
+        // of book like a <br/>), scan backward from document end
+        for (int y = fh; y >= 0; y--) {
+            end = createXPointer( lvPoint(10000, y), reverse ? PT_DIR_SCAN_BACKWARD_LOGICAL_LAST
+                                                             : PT_DIR_SCAN_FORWARD_LOGICAL_LAST );
+            if (!end.isNull())
+                break;
+        }
     }
 
     if ( start.isNull() || end.isNull() )

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -87,7 +87,7 @@ int gDOMVersionRequested     = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.50k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.51k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -16897,7 +16897,7 @@ ldomNode * ldomNode::getLastTextChild()
 
 #if BUILD_LITE!=1
 /// find node by coordinates of point in formatted document
-ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
+ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction, bool strict_bounds_checking )
 {
     ASSERT_NODE_NOT_NULL;
     if ( !isElement() )
@@ -16935,7 +16935,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
     RenderRectAccessor fmt( this );
 
     if ( BLOCK_RENDERING_G(ENHANCED) ) {
-        // In enhanced rendering mode, because of collpasing of vertical margins
+        // In enhanced rendering mode, because of collapsing of vertical margins
         // and the fact that we did not update style margins to their computed
         // values, a children box with margins can overlap its parent box, if
         // the child bigger margin collapsed with the parent smaller margin.
@@ -16999,6 +16999,19 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
                 // Float starts after pt.y: next non-float siblings may contain pt.y
                 return NULL;
             }
+            // When children of the parent node have been re-ordered, we can't
+            // trust the ordering, and if pt.y is before fmt.getY(), we might
+            // still find it in a next node that have been re-ordered before
+            // this one for rendering.
+            // Note: for now, happens only with re-ordered table rows, so
+            // we're only ensuring it here for y. This check might have to
+            // also be done elsewhere in this function when we use it for
+            // other things.
+            if ( strict_bounds_checking && pt.y < fmt.getY() ) {
+                // Box fully after pt.y: not a candidate, next one
+                // (if reordered) may be
+                return NULL;
+            }
             // pt.y is inside the box (without overflows), go on with it.
             // Note: we don't check for next elements which may have a top
             // overflow and have pt.y inside it, because it would be a bit
@@ -17008,7 +17021,12 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
         else { // PT_DIR_SCAN_BACKWARD*
             // We get the parent node's children in descending order
             if ( pt.y < fmt.getY() ) {
-                // Box fully before pt.y: not a candidate, next one may be
+                // Box fully after pt.y: not a candidate, next one may be
+                return NULL;
+            }
+            if ( strict_bounds_checking && pt.y >= fmt.getY() + fmt.getHeight() ) {
+                // Box fully before pt.y: not a candidate, next one
+                // (if reordered) may be
                 return NULL;
             }
         }
@@ -17078,17 +17096,18 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction )
     // Not a final node, but a block container node that must contain
     // the final node we look for: check its children.
     int count = getChildCount();
+    strict_bounds_checking = RENDER_RECT_HAS_FLAG(fmt, CHILDREN_RENDERING_REORDERED);
     if ( direction >= PT_DIR_EXACT ) { // PT_DIR_EXACT or PT_DIR_SCAN_FORWARD*
         for ( int i=0; i<count; i++ ) {
             ldomNode * p = getChildNode( i );
-            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction );
+            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction, strict_bounds_checking );
             if ( e )
                 return e;
         }
     } else {
         for ( int i=count-1; i>=0; i-- ) {
             ldomNode * p = getChildNode( i );
-            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction );
+            ldomNode * e = p->elementFromPoint( lvPoint(pt.x-fmt.getX(), pt.y-fmt.getY()), direction, strict_bounds_checking );
             if ( e )
                 return e;
         }

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5580,9 +5580,25 @@ bool LVXMLParser::ReadText()
         if ( m_read_buffer_pos + 1 >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
                 m_eof = true;
-                return false;
+                bool done = true;
+                if ( tlen > 0 ) {
+                    // We still have some text in m_txt_buf to handle.
+                    // But ignore it if empty space
+                    done = true;
+                    for (int i=0; i<m_txt_buf.length(); i++) {
+                        lChar16 ch = m_txt_buf[i];
+                        if ( ch!=' ' && ch!='\r' && ch!='\n' && ch!='\t') {
+                            done = false;
+                            flgBreak = true;
+                            break;
+                        }
+                    }
+                }
+                if ( done )
+                    return false;
             }
         }
+      if ( !m_eof ) { // just skip the following if m_eof but still some text in buffer to handle
         for ( ; m_read_buffer_pos+i<m_read_buffer_len; i++ ) {
             lChar16 ch = m_read_buffer[m_read_buffer_pos + i];
             lChar16 nextch = m_read_buffer_pos + i + 1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 1] : 0;
@@ -5616,6 +5632,7 @@ bool LVXMLParser::ReadText()
             m_txt_buf.append( m_read_buffer + m_read_buffer_pos, i );
             m_read_buffer_pos += i;
         }
+      }
         if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas)
         {
             //=====================================================


### PR DESCRIPTION
#### `epub.css: update HR default style`
Should allow closing https://github.com/koreader/koreader/issues/6632.

#### `fb2.css: keep <date> in main text left-aligned`
See https://github.com/koreader/koreader/issues/6622#issuecomment-686292173

#### `getRenderedWidths(): inline-block and table fixes`
Fix some possible issues with RUBY that would have blank in between or on the sides because of too large estimated widths.

Before | after:
<kbd>![image](https://user-images.githubusercontent.com/24273478/93483385-0ad16500-f901-11ea-8453-3e3798708733.png)</kbd> <kbd>![image](https://user-images.githubusercontent.com/24273478/93483030-a7473780-f900-11ea-8f18-d88eff1bc0ac.png)</kbd>

Also fixe some issues with [the ugly rendering while playing with the MathML CSS handling](https://github.com/koreader/koreader/issues/6346#issuecomment-653774141).

#### `CSS: avoid style hash mismatch when serializing content:''`
Noticed while playing with that MathML CSS handling styletweak on the big EPUB full of MathML from https://github.com/koreader/koreader/issues/4381.

#### `Tables: re-order row groups when necessary`
With the following HTML snippet, head1 should be shown above cell1, so rendering in a different order than in the DOM.
```html
<table>
<tr><td>cell1</td></tr>
<thead><tr><td>head1</td></tr></thead>
</table>
```
Noticed while trying to understand why this MathML snippet rendered via CSS was displaying the power of 2 below :) : 
```html
<math><msup><mrow><mi>b</mi></mrow> <mn>2</mn> </msup> <mo>=</mo> <mrow><mi>b</mi></mrow></math>
```
<kbd>![image](https://user-images.githubusercontent.com/24273478/93481928-6ef32980-f8ff-11ea-899a-b63a1185e8fc.png)</kbd>
Because `<msup>` CSS handling use a trick of setting the second child `display:table-header-group
` so it's moved above what precedes it in in the DOM.
With this fix, we'll get:
<kbd>![image](https://user-images.githubusercontent.com/24273478/93482330-e1fca000-f8ff-11ea-9d46-8171604f95e0.png)</kbd>


#### `XML parsing: don't drop trailing text`
Some text in valid HTML documents would not be made part of the DOM, like with:
```html
<!DOCTYPE html>
This is some long text as we need 32 bytes.
```
or
```html
<!DOCTYPE html>
<body>
This would be shown
<p>This would not be shown
```
Not super familiar with that code, but I hope I got that right :/
I wrapped some bit with a misindented `if { ... }` to not indent the huge block I didn't touch and not make a diff more frightening that what I actually did.

#### `HTML parser: tweak implicit head/body insertion code`
Attempt at avoiding unexplainable https://github.com/buggins/coolreader/issues/170#issuecomment-693347145

#### `Fix text search failure when blank at start or end`
Should allow closing https://github.com/koreader/koreader/issues/6672.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/379)
<!-- Reviewable:end -->
