### PR TITLE
(Upstream) replace global variables, some legacy text rendering fixes

### DIFF
--- a/crengine/include/fb3fmt.h
+++ b/crengine/include/fb3fmt.h
@@ -3,8 +3,26 @@
 
 #include "../include/crsetup.h"
 #include "../include/lvtinydom.h"
+#include "../include/lvopc.h"
 
 bool DetectFb3Format( LVStreamRef stream );
 bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback );
+
+class fb3ImportContext
+{
+private:
+    OpcPackage *m_package;
+    OpcPartRef m_bookPart;
+    ldomDocument *m_descDoc;
+public:
+    fb3ImportContext(OpcPackage *package);
+    virtual ~fb3ImportContext();
+
+    lString16 geImageTarget(const lString16 relationId);
+    LVStreamRef openBook();
+    ldomDocument *getDescription();
+public:
+    lString16 m_coverImage;
+};
 
 #endif // FB3FMT_H

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -788,7 +788,7 @@ public:
     LVStreamRef getCoverPageImageStream();
 
     /// returns bookmark
-    ldomXPointer getBookmark();
+    ldomXPointer getBookmark( bool precise = true );
     /// returns bookmark for specified page
     ldomXPointer getPageBookmark( int page );
     /// sets current bookmark

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -766,6 +766,10 @@ public:
             return number.atoi();
         return 0;
     }
+    /// returns book content CRC32
+    lUInt32 getFileCRC32() {
+        return (lUInt32)m_doc_props->getIntDef(DOC_PROP_FILE_CRC32, 0);
+    }
 
     /// export to WOL format
     bool exportWolFile( const char * fname, bool flgGray, int levels );

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -82,6 +82,7 @@
 #define PROP_RENDER_DPI                 "crengine.render.dpi"
 #define PROP_RENDER_SCALE_FONT_WITH_DPI "crengine.render.scale.font.with.dpi"
 #define PROP_RENDER_BLOCK_RENDERING_FLAGS "crengine.render.block.rendering.flags"
+#define PROP_REQUESTED_DOM_VERSION      "crengine.render.requested_dom_version"
 
 #define PROP_CACHE_VALIDATION_ENABLED  "crengine.cache.validation.enabled"
 #define PROP_MIN_FILE_SIZE_TO_CACHE  "crengine.cache.filesize.min"

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -178,7 +178,6 @@ extern int gRootFontSize;
 
 #define INTERLINE_SCALE_FACTOR_NO_SCALE 1024
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
-extern int gInterlineScaleFactor;
 
 // Enhanced rendering flags
 #define BLOCK_RENDERING_ENHANCED                           0x00000001

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -127,12 +127,12 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
                        int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL );
-/// renders block which contains subblocks (with gRenderBlockRenderingFlags as flags)
+/// renders block which contains subblocks (with enode document's getRenderBlockRenderingFlags() as flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
         int usable_left_overflow=0, int usable_right_overflow=0, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );
 /// renders block which contains subblocks
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
-        int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, int rend_flags );
+        int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, lUInt32 rend_flags );
 /// renders table element
 int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
                  bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,
@@ -180,8 +180,6 @@ extern int gRootFontSize;
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
 extern int gInterlineScaleFactor;
 
-extern int gRenderBlockRenderingFlags;
-
 // Enhanced rendering flags
 #define BLOCK_RENDERING_ENHANCED                           0x00000001
 #define BLOCK_RENDERING_ALLOW_PAGE_BREAK_WHEN_NO_CONTENT   0x00000002 // Allow consecutive page breaks when only separated
@@ -222,11 +220,8 @@ extern int gRenderBlockRenderingFlags;
 // Enable everything
 #define BLOCK_RENDERING_FULL_FEATURED                      0x7FFFFFFF
 
-#define BLOCK_RENDERING_G(f) ( gRenderBlockRenderingFlags & BLOCK_RENDERING_##f )
 #define BLOCK_RENDERING(v, f) ( v & BLOCK_RENDERING_##f )
 
 #define DEF_RENDER_BLOCK_RENDERING_FLAGS BLOCK_RENDERING_FULL_FEATURED
-
-int validateBlockRenderingFlags( int f );
 
 #endif

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -176,8 +176,6 @@ extern int gRenderDPI;
 extern bool gRenderScaleFontWithDPI;
 extern int gRootFontSize;
 
-extern bool gHangingPunctuationEnabled;
-
 #define INTERLINE_SCALE_FACTOR_NO_SCALE 1024
 #define INTERLINE_SCALE_FACTOR_SHIFT 10
 extern int gInterlineScaleFactor;

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -127,7 +127,7 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
                        int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL );
-/// renders block which contains subblocks (with enode document's getRenderBlockRenderingFlags() as flags)
+/// renders block which contains subblocks (with enode document's rendering flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
         int usable_left_overflow=0, int usable_right_overflow=0, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );
 /// renders block which contains subblocks
@@ -219,7 +219,10 @@ extern int gRootFontSize;
 // Enable everything
 #define BLOCK_RENDERING_FULL_FEATURED                      0x7FFFFFFF
 
-#define BLOCK_RENDERING(v, f) ( v & BLOCK_RENDERING_##f )
+// Some macros (for shorter lines of code)
+#define BLOCK_RENDERING(v, f) ((bool)( v & BLOCK_RENDERING_##f ))
+#define BLOCK_RENDERING_D(d, f) ((bool)( d->getRenderBlockRenderingFlags() & BLOCK_RENDERING_##f ))
+#define BLOCK_RENDERING_N(n, f) ((bool)( n->getDocument()->getRenderBlockRenderingFlags() & BLOCK_RENDERING_##f ))
 
 #define DEF_RENDER_BLOCK_RENDERING_FLAGS BLOCK_RENDERING_FULL_FEATURED
 

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -81,7 +81,7 @@ private:
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
-    bool parse( const char * & decl, bool higher_importance=false, lxmlDocBase * doc=NULL, lString16 codeBase=lString16::empty_str );
+    bool parse( const char * & decl, lUInt32 domVersionRequested, bool higher_importance=false, lxmlDocBase * doc=NULL, lString16 codeBase=lString16::empty_str );
     lUInt32 getHash();
     LVCssDeclaration() : _data(NULL) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -80,7 +80,8 @@ extern "C" {
 
 #define LTEXT_FIT_GLYPHS             0x08000000  // Avoid glyph overflows and override at line edges and between text nodes
 
-#define LTEXT__AVAILABLE_BIT_29__    0x10000000
+#define LTEXT_LEGACY_RENDERING       0x10000000  // Legacy rendering exceptions: new line processing: set indentation for **each** new line, etc.
+
 #define LTEXT__AVAILABLE_BIT_30__    0x20000000
 #define LTEXT__AVAILABLE_BIT_31__    0x40000000
 #define LTEXT__AVAILABLE_BIT_32__    0x80000000

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -497,6 +497,7 @@ protected:
     bool _hangingPunctuationEnabled;
     lUInt32 _renderBlockRenderingFlags;
     lUInt32 _DOMVersionRequested;
+    int _interlineScaleFactor;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -626,6 +627,11 @@ public:
         return _DOMVersionRequested;
     }
     bool setDOMVersionRequested(lUInt32 version);
+
+    int getInterlineScaleFactor() const {
+        return _interlineScaleFactor;
+    }
+    bool setInterlineScaleFactor(int value);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -496,6 +496,7 @@ protected:
     void dropStyles();
 #endif
     bool _hangingPunctuationEnabled;
+    lUInt32 _renderBlockRenderingFlags;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -614,8 +615,12 @@ public:
     bool getHangingPunctiationEnabled() const {
         return _hangingPunctuationEnabled;
     }
-
     bool setHangingPunctiationEnabled(bool value);
+
+    lUInt32 getRenderBlockRenderingFlags() const {
+        return _renderBlockRenderingFlags;
+    }
+    bool setRenderBlockRenderingFlags(lUInt32 flags);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -42,7 +42,6 @@
 
 // Allows for requesting older DOM building code (including bugs NOT fixed)
 extern const int gDOMVersionCurrent;
-extern int gDOMVersionRequested;
 
 // Also defined in src/lvtinydom.cpp
 #define DOM_VERSION_WITH_NORMALIZED_XPOINTERS 20200223
@@ -497,6 +496,7 @@ protected:
 #endif
     bool _hangingPunctuationEnabled;
     lUInt32 _renderBlockRenderingFlags;
+    lUInt32 _DOMVersionRequested;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -621,6 +621,11 @@ public:
         return _renderBlockRenderingFlags;
     }
     bool setRenderBlockRenderingFlags(lUInt32 flags);
+
+    lUInt32 getDOMVersionRequested() const {
+        return _DOMVersionRequested;
+    }
+    bool setDOMVersionRequested(lUInt32 version);
 
     inline bool getDocFlag( lUInt32 mask )
     {
@@ -1580,7 +1585,8 @@ public:
     /// converts to string
     lString16 toString( XPointerMode mode = XPATH_USE_NAMES) {
         if( XPATH_USE_NAMES==mode ) {
-            if( gDOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
+            tinyNodeCollection* doc = (tinyNodeCollection*)_data->getDocument();
+            if ( doc != NULL && doc->getDOMVersionRequested() >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS )
                 return toStringV2();
             return toStringV1();
         }
@@ -2566,7 +2572,7 @@ public:
     /// create xpointer from relative pointer string
     ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr )
     {
-        if( gDOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
+        if( _DOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
             return createXPointerV2(baseNode, xPointerStr);
         return createXPointerV1(baseNode, xPointerStr);
     }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -495,6 +495,7 @@ protected:
     int calcFinalBlocks();
     void dropStyles();
 #endif
+    bool _hangingPunctuationEnabled;
 
     ldomDataStorageManager _textStorage; // persistent text node data storage
     ldomDataStorageManager _elemStorage; // persistent element data storage
@@ -583,9 +584,7 @@ public:
         _renderedBlockCache.clear();
         return true;
     }
-#endif
 
-#if BUILD_LITE!=1
     /// add named BLOB data to document
     bool addBlob(lString16 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
     /// get BLOB by name
@@ -611,6 +610,12 @@ public:
 
     bool createCacheFile();
 #endif
+
+    bool getHangingPunctiationEnabled() const {
+        return _hangingPunctuationEnabled;
+    }
+
+    bool setHangingPunctiationEnabled(bool value);
 
     inline bool getDocFlag( lUInt32 mask )
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1747,6 +1747,8 @@ public:
     bool prevVisibleWordEndInSentence();
     /// move to next visible word beginning (in sentence)
     bool nextVisibleWordStartInSentence();
+    /// move to end of current word (in sentence)
+    bool thisVisibleWordEndInSentence();
     /// move to next visible word end (in sentence)
     bool nextVisibleWordEndInSentence();
 

--- a/crengine/include/props.h
+++ b/crengine/include/props.h
@@ -76,9 +76,9 @@ public:
     /// set int property by name, if it's not set already
     virtual void setIntDef( const char * propName, int value );
     /// set int property as hex
-    virtual void setHex( const char * propName, int value );
+    virtual void setHex( const char * propName, lUInt32 value );
     /// set int property as hex, if not exist
-    virtual void setHexDef( const char * propName, int value )
+    virtual void setHexDef( const char * propName, lUInt32 value )
     {
         if ( !hasProperty( propName ) )
             setHex( propName, value );

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -976,6 +976,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc_props->setString(DOC_PROP_TITLE, title);
         m_doc_props->setString(DOC_PROP_LANGUAGE, language);
         m_doc_props->setString(DOC_PROP_DESCRIPTION, description);
+        m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
         // Return possibly multiple <dc:creator> (authors) and <dc:subject> (keywords)
         // as a single doc_props string with values separated by \n.

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -1,35 +1,11 @@
 #include "../include/fb3fmt.h"
 #include "../include/lvtinydom.h"
 #include "../include/fb2def.h"
-#include "../include/lvopc.h"
 
 static const lChar16 * const fb3_BodyContentType = L"application/fb3-body+xml";
 static const lChar16 * const fb3_DescriptionContentType = L"application/fb3-description+xml";
 static const lChar16 * const fb3_CoverRelationship = L"http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail";
 static const lChar16 * const fb3_ImageRelationship = L"http://www.fictionbook.org/FictionBook3/relationships/image";
-
-class fb3ImportContext
-{
-private:
-    OpcPackage *m_package;
-    OpcPartRef m_bookPart;
-    ldomDocument *m_descDoc;
-public:
-    fb3ImportContext(OpcPackage *package);
-    virtual ~fb3ImportContext();
-
-    lString16 geImageTarget(const lString16 relationId) {
-        return m_bookPart->getRelatedPartName(fb3_ImageRelationship, relationId);
-    }
-    LVStreamRef openBook() {
-        m_bookPart = m_package->getContentPart(fb3_BodyContentType);
-        m_coverImage = m_package->getRelatedPartName(fb3_CoverRelationship);
-        return m_bookPart->open();
-    }
-    ldomDocument *getDescription();
-public:
-    lString16 m_coverImage;
-};
 
 bool DetectFb3Format( LVStreamRef stream )
 {
@@ -140,6 +116,16 @@ fb3ImportContext::~fb3ImportContext()
 {
     if(m_descDoc)
         delete  m_descDoc;
+}
+
+lString16 fb3ImportContext::geImageTarget(const lString16 relationId) {
+    return m_bookPart->getRelatedPartName(fb3_ImageRelationship, relationId);
+}
+
+LVStreamRef fb3ImportContext::openBook() {
+    m_bookPart = m_package->getContentPart(fb3_BodyContentType);
+    m_coverImage = m_package->getRelatedPartName(fb3_CoverRelationship);
+    return m_bookPart->open();
 }
 
 ldomDocument *fb3ImportContext::getDescription()

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -386,6 +386,14 @@ HyphDictionary * HyphDictionaryList::find( const lString16& id )
 	return NULL;
 }
 
+static int HyphDictionary_comparator(const HyphDictionary ** item1, const HyphDictionary ** item2)
+{
+    if ( ( (*item1)->getType() == HDT_DICT_ALAN || (*item1)->getType() == HDT_DICT_TEX) &&
+         ( (*item2)->getType() == HDT_DICT_ALAN || (*item2)->getType() == HDT_DICT_TEX) )
+        return (*item1)->getTitle().compare((*item2)->getTitle());
+    return (int)((*item1)->getType() - (*item2)->getType());
+}
+
 bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
 {
     CRLog::info("HyphDictionaryList::open(%s)", LCSTR(hyphDirectory) );
@@ -414,9 +422,11 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
 			const LVContainerItemInfo * item = container->GetObjectInfo( i );
 			lString16 name = item->GetName();
             lString16 suffix;
+            lString16 suffix2add;
             HyphDictType t = HDT_NONE;
-            if ( name.endsWith(".pdb") ) {
+            if ( name.endsWith("_hyphen_(Alan).pdb") ) {
                 suffix = "_hyphen_(Alan).pdb";
+                suffix2add = " (Alan)";
                 t = HDT_DICT_ALAN;
             } else if ( name.endsWith(".pattern") ) {
                 suffix = ".pattern";
@@ -431,10 +441,12 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
 			lString16 title = name;
 			if ( title.endsWith( suffix ) )
 				title.erase( title.length() - suffix.length(), suffix.length() );
-
+			if (!suffix2add.empty())
+				title.append(suffix2add);
 			_list.add( new HyphDictionary( t, title, id, filename ) );
             count++;
 		}
+        _list.sort(HyphDictionary_comparator);
 		CRLog::info("%d dictionaries added to list", _list.length());
 		return true;
 	} else {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4497,6 +4497,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
+    m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6526,12 +6527,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             REQUEST_RENDER("propsApply footnotes")
         } else if (name == PROP_FLOATING_PUNCTUATION) {
             bool value = props->getBoolDef(PROP_FLOATING_PUNCTUATION, true);
-            if ( gHangingPunctuationEnabled != value ) {
-                gHangingPunctuationEnabled = value;
-                REQUEST_RENDER("propsApply - hanging punctuation")
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setHangingPunctiationEnabled(value)) {
+                    REQUEST_RENDER("propsApply - hanging punctuation")
                     // requestRender() does m_doc->clearRendBlockCache(), which is needed
                     // on hanging punctuation change
-            }
+                }
         } else if (name == PROP_RENDER_BLOCK_RENDERING_FLAGS) {
             int value = props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);
             value = validateBlockRenderingFlags(value);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -5768,7 +5768,7 @@ int LVDocView::doCommand(LVDocCmd cmd, int param) {
 		break;
 	case DCMD_GO_POS: {
 		if (m_view_mode == DVM_SCROLL) {
-			return SetPos(param);
+			return SetPos(param, true, true);
 		} else {
 			return goToPage(m_pages.FindNearestPage(param, 0));
 		}

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4499,7 +4499,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
-    m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
+    m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, false));
     m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS));
     m_doc->setDOMVersionRequested(m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent));
     if (m_def_interline_space == 100) // (avoid any rounding issue)
@@ -6294,7 +6294,6 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
     for (int i = 0; i < props->getCount(); i++) {
         lString8 name(props->getName(i));
         lString16 value = props->getValue(i);
-        //bool isUnknown = false;
         if (name == PROP_FONT_ANTIALIASING) {
             int antialiasingMode = props->getIntDef(PROP_FONT_ANTIALIASING, 2);
             fontMan->SetAntialiasMode(antialiasingMode);
@@ -6603,12 +6602,13 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
 
             // unknown property, adding to list of unknown properties
             unknown->setString(name.c_str(), value);
-            //isUnknown = true;
         }
-        //if ( !isUnknown ) {
-        // update current value in properties
+        // Update current value in properties
+        // Even if not used above to set anything if no m_doc, this saves
+        // the value in m_props so it might be used by createEmptyDocument()
+        // when creating the coming up document (and further documents
+        // if the value is not re-set).
         m_props->setString(name.c_str(), value);
-        //}
     }
     return unknown;
 }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4499,6 +4499,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
     m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS));
+    m_doc->setDOMVersionRequested(m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6533,6 +6534,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                     REQUEST_RENDER("propsApply - hanging punctuation")
                     // requestRender() does m_doc->clearRendBlockCache(), which is needed
                     // on hanging punctuation change
+                }
+        } else if (name == PROP_REQUESTED_DOM_VERSION) {
+            int value = props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent);
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setDOMVersionRequested(value)) {
+                    REQUEST_RENDER("propsApply requested dom version")
                 }
         } else if (name == PROP_RENDER_BLOCK_RENDERING_FLAGS) {
             lUInt32 value = (lUInt32)props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3465,10 +3465,12 @@ void LVDocView::setDefaultInterlineSpace(int percent) {
     LVLock lock(getMutex());
     REQUEST_RENDER("setDefaultInterlineSpace")
     m_def_interline_space = percent; // not used
-    if (percent == 100) // (avoid any rounding issue)
-        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
-    else
-        gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE * percent / 100;
+    if (m_doc) {
+        if (percent == 100) // (avoid any rounding issue)
+            m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE);
+        else
+            m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE * percent / 100);
+    }
     _posIsSet = false;
 //	goToBookmark( _posBookmark);
 //        updateBookMarksRanges();
@@ -4500,6 +4502,10 @@ void LVDocView::createEmptyDocument() {
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
     m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS));
     m_doc->setDOMVersionRequested(m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent));
+    if (m_def_interline_space == 100) // (avoid any rounding issue)
+        m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE);
+    else
+        m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE * m_def_interline_space / 100);
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4498,6 +4498,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, true));
+    m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6534,12 +6535,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                     // on hanging punctuation change
                 }
         } else if (name == PROP_RENDER_BLOCK_RENDERING_FLAGS) {
-            int value = props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);
-            value = validateBlockRenderingFlags(value);
-            if ( gRenderBlockRenderingFlags != value ) {
-                gRenderBlockRenderingFlags = value;
-                REQUEST_RENDER("propsApply render block rendering flags")
-            }
+            lUInt32 value = (lUInt32)props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setRenderBlockRenderingFlags(value))
+                    REQUEST_RENDER("propsApply render block rendering flags")
         } else if (name == PROP_RENDER_DPI) {
             int value = props->getIntDef(PROP_RENDER_DPI, DEF_RENDER_DPI);
             if ( gRenderDPI != value ) {

--- a/crengine/src/lvopc.cpp
+++ b/crengine/src/lvopc.cpp
@@ -114,8 +114,12 @@ void OpcPackage::readCoreProperties(CRPropRef doc_props)
         if ( propertiesDoc ) {
             lString16 author = propertiesDoc->textFromXPath( cs16("coreProperties/creator") );
             lString16 title = propertiesDoc->textFromXPath( cs16("coreProperties/title") );
+            lString16 language = propertiesDoc->textFromXPath( cs16("coreProperties/language") );
+            lString16 description = propertiesDoc->textFromXPath( cs16("coreProperties/description") );
             doc_props->setString(DOC_PROP_TITLE, title);
             doc_props->setString(DOC_PROP_AUTHORS, author );
+            doc_props->setString(DOC_PROP_LANGUAGE, language );
+            doc_props->setString(DOC_PROP_DESCRIPTION, description );
             delete propertiesDoc;
         } else {
             CRLog::error("Couldn't parse core properties");

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2611,6 +2611,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         int direction = RENDER_RECT_PTR_GET_DIRECTION(fmt);
         bool is_rtl = direction == REND_DIRECTION_RTL;
 
+        ldomNode * parent = enode->getParentNode(); // Needed for various checks below
+        if (parent && parent->isNull())
+            parent = NULL;
+
         // About styleToTextFmtFlags:
         // - with inline nodes, it only updates LTEXT_FLAG_PREFORMATTED flag
         //   when css_ws_pre and LTEXT_FLAG_NOWRAP when css_ws_nowrap.
@@ -2620,7 +2624,24 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // In legacy rendering mode, we should get the same text formatting flags
         // as in CoolReader 3.2.38 and earlier, i.e. set is_block to true for
         // any block elements.
-        bool is_block = BLOCK_RENDERING_G(ENHANCED) ? rm == erm_final : style->display >= css_d_block;
+        bool is_block = rm == erm_final;
+        if (!BLOCK_RENDERING_G(ENHANCED) && !is_block) {
+            is_block = style->display >= css_d_block;
+            if (is_block) {
+                // Hack for "legacy" rendering mode:
+                // First node with "display: block" after node "display: run-in" in one section
+                // must be rendered as inline nodes.
+                if ( enode->getNodeIndex() == 1 && parent && parent->getChildCount() > 1 ) {
+                    ldomNode * first_sibling = parent->getChildNode(0);
+                    if (first_sibling && !first_sibling->isNull() && first_sibling->isElement()) {
+                        css_style_ref_t fs_style = first_sibling->getStyle();
+                        if (!fs_style.isNull() && fs_style->display == css_d_run_in) {
+                            is_block = false;
+                        }
+                    }
+                }
+            }
+        }
         lUInt32 flags = styleToTextFmtFlags( is_block, style, baseflags, direction );
         // Note:
         // - baseflags (passed by reference) is shared and re-used by this node's siblings
@@ -2632,9 +2653,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
         int width = fmt->getWidth();
         int em = enode->getFont()->getSize();
-        ldomNode * parent = enode->getParentNode(); // Needed for various checks below
-        if (parent && parent->isNull())
-            parent = NULL;
 
         // Nodes with "display: run-in" are inline nodes brought at start of the final node
         bool isRunIn = style->display == css_d_run_in;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2558,7 +2558,7 @@ bool renderAsListStylePositionInside( const css_style_ref_t style, bool is_rtl=f
 // and to get paragraph direction (LTR/RTL/UNSET).
 void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & baseflags, int indent, int line_h, TextLangCfg * lang_cfg, int valign_dy, bool * is_link_start )
 {
-    bool legacy_render = !BLOCK_RENDERING_N(enode, ENHANCED);
+    bool legacy_rendering = !BLOCK_RENDERING_N(enode, ENHANCED);
     if ( enode->isElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
         if ( rm == erm_invisible )
@@ -2606,23 +2606,35 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // - with block nodes (so, only with the first "final" node, and not
         //   when recursing its children which are inline), it will also set
         //   horitontal alignment flags.
-        // In legacy rendering mode, we should get the same text formatting flags
-        // as in CoolReader 3.2.38 and earlier, i.e. set is_block to true for
-        // any block elements.
         bool is_block = rm == erm_final;
-        if (legacy_render && !is_block) {
+        if (legacy_rendering && !is_block) {
+            // In legacy rendering mode, we should get the same text formatting flags
+            // as in CoolReader 3.2.38 and earlier, i.e. set is_block to true for
+            // any block-like elements as set by CSS.
             is_block = style->display >= css_d_block;
             if (is_block) {
-                // Hack for "legacy" rendering mode:
+                // With a specific tweak for display:run-in (FB2 footnotes):
                 // First node with "display: block" after node "display: run-in" in one section
-                // must be rendered as inline nodes.
-                if ( enode->getNodeIndex() == 1 && parent && parent->getChildCount() > 1 ) {
+                // must be rendered as an inline node.
+                if ( enode->getNodeIndex() == 1 ) { // we're the 2nd child of parent
                     ldomNode * first_sibling = parent->getChildNode(0);
                     if (first_sibling && !first_sibling->isNull() && first_sibling->isElement()) {
                         css_style_ref_t fs_style = first_sibling->getStyle();
                         if (!fs_style.isNull() && fs_style->display == css_d_run_in) {
                             is_block = false;
                         }
+                    }
+                }
+                if ( is_block ) {
+                    // If still block, also check this block is not contained
+                    // in a run-in, in which case we should keep it inline
+                    ldomNode * n = enode;
+                    while ( n && n->getRendMethod() != erm_final ) {
+                        if ( n->getStyle()->display == css_d_run_in ) {
+                            is_block = false;
+                            break;
+                        }
+                        n = n->getParentNode();
                     }
                 }
             }
@@ -2743,7 +2755,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
 
-        if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( legacy_render && is_block ) ) ) {
+        if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( legacy_rendering && is_block ) ) ) {
             // Top and single 'final' node (unless in the degenerate case
             // of obsolete css_d_list_item_legacy):
             // Get text-indent and line-height that will apply to the full final block
@@ -3538,7 +3550,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else {
             }
             */
-            if ( legacy_render ) {
+            if ( legacy_rendering ) {
                 // Removal of leading spaces is now managed directly by lvtextfm
                 // but in legacy render mode we don't add lines with only spaces.
                 //int offs = 0;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2617,7 +2617,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // - with block nodes (so, only with the first "final" node, and not
         //   when recursing its children which are inline), it will also set
         //   horitontal alignment flags.
-        bool is_block = rm == erm_final;
+        // In legacy rendering mode, we should get the same text formatting flags
+        // as in CoolReader 3.2.38 and earlier, i.e. set is_block to true for
+        // any block elements.
+        bool is_block = BLOCK_RENDERING_G(ENHANCED) ? rm == erm_final : style->display >= css_d_block;
         lUInt32 flags = styleToTextFmtFlags( is_block, style, baseflags, direction );
         // Note:
         // - baseflags (passed by reference) is shared and re-used by this node's siblings
@@ -2737,10 +2740,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
 
-        if ((flags & LTEXT_FLAG_NEWLINE) && rm == erm_final) {
-            // Top and single 'final' node (unless in the degenarate case
+        if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( !BLOCK_RENDERING_G(ENHANCED) && is_block ) ) ) {
+            // Top and single 'final' node (unless in the degenerate case
             // of obsolete css_d_list_item_legacy):
             // Get text-indent and line-height that will apply to the full final block
+            // There is also an exception: in legacy rendering mode, we must also indent any blocks.
 
             // text-indent should really not have to be handled here: it would be
             // better handled in ldomNode::renderFinalBlock(), grabbing it from the
@@ -2770,20 +2774,22 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // does not need that).
             }
 
-            // We set the LFormattedText strut_height and strut_baseline
-            // with the values from this "final" node. All lines made out from
-            // children will have a minimal height and baseline set to these.
-            // See https://www.w3.org/TR/CSS2/visudet.html#line-height
-            //   The minimum height consists of a minimum height above
-            //   the baseline and a minimum depth below it, exactly as if
-            //   each line box starts with a zero-width inline box with the
-            //   element's font and line height properties. We call that
-            //   imaginary box a "strut."
-            // and https://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align
-            int fh = enode->getFont()->getHeight();
-            int fb = enode->getFont()->getBaseline();
-            int f_half_leading = (line_h - fh) / 2;
-            txform->setStrut(line_h, fb + f_half_leading);
+            if (rm == erm_final) {
+                // We set the LFormattedText strut_height and strut_baseline
+                // with the values from this "final" node. All lines made out from
+                // children will have a minimal height and baseline set to these.
+                // See https://www.w3.org/TR/CSS2/visudet.html#line-height
+                //   The minimum height consists of a minimum height above
+                //   the baseline and a minimum depth below it, exactly as if
+                //   each line box starts with a zero-width inline box with the
+                //   element's font and line height properties. We call that
+                //   imaginary box a "strut."
+                // and https://iamvdo.me/en/blog/css-font-metrics-line-height-and-vertical-align
+                int fh = enode->getFont()->getHeight();
+                int fb = enode->getFont()->getBaseline();
+                int f_half_leading = (line_h - fh) / 2;
+                txform->setStrut(line_h, fb + f_half_leading);
+            }
         }
         else if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) ) {
             // Previous branch for the top final node has set the strut.
@@ -3529,19 +3535,23 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else {
             }
             */
-            /* removal of leading spaces is now managed directly by lvtextfm
-            //int offs = 0;
-            if ( txform->GetSrcCount()==0 && style->white_space!=css_ws_pre ) {
-                // clear leading spaces for first text of paragraph
-                int i=0;
-                for ( ;txt.length()>i && (txt[i]==' ' || txt[i]=='\t'); i++ )
-                    ;
-                if ( i>0 ) {
-                    txt.erase(0, i);
-                    //offs = i;
+            if ( !BLOCK_RENDERING_G(ENHANCED) ) {
+                // Removal of leading spaces is now managed directly by lvtextfm
+                // but in legacy render mode we don't add lines with only spaces.
+                //int offs = 0;
+                if ( (txform->GetSrcCount()==0 || (tflags & LTEXT_IS_LINK)) && style->white_space!=css_ws_pre ) {
+                    // clear leading spaces for first text of paragraph
+                    int i=0;
+                    for ( ;txt.length()>i && (txt[i]==' ' || txt[i]=='\t'); i++ )
+                        ;
+                    if ( i>0 ) {
+                        txt.erase(0, i);
+                        //offs = i;
+                    }
                 }
+                // legacy new line processing: set indentation for **each** new line
+                tflags |= LTEXT_LEGACY_RENDERING;
             }
-            */
             if ( txt.length()>0 ) {
                 txform->AddSourceLine( txt.c_str(), txt.length(), cl, bgcl, font.get(), lang_cfg, baseflags | tflags,
                     line_h, valign_dy, indent, enode, 0, letter_spacing );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8948,7 +8948,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     css_style_rec_t * pstyle = style.get();
 
     lUInt16 nodeElementId = enode->getNodeId();
-    lUInt32 domVersionRequested = enode->getDocument() ? enode->getDocument()->getDOMVersionRequested() : gDOMVersionCurrent;
+    ldomDocument * doc = enode->getDocument();
+    lUInt32 domVersionRequested = doc->getDOMVersionRequested();
 
     if (domVersionRequested < 20180524) {
         // The display property initial value has been changed from css_d_inherit
@@ -9048,12 +9049,12 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     //////////////////////////////////////////////////////
     // apply style sheet
     //////////////////////////////////////////////////////
-    enode->getDocument()->applyStyle( enode, pstyle );
+    doc->applyStyle( enode, pstyle );
 
     //////////////////////////////////////////////////////
     // apply node style= attribute
     //////////////////////////////////////////////////////
-    if ( enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasAttribute( LXML_NS_ANY, attr_style ) ) {
+    if ( doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasAttribute( LXML_NS_ANY, attr_style ) ) {
         lString16 nodeStyle = enode->getAttributeValue( LXML_NS_ANY, attr_style );
         if ( !nodeStyle.empty() ) {
             nodeStyle = cs16("{") + nodeStyle + "}";
@@ -9063,7 +9064,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // We can't get the codeBase of this node anymore at this point, which
             // would be needed to resolve "background-image: url(...)" relative
             // file path... So these won't work when defined in a style= attribute.
-            if ( decl.parse( s, domVersionRequested ) ) {
+            if ( decl.parse( s, domVersionRequested, false, doc ) ) {
                 decl.apply( pstyle );
             }
         }
@@ -9136,7 +9137,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->display = css_d_none;
     }
 
-    lUInt32 rend_flags = enode->getDocument()->getRenderBlockRenderingFlags();
+    lUInt32 rend_flags = doc->getRenderBlockRenderingFlags();
     if ( BLOCK_RENDERING(rend_flags, PREPARE_FLOATBOXES) ) {
         // https://developer.mozilla.org/en-US/docs/Web/CSS/float
         //  As float implies the use of the block layout, it modifies the computed value
@@ -9478,7 +9479,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 int pem = parent_font->getSize(); // value in screen px
                 int line_h = lengthToPx(parent_style->line_height, pem, pem);
                 // Scale it according to document's _interlineScaleFactor
-                int interline_scale_factor = enode->getDocument()->getInterlineScaleFactor();
+                int interline_scale_factor = doc->getInterlineScaleFactor();
                 if (interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE)
                     line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
                 pstyle->line_height.value = line_h;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2481,7 +2481,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
                 int em = font->getSize();
                 line_h = lengthToPx(style->line_height, em, em, true);
             }
-            // Scale it according to gInterlineScaleFactor
+            // Scale line_h according to document's _interlineScaleFactor
             if (style->line_height.type != css_val_screen_px && doc->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
                 line_h = (line_h * doc->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
             if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) )
@@ -2558,7 +2558,7 @@ bool renderAsListStylePositionInside( const css_style_ref_t style, bool is_rtl=f
 // and to get paragraph direction (LTR/RTL/UNSET).
 void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & baseflags, int indent, int line_h, TextLangCfg * lang_cfg, int valign_dy, bool * is_link_start )
 {
-    bool legacy_render = !BLOCK_RENDERING(enode->getDocument()->getRenderBlockRenderingFlags(), ENHANCED);
+    bool legacy_render = !BLOCK_RENDERING_N(enode, ENHANCED);
     if ( enode->isElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
         if ( rm == erm_invisible )
@@ -2729,17 +2729,17 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         }
         // having line_h=0 is ugly, but it's allowed and it works
 
-        // Scale line_h according to gInterlineScaleFactor, but not if
-        // it was already in screen_px, which means it has already been
-        // scaled (in setNodeStyle() when inherited).
-        if ( style->line_height.type != css_val_screen_px && enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
-            if ( RENDER_RECT_PTR_HAS_FLAG(fmt, NO_INTERLINE_SCALE_UP)
-                    && enode->getDocument()->getInterlineScaleFactor() > INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+        // Scale line_h according to document's _interlineScaleFactor, but
+        // not if it was already in screen_px, which means it has already
+        // been scaled (in setNodeStyle() when inherited).
+        int interline_scale_factor = enode->getDocument()->getInterlineScaleFactor();
+        if ( style->line_height.type != css_val_screen_px && interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+            if ( RENDER_RECT_PTR_HAS_FLAG(fmt, NO_INTERLINE_SCALE_UP) && interline_scale_factor > INTERLINE_SCALE_FACTOR_NO_SCALE ) {
                 // Don't scale up (for <ruby> content, so we can increase interline to make
                 // the text breath without spreading ruby annotations on the space gained)
             }
             else {
-                line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
+                line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
             }
         }
 
@@ -3428,7 +3428,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 break;
             }
             // Among inline nodes, only <BR> can carry a "clear: left/right/both".
-            // (No need to check for BLOCK_RENDERING(rend_flags, FLOAT_FLOATBOXES), this
+            // (No need to check for BLOCK_RENDERING_FLOAT_FLOATBOXES, this
             // should have no effect when there is not a single float in the way)
             baseflags &= ~LTEXT_SRC_IS_CLEAR_BOTH; // clear previous one
             switch (style->clear) {
@@ -6434,11 +6434,12 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // values and 'rem' (related to root element font size).
                 line_h = lengthToPx(style->line_height, em, em, true);
             }
-            // Scale line_h according to gInterlineScaleFactor, but not if
-            // it was already in screen_px, which means it has already been
-            // scaled (in setNodeStyle() when inherited).
-            if (style->line_height.type != css_val_screen_px && enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            // Scale line_h according to document's _interlineScaleFactor, but
+            // not if it was already in screen_px, which means it has already
+            // been scaled (in setNodeStyle() when inherited).
+            int interline_scale_factor = enode->getDocument()->getInterlineScaleFactor();
+            if (style->line_height.type != css_val_screen_px && interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE)
+                line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
             style_height.value = line_h;
             style_height.type = css_val_screen_px;
         }
@@ -9464,9 +9465,10 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 {
                 int pem = parent_font->getSize(); // value in screen px
                 int line_h = lengthToPx(parent_style->line_height, pem, pem);
-                // Scale it according to gInterlineScaleFactor
-                if (enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                    line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
+                // Scale it according to document's _interlineScaleFactor
+                int interline_scale_factor = enode->getDocument()->getInterlineScaleFactor();
+                if (interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE)
+                    line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
                 pstyle->line_height.value = line_h;
                 pstyle->line_height.type = css_val_screen_px;
                 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8935,7 +8935,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     css_style_rec_t * pstyle = style.get();
 
     lUInt16 nodeElementId = enode->getNodeId();
-    lUInt32 domVersionRequested = enode->getDocument() ? enode->getDocument()->getDOMVersionRequested() : 0;
+    lUInt32 domVersionRequested = enode->getDocument() ? enode->getDocument()->getDOMVersionRequested() : gDOMVersionCurrent;
 
     if (domVersionRequested < 20180524) {
         // The display property initial value has been changed from css_d_inherit

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -50,8 +50,6 @@
 // crengine default used to be "width: 100%", but now that we
 // can shrink to fit, it is "width: auto".
 
-int gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
-
 int gRenderDPI = DEF_RENDER_DPI; // if 0: old crengine behaviour: 1px/pt=1px, 1in/cm/pc...=0px
 bool gRenderScaleFontWithDPI = DEF_RENDER_SCALE_FONT_WITH_DPI;
 int gRootFontSize = 24; // will be reset as soon as font size is set
@@ -2440,9 +2438,10 @@ void SplitLines( const lString16 & str, lString16Collection & lines )
 lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormattedText * txform, int line_h, lUInt32 flags ) {
     lString16 marker;
     marker_width = 0;
+    ldomDocument* doc = enode->getDocument();
     // The UL > LI parent-child chain may have had some of our boxing elements inserted
     ldomNode * parent = enode->getUnboxedParent();
-    ListNumberingPropsRef listProps =  enode->getDocument()->getNodeNumberingProps( parent->getDataIndex() );
+    ListNumberingPropsRef listProps =  doc->getNodeNumberingProps( parent->getDataIndex() );
     if ( listProps.isNull() ) { // no previously cached info: compute and cache it
         // Scan all our siblings to know the widest marker width
         int counterValue = 0;
@@ -2458,7 +2457,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             sibling = sibling->getUnboxedNextSibling(true); // skip text nodes
         }
         listProps = ListNumberingPropsRef( new ListNumberingProps(counterValue, maxWidth) );
-        enode->getDocument()->setNodeNumberingProps( parent->getDataIndex(), listProps );
+        doc->setNodeNumberingProps( parent->getDataIndex(), listProps );
     }
     // Note: node->getNodeListMarker() uses font->getTextWidth() without any hint about
     // text direction, so the marker is measured LTR.. We should probably upgrade them
@@ -2483,8 +2482,8 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
                 line_h = lengthToPx(style->line_height, em, em, true);
             }
             // Scale it according to gInterlineScaleFactor
-            if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            if (style->line_height.type != css_val_screen_px && doc->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
+                line_h = (line_h * doc->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
             if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) )
                 flags |= LTEXT_STRUT_CONFINED;
         }
@@ -2733,14 +2732,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // Scale line_h according to gInterlineScaleFactor, but not if
         // it was already in screen_px, which means it has already been
         // scaled (in setNodeStyle() when inherited).
-        if ( style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+        if ( style->line_height.type != css_val_screen_px && enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
             if ( RENDER_RECT_PTR_HAS_FLAG(fmt, NO_INTERLINE_SCALE_UP)
-                    && gInterlineScaleFactor > INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+                    && enode->getDocument()->getInterlineScaleFactor() > INTERLINE_SCALE_FACTOR_NO_SCALE ) {
                 // Don't scale up (for <ruby> content, so we can increase interline to make
                 // the text breath without spreading ruby annotations on the space gained)
             }
             else {
-                line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+                line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
             }
         }
 
@@ -6438,8 +6437,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             // Scale line_h according to gInterlineScaleFactor, but not if
             // it was already in screen_px, which means it has already been
             // scaled (in setNodeStyle() when inherited).
-            if (style->line_height.type != css_val_screen_px && gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            if (style->line_height.type != css_val_screen_px && enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
+                line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
             style_height.value = line_h;
             style_height.type = css_val_screen_px;
         }
@@ -9466,8 +9465,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 int pem = parent_font->getSize(); // value in screen px
                 int line_h = lengthToPx(parent_style->line_height, pem, pem);
                 // Scale it according to gInterlineScaleFactor
-                if (gInterlineScaleFactor != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                    line_h = (line_h * gInterlineScaleFactor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+                if (enode->getDocument()->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
+                    line_h = (line_h * enode->getDocument()->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
                 pstyle->line_height.value = line_h;
                 pstyle->line_height.type = css_val_screen_px;
                 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -50,8 +50,6 @@
 // crengine default used to be "width: 100%", but now that we
 // can shrink to fit, it is "width: auto".
 
-bool gHangingPunctuationEnabled = false;
-
 int gInterlineScaleFactor = INTERLINE_SCALE_FACTOR_NO_SCALE;
 
 int gRenderDPI = DEF_RENDER_DPI; // if 0: old crengine behaviour: 1px/pt=1px, 1in/cm/pc...=0px

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8936,8 +8936,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     css_style_rec_t * pstyle = style.get();
 
     lUInt16 nodeElementId = enode->getNodeId();
+    lUInt32 domVersionRequested = enode->getDocument() ? enode->getDocument()->getDOMVersionRequested() : 0;
 
-    if (gDOMVersionRequested < 20180524) {
+    if (domVersionRequested < 20180524) {
         // The display property initial value has been changed from css_d_inherit
         // to css_d_inline (as per spec, and so that an unknown element does not
         // become block when contained in a P, and inline when contained in a SPAN)
@@ -8957,14 +8958,14 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->white_space = type_ptr->white_space;
 
         // Account for backward incompatible changes in fb2def.h
-        if (gDOMVersionRequested < 20200824) { // revert what was changed 20200824
+        if (domVersionRequested < 20200824) { // revert what was changed 20200824
             if (nodeElementId >= el_details && nodeElementId <= el_wbr) { // newly added block elements
                 pstyle->display = css_d_inline; // previously unknown and shown as inline
-                if (gDOMVersionRequested < 20180524) {
+                if (domVersionRequested < 20180524) {
                     pstyle->display = css_d_inherit; // previously unknown and display: inherit
                 }
             }
-            if (gDOMVersionRequested < 20180528) { // revert what was changed 20180528
+            if (domVersionRequested < 20180528) { // revert what was changed 20180528
                 if (nodeElementId == el_form) {
                     pstyle->display = css_d_none; // otherwise shown as block, as it may have textual content
                 }
@@ -8973,11 +8974,11 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 }
                 if (nodeElementId >= el_address && nodeElementId <= el_xmp) { // newly added block elements
                     pstyle->display = css_d_inline; // previously unknown and shown as inline
-                    if (gDOMVersionRequested < 20180524) {
+                    if (domVersionRequested < 20180524) {
                         pstyle->display = css_d_inherit; // previously unknown and display: inherit
                     }
                 }
-                if (gDOMVersionRequested < 20180524) { // revert what was fixed 20180524
+                if (domVersionRequested < 20180524) { // revert what was fixed 20180524
                     if (nodeElementId == el_cite) {
                         pstyle->display = css_d_block; // otherwise correctly set to css_d_inline
                     }
@@ -9050,7 +9051,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // We can't get the codeBase of this node anymore at this point, which
             // would be needed to resolve "background-image: url(...)" relative
             // file path... So these won't work when defined in a style= attribute.
-            if ( decl.parse( s ) ) {
+            if ( decl.parse( s, domVersionRequested ) ) {
                 decl.apply( pstyle );
             }
         }
@@ -9248,7 +9249,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     }
 
     // Avoid some new features when migration to normalized xpointers has not yet been done
-    if ( gDOMVersionRequested < DOM_VERSION_WITH_NORMALIZED_XPOINTERS ) {
+    if ( domVersionRequested < DOM_VERSION_WITH_NORMALIZED_XPOINTERS ) {
         // display: ruby may wrap the element content in many inlineBox/rubyBox.
         // Avoid that until migrated to normalized xpointers by handling
         // them as css_d_inline like before ruby support.
@@ -9296,7 +9297,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         //parent_style->text_align = css_ta_center;
     //}
 
-    if (gDOMVersionRequested < 20180524) { // display should not be inherited
+    if (domVersionRequested < 20180524) { // display should not be inherited
         UPDATE_STYLE_FIELD( display, css_d_inherit );
     }
     UPDATE_STYLE_FIELD( white_space, css_ws_inherit );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1885,31 +1885,31 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                         }
                         else if ( name == cr_only_if_legacy ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) == invert;
+                                match = BLOCK_RENDERING_D(doc, ENHANCED) == invert;
                         }
                         else if ( name == cr_only_if_enhanced ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) != invert;
+                                match = BLOCK_RENDERING_D(doc, ENHANCED) != invert;
                         }
                         else if ( name == cr_only_if_float_floatboxes ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES)) != invert;
+                                match = BLOCK_RENDERING_D(doc, FLOAT_FLOATBOXES) != invert;
                         }
                         else if ( name == cr_only_if_box_inlineboxes ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS)) != invert;
+                                match = BLOCK_RENDERING_D(doc, BOX_INLINE_BLOCKS) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_width ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_WIDTH)) != invert;
+                                match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_WIDTH) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_height ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_HEIGHT)) != invert;
+                                match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_HEIGHT) != invert;
                         }
                         else if ( name == cr_only_if_allow_style_w_h_absolute_units ) {
                             if (doc)
-                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ALLOW_STYLE_W_H_ABSOLUTE_UNITS)) != invert;
+                                match = BLOCK_RENDERING_D(doc, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) != invert;
                         }
                         else if ( name == cr_only_if_full_featured ) {
                             if (doc)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1821,7 +1821,7 @@ enum cr_only_if_t {
     cr_only_if_fb2_document, // fb2 or fb3
 };
 
-bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
+bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
 {
     if ( !decl )
         return false;
@@ -1854,7 +1854,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 {
                     int dom_version;
                     if ( parse_integer( decl, dom_version ) ) {
-                        if ( gDOMVersionRequested >= dom_version ) {
+                        if ( domVersionRequested >= dom_version ) {
                             return false; // ignore the whole declaration
                         }
                     }
@@ -1999,7 +1999,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 break;
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
-                if (gDOMVersionRequested < 20180524 && n == css_d_list_item_block) {
+                if (domVersionRequested < 20180524 && n == css_d_list_item_block) {
                     n = css_d_list_item_legacy; // legacy rendering of list-item
                 }
                 break;
@@ -4405,6 +4405,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
     LVCssSelector * prev_selector;
     int err_count = 0;
     int rule_count = 0;
+    lUInt32 domVersionRequested = (_doc != NULL) ? _doc->getDOMVersionRequested() : 0;
     for (;*str;)
     {
         // new rule
@@ -4435,7 +4436,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
             }
             // parse declaration
             LVCssDeclRef decl( new LVCssDeclaration );
-            if ( !decl->parse( str, higher_importance, _doc, codeBase ) )
+            if ( !decl->parse( str, domVersionRequested, higher_importance, _doc, codeBase ) )
             {
                 err = true;
                 err_count++;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1884,28 +1884,36 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             match = invert;
                         }
                         else if ( name == cr_only_if_legacy ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENHANCED)) == invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) == invert;
                         }
                         else if ( name == cr_only_if_enhanced ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENHANCED)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENHANCED)) != invert;
                         }
                         else if ( name == cr_only_if_float_floatboxes ) {
-                            match = ((bool)BLOCK_RENDERING_G(FLOAT_FLOATBOXES)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES)) != invert;
                         }
                         else if ( name == cr_only_if_box_inlineboxes ) {
-                            match = ((bool)BLOCK_RENDERING_G(BOX_INLINE_BLOCKS)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS)) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_width ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENSURE_STYLE_WIDTH)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_WIDTH)) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_height ) {
-                            match = ((bool)BLOCK_RENDERING_G(ENSURE_STYLE_HEIGHT)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ENSURE_STYLE_HEIGHT)) != invert;
                         }
                         else if ( name == cr_only_if_allow_style_w_h_absolute_units ) {
-                            match = ((bool)BLOCK_RENDERING_G(ALLOW_STYLE_W_H_ABSOLUTE_UNITS)) != invert;
+                            if (doc)
+                                match = ((bool)BLOCK_RENDERING(doc->getRenderBlockRenderingFlags(), ALLOW_STYLE_W_H_ABSOLUTE_UNITS)) != invert;
                         }
                         else if ( name == cr_only_if_full_featured ) {
-                            match = (gRenderBlockRenderingFlags == BLOCK_RENDERING_FULL_FEATURED) != invert;
+                            if (doc)
+                                match = (doc->getRenderBlockRenderingFlags() == BLOCK_RENDERING_FULL_FEATURED) != invert;
                         }
                         else if ( name == cr_only_if_epub_document ) {
                             // 'doc' is NULL when parsing elements style= attribute,

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4405,7 +4405,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 co
     LVCssSelector * prev_selector;
     int err_count = 0;
     int rule_count = 0;
-    lUInt32 domVersionRequested = (_doc != NULL) ? _doc->getDOMVersionRequested() : 0;
+    lUInt32 domVersionRequested = (_doc != NULL) ? _doc->getDOMVersionRequested() : gDOMVersionCurrent;
     for (;*str;)
     {
         // new rule

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1883,55 +1883,45 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                         else if ( name == cr_only_if_never ) {
                             match = invert;
                         }
+                        else if ( !doc ) {
+                            // Without a doc, we don't have access to any of the following properties
+                            match = false;
+                        }
                         else if ( name == cr_only_if_legacy ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, ENHANCED) == invert;
+                            match = BLOCK_RENDERING_D(doc, ENHANCED) == invert;
                         }
                         else if ( name == cr_only_if_enhanced ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, ENHANCED) != invert;
+                            match = BLOCK_RENDERING_D(doc, ENHANCED) != invert;
                         }
                         else if ( name == cr_only_if_float_floatboxes ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, FLOAT_FLOATBOXES) != invert;
+                            match = BLOCK_RENDERING_D(doc, FLOAT_FLOATBOXES) != invert;
                         }
                         else if ( name == cr_only_if_box_inlineboxes ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, BOX_INLINE_BLOCKS) != invert;
+                            match = BLOCK_RENDERING_D(doc, BOX_INLINE_BLOCKS) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_width ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_WIDTH) != invert;
+                            match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_WIDTH) != invert;
                         }
                         else if ( name == cr_only_if_ensure_style_height ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_HEIGHT) != invert;
+                            match = BLOCK_RENDERING_D(doc, ENSURE_STYLE_HEIGHT) != invert;
                         }
                         else if ( name == cr_only_if_allow_style_w_h_absolute_units ) {
-                            if (doc)
-                                match = BLOCK_RENDERING_D(doc, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) != invert;
+                            match = BLOCK_RENDERING_D(doc, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) != invert;
                         }
                         else if ( name == cr_only_if_full_featured ) {
-                            if (doc)
-                                match = (doc->getRenderBlockRenderingFlags() == BLOCK_RENDERING_FULL_FEATURED) != invert;
+                            match = (doc->getRenderBlockRenderingFlags() == BLOCK_RENDERING_FULL_FEATURED) != invert;
                         }
                         else if ( name == cr_only_if_epub_document ) {
-                            // 'doc' is NULL when parsing elements style= attribute,
-                            // but we don't expect to see -cr-only-if: in them.
-                            if (doc) {
-                                match = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none) == doc_format_epub;
-                                if (invert) {
-                                    match = !match;
-                                }
+                            match = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none) == doc_format_epub;
+                            if (invert) {
+                                match = !match;
                             }
                         }
                         else if ( name == cr_only_if_fb2_document ) {
-                            if (doc) {
-                                int doc_format = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none);
-                                match = (doc_format == doc_format_fb2) || (doc_format == doc_format_fb3);
-                                if (invert) {
-                                    match = !match;
-                                }
+                            int doc_format = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none);
+                            match = (doc_format == doc_format_fb2) || (doc_format == doc_format_fb3);
+                            if (invert) {
+                                match = !match;
                             }
                         }
                         else { // unknown option: ignore
@@ -4401,11 +4391,15 @@ lUInt32 LVStyleSheet::getHash()
 
 bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 codeBase )
 {
+    if ( !_doc ) {
+        // We can't parse anything if no _doc to get element name ids from
+        return false;
+    }
     LVCssSelector * selector = NULL;
     LVCssSelector * prev_selector;
     int err_count = 0;
     int rule_count = 0;
-    lUInt32 domVersionRequested = (_doc != NULL) ? _doc->getDOMVersionRequested() : gDOMVersionCurrent;
+    lUInt32 domVersionRequested = _doc->getDOMVersionRequested();
     for (;*str;)
     {
         // new rule

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3748,10 +3748,15 @@ public:
         while ( pos<m_length ) { // each loop makes a line
             // x is this line indent. We use it like a x coordinates below, but
             // we'll use it on the right in addLine() if para is RTL.
-            int x = m_indent_current;
-            if ( !m_indent_first_line_done ) {
-                m_indent_first_line_done = true;
-                m_indent_current = m_indent_after_first_line;
+            int x;
+            if (para->flags & LTEXT_LEGACY_RENDERING) {
+                x = para->indent > 0 ? (pos == 0 ? para->indent : 0 ) : (pos==0 ? 0 : -para->indent);
+            } else {
+                x = m_indent_current;
+                if ( !m_indent_first_line_done ) {
+                    m_indent_first_line_done = true;
+                    m_indent_current = m_indent_after_first_line;
+                }
             }
             int w0 = pos>0 ? m_widths[pos-1] : 0; // measured cumulative width at start of this line
             int lastNormalWrap = -1;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4235,7 +4235,7 @@ public:
             LVRendPageContext context( NULL, m_pbuffer->page_height );
             // We don't know if the upper LVRendPageContext wants lines or not,
             // so assume it does (the main flow does).
-            int rend_flags = gRenderBlockRenderingFlags; // global flags
+            int rend_flags = node->getDocument()->getRenderBlockRenderingFlags();
             // We want to avoid negative margins (if allowed in global flags) and
             // going back the flow y, as the transfered lines would not reflect
             // that, and we could get some small mismatches and glitches.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.51k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.52k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 
@@ -2039,6 +2039,7 @@ tinyNodeCollection::tinyNodeCollection()
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(false)
 ,_renderBlockRenderingFlags(DEF_RENDER_BLOCK_RENDERING_FLAGS)
+,_DOMVersionRequested(DOM_VERSION_CURRENT)
 ,_interlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE)
 {
     memset( _textList, 0, sizeof(_textList) );
@@ -2083,6 +2084,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(v._hangingPunctuationEnabled)
 ,_renderBlockRenderingFlags(v._renderBlockRenderingFlags)
+,_DOMVersionRequested(v._DOMVersionRequested)
 ,_interlineScaleFactor(v._interlineScaleFactor)
 {
     memset( _textList, 0, sizeof(_textList) );
@@ -15011,6 +15013,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     res = res * 31 + _spaceWidthScalePercent;
     res = res * 31 + _minSpaceCondensingPercent;
     res = res * 31 + _unusedSpaceThresholdPercent;
+
     // _maxAddedLetterSpacingPercent does not need to be accounted, as, working
     // only on a laid out line, it does not need a re-rendering, but just
     // a _renderedBlockCache.clear() to reformat paragraphs and have the
@@ -15019,8 +15022,8 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // Hanging punctuation does not need to trigger a re-render, as
     // it's now ensured by alignLine() and won't change paragraphs height.
     // We just need to _renderedBlockCache.clear() when it changes.
-    //if ( gHangingPunctuationEnabled )
-    // res = res * 75 + 1761;
+    // if ( _hangingPunctuationEnabled )
+    //     res = res * 75 + 1761;
 
     res = res * 31 + _renderBlockRenderingFlags;
     res = res * 31 + _interlineScaleFactor;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -394,7 +394,6 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
         hash = hash * 75 + 2384761;
     hash = hash * 31 + gRenderDPI;
     hash = hash * 31 + gRootFontSize;
-    hash = hash * 31 + gInterlineScaleFactor;
     // If not yet rendered (initial loading with XML parsing), we can
     // ignore some global flags that have not yet produced any effect,
     // so they can possibly be updated between loading and rendering
@@ -2040,6 +2039,7 @@ tinyNodeCollection::tinyNodeCollection()
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(false)
 ,_renderBlockRenderingFlags(DEF_RENDER_BLOCK_RENDERING_FLAGS)
+,_interlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2083,6 +2083,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 ,_fontMap(113)
 ,_hangingPunctuationEnabled(v._hangingPunctuationEnabled)
 ,_renderBlockRenderingFlags(v._renderBlockRenderingFlags)
+,_interlineScaleFactor(v._interlineScaleFactor)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2116,6 +2117,14 @@ bool tinyNodeCollection::setDOMVersionRequested(lUInt32 version)
 {
     if (_DOMVersionRequested != version) {
         _DOMVersionRequested = version;
+        return true;
+    }
+    return false;
+}
+
+bool tinyNodeCollection::setInterlineScaleFactor(int value) {
+    if (_interlineScaleFactor != value) {
+        _interlineScaleFactor = value;
         return true;
     }
     return false;
@@ -15014,6 +15023,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // res = res * 75 + 1761;
 
     res = res * 31 + _renderBlockRenderingFlags;
+    res = res * 31 + _interlineScaleFactor;
 
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11603,7 +11603,7 @@ bool ldomXPointerEx::prevVisibleWordStartInSentence()
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
             // move to previous text
-            if ( !prevVisibleText(true) )
+            if ( !prevVisibleText(false) )
                 return false;
             node = getNode();
             text = node->getText();
@@ -11640,7 +11640,7 @@ bool ldomXPointerEx::nextVisibleWordStartInSentence()
     bool moved = false;
     for ( ;; ) {
         if ( !isText() || !isVisible() ) {
-            // move to previous text
+            // move to next text
             if ( !nextVisibleText(false) )
                 return false;
             node = getNode();
@@ -11685,6 +11685,37 @@ bool ldomXPointerEx::nextVisibleWordStartInSentence()
         if ( moved && _data->getOffset()<textLen )
             return true;
     }
+}
+
+/// move to end of current word
+bool ldomXPointerEx::thisVisibleWordEndInSentence()
+{
+    if ( isNull() )
+        return false;
+    ldomNode * node = NULL;
+    lString16 text;
+    int textLen = 0;
+    bool moved = false;
+    if ( !isText() || !isVisible() )
+        return false;
+    node = getNode();
+    text = node->getText();
+    textLen = text.length();
+    if ( _data->getOffset() >= textLen )
+        return false;
+    // skip spaces
+    while ( _data->getOffset()<textLen && IsUnicodeSpace(text[ _data->getOffset() ]) ) {
+        _data->addOffset(1);
+        //moved = true;
+    }
+    // skip non-spaces
+    while ( _data->getOffset()<textLen ) {
+        if ( IsUnicodeSpace(text[ _data->getOffset() ]) )
+            break;
+        moved = true;
+        _data->addOffset(1);
+    }
+    return moved;
 }
 
 /// move to next visible word end (in sentence)
@@ -11993,8 +12024,8 @@ bool ldomXPointerEx::isSentenceEnd()
     // word is not ended with . ! ?
     // check whether it's last word of block
     ldomXPointerEx pos(*this);
-    //return !pos.nextVisibleWordStart(true);
-    return !pos.thisVisibleWordEnd(true);
+    //return !pos.nextVisibleWordStartInSentence();
+    return !pos.thisVisibleWordEndInSentence();
 }
 
 /// move to beginning of current visible text sentence
@@ -12046,7 +12077,7 @@ bool ldomXPointerEx::prevSentenceStart()
     if ( !thisSentenceStart() )
         return false;
     for (;;) {
-        if ( !prevVisibleWordStart() )
+        if ( !prevVisibleWordStartInSentence() )
             return false;
         if ( isSentenceStart() )
             return true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -393,11 +393,6 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     // hash = hash * 31 + (int)fontMan->GetHintingMode();
     if ( LVRendGetFontEmbolden() )
         hash = hash * 75 + 2384761;
-    // Hanging punctuation does not need to trigger a re-render, as
-    // it's now ensured by alignLine() and won't change paragraphs height.
-    // We just need to _renderedBlockCache.clear() when it changes.
-    // if ( gHangingPunctuationEnabled )
-    //     hash = hash * 75 + 1761;
     hash = hash * 31 + gRenderDPI;
     hash = hash * 31 + gRenderBlockRenderingFlags;
     hash = hash * 31 + gRootFontSize;
@@ -2025,6 +2020,7 @@ tinyNodeCollection::tinyNodeCollection()
 ,_docProps(LVCreatePropsContainer())
 ,_docFlags(DOC_FLAG_DEFAULTS)
 ,_fontMap(113)
+,_hangingPunctuationEnabled(false)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
@@ -2066,12 +2062,20 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 ,_docFlags(v._docFlags)
 ,_stylesheet(v._stylesheet)
 ,_fontMap(113)
+,_hangingPunctuationEnabled(v._hangingPunctuationEnabled)
 {
     memset( _textList, 0, sizeof(_textList) );
     memset( _elemList, 0, sizeof(_elemList) );
     // _docIndex assigned in ldomDocument constructor
 }
 
+bool tinyNodeCollection::setHangingPunctiationEnabled(bool value) {
+    if (_hangingPunctuationEnabled != value) {
+        _hangingPunctuationEnabled = value;
+        return true;
+    }
+    return false;
+}
 
 #if BUILD_LITE!=1
 bool tinyNodeCollection::openCacheFile()
@@ -2407,7 +2411,7 @@ bool tinyNodeCollection::loadNodeData()
     _textCount = textcount;
     return true;
 }
-#endif
+#endif  // BUILD_LITE!=1
 
 /// get ldomNode instance pointer
 ldomNode * tinyNodeCollection::getTinyNode( lUInt32 index )
@@ -14956,6 +14960,13 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // only on a laid out line, it does not need a re-rendering, but just
     // a _renderedBlockCache.clear() to reformat paragraphs and have the
     // word re-positionned (the paragraphs width & height do not change)
+
+    // Hanging punctuation does not need to trigger a re-render, as
+    // it's now ensured by alignLine() and won't change paragraphs height.
+    // We just need to _renderedBlockCache.clear() when it changes.
+    //if ( gHangingPunctuationEnabled )
+    // res = res * 75 + 1761;
+
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);
     CRLog::debug("calcStyleHash done");
@@ -18355,7 +18366,7 @@ int ldomNode::renderFinalBlock(  LFormattedTextRef & frmtext, RenderRectAccessor
     // cached into the LFormattedText and ready to be used for drawing
     // and text selection.
     int h = f->Format((lUInt16)width, (lUInt16)page_h, direction, usable_left_overflow, usable_right_overflow,
-                            gHangingPunctuationEnabled, float_footprint);
+                            getDocument()->getHangingPunctiationEnabled(), float_footprint);
     frmtext = f;
     //CRLog::trace("Created new formatted object for node #%08X", (lUInt32)this);
     return h;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5145,9 +5145,9 @@ static bool isFloatingNode( ldomNode * node )
 
 static bool isNotBoxWrappingNode( ldomNode * node )
 {
-    if ( BLOCK_RENDERING(node->getDocument()->getRenderBlockRenderingFlags(), PREPARE_FLOATBOXES) && node->getStyle()->float_ > css_f_none )
+    if ( BLOCK_RENDERING_N(node, PREPARE_FLOATBOXES) && node->getStyle()->float_ > css_f_none )
         return false; // floatBox
-    // isBoxingInlineBox() already checks for BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS)
+    // isBoxingInlineBox() already checks for BLOCK_RENDERING_BOX_INLINE_BLOCKS)
     return !node->isBoxingInlineBox();
 }
 
@@ -5475,7 +5475,7 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
         // remove starting empty
         removeChildren(startIndex, firstNonEmpty-1);
         abox->initNodeStyle();
-        if ( !BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) ) {
+        if ( !BLOCK_RENDERING_N(this, FLOAT_FLOATBOXES) ) {
             // If we don't want floatBoxes floating, reset them to be
             // rendered inline among inlines
             abox->recurseMatchingElements( resetRendMethodToInline, isNotBoxingInlineBoxNode );
@@ -5544,7 +5544,7 @@ bool ldomNode::hasNonEmptyInlineContent( bool ignoreFloats )
     if ( getRendMethod() == erm_invisible ) {
         return false;
     }
-    if ( ignoreFloats && BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) && getStyle()->float_ > css_f_none ) {
+    if ( ignoreFloats && BLOCK_RENDERING_N(this, FLOAT_FLOATBOXES) && getStyle()->float_ > css_f_none ) {
         return false;
     }
     // With some other bool param, we might want to also check for
@@ -5659,7 +5659,7 @@ ldomNode * ldomNode::boxWrapChildren( int startIndex, int endIndex, lUInt16 elem
 // init table element render methods
 // states: 0=table, 1=colgroup, 2=rowgroup, 3=row, 4=cell
 // returns table cell count
-// When BLOCK_RENDERING(rend_flags, COMPLETE_INCOMPLETE_TABLES), we follow rules
+// When BLOCK_RENDERING_COMPLETE_INCOMPLETE_TABLES, we follow rules
 // from the "Generate missing child wrappers" section in:
 //   https://www.w3.org/TR/CSS22/tables.html#anonymous-boxes
 //   https://www.w3.org/TR/css-tables-3/#fixup (clearer than previous one)
@@ -5914,10 +5914,10 @@ bool hasInvisibleParent( ldomNode * node )
 
 bool ldomNode::isFloatingBox() const
 {
-    // BLOCK_RENDERING(rend_flags, FLOAT_FLOATBOXES) is what triggers rendering
+    // BLOCK_RENDERING_FLOAT_FLOATBOXES is what triggers rendering
     // the floats floating. They are wrapped in a floatBox, possibly
-    // not floating, when BLOCK_RENDERING(rend_flags, WRAP_FLOATS)).
-    if ( BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), FLOAT_FLOATBOXES) && getNodeId() == el_floatBox
+    // not floating, when BLOCK_RENDERING_WRAP_FLOATS.
+    if ( BLOCK_RENDERING_N(this, FLOAT_FLOATBOXES) && getNodeId() == el_floatBox
                 && getStyle()->float_ > css_f_none)
         return true;
     return false;
@@ -5927,11 +5927,11 @@ bool ldomNode::isFloatingBox() const
 /// its child no more inline-block/inline-table
 bool ldomNode::isBoxingInlineBox() const
 {
-    // BLOCK_RENDERING(rend_flags, BOX_INLINE_BLOCKS) is what ensures inline-block
+    // BLOCK_RENDERING_BOX_INLINE_BLOCKS) is what ensures inline-block
     // are boxed and rendered as an inline block, but we may have them
     // wrapping a node that is no more inline-block (when some style
     // tweaks have changed the display: property).
-    if ( getNodeId() == el_inlineBox && BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS) ) {
+    if ( getNodeId() == el_inlineBox && BLOCK_RENDERING_N(this, BOX_INLINE_BLOCKS) ) {
         if (getChildCount() == 1) {
             css_display_t d = getChildNode(0)->getStyle()->display;
             if (d == css_d_inline_block || d == css_d_inline_table) {
@@ -5955,7 +5955,7 @@ bool ldomNode::isBoxingInlineBox() const
 bool ldomNode::isEmbeddedBlockBoxingInlineBox(bool inline_box_checks_done) const
 {
     if ( !inline_box_checks_done ) {
-        if ( getNodeId() != el_inlineBox || !BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), BOX_INLINE_BLOCKS) )
+        if ( getNodeId() != el_inlineBox || !BLOCK_RENDERING_N(this, BOX_INLINE_BLOCKS) )
             return false;
         if (getChildCount() != 1)
             return false;
@@ -14982,7 +14982,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
                         if (style.get()->white_space >= css_ws_pre_line)
                             _nodeDisplayStyleHash += 29;
                         // Also account for style->float_, as it should create/remove new floatBox
-                        // elements wrapping floats when toggling BLOCK_RENDERING(rend_flags, ENHANCED)
+                        // elements wrapping floats when toggling BLOCK_RENDERING_ENHANCED
                         if (style.get()->float_ > css_f_none)
                             _nodeDisplayStyleHash += 123;
                     }
@@ -17058,7 +17058,7 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction, bool strict_bo
 
     RenderRectAccessor fmt( this );
 
-    if ( BLOCK_RENDERING(getDocument()->getRenderBlockRenderingFlags(), ENHANCED) ) {
+    if ( BLOCK_RENDERING_N(this, ENHANCED) ) {
         // In enhanced rendering mode, because of collapsing of vertical margins
         // and the fact that we did not update style margins to their computed
         // values, a children box with margins can overlap its parent box, if

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2083,7 +2083,7 @@ bool tinyNodeCollection::openCacheFile()
 
     lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
     //lUInt32 sz = (lUInt32)getProps()->getInt64Def(DOC_PROP_FILE_SIZE, 0);
-    lUInt32 crc = getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
+    lUInt32 crc = (lUInt32)getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
 
     if ( !ldomDocCache::enabled() ) {
         CRLog::error("Cannot open cached document: cache dir is not initialized");
@@ -2133,7 +2133,7 @@ bool tinyNodeCollection::createCacheFile()
 
     lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
     lUInt32 sz = (lUInt32)getProps()->getInt64Def(DOC_PROP_FILE_SIZE, 0);
-    lUInt32 crc = getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
+    lUInt32 crc = (lUInt32)getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
 
     if ( !ldomDocCache::enabled() ) {
         CRLog::error("Cannot swap: cache dir is not initialized");

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -297,7 +297,7 @@ int CRPropAccessor::getIntDef( const char * propName, int defValue ) const
 }
 
 /// set int property as hex
-void CRPropAccessor::setHex( const char * propName, int value )
+void CRPropAccessor::setHex( const char * propName, lUInt32 value )
 {
     char s[16];
     sprintf(s, "0x%08X", value);


### PR DESCRIPTION
`(Upstream) Allow faster LVDocView::getBookmark()`
`(Upstream) Fix scroll mode at start and end of book`
`(Upstream) Fix sentence selection in TTS`
`(Upstream) Fix issues with legacy text rendering`
`(Upstream) Fix FB2 footnotes in legacy text rendering`
`(Upstream) Some CRC32 management fixes`
`(Upstream) FB3/DocX/ODT: get lang and description metadata`
`(Upstream) HyphMan: tweak handling of obsolete pdb files`
`(Upstream) remove global gHangingPunctuationEnabled`
`(Upstream) remove global gRenderBlockRenderingFlags`
`(Upstream) remove global gDOMVersionRequested`
`(Upstream) remove global gInterlineScaleFactor`
Commits from: https://github.com/buggins/coolreader/pull/156 https://github.com/buggins/coolreader/pull/157 https://github.com/buggins/coolreader/pull/160 https://github.com/buggins/coolreader/pull/171 https://github.com/buggins/coolreader/pull/173
Nothing much noticable for KOReader - that's just to avoid diverting too much from upstream for code we update often on our side (so, easying their future syncs with us).

`Minor fixes after global variables replacements`
- consistent default for hanging punctuation: false https://github.com/buggins/coolreader/pull/171#discussion_r497530260
- initialize _DOMVersionRequested in constructor
- use gDOMVersionCurrent instead of 0 in case some   code is used when there is no document
- bump cache file version (not really necessary, but it avoids wondering about the "style hash mismatch" that will happen on all previously opened books because the global variables values are now in different hashes).

`Add macros BLOCK_RENDERING_D/N()`
For shorter lines of code and better readability https://github.com/buggins/coolreader/pull/171#discussion_r495482151

`Fix FB2 footnotes alignment in legacy rendering`
Proposed at https://github.com/buggins/coolreader/pull/157#issuecomment-683778100 but not picked. I think it makes sense.

`lvstsheet.cpp: fix some clang-tidy warnings`
Fix some warning, discussed below.

Pinging @virxkane for info and review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/384)
<!-- Reviewable:end -->
