### PR TITLE
Allows for more than 64 styles, some table layout fixes

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -8,6 +8,7 @@ hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0
 
 a { display: inline; text-decoration: underline; }
 a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
+a[type="note"]::before { content: "\2060" } /* word joiner, avoid break before */
 
 image { text-align: center; text-indent: 0px; display: block }
 p image { display: inline }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -548,6 +548,8 @@ public:
     virtual void getFaceList( lString16Collection & ) { }
     /// returns available font files
     virtual void getFontFileNameList( lString16Collection & ) { }
+    /// returns font filename and face index for font name
+    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index ) { return false; }
 
     /// returns first found face from passed list, or return face for font found by family only
     virtual lString8 findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily);

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -20,72 +20,80 @@
 #include "lvtextfm.h"
 #include "lvfntman.h"
 
-/* bit position (in 'lUInt64 important' and 'lUInt64 importance' bitmaps) of
- * each css_style_rec_tag properties to flag its '!important' status */
-// enum css_style_rec_important_bit : lUInt64 {  <= disliked by clang
+/* bit position (in 'lUInt32[] important' and 'lUInt32[] importance' bitmaps)
+ * of each css_style_rec_tag properties to flag its '!important' status */
 enum css_style_rec_important_bit {
-    imp_bit_display               = 1ULL << 0,
-    imp_bit_white_space           = 1ULL << 1,
-    imp_bit_text_align            = 1ULL << 2,
-    imp_bit_text_align_last       = 1ULL << 3,
-    imp_bit_text_decoration       = 1ULL << 4,
-    imp_bit_text_transform        = 1ULL << 5,
-    imp_bit_vertical_align        = 1ULL << 6,
-    imp_bit_font_family           = 1ULL << 7,
-    imp_bit_font_name             = 1ULL << 8,
-    imp_bit_font_size             = 1ULL << 9,
-    imp_bit_font_style            = 1ULL << 10,
-    imp_bit_font_weight           = 1ULL << 11,
-    imp_bit_font_features         = 1ULL << 12,
-    imp_bit_text_indent           = 1ULL << 13,
-    imp_bit_line_height           = 1ULL << 14,
-    imp_bit_width                 = 1ULL << 15,
-    imp_bit_height                = 1ULL << 16,
-    imp_bit_margin_left           = 1ULL << 17,
-    imp_bit_margin_right          = 1ULL << 18,
-    imp_bit_margin_top            = 1ULL << 19,
-    imp_bit_margin_bottom         = 1ULL << 20,
-    imp_bit_padding_left          = 1ULL << 21,
-    imp_bit_padding_right         = 1ULL << 22,
-    imp_bit_padding_top           = 1ULL << 23,
-    imp_bit_padding_bottom        = 1ULL << 24,
-    imp_bit_color                 = 1ULL << 25,
-    imp_bit_background_color      = 1ULL << 26,
-    imp_bit_letter_spacing        = 1ULL << 27,
-    imp_bit_page_break_before     = 1ULL << 28,
-    imp_bit_page_break_after      = 1ULL << 29,
-    imp_bit_page_break_inside     = 1ULL << 30,
-    imp_bit_hyphenate             = 1ULL << 31,
-    imp_bit_list_style_type       = 1ULL << 32,
-    imp_bit_list_style_position   = 1ULL << 33,
-    imp_bit_border_style_top      = 1ULL << 34,
-    imp_bit_border_style_bottom   = 1ULL << 35,
-    imp_bit_border_style_right    = 1ULL << 36,
-    imp_bit_border_style_left     = 1ULL << 37,
-    imp_bit_border_width_top      = 1ULL << 38,
-    imp_bit_border_width_right    = 1ULL << 39,
-    imp_bit_border_width_bottom   = 1ULL << 40,
-    imp_bit_border_width_left     = 1ULL << 41,
-    imp_bit_border_color_top      = 1ULL << 42,
-    imp_bit_border_color_right    = 1ULL << 43,
-    imp_bit_border_color_bottom   = 1ULL << 44,
-    imp_bit_border_color_left     = 1ULL << 45,
-    imp_bit_background_image      = 1ULL << 46,
-    imp_bit_background_repeat     = 1ULL << 47,
-    imp_bit_background_position   = 1ULL << 48,
-    imp_bit_background_size_h     = 1ULL << 49,
-    imp_bit_background_size_v     = 1ULL << 50,
-    imp_bit_border_collapse       = 1ULL << 51,
-    imp_bit_border_spacing_h      = 1ULL << 52,
-    imp_bit_border_spacing_v      = 1ULL << 53,
-    imp_bit_orphans               = 1ULL << 54,
-    imp_bit_widows                = 1ULL << 55,
-    imp_bit_float                 = 1ULL << 56,
-    imp_bit_clear                 = 1ULL << 57,
-    imp_bit_direction             = 1ULL << 58,
-    imp_bit_content               = 1ULL << 59,
-    imp_bit_cr_hint               = 1ULL << 60
+    imp_bit_display = 0,
+    imp_bit_white_space,
+    imp_bit_text_align,
+    imp_bit_text_align_last,
+    imp_bit_text_decoration,
+    imp_bit_text_transform,
+    imp_bit_vertical_align,
+    imp_bit_font_family,
+    imp_bit_font_name,
+    imp_bit_font_size,
+    imp_bit_font_style,
+    imp_bit_font_weight,
+    imp_bit_font_features,
+    imp_bit_text_indent,
+    imp_bit_line_height,
+    imp_bit_width,
+    imp_bit_height,
+    imp_bit_margin_left,
+    imp_bit_margin_right,
+    imp_bit_margin_top,
+    imp_bit_margin_bottom,
+    imp_bit_padding_left,
+    imp_bit_padding_right,
+    imp_bit_padding_top,
+    imp_bit_padding_bottom,
+    imp_bit_color,
+    imp_bit_background_color,
+    imp_bit_letter_spacing,
+    imp_bit_page_break_before,
+    imp_bit_page_break_after,
+    imp_bit_page_break_inside,
+    imp_bit_hyphenate,
+    imp_bit_list_style_type,
+    imp_bit_list_style_position,
+    imp_bit_border_style_top,
+    imp_bit_border_style_bottom,
+    imp_bit_border_style_right,
+    imp_bit_border_style_left,
+    imp_bit_border_width_top,
+    imp_bit_border_width_right,
+    imp_bit_border_width_bottom,
+    imp_bit_border_width_left,
+    imp_bit_border_color_top,
+    imp_bit_border_color_right,
+    imp_bit_border_color_bottom,
+    imp_bit_border_color_left,
+    imp_bit_background_image,
+    imp_bit_background_repeat,
+    imp_bit_background_position,
+    imp_bit_background_size_h,
+    imp_bit_background_size_v,
+    imp_bit_border_collapse,
+    imp_bit_border_spacing_h,
+    imp_bit_border_spacing_v,
+    imp_bit_orphans,
+    imp_bit_widows,
+    imp_bit_float,
+    imp_bit_clear,
+    imp_bit_direction,
+    imp_bit_content,
+    imp_bit_cr_hint
 };
+#define NB_IMP_BITS 61 // The number of lines in the enum above: KEEP IT UPDATED.
+
+#define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
+// In lvstyles.cpp, we have hardcoded important[0] ... importance[1]
+// So once NB_IMP_SLOTS becomes 3 when IMP_BIT_MAX > 64, add in lvstyles.cpp
+// the needed important[2] and importance[2]. Let us know if we forget that:
+#if (NB_IMP_SLOTS != 2)
+    #error "NB_IMP_SLOTS != 2, some updates in lvstyles.cpp (and then here) are needed"
+#endif
 
 // Style handling flags
 #define STYLE_REC_FLAG_MATCHED  0x01 // This style has had some stylesheet declaration matched and applied.
@@ -101,12 +109,9 @@ typedef struct css_style_rec_tag css_style_rec_t;
 struct css_style_rec_tag {
     int                  refCount; // for reference counting
     lUInt32              hash; // cache calculated hash value here
-    lUInt64              important;  // bitmap for !important (used only by LVCssDeclaration)
-                                     // we have currently below 61 css properties
-                                     // lvstsheet knows about 83, which are mapped to these 61
-                                     // update bits above if you add new properties below
-    lUInt64              importance; // bitmap for important bit's importance/origin
-                                     // (allows for 2 level of !important importance)
+    lUInt32              important[NB_IMP_SLOTS];  // bitmap for !important (used only by LVCssDeclaration)
+    lUInt32              importance[NB_IMP_SLOTS]; // bitmap for important bit's importance/origin
+                                                   // (allows for 2 level of !important importance)
     css_display_t        display;
     css_white_space_t    white_space;
     css_text_align_t     text_align;
@@ -163,8 +168,8 @@ struct css_style_rec_tag {
     css_style_rec_tag()
     : refCount(0)
     , hash(0)
-    , important(0)
-    , importance(0)
+    , important{} // zero-initialization of all array slots
+    , importance{}
     , display( css_d_inline )
     , white_space(css_ws_inherit)
     , text_align(css_ta_inherit)
@@ -224,32 +229,36 @@ struct css_style_rec_tag {
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
     //  important bitmap management
-    bool isImportant( css_style_rec_important_bit bit ) { return important & bit; }
-    void setImportant( css_style_rec_important_bit bit ) { important |= bit; }
+    bool isImportant( css_style_rec_important_bit bit ) { return important[bit>>5] & (1<<(bit&0x1f)); }
+    void setImportant( css_style_rec_important_bit bit ) { important[bit>>5] |= (1<<(bit&0x1f)); }
     // apply value to field if important bit not yet set, then set it if is_important
     template <typename T> inline void Apply( T value, T *field, css_style_rec_important_bit bit, lUInt8 is_important ) {
+        int slot = bit>>5;        // 32 bits per LUint32 slot
+        int sbit = 1<<(bit&0x1f); // bitmask for this single bit in its slot
         // is_important is 2 bits: (high_importance, is_important) (see lvstsheet.cpp)
-        if (     !(important & bit)     // important flag not previously set
+        if (     !(important[slot] & sbit)     // important flag not previously set
               || (is_important == 0x3)  // coming value has '!important' and comes from some CSS parsed with higher_importance=true
-              || (is_important == 0x1 && !(importance & bit) ) // coming value has '!important' and comes from some CSS parsed
+              || (is_important == 0x1 && !(importance[slot] & sbit) ) // coming value has '!important' and comes from some CSS parsed
                                                                // with higher_importance=false, but previous value was not set from
                                                                // a !important that came from CSS parsed with higher_importance=true
            ) {
             *field = value; // apply
-            if (is_important & 0x1) important |= bit;   // update important flag
-            if (is_important == 0x3) importance |= bit; // update importance flag (!important comes from higher_importance CSS)
+            if (is_important & 0x1) important[slot] |= sbit;   // update important flag
+            if (is_important == 0x3) importance[slot] |= sbit; // update importance flag (!important comes from higher_importance CSS)
         }
     }
     // Similar to previous one, but logical-OR'ing values, for bitmaps (currently, only style->font_features and style->cr_hint)
     inline void ApplyAsBitmapOr( css_length_t value, css_length_t *field, css_style_rec_important_bit bit, lUInt8 is_important ) {
-        if (     !(important & bit)
+        int slot = bit>>5;        // 32 bits per LUint32 slot
+        int sbit = 1<<(bit&0x1f); // bitmask for this bit in its slot
+        if (     !(important[slot] & sbit)
               || (is_important == 0x3)
-              || (is_important == 0x1 && !(importance & bit) )
+              || (is_important == 0x1 && !(importance[slot] & sbit) )
            ) {
             field->value |= value.value; // logical-or values
             field->type = value.type;    // use the one from value (always css_val_unspecified for font_features)
-            if (is_important & 0x1) important |= bit;
-            if (is_important == 0x3) importance |= bit;
+            if (is_important & 0x1) important[slot] |= sbit;
+            if (is_important == 0x3) importance[slot] |= sbit;
         }
     }
 };

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -561,6 +561,25 @@ public:
         }
         list.sort();
     }
+    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index )
+    {
+        for ( int i=0; i<_registered_list.length(); i++ ) {
+            if (_registered_list[i]->getDef()->getDocumentId() == -1) {
+                LVFontDef * fdef = _registered_list[i]->getDef();
+                lString16 facename = Utf8ToUnicode( fdef->getTypeFace() );
+                if (facename != name )
+                    continue;
+                if ( (bold && fdef->getWeight() < 650) || (!bold && fdef->getWeight() >= 650) )
+                    continue;
+                if ( (italic && !fdef->isRealItalic()) || (!italic && fdef->isRealItalic()) )
+                    continue;
+                filename = fdef->getName();
+                index = fdef->getIndex();
+                return true;
+            }
+        }
+        return false;
+    }
     virtual void clearFallbackFonts()
     {
         LVPtrVector< LVFontCacheItem > * fonts = getInstances();
@@ -4152,6 +4171,12 @@ public:
     {
         FONT_MAN_GUARD
         _cache.getFontFileNameList(list);
+    }
+
+    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index )
+    {
+        FONT_MAN_GUARD
+        return _cache.getFontFileNameAndFaceIndex(name, bold, italic, filename, index);
     }
 
     bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9964,14 +9964,18 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             typedef struct CellWidths {
                 int min_w;
                 int max_w;
-                bool colspan_involved;
-                CellWidths() : min_w(0), max_w(0), colspan_involved(false) {};
-                CellWidths(int min, int max, bool csi=false)
-                    : min_w(min), max_w(max), colspan_involved(csi) {};
+                int colspan;
+                int rowspan;
+                int last_row_idx; // when used as column: index of last row occupied by previous rowspans
+                CellWidths() : min_w(0), max_w(0), colspan(1), rowspan(1), last_row_idx(-1) {};
+                CellWidths(int min, int max, int cspan=1, int rspan=1)
+                    : min_w(min), max_w(max), colspan(cspan), rowspan(rspan), last_row_idx(-1) {};
             } CellWidths;
             typedef LVArray<CellWidths> RowCells;
             LVArray<RowCells> table;
             int seen_nb_cells = 2; // for RowCells() initial allocation, to avoid realloc
+            int caption_min_width = 0;
+            int caption_max_width = 0;
 
             // Non-recursive sub tree walker, to find erm_table_row nodes
             ldomNode * n = node;
@@ -9988,7 +9992,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                             // Measures cells in that row
                             RowCells row;
                             row.reserve(seen_nb_cells);
-                            bool colspan_involved = false;
                             for (int i = 0; i < n->getChildCount(); i++) {
                                 ldomNode * child = n->getChildNode(i);
                                 if ( child->isText() ) {
@@ -10010,18 +10013,19 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                                 int _lastSpaceWidth = 0;
                                 getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
                                     _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, lang_cfg);
-                                int cs = StrToIntPercent( child->getAttributeValue(attr_colspan).c_str() );
-                                if ( cs > 1 ) { // 0 if no attribute
-                                    // Keep flagging next cells, as their mapping to columns is now messed up
-                                    colspan_involved = true;
-                                }
-                                else { // also check obsolete rbspan attribute for <ruby> tables
-                                    cs = StrToIntPercent( child->getAttributeValue(attr_rbspan).c_str() );
-                                    if ( cs > 1 ) {
-                                        colspan_involved = true;
+                                int cspan = StrToIntPercent( child->getAttributeValue(attr_colspan).c_str() );
+                                if ( !cspan ) { // 0 if no attribute
+                                    // also check obsolete rbspan attribute for <ruby> tables
+                                    cspan = StrToIntPercent( child->getAttributeValue(attr_rbspan).c_str() );
+                                    if ( !cspan ) {
+                                        cspan = 1;
                                     }
                                 }
-                                row.add( CellWidths(_minw, _maxw, colspan_involved) );
+                                int rspan = StrToIntPercent( child->getAttributeValue(attr_rowspan).c_str() );
+                                if ( !rspan ) { // 0 if no attribute
+                                    rspan = 1;
+                                }
+                                row.add( CellWidths(_minw, _maxw, cspan, rspan) );
                             }
                             if ( row.length() > seen_nb_cells )
                                 seen_nb_cells = row.length();
@@ -10029,6 +10033,21 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                             //
                             // Non-recursive sub tree walker (continued)
                             index = n->getChildCount(); // Skip walking/entering that row
+                        }
+                        else if ( n->isElement() && n->getStyle()->display == css_d_table_caption && n->getRendMethod() != erm_invisible ) {
+                            // Also measure caption(s)
+                            int _maxw = 0;
+                            int _minw = 0;
+                            int _curMaxWidth = 0;
+                            int _curWordWidth = 0;
+                            bool _collapseNextSpace = true;
+                            int _lastSpaceWidth = 0;
+                            getRenderedWidths(n, _maxw, _minw, direction, false, rendFlags,
+                                _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, lang_cfg);
+                            if ( _minw > caption_min_width )
+                                caption_min_width = _minw;
+                            if ( _maxw > caption_max_width )
+                                caption_max_width = _maxw;
                         }
                     }
                     // Process next child
@@ -10045,34 +10064,72 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 }
             } // Done with non-recursive sub tree walker
 
-            // nb_columns is the largest nb of cells in a row
+            // nb_columns is the largest nb of cells+colspan in a row (helps avoiding reallocs)
             int nb_columns = 0;
+            int last_cell_start_column_idx = 0; // to correct nb_columns
             for (int r=0; r<table.length(); r++) {
-                int row_len = table[r].length();
+                int row_len = 0;
+                for (int c=0; c<table[r].length(); c++) {
+                    row_len += table[r][c].colspan;
+                }
                 if ( row_len > nb_columns ) {
                     nb_columns = row_len;
                 }
             }
             // We still compute cumulative cells widths (might be right when colspan involved)
+            // Note: this feels like no longer needed now that we handle colspan and rowspan,
+            // so we won't use them, but let's keep computing them for debugging
             int cumulative_min_width = 0;
             int cumulative_max_width = 0;
             //
             RowCells columns(nb_columns, CellWidths()); // Columns widths
+            // Fill columns accounting for colspan and rowspan, similarly to
+            // how it's done in the first step of PlaceCells()
             for (int r=0; r<table.length(); r++) {
-                bool giveup_columns = false;
                 int row_cumul_min_w = 0;
                 int row_cumul_max_w = 0;
                 int row_len = table[r].length();
+                int x = 0; // index of column the current cell will be in
                 for (int c=0; c<row_len; c++) {
-                    if ( table[r][c].colspan_involved ) {
-                        // cells from now on do not map to columns anymore
-                        giveup_columns = true;
+                    // Find a column that has nothing row-spanning current row
+                    while ( x < nb_columns && r <= columns[x].last_row_idx ) {
+                        x++;
                     }
-                    if ( !giveup_columns ) {
-                        if ( columns[c].min_w < table[r][c].min_w )
-                             columns[c].min_w = table[r][c].min_w;
-                        if ( columns[c].max_w < table[r][c].max_w )
-                             columns[c].max_w = table[r][c].max_w;
+                    if ( last_cell_start_column_idx < x )
+                        last_cell_start_column_idx = x;
+                    // Add columns if necessary, if colspan/rowspan combinations
+                    // exceed what we estimated previously
+                    int cs = table[r][c].colspan;
+                    while ( x + cs-1 > nb_columns-1 ) {
+                        columns.add( CellWidths() );
+                        nb_columns++;
+                    }
+                    // Update columns this cell will colspan with the number
+                    // of rows rowspanned by this cell
+                    int rs = table[r][c].rowspan;
+                    for (int xx=0; xx<cs; xx++) {
+                        if ( columns[x+xx].last_row_idx < r + rs-1 )
+                            columns[x+xx].last_row_idx = r + rs-1;
+                    }
+                    // Update columns this cell will colspan with
+                    // the distributed cell min_w and max_w
+                    int all_min_w = table[r][c].min_w / cs;
+                    int extra_min_w = table[r][c].min_w - all_min_w*cs;
+                    int all_max_w = table[r][c].max_w / cs;
+                    int extra_max_w = table[r][c].max_w - all_max_w*cs;
+                    for (int xx=0; xx<cs; xx++) {
+                        int min_w = all_min_w;
+                        if (extra_min_w > 0) {
+                            min_w++; extra_min_w--;
+                        }
+                        int max_w = all_max_w;
+                        if (extra_max_w > 0) {
+                            max_w++; extra_max_w--;
+                        }
+                        if ( columns[x+xx].min_w < min_w )
+                             columns[x+xx].min_w = min_w;
+                        if ( columns[x+xx].max_w < max_w )
+                             columns[x+xx].max_w = max_w;
                     }
                     row_cumul_min_w += table[r][c].min_w;
                     row_cumul_max_w += table[r][c].max_w;
@@ -10089,20 +10146,31 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 columns_min_width += columns[c].min_w;
                 columns_max_width += columns[c].max_w;
             }
-            // _minWidth is the max of columns_min_width and cumulative_min_width
+            // _minWidth is the max of columns_min_width and caption_min_width (and cumulative_min_width previously)
             if ( _minWidth < columns_min_width )
                  _minWidth = columns_min_width;
+            if ( _minWidth < caption_min_width )
+                 _minWidth = caption_min_width;
+            /* This feels like no longer needed, so let's not use them
             if ( _minWidth < cumulative_min_width )
                  _minWidth = cumulative_min_width;
-            // _maxWidth is the max of columns_max_width and cumulative_max_width
+            */
+            // _maxWidth is the max of columns_max_width and caption_max_width (and cumulative_max_width previously)
             if ( _maxWidth < columns_max_width )
                  _maxWidth = columns_max_width;
+            if ( _maxWidth < caption_max_width )
+                 _maxWidth = caption_max_width;
+            /* This feels like no longer needed, so let's not use them
             if ( _maxWidth < cumulative_max_width )
                  _maxWidth = cumulative_max_width;
+            */
             // add horizontal border_spacing if "border-collapse: separate"
             if ( style->border_collapse != css_border_collapse ) {
+                int final_nb_cols = nb_columns;
+                if ( last_cell_start_column_idx < nb_columns-1 )
+                    final_nb_cols = last_cell_start_column_idx + 1;
                 int em = node->getFont()->getSize();
-                int extra_width = lengthToPx(style->border_spacing[0], 0, em) * (nb_columns+1);
+                int extra_width = lengthToPx(style->border_spacing[0], 0, em) * (final_nb_cols+1);
                 _minWidth += extra_width;
                 _maxWidth += extra_width;
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -145,6 +145,7 @@ public:
     int width;
     int height;
     int baseline;
+    int adjusted_baseline;
     int percent;
     int max_content_width;
     int min_content_width;
@@ -158,6 +159,7 @@ public:
     , width(0)
     , height(0)
     , baseline(0)
+    , adjusted_baseline(0)
     , percent(0)
     , max_content_width(0)
     , min_content_width(0)
@@ -1599,21 +1601,23 @@ public:
                         fmt.push();
                         int h = cell->elem->renderFinalBlock( txform, &fmt, cell->width - padding_left - padding_right);
                         cell->height = padding_top + h + padding_bottom;
-
                         // A cell baseline is the baseline of its first line of text (or
                         // the bottom of content edge of the cell if no line)
+                        if ( txform->GetLineCount() > 0 ) // we have a line
+                            cell->baseline = padding_top + txform->GetLineInfo(0)->baseline;
+                        else // no line, no image: bottom of content edge is at padding_top
+                            cell->baseline = padding_top;
+
                         if ( cell->valign == 0 ) { // vertical-align: baseline
-                            if ( txform->GetLineCount() > 0 ) // we have a line
-                                cell->baseline = padding_top + txform->GetLineInfo(0)->baseline;
-                            else // no line, no image: bottom of content edge is at padding_top
-                                cell->baseline = padding_top;
+                            // We'll use that baseline
+                            cell->adjusted_baseline = cell->baseline;
                         }
                         else { // all other vertical-align: values
                             // "If a row has no cell box aligned to its baseline,
                             // the baseline of that row is the bottom content edge
                             // of the lowest cell in the row."
-                            // So, store that bottom content edge in cell->baseline
-                            cell->baseline += h;
+                            // We'll position that bottom content edge
+                            cell->adjusted_baseline = padding_top + h;
                         }
 
                         // Gather footnotes links, as done in renderBlockElement() when erm_final/flgSplit
@@ -1705,26 +1709,27 @@ public:
                         else {
                             cell_context = new LVRendPageContext( NULL, context.getPageHeight(), false );
                         }
-                        // See above about what we'll store in cell->baseline
-                        int baseline = REQ_BASELINE_NOT_NEEDED;
-                        if ( cell->valign == 0 ) { // vertical-align: baseline
-                            baseline = REQ_BASELINE_FOR_TABLE;
-                        }
+                        // We request renderBlockElement() to give us back the baseline
+                        // of the block as expected for tables
+                        cell->baseline = REQ_BASELINE_FOR_TABLE;
                         int h = renderBlockElement( *cell_context, cell->elem, 0, 0, cell->width,
                                                     0, 0, // no usable left/right overflow outside cell
-                                                    cell->direction, &baseline, rend_flags);
+                                                    cell->direction, &cell->baseline, rend_flags);
                         cell->height = h;
+                        // See above about what we store in cell->adjusted_baseline
                         if ( cell->valign == 0 ) { // vertical-align: baseline
-                            cell->baseline = baseline;
+                            // We'll use that baseline
+                            cell->adjusted_baseline = cell->baseline;
                         }
                         else {
-                            // We'd need the bottom content edge of what's been rendered.
+                            // We need the bottom content edge of what's been rendered.
                             // We just need to remove this cell bottom padding (we should
                             // not remove the inner content bottom margins or paddings).
                             int em = cell->elem->getFont()->getSize();
                             css_style_ref_t elem_style = cell->elem->getStyle();
                             int padding_bottom = lengthToPx( elem_style->padding[3], cell->width, em ) + measureBorder(cell->elem,2);
-                            cell->baseline = h - padding_bottom;
+                            // We'll position that bottom content edge
+                            cell->adjusted_baseline = h - padding_bottom;
                         }
                         if ( !is_single_column ) {
                             // Gather footnotes links accumulated by cell_context
@@ -1765,8 +1770,9 @@ public:
                     //   This will establish the baseline of the row"
                     if ( cell->valign == 0 ) { // only cells with vertical-align: baseline
                         row_has_baseline_aligned_cells = true;
-                        if ( row->baseline < cell->baseline )
-                            row->baseline = cell->baseline;
+                        if ( row->baseline < cell->adjusted_baseline )
+                            row->baseline = cell->adjusted_baseline;
+                                // (cell->adjusted_baseline is cell->baseline)
                     }
                 }
             }
@@ -1779,26 +1785,22 @@ public:
                         // "If a row has no cell box aligned to its baseline,
                         // the baseline of that row is the bottom content edge
                         // of the lowest cell in the row."
-                        // We have computed cell->baseline that way
-                        // when cell->valign != 0, so just use it:
-                        if ( row->baseline < cell->baseline )
-                            row->baseline = cell->baseline;
-                        // cell->baseline = 0; // (not needed, as not used)
+                        // We have stored in cell->adjusted_baseline the
+                        // cells bottom content edges.
+                        if ( row->baseline < cell->adjusted_baseline )
+                            row->baseline = cell->adjusted_baseline;
                     }
                     else if ( cell->valign == 0 ) {
                         // Cells with vertical-align: baseline must align with
                         // the row baseline: this can increase the height of
                         // a cell, and so the height of the row.
-                        // As we don't need the real cell->baseline after this,
-                        // we store in it the shift-down frop top for this cell,
-                        // that we'll use below when handling cell->valign==0.
-                        int shift_down = row->baseline - cell->baseline;
-                        cell->baseline = shift_down;
+                        int shift_down = row->baseline - cell->adjusted_baseline;
+                        cell->adjusted_baseline = row->baseline;
                         // And update row height from this cell height if it is rowspan=1
                         if ( cell->rowspan == 1 && row->height < cell->height + shift_down )
                             row->height = cell->height + shift_down;
                     }
-                    // else cell->baseline = 0; // (not needed, as not used)
+                    // else cell->adjusted_baseline won't be used
                 }
             }
         }
@@ -2050,7 +2052,7 @@ public:
                     if ( cell_h < row_h ) {
                         int pad = 0; // default when cell->valign=1 / top
                         if (cell->valign == 0) // baseline
-                            pad = cell->baseline; // contains the shift-down to align cell and row baselines
+                            pad = cell->adjusted_baseline - cell->baseline; // shift-down to align cell and row baselines
                         else if (cell->valign == 2) // center
                             pad = (row_h - cell_h)/2;
                         else if (cell->valign == 3) // bottom

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -705,21 +705,22 @@ public:
             for (j=0; j<rows[i]->cells.length(); j++) {
                 CCRTableCell * cell = rows[i]->cells[j];
                 int cs = cell->colspan;
-                //int rs = cell->rowspan;
+                // Find col (in cols) that does not have something rowspan'ing
+                // current row and can accept this cell. Extend nb of cols until
+                // we find one
                 while (x<cols.length() && cols[x]->nrows>i) { // find free cell position
                     x++;
                     ExtendCols(x); // update col count
                 }
                 ExtendCols( x + cs ); // update col count
                 cell->col = cols[x];
+                // Update nrows (used rows last index) for columns this cell will
+                // colspan with the number of rows it will rowspan
                 for (int xx=0; xx<cs; xx++) {
                     // place cell
                     ExtendCols(x+xx+1); // update col count
                     if ( cols[x+xx]->nrows < i+cell->rowspan )
                         cols[x+xx]->nrows = i+cell->rowspan;
-                    if (cell->rowspan>1) {
-                        //int flg =1;
-                    }
                 }
                 // update col width (for regular cells with colspan=1 only)
                 if (cell->colspan==1) {
@@ -730,7 +731,34 @@ public:
                     }
                 }
                 x += cs;
+                // Note: we don't handle rowspan/colspan conflicts like with:
+                //   <table>
+                //     <tr><td rowspan=3>col1</td> <td>col2 </td> <td rowspan=3>col3</td></tr>
+                //     <tr><td colspan=2>col2</td></tr>
+                //     <tr><td>col3b</td></tr>
+                //   </table>
+                // Firefox seems to kill the colspan=2 and make it =1
             }
+            /* The following code (now commented out) looks wrong:
+             * it's supposed to look at each col passed by our last
+             * cell (but not the cols on its right), and find out
+             * the one with the min number of rows occupied.
+             * If that min nb of rows is larger than our current
+             * row number, it would insert empty rows to fill it.
+             * By doing so, it was inserting rows in between
+             * existing ones, and messing with rowspans.
+             * For example, with:
+             *   <table>
+             *     <tr><td rowspan=3>col1</td> <td rowspan=3>col2</td></tr>
+             *     <tr><td>col3a</td></tr>
+             *     <tr><td>col3b</td></tr>
+             *   </table>
+             * col3a abd col3b were pushed below col1+col2, instead
+             * of creating and being in a 3rd column on their right.
+             *
+             * I can't guess which other case this was supposed to solve...
+             * So let's disable it until we find why it was needed.
+             *
             // update min row count
             for (j=0; j<x; j++) {
                 if (miny==-1 || miny>cols[j]->nrows)
@@ -744,6 +772,7 @@ public:
                 nrow->index = i;
                 rows.insert(i, nrow);
             }
+            */
         }
         int maxy = 0; // check highest column
         for (j=0; j<cols.length(); j++)
@@ -1764,9 +1793,10 @@ public:
                         // we store in it the shift-down frop top for this cell,
                         // that we'll use below when handling cell->valign==0.
                         int shift_down = row->baseline - cell->baseline;
-                        if ( row->height < cell->height + shift_down )
-                            row->height = cell->height + shift_down;
                         cell->baseline = shift_down;
+                        // And update row height from this cell height if it is rowspan=1
+                        if ( cell->rowspan == 1 && row->height < cell->height + shift_down )
+                            row->height = cell->height + shift_down;
                     }
                     // else cell->baseline = 0; // (not needed, as not used)
                 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4821,8 +4821,11 @@ public:
                             break; // found the first row
                         }
                     }
-                    // Process next child
-                    if ( nextChildIndex < n->getChildCount() ) {
+                    // Process next child, but don't go look into erm_final nodes
+                    // (they may contain other inline-tables with rows which have
+                    // already contributed to set the final node baseline that
+                    // was accounted in baseline_y when it did addContentLine()).
+                    if ( n->getRendMethod() != erm_final && nextChildIndex < n->getChildCount() ) {
                         n = n->getChildNode(nextChildIndex);
                         nextChildIndex = 0;
                         continue;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -45,10 +45,10 @@ lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
         rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
-           (lUInt32)(rec.important >> 32)) * 31
-         + (lUInt32)(rec.important & 0xFFFFFFFFULL)) * 31
-         + (lUInt32)(rec.importance >> 32)) * 31
-         + (lUInt32)(rec.importance & 0xFFFFFFFFULL)) * 31
+         + (lUInt32)rec.important[0]) * 31
+         + (lUInt32)rec.important[1]) * 31
+         + (lUInt32)rec.importance[0]) * 31
+         + (lUInt32)rec.importance[1]) * 31
          + (lUInt32)rec.display) * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
@@ -115,8 +115,10 @@ lUInt32 calcHash(css_style_rec_t & rec)
 bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
 {
     return 
-           r1.important == r2.important &&
-           r1.importance == r2.importance &&
+           r1.important[0] == r2.important[0] &&
+           r1.important[1] == r2.important[1] &&
+           r1.importance[0] == r2.importance[0] &&
+           r1.importance[1] == r2.importance[1] &&
            r1.display == r2.display &&
            r1.white_space == r2.white_space &&
            r1.text_align == r2.text_align &&
@@ -313,8 +315,10 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     if ( buf.error() )
         return false;
     buf.putMagic(style_magic);
-    ST_PUT_UI64(important);         //    lUInt64              important;
-    ST_PUT_UI64(importance);        //    lUInt64              importance;
+    buf << important[0];            //    lUInt32              important[0];
+    buf << important[1];            //    lUInt32              important[1];
+    buf << importance[0];           //    lUInt32              importance[0];
+    buf << importance[1];           //    lUInt32              importance[1];
     ST_PUT_ENUM(display);           //    css_display_t        display;
     ST_PUT_ENUM(white_space);       //    css_white_space_t    white_space;
     ST_PUT_ENUM(text_align);        //    css_text_align_t     text_align;
@@ -374,8 +378,10 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     if ( buf.error() )
         return false;
     buf.putMagic(style_magic);
-    ST_GET_UI64(important);                                 //    lUInt64              important;
-    ST_GET_UI64(importance);                                //    lUInt64              importance;
+    buf >> important[0];                                    //    lUInt32              important[0];
+    buf >> important[1];                                    //    lUInt32              important[1];
+    buf >> importance[0];                                   //    lUInt32              importance[0];
+    buf >> importance[1];                                   //    lUInt32              importance[1];
     ST_GET_ENUM(css_display_t, display);                    //    css_display_t        display;
     ST_GET_ENUM(css_white_space_t, white_space);            //    css_white_space_t    white_space;
     ST_GET_ENUM(css_text_align_t, text_align);              //    css_text_align_t     text_align;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.52k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.53k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0025
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13974,11 +13974,12 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     // HTML valign= => CSS vertical-align: only for TH & TD (as lvrend.cpp
     // only uses it with table cells (erm_final or erm_block))
     if (id == el_th || id == el_td) {
-        // Default rendering for cells is valign=top
-        // There is no support for valign=baseline.
+        // Default rendering for cells is valign=baseline
         if ( !lStr_cmp(attrname, "valign") ) {
             lString16 valign = lString16(attrvalue).lowercase();
-            if ( valign == L"middle" )
+            if ( valign == L"top" )
+                appendStyle( L"vertical-align: top" );
+            else if ( valign == L"middle" )
                 appendStyle( L"vertical-align: middle" );
             else if ( valign == L"bottom")
                 appendStyle( L"vertical-align: bottom" );

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -716,10 +716,18 @@ TextLangCfg::TextLangCfg( lString16 lang_tag ) {
         has_left_single_quotation_mark_closing = true;
         has_right_single_quotation_mark_glue = true;
         has_left_double_quotation_mark_closing = true;
+        /* Next ones commented out, as non-inverted usage of these
+         * quotation marks can be found in pure "de" text - and
+         * generally, these quotations marks are stuck to their
+         * quoted first or last word and have only a space on the
+         * other side, and so should be fine with just being "QU"
+         * for libunibreak.
+         * See https://github.com/koreader/koreader/issues/6717
         has_left_single_angle_quotation_mark_closing = true;
         has_right_single_angle_quotation_mark_opening = true;
         has_left_double_angle_quotation_mark_closing = true;
         has_right_double_angle_quotation_mark_opening = true;
+        */
     }
     else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
         has_left_double_quotation_mark_closing = true;


### PR DESCRIPTION
`TextLang: German: loosen quotation marks handling`
See https://github.com/koreader/koreader/issues/6717 . This removes some libunibreak specific defaults for "de", but we'll then see if and why these are really needed.

`Fonts: add LVFontManager::getFontFileNameAndFaceIndex()`
Will allow showing font faces in their own font in KOReader Font menu.
See https://github.com/koreader/koreader/issues/6739#issuecomment-703131167.

`fb2.css: avoid break before footnote links`
See https://github.com/koreader/koreader/issues/6718#issuecomment-699600019.

`FlowState: fix possible wrong baseline with nested inline-table`
`Tables: fix possible layout issues with rowspan`
`Table cells: minor refactoring of baseline handling`
`getRenderedWidths(): better estimate table width`
Various generic table fixes I needed while playing with adding MathML support (still playing with it, but yet no feeling if it will be worth it...)

`lvstyles: allow for more than 64 styles`
See https://github.com/koreader/crengine/issues/360#issuecomment-702894363. Idea from @pkb at https://github.com/koreader/koreader/issues/6345#issuecomment-653720509.
Not needed right now, but let's switch early so we can see that everything works fine with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/385)
<!-- Reviewable:end -->
