### PR TITLE
(Upstream) lChar16/lString16 renamed to lChar32/lString32 - Other rendering fixes

### DIFF
--- a/crengine/Tools/Fb2Linux/fb2v.cpp
+++ b/crengine/Tools/Fb2Linux/fb2v.cpp
@@ -284,8 +284,8 @@ int main( int argc, const char * argv[] )
         if ( !dir.isNull() )
         for ( int i=0; i<dir->GetObjectCount(); i++ ) {
             const LVContainerItemInfo * item = dir->GetObjectInfo(i);
-            lString16 fileName = item->GetName();
-            if ( !item->IsContainer() && fileName.length()>4 && lString16(fileName, fileName.length()-4, 4)==L".ttf" ) {
+            lString32 fileName = item->GetName();
+            if ( !item->IsContainer() && fileName.length()>4 && lString32(fileName, fileName.length()-4, 4)==U".ttf" ) {
                 lString8 fn = UnicodeToLocal(fileName);
                 printf("loading font: %s\n", fn.c_str());
                 if ( !fontMan->RegisterFont(fn) ) {

--- a/crengine/Tools/Fb2Test/Fb2Test.cpp
+++ b/crengine/Tools/Fb2Test/Fb2Test.cpp
@@ -31,9 +31,9 @@ void testFormatting()
     class Tester {
     public:
         LFormattedText txt;
-        void addLine( const lChar16 * str, int flags, LVFontRef font )
+        void addLine( const lChar32 * str, int flags, LVFontRef font )
         {
-            lString16 s( str );
+            lString32 s( str );
             txt.AddSourceLine(
                s.c_str(),        /* pointer to unicode text string */
                s.length(),         /* number of chars in text, 0 for auto(strlen) */
@@ -51,24 +51,24 @@ void testFormatting()
     LVFontRef font1 = fontMan->GetFont(20, 300, false, css_ff_sans_serif, lString8("Arial") );
     LVFontRef font2 = fontMan->GetFont(20, 300, false, css_ff_serif, lString8("Times New Roman") );
     Tester t;
-    t.addLine( L"Testing simple paragraph formatting. Just a test. ", LTEXT_ALIGN_WIDTH|LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L"Another fragment of text. ", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L"And the last one written with another font", LTEXT_FLAG_OWNTEXT, font2 );
-    t.addLine( L"Next paragraph: left-aligned. ", LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L"One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L"One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L"Testing simple paragraph formatting. Just a test. ", LTEXT_ALIGN_WIDTH|LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font2 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font2 );
-    t.addLine( L" Word", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
-    t.addLine( L" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"Testing simple paragraph formatting. Just a test. ", LTEXT_ALIGN_WIDTH|LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"Another fragment of text. ", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"And the last one written with another font", LTEXT_FLAG_OWNTEXT, font2 );
+    t.addLine( U"Next paragraph: left-aligned. ", LTEXT_ALIGN_LEFT|LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U"Testing simple paragraph formatting. Just a test. ", LTEXT_ALIGN_WIDTH|LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font2 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font2 );
+    t.addLine( U" Word", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
+    t.addLine( U" One more sentence. Second sentence.", LTEXT_FLAG_OWNTEXT, font1 );
     int N = 100000;
     int i;
     time_t start1 = time((time_t*)0);
@@ -323,7 +323,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
 	//TestWol();
 /*
-    LVStreamRef zipfile = LVOpenFileStream( L"zip_test.zip", LVOM_READ );
+    LVStreamRef zipfile = LVOpenFileStream( U"zip_test.zip", LVOM_READ );
     if (!zipfile.isNull())
     {
         LVContainerRef zip = LVOpenArchieve( zipfile );
@@ -387,8 +387,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
         if ( !dir.isNull() )
         for ( i=0; i<dir->GetObjectCount(); i++ ) {
             const LVContainerItemInfo * item = dir->GetObjectInfo(i);
-            lString16 fileName = item->GetName();
-            if ( !item->IsContainer() && fileName.length()>4 && lString16(fileName, fileName.length()-4, 4)==L".ttf" ) {
+            lString32 fileName = item->GetName();
+            if ( !item->IsContainer() && fileName.length()>4 && lString32(fileName, fileName.length()-4, 4)==U".ttf" ) {
                 lString8 fn = UnicodeToLocal(fileName);
                 printf("loading font: %s\n", fn.c_str());
                 if ( !fontMan->RegisterFont(fn) ) {
@@ -515,7 +515,7 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 	wcex.hCursor		= LoadCursor(NULL, IDC_ARROW);
 	wcex.hbrBackground	= (HBRUSH)(COLOR_WINDOW+1);
 	wcex.lpszMenuName	= NULL;
-	wcex.lpszClassName	= L"CoolReader";
+	wcex.lpszClassName	= U"CoolReader";
 	wcex.hIconSm		= LoadIcon(wcex.hInstance, (LPCTSTR)IDI_SMALL);
 
 	return RegisterClassExW(&wcex);
@@ -571,8 +571,8 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 #endif
 
    hWnd = CreateWindowW(
-	   L"CoolReader",
-	   L"CREngine - Simple FB2 viewer",
+	   U"CoolReader",
+	   U"CREngine - Simple FB2 viewer",
       flags, //WS_OVERLAPPEDWINDOW
       x, y, dx, dy,
       NULL, NULL, hInstance, NULL);
@@ -832,7 +832,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                     sel.clear();
                     sel.add( new ldomXRange(*links[0]) );
                     for ( int i=0; i<linkCount; i++ ) {
-                        lString16 txt = links[i]->getRangeText();
+                        lString32 txt = links[i]->getRangeText();
                         lString8 txt8 = UnicodeToLocal( txt );
                         const char * s = txt8.c_str();
                         txt.clear();

--- a/crengine/Tools/FontConv/LFntConvDlg.cpp
+++ b/crengine/Tools/FontConv/LFntConvDlg.cpp
@@ -277,7 +277,7 @@ DWORD GetGlyphIndicesW(
   DWORD fl       // glyph options
 );
 
-#define SH L"\xad"
+#define SH U"\xad"
 void CLFntConvDlg::FormatSampleText()
 {
     LVFont * font = m_fontref.get();
@@ -286,20 +286,20 @@ void CLFntConvDlg::FormatSampleText()
     m_frmtext = new LFormattedText();
     if ( !font )
         return;
-    m_frmtext->AddSourceLine( L"Centered paragraph!",
+    m_frmtext->AddSourceLine( U"Centered paragraph!",
         0, font, LTEXT_FLAG_OWNTEXT|LTEXT_ALIGN_CENTER, 16, 0, NULL );
-    m_frmtext->AddSourceLine( L"Russian: " 
-        L"\x042D\x0442\x043E \x0442\x0435\x043A\x0441\x0442 \x043D\x0430 "
-        L"\x0440\x0443\x0441" SH L"\x0441\x043A\x043E\x043C \x044F\x0437\x044B" SH L"\x043A\x0435. ",
+    m_frmtext->AddSourceLine( U"Russian: " 
+        U"\x042D\x0442\x043E \x0442\x0435\x043A\x0441\x0442 \x043D\x0430 "
+        U"\x0440\x0443\x0441" SH U"\x0441\x043A\x043E\x043C \x044F\x0437\x044B" SH U"\x043A\x0435. ",
         0, font, LTEXT_FLAG_OWNTEXT|LTEXT_ALIGN_WIDTH, 16, 40, NULL );
-    m_frmtext->AddSourceLine( L"New para.",
+    m_frmtext->AddSourceLine( U"New para.",
         0, font, LTEXT_FLAG_OWNTEXT|LTEXT_ALIGN_WIDTH, 16, 40, NULL );
-    m_frmtext->AddSourceLine( L"This sentence should be appended to the same paragraph.",
+    m_frmtext->AddSourceLine( U"This sentence should be appended to the same paragraph.",
         0, font, LTEXT_FLAG_OWNTEXT, 16, 40, NULL );
-    m_frmtext->AddSourceLine( L"This is right aligned paragraph. Is it wrapped properly? Check it!",
+    m_frmtext->AddSourceLine( U"This is right aligned paragraph. Is it wrapped properly? Check it!",
         0, font, LTEXT_FLAG_OWNTEXT|LTEXT_ALIGN_RIGHT, 16, 0, NULL );
-    m_frmtext->AddSourceLine( L"This is paragraph tests width alignment. "
-        L"First line has margin.",
+    m_frmtext->AddSourceLine( U"This is paragraph tests width alignment. "
+        U"First line has margin.",
         0, font, LTEXT_FLAG_OWNTEXT|LTEXT_ALIGN_WIDTH, 16, 40, NULL );
     m_frmtext->Format( 340, 300 );
 }

--- a/crengine/Tools/HyphConv/mkpattern.cpp
+++ b/crengine/Tools/HyphConv/mkpattern.cpp
@@ -19,23 +19,23 @@ public:
         fprintf(out, "</HyphenationDescription>\n");
         //fclose(out);
     }
-    void processLine(lString16 & line) {
+    void processLine(lString32 & line) {
         if (line.lastChar()=='\r' || line.lastChar()=='\n')
             line.erase(line.length()-1, 1);
         if (state == 0) {
             //
-            if (line.startsWith(lString16("%"))) {
+            if (line.startsWith(lString32("%"))) {
                 fprintf(out, "%s\n", LCSTR(line));
                 return;
             }
-            if (line.startsWith(lString16("\\patterns{"))) {
+            if (line.startsWith(lString32("\\patterns{"))) {
                 start();
                 return;
             }
         } else {
-            lString16 word;
+            lString32 word;
             for (int i=0; i<=line.length(); i++) {
-                lChar16 ch = (i<line.length()) ? line[i] : 0;
+                lChar32 ch = (i<line.length()) ? line[i] : 0;
                 if (ch == '}')
                     break;
                 if (ch==' ' || ch=='\t' || ch=='%' || ch==0) {
@@ -52,7 +52,7 @@ public:
         }
     }
 private:
-    void addPattern(lString16 pattern) {
+    void addPattern(lString32 pattern) {
         if (pattern[0] == '.')
             pattern[0] = ' ';
         if (pattern[pattern.length()-1] == '.')
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
     Convertor cnv(out);
     char buf[4096];
     while (fgets(buf, 4096, src)) {
-        lString16 line(buf);
+        lString32 line(buf);
         cnv.processLine(line);
     }
     fclose(src);

--- a/crengine/include/bookformats.h
+++ b/crengine/include/bookformats.h
@@ -22,8 +22,8 @@ typedef enum {
     // don't forget update getDocFormatName() when changing this enum
 } doc_format_t;
 
-lString16 LVDocFormatName(int fmt);
-int LVDocFormatFromExtension(lString16 &pathName);
+lString32 LVDocFormatName(int fmt);
+int LVDocFormatFromExtension(lString32 &pathName);
 lString8 LVDocFormatCssFileName(int fmt);
 
 

--- a/crengine/include/crgui.h
+++ b/crengine/include/crgui.h
@@ -207,7 +207,7 @@ typedef LVRef<CRGUIAcceleratorTable> CRGUIAcceleratorTableRef;
 class CRGUIAcceleratorTableList
 {
 private:
-    LVHashTable<lString16, CRGUIAcceleratorTableRef> _table;
+    LVHashTable<lString32, CRGUIAcceleratorTableRef> _table;
 public:
 	/// add all tables
 	void addAll( const CRGUIAcceleratorTableList & v );
@@ -216,18 +216,18 @@ public:
     /// add accelerator table definition from array
     void add( const char * name, const int * defs )
     {
-        add( lString16( name ), defs );
+        add( lString32( name ), defs );
     }
     /// add accelerator table definition from array
-    void add( const lString16 & name, const int * defs )
+    void add( const lString32 & name, const int * defs )
     {
         _table.set( name, CRGUIAcceleratorTableRef( new CRGUIAcceleratorTable( defs ) ) );
     }
     /// find accelerator table by name
-    CRGUIAcceleratorTableRef get( const lString16 & name ) { return _table.get( name ); }
-    CRGUIAcceleratorTableRef get( const lString16 & name, CRPropRef keyRemappingOptions );
+    CRGUIAcceleratorTableRef get( const lString32 & name ) { return _table.get( name ); }
+    CRGUIAcceleratorTableRef get( const lString32 & name, CRPropRef keyRemappingOptions );
     /// find accelerator table by name
-    CRGUIAcceleratorTableRef get( const char * name ) { return _table.get( lString16( name ) ); }
+    CRGUIAcceleratorTableRef get( const char * name ) { return _table.get( lString32( name ) ); }
     /// returns true if there are no no tables in list
     bool empty() { return _table.length()==0; }
     /// constructs empty list, then it should be filled from file using openFromFile()
@@ -241,22 +241,22 @@ public:
 
 class CRKeyboardLayout
 {
-	lString16Collection _items;
+	lString32Collection _items;
 public:
 	CRKeyboardLayout() { }
-	const lString16Collection & getItems() { return _items; }
-	lString16 get( int i )
+	const lString32Collection & getItems() { return _items; }
+	lString32 get( int i )
 	{
 		if ( i<0 || i>= (int)_items.length() )
-            return lString16::empty_str;
+            return lString32::empty_str;
 		return _items[i];
 	}
-	void set( int index, lString16 chars )
+	void set( int index, lString32 chars )
 	{
 		if ( index<0 || index>20 )
 			return;
 		while ( (int)_items.length() <= index )
-            _items.add(lString16::empty_str);
+            _items.add(lString32::empty_str);
 		_items[ index ] = chars;
 	}
 };
@@ -264,7 +264,7 @@ public:
 class CRKeyboardLayoutSet
 {
 public:
-	lString16 name;
+	lString32 name;
 	LVRef<CRKeyboardLayout> vKeyboard;
 	LVRef<CRKeyboardLayout> tXKeyboard;
 	CRKeyboardLayoutSet()
@@ -288,7 +288,7 @@ typedef LVRef<CRKeyboardLayoutSet> CRKeyboardLayoutRef;
 
 class CRKeyboardLayoutList
 {
-    LVHashTable<lString16, CRKeyboardLayoutRef> _table;
+    LVHashTable<lString32, CRKeyboardLayoutRef> _table;
 	CRKeyboardLayoutRef _current;
 public:
 	// get currently set layout
@@ -298,8 +298,8 @@ public:
 	// get previous layout
 	CRKeyboardLayoutRef prevLayout();
 
-	CRKeyboardLayoutRef get( lString16 name ) { return _table.get( name ); }
-	void set( lString16 name, CRKeyboardLayoutRef v ) { _table.set( name, v ); }
+	CRKeyboardLayoutRef get( lString32 name ) { return _table.get( name ); }
+	void set( lString32 name, CRKeyboardLayoutRef v ) { _table.set( name, v ); }
 	CRKeyboardLayoutList() : _table(16) { }
     /// reads definitions from files
     bool openFromFile( const char  * layoutFile );
@@ -310,7 +310,7 @@ class CRGUIStringTranslator
 {
 public:
     /// translate string by key, return default value if not found
-    virtual lString16 translateString( const char *, const char * defValue )
+    virtual lString32 translateString( const char *, const char * defValue )
     {
         return Utf8ToUnicode( lString8(defValue) );
     }
@@ -414,13 +414,13 @@ class CRGUIWindow
             return event->handle( this );
         }
         /// sets scroll label (e.g. "Page $1 of $2" or "$1 / $2")
-        virtual void setScrollLabelTemplate( lString16 text ) = 0;
+        virtual void setScrollLabelTemplate( lString32 text ) = 0;
         /// returns scroll label (e.g. "$1 of $2")
-        virtual lString16 getScrollLabelTemplate() = 0;
+        virtual lString32 getScrollLabelTemplate() = 0;
         /// sets skin name for window
-        virtual void setSkinName( const lString16  & skin ) = 0;
+        virtual void setSkinName( const lString32  & skin ) = 0;
         /// returns skin name for window
-        virtual lString16 getSkinName() = 0;
+        virtual lString32 getSkinName() = 0;
         /// set accelerator table for window
         virtual void setAccelerators( CRGUIAcceleratorTableRef ) { }
         /// get window accelerator table
@@ -519,11 +519,11 @@ class CRGUIWindowManager : public CRGUIStringTranslator
         /// returns current screen orientation
         virtual cr_rotate_angle_t getScreenOrientation() { return _orientation; }
         /// draws icon at center of screen, with optional progress gauge
-        virtual void showWaitIcon( lString16 filename, int progressPercent=-1 );
+        virtual void showWaitIcon( lString32 filename, int progressPercent=-1 );
         /// draws icon with gauge at center of screen, skipping too frequent updates
-        virtual void showProgress( lString16 filename, int progressPercent );
+        virtual void showProgress( lString32 filename, int progressPercent );
 		/// loads skin from file
-	    virtual bool loadSkin( lString16 pathname );
+	    virtual bool loadSkin( lString32 pathname );
 		/// returns keyboard layouts
 		virtual CRKeyboardLayoutList & getKeyboardLayouts() { return _kbLayouts; }
         /// returns accelerator table list
@@ -544,7 +544,7 @@ class CRGUIWindowManager : public CRGUIStringTranslator
             _i18n = i18n;
         }
         /// translate string by key, return default value if not found
-        virtual lString16 translateString( const char * key, const char * defValue )
+        virtual lString32 translateString( const char * key, const char * defValue )
         {
             if ( _i18n.isNull() )
                 return Utf8ToUnicode( lString8(defValue) );
@@ -652,17 +652,17 @@ class CRGUIWindowBase : public CRGUIWindow
         int _page;
         int _pages;
         CRGUIAcceleratorTableRef _acceleratorTable;
-        lString16 _skinName;
-        lString16 _scrollLabel;
-        lString16 _caption;
-        lString16 _statusText;
-        lString16 _inputText;
+        lString32 _skinName;
+        lString32 _scrollLabel;
+        lString32 _caption;
+        lString32 _statusText;
+        lString32 _inputText;
         LVImageSourceRef _icon; // window title icon
         // draws frame, title, status and client
         virtual void draw();
 
         /// use to override status text
-        virtual lString16 getStatusText() { return _statusText; }
+        virtual lString32 getStatusText() { return _statusText; }
 
         /// draw status bar using current skin, with optional status text and scroll/tab/page indicator
         virtual void drawStatusBar();
@@ -687,21 +687,21 @@ class CRGUIWindowBase : public CRGUIWindow
         virtual bool getScrollRect( lvRect & rc );
     public:
         /// use to override status text
-        virtual void setStatusText( lString16 s ) { _statusText = s; }
+        virtual void setStatusText( lString32 s ) { _statusText = s; }
         /// formats scroll label (like "1 of 2")
-        virtual lString16 getScrollLabel( int page, int pages );
+        virtual lString32 getScrollLabel( int page, int pages );
         /// calculates minimum scroll size
         virtual lvPoint getMinScrollSize( int page, int pages );
         /// sets scroll label (e.g. "Page $1 of $2" or "$1 / $2")
-        virtual void setScrollLabelTemplate( lString16 text ) { _scrollLabel=text; }
+        virtual void setScrollLabelTemplate( lString32 text ) { _scrollLabel=text; }
         /// returns scroll label (e.g. "$1 of $2")
-        virtual lString16 getScrollLabelTemplate() { return _scrollLabel; }
+        virtual lString32 getScrollLabelTemplate() { return _scrollLabel; }
         /// called on system configuration change: screen size and orientation
         virtual void reconfigure( int flags );
         /// sets skin name for window
-        virtual void setSkinName( const lString16  & skin ) { _skinName = skin; }
+        virtual void setSkinName( const lString32  & skin ) { _skinName = skin; }
         /// returns skin name for window
-        virtual lString16 getSkinName() { return _skinName; }
+        virtual lString32 getSkinName() { return _skinName; }
         /// returns true if command is processed
         virtual bool onCommand( int command, int params = 0 ) { return !_passCommandsToParent; }
         /// returns true if key is processed (by default, let's translate key to command using accelerator table)
@@ -1001,10 +1001,10 @@ class CRMenuItem
     protected:
         CRMenu * _menu;
         int _id;
-        lString16 _label;
+        lString32 _label;
         LVImageSourceRef _image;
         LVFontRef _defFont;
-        lString16 _propValue;
+        lString32 _propValue;
         bool _itemDirty;
     public:
         /// id of item
@@ -1012,17 +1012,17 @@ class CRMenuItem
         /// set id of item
         void setId( int id ) { _id = id; }
         /// item label
-        lString16 getLabel() { return _label; }
-        void setLabel(lString16 label) { _label = label; setItemDirty(); }
+        lString32 getLabel() { return _label; }
+        void setLabel(lString32 label) { _label = label; setItemDirty(); }
         /// item icon
         LVImageSourceRef getImage() { return _image; }
         /// item label font
         virtual LVFontRef getFont() { return _defFont; }
         /// constructor
-        CRMenuItem( CRMenu * menu, int id, lString16 label, LVImageSourceRef image, LVFontRef defFont, const lChar16 * propValue=NULL  )
+        CRMenuItem( CRMenu * menu, int id, lString32 label, LVImageSourceRef image, LVFontRef defFont, const lChar32 * propValue=NULL  )
     : _menu(menu), _id(id), _label(label), _image(image), _defFont(defFont), _propValue(propValue) { }
         /// constructor
-        CRMenuItem( CRMenu * menu, int id, const char * label, LVImageSourceRef image, LVFontRef defFont, const lChar16 * propValue=NULL  )
+        CRMenuItem( CRMenu * menu, int id, const char * label, LVImageSourceRef image, LVFontRef defFont, const lChar32 * propValue=NULL  )
     : _menu(menu), _id(id), _label(label), _image(image), _defFont(defFont), _propValue(propValue) { }
         /// measures item size
         virtual lvPoint getItemSize( CRRectSkinRef skin );
@@ -1034,9 +1034,9 @@ class CRMenuItem
         virtual int onSelect() { return 0; }
         virtual ~CRMenuItem() { }
         /// submenu for options dialog support
-        virtual lString16 getSubmenuValue() { return lString16::empty_str; }
+        virtual lString32 getSubmenuValue() { return lString32::empty_str; }
         /// property value, for options editor support
-        virtual lString16 getPropValue() { return _propValue; }
+        virtual lString32 getPropValue() { return _propValue; }
         virtual bool isItemDirty() { return _itemDirty; }
         virtual void setItemDirty() { _itemDirty = true; }
         virtual void onLeave() { CRLog::trace("Menu item %d leave", _id); setItemDirty(); }
@@ -1050,7 +1050,7 @@ class CRMenu : public CRGUIWindowBase, public CRMenuItem {
     protected:
         LVPtrVector<CRMenuItem> _items;
         CRPropRef _props;
-        lString16 _propName;
+        lString32 _propName;
         LVFontRef _valueFont;
         int _topItem;
         int _pageItems;
@@ -1081,7 +1081,7 @@ class CRMenu : public CRGUIWindowBase, public CRMenuItem {
         virtual void drawClient();
         virtual int getScrollHeight();
         CRMenuSkinRef getSkin();
-        CRMenu( CRGUIWindowManager * wm, CRMenu * parentMenu, int id, lString16 label, LVImageSourceRef image, LVFontRef defFont, LVFontRef valueFont, CRPropRef props=CRPropRef(), const char * propName=NULL, int pageItems=8 )
+        CRMenu( CRGUIWindowManager * wm, CRMenu * parentMenu, int id, lString32 label, LVImageSourceRef image, LVFontRef defFont, LVFontRef valueFont, CRPropRef props=CRPropRef(), const char * propName=NULL, int pageItems=8 )
         : CRGUIWindowBase( wm ), CRMenuItem( parentMenu, id, label, image, defFont ), _props(props), _propName(Utf8ToUnicode(lString8(propName))), _valueFont(valueFont), _topItem(0), _pageItems(pageItems),
           _cmdToHighlight(-1), _selectedItem(-1), _pageUpdate(true)
         { _fullscreen = false; _helpHeight=0; }
@@ -1092,7 +1092,7 @@ class CRMenu : public CRGUIWindowBase, public CRMenuItem {
         virtual bool isSubmenu() const { return true; }
         LVPtrVector<CRMenuItem> & getItems() { return _items; }
         CRPropRef getProps() const { return _props; }
-        lString16 getPropName() const { return _propName; }
+        lString32 getPropName() const { return _propName; }
         LVFontRef getValueFont() const { return _valueFont; }
         void setValueFont( LVFontRef font ) { _valueFont = font; }
         void addItem( CRMenuItem * item ) { _items.add( item ); }
@@ -1116,7 +1116,7 @@ class CRMenu : public CRGUIWindowBase, public CRMenuItem {
 		virtual void setCurItem(int nItem);
         virtual int getCurPage( );
         virtual int getTopItem();
-        virtual lString16 getSubmenuValue();
+        virtual lString32 getSubmenuValue();
         virtual void toggleSubmenuValue();
         virtual int getItemHeight();
         virtual lvPoint getMaxItemSize();

--- a/crengine/include/cri18n.h
+++ b/crengine/include/cri18n.h
@@ -34,7 +34,7 @@ public:
 	static void setDefTranslator( CRI18NTranslator * translator );
     static const char * translate( const char * src );
     static const lString8 translate8( const char * src );
-    static const lString16 translate16( const char * src );
+    static const lString32 translate32( const char * src );
 };
 
 class CRMoFileTranslator : public CRI18NTranslator
@@ -61,7 +61,7 @@ protected:
 	virtual void sort();
 public:
 	CRMoFileTranslator();
-	bool openMoFile( lString16 fileName );
+	bool openMoFile( lString32 fileName );
 	virtual ~CRMoFileTranslator();
 };
 
@@ -85,12 +85,12 @@ public:
 #ifdef _8
 #undef _8
 #endif
-#ifdef _16
-#undef _16
+#ifdef _32
+#undef _32
 #endif
 #define _(String) CRI18NTranslator::translate(String)
 #define _8(String) CRI18NTranslator::translate8(String)
-#define _16(String) CRI18NTranslator::translate16(String)
+#define _32(String) CRI18NTranslator::translate32(String)
 
 
 #endif

--- a/crengine/include/crsetup.h
+++ b/crengine/include/crsetup.h
@@ -303,4 +303,13 @@
 #define USE_GLYPHCACHE_HASHTABLE 0
 #endif
 
+// Maximum & minimum screen resolution
+#ifndef SCREEN_SIZE_MIN
+#define SCREEN_SIZE_MIN 80
+#endif
+
+#ifndef SCREEN_SIZE_MAX
+#define SCREEN_SIZE_MAX 32767
+#endif
+
 #endif//CRSETUP_H_INCLUDED

--- a/crengine/include/crskin.h
+++ b/crengine/include/crskin.h
@@ -54,7 +54,7 @@ inline int toSkinPercent( int x )
 }
 
 /// encodes percent value*100 (0..10000), to store in skin, from string like "75%" or "10"
-int toSkinPercent( const lString16 & value, int defValue, bool * res );
+int toSkinPercent( const lString32 & value, int defValue, bool * res );
 
 /// decodes skin percent to pixels (fullx is value corresponding to 100%)
 int fromSkinPercent( int x, int fullx );
@@ -141,7 +141,7 @@ protected:
     //lUInt32 _bgcolor;
     //LVImageSourceRef _bgimage;
     //lvPoint _bgimagesplit;
-    lString16 _fontFace;
+    lString32 _fontFace;
     int _fontSize;
     bool _fontBold;
     bool _fontItalic;
@@ -173,11 +173,11 @@ public:
     //virtual lUInt32 getBackgroundColor() { return _bgcolor; }
     //virtual LVImageSourceRef getBackgroundImage() { return _bgimage; }
     //virtual lvPoint getBackgroundImageSplit() { return _bgimagesplit; }
-    virtual lString16 getFontFace() { return _fontFace; }
+    virtual lString32 getFontFace() { return _fontFace; }
     virtual int getFontSize() { return _fontSize; }
     virtual bool getFontBold() { return _fontBold; }
     virtual bool getFontItalic() { return _fontItalic; }
-    virtual void setFontFace( lString16 face );
+    virtual void setFontFace( lString32 face );
     virtual void setFontSize( int size );
     virtual void setFontBold( bool bold );
     virtual void setFontItalic( bool italic );
@@ -188,21 +188,21 @@ public:
     //virtual void setBackgroundImageSplit( lvPoint pt ) { _bgimagesplit = pt; }
     virtual void setFont( LVFontRef fnt ) { _font = fnt; }
     virtual void draw( LVDrawBuf & buf, const lvRect & rc );
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags );
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font )
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags );
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font )
     {
         drawText(  buf, rc, text, font, getTextColor(), getBackgroundColor(), getTextAlign() );
     }
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text )
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text )
     {
         drawText(  buf, rc, text, LVFontRef(), getTextColor(), getBackgroundColor(), getTextAlign() );
     }
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, lUInt32 color )
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, lUInt32 color )
     {
         drawText(  buf, rc, text, LVFontRef(), color, getBackgroundColor(), getTextAlign() );
     }
     /// measures text string using current font
-    virtual lvPoint measureText( lString16 text );
+    virtual lvPoint measureText( lString32 text );
     virtual ~CRSkinnedItem() { }
 };
 
@@ -217,7 +217,7 @@ protected:
     int _align;
 public:
     /// same as measureText, but with added margins and minSize applied
-    virtual lvPoint measureTextItem( lString16 text );
+    virtual lvPoint measureTextItem( lString32 text );
     CRRectSkin();
     virtual ~CRRectSkin() { }
     /// returns rect based on pos and size
@@ -239,9 +239,9 @@ public:
     virtual void setBorderWidths( const lvRect & rc) { _margins = rc; }
     virtual lvRect getBorderWidths() { return _margins; }
     virtual lvRect getClientRect( const lvRect &windowRect );
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text );
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font );
-    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags )
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text );
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font );
+    virtual void drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags )
     {
         CRSkinnedItem::drawText( buf, rc, text, font, textColor, bgColor, flags );
     }
@@ -262,10 +262,10 @@ class CRPageSkin : public CRSkinnedItem
     CRRectSkinRef _leftPageSkin;
     CRRectSkinRef _rightPageSkin;
     CRRectSkinRef _singlePageSkin;
-    lString16     _name;
+    lString32     _name;
 public:
-    const lString16 & getName() { return _name; }
-    void setName( const lString16 & newName ) { _name = newName; }
+    const lString32 & getName() { return _name; }
+    void setName( const lString32 & newName ) { _name = newName; }
     CRPageSkin();
     CRRectSkinRef getSkin( page_skin_type_t type );
 };
@@ -274,7 +274,7 @@ typedef LVFastRef<CRPageSkin> CRPageSkinRef;
 class CRPageSkinList : public LVArray<CRPageSkinRef>
 {
 public:
-    CRPageSkinRef findByName( const lString16 & name );
+    CRPageSkinRef findByName( const lString32 & name );
 };
 typedef LVRef<CRPageSkinList> CRPageSkinListRef;
 
@@ -493,67 +493,67 @@ typedef LVFastRef<CRMenuSkin> CRMenuSkinRef;
 class CRSkinContainer : public LVRefCounter
 {
 protected:
-    virtual bool readRectSkin(  const lChar16 * path, CRRectSkin * res );
-    virtual bool readIconSkin(  const lChar16 * path, CRIconSkin * res );
-    virtual bool readButtonSkin(  const lChar16 * path, CRButtonSkin * res );
-    virtual bool readScrollSkin(  const lChar16 * path, CRScrollSkin * res );
-    virtual bool readWindowSkin(  const lChar16 * path, CRWindowSkin * res );
-    virtual bool readPageSkin(  const lChar16 * path, CRPageSkin * res );
-    virtual bool readMenuSkin(  const lChar16 * path, CRMenuSkin * res );
-    virtual bool readToolBarSkin( const lChar16 * path, CRToolBarSkin *res );
+    virtual bool readRectSkin(  const lChar32 * path, CRRectSkin * res );
+    virtual bool readIconSkin(  const lChar32 * path, CRIconSkin * res );
+    virtual bool readButtonSkin(  const lChar32 * path, CRButtonSkin * res );
+    virtual bool readScrollSkin(  const lChar32 * path, CRScrollSkin * res );
+    virtual bool readWindowSkin(  const lChar32 * path, CRWindowSkin * res );
+    virtual bool readPageSkin(  const lChar32 * path, CRPageSkin * res );
+    virtual bool readMenuSkin(  const lChar32 * path, CRMenuSkin * res );
+    virtual bool readToolBarSkin( const lChar32 * path, CRToolBarSkin *res );
 public:
     /// retuns path to base definition, if attribute base="#nodeid" is specified for element of path
-    virtual lString16 getBasePath( const lChar16 * path );
+    virtual lString32 getBasePath( const lChar32 * path );
     /// find path by id
-    virtual lString16 pathById( const lChar16 * id ) = 0;
+    virtual lString32 pathById( const lChar32 * id ) = 0;
     /// gets image from container
-    virtual LVImageSourceRef getImage( const lChar16 * filename ) = 0;
+    virtual LVImageSourceRef getImage( const lChar32 * filename ) = 0;
     /// gets image from container
-    virtual LVImageSourceRef getImage( const lString16 & filename ) { return getImage( filename.c_str() ); }
+    virtual LVImageSourceRef getImage( const lString32 & filename ) { return getImage( filename.c_str() ); }
     /// gets doc pointer by path
-    virtual ldomXPointer getXPointer( const lString16 & xPointerStr ) = 0;
+    virtual ldomXPointer getXPointer( const lString32 & xPointerStr ) = 0;
     /// gets doc pointer by path
-    virtual ldomXPointer getXPointer( const lChar16 * xPointerStr ) { return getXPointer( lString16(xPointerStr) ); }
+    virtual ldomXPointer getXPointer( const lChar32 * xPointerStr ) { return getXPointer( lString32(xPointerStr) ); }
     /// reads int value from attrname attribute of element specified by path, returns defValue if not found
-    virtual int readInt( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res=NULL );
+    virtual int readInt( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res=NULL );
     /// reads boolean value from attrname attribute of element specified by path, returns defValue if not found
-    virtual bool readBool( const lChar16 * path, const lChar16 * attrname, bool defValue, bool * res=NULL );
+    virtual bool readBool( const lChar32 * path, const lChar32 * attrname, bool defValue, bool * res=NULL );
     /// reads image transform value from attrname attribute of element specified by path, returns defValue if not found
-    ImageTransform readTransform( const lChar16 * path, const lChar16 * attrname, ImageTransform defValue, bool * res );
+    ImageTransform readTransform( const lChar32 * path, const lChar32 * attrname, ImageTransform defValue, bool * res );
     /// reads h align value from attrname attribute of element specified by path, returns defValue if not found
-    virtual int readHAlign( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res=NULL );
+    virtual int readHAlign( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res=NULL );
     /// reads h align value from attrname attribute of element specified by path, returns defValue if not found
-    virtual int readVAlign( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res=NULL );
+    virtual int readVAlign( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res=NULL );
     /// reads string value from attrname attribute of element specified by path, returns empty string if not found
-    virtual lString16 readString( const lChar16 * path, const lChar16 * attrname, bool * res=NULL );
+    virtual lString32 readString( const lChar32 * path, const lChar32 * attrname, bool * res=NULL );
     /// reads string value from attrname attribute of element specified by path, returns defValue if not found
-    virtual lString16 readString( const lChar16 * path, const lChar16 * attrname, const lString16 & defValue, bool * res=NULL );
+    virtual lString32 readString( const lChar32 * path, const lChar32 * attrname, const lString32 & defValue, bool * res=NULL );
     /// reads color value from attrname attribute of element specified by path, returns defValue if not found
-    virtual lUInt32 readColor( const lChar16 * path, const lChar16 * attrname, lUInt32 defValue, bool * res=NULL );
+    virtual lUInt32 readColor( const lChar32 * path, const lChar32 * attrname, lUInt32 defValue, bool * res=NULL );
     /// reads rect value from attrname attribute of element specified by path, returns defValue if not found
-    virtual lvRect readRect( const lChar16 * path, const lChar16 * attrname, lvRect defValue, bool * res=NULL );
+    virtual lvRect readRect( const lChar32 * path, const lChar32 * attrname, lvRect defValue, bool * res=NULL );
     /// reads point(size) value from attrname attribute of element specified by path, returns defValue if not found
-    virtual lvPoint readSize( const lChar16 * path, const lChar16 * attrname, lvPoint defValue, bool * res=NULL );
+    virtual lvPoint readSize( const lChar32 * path, const lChar32 * attrname, lvPoint defValue, bool * res=NULL );
     /// reads rect value from attrname attribute of element specified by path, returns null ref if not found
-    virtual LVImageSourceRef readImage( const lChar16 * path, const lChar16 * attrname, bool * res=NULL );
+    virtual LVImageSourceRef readImage( const lChar32 * path, const lChar32 * attrname, bool * res=NULL );
     /// reads list of icons
-    virtual CRIconListRef readIcons( const lChar16 * path, bool * res=NULL );
+    virtual CRIconListRef readIcons( const lChar32 * path, bool * res=NULL );
 	/// reads list of buttons
-    virtual CRButtonListRef readButtons( const lChar16 * path, bool * res=NULL );
+    virtual CRButtonListRef readButtons( const lChar32 * path, bool * res=NULL );
     /// returns rect skin by path or #id
-    virtual CRRectSkinRef getRectSkin( const lChar16 * path ) = 0;
+    virtual CRRectSkinRef getRectSkin( const lChar32 * path ) = 0;
     /// returns scroll skin by path or #id
-    virtual CRScrollSkinRef getScrollSkin( const lChar16 * path ) = 0;
+    virtual CRScrollSkinRef getScrollSkin( const lChar32 * path ) = 0;
     /// returns window skin by path or #id
-    virtual CRWindowSkinRef getWindowSkin( const lChar16 * path ) = 0;
+    virtual CRWindowSkinRef getWindowSkin( const lChar32 * path ) = 0;
     /// returns menu skin by path or #id
-    virtual CRMenuSkinRef getMenuSkin( const lChar16 * path ) = 0;
+    virtual CRMenuSkinRef getMenuSkin( const lChar32 * path ) = 0;
     /// returns book page skin by path or #id
-    virtual CRPageSkinRef getPageSkin( const lChar16 * path ) = 0;
+    virtual CRPageSkinRef getPageSkin( const lChar32 * path ) = 0;
     /// returns book page skin list
     virtual CRPageSkinListRef getPageSkinList() = 0;
     /// returns toolbar skin by path or #id
-    virtual CRToolBarSkinRef getToolBarSkin( const lChar16 * path ) = 0;
+    virtual CRToolBarSkinRef getToolBarSkin( const lChar32 * path ) = 0;
 
     /// garbage collection
     virtual void gc() { }
@@ -567,29 +567,29 @@ typedef LVFastRef<CRSkinContainer> CRSkinRef;
 
 class CRSkinListItem
 {
-    lString16 _name;
-    lString16 _baseDir;
-    lString16 _fileName;
-    lString16Collection _pageSkinList;
+    lString32 _name;
+    lString32 _baseDir;
+    lString32 _fileName;
+    lString32Collection _pageSkinList;
     CRSkinListItem() { }
 public:
-    lString16 getName() { return _name; }
-    lString16 getFileName() { return _fileName; }
-    lString16 getDirName() { return _baseDir; }
-    lString16Collection & getPageSkinList() { return _pageSkinList; }
-    static CRSkinListItem * init( lString16 baseDir, lString16 fileName );
+    lString32 getName() { return _name; }
+    lString32 getFileName() { return _fileName; }
+    lString32 getDirName() { return _baseDir; }
+    lString32Collection & getPageSkinList() { return _pageSkinList; }
+    static CRSkinListItem * init( lString32 baseDir, lString32 fileName );
     CRSkinRef getSkin();
     virtual ~CRSkinListItem() { }
 };
 class CRSkinList : public LVPtrVector<CRSkinListItem>
 {
 public:
-    CRSkinListItem * findByName(const lString16 & name);
+    CRSkinListItem * findByName(const lString32 & name);
 };
 
 
 /// opens skin from directory or .zip file
-CRSkinRef LVOpenSkin( const lString16 & pathname );
+CRSkinRef LVOpenSkin( const lString32 & pathname );
 /// open simple skin, without image files, from string
 CRSkinRef LVOpenSimpleSkin( const lString8 & xml );
 

--- a/crengine/include/crtrace.h
+++ b/crengine/include/crtrace.h
@@ -28,8 +28,8 @@ public:
         return *this;
     }
 
-    crtrace& operator << (const lString16& ls16) {
-        buffer_.append(UnicodeToUtf8(ls16));
+    crtrace& operator << (const lString32& ls32) {
+        buffer_.append(UnicodeToUtf8(ls32));
         return *this;
     }
 

--- a/crengine/include/crtxtenc.h
+++ b/crengine/include/crtxtenc.h
@@ -61,7 +61,7 @@ enum char_encoding_type {
 #define CRENC_ID_UTF32_BE     ce_utf32_be
 #define CRENC_ID_8BIT_START   ce_8bit_cp
 
-int CREncodingNameToId( const lChar16 * name );
+int CREncodingNameToId( const lChar32 * name );
 const char * CREncodingIdToName( int id );
 
 /**
@@ -75,13 +75,13 @@ const char * CREncodingIdToName( int id );
 
     \return pointer to conversion table if found, NULL otherwise
 */
-const lChar16 * GetCharsetByte2UnicodeTable( const lChar16 * encoding_name );
-const lChar16 * GetCharsetByte2UnicodeTableById( int id );
-const lChar8 ** GetCharsetUnicode2ByteTable( const lChar16 * encoding_name );
+const lChar32 * GetCharsetByte2UnicodeTable( const lChar32 * encoding_name );
+const lChar32 * GetCharsetByte2UnicodeTableById( int id );
+const lChar8 ** GetCharsetUnicode2ByteTable( const lChar32 * encoding_name );
 /// get conversion table for upper 128 characters of codepage, by codepage number
-const lChar16 * GetCharsetByte2UnicodeTable( int codepage );
+const lChar32 * GetCharsetByte2UnicodeTable( int codepage );
 /// returns "cp1251" for 1251, etc. for supported codepages
-const lChar16 * GetCharsetName( int codepage );
+const lChar32 * GetCharsetName( int codepage );
 /// convert language id to codepage number (MS)
 int langToCodepage( int lang );
 const char* langToLanguage( int lang );

--- a/crengine/include/epubfmt.h
+++ b/crengine/include/epubfmt.h
@@ -13,7 +13,7 @@
 
 bool DetectEpubFormat( LVStreamRef stream );
 bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback, bool metadataOnly = false );
-lString16 EpubGetRootFilePath( LVContainerRef m_arc );
+lString32 EpubGetRootFilePath( LVContainerRef m_arc );
 LVStreamRef GetEpubCoverpage(LVContainerRef arc);
 
 

--- a/crengine/include/fb3fmt.h
+++ b/crengine/include/fb3fmt.h
@@ -18,11 +18,11 @@ public:
     fb3ImportContext(OpcPackage *package);
     virtual ~fb3ImportContext();
 
-    lString16 geImageTarget(const lString16 relationId);
+    lString32 geImageTarget(const lString32 relationId);
     LVStreamRef openBook();
     ldomDocument *getDescription();
 public:
-    lString16 m_coverImage;
+    lString32 m_coverImage;
 };
 
 #endif // FB3FMT_H

--- a/crengine/include/hist.h
+++ b/crengine/include/hist.h
@@ -24,29 +24,29 @@ enum bmk_type {
 
 class CRBookmark {
 private:
-    lString16 _startpos;
-    lString16 _endpos;
+    lString32 _startpos;
+    lString32 _endpos;
     int       _percent;
     int       _type;
 	int       _shortcut;
-    lString16 _postext;
-    lString16 _titletext;
-    lString16 _commenttext;
+    lString32 _postext;
+    lString32 _titletext;
+    lString32 _commenttext;
     time_t    _timestamp;
     int       _page;
 public:
-	static lString16 getChapterName( ldomXPointer p );
+	static lString32 getChapterName( ldomXPointer p );
 
     // fake bookmark for range
-    CRBookmark(lString16 startPos,lString16 endPos)
+    CRBookmark(lString32 startPos,lString32 endPos)
                 : _startpos(startPos)
     , _endpos(endPos)
     , _percent(0)
     , _type(0)
         , _shortcut(0)
-    , _postext(lString16::empty_str)
-    , _titletext(lString16::empty_str)
-    , _commenttext(lString16::empty_str)
+    , _postext(lString32::empty_str)
+    , _titletext(lString32::empty_str)
+    , _commenttext(lString32::empty_str)
     , _timestamp(time_t(0))
     ,_page(0)
     {
@@ -80,20 +80,20 @@ public:
     }
     CRBookmark() : _percent(0), _type(0), _shortcut(0), _timestamp(0), _page(0) { }
     CRBookmark ( ldomXPointer ptr );
-    lString16 getStartPos() { return _startpos; }
-    lString16 getEndPos() { return _endpos; }
-    lString16 getPosText() { return _postext; }
-    lString16 getTitleText() { return _titletext; }
-    lString16 getCommentText() { return _commenttext; }
+    lString32 getStartPos() { return _startpos; }
+    lString32 getEndPos() { return _endpos; }
+    lString32 getPosText() { return _postext; }
+    lString32 getTitleText() { return _titletext; }
+    lString32 getCommentText() { return _commenttext; }
 	int getShortcut() { return _shortcut; }
     int getType() { return _type; }
     int getPercent() { return _percent; }
     time_t getTimestamp() { return _timestamp; }
-    void setStartPos(const lString16 & s ) { _startpos = s; }
-    void setEndPos(const lString16 & s ) { _endpos = s; }
-    void setPosText(const lString16 & s ) { _postext= s; }
-    void setTitleText(const lString16 & s ) { _titletext = s; }
-    void setCommentText(const lString16 & s ) { _commenttext = s; }
+    void setStartPos(const lString32 & s ) { _startpos = s; }
+    void setEndPos(const lString32 & s ) { _endpos = s; }
+    void setPosText(const lString32 & s ) { _postext= s; }
+    void setTitleText(const lString32 & s ) { _titletext = s; }
+    void setCommentText(const lString32 & s ) { _commenttext = s; }
     void setType( int n ) { _type = n; }
 	void setShortcut( int n ) { _shortcut = n; }
     void setPercent( int n ) { _percent = n; }
@@ -114,7 +114,7 @@ public:
 /// bookmark/position change info for synchronization/replication
 class ChangeInfo {
     CRBookmark * _bookmark;
-    lString16 _fileName;
+    lString32 _fileName;
     bool _deleted;
     time_t _timestamp;
 
@@ -122,7 +122,7 @@ public:
     ChangeInfo() : _bookmark(NULL), _deleted(false), _timestamp(0) {
     }
 
-    ChangeInfo(CRBookmark * bookmark, lString16 fileName, bool deleted);
+    ChangeInfo(CRBookmark * bookmark, lString32 fileName, bool deleted);
 
     ~ChangeInfo() {
         if (_bookmark)
@@ -131,7 +131,7 @@ public:
 
     CRBookmark * getBookmark() { return _bookmark; }
 
-    lString16 getFileName() { return _fileName; }
+    lString32 getFileName() { return _fileName; }
 
     bool isDeleted() { return _deleted; }
 
@@ -152,11 +152,11 @@ class ChangeInfoList : public LVPtrVector<ChangeInfo> {
 
 class CRFileHistRecord {
 private:
-    lString16 _fname;
-    lString16 _fpath;
-    lString16 _title;
-    lString16 _author;
-    lString16 _series;
+    lString32 _fname;
+    lString32 _fpath;
+    lString32 _title;
+    lString32 _author;
+    lString32 _series;
     lvpos_t   _size;
     LVPtrVector<CRBookmark> _bookmarks;
     CRBookmark _lastpos;
@@ -168,23 +168,23 @@ public:
     CRBookmark * setShortcutBookmark( int shortcut, ldomXPointer ptr );
     CRBookmark * getShortcutBookmark( int shortcut );
     time_t getLastTime() { return _lastpos.getTimestamp(); }
-    lString16 getLastTimeString( bool longFormat=false );
+    lString32 getLastTimeString( bool longFormat=false );
     void setLastTime( time_t t ) { _lastpos.setTimestamp(t); }
     LVPtrVector<CRBookmark>  & getBookmarks() { return _bookmarks; }
     CRBookmark * getLastPos() { return &_lastpos; }
     void setLastPos( CRBookmark * bmk );
-    lString16 getTitle() { return _title; }
-    lString16 getAuthor() { return _author; }
-    lString16 getSeries() { return _series; }
-    lString16 getFileName() { return _fname; }
-    lString16 getFilePath() { return _fpath; }
-    lString16 getFilePathName() { return _fpath + _fname; }
+    lString32 getTitle() { return _title; }
+    lString32 getAuthor() { return _author; }
+    lString32 getSeries() { return _series; }
+    lString32 getFileName() { return _fname; }
+    lString32 getFilePath() { return _fpath; }
+    lString32 getFilePathName() { return _fpath + _fname; }
     lvpos_t   getFileSize() { return _size; }
-    void setTitle( const lString16 & s ) { _title = s; }
-    void setAuthor( const lString16 & s ) { _author = s; }
-    void setSeries( const lString16 & s ) { _series = s; }
-    void setFileName( const lString16 & s ) { _fname = s; }
-    void setFilePath( const lString16 & s ) { _fpath = s; }
+    void setTitle( const lString32 & s ) { _title = s; }
+    void setAuthor( const lString32 & s ) { _author = s; }
+    void setSeries( const lString32 & s ) { _series = s; }
+    void setFileName( const lString32 & s ) { _fname = s; }
+    void setFilePath( const lString32 & s ) { _fpath = s; }
     void setFileSize( lvsize_t sz ) { _size = sz; }
     CRFileHistRecord()
         : _size(0)
@@ -210,7 +210,7 @@ public:
 class CRFileHist {
 private:
     LVPtrVector<CRFileHistRecord> _records;
-    int findEntry( const lString16 & fname, const lString16 & fpath, lvsize_t sz );
+    int findEntry( const lString32 & fname, const lString32 & fpath, lvsize_t sz );
     void makeTop( int index );
 public:
     void limit( int maxItems )
@@ -222,12 +222,12 @@ public:
     LVPtrVector<CRFileHistRecord> & getRecords() { return _records; }
     bool loadFromStream( LVStreamRef stream );
     bool saveToStream( LVStream * stream );
-    CRFileHistRecord * savePosition( lString16 fpathname, size_t sz, 
-        const lString16 & title,
-        const lString16 & author,
-        const lString16 & series,
+    CRFileHistRecord * savePosition( lString32 fpathname, size_t sz, 
+        const lString32 & title,
+        const lString32 & author,
+        const lString32 & series,
         ldomXPointer ptr );
-    ldomXPointer restorePosition(  ldomDocument * doc, lString16 fpathname, size_t sz );
+    ldomXPointer restorePosition(  ldomDocument * doc, lString32 fpathname, size_t sz );
     CRFileHist()
     {
     }

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -39,17 +39,17 @@
 class HyphMethod
 {
 protected:
-    lString16 _id;
+    lString32 _id;
     int _left_hyphen_min;
     int _right_hyphen_min;
 public:
-    HyphMethod(lString16 id, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN, int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN)
+    HyphMethod(lString32 id, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN, int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN)
         : _id(id)
         , _left_hyphen_min(leftHyphenMin)
         , _right_hyphen_min(rightHyphenMin)
         { }
-    lString16 getId() { return _id; }
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 ) = 0;
+    lString32 getId() { return _id; }
+    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 ) = 0;
     virtual ~HyphMethod() { }
     virtual lUInt32 getCount() { return 0; }
     virtual lUInt32 getSize() { return 0; }
@@ -70,25 +70,25 @@ enum HyphDictType
 class HyphDictionary
 {
 	HyphDictType _type;
-	lString16 _title;
-	lString16 _id;
-	lString16 _filename;
+	lString32 _title;
+	lString32 _id;
+	lString32 _filename;
 public:
-	HyphDictionary( HyphDictType type, lString16 title, lString16 id, lString16 filename )
+	HyphDictionary( HyphDictType type, lString32 title, lString32 id, lString32 filename )
 		: _type(type), _title(title), _id( id ), _filename( filename ) { }
 	HyphDictType getType() const { return _type; }
-	lString16 getTitle() const { return _title; }
-	lString16 getId() const { return _id; }
-	lString16 getFilename() const { return _filename; }
+	lString32 getTitle() const { return _title; }
+	lString32 getId() const { return _id; }
+	lString32 getFilename() const { return _filename; }
 	bool activate();
 	virtual lUInt32 getHash() const { return getTitle().getHash(); }
     virtual ~HyphDictionary() { }
 };
 
-#define HYPH_DICT_ID_NONE L"@none"
-#define HYPH_DICT_ID_ALGORITHM L"@algorithm"
-#define HYPH_DICT_ID_SOFTHYPHENS L"@softhyphens"
-#define HYPH_DICT_ID_DICTIONARY L"@dictionary"
+#define HYPH_DICT_ID_NONE U"@none"
+#define HYPH_DICT_ID_ALGORITHM U"@algorithm"
+#define HYPH_DICT_ID_SOFTHYPHENS U"@softhyphens"
+#define HYPH_DICT_ID_DICTIONARY U"@dictionary"
 
 class HyphDictionaryList
 {
@@ -99,9 +99,9 @@ public:
 	int length() { return _list.length(); }
 	HyphDictionary * get( int index ) { return (index>=0 && index<+_list.length()) ? _list[index] : NULL; }
 	HyphDictionaryList() { addDefault(); }
-    bool open(lString16 hyphDirectory, bool clear = true);
-	HyphDictionary * find( const lString16& id );
-	bool activate( lString16 id );
+    bool open(lString32 hyphDirectory, bool clear = true);
+	HyphDictionary * find( const lString32& id );
+	bool activate( lString32 id );
 };
 
 #define DEF_HYPHENATION_DICT "English_US.pattern"
@@ -120,7 +120,7 @@ class HyphDataLoader
 public:
     HyphDataLoader() {}
     virtual ~HyphDataLoader() {}
-	virtual LVStreamRef loadData(lString16 id) = 0;
+	virtual LVStreamRef loadData(lString32 id) = 0;
 };
 
 /// hyphenation manager
@@ -134,18 +134,18 @@ class HyphMan
     // static HyphMethod * _method;
     // static HyphDictionary * _selectedDictionary;
     static HyphDictionaryList * _dictList; // available hyph dict files (+ none/algo/softhyphens)
-    static LVHashTable<lString16, HyphMethod*> _loaded_hyph_methods; // methods with loaded dictionaries
+    static LVHashTable<lString32, HyphMethod*> _loaded_hyph_methods; // methods with loaded dictionaries
     static HyphDataLoader* _dataLoader;
     static int _LeftHyphenMin;
     static int _RightHyphenMin;
     static int _TrustSoftHyphens;
 public:
     static void uninit();
-    static bool initDictionaries(lString16 dir, bool clear = true);
+    static bool initDictionaries(lString32 dir, bool clear = true);
     static HyphDictionaryList * getDictList() { return _dictList; }
     static bool addDictionaryItem(HyphDictionary* dict);
     static void setDataLoader(HyphDataLoader* loader);
-    static bool activateDictionary( lString16 id ) { return _dictList->activate(id); }
+    static bool activateDictionary( lString32 id ) { return _dictList->activate(id); }
     static HyphDictionary * getSelectedDictionary(); // was: { return _selectedDictionary; }
     static int getLeftHyphenMin() { return _LeftHyphenMin; }
     static int getRightHyphenMin() { return _RightHyphenMin; }
@@ -154,15 +154,15 @@ public:
     static int getTrustSoftHyphens() { return _TrustSoftHyphens; }
     static bool setTrustSoftHyphens( int trust_soft_hyphen );
     static bool isEnabled();
-    static HyphMethod * getHyphMethodForDictionary( lString16 id, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN,
+    static HyphMethod * getHyphMethodForDictionary( lString32 id, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN,
                                                         int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN );
 
     HyphMan();
     ~HyphMan();
 
-    static bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 );
+    static bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 );
     /* Obsolete:
-    inline static bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 )
+    inline static bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 )
     {
         return _method->hyphenate( str, len, widths, flags, hyphCharWidth, maxWidth, flagSize );
     }

--- a/crengine/include/lstridmap.h
+++ b/crengine/include/lstridmap.h
@@ -31,9 +31,9 @@ public:
     /// id
     lUInt16    id;
     /// value
-    lString16 value;
+    lString32 value;
 	/// constructor
-    LDOMNameIdMapItem(lUInt16 _id, const lString16 & _value, const css_elem_def_props_t * _data);
+    LDOMNameIdMapItem(lUInt16 _id, const lString32 & _value, const css_elem_def_props_t * _data);
     /// copy constructor
     LDOMNameIdMapItem(LDOMNameIdMapItem & item);
 	/// destructor
@@ -74,7 +74,7 @@ public:
 
     void Clear();
 
-    void AddItem( lUInt16 id, const lString16 & value, const css_elem_def_props_t * data );
+    void AddItem( lUInt16 id, const lString32 & value, const css_elem_def_props_t * data );
 
     void AddItem( LDOMNameIdMapItem * item );
 
@@ -83,11 +83,11 @@ public:
        return m_by_id[id];
     }
 
-    const LDOMNameIdMapItem * findItem( const lChar16 * name );
+    const LDOMNameIdMapItem * findItem( const lChar32 * name );
     const LDOMNameIdMapItem * findItem( const lChar8 * name );
-    const LDOMNameIdMapItem * findItem( const lString16 & name ) { return findItem(name.c_str()); }
+    const LDOMNameIdMapItem * findItem( const lString32 & name ) { return findItem(name.c_str()); }
 
-    inline lUInt16 idByName( const lChar16 * name )
+    inline lUInt16 idByName( const lChar32 * name )
     {
         const LDOMNameIdMapItem * item = findItem(name);
         return item?item->id:0;
@@ -99,12 +99,12 @@ public:
         return item?item->id:0;
     }
 
-    inline const lString16 & nameById( lUInt16 id )
+    inline const lString32 & nameById( lUInt16 id )
     { 
         if (id>=m_size)
-            return lString16::empty_str;
+            return lString32::empty_str;
         const LDOMNameIdMapItem * item = findItem(id);
-        return item?item->value:lString16::empty_str;
+        return item?item->value:lString32::empty_str;
     }
 
     inline const css_elem_def_props_t * dataById( lUInt16 id )
@@ -117,7 +117,7 @@ public:
 
     // debug dump of all unknown entities
     void dumpUnknownItems( FILE * f, int start_id );
-    lString16 getUnknownItems( int start_id );
+    lString32 getUnknownItems( int start_id );
 };
 
 #endif

--- a/crengine/include/lvbmpbuf.h
+++ b/crengine/include/lvbmpbuf.h
@@ -57,7 +57,7 @@ void lvdrawbufDraw( draw_buf_t * buf, int x, int y, const unsigned char * bitmap
    \param text is string to draw
    \param len is number of chars from text to draw
 */
-void lvdrawbufDrawText( draw_buf_t * buf, int x, int y, const lvfont_handle pfont, const lChar16 * text, int len, lChar16 def_char );
+void lvdrawbufDrawText( draw_buf_t * buf, int x, int y, const lvfont_handle pfont, const lChar32 * text, int len, lChar32 def_char );
 
 
 #endif

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -24,7 +24,7 @@
 #include "lvdocviewprops.h"
 
 
-const lChar16 * getDocFormatName( doc_format_t fmt );
+const lChar32 * getDocFormatName( doc_format_t fmt );
 
 /// text format import options
 typedef enum {
@@ -185,7 +185,7 @@ public:
     // access to words
     ldomWordExList & getWords() { return _words; }
     // append chars to search pattern
-    ldomWordEx * appendPattern( lString16 chars );
+    ldomWordEx * appendPattern( lString32 chars );
     // remove last item from pattern
     ldomWordEx * reducePattern();
     // selects word of current page with specified coords;
@@ -209,7 +209,7 @@ public:
     int maxpos;
     int pagesize;
     int scale;
-    lString16 posText;
+    lString32 posText;
     LVScrollInfo()
     : pos(0), maxpos(0), pagesize(0), scale(1)
     {
@@ -299,16 +299,16 @@ private:
     LVPtrVector<LVBookMarkPercentInfo> m_bookmarksPercents;
 
 protected:
-    lString16 m_last_clock;
+    lString32 m_last_clock;
 
     ldomMarkedRangeList m_markRanges;
     ldomMarkedRangeList m_bmkRanges;
 
 private:
-    lString16 m_filename;
+    lString32 m_filename;
 #define ORIGINAL_FILENAME_PATCH
 #ifdef ORIGINAL_FILENAME_PATCH
-    lString16 m_originalFilename;
+    lString32 m_originalFilename;
 #endif
     lvsize_t  m_filesize;
 
@@ -355,7 +355,7 @@ private:
     /// edit cursor position
     ldomXPointer m_cursorPos;
 
-    lString16 m_pageHeaderOverride;
+    lString32 m_pageHeaderOverride;
 
     int m_drawBufferBits;
 
@@ -420,7 +420,7 @@ public:
     /// set buffer format
     void setDrawBufferBits( int bits ) { m_drawBufferBits = bits; }
     /// substitute page header with custom text (e.g. to be used while loading)
-    void setPageHeaderOverride( lString16 s );
+    void setPageHeaderOverride( lString32 s );
     /// get screen rectangle for current cursor position, returns false if not visible
     bool getCursorRect( lvRect & rc, bool scrollToCursor = false )
     {
@@ -449,11 +449,11 @@ public:
     /// saves current position to navigation history, to be able return back
     bool savePosToNavigationHistory();
     /// saves position to navigation history, to be able return back
-    bool savePosToNavigationHistory(lString16 path);
+    bool savePosToNavigationHistory(lString32 path);
     /// navigate to history path URL
-    bool navigateTo( lString16 historyPath );
+    bool navigateTo( lString32 historyPath );
     /// packs current file path and name
-    lString16 getNavigationPath();
+    lString32 getNavigationPath();
     /// returns pointer to bookmark/last position containter of currently opened file
     CRFileHistRecord * getCurrentFileHistRecord();
 	/// -1 moveto previous chapter, 0 to current chaoter first pae, 1 to next chapter
@@ -461,13 +461,13 @@ public:
 	/// -1 moveto previous page, 1 to next page
 	bool moveByPage( int delta );
 	/// saves new bookmark
-    CRBookmark * saveRangeBookmark( ldomXRange & range, bmk_type type, lString16 comment );
+    CRBookmark * saveRangeBookmark( ldomXRange & range, bmk_type type, lString32 comment );
 	/// export bookmarks to text file
-	bool exportBookmarks( lString16 filename );
+	bool exportBookmarks( lString32 filename );
 	/// saves current page bookmark under numbered shortcut
     CRBookmark * saveCurrentPageShortcutBookmark( int number );
     /// saves current page bookmark under numbered shortcut
-    CRBookmark * saveCurrentPageBookmark( lString16 comment );
+    CRBookmark * saveCurrentPageBookmark( lString32 comment );
     /// removes bookmark from list, and deletes it, false if not found
     bool removeBookmark( CRBookmark * bm );
     /// sets new list of bookmarks, removes old values
@@ -488,7 +488,7 @@ public:
     void propsUpdateDefaults( CRPropRef props );
 
     /// applies only one property by name, return false if property is unknown
-    virtual bool propApply( lString8 name, lString16 value );
+    virtual bool propApply( lString8 name, lString32 value );
     /// applies properties, returns list of not recognized properties
     virtual CRPropRef propsApply( CRPropRef props );
     /// returns current values of supported properties
@@ -548,7 +548,7 @@ public:
     /// returns selected link on page, if any. null if no links.
     virtual ldomXRange * getCurrentPageSelectedLink();
     /// follow link, returns true if navigation was successful
-    virtual bool goLink( lString16 href, bool savePos=true );
+    virtual bool goLink( lString32 href, bool savePos=true );
     /// follow selected link, returns true if navigation was successful
     virtual bool goSelectedLink();
     /// go back. returns true if navigation was successful
@@ -562,9 +562,9 @@ public:
 
 
     /// create empty document with specified message (e.g. to show errors)
-    virtual void createDefaultDocument( lString16 title, lString16 message );
+    virtual void createDefaultDocument( lString32 title, lString32 message );
     /// create empty document with specified message (to show errors)
-    virtual void createHtmlDocument(lString16 code);
+    virtual void createHtmlDocument(lString32 code);
 
     /// returns default font face
     lString8 getDefaultFontFace() { return m_defaultFontFace; }
@@ -596,7 +596,7 @@ public:
     /// get page document range, -1 for current page
     LVRef<ldomXRange> getPageDocumentRange( int pageIndex=-1 );
     /// get page text, -1 for current page
-    lString16 getPageText( bool wrapWords, int pageIndex=-1 );
+    lString32 getPageText( bool wrapWords, int pageIndex=-1 );
     /// returns number of non-space characters on current page
     int getCurrentPageCharCount();
     /// returns number of images on current page
@@ -634,7 +634,7 @@ public:
     /// returns battery state
     int getBatteryState( ) { return m_battery_state; }
     /// returns current time representation string
-    virtual lString16 getTimeString();
+    virtual lString32 getTimeString();
     /// returns true if time changed since clock has been last drawed
     bool isTimeChanged();
     /// returns if Render has been called
@@ -733,35 +733,35 @@ public:
     /// return document properties
     CRPropRef getDocProps() { return m_doc_props; }
     /// returns book title
-    lString16 getTitle() { return m_doc_props->getStringDef(DOC_PROP_TITLE); }
+    lString32 getTitle() { return m_doc_props->getStringDef(DOC_PROP_TITLE); }
     /// returns book language
-    lString16 getLanguage() { return m_doc_props->getStringDef(DOC_PROP_LANGUAGE); }
+    lString32 getLanguage() { return m_doc_props->getStringDef(DOC_PROP_LANGUAGE); }
     /// returns book author(s)
-    lString16 getAuthors() { return m_doc_props->getStringDef(DOC_PROP_AUTHORS); }
+    lString32 getAuthors() { return m_doc_props->getStringDef(DOC_PROP_AUTHORS); }
     /// returns book description
-    lString16 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
+    lString32 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
     /// returns book keywords (separated by "; ")
-    lString16 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
+    lString32 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
     /// returns book series name and number (series name #1)
-    lString16 getSeries()
+    lString32 getSeries()
     {
-        lString16 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
-        lString16 number = m_doc_props->getStringDef(DOC_PROP_SERIES_NUMBER);
+        lString32 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
+        lString32 number = m_doc_props->getStringDef(DOC_PROP_SERIES_NUMBER);
         if ( !name.empty() && !number.empty() )
             name << " #" << number;
         return name;
     }
     /// returns book series name and number (series name #1)
-    lString16 getSeriesName()
+    lString32 getSeriesName()
     {
-        lString16 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
+        lString32 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
         return name;
     }
     /// returns book series name and number (series name #1)
     int getSeriesNumber()
     {
-        lString16 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
-        lString16 number = m_doc_props->getStringDef(DOC_PROP_SERIES_NUMBER);
+        lString32 name = m_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
+        lString32 number = m_doc_props->getStringDef(DOC_PROP_SERIES_NUMBER);
         if (!name.empty() && !number.empty())
             return number.atoi();
         return 0;
@@ -774,13 +774,13 @@ public:
     /// export to WOL format
     bool exportWolFile( const char * fname, bool flgGray, int levels );
     /// export to WOL format
-    bool exportWolFile( const wchar_t * fname, bool flgGray, int levels );
+    bool exportWolFile( const lChar32 * fname, bool flgGray, int levels );
     /// export to WOL format
     bool exportWolFile( LVStream * stream, bool flgGray, int levels );
 
     /// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
     /// path relative to document directory for non-container documents like HTML)
-    LVStreamRef getDocumentFileStream( lString16 filePath );
+    LVStreamRef getDocumentFileStream( lString32 filePath );
 
     /// draws page to image buffer
     void drawPageTo( LVDrawBuf * drawBuf, LVRendPageInfo & page, lvRect * pageRect, int pageCount, int basePage);
@@ -802,7 +802,7 @@ public:
     /// get page number by bookmark
     int getBookmarkPage(ldomXPointer bm);
     /// get bookmark position text
-    bool getBookmarkPosText( ldomXPointer bm, lString16 & titleText, lString16 & posText );
+    bool getBookmarkPosText( ldomXPointer bm, lString32 & titleText, lString32 & posText );
 
     /// returns scrollbar control info
     const LVScrollInfo * getScrollInfo() { updateScroll(); return &m_scrollinfo; }
@@ -881,7 +881,7 @@ public:
     /// load document from file
     bool LoadDocument( const char * fname, bool metadataOnly = false );
     /// load document from file
-    bool LoadDocument( const lChar16 * fname, bool metadataOnly = false );
+    bool LoadDocument( const lChar32 * fname, bool metadataOnly = false );
     /// load document from stream
     bool LoadDocument( LVStreamRef stream, bool metadataOnly = false );
 
@@ -891,10 +891,10 @@ public:
     void restorePosition();
 
 #ifdef ORIGINAL_FILENAME_PATCH
-    void setOriginalFilename( const lString16 & fn ) {
+    void setOriginalFilename( const lString32 & fn ) {
         m_originalFilename = fn;
     }
-    const lString16 & getOriginalFilename() {
+    const lString32 & getOriginalFilename() {
         return m_originalFilename;
     }
     void setMinFileSizeToCache( int size ) {
@@ -914,8 +914,8 @@ public:
 };
 
 class SimpleTitleFormatter {
-    lString16 _text;
-    lString16Collection _lines;
+    lString32 _text;
+    lString32Collection _lines;
     lString8 _fontFace;
     bool _bold;
     bool _italic;
@@ -930,18 +930,18 @@ class SimpleTitleFormatter {
 public:
     int getHeight() { return _height; }
     int getWidth() { return _width; }
-    SimpleTitleFormatter(lString16 text, lString8 fontFace, bool bold, bool italic, lUInt32 color, int maxWidth, int maxHeight, int fntSize = 0);
+    SimpleTitleFormatter(lString32 text, lString8 fontFace, bool bold, bool italic, lUInt32 color, int maxWidth, int maxHeight, int fntSize = 0);
 
     bool measure();
     bool splitLines(const char * delimiter);
     bool format(int fontSize);
     bool findBestSize();
-    void draw(LVDrawBuf & buf, lString16 str, int x, int y, int align);
+    void draw(LVDrawBuf & buf, lString32 str, int x, int y, int align);
     void draw(LVDrawBuf & buf, lvRect rc, int halign, int valign);
 };
 
 
 /// draw book cover, either from image, or generated from title/authors
-void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString16 title, lString16 authors, lString16 seriesName, int seriesNumber);
+void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber);
 
 #endif

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -201,8 +201,8 @@ public:
     /// draws text string
     /*
     virtual void DrawTextString( int x, int y, LVFont * pfont,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen=false ) = 0;
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette, bool addHyphen=false ) = 0;
     */
 
 /*
@@ -274,8 +274,8 @@ public:
     /// draws text string
     /*
     virtual void DrawTextString( int x, int y, LVFont * pfont,
-                       const lChar16 * text, int len,
-                       lChar16 def_char,
+                       const lChar32 * text, int len,
+                       lChar32 def_char,
                        lUInt32 * palette, bool addHyphen=false );
     */
     /// draws formatted text

--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -208,11 +208,11 @@ const lvfont_glyph_t * lvfontGetGlyph( const lvfont_handle hfont, lUInt16 code )
     \return number of items written to widths[]
 */
 lUInt16 lvfontMeasureText( const lvfont_handle pfont, 
-                    const lChar16 * text, int len, 
+                    const lChar32 * text, int len, 
                     lUInt16 * widths,
                     lUInt8 * flags,
                     int max_width,
-                    lChar16 def_char
+                    lChar32 def_char
                  );
 
 // These lower than 0x0100 (that fit in a lUint8) may be set by lvfntman's measureText()
@@ -267,7 +267,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
     \param code is character
     \return 1 if character is space, 0 otherwise 
 */
-inline int lvfontIsUnicodeSpace( lChar16 code ) { return code==0x0020; }
+inline int lvfontIsUnicodeSpace( lChar32 code ) { return code==0x0020; }
 
 /** \brief returns unpacked glyph image 
     \param packed is RLE/Huffman encoded glyph data

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -40,7 +40,7 @@ extern "C" {
 struct LVFontGlyphCacheItem;
 
 union GlyphCacheItemData {
-	lChar16 ch;
+	lChar32 ch;
 #if USE_HARFBUZZ==1
 	lUInt32 gindex;
 #endif
@@ -52,7 +52,7 @@ inline lUInt32 getHash(GlyphCacheItemData data)
     return getHash(*((lUInt32*)&data));
 }
 
-// Note: this may cause some issue when building on Win32 (or anywhere lChar16
+// Note: this may cause some issue when building on Win32 (or anywhere lChar32
 // is not 32bits), see https://github.com/buggins/coolreader/pull/117
 inline bool operator==(GlyphCacheItemData data1, GlyphCacheItemData data2)
 {
@@ -111,7 +111,7 @@ public:
         clear();
     }
     void clear();
-    LVFontGlyphCacheItem * getByChar(lChar16 ch);
+    LVFontGlyphCacheItem * getByChar(lChar32 ch);
     #if USE_HARFBUZZ==1
     LVFontGlyphCacheItem * getByIndex(lUInt32 index);
     #endif
@@ -139,7 +139,7 @@ struct LVFontGlyphCacheItem
         return sizeof(LVFontGlyphCacheItem)
             + (bmp_width * bmp_height - 1) * sizeof(lUInt8);
     }
-    static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar16 ch, int w, int h )
+    static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar32 ch, int w, int h )
     {
         LVFontGlyphCacheItem * item = (LVFontGlyphCacheItem *)malloc( sizeof(LVFontGlyphCacheItem)
                                                                         + (w*h - 1)*sizeof(lUInt8) );
@@ -314,7 +314,7 @@ public:
     };
 
     /// hyphenation character
-    virtual lChar16 getHyphChar() { return UNICODE_SOFT_HYPHEN_CODE; }
+    virtual lChar32 getHyphChar() { return UNICODE_SOFT_HYPHEN_CODE; }
 
     /// hyphen width
     virtual int getHyphenWidth() { return getCharWidth( getHyphChar() ); }
@@ -328,7 +328,7 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found 
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false ) = 0;
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false ) = 0;
 
     /** \brief measure text
         \param text is text string pointer
@@ -340,11 +340,11 @@ public:
         \return number of characters before max_width reached 
     */
     virtual lUInt16 measureText( 
-                        const lChar16 * text, int len, 
+                        const lChar32 * text, int len, 
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg=NULL,
                         int letter_spacing=0,
                         bool allow_hyphenation=true,
@@ -356,20 +356,20 @@ public:
         \param len is number of characters to measure
         \return width of specified string 
     */
-    virtual lUInt32 getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL ) = 0;
+    virtual lUInt32 getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL ) = 0;
 
     // /** \brief get glyph image in 1 byte per pixel format
     //     \param code is unicode character
     //     \param buf is buffer [width*height] to place glyph data
     //     \return true if glyph was found
     // */
-    // virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char=0) = 0;
+    // virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar32 def_char=0) = 0;
 
     /** \brief get glyph item
         \param code is unicode character
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0, bool is_fallback=false) = 0;
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, bool is_fallback=false) = 0;
 
     /// returns font baseline offset
     virtual int getBaseline() = 0;
@@ -382,11 +382,11 @@ public:
     /// returns italic flag
     virtual int getItalic() const = 0;
     /// returns char glyph advance width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 ) = 0;
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 ) = 0;
     /// returns char glyph left side bearing
-    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) = 0;
+    virtual int getLeftSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false ) = 0;
     /// returns char glyph right side bearing
-    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) = 0;
+    virtual int getRightSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false ) = 0;
     /// retrieves font handle
     virtual void * GetHandle() = 0;
     /// returns font typeface name
@@ -395,8 +395,8 @@ public:
     virtual css_font_family_t getFontFamily() const = 0;
     /// draws text string (returns x advance)
     virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette = NULL, bool addHyphen = false,
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette = NULL, bool addHyphen = false,
                        TextLangCfg * lang_cfg=NULL,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
                        int text_decoration_back_gap=0 ) = 0;
@@ -434,7 +434,7 @@ public:
 
     virtual bool kerningEnabled() { return false; }
     // Obsolete:
-    // virtual int getKerningOffset(lChar16 ch1, lChar16 ch2, lChar16 def_char) { CR_UNUSED3(ch1,ch2,def_char); return 0; }
+    // virtual int getKerningOffset(lChar32 ch1, lChar32 ch2, lChar32 def_char) { CR_UNUSED3(ch1,ch2,def_char); return 0; }
 
     /// set fallback font for this font
     virtual void setFallbackFont( LVProtectedFastRef<LVFont> font ) { CR_UNUSED(font); }
@@ -457,19 +457,19 @@ enum font_antialiasing_t
 };
 
 class LVEmbeddedFontDef {
-    lString16 _url;
+    lString32 _url;
     lString8 _face;
     bool _bold;
     bool _italic;
 public:
-    LVEmbeddedFontDef(lString16 url, lString8 face, bool bold, bool italic) :
+    LVEmbeddedFontDef(lString32 url, lString8 face, bool bold, bool italic) :
         _url(url), _face(face), _bold(bold), _italic(italic)
     {
     }
     LVEmbeddedFontDef() : _bold(false), _italic(false) {
     }
 
-    const lString16 & getUrl() { return _url; }
+    const lString32 & getUrl() { return _url; }
     const lString8 & getFace() { return _face; }
     bool getBold() { return _bold; }
     bool getItalic() { return _italic; }
@@ -482,10 +482,10 @@ public:
 
 class LVEmbeddedFontList : public LVPtrVector<LVEmbeddedFontDef> {
 public:
-    LVEmbeddedFontDef * findByUrl(lString16 url);
+    LVEmbeddedFontDef * findByUrl(lString32 url);
     void add(LVEmbeddedFontDef * def) { LVPtrVector<LVEmbeddedFontDef>::add(def); }
-    bool add(lString16 url, lString8 face, bool bold, bool italic);
-    bool add(lString16 url) { return add(url, lString8::empty_str, false, false); }
+    bool add(lString32 url, lString8 face, bool bold, bool italic);
+    bool add(lString32 url) { return add(url, lString8::empty_str, false, false); }
     bool addAll(LVEmbeddedFontList & list);
     void set(LVEmbeddedFontList & list) { clear(); addAll(list); }
     bool serialize(SerialBuf & buf);
@@ -516,9 +516,9 @@ public:
     /// registers font by name
     virtual bool RegisterFont( lString8 name ) = 0;
     /// registers font by name and face
-    virtual bool RegisterExternalFont(lString16 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
+    virtual bool RegisterExternalFont(lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// registers document font
-    virtual bool RegisterDocumentFont(int /*documentId*/, LVContainerRef /*container*/, lString16 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
+    virtual bool RegisterDocumentFont(int /*documentId*/, LVContainerRef /*container*/, lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// unregisters all document fonts
     virtual void UnregisterDocumentFonts(int /*documentId*/) { }
     /// initializes font manager
@@ -545,11 +545,11 @@ public:
     /// destructor
     virtual ~LVFontManager() { }
     /// returns available typefaces
-    virtual void getFaceList( lString16Collection & ) { }
+    virtual void getFaceList( lString32Collection & ) { }
     /// returns available font files
-    virtual void getFontFileNameList( lString16Collection & ) { }
+    virtual void getFontFileNameList( lString32Collection & ) { }
     /// returns font filename and face index for font name
-    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index ) { return false; }
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index ) { return false; }
 
     /// returns first found face from passed list, or return face for font found by family only
     virtual lString8 findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily);
@@ -588,8 +588,8 @@ public:
     virtual css_font_family_t getFontFamily() const { return _family; }
     /// draws text string (returns x advance)
     virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette, bool addHyphen,
                        TextLangCfg * lang_cfg=NULL,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
                        int text_decoration_back_gap=0 );
@@ -603,13 +603,13 @@ private:
     lvfont_handle m_font;
 public:
     LBitmapFont() : m_font(NULL) { }
-    virtual bool getGlyphInfo( lUInt32 code, LVFont::glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false );
+    virtual bool getGlyphInfo( lUInt32 code, LVFont::glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false );
     virtual lUInt16 measureText( 
-                        const lChar16 * text, int len, 
+                        const lChar32 * text, int len, 
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg=NULL,
                         int letter_spacing=0,
                         bool allow_hyphenation=true,
@@ -621,9 +621,9 @@ public:
         \return width of specified string 
     */
     virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL
+                        const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL
         );
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0, bool is_fallback=false);
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, bool is_fallback=false);
     /// returns font baseline offset
     virtual int getBaseline();
     /// returns font height
@@ -635,10 +635,10 @@ public:
     /// returns italic flag
     virtual int getItalic() const;
     
-    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar16 def_char=0 );
+    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar32 def_char=0 );
     
     /// returns char width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 )
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 )
     {
         glyph_info_t glyph;
         if ( getGlyphInfo(ch, &glyph, def_char ) )
@@ -646,9 +646,9 @@ public:
         return 0;
     }
     /// returns char glyph left side bearing (not implemented)
-    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
+    virtual int getLeftSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
     /// returns char glyph right side bearing (not implemented)
-    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
+    virtual int getRightSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false ) { return 0; }
 
     virtual lvfont_handle GetHandle() { return m_font; }
     
@@ -700,7 +700,7 @@ public:
     }
     
     /// returns char width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 )
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 )
     {
         glyph_info_t glyph;
         if ( getGlyphInfo(ch, &glyph, def_char) )
@@ -740,7 +740,7 @@ public:
         return css_ff_inherit;
     }
 
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0, bool is_fallback=false) {
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, bool is_fallback=false) {
         return NULL;
     }
 
@@ -763,18 +763,18 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found 
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false );
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false );
 
     /** \brief measure text
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyph was found 
     */
     virtual lUInt16 measureText( 
-                        const lChar16 * text, int len, 
+                        const lChar32 * text, int len, 
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg=NULL,
                         int letter_spacing=0,
                         bool allow_hyphenation=true,
@@ -786,16 +786,16 @@ public:
         \return width of specified string 
     */
     virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL
+                        const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL
         );
 
     /// returns char width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 );
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 );
 
     /// draws text string (returns x advance)
     virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette, bool addHyphen,
                        TextLangCfg * lang_cfg=NULL,
                        lUInt32 flags=0, int letter_spacing=0, int width=-1,
                        int text_decoration_back_gap=0 );
@@ -805,18 +805,18 @@ public:
         \param buf is buffer [width*height] to place glyph data
         \return true if glyph was found 
     */
-    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar16 def_char=0);
+    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar32 def_char=0);
     
 };
 
 struct glyph_t {
     lUInt8 *     glyph;
-    lChar16      ch;
+    lChar32      ch;
     bool         flgNotExists;
     bool         flgValid;
     LVFont::glyph_info_t gi;
     glyph_t *    next;
-    glyph_t(lChar16 c)
+    glyph_t(lChar32 c)
     : glyph(NULL), ch(c), flgNotExists(false), flgValid(false), next(NULL)
     {
         memset( &gi, 0, sizeof(gi) );
@@ -863,7 +863,7 @@ public:
             delete _hashtable;
         }
     }
-    glyph_t * find( lChar16 ch )
+    glyph_t * find( lChar32 ch )
     {
         lUInt32 index = (((lUInt32)ch)*113) % _size;
         glyph_t * p = _hashtable[index];
@@ -885,7 +885,7 @@ public:
         return NULL;
     }
     /// returns found or creates new
-    glyph_t * get( lChar16 ch )
+    glyph_t * get( lChar32 ch )
     {
         lUInt32 index = (((lUInt32)ch)*113) % _size;
         glyph_t * * p = &_hashtable[index];
@@ -931,30 +931,30 @@ public:
 class LVWin32Font : public LVBaseWin32Font
 {
 private:    
-    lChar16 _unknown_glyph_index;
+    lChar32 _unknown_glyph_index;
     GlyphCache _cache;
     
     static int GetGlyphIndex( HDC hdc, wchar_t code );
     
-    glyph_t * GetGlyphRec( lChar16 ch );
+    glyph_t * GetGlyphRec( lChar32 ch );
 
 public:
     /** \brief get glyph info
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found 
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false );
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false );
 
     /** \brief measure text
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyph was found 
     */
     virtual lUInt16 measureText( 
-                        const lChar16 * text, int len, 
+                        const lChar32 * text, int len, 
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg=NULL,
                         int letter_spacing=0,
                         bool allow_hyphenation=true,
@@ -966,7 +966,7 @@ public:
         \return width of specified string 
     */
     virtual lUInt32 getTextWidth(
-                        const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL
+                        const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL
         );
 
     /** \brief get glyph image in 1 byte per pixel format
@@ -974,7 +974,7 @@ public:
         \param buf is buffer [width*height] to place glyph data
         \return true if glyph was found 
     */
-    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar16 def_char=0);
+    virtual bool getGlyphImage(lUInt32 code, lUInt8 * buf, lChar32 def_char=0);
     
     virtual void Clear();
 

--- a/crengine/include/lvimg.h
+++ b/crengine/include/lvimg.h
@@ -110,7 +110,7 @@ LVImageSourceRef LVCreateDummyImageSource( ldomNode * node, int width, int heigh
 /// creates image source from stream
 LVImageSourceRef LVCreateStreamImageSource( LVStreamRef stream );
 /// creates image source as memory copy of file contents
-LVImageSourceRef LVCreateFileCopyImageSource( lString16 fname );
+LVImageSourceRef LVCreateFileCopyImageSource( lString32 fname );
 /// creates image source as memory copy of stream contents
 LVImageSourceRef LVCreateStreamCopyImageSource( LVStreamRef stream );
 /// creates decoded memory copy of image, if it's unpacked size is less than maxSize (8 bit gray or 32 bit color)

--- a/crengine/include/lvopc.h
+++ b/crengine/include/lvopc.h
@@ -19,22 +19,22 @@ class OpcPart : public LVRefCounter
 public:
     ~OpcPart();
     LVStreamRef open();
-    lString16 getRelatedPartName(const lChar16 * const relationType, const lString16 id = lString16());
-    OpcPartRef getRelatedPart(const lChar16 * const relationType, const lString16 id = lString16());
+    lString32 getRelatedPartName(const lChar32 * const relationType, const lString32 id = lString32());
+    OpcPartRef getRelatedPart(const lChar32 * const relationType, const lString32 id = lString32());
 protected:
-    OpcPart(OpcPackage* package, lString16 name):
+    OpcPart(OpcPackage* package, lString32 name):
        m_relations(16), m_package(package), m_name(name), m_relationsValid(false)
     {
     }
     void readRelations();
-    lString16 getTargetPath(const lString16 srcPath, const lString16 targetMode, lString16 target);
-    OpcPart* createPart(OpcPackage* package, lString16 name) {
+    lString32 getTargetPath(const lString32 srcPath, const lString32 targetMode, lString32 target);
+    OpcPart* createPart(OpcPackage* package, lString32 name) {
         return new OpcPart(package, name);
     }
 private:
-    LVHashTable<lString16, LVHashTable<lString16, lString16> *> m_relations;
+    LVHashTable<lString32, LVHashTable<lString32, lString32> *> m_relations;
     OpcPackage* m_package;
-    lString16 m_name;
+    lString32 m_name;
     bool m_relationsValid;
 private:
     // non copyable
@@ -49,30 +49,30 @@ class OpcPackage : public OpcPart
 private:
     bool m_contentTypesValid;
     LVContainerRef m_container;
-    LVHashTable<lString16, lString16> m_contentTypes;
+    LVHashTable<lString32, lString32> m_contentTypes;
 private:
     // non copyable
     OpcPackage();
     OpcPackage( const OpcPackage& );
     OpcPackage& operator=( const OpcPart& );
 public:
-    OpcPackage(LVContainerRef container) : OpcPart(this, L"/"),
+    OpcPackage(LVContainerRef container) : OpcPart(this, U"/"),
         m_contentTypesValid(false), m_container(container),
         m_contentTypes(16)
     {
     }
-    LVStreamRef open(lString16 partName) {
+    LVStreamRef open(lString32 partName) {
         return m_container->OpenStream(partName.c_str(), LVOM_READ);
     }
-    lString16 getContentPartName(const lChar16* contentType);
-    OpcPartRef getContentPart(const lChar16* contentType) {
+    lString32 getContentPartName(const lChar32* contentType);
+    OpcPartRef getContentPart(const lChar32* contentType) {
         return getPart(getContentPartName(contentType));
     }
-    LVStreamRef openContentPart(const lChar16* contentType) {
+    LVStreamRef openContentPart(const lChar32* contentType) {
         return open(getContentPartName(contentType));
     }
-    OpcPartRef getPart(const lString16 partName);
-    bool partExist(const lString16 partName);
+    OpcPartRef getPart(const lString32 partName);
+    bool partExist(const lString32 partName);
     void readCoreProperties(CRPropRef doc_props);
 private:
     void readContentTypes();

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -314,10 +314,10 @@ public:
 typedef LVFastRef<LVFootNote> LVFootNoteRef;
 
 class LVFootNote : public LVRefCounter {
-    lString16 id;
+    lString32 id;
     CompactArray<LVRendLineInfo*, 2, 4> lines;
 public:
-    LVFootNote( lString16 noteId )
+    LVFootNote( lString32 noteId )
         : id(noteId)
     {
     }
@@ -328,7 +328,7 @@ public:
     CompactArray<LVRendLineInfo*, 2, 4> & getLines() { return lines; }
     bool empty() { return lines.empty(); }
     void clear() { lines.clear(); }
-    lString16 getId() { return id; }
+    lString32 getId() { return id; }
 };
 
 class LVDocViewCallback;
@@ -360,13 +360,13 @@ class LVRendPageContext
     // Whether to gather lines or not (only footnote links will be gathered if not)
     bool gather_lines;
     // Links gathered when !gather_lines
-    lString16Collection link_ids;
+    lString32Collection link_ids;
 
-    LVHashTable<lString16, LVFootNoteRef> footNotes;
+    LVHashTable<lString32, LVFootNoteRef> footNotes;
 
     LVFootNote * curr_note;
 
-    LVFootNoteRef getOrCreateFootNote( lString16 id )
+    LVFootNoteRef getOrCreateFootNote( lString32 id )
     {
         LVFootNoteRef ref = footNotes.get(id);
         if ( ref.isNull() ) {
@@ -393,15 +393,15 @@ public:
     int getCurrentLinksCount();
 
     /// append or insert footnote link to last added line
-    void addLink( lString16 id, int pos=-1 );
+    void addLink( lString32 id, int pos=-1 );
 
     /// get gathered links when !gather_lines
-    // (returns a reference to avoid lString16Collection destructor from
+    // (returns a reference to avoid lString32Collection destructor from
     // being called twice and a double free crash)
-    lString16Collection * getLinkIds() { return &link_ids; }
+    lString32Collection * getLinkIds() { return &link_ids; }
 
     /// mark start of foot note
-    void enterFootNote( lString16 id );
+    void enterFootNote( lString32 id );
 
     /// mark end of foot note
     void leaveFootNote();

--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -87,9 +87,9 @@ public:
     /// returns true for container (directory), false for stream (file)
     virtual bool IsContainer();
     /// returns stream/container name, may be NULL if unknown
-    virtual const lChar16 * GetName();
+    virtual const lChar32 * GetName();
     /// sets stream/container name, may be not implemented for some objects
-    virtual void SetName(const lChar16 * name);
+    virtual void SetName(const lChar32 * name);
     /// returns parent container, if opened from container
     virtual LVContainer * GetParentContainer();
     /// returns object size (file size or directory entry count)
@@ -354,11 +354,11 @@ public:
 };
 
 
-/// Writes lString16 string to stream
-inline LVStream & operator << (LVStream & stream, const lString16 & str)
+/// Writes lString32 string to stream
+inline LVStream & operator << (LVStream & stream, const lString32 & str)
 {
    if (!str.empty())
-      stream.Write( str.c_str(), sizeof(lChar16)*str.length(), NULL);
+      stream.Write( str.c_str(), sizeof(lChar32)*str.length(), NULL);
    return stream;
 }
 
@@ -370,11 +370,11 @@ inline LVStream & operator << (LVStream & stream, const lString8 & str)
    return stream;
 }
 
-/// Writes lChar16 string to stream
-inline LVStream & operator << (LVStream & stream, const lChar16 * str)
+/// Writes lChar32 string to stream
+inline LVStream & operator << (LVStream & stream, const lChar32 * str)
 {
    if (str)
-      stream.Write( str, sizeof(lChar16)*lStr_len(str), NULL);
+      stream.Write( str, sizeof(lChar32)*lStr_len(str), NULL);
    return stream;
 }
 
@@ -418,9 +418,9 @@ inline LVStream & operator << (LVStream & stream, LVArray<T> & array )
 class LVNamedStream : public LVStream
 {
 protected:
-    lString16 m_fname;
-    lString16 m_filename;
-    lString16 m_path;
+    lString32 m_fname;
+    lString32 m_filename;
+    lString32 m_path;
     lvopen_mode_t          m_mode;
     lUInt32 _crc;
     bool _crcFailed;
@@ -441,9 +441,9 @@ public:
     /// set write bytes limit to call flush(true) automatically after writing of each sz bytes
     virtual void setAutoSyncSize(lvsize_t sz) { _autosyncLimit = sz; }
     /// returns stream/container name, may be NULL if unknown
-    virtual const lChar16 * GetName();
+    virtual const lChar32 * GetName();
     /// sets stream/container name, may be not implemented for some objects
-    virtual void SetName(const lChar16 * name);
+    virtual void SetName(const lChar32 * name);
     /// returns open mode
     virtual lvopen_mode_t GetMode()
     {
@@ -459,7 +459,7 @@ class LVStreamProxy : public LVStream
 protected:
     LVStream * m_base_stream;
 public:
-    virtual const lChar16 * GetName()
+    virtual const lChar32 * GetName()
             { return m_base_stream->GetName(); }
     virtual lvopen_mode_t GetMode()
             { return m_base_stream->GetMode(); }
@@ -504,7 +504,7 @@ class LVContainerItemInfo
 {
 public:
     virtual lvsize_t        GetSize() const = 0;
-    virtual const lChar16 * GetName() const = 0;
+    virtual const lChar32 * GetName() const = 0;
     virtual lUInt32         GetFlags() const = 0;
     virtual bool            IsContainer() const = 0;
     LVContainerItemInfo() {}
@@ -515,11 +515,11 @@ class LVContainer : public LVStorageObject
 {
 public:
     virtual LVContainer * GetParentContainer() = 0;
-    //virtual const LVContainerItemInfo * GetObjectInfo(const wchar_t * pname);
+    //virtual const LVContainerItemInfo * GetObjectInfo(const char32_t * pname);
     virtual const LVContainerItemInfo * GetObjectInfo(int index) = 0;
     virtual const LVContainerItemInfo * operator [] (int index) { return GetObjectInfo(index); }
     virtual int GetObjectCount() const = 0;
-    virtual LVStreamRef OpenStream( const lChar16 * fname, lvopen_mode_t mode ) = 0;
+    virtual LVStreamRef OpenStream( const lChar32 * fname, lvopen_mode_t mode ) = 0;
     LVContainer() {}
     virtual ~LVContainer() { }
 };
@@ -530,7 +530,7 @@ class LVCommonContainerItemInfo : public LVContainerItemInfo
     friend class LVArcContainer;
 protected:
     lvsize_t     m_size;
-    lString16    m_name;
+    lString32    m_name;
     lUInt32      m_flags;
     bool         m_is_container;
     lUInt32      m_srcpos;
@@ -538,7 +538,7 @@ protected:
     lUInt32      m_srcflags;
 public:
     virtual lvsize_t        GetSize() const { return m_size; }
-    virtual const lChar16 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
+    virtual const lChar32 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
     virtual lUInt32         GetFlags() const  { return m_flags; }
     virtual bool            IsContainer() const  { return m_is_container; }
     lUInt32 GetSrcPos() { return m_srcpos; }
@@ -550,11 +550,11 @@ public:
         m_srcsize = size;
         m_srcflags = flags;
     }
-    void SetName( const lChar16 * name )
+    void SetName( const lChar32 * name )
     {
         m_name = name;
     }
-    void SetItemInfo( lString16 fname, lvsize_t size, lUInt32 flags, bool isContainer = false )
+    void SetItemInfo( lString32 fname, lvsize_t size, lUInt32 flags, bool isContainer = false )
     {
         m_name = fname;
         m_size = size;
@@ -573,10 +573,10 @@ public:
 class LVNamedContainer : public LVContainer
 {
 protected:
-    lString16 m_fname;
-    lString16 m_filename;
-    lString16 m_path;
-    lChar16 m_path_separator;
+    lString32 m_fname;
+    lString32 m_filename;
+    lString32 m_path;
+    lChar32 m_path_separator;
     LVPtrVector<LVCommonContainerItemInfo> m_list;
 public:
     virtual bool IsContainer()
@@ -584,23 +584,23 @@ public:
         return true;
     }
     /// returns stream/container name, may be NULL if unknown
-    virtual const lChar16 * GetName()
+    virtual const lChar32 * GetName()
     {
         if (m_fname.empty())
             return NULL;
         return m_fname.c_str();
     }
     /// sets stream/container name, may be not implemented for some objects
-    virtual void SetName(const lChar16 * name)
+    virtual void SetName(const lChar32 * name)
     {
         m_fname = name;
         m_filename.clear();
         m_path.clear();
         if (m_fname.empty())
             return;
-        const lChar16 * fn = m_fname.c_str();
+        const lChar32 * fn = m_fname.c_str();
 
-        const lChar16 * p = fn + m_fname.length() - 1;
+        const lChar32 * p = fn + m_fname.length() - 1;
         for ( ;p>fn; p--) {
             if (p[-1] == '/' || p[-1]=='\\')
             {
@@ -641,7 +641,7 @@ protected:
     LVContainer * m_parent;
     LVStreamRef m_stream;
 public:
-    virtual LVStreamRef OpenStream( const wchar_t *, lvopen_mode_t )
+    virtual LVStreamRef OpenStream( const char32_t *, lvopen_mode_t )
     {
         return LVStreamRef();
     }
@@ -655,7 +655,7 @@ public:
             return m_list[index];
         return NULL;
     }
-    virtual const LVContainerItemInfo * GetObjectInfo(lString16 name)
+    virtual const LVContainerItemInfo * GetObjectInfo(lString32 name)
     {
         for ( int i=0; i<m_list.length(); i++ )
             if (m_list[i]->GetName()==name )
@@ -756,7 +756,7 @@ typedef LVFastRef<LVContainer> LVContainerRef;
     \param mode is mode file should be opened in
     \return reference to opened stream if success, NULL if error
 */
-LVStreamRef LVOpenFileStream( const lChar16 * pathname, int mode );
+LVStreamRef LVOpenFileStream( const lChar32 * pathname, int mode );
 
 /// Open file stream
 /**
@@ -773,7 +773,7 @@ LVStreamRef LVOpenFileStream( const lChar8 * pathname, int mode );
 	\param minSize is minimum file size for R/W mode
     \return reference to opened stream if success, NULL if error
 */
-LVStreamRef LVMapFileStream( const lChar16 * pathname, lvopen_mode_t mode, lvsize_t minSize );
+LVStreamRef LVMapFileStream( const lChar32 * pathname, lvopen_mode_t mode, lvsize_t minSize );
 
 /// Open memory mapped file
 /**
@@ -806,34 +806,34 @@ LVStreamRef LVCreateMemoryStream( void * buf = NULL, int bufSize = 0, bool creat
 /// Creates memory stream as copy of another stream.
 LVStreamRef LVCreateMemoryStream( LVStreamRef srcStream );
 /// Creates memory stream as copy of file contents.
-LVStreamRef LVCreateMemoryStream( lString16 filename );
+LVStreamRef LVCreateMemoryStream( lString32 filename );
 /// Creates memory stream as copy of string contents
 LVStreamRef LVCreateStringStream( lString8 data );
 /// Creates memory stream as copy of string contents
-LVStreamRef LVCreateStringStream( lString16 data );
+LVStreamRef LVCreateStringStream( lString32 data );
 
 /// creates cache buffers for stream, to write data by big blocks to optimize Flash drives writing performance
 LVStreamRef LVCreateBlockWriteStream( LVStreamRef baseStream, int blockSize, int blockCount );
 
-LVContainerRef LVOpenDirectory( const lChar16 * path, const wchar_t * mask = L"*.*" );
-LVContainerRef LVOpenDirectory(const lString16& path, const wchar_t * mask = L"*.*" );
-LVContainerRef LVOpenDirectory(const lString8& path, const wchar_t * mask = L"*.*" );
+LVContainerRef LVOpenDirectory( const lChar32 * path, const char32_t * mask = U"*.*" );
+LVContainerRef LVOpenDirectory(const lString32& path, const char32_t * mask = U"*.*" );
+LVContainerRef LVOpenDirectory(const lString8& path, const char32_t * mask = U"*.*" );
 
 bool LVDirectoryIsEmpty(const lString8& path);
-bool LVDirectoryIsEmpty(const lString16& path);
+bool LVDirectoryIsEmpty(const lString32& path);
 
 /// Create directory if not exist
-bool LVCreateDirectory( lString16 path );
+bool LVCreateDirectory( lString32 path );
 /// delete file, return true if file found and successfully deleted
-bool LVDeleteFile( lString16 filename );
+bool LVDeleteFile( lString32 filename );
 /// delete file, return true if file found and successfully deleted
 bool LVDeleteFile( lString8 filename );
 /// delete directory, return true if directory is found and successfully deleted
-bool LVDeleteDirectory( lString16 filename );
+bool LVDeleteDirectory( lString32 filename );
 /// delete directory, return true if directory is found and successfully deleted
 bool LVDeleteDirectory( lString8 filename );
 /// rename file
-bool LVRenameFile(lString16 oldname, lString16 newname);
+bool LVRenameFile(lString32 oldname, lString32 newname);
 /// rename file
 bool LVRenameFile(lString8 oldname, lString8 newname);
 
@@ -848,66 +848,66 @@ LVStreamRef LVCreateBufferedStream( LVStreamRef stream, int bufSize );
 LVStreamRef LVCreateTCRDecoderStream( LVStreamRef stream );
 
 /// returns path part of pathname (appended with / or \ delimiter)
-lString16 LVExtractPath( lString16 pathName, bool appendEmptyPath=true );
+lString32 LVExtractPath( lString32 pathName, bool appendEmptyPath=true );
 /// returns path part of pathname (appended with / or \ delimiter)
 lString8 LVExtractPath( lString8 pathName, bool appendEmptyPath=true );
 /// removes first path part from pathname and returns it
-lString16 LVExtractFirstPathElement( lString16 & pathName );
+lString32 LVExtractFirstPathElement( lString32 & pathName );
 /// removes last path part from pathname and returns it
-lString16 LVExtractLastPathElement( lString16 & pathName );
+lString32 LVExtractLastPathElement( lString32 & pathName );
 /// returns filename part of pathname
-lString16 LVExtractFilename( lString16 pathName );
+lString32 LVExtractFilename( lString32 pathName );
 /// returns filename part of pathname
 lString8 LVExtractFilename( lString8 pathName );
 /// returns filename part of pathname without extension
-lString16 LVExtractFilenameWithoutExtension( lString16 pathName );
+lString32 LVExtractFilenameWithoutExtension( lString32 pathName );
 /// appends path delimiter character to end of path, if absent
-void LVAppendPathDelimiter( lString16 & pathName );
+void LVAppendPathDelimiter( lString32 & pathName );
 /// appends path delimiter character to end of path, if absent
 void LVAppendPathDelimiter( lString8 & pathName );
 /// removes path delimiter from end of path, if present
 void LVRemoveLastPathDelimiter( lString8 & pathName );
 /// removes path delimiter from end of path, if present
-void LVRemoveLastPathDelimiter( lString16 & pathName );
+void LVRemoveLastPathDelimiter( lString32 & pathName );
 /// replaces any found / or \\ separator with specified one
-void LVReplacePathSeparator( lString16 & pathName, lChar16 separator );
+void LVReplacePathSeparator( lString32 & pathName, lChar32 separator );
 /// removes path delimiter character from end of path, if exists
-void LVRemovePathDelimiter( lString16 & pathName );
+void LVRemovePathDelimiter( lString32 & pathName );
 /// removes path delimiter character from end of path, if exists
 void LVRemovePathDelimiter( lString8 & pathName );
 /// returns path delimiter character
-lChar16 LVDetectPathDelimiter( lString16 pathName );
+lChar32 LVDetectPathDelimiter( lString32 pathName );
 /// returns path delimiter character
 char LVDetectPathDelimiter( lString8 pathName );
 /// returns true if absolute path is specified
-bool LVIsAbsolutePath( lString16 pathName );
+bool LVIsAbsolutePath( lString32 pathName );
 /// returns full path to file identified by pathName, with base directory == basePath
-lString16 LVMakeRelativeFilename( lString16 basePath, lString16 pathName );
+lString32 LVMakeRelativeFilename( lString32 basePath, lString32 pathName );
 // resolve relative links
-lString16 LVCombinePaths( lString16 basePath, lString16 newPath );
+lString32 LVCombinePaths( lString32 basePath, lString32 newPath );
 
 /// tries to split full path name into archive name and file name inside archive using separator "@/" or "@\"
-bool LVSplitArcName(lString16 fullPathName, lString16 & arcPathName, lString16 & arcItemPathName);
+bool LVSplitArcName(lString32 fullPathName, lString32 & arcPathName, lString32 & arcItemPathName);
 /// tries to split full path name into archive name and file name inside archive using separator "@/" or "@\"
 bool LVSplitArcName(lString8 fullPathName, lString8 & arcPathName, lString8 & arcItemPathName);
 
 /// returns true if specified file exists
-bool LVFileExists( const lString16 & pathName );
+bool LVFileExists( const lString32 & pathName );
 /// returns true if specified file exists
 bool LVFileExists( const lString8 & pathName );
 /// returns true if specified directory exists
-bool LVDirectoryExists( const lString16 & pathName );
+bool LVDirectoryExists( const lString32 & pathName );
 /// returns true if specified directory exists
 bool LVDirectoryExists( const lString8 & pathName );
 /// returns true if directory exists and your app can write to directory
-bool LVDirectoryIsWritable(const lString16 & pathName);
+bool LVDirectoryIsWritable(const lString32 & pathName);
 
 
 /// factory to handle filesystem access for paths started with ASSET_PATH_PREFIX (@ sign)
 class LVAssetContainerFactory {
 public:
-	virtual LVContainerRef openAssetContainer(lString16 path) = 0;
-	virtual LVStreamRef openAssetStream(lString16 path) = 0;
+	virtual LVContainerRef openAssetContainer(lString32 path) = 0;
+	virtual LVStreamRef openAssetStream(lString32 path) = 0;
 	LVAssetContainerFactory() {}
 	virtual ~LVAssetContainerFactory() {}
 };

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -57,48 +57,48 @@
 #define UNICODE_ASCII_FULL_WIDTH_OFFSET 0xFEE0 // substract or add to convert to/from ASCII
 
 
-/// strlen for lChar16
-int lStr_len(const lChar16 * str);
+/// strlen for lChar32
+int lStr_len(const lChar32 * str);
 /// strlen for lChar8
 int lStr_len(const lChar8 * str);
-/// strnlen for lChar16
-int lStr_nlen(const lChar16 * str, int maxcount);
+/// strnlen for lChar32
+int lStr_nlen(const lChar32 * str, int maxcount);
 /// strnlen for lChar8
 int lStr_nlen(const lChar8 * str, int maxcount);
-/// strcpy for lChar16
-int lStr_cpy(lChar16 * dst, const lChar16 * src);
-/// strcpy for lChar16 -> lChar8
-int lStr_cpy(lChar16 * dst, const lChar8 * src);
+/// strcpy for lChar32
+int lStr_cpy(lChar32 * dst, const lChar32 * src);
+/// strcpy for lChar32 -> lChar8
+int lStr_cpy(lChar32 * dst, const lChar8 * src);
 /// strcpy for lChar8
 int lStr_cpy(lChar8 * dst, const lChar8 * src);
-/// strncpy for lChar16
-int lStr_ncpy(lChar16 * dst, const lChar16 * src, int maxcount);
+/// strncpy for lChar32
+int lStr_ncpy(lChar32 * dst, const lChar32 * src, int maxcount);
 /// strncpy for lChar8
 int lStr_ncpy(lChar8 * dst, const lChar8 * src, int maxcount);
-/// memcpy for lChar16
-void   lStr_memcpy(lChar16 * dst, const lChar16 * src, int count);
+/// memcpy for lChar32
+void   lStr_memcpy(lChar32 * dst, const lChar32 * src, int count);
 /// memcpy for lChar8
 void   lStr_memcpy(lChar8 * dst, const lChar8 * src, int count);
-/// memset for lChar16
-void   lStr_memset(lChar16 * dst, lChar16 value, int count);
+/// memset for lChar32
+void   lStr_memset(lChar32 * dst, lChar32 value, int count);
 /// memset for lChar8
 void   lStr_memset(lChar8 * dst, lChar8 value, int count);
-/// strcmp for lChar16
-int    lStr_cmp(const lChar16 * str1, const lChar16 * str2);
-/// strcmp for lChar16 <> lChar8
-int    lStr_cmp(const lChar16 * str1, const lChar8 * str2);
-/// strcmp for lChar8 <> lChar16
-int    lStr_cmp(const lChar8 * str1, const lChar16 * str2);
+/// strcmp for lChar32
+int    lStr_cmp(const lChar32 * str1, const lChar32 * str2);
+/// strcmp for lChar32 <> lChar8
+int    lStr_cmp(const lChar32 * str1, const lChar8 * str2);
+/// strcmp for lChar8 <> lChar32
+int    lStr_cmp(const lChar8 * str1, const lChar32 * str2);
 /// strcmp for lChar8
 int    lStr_cmp(const lChar8 * str1, const lChar8 * str2);
 /// convert string to uppercase
-void lStr_uppercase( lChar16 * str, int len );
+void lStr_uppercase( lChar32 * str, int len );
 /// convert string to lowercase
-void lStr_lowercase( lChar16 * str, int len );
+void lStr_lowercase( lChar32 * str, int len );
 /// convert string to be capitalized
-void lStr_capitalize( lChar16 * str, int len );
+void lStr_capitalize( lChar32 * str, int len );
 /// convert string to use full width chars
-void lStr_fullWidthChars( lChar16 * str, int len );
+void lStr_fullWidthChars( lChar32 * str, int len );
 /// calculates CRC32 for buffer contents
 lUInt32 lStr_crc32( lUInt32 prevValue, const void * buf, int size );
 
@@ -107,9 +107,9 @@ char toHexDigit( int c );
 // returns 0..15 if c is hex digit, -1 otherwise
 int hexDigit( int c );
 // decode LEN hex digits, return decoded number, -1 if invalid
-int decodeHex( const lChar16 * str, int len );
+int decodeHex( const lChar32 * str, int len );
 // decode LEN decimal digits, return decoded number, -1 if invalid
-int decodeDecimal( const lChar16 * str, int len );
+int decodeDecimal( const lChar32 * str, int len );
 
 
 #define CH_PROP_UPPER       0x0001 ///< uppercase alpha character flag
@@ -129,13 +129,13 @@ int decodeDecimal( const lChar16 * str, int len );
 #define CH_PROP_AVOID_WRAP_BEFORE  0x2000 ///< avoid wrap on preceding space
 
 /// retrieve character properties mask array for wide c-string
-void lStr_getCharProps( const lChar16 * str, int sz, lUInt16 * props );
+void lStr_getCharProps( const lChar32 * str, int sz, lUInt16 * props );
 /// retrieve character properties mask for single wide character
-lUInt16 lGetCharProps( lChar16 ch );
+lUInt16 lGetCharProps( lChar32 ch );
 /// find alpha sequence bounds
-void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int & end );
+void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end );
 // is char a word separator
-bool lStr_isWordSeparator( lChar16 ch );
+bool lStr_isWordSeparator( lChar32 ch );
 
 
 // must be power of 2
@@ -146,7 +146,7 @@ bool lStr_isWordSeparator( lChar16 ch );
 
 struct lstring8_chunk_t {
     friend class lString8;
-    friend class lString16;
+    friend class lString32;
     friend struct lstring_chunk_slice_t;
 public:
     lstring8_chunk_t(lChar8 * _buf8) : buf8(_buf8), size(1), len(0), nref(1) {}
@@ -165,24 +165,24 @@ private:
 
 };
 
-struct lstring16_chunk_t {
+struct lstring32_chunk_t {
     friend class lString8;
-    friend class lString16;
+    friend class lString32;
     friend struct lstring_chunk_slice_t;
 public:
-    lstring16_chunk_t(lChar16 * _buf16) : buf16(_buf16), size(1), len(0), nref(1) {}
-    const lChar16 * data16() const { return buf16; }
+    lstring32_chunk_t(lChar32 * _buf32) : buf32(_buf32), size(1), len(0), nref(1) {}
+    const lChar32 * data32() const { return buf32; }
 private:
-    lChar16 * buf16; // z-string
+    lChar32 * buf32; // z-string
     lInt32 size;   // 0 for free chunk
     lInt32 len;    // count of chars in string
     int nref;      // reference counter
 
-    lstring16_chunk_t() {}
+    lstring32_chunk_t() {}
 
     // chunk allocation functions
-    static lstring16_chunk_t * alloc();
-    static void free( lstring16_chunk_t * pChunk );
+    static lstring32_chunk_t * alloc();
+    static void free( lstring32_chunk_t * pChunk );
 };
 
 
@@ -256,8 +256,8 @@ public:
     lString8(const lString8 & str) : pchunk(str.pchunk) { addref(); }
     /// constructor from C string
     explicit lString8(const value_type * str);
-    /// constructor from 16-bit C string
-    explicit lString8(const lChar16 * str);
+    /// constructor from 32-bit C string
+    explicit lString8(const lChar32 * str);
     /// constructor from string of specified length
     explicit lString8(const value_type * str, size_type count);
     /// fragment copy constructor
@@ -444,23 +444,23 @@ public:
 
     static const lString8 empty_str;
 
-    friend class lString16Collection;
+    friend class lString32Collection;
 };
 
 /**
-    \brief Wide character (lChar16) string. 
+    \brief Wide character (lChar32) string. 
 
    Reference counting, copy-on-write implementation.
    Interface is similar to STL strings.
 
 */
-class lString16
+class lString32
 {
-    friend const lString16 & cs16(const char * str);
-    friend const lString16 & cs16(const lChar16 * str);
+    friend const lString32 & cs32(const char * str);
+    friend const lString32 & cs32(const lChar32 * str);
 public:
     // typedefs for STL compatibility
-    typedef lChar16             value_type;
+    typedef lChar32             value_type;
     typedef int                 size_type;
     typedef int                 difference_type;
     typedef value_type *        pointer;
@@ -468,36 +468,36 @@ public:
     typedef const value_type *  const_pointer;
     typedef const value_type &  const_reference;
 
-    typedef lstring16_chunk_t    lstring_chunk_t; ///< data container
+    typedef lstring32_chunk_t    lstring_chunk_t; ///< data container
 
 private:
     lstring_chunk_t * pchunk;
-    static lstring_chunk_t * EMPTY_STR_16;
+    static lstring_chunk_t * EMPTY_STR_32;
     void alloc(size_type sz);
     void free();
     inline void addref() const { ++pchunk->nref; }
     inline void release() { if (--pchunk->nref==0) free(); }
 public:
-    explicit lString16(lstring_chunk_t * chunk) : pchunk(chunk) { addref(); }
+    explicit lString32(lstring_chunk_t * chunk) : pchunk(chunk) { addref(); }
     /// empty string constructor
-    explicit lString16() : pchunk(EMPTY_STR_16) { addref(); }
+    explicit lString32() : pchunk(EMPTY_STR_32) { addref(); }
     /// copy constructor
-    lString16(const lString16 & str) : pchunk(str.pchunk) { addref(); }
+    lString32(const lString32 & str) : pchunk(str.pchunk) { addref(); }
     /// constructor from wide c-string
-    lString16(const value_type * str);
+    lString32(const value_type * str);
     /// constructor from 8bit c-string (ASCII only)
-    explicit lString16(const lChar8 * str);
+    explicit lString32(const lChar8 * str);
     /// constructor from 8bit (ASCII only) character array fragment
-    explicit lString16(const lChar8 * str, size_type count);
+    explicit lString32(const lChar8 * str, size_type count);
     /// constructor from wide character array fragment
-    explicit lString16(const value_type * str, size_type count);
+    explicit lString32(const value_type * str, size_type count);
     /// constructor from another string substring
-    explicit lString16(const lString16 & str, size_type offset, size_type count);
+    explicit lString32(const lString32 & str, size_type offset, size_type count);
     /// desctructor
-    ~lString16() { release(); }
+    ~lString32() { release(); }
 
     /// assignment from string
-    lString16 & assign(const lString16 & str)
+    lString32 & assign(const lString32 & str)
     {
         if (pchunk!=str.pchunk)
         {
@@ -508,125 +508,125 @@ public:
         return *this;
     }
     /// assignment from c-string
-    lString16 & assign(const value_type * str);
+    lString32 & assign(const value_type * str);
     /// assignment from 8bit c-string (ASCII only)
-    lString16 & assign(const lChar8 * str);
+    lString32 & assign(const lChar8 * str);
     /// assignment from character array fragment
-    lString16 & assign(const value_type * str, size_type count);
+    lString32 & assign(const value_type * str, size_type count);
     /// assignment from 8-bit character array fragment (ASCII only)
-    lString16 & assign(const lChar8 * str, size_type count);
+    lString32 & assign(const lChar8 * str, size_type count);
     /// assignment from string fragment
-    lString16 & assign(const lString16 & str, size_type offset, size_type count);
+    lString32 & assign(const lString32 & str, size_type offset, size_type count);
     /// assignment from c-string
-    lString16 & operator = (const value_type * str) { return assign(str); }
+    lString32 & operator = (const value_type * str) { return assign(str); }
     /// assignment from string 8bit ASCII only
-    lString16 & operator = (const lChar8 * str) { return assign(str); }
+    lString32 & operator = (const lChar8 * str) { return assign(str); }
     /// assignment from string
-    lString16 & operator = (const lString16 & str) { return assign(str); }
-    lString16 & erase(size_type offset, size_type count);
+    lString32 & operator = (const lString32 & str) { return assign(str); }
+    lString32 & erase(size_type offset, size_type count);
 
-    lString16 & append(const value_type * str);
-    lString16 & append(const value_type * str, size_type count);
-    lString16 & append(const lChar8 * str);
-    lString16 & append(const lChar8 * str, size_type count);
-    lString16 & append(const lString16 & str);
-    lString16 & append(const lString16 & str, size_type offset, size_type count);
-    lString16 & append(size_type count, value_type ch);
+    lString32 & append(const value_type * str);
+    lString32 & append(const value_type * str, size_type count);
+    lString32 & append(const lChar8 * str);
+    lString32 & append(const lChar8 * str, size_type count);
+    lString32 & append(const lString32 & str);
+    lString32 & append(const lString32 & str, size_type offset, size_type count);
+    lString32 & append(size_type count, value_type ch);
     /// append decimal number
-    lString16 & appendDecimal(lInt64 v);
+    lString32 & appendDecimal(lInt64 v);
     /// append hex number
-    lString16 & appendHex(lUInt64 v);
-    lString16 & insert(size_type p0, const value_type * str);
-    lString16 & insert(size_type p0, const value_type * str, size_type count);
-    lString16 & insert(size_type p0, const lString16 & str);
-    lString16 & insert(size_type p0, const lString16 & str, size_type offset, size_type count);
-    lString16 & insert(size_type p0, size_type count, value_type ch);
-    lString16 & replace(size_type p0, size_type n0, const value_type * str);
-    lString16 & replace(size_type p0, size_type n0, const value_type * str, size_type count);
-    lString16 & replace(size_type p0, size_type n0, const lString16 & str);
-    lString16 & replace(size_type p0, size_type n0, const lString16 & str, size_type offset, size_type count);
+    lString32 & appendHex(lUInt64 v);
+    lString32 & insert(size_type p0, const value_type * str);
+    lString32 & insert(size_type p0, const value_type * str, size_type count);
+    lString32 & insert(size_type p0, const lString32 & str);
+    lString32 & insert(size_type p0, const lString32 & str, size_type offset, size_type count);
+    lString32 & insert(size_type p0, size_type count, value_type ch);
+    lString32 & replace(size_type p0, size_type n0, const value_type * str);
+    lString32 & replace(size_type p0, size_type n0, const value_type * str, size_type count);
+    lString32 & replace(size_type p0, size_type n0, const lString32 & str);
+    lString32 & replace(size_type p0, size_type n0, const lString32 & str, size_type offset, size_type count);
     /// replace range of string with character ch repeated count times
-    lString16 & replace(size_type p0, size_type n0, size_type count, value_type ch);
+    lString32 & replace(size_type p0, size_type n0, size_type count, value_type ch);
     /// make string uppercase
-    lString16 & uppercase();
+    lString32 & uppercase();
     /// make string lowercase
-    lString16 & lowercase();
+    lString32 & lowercase();
     /// make string capitalized
-    lString16 & capitalize();
+    lString32 & capitalize();
     /// make string use full width chars
-    lString16 & fullWidthChars();
+    lString32 & fullWidthChars();
     /// compare with another string
-    int compare(const lString16& str) const { return lStr_cmp(pchunk->buf16, str.pchunk->buf16); }
+    int compare(const lString32& str) const { return lStr_cmp(pchunk->buf32, str.pchunk->buf32); }
     /// compare subrange with another string
-    int compare(size_type p0, size_type n0, const lString16& str) const;
+    int compare(size_type p0, size_type n0, const lString32& str) const;
     /// compare subrange with substring of another string
-    int compare(size_type p0, size_type n0, const lString16& str, size_type pos, size_type n) const;
-    int compare(const value_type *s) const  { return lStr_cmp(pchunk->buf16, s); }
-    int compare(const lChar8 *s) const  { return lStr_cmp(pchunk->buf16, s); }
+    int compare(size_type p0, size_type n0, const lString32& str, size_type pos, size_type n) const;
+    int compare(const value_type *s) const  { return lStr_cmp(pchunk->buf32, s); }
+    int compare(const lChar8 *s) const  { return lStr_cmp(pchunk->buf32, s); }
     int compare(size_type p0, size_type n0, const value_type *s) const;
     int compare(size_type p0, size_type n0, const value_type *s, size_type pos) const;
 
     /// split string into two strings using delimiter
-    bool split2( const lString16 & delim, lString16 & value1, lString16 & value2 );
+    bool split2( const lString32 & delim, lString32 & value1, lString32 & value2 );
     /// split string into two strings using delimiter
-    bool split2( const lChar16 * delim, lString16 & value1, lString16 & value2 );
+    bool split2( const lChar32 * delim, lString32 & value1, lString32 & value2 );
     /// split string into two strings using delimiter
-    bool split2( const lChar8 * delim, lString16 & value1, lString16 & value2 );
+    bool split2( const lChar8 * delim, lString32 & value1, lString32 & value2 );
 
     /// returns n characters beginning with pos
-    lString16 substr(size_type pos, size_type n) const;
+    lString32 substr(size_type pos, size_type n) const;
     /// returns part of string from specified position to end of string
-    lString16 substr(size_type pos) const { return substr(pos, length()-pos); }
+    lString32 substr(size_type pos) const { return substr(pos, length()-pos); }
     /// replaces first found occurence of pattern
-    bool replace(const lString16 & findStr, const lString16 & replaceStr);
+    bool replace(const lString32 & findStr, const lString32 & replaceStr);
     /// replaces first found occurence of "$N" pattern with string, where N=index
-    bool replaceParam(int index, const lString16 & replaceStr);
+    bool replaceParam(int index, const lString32 & replaceStr);
     /// replaces first found occurence of "$N" pattern with itoa of integer, where N=index
     bool replaceIntParam(int index, int replaceNumber);
 
     /// find position of substring inside string, -1 if not found
-    int pos(lString16 subStr) const;
+    int pos(lString32 subStr) const;
     /// find position of substring inside string starting from specified position, -1 if not found
-    int pos(const lString16 & subStr, int start) const;
+    int pos(const lString32 & subStr, int start) const;
     /// find position of substring inside string, -1 if not found
-    int pos(const lChar16 * subStr) const;
+    int pos(const lChar32 * subStr) const;
     /// find position of substring inside string (8bit ASCII only), -1 if not found
     int pos(const lChar8 * subStr) const;
     /// find position of substring inside string starting from specified position, -1 if not found
-    int pos(const lChar16 * subStr, int start) const;
+    int pos(const lChar32 * subStr, int start) const;
     /// find position of substring inside string (8bit ASCII only) starting from specified position, -1 if not found
     int pos(const lChar8 * subStr, int start) const;
 
     /// find position of substring inside string, right to left, return -1 if not found
-    int rpos(lString16 subStr) const;
+    int rpos(lString32 subStr) const;
 
     /// append single character
-    lString16 & operator << (value_type ch) { return append(1, ch); }
+    lString32 & operator << (value_type ch) { return append(1, ch); }
     /// append c-string
-    lString16 & operator << (const value_type * str) { return append(str); }
+    lString32 & operator << (const value_type * str) { return append(str); }
     /// append 8-bit c-string (ASCII only)
-    lString16 & operator << (const lChar8 * str) { return append(str); }
+    lString32 & operator << (const lChar8 * str) { return append(str); }
     /// append string
-    lString16 & operator << (const lString16 & str) { return append(str); }
+    lString32 & operator << (const lString32 & str) { return append(str); }
     /// append decimal number
-    lString16 & operator << (const fmt::decimal v) { return appendDecimal(v.get()); }
+    lString32 & operator << (const fmt::decimal v) { return appendDecimal(v.get()); }
     /// append hex number
-    lString16 & operator << (const fmt::hex v) { return appendHex(v.get()); }
+    lString32 & operator << (const fmt::hex v) { return appendHex(v.get()); }
 
     /// returns true if string starts with specified substring
-    bool startsWith (const lString16 & substring) const;
+    bool startsWith (const lString32 & substring) const;
     /// returns true if string starts with specified substring
-    bool startsWith (const lChar16 * substring) const;
+    bool startsWith (const lChar32 * substring) const;
     /// returns true if string starts with specified substring (8bit ASCII only)
     bool startsWith (const lChar8 * substring) const;
     /// returns true if string ends with specified substring
-    bool endsWith(const lChar16 * substring) const;
+    bool endsWith(const lChar32 * substring) const;
     /// returns true if string ends with specified substring (8-bit ASCII only)
     bool endsWith(const lChar8 * substring) const;
     /// returns true if string ends with specified substring
-    bool endsWith (const lString16 & substring) const;
+    bool endsWith (const lString32 & substring) const;
     /// returns true if string starts with specified substring, case insensitive
-    bool startsWithNoCase (const lString16 & substring) const;
+    bool startsWithNoCase (const lString32 & substring) const;
 
     /// returns last character
     value_type lastChar() { return empty() ? 0 : at(length()-1); }
@@ -638,15 +638,15 @@ public:
     /// returns character at specified position, with index bounds checking, fatal error if fails
     value_type & at( size_type pos ) { if ((unsigned)pos > (unsigned)pchunk->len) crFatalError(); return modify()[pos]; }
     /// returns character at specified position, without index bounds checking
-    value_type operator [] ( size_type pos ) const { return pchunk->buf16[pos]; }
+    value_type operator [] ( size_type pos ) const { return pchunk->buf32[pos]; }
     /// returns reference to specified character position (lvalue)
     value_type & operator [] ( size_type pos ) { return modify()[pos]; }
     /// resizes string, copies if several references exist
     void  lock( size_type newsize );
     /// returns writable pointer to string buffer
-    value_type * modify() { if (pchunk->nref>1) lock(pchunk->len); return pchunk->buf16; }
+    value_type * modify() { if (pchunk->nref>1) lock(pchunk->len); return pchunk->buf32; }
     /// clears string contents
-    void  clear() { release(); pchunk = EMPTY_STR_16; addref(); }
+    void  clear() { release(); pchunk = EMPTY_STR_32; addref(); }
     /// resets string, allocates space for specified amount of characters
     void  reset( size_type size );
     /// returns string length, in characters
@@ -664,17 +664,17 @@ public:
     /// returns true if string is empty
     bool  empty() const { return pchunk->len==0; }
     /// swaps two string variables contents
-    void  swap( lString16 & str ) { lstring_chunk_t * tmp = pchunk;
+    void  swap( lString32 & str ) { lstring_chunk_t * tmp = pchunk;
                 pchunk=str.pchunk; str.pchunk=tmp; }
     /// trims all unused space at end of string (sets size to length)
-    lString16 & pack();
+    lString32 & pack();
 
     /// trims non alpha at beginning and end of string
-    lString16 & trimNonAlpha();
+    lString32 & trimNonAlpha();
     /// trims spaces at beginning and end of string
-    lString16 & trim();
+    lString32 & trim();
     /// trims duplicate space characters inside string and (optionally) at end and beginning of string
-    lString16 & trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens=false );
+    lString32 & trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens=false );
     /// converts to integer
     int atoi() const;
     /// converts to integer, returns true if success
@@ -682,39 +682,39 @@ public:
     /// converts to 64 bit integer, returns true if success
     bool atoi( lInt64 &n ) const;
     /// returns constant c-string pointer
-    const value_type * c_str() const { return pchunk->buf16; }
+    const value_type * c_str() const { return pchunk->buf32; }
     /// returns constant c-string pointer, same as c_str()
-    const value_type * data() const { return pchunk->buf16; }
+    const value_type * data() const { return pchunk->buf32; }
     /// appends string
-    lString16 & operator += ( lString16 s ) { return append(s); }
+    lString32 & operator += ( lString32 s ) { return append(s); }
     /// appends c-string
-    lString16 & operator += ( const value_type * s ) { return append(s); }
+    lString32 & operator += ( const value_type * s ) { return append(s); }
     /// append C-string
-    lString16 & operator += ( const lChar8 * s ) { return append(s); }
+    lString32 & operator += ( const lChar8 * s ) { return append(s); }
     /// appends single character
-    lString16 & operator += ( value_type ch ) { return append(1, ch); }
+    lString32 & operator += ( value_type ch ) { return append(1, ch); }
     /// append decimal
-    lString16 & operator += ( fmt::decimal v ) { return appendDecimal(v.get()); }
+    lString32 & operator += ( fmt::decimal v ) { return appendDecimal(v.get()); }
     /// append hex
-    lString16 & operator += ( fmt::hex v ) { return appendHex(v.get()); }
+    lString32 & operator += ( fmt::hex v ) { return appendHex(v.get()); }
 
     /// constructs string representation of integer
-    static lString16 itoa( int i );
+    static lString32 itoa( int i );
     /// constructs string representation of unsigned integer
-    static lString16 itoa( unsigned int i );
+    static lString32 itoa( unsigned int i );
     /// constructs string representation of 64 bit integer
-    static lString16 itoa( lInt64 i );
+    static lString32 itoa( lInt64 i );
     /// constructs string representation of unsigned 64 bit integer
-    static lString16 itoa( lUInt64 i );
+    static lString32 itoa( lUInt64 i );
 
     /// empty string global instance
-    static const lString16 empty_str;
+    static const lString32 empty_str;
 
-    friend class lString16Collection;
+    friend class lString32Collection;
 };
 
 /// calculates hash for wide string
-inline lUInt32 getHash( const lString16 & s )
+inline lUInt32 getHash( const lString32 & s )
 {
     return s.getHash();
 }
@@ -727,54 +727,54 @@ inline lUInt32 getHash( const lString8 & s )
 
 /// get reference to atomic constant string for string literal e.g. cs8("abc") -- fast and memory effective replacement of lString8("abc")
 const lString8 & cs8(const char * str);
-/// get reference to atomic constant wide string for string literal e.g. cs16("abc") -- fast and memory effective replacement of lString16("abc")
-const lString16 & cs16(const char * str);
-/// get reference to atomic constant wide string for string literal e.g. cs16(L"abc") -- fast and memory effective replacement of lString16(L"abc")
-const lString16 & cs16(const lChar16 * str);
+/// get reference to atomic constant wide string for string literal e.g. cs32("abc") -- fast and memory effective replacement of lString32("abc")
+const lString32 & cs32(const char * str);
+/// get reference to atomic constant wide string for string literal e.g. cs32(U"abc") -- fast and memory effective replacement of lString32(U"abc")
+const lString32 & cs32(const lChar32 * str);
 
 /// collection of wide strings
-class lString16Collection
+class lString32Collection
 {
 private:
-    lstring16_chunk_t * * chunks;
+    lstring32_chunk_t * * chunks;
     int count;
     int size;
 public:
-    lString16Collection()
+    lString32Collection()
         : chunks(NULL), count(0), size(0)
     { }
     /// parse delimiter-separated string
-    void parse( lString16 string, lChar16 delimiter, bool flgTrim );
+    void parse( lString32 string, lChar32 delimiter, bool flgTrim );
     /// parse delimiter-separated string
-    void parse( lString16 string, lString16 delimiter, bool flgTrim );
+    void parse( lString32 string, lString32 delimiter, bool flgTrim );
     void reserve(int space);
-    int add( const lString16 & str );
-    int add(const lChar16 * str) { return add(lString16(str)); }
-    int add(const lChar8 * str) { return add(lString16(str)); }
-    void addAll( const lString16Collection & v )
+    int add( const lString32 & str );
+    int add(const lChar32 * str) { return add(lString32(str)); }
+    int add(const lChar8 * str) { return add(lString32(str)); }
+    void addAll( const lString32Collection & v )
 	{
         for (int i=0; i<v.length(); i++)
 			add( v[i] );
 	}
-    int insert( int pos, const lString16 & str );
+    int insert( int pos, const lString32 & str );
     void erase(int offset, int count);
     /// split into several lines by delimiter
-    void split(const lString16 & str, const lString16 & delimiter);
-    const lString16 & at(int index)
+    void split(const lString32 & str, const lString32 & delimiter);
+    const lString32 & at(int index)
     {
-        return ((lString16 *)chunks)[index];
+        return ((lString32 *)chunks)[index];
     }
-    const lString16 & operator [] (int index) const
+    const lString32 & operator [] (int index) const
     {
-        return ((lString16 *)chunks)[index];
+        return ((lString32 *)chunks)[index];
     }
-    lString16 & operator [] (int index)
+    lString32 & operator [] (int index)
     {
-        return ((lString16 *)chunks)[index];
+        return ((lString32 *)chunks)[index];
     }
     int length() const { return count; }
     void clear();
-    bool contains( lString16 value )
+    bool contains( lString32 value )
     {
         for (int i = 0; i < count; i++)
             if (value.compare(at(i)) == 0)
@@ -782,8 +782,8 @@ public:
         return false;
     }
     void sort();
-    void sort(int(comparator)(lString16 & s1, lString16 & s2));
-    ~lString16Collection()
+    void sort(int(comparator)(lString32 & s1, lString32 & s2));
+    ~lString32Collection()
     {
         clear();
     }
@@ -846,12 +846,12 @@ public:
 };
 
 /// calculates hash for wide c-string
-lUInt32 calcStringHash( const lChar16 * s );
+lUInt32 calcStringHash( const lChar32 * s );
 
 class SerialBuf;
 
 /// hashed wide string collection
-class lString16HashedCollection : public lString16Collection
+class lString32HashedCollection : public lString32Collection
 {
 private:
     int hashSize;
@@ -871,50 +871,50 @@ public:
 	/// deserialize from byte array (pointer will be incremented by number of bytes read)
 	bool deserialize( SerialBuf & buf );
 
-    lString16HashedCollection( lString16HashedCollection & v );
-    lString16HashedCollection( lUInt32 hashSize );
-    ~lString16HashedCollection();
-    int add( const lChar16 * s );
-    int find( const lChar16 * s );
+    lString32HashedCollection( lString32HashedCollection & v );
+    lString32HashedCollection( lUInt32 hashSize );
+    ~lString32HashedCollection();
+    int add( const lChar32 * s );
+    int find( const lChar32 * s );
 };
 
 /// returns true if two wide strings are equal
-inline bool operator == (const lString16& s1, const lString16& s2 )
+inline bool operator == (const lString32& s1, const lString32& s2 )
     { return s1.compare(s2)==0; }
 /// returns true if wide strings is equal to wide c-string
-inline bool operator == (const lString16& s1, const lChar16 * s2 )
+inline bool operator == (const lString32& s1, const lChar32 * s2 )
     { return s1.compare(s2)==0; }
 /// returns true if wide strings is equal to wide c-string
-inline bool operator == (const lString16& s1, const lChar8 * s2 )
+inline bool operator == (const lString32& s1, const lChar8 * s2 )
     { return s1.compare(s2)==0; }
 /// returns true if wide strings is equal to wide c-string
-inline bool operator == (const lChar16 * s1, const lString16& s2 )
+inline bool operator == (const lChar32 * s1, const lString32& s2 )
     { return s2.compare(s1)==0; }
 
 /// returns true if wide strings is equal to wide c-string
-inline bool operator == (const lString16& s1, const lString8& s2 )
+inline bool operator == (const lString32& s1, const lString8& s2 )
     { return lStr_cmp(s2.c_str(), s1.c_str())==0; }
 /// returns true if wide strings is equal to wide c-string
-inline bool operator == (const lString8& s1, const lString16& s2 )
+inline bool operator == (const lString8& s1, const lString32& s2 )
     { return lStr_cmp(s2.c_str(), s1.c_str())==0; }
 
-inline bool operator != (const lString16& s1, const lString16& s2 )
+inline bool operator != (const lString32& s1, const lString32& s2 )
     { return s1.compare(s2)!=0; }
-inline bool operator != (const lString16& s1, const lChar16 * s2 )
+inline bool operator != (const lString32& s1, const lChar32 * s2 )
     { return s1.compare(s2)!=0; }
-inline bool operator != (const lString16& s1, const lChar8 * s2 )
+inline bool operator != (const lString32& s1, const lChar8 * s2 )
     { return s1.compare(s2)!=0; }
-inline bool operator != (const lChar16 * s1, const lString16& s2 )
+inline bool operator != (const lChar32 * s1, const lString32& s2 )
     { return s2.compare(s1)!=0; }
-inline bool operator != (const lChar8 * s1, const lString16& s2 )
+inline bool operator != (const lChar8 * s1, const lString32& s2 )
     { return s2.compare(s1)!=0; }
-inline lString16 operator + (const lString16 &s1, const lString16 &s2) { lString16 s(s1); s.append(s2); return s; }
-inline lString16 operator + (const lString16 &s1, const lChar16 * s2) { lString16 s(s1); s.append(s2); return s; }
-inline lString16 operator + (const lString16 &s1, const lChar8 * s2) { lString16 s(s1); s.append(s2); return s; }
-inline lString16 operator + (const lChar16 * s1,  const lString16 &s2) { lString16 s(s1); s.append(s2); return s; }
-inline lString16 operator + (const lChar8 * s1,  const lString16 &s2) { lString16 s(s1); s.append(s2); return s; }
-inline lString16 operator + (const lString16 &s1, fmt::decimal v) { lString16 s(s1); s.appendDecimal(v.get()); return s; }
-inline lString16 operator + (const lString16 &s1, fmt::hex v) { lString16 s(s1); s.appendHex(v.get()); return s; }
+inline lString32 operator + (const lString32 &s1, const lString32 &s2) { lString32 s(s1); s.append(s2); return s; }
+inline lString32 operator + (const lString32 &s1, const lChar32 * s2) { lString32 s(s1); s.append(s2); return s; }
+inline lString32 operator + (const lString32 &s1, const lChar8 * s2) { lString32 s(s1); s.append(s2); return s; }
+inline lString32 operator + (const lChar32 * s1,  const lString32 &s2) { lString32 s(s1); s.append(s2); return s; }
+inline lString32 operator + (const lChar8 * s1,  const lString32 &s2) { lString32 s(s1); s.append(s2); return s; }
+inline lString32 operator + (const lString32 &s1, fmt::decimal v) { lString32 s(s1); s.appendDecimal(v.get()); return s; }
+inline lString32 operator + (const lString32 &s1, fmt::hex v) { lString32 s(s1); s.appendHex(v.get()); return s; }
 
 inline bool operator == (const lString8& s1, const lString8& s2 )
     { return s1.compare(s2)==0; }
@@ -938,29 +938,29 @@ inline lString8 operator + (const lString8 &s1, fmt::hex v)
     { lString8 s(s1); s.appendHex(v.get()); return s; }
 
 
-/// fast 16-bit string character appender
-template <int BUFSIZE> class lStringBuf16 {
-    lString16 & str;
-    lChar16 buf[BUFSIZE];
+/// fast 32-bit string character appender
+template <int BUFSIZE> class lStringBuf32 {
+    lString32 & str;
+    lChar32 buf[BUFSIZE];
     int pos;
-	lStringBuf16 & operator = (const lStringBuf16 & v)
+	lStringBuf32 & operator = (const lStringBuf32 & v)
 	{
         CR_UNUSED(v);
 		// not available
 		return *this;
 	}
 public:
-    lStringBuf16( lString16 & s )
+    lStringBuf32( lString32 & s )
     : str(s), pos(0)
     {
     }
-    inline void append( lChar16 ch )
+    inline void append( lChar32 ch )
     {
         buf[ pos++ ] = ch;
         if ( pos==BUFSIZE )
             flush();
     }
-    inline lStringBuf16& operator << ( lChar16 ch )
+    inline lStringBuf32& operator << ( lChar32 ch )
     {
         buf[ pos++ ] = ch;
         if ( pos==BUFSIZE )
@@ -972,7 +972,7 @@ public:
         str.append( buf, pos );
         pos = 0;
     }
-    ~lStringBuf16( )
+    ~lStringBuf32( )
     {
         flush();
     }
@@ -1012,40 +1012,40 @@ public:
     }
 };
 
-lString8  UnicodeToTranslit( const lString16 & str );
+lString8  UnicodeToTranslit( const lString32 & str );
 /// converts wide unicode string to local 8-bit encoding
-lString8  UnicodeToLocal( const lString16 & str );
+lString8  UnicodeToLocal( const lString32 & str );
 /// converts wide unicode string to utf-8 string
-lString8  UnicodeToUtf8( const lString16 & str );
+lString8  UnicodeToUtf8( const lString32 & str );
 /// converts wide unicode string to utf-8 string
-lString8 UnicodeToUtf8(const lChar16 * s, int count);
+lString8 UnicodeToUtf8(const lChar32 * s, int count);
 /// converts unicode string to 8-bit string using specified conversion table
-lString8  UnicodeTo8Bit( const lString16 & str, const lChar8 * * table );
+lString8  UnicodeTo8Bit( const lString32 & str, const lChar8 * * table );
 /// converts 8-bit string to unicode string using specified conversion table for upper 128 characters
-lString16 ByteToUnicode( const lString8 & str, const lChar16 * table );
+lString32 ByteToUnicode( const lString8 & str, const lChar32 * table );
 /// converts 8-bit string in local encoding to wide unicode string
-lString16 LocalToUnicode( const lString8 & str );
+lString32 LocalToUnicode( const lString8 & str );
 /// converts utf-8 string to wide unicode string
-lString16 Utf8ToUnicode( const lString8 & str );
+lString32 Utf8ToUnicode( const lString8 & str );
 /// converts utf-8 c-string to wide unicode string
-lString16 Utf8ToUnicode( const char * s );
+lString32 Utf8ToUnicode( const char * s );
 /// converts utf-8 string fragment to wide unicode string
-lString16 Utf8ToUnicode( const char * s, int sz );
+lString32 Utf8ToUnicode( const char * s, int sz );
 /// converts utf-8 string fragment to wide unicode string
-void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen);
+void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar32 * dst, int &dstlen);
 /// decodes path like "file%20name" to "file name"
-lString16 DecodeHTMLUrlString( lString16 s );
+lString32 DecodeHTMLUrlString( lString32 s );
 /// truncates string by specified size, appends ... if truncated, prefers to wrap whole words
-void limitStringSize(lString16 & str, int maxSize);
+void limitStringSize(lString32 & str, int maxSize);
 
-int TrimDoubleSpaces(lChar16 * buf, int len,  bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens);
+int TrimDoubleSpaces(lChar32 * buf, int len,  bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens);
 
 /// remove soft-hyphens from string
-lString16 removeSoftHyphens( lString16 s );
+lString32 removeSoftHyphens( lString32 s );
 
 
 #define LCSTR(x) (UnicodeToUtf8(x).c_str())
-bool splitIntegerList( lString16 s, lString16 delim, int & value1, int & value2 );
+bool splitIntegerList( lString32 s, lString32 delim, int & value1, int & value2 );
 
 /// serialization/deserialization buffer
 class SerialBuf
@@ -1118,7 +1118,7 @@ public:
 
     SerialBuf & operator << ( lInt32 n );
 
-    SerialBuf & operator << ( const lString16 & s );
+    SerialBuf & operator << ( const lString32 & s );
 
     SerialBuf & operator << ( const lString8 & s8 );
 
@@ -1139,7 +1139,7 @@ public:
 
 	SerialBuf & operator >> ( lString8 & s8 );
 
-	SerialBuf & operator >> ( lString16 & s );
+	SerialBuf & operator >> ( lString32 & s );
 
 	bool checkMagic( const char * s );
     /// read crc32 code, comapare with CRC32 for last N bytes

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -81,7 +81,7 @@ private:
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
-    bool parse( const char * & decl, lUInt32 domVersionRequested, bool higher_importance=false, lxmlDocBase * doc=NULL, lString16 codeBase=lString16::empty_str );
+    bool parse( const char * & decl, lUInt32 domVersionRequested, bool higher_importance=false, lxmlDocBase * doc=NULL, lString32 codeBase=lString32::empty_str );
     lUInt32 getHash();
     LVCssDeclaration() : _data(NULL) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }
@@ -121,14 +121,14 @@ class LVCssSelectorRule
     lUInt16 _id;
     lUInt16 _attrid;
     LVCssSelectorRule * _next;
-    lString16 _value;
+    lString32 _value;
 public:
     LVCssSelectorRule(LVCssSelectorRuleType type)
     : _type(type), _id(0), _attrid(0), _next(NULL)
     { }
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
-    void setAttr( lUInt16 id, lString16 value ) { _attrid = id; _value = value; }
+    void setAttr( lUInt16 id, lString32 value ) { _attrid = id; _value = value; }
     LVCssSelectorRule * getNext() { return _next; }
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }
@@ -265,7 +265,7 @@ public:
     /// copy constructor
     LVStyleSheet( LVStyleSheet & sheet );
     /// parse stylesheet, compile and add found rules to sheet
-    bool parse( const char * str, bool higher_importance=false, lString16 codeBase=lString16::empty_str );
+    bool parse( const char * str, bool higher_importance=false, lString32 codeBase=lString32::empty_str );
     /// apply stylesheet to node style
     void apply( const ldomNode * node, css_style_rec_t * style );
     /// calculate hash
@@ -279,11 +279,11 @@ bool parse_color_value( const char * & str, css_length_t & value );
 //  applying to a node's style
 void update_style_content_property( css_style_rec_t * style, ldomNode * node );
 /// get the computed final text value for a node from its style->content
-lString16 get_applied_content_property( ldomNode * node );
+lString32 get_applied_content_property( ldomNode * node );
 
 /// extract @import filename from beginning of CSS
 bool LVProcessStyleSheetImport( const char * &str, lString8 & import_file );
 /// load stylesheet from file, with processing of import
-bool LVLoadStylesheetFile( lString16 pathName, lString8 & css );
+bool LVLoadStylesheetFile( lString32 pathName, lString8 & css );
 
 #endif // __LVSTSHEET_H_INCLUDED__

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -207,6 +207,7 @@ class LVStyleSheet {
 
     int _selector_count;
     LVArray <int> _selector_count_stack;
+    lString8 _charset;
 
     LVPtrVector <LVCssSelector> _selectors;
     LVPtrVector <LVPtrVector <LVCssSelector> > _stack;
@@ -266,6 +267,8 @@ public:
     LVStyleSheet( LVStyleSheet & sheet );
     /// parse stylesheet, compile and add found rules to sheet
     bool parse( const char * str, bool higher_importance=false, lString32 codeBase=lString32::empty_str );
+    /// parse @charset rule
+    bool parseCharsetRule( const char * &str );
     /// apply stylesheet to node style
     void apply( const ldomNode * node, css_style_rec_t * style );
     /// calculate hash

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -157,7 +157,7 @@ struct css_style_rec_tag {
     css_float_t            float_; // "float" is a C++ keyword...
     css_clear_t            clear;
     css_direction_t        direction;
-    lString16              content;
+    lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
     // and cleaned up there, before the style is cached and shared. They are not serialized.

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -104,7 +104,7 @@ typedef struct
     union {
         struct {
             lvfont_handle   font;     /**< \brief handle of font to draw string */
-            const lChar16 * text;     /**< \brief pointer to unicode text string */
+            const lChar32 * text;     /**< \brief pointer to unicode text string */
             lUInt16         len;      /**< \brief number of chars in text */
             lUInt16         offset;   /**< \brief offset from node start to beginning of line */
         } t;
@@ -216,7 +216,7 @@ typedef struct
    css_clear_t           clear;       /**< clear: css property value */
    bool                  is_right;    /**< is float: right */
    bool                  to_position; /**< not yet positionned */
-   lString16Collection * links;       /** footnote links found in this float text */
+   lString32Collection * links;       /** footnote links found in this float text */
 } embedded_float_t;
 
 /** \brief Bookmark highlight modes.
@@ -316,7 +316,7 @@ void lvtextAddSourceLine(
    formatted_text_fragment_t * pbuffer,
    lvfont_handle   font,     /* handle of font to draw string */
    TextLangCfg *   lang_cfg,
-   const lChar16 * text,     /* pointer to unicode text string */
+   const lChar32 * text,     /* pointer to unicode text string */
    lUInt32         len,      /* number of chars in text, 0 for auto(strlen) */
    lUInt32         color,    /* text color */
    lUInt32         bgcolor,  /* background color */
@@ -408,7 +408,7 @@ public:
          );
 
     void AddSourceLine(
-           const lChar16 * text,        /* pointer to unicode text string */
+           const lChar32 * text,        /* pointer to unicode text string */
            lUInt32         len,         /* number of chars in text, 0 for auto(strlen) */
            lUInt32         color,       /* text color */
            lUInt32         bgcolor,     /* background color */

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -202,7 +202,7 @@ class DataBuffer;
 class LVDocViewCallback {
 public:
     /// on starting file loading
-    virtual void OnLoadFileStart( lString16 filename ) { CR_UNUSED(filename); }
+    virtual void OnLoadFileStart( lString32 filename ) { CR_UNUSED(filename); }
     /// format detection finished
     virtual void OnLoadFileFormatDetected( doc_format_t /*fileFormat*/) { }
     /// file loading is finished successfully - drawCoveTo() may be called there
@@ -212,7 +212,7 @@ public:
     /// file progress indicator, called with values 0..100
     virtual void OnLoadFileProgress( int /*percent*/) { }
     /// file load finiished with error
-    virtual void OnLoadFileError(lString16 /*message*/) { }
+    virtual void OnLoadFileError(lString32 /*message*/) { }
     /// node style update started
     virtual void OnNodeStylesUpdateStart() { }
     /// node style update finished
@@ -230,7 +230,7 @@ public:
     /// format progress, called with values 0..100
     virtual void OnExportProgress(int /*percent*/) { }
     /// Override to handle external links
-    virtual void OnExternalLink(lString16 /*url*/, ldomNode * /*node*/) { }
+    virtual void OnExternalLink(lString32 /*url*/, ldomNode * /*node*/) { }
     /// Called when page images should be invalidated (clearImageCache() called in LVDocView)
     virtual void OnImageCacheClear() { }
     /// return true if reload will be processed by external code, false to let internal code process it
@@ -267,8 +267,8 @@ struct ldomNodeStyleInfo
 };
 
 class ldomBlobItem;
-#define BLOB_NAME_PREFIX L"@blob#"
-#define MOBI_IMAGE_NAME_PREFIX L"mobi_image_"
+#define BLOB_NAME_PREFIX U"@blob#"
+#define MOBI_IMAGE_NAME_PREFIX U"mobi_image_"
 class ldomBlobCache
 {
     CacheFile * _cacheFile;
@@ -280,8 +280,8 @@ public:
     ldomBlobCache();
     void setCacheFile( CacheFile * cacheFile );
     ContinuousOperationResult saveToCache(CRTimerUtil & timeout);
-    bool addBlob( const lUInt8 * data, int size, lString16 name );
-    LVStreamRef getBlob( lString16 name );
+    bool addBlob( const lUInt8 * data, int size, lString32 name );
+    LVStreamRef getBlob( lString32 name );
 };
 
 class ldomDataStorageManager
@@ -588,9 +588,9 @@ public:
     }
 
     /// add named BLOB data to document
-    bool addBlob(lString16 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
+    bool addBlob(lString32 name, const lUInt8 * data, int size) { _cacheFileStale = true ; return _blobCache.addBlob(data, size, name); }
     /// get BLOB by name
-    LVStreamRef getBlob(lString16 name) { return _blobCache.getBlob(name); }
+    LVStreamRef getBlob(lString32 name) { return _blobCache.getBlob(name); }
 
     /// called on document loading end
     bool validateDocument();
@@ -684,7 +684,7 @@ public:
     /// set cache file as dirty, so it's not re-used on next load
     void invalidateCacheFile() { _cacheFileLeaveAsDirty = true; }
     /// get cache file full path
-    lString16 getCacheFilePath();
+    lString32 getCacheFilePath();
 #endif
 
     /// minimize memory consumption
@@ -692,7 +692,7 @@ public:
     /// dumps memory usage statistics to debug log
     void dumpStatistics();
     /// get memory usage statistics
-    lString16 getStatistics();
+    lString32 getStatistics();
 
     /// get ldomNode instance pointer
     ldomNode * getTinyNode( lUInt32 index );
@@ -941,37 +941,37 @@ public:
     /// returns element attribute count
     int getAttrCount() const;
     /// returns attribute value by attribute name id and namespace id
-    const lString16 & getAttributeValue( lUInt16 nsid, lUInt16 id ) const;
+    const lString32 & getAttributeValue( lUInt16 nsid, lUInt16 id ) const;
     /// returns attribute value by attribute name
-    inline const lString16 & getAttributeValue( const lChar16 * attrName ) const
+    inline const lString32 & getAttributeValue( const lChar32 * attrName ) const
     {
         return getAttributeValue( NULL, attrName );
     }
     /// returns attribute value by attribute name
-    inline const lString16 & getAttributeValue( const lChar8 * attrName ) const
+    inline const lString32 & getAttributeValue( const lChar8 * attrName ) const
     {
         return getAttributeValue( NULL, attrName );
     }
     /// returns attribute value by attribute name and namespace
-    const lString16 & getAttributeValue( const lChar16 * nsName, const lChar16 * attrName ) const;
+    const lString32 & getAttributeValue( const lChar32 * nsName, const lChar32 * attrName ) const;
     /// returns attribute value by attribute name and namespace
-    const lString16 & getAttributeValue( const lChar8 * nsName, const lChar8 * attrName ) const;
+    const lString32 & getAttributeValue( const lChar8 * nsName, const lChar8 * attrName ) const;
     /// returns attribute by index
     const lxmlAttribute * getAttribute( lUInt32 ) const;
     /// returns true if element node has attribute with specified name id and namespace id
     bool hasAttribute( lUInt16 nsId, lUInt16 attrId ) const;
     /// returns attribute name by index
-    const lString16 & getAttributeName( lUInt32 ) const;
+    const lString32 & getAttributeName( lUInt32 ) const;
     /// sets attribute value
-    void setAttributeValue( lUInt16 , lUInt16 , const lChar16 *  );
+    void setAttributeValue( lUInt16 , lUInt16 , const lChar32 *  );
     /// returns attribute value by attribute name id
-    inline const lString16 & getAttributeValue( lUInt16 id ) const { return getAttributeValue( LXML_NS_ANY, id ); }
+    inline const lString32 & getAttributeValue( lUInt16 id ) const { return getAttributeValue( LXML_NS_ANY, id ); }
     /// returns true if element node has attribute with specified name id
     inline bool hasAttribute( lUInt16 id ) const  { return hasAttribute( LXML_NS_ANY, id ); }
 
     /// returns attribute value by attribute name id, looking at children if needed
-    const lString16 & getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const;
-    const lString16 & getFirstInnerAttributeValue( lUInt16 id ) const { return getFirstInnerAttributeValue( LXML_NS_ANY, id ); }
+    const lString32 & getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const;
+    const lString32 & getFirstInnerAttributeValue( lUInt16 id ) const { return getFirstInnerAttributeValue( LXML_NS_ANY, id ); }
 
     /// returns element type structure pointer if it was set in document for this element name
     const css_elem_def_props_t * getElementTypePtr();
@@ -982,11 +982,11 @@ public:
     /// replace element name id with another value
     void setNodeId( lUInt16 );
     /// returns element name
-    const lString16 & getNodeName() const;
+    const lString32 & getNodeName() const;
     /// compares node name with value, returns true if matches
     bool isNodeName(const char * name) const;
     /// returns element namespace name
-    const lString16 & getNodeNsName() const;
+    const lString32 & getNodeNsName() const;
 
     /// returns child node by index
     ldomNode * getChildNode( lUInt32 index ) const;
@@ -997,14 +997,14 @@ public:
     /// returns child node by index, NULL if node with this index is not element or nodeId!=0 and element node id!=nodeId
     ldomNode * getChildElementNode( lUInt32 index, lUInt16 nodeId=0 ) const;
     /// returns child node by index, NULL if node with this index is not element or nodeTag!=0 and element node name!=nodeTag
-    ldomNode * getChildElementNode( lUInt32 index, const lChar16 * nodeTag ) const;
+    ldomNode * getChildElementNode( lUInt32 index, const lChar32 * nodeTag ) const;
 
     /// returns text node text as wide string
-    lString16 getText( lChar16 blockDelimiter = 0, int maxSize=0 ) const;
+    lString32 getText( lChar32 blockDelimiter = 0, int maxSize=0 ) const;
     /// returns text node text as utf8 string
     lString8 getText8( lChar8 blockDelimiter = 0, int maxSize=0 ) const;
     /// sets text node text as wide string
-    void setText( lString16 );
+    void setText( lString32 );
     /// sets text node text as utf8 string
     void setText8( lString8 );
 
@@ -1071,16 +1071,16 @@ public:
     /// inserts child element
     ldomNode * insertChildElement( lUInt16 id );
     /// inserts child text
-    ldomNode * insertChildText( lUInt32 index, const lString16 & value );
+    ldomNode * insertChildText( lUInt32 index, const lString32 & value );
     /// inserts child text
-    ldomNode * insertChildText( const lString16 & value );
+    ldomNode * insertChildText( const lString32 & value );
     /// inserts child text
     ldomNode * insertChildText(const lString8 & value, bool before_last_child=false);
     /// remove child
     ldomNode * removeChild( lUInt32 index );
 
     /// returns XPath segment for this element relative to parent element (e.g. "p[10]")
-    lString16 getXPathSegment();
+    lString32 getXPathSegment();
 
     /// creates stream to read base64 encoded data from element
     LVStreamRef createBase64Stream();
@@ -1088,7 +1088,7 @@ public:
     /// returns object image source
     LVImageSourceRef getObjectImageSource();
     /// returns object image ref name
-    lString16 getObjectImageRefName( bool percentDecode=true );
+    lString32 getObjectImageRefName( bool percentDecode=true );
     /// returns object image stream
     LVStreamRef getObjectImageStream();
     /// returns the sum of this node and its parents' top and bottom margins, borders and paddings
@@ -1105,7 +1105,7 @@ public:
     ldomNode * modify();
 
     /// for display:list-item node, get marker
-    bool getNodeListMarker( int & counterValue, lString16 & marker, int & markerWidth );
+    bool getNodeListMarker( int & counterValue, lString32 & marker, int & markerWidth );
     /// is node a floating floatBox
     bool isFloatingBox() const;
     /// is node an inlineBox that has not been re-inlined by having
@@ -1172,7 +1172,7 @@ public:
         \param id is numeric value of namespace
         \return string value of namespace
     */
-    inline const lString16 & getNsName( lUInt16 id )
+    inline const lString32 & getNsName( lUInt16 id )
     {
         return _nsNameTable.nameById( id );
     }
@@ -1182,7 +1182,7 @@ public:
         \param name is string value of namespace
         \return id of namespace
     */
-    lUInt16 getNsNameIndex( const lChar16 * name );
+    lUInt16 getNsNameIndex( const lChar32 * name );
 
     /// Get namespace id by name
     /**
@@ -1196,7 +1196,7 @@ public:
         \param id is numeric value of attribute
         \return string value of attribute
     */
-    inline const lString16 & getAttrName( lUInt16 id )
+    inline const lString32 & getAttrName( lUInt16 id )
     {
         return _attrNameTable.nameById( id );
     }
@@ -1206,7 +1206,7 @@ public:
         \param name is string value of attribute
         \return id of attribute
     */
-    lUInt16 getAttrNameIndex( const lChar16 * name );
+    lUInt16 getAttrNameIndex( const lChar32 * name );
 
     /// Get attribute id by name
     /**
@@ -1216,19 +1216,19 @@ public:
     lUInt16 getAttrNameIndex( const lChar8 * name );
 
     /// helper: returns attribute value
-    inline const lString16 & getAttrValue( lUInt32 index ) const
+    inline const lString32 & getAttrValue( lUInt32 index ) const
     {
         return _attrValueTable[index];
     }
 
     /// helper: returns attribute value index
-    inline lUInt32 getAttrValueIndex( const lChar16 * value )
+    inline lUInt32 getAttrValueIndex( const lChar32 * value )
     {
         return (lUInt32)_attrValueTable.add( value );
     }
 
     /// helper: returns attribute value index, 0xffffffff if not found
-    inline lUInt32 findAttrValueIndex( const lChar16 * value )
+    inline lUInt32 findAttrValueIndex( const lChar32 * value )
     {
         return (lUInt32)_attrValueTable.find( value );
     }
@@ -1238,7 +1238,7 @@ public:
         \param id is numeric value of element name
         \return string value of element name
     */
-    inline const lString16 & getElementName( lUInt16 id )
+    inline const lString32 & getElementName( lUInt16 id )
     {
         return _elementNameTable.nameById( id );
     }
@@ -1248,7 +1248,7 @@ public:
         \param name is string value of element name
         \return id of element
     */
-    lUInt16 getElementNameIndex( const lChar16 * name );
+    lUInt16 getElementNameIndex( const lChar32 * name );
 
     /// Get element id by name
     /**
@@ -1284,7 +1284,7 @@ public:
 
     // debug dump
     void dumpUnknownEntities( const char * fname );
-    lString16Collection getUnknownEntities();
+    lString32Collection getUnknownEntities();
 
     /// garbage collector
     virtual void gc()
@@ -1315,7 +1315,7 @@ public:
     }
 
     /// get element by id attribute value
-    inline ldomNode * getElementById( const lChar16 * id )
+    inline ldomNode * getElementById( const lChar32 * id )
     {
         lUInt32 attrValueId = getAttrValueIndex( id );
         ldomNode * node = getNodeById( attrValueId );
@@ -1325,9 +1325,9 @@ public:
     ldomNode * getRootNode();
 
     /// returns code base path relative to document container
-    inline lString16 getCodeBase() { return getProps()->getStringDef(DOC_PROP_CODE_BASE, ""); }
+    inline lString32 getCodeBase() { return getProps()->getStringDef(DOC_PROP_CODE_BASE, ""); }
     /// sets code base path relative to document container
-    inline void setCodeBase(const lString16 & codeBase) { getProps()->setStringDef(DOC_PROP_CODE_BASE, codeBase); }
+    inline void setCodeBase(const lString32 & codeBase) { getProps()->setStringDef(DOC_PROP_CODE_BASE, codeBase); }
 
 #ifdef _DEBUG
 #if BUILD_LITE!=1
@@ -1373,9 +1373,9 @@ protected:
     lUInt16       _nextUnknownElementId; // Next Id for unknown element
     lUInt16       _nextUnknownAttrId;    // Next Id for unknown attribute
     lUInt16       _nextUnknownNsId;      // Next Id for unknown namespace
-    lString16HashedCollection _attrValueTable;
+    lString32HashedCollection _attrValueTable;
     LVHashTable<lUInt32,lInt32> _idNodeMap; // id to data index map
-    LVHashTable<lString16,LVImageSourceRef> _urlImageMap; // url to image source map
+    LVHashTable<lString32,LVImageSourceRef> _urlImageMap; // url to image source map
     lUInt16 _idAttrId; // Id for "id" attribute name
     lUInt16 _nameAttrId; // Id for "name" attribute name
 
@@ -1542,11 +1542,11 @@ public:
 	{
 	}
     /// get pointer for relative path
-    ldomXPointer relative( lString16 relativePath );
+    ldomXPointer relative( lString32 relativePath );
     /// get pointer for relative path
-    ldomXPointer relative( const lChar16 * relativePath )
+    ldomXPointer relative( const lChar32 * relativePath )
     {
-        return relative( lString16(relativePath) );
+        return relative( lString32(relativePath) );
     }
 
     /// returns true for NULL pointer
@@ -1589,7 +1589,7 @@ public:
     lvPoint toPoint( bool extended=false ) const;
 //#endif
     /// converts to string
-    lString16 toString( XPointerMode mode = XPATH_USE_NAMES) {
+    lString32 toString( XPointerMode mode = XPATH_USE_NAMES) {
         if( XPATH_USE_NAMES==mode ) {
             tinyNodeCollection* doc = (tinyNodeCollection*)_data->getDocument();
             if ( doc != NULL && doc->getDOMVersionRequested() >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS )
@@ -1598,22 +1598,22 @@ public:
         }
         return toStringV2AsIndexes();
     }
-    lString16 toStringV1(); // Using names, old, with boxing elements (non-normalized)
-    lString16 toStringV2(); // Using names, new, without boxing elements, so: normalized
-    lString16 toStringV2AsIndexes(); // Without element names, normalized (not used)
+    lString32 toStringV1(); // Using names, old, with boxing elements (non-normalized)
+    lString32 toStringV2(); // Using names, new, without boxing elements, so: normalized
+    lString32 toStringV2AsIndexes(); // Without element names, normalized (not used)
 
     /// returns XPath node text
-    lString16 getText(  lChar16 blockDelimiter=0 )
+    lString32 getText(  lChar32 blockDelimiter=0 )
     {
         ldomNode * node = getNode();
         if ( !node )
-            return lString16::empty_str;
+            return lString32::empty_str;
         return node->getText( blockDelimiter );
     }
     /// returns href attribute of <A> element, null string if not found
-    lString16 getHRef();
+    lString32 getHRef();
     /// returns href attribute of <A> element, plus xpointer of <A> element itself
-    lString16 getHRef(ldomXPointer & a_xpointer);
+    lString32 getHRef(ldomXPointer & a_xpointer);
     /// create a copy of pointer data
     ldomXPointer * clone()
     {
@@ -1624,9 +1624,9 @@ public:
     /// returns true if current node is element
     inline bool isText() const { return !isNull() && getNode()->isText(); }
     /// returns HTML (serialized from the DOM, may be different from the source HTML)
-    lString8 getHtml( lString16Collection & cssFiles, int wflags=0 );
+    lString8 getHtml( lString32Collection & cssFiles, int wflags=0 );
     lString8 getHtml( int wflags=0 ) {
-        lString16Collection cssFiles; return getHtml(cssFiles, wflags);
+        lString32Collection cssFiles; return getHtml(cssFiles, wflags);
     }
 };
 
@@ -1869,11 +1869,11 @@ public:
     /// get word start XPointer
     ldomXPointer getEndXPointer() const { return ldomXPointer( _node, _end ); }
     /// get word text
-    lString16 getText()
+    lString32 getText()
     {
         if ( isNull() )
-            return lString16::empty_str;
-        lString16 txt = _node->getText();
+            return lString32::empty_str;
+        lString32 txt = _node->getText();
         return txt.substr( _start, _end-_start );
     }
 };
@@ -1967,13 +1967,13 @@ public:
     /// returns true if this interval intersects specified interval
     bool checkIntersection( ldomXRange & v );
     /// returns text between two XPointer positions
-    lString16 getRangeText( lChar16 blockDelimiter='\n', int maxTextLen=0 );
+    lString32 getRangeText( lChar32 blockDelimiter='\n', int maxTextLen=0 );
     /// get all words from specified range
     void getRangeWords( LVArray<ldomWord> & list );
     /// returns href attribute of <A> element, null string if not found
-    lString16 getHRef();
+    lString32 getHRef();
     /// returns href attribute of <A> element, plus xpointer of <A> element itself
-    lString16 getHRef(ldomXPointer & a_xpointer);
+    lString32 getHRef(ldomXPointer & a_xpointer);
     /// sets range to nearest word bounds, returns true if success
     static bool getWordRange( ldomXRange & range, ldomXPointer & p );
     /// run callback for each node in range
@@ -1991,22 +1991,22 @@ public:
     /// returns nearest common element for start and end points
     ldomNode * getNearestCommonParent();
     /// returns HTML (serialized from the DOM, may be different from the source HTML)
-    lString8 getHtml( lString16Collection & cssFiles, int wflags=0, bool fromRootNode=false );
+    lString8 getHtml( lString32Collection & cssFiles, int wflags=0, bool fromRootNode=false );
     lString8 getHtml( int wflags=0, bool fromRootNode=false ) {
-        lString16Collection cssFiles; return getHtml(cssFiles, wflags, fromRootNode);
+        lString32Collection cssFiles; return getHtml(cssFiles, wflags, fromRootNode);
     };
 
     /// searches for specified text inside range
-    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1, bool checkMaxFromStart = false );
+    bool findText( lString32 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1, bool checkMaxFromStart = false );
 };
 
 class ldomMarkedText
 {
 public:
-    lString16 text;
+    lString32 text;
     lUInt32   flags;
     int offset;
-    ldomMarkedText( lString16 s, lUInt32 flg, int offs )
+    ldomMarkedText( lString32 s, lUInt32 flg, int offs )
     : text(s), flags(flg), offset(offs)
     {
     }
@@ -2076,7 +2076,7 @@ class ldomWordEx : public ldomWord
     ldomWord _word;
     ldomMarkedRange _mark;
     ldomXRange _range;
-    lString16 _text;
+    lString32 _text;
 public:
     ldomWordEx( ldomWord & word )
         :  _word(word), _mark(word), _range(word)
@@ -2086,7 +2086,7 @@ public:
     ldomWord & getWord() { return _word; }
     ldomXRange & getRange() { return _range; }
     ldomMarkedRange & getMark() { return _mark; }
-    lString16 & getText() { return _text; }
+    lString32 & getText() { return _text; }
 };
 
 /// list of extended words
@@ -2099,7 +2099,7 @@ class ldomWordExList : public LVPtrVector<ldomWordEx>
     int x;
     int y;
     ldomWordEx * selWord;
-    lString16Collection pattern;
+    lString32Collection pattern;
     void init();
     ldomWordEx * findWordByPattern();
 public:
@@ -2120,7 +2120,7 @@ public:
     /// get selected word
     ldomWordEx * getSelWord() { return selWord; }
     /// try append search pattern and find word
-    ldomWordEx * appendPattern(lString16 chars);
+    ldomWordEx * appendPattern(lString32 chars);
     /// remove last character from pattern and try to search
     ldomWordEx * reducePattern();
 };
@@ -2181,13 +2181,13 @@ private:
     lInt32          _index;
     lInt32          _page;
     lInt32          _percent;
-    lString16       _name;
-    lString16       _path;
+    lString32       _name;
+    lString32       _path;
     ldomXPointer    _position;
     LVPtrVector<LVTocItem> _children;
     //====================================================
-    //LVTocItem( ldomXPointer pos, const lString16 & name ) : _parent(NULL), _level(0), _index(0), _page(0), _percent(0), _name(name), _path(pos.toString()), _position(pos) { }
-    LVTocItem( ldomXPointer pos, lString16 path, const lString16 & name ) : _parent(NULL), _level(0), _index(0), _page(0), _percent(0), _name(name), _path(path), _position(pos) { }
+    //LVTocItem( ldomXPointer pos, const lString32 & name ) : _parent(NULL), _level(0), _index(0), _page(0), _percent(0), _name(name), _path(pos.toString()), _position(pos) { }
+    LVTocItem( ldomXPointer pos, lString32 path, const lString32 & name ) : _parent(NULL), _level(0), _index(0), _page(0), _percent(0), _name(name), _path(path), _position(pos) { }
     void addChild( LVTocItem * item ) { item->_level=_level+1; item->_parent=this; item->_index=_children.length(), item->_doc=_doc; _children.add(item); }
     //====================================================
     void setPage( int n ) { _page = n; }
@@ -2208,14 +2208,14 @@ public:
     /// returns node index
     int getIndex() const { return _index; }
     /// returns section title
-    lString16 getName() const { return _name; }
+    lString32 getName() const { return _name; }
     /// returns position pointer
     ldomXPointer getXPointer();
     /// set position pointer (for cases where we need to create a LVTocItem as a container, but
     /// we'll know the xpointer only later, mostly always the same xpointer as its first child)
     void setXPointer(ldomXPointer xp) { _position = xp; }
     /// returns position path
-    lString16 getPath();
+    lString32 getPath();
     /// returns Y position
     int getY();
     /// returns page number
@@ -2225,7 +2225,7 @@ public:
     /// returns child node by index
     LVTocItem * getChild( int index ) const { return _children[index]; }
     /// add child TOC node
-    LVTocItem * addChild( const lString16 & name, ldomXPointer ptr, lString16 path )
+    LVTocItem * addChild( const lString32 & name, ldomXPointer ptr, lString32 path )
     {
         LVTocItem * item = new LVTocItem( ptr, path, name );
         addChild( item );
@@ -2256,10 +2256,10 @@ private:
     lInt32          _index;
     lInt32          _page;
     lInt32          _doc_y;
-    lString16       _label;
-    lString16       _path;
+    lString32       _label;
+    lString32       _path;
     ldomXPointer    _position;
-    LVPageMapItem( ldomXPointer pos, lString16 path, const lString16 & label )
+    LVPageMapItem( ldomXPointer pos, lString32 path, const lString32 & label )
         : _index(0), _page(0), _doc_y(-1), _label(label), _path(path), _position(pos)
         { }
     void setPage( int n ) { _page = n; }
@@ -2274,11 +2274,11 @@ public:
     /// returns node index
     int getIndex() const { return _index; }
     /// returns page label
-    lString16 getLabel() const { return _label; }
+    lString32 getLabel() const { return _label; }
     /// returns position pointer
     ldomXPointer getXPointer();
     /// returns position path
-    lString16 getPath();
+    lString32 getPath();
     /// returns Y position
     int getDocY(bool refresh=false);
     LVPageMapItem( ldomDocument * doc ) : _doc(doc), _index(0), _page(0), _doc_y(-1) { }
@@ -2291,7 +2291,7 @@ class LVPageMap
 private:
     ldomDocument *  _doc;
     bool            _page_info_valid;
-    lString16       _source;
+    lString32       _source;
     LVPtrVector<LVPageMapItem> _children;
     void addPage( LVPageMapItem * item ) {
         item->_doc = _doc;
@@ -2308,7 +2308,7 @@ public:
     /// returns child node by index
     LVPageMapItem * getChild( int index ) const { return _children[index]; }
     /// add page item
-    LVPageMapItem * addPage( const lString16 & label, ldomXPointer ptr, lString16 path )
+    LVPageMapItem * addPage( const lString32 & label, ldomXPointer ptr, lString32 path )
     {
         LVPageMapItem * item = new LVPageMapItem( ptr, path, label );
         addPage( item );
@@ -2318,8 +2318,8 @@ public:
     bool hasValidPageInfo() { return _page_info_valid; }
     void invalidatePageInfo() { _page_info_valid = false; }
     // Page source (info about the book paper version the page labels reference)
-    void setSource( lString16 source ) { _source = source; }
-    lString16 getSource() const { return _source; }
+    void setSource( lString32 source ) { _source = source; }
+    lString32 getSource() const { return _source; }
     // root node constructor
     LVPageMap( ldomDocument * doc )
         : _doc(doc), _page_info_valid(false) { }
@@ -2330,7 +2330,7 @@ public:
 class ldomNavigationHistory
 {
     private:
-        lString16Collection _links;
+        lString32Collection _links;
         int _pos;
         void clearTail()
         {
@@ -2343,7 +2343,7 @@ class ldomNavigationHistory
             _links.clear();
             _pos = 0;
         }
-        bool save( lString16 link )
+        bool save( lString32 link )
         {
             if (_pos==(int)_links.length() && _pos>0 && _links[_pos-1]==link )
                 return false;
@@ -2358,16 +2358,16 @@ class ldomNavigationHistory
             }
             return false;
         }
-        lString16 back()
+        lString32 back()
         {
             if (_pos==0)
-                return lString16::empty_str;
+                return lString32::empty_str;
             return _links[--_pos];
         }
-        lString16 forward()
+        lString32 forward()
         {
             if (_pos>=(int)_links.length()-1)
-                return lString16::empty_str;
+                return lString32::empty_str;
             return _links[++_pos];
         }
         int backCount()
@@ -2412,7 +2412,7 @@ private:
     ldomXRangeList _selections;
 #endif
 
-    lString16 _docStylesheetFileName;
+    lString32 _docStylesheetFileName;
 
     LVContainerRef _container;
 
@@ -2432,9 +2432,9 @@ private:
 #endif
 
     /// create XPointer from a non-normalized string made by toStringV1()
-    ldomXPointer createXPointerV1( ldomNode * baseNode, const lString16 & xPointerStr );
+    ldomXPointer createXPointerV1( ldomNode * baseNode, const lString32 & xPointerStr );
     /// create XPointer from a normalized string made by toStringV2()
-    ldomXPointer createXPointerV2( ldomNode * baseNode, const lString16 & xPointerStr );
+    ldomXPointer createXPointerV2( ldomNode * baseNode, const lString32 & xPointerStr );
 protected:
 
 #if BUILD_LITE!=1
@@ -2457,9 +2457,9 @@ public:
 
 #if BUILD_LITE!=1
     /// returns object image stream
-    LVStreamRef getObjectImageStream( lString16 refName );
+    LVStreamRef getObjectImageStream( lString32 refName );
     /// returns object image source
-    LVImageSourceRef getObjectImageSource( lString16 refName );
+    LVImageSourceRef getObjectImageSource( lString32 refName );
 
     bool isDefStyleSet()
     {
@@ -2516,8 +2516,8 @@ public:
     void clearRendBlockCache() { _renderedBlockCache.clear(); }
 #endif
     void clear();
-    lString16 getDocStylesheetFileName() { return _docStylesheetFileName; }
-    void setDocStylesheetFileName(lString16 fileName) { _docStylesheetFileName = fileName; }
+    lString32 getDocStylesheetFileName() { return _docStylesheetFileName; }
+    void setDocStylesheetFileName(lString32 fileName) { _docStylesheetFileName = fileName; }
 
     ldomDocument();
     /// creates empty document which is ready to be copy target of doc partial contents
@@ -2544,8 +2544,8 @@ public:
     /// get default style reference
     css_style_ref_t getDefaultStyle() { return _def_style; }
 
-    inline bool parseStyleSheet(lString16 codeBase, lString16 css);
-    inline bool parseStyleSheet(lString16 cssFile);
+    inline bool parseStyleSheet(lString32 codeBase, lString32 css);
+    inline bool parseStyleSheet(lString32 cssFile);
 #endif
     /// destructor
     virtual ~ldomDocument();
@@ -2560,23 +2560,23 @@ public:
                                  int def_interline_space, CRPropRef props );
 #endif
     /// create xpointer from pointer string
-    ldomXPointer createXPointer( const lString16 & xPointerStr );
+    ldomXPointer createXPointer( const lString32 & xPointerStr );
     /// create xpointer from pointer string
-    ldomNode * nodeFromXPath( const lString16 & xPointerStr )
+    ldomNode * nodeFromXPath( const lString32 & xPointerStr )
     {
         return createXPointer( xPointerStr ).getNode();
     }
     /// get element text by pointer string
-    lString16 textFromXPath( const lString16 & xPointerStr )
+    lString32 textFromXPath( const lString32 & xPointerStr )
     {
         ldomNode * node = nodeFromXPath( xPointerStr );
         if ( !node )
-            return lString16::empty_str;
+            return lString32::empty_str;
         return node->getText();
     }
 
     /// create xpointer from relative pointer string
-    ldomXPointer createXPointer( ldomNode * baseNode, const lString16 & xPointerStr )
+    ldomXPointer createXPointer( ldomNode * baseNode, const lString32 & xPointerStr )
     {
         if( _DOMVersionRequested >= DOM_VERSION_WITH_NORMALIZED_XPOINTERS)
             return createXPointerV2(baseNode, xPointerStr);
@@ -2589,7 +2589,7 @@ public:
     /// get rendered block cache object
     CVRendBlockCache & getRendBlockCache() { return _renderedBlockCache; }
 
-    bool findText( lString16 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1 );
+    bool findText( lString32 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY = -1 );
 #endif
 };
 
@@ -2603,7 +2603,7 @@ class ldomElementWriter
 
     ldomNode * _element;
     LVTocItem * _tocItem;
-    lString16 _path;
+    lString32 _path;
     const css_elem_def_props_t * _typeDef;
     bool _allowText;
     bool _isBlock;
@@ -2620,9 +2620,9 @@ class ldomElementWriter
     {
         return _element;
     }
-    lString16 getPath();
-    void onText( const lChar16 * text, int len, lUInt32 flags, bool insert_before_last_child=false );
-    void addAttribute( lUInt16 nsid, lUInt16 id, const wchar_t * value );
+    lString32 getPath();
+    void onText( const lChar32 * text, int len, lUInt32 flags, bool insert_before_last_child=false );
+    void addAttribute( lUInt16 nsid, lUInt16 id, const lChar32 * value );
     //lxmlElementWriter * pop( lUInt16 id );
 
     ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUInt16 id, ldomElementWriter * parent, bool insert_before_last_child=false);
@@ -2653,8 +2653,8 @@ protected:
     //============================
     lUInt32 _flags;
     bool _inHeadStyle;
-    lString16 _headStyleText;
-    lString16Collection _stylesheetLinks;
+    lString32 _headStyleText;
+    lString32Collection _stylesheetLinks;
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
 public:
     /// returns flags
@@ -2663,25 +2663,25 @@ public:
     virtual void setFlags( lUInt32 flags ) { _flags = flags; }
     // overrides
     /// called when encoding directive found in document
-    virtual void OnEncoding( const lChar16 * name, const lChar16 * table );
+    virtual void OnEncoding( const lChar32 * name, const lChar32 * table );
     /// called on parsing start
     virtual void OnStart(LVFileFormatParser * parser);
     /// called on parsing end
     virtual void OnStop();
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname );
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname );
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false );
     /// called on attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue );
     /// close tags
     ldomElementWriter * pop( ldomElementWriter * obj, lUInt16 id );
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags );
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags );
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) {
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) {
 #if BUILD_LITE!=1
         return _document->addBlob(name, data, size);
 #else
@@ -2730,19 +2730,19 @@ protected:
     virtual lUInt16 popUpTo( ldomElementWriter * target, lUInt16 target_id=0, int scope=0 );
     virtual bool CheckAndEnsureFosterParenting(lUInt16 tag_id);
     virtual void ElementCloseHandler( ldomNode * node ) { node->persist(); }
-    virtual void appendStyle( const lChar16 * style );
-    virtual void setClass( const lChar16 * className, bool overrideExisting=false );
+    virtual void appendStyle( const lChar32 * style );
+    virtual void setClass( const lChar32 * className, bool overrideExisting=false );
 public:
     /// called on attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue );
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname );
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname );
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false );
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags );
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags );
     /// constructor
     ldomDocumentWriterFilter(ldomDocument * document, bool headerOnly, const char *** rules);
     /// destructor
@@ -2754,17 +2754,17 @@ class ldomDocumentFragmentWriter : public LVXMLParserCallback
 private:
     //============================
     LVXMLParserCallback * parent;
-    lString16 baseTag;
-    lString16 baseTagReplacement;
-    lString16 codeBase;
-    lString16 filePathName;
-    lString16 codeBasePrefix;
-    lString16 stylesheetFile;
-    lString16 tmpStylesheetFile;
-    lString16Collection stylesheetLinks;
+    lString32 baseTag;
+    lString32 baseTagReplacement;
+    lString32 codeBase;
+    lString32 filePathName;
+    lString32 codeBasePrefix;
+    lString32 stylesheetFile;
+    lString32 tmpStylesheetFile;
+    lString32Collection stylesheetLinks;
     bool insideTag;
     int styleDetectionState;
-    LVHashTable<lString16, lString16> pathSubstitutions;
+    LVHashTable<lString32, lString32> pathSubstitutions;
 
     ldomNode * baseElement;
     ldomNode * lastBaseElement;
@@ -2772,8 +2772,8 @@ private:
     lString8 headStyleText;
     int headStyleState;
 
-    lString16 htmlDir;
-    lString16 htmlLang;
+    lString32 htmlDir;
+    lString32 htmlLang;
     bool insideHtmlTag;
 
 public:
@@ -2783,22 +2783,22 @@ public:
 
     ldomNode * getBaseElement() { return lastBaseElement; }
 
-    lString16 convertId( lString16 id );
-    lString16 convertHref( lString16 href );
+    lString32 convertId( lString32 id );
+    lString32 convertHref( lString32 href );
 
-    void addPathSubstitution( lString16 key, lString16 value )
+    void addPathSubstitution( lString32 key, lString32 value )
     {
         pathSubstitutions.set(key, value);
     }
 
-    virtual void setCodeBase( lString16 filePath );
+    virtual void setCodeBase( lString32 filePath );
     /// returns flags
     virtual lUInt32 getFlags() { return parent->getFlags(); }
     /// sets flags
     virtual void setFlags( lUInt32 flags ) { parent->setFlags(flags); }
     // overrides
     /// called when encoding directive found in document
-    virtual void OnEncoding( const lChar16 * name, const lChar16 * table )
+    virtual void OnEncoding( const lChar32 * name, const lChar32 * table )
     { parent->OnEncoding( name, table ); }
     /// called on parsing start
     virtual void OnStart(LVFileFormatParser *)
@@ -2816,7 +2816,7 @@ public:
         if ( insideTag ) {
             insideTag = false;
             if ( !baseTagReplacement.empty() ) {
-                parent->OnTagClose(L"", baseTagReplacement.c_str());
+                parent->OnTagClose(U"", baseTagReplacement.c_str());
             }
             baseElement = NULL;
             return;
@@ -2824,29 +2824,29 @@ public:
         insideTag = false;
     }
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname );
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname );
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody();
     /// called on closing tag
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false );
     /// called on attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue );
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags )
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
         if (headStyleState == 1) {
-            headStyleText << UnicodeToUtf8(lString16(text).substr(0,len-1));
+            headStyleText << UnicodeToUtf8(lString32(text).substr(0,len-1));
             return;
         }
         if ( insideTag )
             parent->OnText( text, len, flags );
     }
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) { return parent->OnBlob(name, data, size); }
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) { return parent->OnBlob(name, data, size); }
     /// set document property
     virtual void OnDocProperty(const char * name, lString8 value) { parent->OnDocProperty(name, value); }
     /// constructor
-    ldomDocumentFragmentWriter( LVXMLParserCallback * parentWriter, lString16 baseTagName, lString16 baseTagReplacementName, lString16 fragmentFilePath )
+    ldomDocumentFragmentWriter( LVXMLParserCallback * parentWriter, lString32 baseTagName, lString32 baseTagReplacementName, lString32 fragmentFilePath )
     : parent(parentWriter), baseTag(baseTagName), baseTagReplacement(baseTagReplacementName),
     insideTag(false), styleDetectionState(0), pathSubstitutions(100), baseElement(NULL), lastBaseElement(NULL),
     headStyleState(0), insideHtmlTag(false)
@@ -2858,16 +2858,16 @@ public:
 };
 
 //utils
-/// extract authors from FB2 document, delimiter is lString16 by default
-lString16 extractDocAuthors( ldomDocument * doc, lString16 delimiter=lString16::empty_str, bool shortMiddleName=true );
-lString16 extractDocTitle( ldomDocument * doc );
-lString16 extractDocLanguage( ldomDocument * doc );
+/// extract authors from FB2 document, delimiter is lString32 by default
+lString32 extractDocAuthors( ldomDocument * doc, lString32 delimiter=lString32::empty_str, bool shortMiddleName=true );
+lString32 extractDocTitle( ldomDocument * doc );
+lString32 extractDocLanguage( ldomDocument * doc );
 /// returns "(Series Name #number)" if pSeriesNumber is NULL, separate name and number otherwise
-lString16 extractDocSeries( ldomDocument * doc, int * pSeriesNumber=NULL );
-lString16 extractDocKeywords( ldomDocument * doc );
-lString16 extractDocDescription( ldomDocument * doc );
+lString32 extractDocSeries( ldomDocument * doc, int * pSeriesNumber=NULL );
+lString32 extractDocKeywords( ldomDocument * doc );
+lString32 extractDocDescription( ldomDocument * doc );
 
-bool IsEmptySpace( const lChar16 * text, int len );
+bool IsEmptySpace( const lChar32 * text, int len );
 
 /// parse XML document from stream, returns NULL if failed
 ldomDocument * LVParseXMLStream( LVStreamRef stream,
@@ -2886,11 +2886,11 @@ class ldomDocCache
 {
 public:
     /// open existing cache file stream
-    static LVStreamRef openExisting( lString16 filename, lUInt32 crc, lUInt32 docFlags, lString16 &cachePath );
+    static LVStreamRef openExisting( lString32 filename, lUInt32 crc, lUInt32 docFlags, lString32 &cachePath );
     /// create new cache file
-    static LVStreamRef createNew( lString16 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString16 &cachePath );
+    static LVStreamRef createNew( lString32 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString32 &cachePath );
     /// init document cache
-    static bool init( lString16 cacheDir, lvsize_t maxSize );
+    static bool init( lString32 cacheDir, lvsize_t maxSize );
     /// close document cache manager
     static bool close();
     /// delete all cache files

--- a/crengine/include/lvtypes.h
+++ b/crengine/include/lvtypes.h
@@ -33,7 +33,7 @@ typedef unsigned short int lUInt16; ///< unsigned 16 bit int
 typedef signed char lInt8;          ///< signed 8 bit int
 typedef unsigned char lUInt8;       ///< unsigned 8 bit int
 
-typedef wchar_t lChar16;            ///< 16 bit char
+typedef char32_t lChar32;           ///< 32 bit char
 typedef char lChar8;                ///< 8 bit char
 
 #if defined(_WIN32) && !defined(CYGWIN)

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -41,36 +41,36 @@ public:
     /// sets flags
     virtual void setFlags( lUInt32 ) { }
     /// called on document encoding definition
-    virtual void OnEncoding( const lChar16 *, const lChar16 * ) { }
+    virtual void OnEncoding( const lChar32 *, const lChar32 * ) { }
     /// called on parsing start
     virtual void OnStart(LVFileFormatParser * parser) { _parser = parser; }
     /// called on parsing end
     virtual void OnStop() = 0;
     /// called on opening tag <
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname) = 0;
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname) = 0;
     /// called after > of opening tag (when entering tag body)
     virtual void OnTagBody() = 0;
     /// calls OnTagOpen & OnTagBody
-    virtual void OnTagOpenNoAttr( const lChar16 * nsname, const lChar16 * tagname)
+    virtual void OnTagOpenNoAttr( const lChar32 * nsname, const lChar32 * tagname)
     {
         OnTagOpen( nsname, tagname);
         OnTagBody();
     }
     /// calls OnTagOpen & OnTagClose
-    virtual void OnTagOpenAndClose( const lChar16 * nsname, const lChar16 * tagname)
+    virtual void OnTagOpenAndClose( const lChar32 * nsname, const lChar32 * tagname)
     {
         OnTagOpen( nsname, tagname );
         OnTagBody();
         OnTagClose( nsname, tagname, true );
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) = 0;
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false ) = 0;
     /// called on element attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue ) = 0;
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue ) = 0;
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags ) = 0;
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags ) = 0;
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) = 0;
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) = 0;
     /// call to set document property
     virtual void OnDocProperty(const char * /*name*/, lString8 /*value*/) { }
     /// destructor
@@ -94,9 +94,9 @@ public:
 #define TXTFLG_PROCESS_ATTRIBUTE            0x20000
 
 /// converts XML text: decode character entities, convert space chars
-void PreProcessXmlString( lString16 & s, lUInt32 flags, const lChar16 * enc_table=NULL );
+void PreProcessXmlString( lString32 & s, lUInt32 flags, const lChar32 * enc_table=NULL );
 /// converts XML text in-place: decode character entities, convert space chars, returns new length of string
-int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * enc_table = NULL);
+int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * enc_table = NULL);
 
 #define MAX_PERSISTENT_BUF_SIZE 16384
 
@@ -119,11 +119,11 @@ public:
     /// stops parsing in the middle of file, to read header only
     virtual void Stop() = 0;
     /// sets charset by name
-    virtual void SetCharset( const lChar16 * name ) = 0;
+    virtual void SetCharset( const lChar32 * name ) = 0;
     /// sets 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual void SetCharsetTable( const lChar16 * table ) = 0;
+    virtual void SetCharsetTable( const lChar32 * table ) = 0;
     /// returns 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual lChar16 * GetCharsetTable( ) = 0;
+    virtual lChar32 * GetCharsetTable( ) = 0;
     /// changes space mode
     virtual void SetSpaceMode( bool ) { }
     /// returns space mode
@@ -168,7 +168,7 @@ public:
     /// returns source stream
     LVStreamRef getStream() { return m_stream; }
     /// return stream file name
-    lString16 getFileName();
+    lString32 getFileName();
     /// returns true if end of fle is reached, and there is no data left in buffer
     virtual bool Eof() { return m_buf_fpos + m_buf_pos >= m_stream_size; }
     /// resets parsing, moves to beginning of stream
@@ -181,19 +181,19 @@ class LVTextFileBase : public LVFileParserBase
 {
 protected:
     char_encoding_type m_enc_type;
-    lString16 m_txt_buf;
-    lString16 m_encoding_name;
-    lString16 m_lang_name;
-    lChar16 * m_conv_table; // charset conversion table for 8-bit encodings
+    lString32 m_txt_buf;
+    lString32 m_encoding_name;
+    lString32 m_lang_name;
+    lChar32 * m_conv_table; // charset conversion table for 8-bit encodings
 
-    lChar16 m_read_buffer[XML_CHAR_BUFFER_SIZE];
+    lChar32 m_read_buffer[XML_CHAR_BUFFER_SIZE];
     int m_read_buffer_len;
     int m_read_buffer_pos;
     bool m_eof;
 
     void checkEof();
 
-    inline lChar16 ReadCharFromBuffer()
+    inline lChar32 ReadCharFromBuffer()
     {
         if ( m_read_buffer_pos >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
@@ -203,7 +203,7 @@ protected:
         }
         return m_read_buffer[m_read_buffer_pos++];
     }
-    inline lChar16 PeekCharFromBuffer()
+    inline lChar32 PeekCharFromBuffer()
     {
         if ( m_read_buffer_pos >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
@@ -213,7 +213,7 @@ protected:
         }
         return m_read_buffer[m_read_buffer_pos];
     }
-    inline lChar16 PeekCharFromBuffer( int offset )
+    inline lChar32 PeekCharFromBuffer( int offset )
     {
         if ( m_read_buffer_pos + offset >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
@@ -226,7 +226,7 @@ protected:
         return m_read_buffer[m_read_buffer_pos + offset];
     }
     // skip current char (was already peeked), peek next
-    inline lChar16 PeekNextCharFromBuffer()
+    inline lChar32 PeekNextCharFromBuffer()
     {
         if ( m_read_buffer_pos + 1 >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
@@ -237,7 +237,7 @@ protected:
         return m_read_buffer[++m_read_buffer_pos];
     }
     // skip current char (was already peeked), peek next
-    inline lChar16 PeekNextCharFromBuffer( int offset )
+    inline lChar32 PeekNextCharFromBuffer( int offset )
     {
         if ( m_read_buffer_pos+offset >= m_read_buffer_len ) {
             if ( !fillCharBuffer() ) {
@@ -257,16 +257,16 @@ protected:
     int fillCharBuffer();
 
     /// reads one character from buffer
-    //lChar16 ReadChar();
+    //lChar32 ReadChar();
     /// reads several characters from buffer
-    int ReadChars( lChar16 * buf, int maxsize );
+    int ReadChars( lChar32 * buf, int maxsize );
     /// reads one character from buffer in RTF format
-    lChar16 ReadRtfChar( int enc_type, const lChar16 * conv_table );
+    lChar32 ReadRtfChar( int enc_type, const lChar32 * conv_table );
     /// reads specified number of bytes, converts to characters and saves to buffer, returns number of chars read
-    int ReadTextBytes( lvpos_t pos, int bytesToRead, lChar16 * buf, int buf_size, int flags );
+    int ReadTextBytes( lvpos_t pos, int bytesToRead, lChar32 * buf, int buf_size, int flags );
 #if 0
     /// reads specified number of characters and saves to buffer, returns number of chars read
-    int ReadTextChars( lvpos_t pos, int charsToRead, lChar16 * buf, int buf_size, int flags );
+    int ReadTextChars( lvpos_t pos, int charsToRead, lChar32 * buf, int buf_size, int flags );
 #endif
 public:
     /// returns true if end of fle is reached, and there is no data left in buffer
@@ -275,20 +275,20 @@ public:
     /// tries to autodetect text encoding
     bool AutodetectEncoding( bool utfOnly=false );
     /// reads next text line, tells file position and size of line, sets EOL flag
-    lString16 ReadLine( int maxLineSize, lUInt32 & flags );
-    //lString16 ReadLine( int maxLineSize, lvpos_t & fpos, lvsize_t & fsize, lUInt32 & flags );
+    lString32 ReadLine( int maxLineSize, lUInt32 & flags );
+    //lString32 ReadLine( int maxLineSize, lvpos_t & fpos, lvsize_t & fsize, lUInt32 & flags );
     /// returns name of character encoding
-    lString16 GetEncodingName() { return m_encoding_name; }
+    lString32 GetEncodingName() { return m_encoding_name; }
     /// returns name of language
-    lString16 GetLangName() { return m_lang_name; }
+    lString32 GetLangName() { return m_lang_name; }
 
     // overrides
     /// sets charset by name
-    virtual void SetCharset( const lChar16 * name );
+    virtual void SetCharset( const lChar32 * name );
     /// sets 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual void SetCharsetTable( const lChar16 * table );
+    virtual void SetCharsetTable( const lChar32 * table );
     /// returns 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual lChar16 * GetCharsetTable( ) { return m_conv_table; }
+    virtual lChar32 * GetCharsetTable( ) { return m_conv_table; }
 
     /// constructor
     LVTextFileBase( LVStreamRef stream );
@@ -310,8 +310,8 @@ private:
         lUInt32      pos;
         lUInt32      size;
         lUInt32      flags;
-        lString16    text;
-        cache_item( lString16 & txt )
+        lString32    text;
+        cache_item( lString32 & txt )
             : next(NULL), pos(0), size(0), flags(0), text(txt)
         {
         }
@@ -324,7 +324,7 @@ private:
     void cleanOldItems( lUInt32 newItemChars );
 
     /// adds new item
-    void addItem( lString16 & str );
+    void addItem( lString32 & str );
 
 public:
     /// returns true if format is recognized by parser
@@ -341,7 +341,7 @@ public:
     /// destructor
     virtual ~LVXMLTextCache();
     /// reads text from cache or input stream
-    lString16 getText( lUInt32 pos, lUInt32 size, lUInt32 flags );
+    lString32 getText( lUInt32 pos, lUInt32 size, lUInt32 flags );
 };
 
 
@@ -394,8 +394,8 @@ private:
     bool m_trimspaces;
     int  m_state;
     bool SkipSpaces();
-    bool SkipTillChar( lChar16 ch );
-    bool ReadIdent( lString16 & ns, lString16 & str );
+    bool SkipTillChar( lChar32 ch );
+    bool ReadIdent( lString32 & ns, lString32 & str );
     bool ReadText();
 protected:
     bool m_citags;
@@ -407,7 +407,7 @@ public:
     /// parses input stream
     virtual bool Parse();
     /// sets charset by name
-    virtual void SetCharset( const lChar16 * name );
+    virtual void SetCharset( const lChar32 * name );
     /// resets parsing, moves to beginning of stream
     virtual void Reset();
     /// constructor
@@ -438,9 +438,9 @@ public:
 };
 
 /// read stream contents to string
-lString16 LVReadTextFile( LVStreamRef stream );
+lString32 LVReadTextFile( LVStreamRef stream );
 /// read file contents to string
-lString16 LVReadTextFile( lString16 filename );
+lString32 LVReadTextFile( lString32 filename );
 
 LVStreamRef GetFB2Coverpage(LVStreamRef stream);
 

--- a/crengine/include/props.h
+++ b/crengine/include/props.h
@@ -32,26 +32,26 @@ public:
     /// returns property name by index
     virtual const char * getName( int index ) const = 0;
     /// returns property value by index
-    virtual const lString16 & getValue( int index ) const = 0;
+    virtual const lString32 & getValue( int index ) const = 0;
     /// sets property value by index
-    virtual void setValue( int index, const lString16 &value ) = 0;
+    virtual void setValue( int index, const lString32 &value ) = 0;
 
     /// returns true if specified property exists
     virtual bool hasProperty( const char * propName ) const = 0;
     /// get string property by name, returns false if not found
-    virtual bool getString( const char * propName, lString16 &result ) const = 0;
+    virtual bool getString( const char * propName, lString32 &result ) const = 0;
     /// get string property by name, returns default value if not found
-    virtual lString16 getStringDef( const char * propName, const char * defValue = NULL ) const;
+    virtual lString32 getStringDef( const char * propName, const char * defValue = NULL ) const;
     /// set string property by name, if it's not set already
     virtual void setStringDef( const char * propName, const char * defValue );
     /// set string property by name, if it's not set already
-    virtual void setStringDef( const char * propName, lString16 defValue )
+    virtual void setStringDef( const char * propName, lString32 defValue )
     {
         if ( !hasProperty(propName) )
             setString( propName, defValue );
     }
     /// set string property by name
-    virtual void setString( const char * propName, const lString16 &value ) = 0;
+    virtual void setString( const char * propName, const lString32 &value ) = 0;
     /// set string property by name
     virtual void setString( const char * propName, const lString8 &value )
     {
@@ -99,7 +99,7 @@ public:
     virtual void setInt64( const char * propName, lInt64 value );
 
 
-    static bool parseColor(lString16 value, lUInt32 & result);
+    static bool parseColor(lString32 value, lUInt32 & result);
     /// get argb color (#xxxxxx) property by name, returns false if not found
     virtual bool getColor( const char * propName, lUInt32 &result ) const;
     /// get argb color (#xxxxxx) property by name, returns default value if not found

--- a/crengine/include/rtfimp.h
+++ b/crengine/include/rtfimp.h
@@ -168,9 +168,9 @@ public:
     virtual void OnTblProp( int id, int param ) = 0;
     virtual void OnAction( int action ) = 0;
     virtual void OnControlWord( const char * control, int param ) = 0;
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags ) = 0;
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags ) = 0;
     virtual void OnBlob(const lUInt8 * data, int size) = 0;
-    virtual void SetCharsetTable(const lChar16 * table);
+    virtual void SetCharsetTable(const lChar32 * table);
     virtual ~LVRtfDestination() { }
 };
 
@@ -216,7 +216,7 @@ public:
     /// returns current destination
     inline LVRtfDestination * getDestination() { return dest; }
     /// converts byte to unicode using current code page
-    inline lChar16 byteToUnicode( lUInt8 ch )
+    inline lChar32 byteToUnicode( lUInt8 ch )
     {
         // skip ANSI character counter support
         if ( decInt(pi_skip_ch_count) )
@@ -226,7 +226,7 @@ public:
             return 0;
         // TODO: add codepage support
         if ( ch & 0x80 ) {
-            const lChar16 * conv_table = (const lChar16 *)props[pi_ansicpg].p;
+            const lChar32 * conv_table = (const lChar32 *)props[pi_ansicpg].p;
             return ( conv_table[ch & 0x7F] );
         } else {
             return ( ch );
@@ -270,7 +270,7 @@ public:
             stack[sp].index = index;
             if ( index==pi_ansicpg ) {
                 stack[sp++].value.p = props[index].p;
-                const lChar16 * table = GetCharsetByte2UnicodeTable( value );
+                const lChar32 * table = GetCharsetByte2UnicodeTable( value );
                 props[index].p = (void*)table;
                 //this->getDestination()->SetCharsetTable(table);
             } else {
@@ -340,7 +340,7 @@ public:
                 sp--;
                 props[i] = stack[sp].value;
 //                if (i == pi_ansicpg) {
-//                    const lChar16 * table = (const lChar16 *)props[i].p;
+//                    const lChar32 * table = (const lChar32 *)props[i].p;
 //                    this->getDestination()->SetCharsetTable(table);
 //                }
             }
@@ -355,8 +355,8 @@ class LVRtfParser : public LVFileParserBase
 protected:
     LVXMLParserCallback * m_callback;
     LVRtfValueStack m_stack;
-    const lChar16 * m_conv_table; // charset conversion table for 8-bit encodings
-    lChar16 * txtbuf; /// text buffer
+    const lChar32 * m_conv_table; // charset conversion table for 8-bit encodings
+    lChar32 * txtbuf; /// text buffer
     int txtpos; /// text chars
     int txtfstart; /// text start file offset
     int imageIndex;
@@ -366,7 +366,7 @@ protected:
     void OnBraceClose();
     void OnControlWord( const char * control, int param, bool asterisk );
     void CommitText();
-    void AddChar( lChar16 ch );
+    void AddChar( lChar32 ch );
     void AddChar8( lUInt8 ch );
 public:
     /// counter for image index
@@ -380,11 +380,11 @@ public:
     /// resets parsing, moves to beginning of stream
     virtual void Reset();
     /// sets charset by name
-    virtual void SetCharset( const lChar16 * name );
+    virtual void SetCharset( const lChar32 * name );
     /// sets 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual void SetCharsetTable( const lChar16 * table );
+    virtual void SetCharsetTable( const lChar32 * table );
     /// returns 8-bit charset conversion table (128 items, for codes 128..255)
-    virtual lChar16 * GetCharsetTable( );
+    virtual lChar32 * GetCharsetTable( );
     /// virtual destructor
     virtual ~LVRtfParser();
 };

--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -19,19 +19,19 @@
 
 // Be similar to HyphMan default state with "English_US.pattern"
 #define TEXTLANG_DEFAULT_MAIN_LANG              "en"   // for LVDocView
-#define TEXTLANG_DEFAULT_MAIN_LANG_16           L"en"  // for textlang.cpp
+#define TEXTLANG_DEFAULT_MAIN_LANG_32           U"en"  // for textlang.cpp
 #define TEXTLANG_DEFAULT_EMBEDDED_LANGS_ENABLED false
 #define TEXTLANG_DEFAULT_HYPHENATION_ENABLED    true
 #define TEXTLANG_DEFAULT_HYPH_SOFT_HYPHENS_ONLY false
 #define TEXTLANG_DEFAULT_HYPH_FORCE_ALGORITHMIC false
-#define TEXTLANG_FALLBACK_HYPH_DICT_ID  L"English_US.pattern" // For languages without specific hyph dicts
+#define TEXTLANG_FALLBACK_HYPH_DICT_ID  U"English_US.pattern" // For languages without specific hyph dicts
 
 class TextLangCfg;
 
 class TextLangMan
 {
     friend class TextLangCfg;
-    static lString16 _main_lang;
+    static lString32 _main_lang;
     static bool _embedded_langs_enabled;
     static LVPtrVector<TextLangCfg> _lang_cfg_list;
 
@@ -43,14 +43,14 @@ class TextLangMan
     static HyphMethod * _soft_hyphens_method;  // instance of hyphman SoftHyphensHyph
     static HyphMethod * _algo_hyph_method;     // instance of hyphman AlgoHyph
 
-    static HyphMethod * getHyphMethodForLang( lString16 lang_tag ); // Used by TextLangCfg
+    static HyphMethod * getHyphMethodForLang( lString32 lang_tag ); // Used by TextLangCfg
 public:
     static void uninit();
     static lUInt32 getHash();
 
-    static void setMainLang( lString16 lang_tag ) { _main_lang = lang_tag; }
-    static void setMainLangFromHyphDict( lString16 id ); // For HyphMan legacy methods
-    static lString16 getMainLang() { return _main_lang; }
+    static void setMainLang( lString32 lang_tag ) { _main_lang = lang_tag; }
+    static void setMainLangFromHyphDict( lString32 id ); // For HyphMan legacy methods
+    static lString32 getMainLang() { return _main_lang; }
 
     static void setEmbeddedLangsEnabled( bool enabled ) { _embedded_langs_enabled = enabled; }
     static bool getEmbeddedLangsEnabled() { return _embedded_langs_enabled; }
@@ -74,7 +74,7 @@ public:
     }
 
     static TextLangCfg * getTextLangCfg(); // get LangCfg for _main_lang
-    static TextLangCfg * getTextLangCfg( lString16 lang_tag );
+    static TextLangCfg * getTextLangCfg( lString32 lang_tag );
     static TextLangCfg * getTextLangCfg( ldomNode * node );
     static int getLangNodeIndex( ldomNode * node );
 
@@ -94,19 +94,19 @@ public:
 #define MAX_NB_LB_PROPS_ITEMS 20 // for our statically sized array (increase if needed)
 
 #if USE_LIBUNIBREAK==1
-typedef lChar16 (*lb_char_sub_func_t)(struct LineBreakContext *lbpCtx, const lChar16 * text, int pos, int next_usable);
+typedef lChar32 (*lb_char_sub_func_t)(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable);
 #endif
 
 class TextLangCfg
 {
     friend class TextLangMan;
-    lString16 _lang_tag;
+    lString32 _lang_tag;
     HyphMethod * _hyph_method;
 
-    lString16 _open_quote1;
-    lString16 _close_quote1;
-    lString16 _open_quote2;
-    lString16 _close_quote2;
+    lString32 _open_quote1;
+    lString32 _close_quote1;
+    lString32 _open_quote2;
+    lString32 _close_quote2;
     int _quote_nesting_level;
 
     #if USE_HARFBUZZ==1
@@ -123,7 +123,7 @@ class TextLangCfg
     void resetCounters();
 
 public:
-    lString16 getLangTag() const { return _lang_tag; }
+    lString32 getLangTag() const { return _lang_tag; }
 
     HyphMethod * getHyphMethod() const {
         if ( !TextLangMan::_overridden_hyph_method )
@@ -141,11 +141,11 @@ public:
         return _hyph_method;
     }
 
-    lString16 & getOpeningQuote( bool update_level=true );
-    lString16 & getClosingQuote( bool update_level=true );
+    lString32 & getOpeningQuote( bool update_level=true );
+    lString32 & getClosingQuote( bool update_level=true );
 
     int getHyphenHangingPercent();
-    int getHangingPercent( bool right_hanging, bool & check_font, const lChar16 * text, int pos, int next_usable );
+    int getHangingPercent( bool right_hanging, bool & check_font, const lChar32 * text, int pos, int next_usable );
 
     #if USE_HARFBUZZ==1
     hb_language_t getHBLanguage() const { return _hb_language; }
@@ -159,7 +159,7 @@ public:
 
     bool duplicateRealHyphenOnNextLine() const { return _duplicate_real_hyphen_on_next_line; }
 
-    TextLangCfg( lString16 lang_tag );
+    TextLangCfg( lString32 lang_tag );
     ~TextLangCfg();
 };
 

--- a/crengine/src/bookformats.cpp
+++ b/crengine/src/bookformats.cpp
@@ -1,18 +1,18 @@
 
 #include "bookformats.h"
 
-lString16 LVDocFormatName(int fmt) {
+lString32 LVDocFormatName(int fmt) {
     switch (fmt) {
-    case doc_format_fb2: return lString16("FB2");
-    case doc_format_txt: return lString16("TXT");
-    case doc_format_rtf: return lString16("RTF");
-    case doc_format_epub: return lString16("EPUB");
-    case doc_format_html: return lString16("HTML");
-    case doc_format_txt_bookmark: return lString16("BMK");
-    case doc_format_chm: return lString16("CHM");
-    case doc_format_doc: return lString16("DOC");
-    case doc_format_pdb: return lString16("PDB");
-    default: return lString16("?");
+    case doc_format_fb2: return lString32("FB2");
+    case doc_format_txt: return lString32("TXT");
+    case doc_format_rtf: return lString32("RTF");
+    case doc_format_epub: return lString32("EPUB");
+    case doc_format_html: return lString32("HTML");
+    case doc_format_txt_bookmark: return lString32("BMK");
+    case doc_format_chm: return lString32("CHM");
+    case doc_format_doc: return lString32("DOC");
+    case doc_format_pdb: return lString32("PDB");
+    default: return lString32("?");
     }
 }
 
@@ -31,7 +31,7 @@ lString8 LVDocFormatCssFileName(int fmt) {
     }
 }
 
-int LVDocFormatFromExtension(lString16 &pathName) {
+int LVDocFormatFromExtension(lString32 &pathName) {
     if (pathName.endsWith(".fb2"))
         return doc_format_fb2;
     if (pathName.endsWith(".txt") || pathName.endsWith(".tcr") || pathName.endsWith(".pml"))

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -176,17 +176,17 @@ protected:
     crChmExternalFileStream _stream;
     chmFile* _file;
 public:
-    virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t mode )
+    virtual LVStreamRef OpenStream( const lChar32 * fname, lvopen_mode_t mode )
     {
         LVStreamRef stream;
         if ( mode!=LVOM_READ )
             return stream;
 
         LVCHMStream * p = new LVCHMStream(_file);
-        lString16 fn(fname);
+        lString32 fn(fname);
         if ( fn[0]!='/' )
-            fn = cs16("/") + fn;
-        if ( !p->open( UnicodeToUtf8(lString16(fn)).c_str() )) {
+            fn = cs32("/") + fn;
+        if ( !p->open( UnicodeToUtf8(lString32(fn)).c_str() )) {
             delete p;
             return stream;
         }
@@ -229,7 +229,7 @@ public:
     void addFileItem( const char * filename, LONGUINT64 len )
     {
         LVCommonContainerItemInfo * item = new LVCommonContainerItemInfo();
-        item->SetItemInfo( lString16(filename), (lvsize_t)len, 0, false );
+        item->SetItemInfo( lString32(filename), (lvsize_t)len, 0, false );
         //CRLog::trace("CHM file item: %s [%d]", filename, (int)len);
         Add(item);
     }
@@ -363,13 +363,13 @@ public:
         return res;
     }
     // offset==-1 to avoid changing position, length==-1 to use 0-terminated
-    lString16 readStringUtf16( int offset, int length ) {
+    lString32 readStringUtf16( int offset, int length ) {
         if ( length==0 )
-            return lString16::empty_str;
+            return lString32::empty_str;
         if ( offset>=0 )
             if ((int)_stream->SetPos(offset) != offset)
-                return lString16::empty_str;
-        lString16 res;
+                return lString32::empty_str;
+        lString32 res;
         if ( length>0 )
             res.reserve(length);
         for ( int i=0; i<length || length==-1; i++ ) {
@@ -379,7 +379,7 @@ public:
             int b2 = _stream->ReadByte();
             if ( b2==-1 || b2==0 )
                 break;
-            res.append(1, (lChar16)(b1 | (b2<<16)));
+            res.append(1, (lChar32)(b1 | (b2<<16)));
         }
         return res;
     }
@@ -473,7 +473,7 @@ class CHMUrlStr {
     }
 public:
     static CHMUrlStr * open( LVContainerRef container ) {
-        LVStreamRef stream = container->OpenStream(L"#URLSTR", LVOM_READ);
+        LVStreamRef stream = container->OpenStream(U"#URLSTR", LVOM_READ);
         if ( stream.isNull() )
             return NULL;
         CHMUrlStr * res = new CHMUrlStr( container, stream );
@@ -491,7 +491,7 @@ public:
         }
         return lString8::empty_str;
     }
-    void getUrlList( lString16Collection & urlList ) {
+    void getUrlList( lString32Collection & urlList ) {
         for ( int i=0; i<_table.length(); i++ ) {
             lString8 s = _table[i]->url;
             if ( !s.empty() ) {
@@ -581,7 +581,7 @@ public:
     }
 
     static CHMUrlTable * open( LVContainerRef container ) {
-        LVStreamRef stream = container->OpenStream(L"#URLTBL", LVOM_READ);
+        LVStreamRef stream = container->OpenStream(U"#URLTBL", LVOM_READ);
         if ( stream.isNull() )
             return NULL;
         CHMUrlTable * res = new CHMUrlTable( container, stream );
@@ -618,7 +618,7 @@ public:
         return NULL;
     }
 
-    void getUrlList( lString16Collection & urlList ) {
+    void getUrlList( lString32Collection & urlList ) {
         if ( !_strings )
             return;
         _strings->getUrlList( urlList );
@@ -649,8 +649,8 @@ class CHMSystem {
     bool _hasALinks;
     lUInt32 _binaryIndexURLTableId;
     lUInt32 _binaryTOCURLTableId;
-    const lChar16 * _enc_table;
-    lString16 _enc_name;
+    const lChar32 * _enc_table;
+    lString32 _enc_name;
     CHMUrlTable * _urlTable;
 
     CHMSystem( LVContainerRef container, LVStreamRef stream ) : _container(container), _reader(stream)
@@ -692,12 +692,12 @@ class CHMSystem {
             {
                 _lcid = _reader.readInt32(err);
                 int codepage = langToCodepage( _lcid );
-                const lChar16 * enc_name = GetCharsetName( codepage );
-                const lChar16 * table = GetCharsetByte2UnicodeTable( codepage );
+                const lChar32 * enc_name = GetCharsetName( codepage );
+                const lChar32 * table = GetCharsetByte2UnicodeTable( codepage );
 		_language = langToLanguage( _lcid );
                 if ( enc_name!=NULL ) {
                     _enc_table = table;
-                    _enc_name = lString16(enc_name);
+                    _enc_name = lString32(enc_name);
                     CRLog::info("CHM LCID: %08x, charset=%s", _lcid, LCSTR(_enc_name));
                 } else {
                     CRLog::info("CHM LCID: %08x -- cannot find charset encoding table", _lcid);
@@ -728,23 +728,23 @@ class CHMSystem {
                 for ( int i=_defaultFont.length()-1; i>0; i-- ) {
                     if ( _defaultFont[i]==',' ) {
                         int cs = _defaultFont.substr(i+1, _defaultFont.length()-i-1).atoi();
-                        const lChar16 * cpname = NULL;
+                        const lChar32 * cpname = NULL;
                         switch (cs) {
-                        case 0x00: cpname = L"windows-1252"; break;
-                        case 0xCC: cpname = L"windows-1251"; break;
-                        case 0xEE: cpname = L"windows-1250"; break;
-                        case 0xA1: cpname = L"windows-1253"; break;
-                        case 0xA2: cpname = L"windows-1254"; break;
-                        case 0xBA: cpname = L"windows-1257"; break;
-                        case 0xB1: cpname = L"windows-1255"; break;
-                        case 0xB2: cpname = L"windows-1256"; break;
+                        case 0x00: cpname = U"windows-1252"; break;
+                        case 0xCC: cpname = U"windows-1251"; break;
+                        case 0xEE: cpname = U"windows-1250"; break;
+                        case 0xA1: cpname = U"windows-1253"; break;
+                        case 0xA2: cpname = U"windows-1254"; break;
+                        case 0xBA: cpname = U"windows-1257"; break;
+                        case 0xB1: cpname = U"windows-1255"; break;
+                        case 0xB2: cpname = U"windows-1256"; break;
                         default: break;
                         }
-                        const lChar16 * table = GetCharsetByte2UnicodeTable( cpname );
+                        const lChar32 * table = GetCharsetByte2UnicodeTable( cpname );
                         if ( cpname!=NULL && table!=NULL ) {
-                            CRLog::info("CHM charset detected from default font: %s", LCSTR(lString16(cpname)));
+                            CRLog::info("CHM charset detected from default font: %s", LCSTR(lString32(cpname)));
                             _enc_table = table;
-                            _enc_name = lString16(cpname);
+                            _enc_name = lString32(cpname);
                         }
                         break;
                     }
@@ -774,7 +774,7 @@ class CHMSystem {
         }
         if ( _enc_table==NULL ) {
             _enc_table = GetCharsetByte2UnicodeTable( 1252 );
-            _enc_name = cs16("windows-1252");
+            _enc_name = cs32("windows-1252");
         }
         _urlTable = CHMUrlTable::open(_container);
         return !err;
@@ -787,7 +787,7 @@ public:
     }
 
     static CHMSystem * open( LVContainerRef container ) {
-        LVStreamRef stream = container->OpenStream(L"#SYSTEM", LVOM_READ);
+        LVStreamRef stream = container->OpenStream(U"#SYSTEM", LVOM_READ);
         if ( stream.isNull() )
             return NULL;
         CHMSystem * res = new CHMSystem( container, stream );
@@ -798,42 +798,42 @@ public:
         return res;
     }
 
-    lString16 decodeString( const lString8 & str ) {
+    lString32 decodeString( const lString8 & str ) {
         return ByteToUnicode( str, _enc_table );
     }
 
-    lString16 getTitle() {
+    lString32 getTitle() {
         return decodeString(_title);
     }
 
-    lString16 getLanguage() {
+    lString32 getLanguage() {
         return decodeString(_language);
     }
 
-    lString16 getDefaultTopic() {
+    lString32 getDefaultTopic() {
         return decodeString(_defaultTopic);
     }
 
-    lString16 getEncodingName() {
+    lString32 getEncodingName() {
         return _enc_name;
     }
 
-    lString16 getContentsFileName() {
+    lString32 getContentsFileName() {
         if ( _binaryTOCURLTableId!=0 ) {
             lString8 url = _urlTable->urlById(_binaryTOCURLTableId);
             if ( !url.empty() )
                 return decodeString(url);
         }
         if ( _contentsFile.empty() ) {
-            lString16 hhcName;
+            lString32 hhcName;
             int bestSize = 0;
             for ( int i=0; i<_container->GetObjectCount(); i++ ) {
                 const LVContainerItemInfo * item = _container->GetObjectInfo(i);
                 if ( !item->IsContainer() ) {
-                    lString16 name = item->GetName();
+                    lString32 name = item->GetName();
                     int sz = item->GetSize();
                     //CRLog::trace("CHM item: %s", LCSTR(name));
-                    lString16 lname = name;
+                    lString32 lname = name;
                     lname.lowercase();
                     if ( lname.endsWith(".hhc") ) {
                         if ( sz > bestSize ) {
@@ -848,14 +848,14 @@ public:
         }
         return decodeString(_contentsFile);
     }
-    void getUrlList( lString16Collection & urlList ) {
+    void getUrlList( lString32Collection & urlList ) {
         if ( !_urlTable )
             return;
         _urlTable->getUrlList(urlList);
     }
 };
 
-ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString16 defEncodingName )
+ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingName )
 {
     if ( stream.isNull() )
         return NULL;
@@ -867,15 +867,15 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString16 defEncodingNa
     ldomDocument * encDetectionDoc = LVParseHTMLStream( stream );
     int encoding = 0;
     if ( encDetectionDoc!=NULL ) {
-        ldomNode * node = encDetectionDoc->nodeFromXPath(L"/html/body/object[1]");
+        ldomNode * node = encDetectionDoc->nodeFromXPath(U"/html/body/object[1]");
         if ( node!=NULL ) {
             for ( int i=0; i<node->getChildCount(); i++ ) {
                 ldomNode * child = node->getChildNode(i);
-                if (child && child->isElement() && child->getNodeName() == "param" && child->getAttributeValue(L"name") == "Font") {
-                    lString16 s = child->getAttributeValue(L"value");
-                    lString16 lastDigits;
+                if (child && child->isElement() && child->getNodeName() == "param" && child->getAttributeValue(U"name") == "Font") {
+                    lString32 s = child->getAttributeValue(U"value");
+                    lString32 lastDigits;
                     for ( int i=s.length()-1; i>=0; i-- ) {
-                        lChar16 ch = s[i];
+                        lChar32 ch = s[i];
                         if ( ch>='0' && ch<='9' )
                             lastDigits.insert(0, 1, ch);
                         else
@@ -888,9 +888,9 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString16 defEncodingNa
         }
         delete encDetectionDoc;
     }
-    const lChar16 * enc = L"cp1252";
+    const lChar32 * enc = U"cp1252";
     if ( encoding==1 ) {
-        enc = L"cp1251";
+        enc = U"cp1251";
     }
 #endif
 
@@ -920,9 +920,9 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString16 defEncodingNa
     return doc;
 }
 
-static int filename_comparator(lString16 & _s1, lString16 & _s2) {
-    lString16 s1 = _s1.substr(1);
-    lString16 s2 = _s2.substr(1);
+static int filename_comparator(lString32 & _s1, lString32 & _s2) {
+    lString32 s1 = _s1.substr(1);
+    lString32 s2 = _s2.substr(1);
     if (s1.endsWith(".htm"))
         s1.erase(s1.length()-4, 4);
     else if (s1.endsWith(".html"))
@@ -964,9 +964,9 @@ class CHMTOCReader {
     ldomDocumentFragmentWriter * _appender;
     ldomDocument * _doc;
     LVTocItem * _toc;
-    lString16HashedCollection _fileList;
-    lString16 lastFile;
-    lString16 _defEncodingName;
+    lString32HashedCollection _fileList;
+    lString32 lastFile;
+    lString32 _defEncodingName;
     bool _fakeToc;
 public:
     CHMTOCReader( LVContainerRef cont, ldomDocument * doc, ldomDocumentFragmentWriter * appender )
@@ -974,27 +974,27 @@ public:
     {
         _toc = _doc->getToc();
     }
-    void addFile( const lString16 & v1 ) {
+    void addFile( const lString32 & v1 ) {
         int index = _fileList.find(v1.c_str());
         if ( index>=0 )
             return; // already added
         _fileList.add(v1.c_str());
         CRLog::trace("New source file: %s", LCSTR(v1) );
-        _appender->addPathSubstitution( v1, cs16("_doc_fragment_") + fmt::decimal(_fileList.length()) );
+        _appender->addPathSubstitution( v1, cs32("_doc_fragment_") + fmt::decimal(_fileList.length()) );
         _appender->setCodeBase( v1 );
     }
 
-    void addTocItem( lString16 name, lString16 url, int level )
+    void addTocItem( lString32 name, lString32 url, int level )
     {
         //CRLog::trace("CHM toc level %d: '%s' : %s", level, LCSTR(name), LCSTR(url) );
         if (url.startsWith(".."))
             url = LVExtractFilename( url );
-        lString16 v1, v2;
-        if ( !url.split2(cs16("#"), v1, v2) )
+        lString32 v1, v2;
+        if ( !url.split2(cs32("#"), v1, v2) )
             v1 = url;
         PreProcessXmlString( name, 0 );
         addFile(v1);
-        lString16 url2 = _appender->convertHref(url);
+        lString32 url2 = _appender->convertHref(url);
         //CRLog::trace("new url: %s", LCSTR(url2) );
         while ( _toc->getLevel()>level && _toc->getParent() )
             _toc = _toc->getParent();
@@ -1003,19 +1003,19 @@ public:
 
     void recurseToc( ldomNode * node, int level )
     {
-        lString16 nodeName = node->getNodeName();
-        lUInt16 paramElemId = node->getDocument()->getElementNameIndex(L"param");
+        lString32 nodeName = node->getNodeName();
+        lUInt16 paramElemId = node->getDocument()->getElementNameIndex(U"param");
         if (nodeName == "object") {
             if ( level>0 ) {
                 // process object
                 if (node->getAttributeValue("type") == "text/sitemap") {
-                    lString16 name, local;
+                    lString32 name, local;
                     int cnt = node->getChildCount();
                     for ( int i=0; i<cnt; i++ ) {
                         ldomNode * child = node->getChildElementNode(i, paramElemId);
                         if ( child ) {
-                            lString16 paramName = child->getAttributeValue("name");
-                            lString16 paramValue = child->getAttributeValue("value");
+                            lString32 paramName = child->getAttributeValue("name");
+                            lString32 paramValue = child->getAttributeValue("value");
                             if (paramName == "Name")
                                 name = paramValue;
                             else if (paramName == "Local")
@@ -1041,15 +1041,15 @@ public:
         }
     }
 
-    bool init( LVContainerRef cont, lString16 hhcName, lString16 defEncodingName, lString16Collection & urlList, lString16 mainPageName )
+    bool init( LVContainerRef cont, lString32 hhcName, lString32 defEncodingName, lString32Collection & urlList, lString32 mainPageName )
     {
         if ( hhcName.empty() && urlList.length()==0 ) {
-            lString16Collection htms;
+            lString32Collection htms;
             for (int i=0; i<cont->GetObjectCount(); i++) {
                 const LVContainerItemInfo * item = cont->GetObjectInfo(i);
                 if (item->IsContainer())
                     continue;
-                lString16 name = item->GetName();
+                lString32 name = item->GetName();
                 if (name == "/bookindex.htm" || name == "/headerindex.htm")
                     continue;
                 //CRLog::trace("item %d : %s", i, LCSTR(name));
@@ -1079,8 +1079,8 @@ public:
         if ( hhcName.empty() ) {
             _fakeToc = true;
             for ( int i=0; i<urlList.length(); i++ ) {
-                //lString16 name = lString16::itoa(i+1);
-                lString16 name = urlList[i];
+                //lString32 name = lString32::itoa(i+1);
+                lString32 name = urlList[i];
                 if ( name.endsWith(".htm") )
                     name = name.substr(0, name.length()-4);
                 else if ( name.endsWith(".html") )
@@ -1104,19 +1104,19 @@ public:
             }
 
     #if DUMP_CHM_DOC==1
-        LVStreamRef out = LVOpenFileStream(L"/tmp/chm-toc.html", LVOM_WRITE);
+        LVStreamRef out = LVOpenFileStream(U"/tmp/chm-toc.html", LVOM_WRITE);
         if ( !out.isNull() )
             doc->saveToStream( out, NULL, true );
     #endif
 
-            ldomNode * body = doc->getRootNode(); //doc->createXPointer(cs16("/html[1]/body[1]"));
+            ldomNode * body = doc->getRootNode(); //doc->createXPointer(cs32("/html[1]/body[1]"));
             bool res = false;
             if ( body->isElement() ) {
                 // body element
                 recurseToc( body, 0 );
                 // add rest of pages
                 for ( int i=0; i<urlList.length(); i++ ) {
-                    lString16 name = urlList[i];
+                    lString32 name = urlList[i];
                     if ( name.endsWith(".htm") || name.endsWith(".html") )
                         addFile(name);
                 }
@@ -1125,7 +1125,7 @@ public:
                 while ( _toc && _toc->getParent() )
                     _toc = _toc->getParent();
                 if ( res && _toc && _toc->getChildCount()>0 ) {
-                    lString16 name = _toc->getChild(0)->getName();
+                    lString32 name = _toc->getChild(0)->getName();
                     CRPropRef m_doc_props = _doc->getProps();
                     m_doc_props->setString(DOC_PROP_TITLE, name);
                 }
@@ -1150,7 +1150,7 @@ public:
                     lastProgressPercent = percent;
                 }
             }
-            lString16 fname = _fileList[i];
+            lString32 fname = _fileList[i];
             CRLog::trace("Import file %s", LCSTR(fname));
             LVStreamRef stream = _cont->OpenStream(fname.c_str(), LVOM_READ);
             if ( stream.isNull() )
@@ -1192,14 +1192,14 @@ bool ImportCHMDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     CHMSystem * chm = CHMSystem::open(cont);
     if ( !chm )
         return false;
-    lString16 tocFileName = chm->getContentsFileName();
-    lString16 defEncodingName = chm->getEncodingName();
-    lString16 mainPageName = chm->getDefaultTopic();
-    lString16 title = chm->getTitle();
-    lString16 language = chm->getLanguage();
+    lString32 tocFileName = chm->getContentsFileName();
+    lString32 defEncodingName = chm->getEncodingName();
+    lString32 mainPageName = chm->getDefaultTopic();
+    lString32 title = chm->getTitle();
+    lString32 language = chm->getLanguage();
     CRLog::info("CHM: toc=%s, enc=%s, title=%s", LCSTR(tocFileName), LCSTR(defEncodingName), LCSTR(title));
     //
-    lString16Collection urlList;
+    lString32Collection urlList;
     chm->getUrlList(urlList);
     delete chm;
 
@@ -1207,8 +1207,8 @@ bool ImportCHMDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     ldomDocumentWriterFilter writer(doc, false, HTML_AUTOCLOSE_TABLE);
     //ldomDocumentWriter writer(doc);
     writer.OnStart(NULL);
-    writer.OnTagOpenNoAttr(L"", L"body");
-    ldomDocumentFragmentWriter appender(&writer, cs16("body"), cs16("DocFragment"), lString16::empty_str );
+    writer.OnTagOpenNoAttr(U"", U"body");
+    ldomDocumentFragmentWriter appender(&writer, cs32("body"), cs32("DocFragment"), lString32::empty_str );
     CHMTOCReader tocReader(cont, doc, &appender);
     if ( !tocReader.init(cont, tocFileName, defEncodingName, urlList, mainPageName) )
         return false;
@@ -1219,11 +1219,11 @@ bool ImportCHMDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
         doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
 
     fragmentCount = tocReader.appendFragments( progressCallback );
-    writer.OnTagClose(L"", L"body");
+    writer.OnTagClose(U"", U"body");
     writer.OnStop();
     CRLog::debug("CHM: %d documents merged", fragmentCount);
 #if DUMP_CHM_DOC==1
-    LVStreamRef out = LVOpenFileStream(L"/tmp/chm.html", LVOM_WRITE);
+    LVStreamRef out = LVOpenFileStream(U"/tmp/chm.html", LVOM_WRITE);
     if ( !out.isNull() )
         doc->saveToStream( out, NULL, true );
 #endif

--- a/crengine/src/crgui.cpp
+++ b/crengine/src/crgui.cpp
@@ -85,7 +85,7 @@ const char * cr_default_skin =
 "  </menu>\n"
 "</CR3Skin>\n";
 
-bool CRGUIWindowManager::loadSkin( lString16 pathname )
+bool CRGUIWindowManager::loadSkin( lString32 pathname )
 {
     CRSkinRef skin;
     if ( !pathname.empty() )
@@ -129,24 +129,24 @@ bool CRGUIAcceleratorTable::add( int keyCode, int keyFlags, int commandId, int c
     return true;
 }
 
-CRGUIAcceleratorTableRef CRGUIAcceleratorTableList::get( const lString16 & name, CRPropRef keyRemappingOptions )
+CRGUIAcceleratorTableRef CRGUIAcceleratorTableList::get( const lString32 & name, CRPropRef keyRemappingOptions )
 {
     CRGUIAcceleratorTableRef prev = get(name);
     if ( !prev )
         return prev;
-    CRPropRef keymaps = keyRemappingOptions->getSubProps(LCSTR(cs16("keymap.") + name + "."));
+    CRPropRef keymaps = keyRemappingOptions->getSubProps(LCSTR(cs32("keymap.") + name + "."));
     if ( keymaps.isNull() || keymaps->getCount()==0 )
         return prev;
     CRGUIAcceleratorTableRef acc( new CRGUIAcceleratorTable( *prev ));
     for ( int i=0; i<keymaps->getCount(); i++ ) {
-        lString16 name( keymaps->getName(i) );
-        lString16 value = keymaps->getValue(i);
+        lString32 name( keymaps->getName(i) );
+        lString32 value = keymaps->getValue(i);
 //        CRLog::trace("Override key map: %s -> %s", LCSTR(name), LCSTR(value) );
         int key, flags;
         int cmd, params;
-        if ( !splitIntegerList( name, cs16("."), key, flags ))
+        if ( !splitIntegerList( name, cs32("."), key, flags ))
             continue;
-        if ( !splitIntegerList( value, cs16(","), cmd, params ))
+        if ( !splitIntegerList( value, cs32(","), cmd, params ))
             continue;
         acc->add(key, flags, cmd, params);
     }
@@ -156,9 +156,9 @@ CRGUIAcceleratorTableRef CRGUIAcceleratorTableList::get( const lString16 & name,
 /// add all tables
 void CRGUIAcceleratorTableList::addAll( const CRGUIAcceleratorTableList & v )
 {
-	LVHashTable<lString16, CRGUIAcceleratorTableRef>::iterator i( v._table );
+	LVHashTable<lString32, CRGUIAcceleratorTableRef>::iterator i( v._table );
 	for ( ;; ) {
-		LVHashTable<lString16, CRGUIAcceleratorTableRef>::pair * p = i.next();
+		LVHashTable<lString32, CRGUIAcceleratorTableRef>::pair * p = i.next();
 		if ( !p )
 			break;
 		CRGUIAcceleratorTableRef t = _table.get( p->key );
@@ -439,7 +439,7 @@ bool CRGUIWindowManager::handleEvent( CRGUIEvent * event )
 static bool firstWaitUpdate = true;
 
 /// draws icon at center of screen
-void CRGUIWindowManager::showWaitIcon( lString16 filename, int progressPercent )
+void CRGUIWindowManager::showWaitIcon( lString32 filename, int progressPercent )
 {
     LVImageSourceRef img = _skin->getImage( filename );
     if ( !img.isNull() ) {
@@ -451,7 +451,7 @@ void CRGUIWindowManager::showWaitIcon( lString16 filename, int progressPercent )
         _screen->getCanvas()->Draw( img, x, y, dx, dy, true );
         int gaugeH = 0;
         if ( progressPercent>=0 && progressPercent<=100 ) {
-            CRScrollSkinRef skin = _skin->getScrollSkin(L"#progress");
+            CRScrollSkinRef skin = _skin->getScrollSkin(U"#progress");
             if ( !skin.isNull() ) {
                 CRLog::trace("Drawing gauge %d%%", progressPercent);
                 gaugeH = 16;
@@ -469,7 +469,7 @@ void CRGUIWindowManager::showWaitIcon( lString16 filename, int progressPercent )
 
 #define PROGRESS_UPDATE_INTERVAL 5
 /// draws icon at center of screen, with optional progress gauge
-void CRGUIWindowManager::showProgress( lString16 filename, int progressPercent )
+void CRGUIWindowManager::showProgress( lString32 filename, int progressPercent )
 {
     time_t t = (time_t)time((time_t*)0);
     if ( t<_lastProgressUpdate+PROGRESS_UPDATE_INTERVAL || progressPercent==_lastProgressPercent )
@@ -589,9 +589,9 @@ bool CRGUIWindowBase::getClientRect( lvRect & rc )
 }
 
 /// formats scroll label (like "1 of 2")
-lString16 CRGUIWindowBase::getScrollLabel( int page, int pages )
+lString32 CRGUIWindowBase::getScrollLabel( int page, int pages )
 {
-    return lString16::itoa(page) << " of " << fmt::decimal(pages);
+    return lString32::itoa(page) << " of " << fmt::decimal(pages);
 }
 
 /// calculates minimum scroll size
@@ -608,7 +608,7 @@ lvPoint CRGUIWindowBase::getMinScrollSize( int page, int pages )
         int h = sf.isNull() ? sskin->getFontSize() : sf->getHeight();
         int w = 0;
         bool noData = sskin->getAutohide() && pages<=1;
-        lString16 label = getScrollLabel( page, pages );
+        lString32 label = getScrollLabel( page, pages );
         if ( !label.empty() )
             w = sskin->getFont()->getTextWidth(label.c_str(), label.length());
         if ( !sskin->getBottomTabSkin().isNull() ) {
@@ -929,10 +929,10 @@ void CRMenuItem::Draw( LVDrawBuf & buf, lvRect & rc, CRRectSkinRef skin, CRRectS
     lvRect textRect = rc;
     textRect.left += imgWidth;
 
-    lString16 s1;
-    lString16 s2;
+    lString32 s1;
+    lString32 s2;
     lvRect valueRect = textRect;
-    if ( _label.split2(cs16("\t"), s1, s2 ) ) {
+    if ( _label.split2(cs32("\t"), s1, s2 ) ) {
         //valueSkin->drawText( buf, textRect, s2 );
     } else {
         s1 = _label;
@@ -1011,7 +1011,7 @@ void CRMenu::Draw( LVDrawBuf & buf, lvRect & rc, CRRectSkinRef skin, CRRectSkinR
     textRect.left += imgWidth;
     //textRect.shrinkBy( itemBorders );
 
-    lString16 s = getSubmenuValue();
+    lString32 s = getSubmenuValue();
     lvRect valueRect = textRect;
     if ( !s.empty() ) {
         if ( valueSkin.isNull() ) {
@@ -1034,7 +1034,7 @@ void CRMenu::Draw( LVDrawBuf & buf, lvRect & rc, CRRectSkinRef skin, CRRectSkinR
             rc2.top += rc2.height()*3/8;
             int hh = rc2.height();
             buf.SetTextColor( skin->getTextColor() );
-            _valueFont->DrawTextString( &buf, rc2.right - w - ITEM_MARGIN, rc2.top + hh/2 - _valueFont->getHeight()/2, s.c_str(), s.length(), L'?', NULL, false, 0 );
+            _valueFont->DrawTextString( &buf, rc2.right - w - ITEM_MARGIN, rc2.top + hh/2 - _valueFont->getHeight()/2, s.c_str(), s.length(), U'?', NULL, false, 0 );
         } else {
             valueSkin->drawText( buf, valueRect, s );
         }
@@ -1076,10 +1076,10 @@ CRMenuSkinRef CRMenu::getSkin()
 {
     if ( !_skin.isNull() )
         return _skin;
-    lString16 path = getSkinName();
-    lString16 path2;
+    lString32 path = getSkinName();
+    lString32 path2;
     if (!path.startsWith("#"))
-        path = cs16("/CR3Skin/") + path;
+        path = cs32("/CR3Skin/") + path;
     else if ( _wm->getScreenOrientation()&1 )
         _skin = _wm->getSkin()->getMenuSkin( (path + "-rotated").c_str() );
     if ( !_skin )
@@ -1097,7 +1097,7 @@ lvPoint CRMenu::getItemSize()
         return sz;
     int maxw = 0;
     for ( int i=0; i<_items.length(); i++ ) {
-        lString16 s = _items[i]->getLabel();
+        lString32 s = _items[i]->getLabel();
         int w = _valueFont->getTextWidth( s.c_str(), s.length() );
         if ( w > maxw )
             maxw = w;
@@ -1195,25 +1195,25 @@ lvPoint CRMenu::getSize()
     return res;
 }
 
-lString16 CRMenu::getSubmenuValue()
+lString32 CRMenu::getSubmenuValue()
 {
     if ( !isSubmenu() || _propName.empty() || _props.isNull() )
-        return lString16::empty_str;
-    lString16 value = getProps()->getStringDef(
+        return lString32::empty_str;
+    lString32 value = getProps()->getStringDef(
                                UnicodeToUtf8(getPropName()).c_str(), "");
     for ( int i=0; i<_items.length(); i++ ) {
         if ( !_items[i]->getPropValue().empty() &&
                 value==(_items[i]->getPropValue()) )
             return _items[i]->getLabel();
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 void CRMenu::toggleSubmenuValue()
 {
     if ( !isSubmenu() || _propName.empty() || _props.isNull() )
         return;
-    lString16 value = getProps()->getStringDef(
+    lString32 value = getProps()->getStringDef(
                                UnicodeToUtf8(getPropName()).c_str(), "");
     for ( int i=0; i<_items.length(); i++ ) {
         if ( !_items[i]->getPropValue().empty() &&
@@ -1395,7 +1395,7 @@ void CRMenu::drawClient()
             numberRc.right = numberRc.left + shortcutSize;
 
             ss->draw( buf, numberRc );
-            lString16 number = index<9 ? lString16::itoa( index+1 ) : L"0";
+            lString32 number = index<9 ? lString32::itoa( index+1 ) : U"0";
             buf.SetTextColor( ss->getTextColor() );
             buf.SetBackgroundColor( ss->getBackgroundColor() );
             ss->drawText( buf, numberRc, number );
@@ -1696,7 +1696,7 @@ void CRMenu::draw()
 	}
 }
 
-static bool readNextLine( const LVStreamRef & stream, lString16 & dst )
+static bool readNextLine( const LVStreamRef & stream, lString32 & dst )
 {
     lString8 line;
     bool flgComment = false;
@@ -1725,7 +1725,7 @@ static bool readNextLine( const LVStreamRef & stream, lString16 & dst )
     return false;
 }
 
-static bool splitLine( lString16 line, const lString16 & delimiter, lString16 & key, lString16 & value )
+static bool splitLine( lString32 line, const lString32 & delimiter, lString32 & key, lString32 & value )
 {
     if ( !line.empty() ) {
         int n = line.pos(delimiter);
@@ -1742,13 +1742,13 @@ static bool splitLine( lString16 line, const lString16 & delimiter, lString16 & 
     return false;
 }
 
-static int decodeKey( lString16 name )
+static int decodeKey( lString32 name )
 {
     name.trim();
     if ( name.empty() )
         return 0;
     int key = 0;
-    lChar16 ch0 = name[0];
+    lChar32 ch0 = name[0];
     if ( ch0 >= '0' && ch0 <= '9' )
         return name.atoi();
     if ( ch0=='-' && name.length()>=2 && name[1] >= '0' && name[1] <= '9' )
@@ -1759,7 +1759,7 @@ static int decodeKey( lString16 name )
         key = name[0];
     if ( key == 0 && name.length()>=4 && name[0]=='0' && name[1]=='x' ) {
         for ( int i=2; i<name.length(); i++ ) {
-            lChar16 ch = name[i];
+            lChar32 ch = name[i];
             if ( ch>='0' && ch<='9' )
                 key = key*16 + (ch-'0');
             else if ( ch>='a' && ch<='f' )
@@ -1776,7 +1776,7 @@ static int decodeKey( lString16 name )
 bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char * mapFile )
 {
     _table.clear();
-    LVHashTable<lString16, int> defs( 256 );
+    LVHashTable<lString32, int> defs( 256 );
     LVStreamRef defStream = LVOpenFileStream( defFile, LVOM_READ );
     if ( defStream.isNull() ) {
         CRLog::error( "cannot open keymap def file %s", defFile );
@@ -1787,12 +1787,12 @@ bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char 
         CRLog::error( "cannot open keymap file %s", defFile );
         return false;
     }
-    lString16 line;
+    lString32 line;
     CRPropRef props = LVCreatePropsContainer();
     while ( readNextLine(defStream, line) ) {
-        lString16 name;
-        lString16 value;
-        if ( splitLine( line, cs16("="), name, value ) )  {
+        lString32 name;
+        lString32 value;
+        if ( splitLine( line, cs32("="), name, value ) )  {
             int key = decodeKey( value );
             if ( key!=0 )
                 defs.set( name, key );
@@ -1806,7 +1806,7 @@ bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char 
         return false;
 
     }
-    lString16 section;
+    lString32 section;
     CRGUIAcceleratorTableRef table( new CRGUIAcceleratorTable() );
     bool eof = false;
     do {
@@ -1823,7 +1823,7 @@ bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char 
             // begin new section
             if ( !eof ) {
                 table = CRGUIAcceleratorTableRef( new CRGUIAcceleratorTable() );
-                int endbracket = line.pos( cs16("]") );
+                int endbracket = line.pos( cs32("]") );
                 if ( endbracket<=0 )
                     endbracket = line.length();
                 if ( endbracket >= 2 )
@@ -1833,14 +1833,14 @@ bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char 
             }
         } else if ( !section.empty() ) {
             // read definition
-            lString16 name;
-            lString16 value;
-            if ( splitLine( line, cs16("="), name, value ) ) {
+            lString32 name;
+            lString32 value;
+            if ( splitLine( line, cs32("="), name, value ) ) {
                 int flag = 0;
                 int key = 0;
-                lString16 keyName;
-                lString16 flagName;
-                splitLine( name, cs16(","), keyName, flagName );
+                lString32 keyName;
+                lString32 flagName;
+                splitLine( name, cs32(","), keyName, flagName );
                 if ( !flagName.empty() ) {
                     flag = decodeKey( flagName );
                     if ( !flag )
@@ -1856,9 +1856,9 @@ bool CRGUIAcceleratorTableList::openFromFile( const char  * defFile, const char 
                 }
                 int cmd = 0;
                 int cmdParam = 0;
-                lString16 cmdName;
-                lString16 paramName;
-                splitLine( value, cs16(","), cmdName, paramName );
+                lString32 cmdName;
+                lString32 paramName;
+                splitLine( value, cs32(","), cmdName, paramName );
                 if ( !paramName.empty() ) {
                     cmdParam = decodeKey( paramName );
                     if ( !cmdParam )
@@ -1886,7 +1886,7 @@ CRKeyboardLayoutRef CRKeyboardLayoutList::getCurrentLayout()
 {
 	if ( !_current.isNull() )
 		return _current;
-    _current = get(cs16("english"));
+    _current = get(cs32("english"));
 	if ( !_current )
 		nextLayout();
 	return _current;
@@ -1900,9 +1900,9 @@ CRKeyboardLayoutRef CRKeyboardLayoutList::prevLayout()
 	CRKeyboardLayoutRef next;
 	CRKeyboardLayoutRef first;
 	CRKeyboardLayoutRef last;
-	LVHashTable<lString16, CRKeyboardLayoutRef>::iterator i( _table );
+	LVHashTable<lString32, CRKeyboardLayoutRef>::iterator i( _table );
 	for ( ;; ) {
-		LVHashTable<lString16, CRKeyboardLayoutRef>::pair * item = i.next();
+		LVHashTable<lString32, CRKeyboardLayoutRef>::pair * item = i.next();
 		if ( !item )
 			break;
 		if ( first.isNull() )
@@ -1933,9 +1933,9 @@ CRKeyboardLayoutRef CRKeyboardLayoutList::nextLayout()
 	CRKeyboardLayoutRef next;
 	CRKeyboardLayoutRef first;
 	CRKeyboardLayoutRef last;
-	LVHashTable<lString16, CRKeyboardLayoutRef>::iterator i( _table );
+	LVHashTable<lString32, CRKeyboardLayoutRef>::iterator i( _table );
 	for ( ;; ) {
-		LVHashTable<lString16, CRKeyboardLayoutRef>::pair * item = i.next();
+		LVHashTable<lString32, CRKeyboardLayoutRef>::pair * item = i.next();
 		if ( !item )
 			break;
 		if ( first.isNull() )
@@ -1966,8 +1966,8 @@ bool CRKeyboardLayoutList::openFromFile( const char  * layoutFile )
         CRLog::error( "cannot open keyboard layout file %s", layoutFile );
         return false;
     }
-    lString16 line;
-    lString16 section;
+    lString32 line;
+    lString32 section;
 	CRKeyboardLayoutRef table;
 	LVRef<CRKeyboardLayout> layout;
     bool eof = false;
@@ -1984,16 +1984,16 @@ bool CRKeyboardLayoutList::openFromFile( const char  * layoutFile )
             }
             // begin new section
             if ( !eof ) {
-                int endbracket = line.pos( cs16("]") );
+                int endbracket = line.pos( cs32("]") );
                 if ( endbracket<=0 )
                     endbracket = line.length();
                 if ( endbracket >= 2 )
                     section = line.substr( 1, endbracket - 1 );
                 else
                     section.clear(); // wrong sectino
-				lString16 langname;
-				lString16 layouttype;
-                if ( !section.empty() && splitLine( section, cs16("."), langname, layouttype ) ) {
+				lString32 langname;
+				lString32 layouttype;
+                if ( !section.empty() && splitLine( section, cs32("."), langname, layouttype ) ) {
 					table = _table.get( langname );
 					if ( table.isNull() ) {
 						table = CRKeyboardLayoutRef( new CRKeyboardLayoutSet() );
@@ -2008,11 +2008,11 @@ bool CRKeyboardLayoutList::openFromFile( const char  * layoutFile )
             }
         } else if ( !section.empty() ) {
             // read definition
-            lString16 name;
-            lString16 value;
-            if ( splitLine( line, cs16("="), name, value ) ) {
+            lString32 name;
+            lString32 value;
+            if ( splitLine( line, cs32("="), name, value ) ) {
                 if (name == "enabled") {
-					//if ( value == L"0" )
+					//if ( value == U"0" )
 					//	; //TODO:set disabled flag
 					continue;
 				}

--- a/crengine/src/cri18n.cpp
+++ b/crengine/src/cri18n.cpp
@@ -62,7 +62,7 @@ const lString8 CRI18NTranslator::translate8( const char * src )
 	return lString8( translate( src ) );
 }
 
-const lString16 CRI18NTranslator::translate16( const char * src )
+const lString32 CRI18NTranslator::translate32( const char * src )
 {
 	return Utf8ToUnicode( translate8( src ) );
 }
@@ -117,7 +117,7 @@ static void reverse( lUInt32 & n )
 
 #define MO_MAGIC_NUMBER 0x950412de
 #define MO_MAGIC_NUMBER_REV 0xde120495
-bool CRMoFileTranslator::openMoFile( lString16 fileName )
+bool CRMoFileTranslator::openMoFile( lString32 fileName )
 {
 	LVStreamRef stream = LVOpenFileStream( fileName.c_str(), LVOM_READ );
 	if ( stream.isNull() ) {

--- a/crengine/src/crskin.cpp
+++ b/crengine/src/crskin.cpp
@@ -60,7 +60,7 @@ lvPoint fromSkinPercent( lvPoint pt, lvPoint fullpt )
 }
 
 /// encodes percent value*100 (0..10000), to store in skin, from string like "75%" or "10"
-int toSkinPercent( const lString16 & value, int defValue, bool * res )
+int toSkinPercent( const lString32 & value, int defValue, bool * res )
 {
     // "75%" format - in percent
     int p = value.pos("%");
@@ -90,7 +90,7 @@ int toSkinPercent( const lString16 & value, int defValue, bool * res )
     return defValue;
 }
 
-CRPageSkinRef CRPageSkinList::findByName( const lString16 & name )
+CRPageSkinRef CRPageSkinList::findByName( const lString32 & name )
 {
     for ( int i=0; i<length(); i++ ) {
         if ( get(i)->getName()==name )
@@ -245,20 +245,20 @@ void CRIconList::draw( LVDrawBuf & buf, const lvRect & rc )
 }
 
 /// retuns path to base definition, if attribute base="#nodeid" is specified for element of path
-lString16 CRSkinContainer::getBasePath( const lChar16 * path )
+lString32 CRSkinContainer::getBasePath( const lChar32 * path )
 {
-    lString16 res;
-    ldomXPointer p = getXPointer( lString16( path ) );
+    lString32 res;
+    ldomXPointer p = getXPointer( lString32( path ) );
     if ( !p )
         return res;
     if ( !p.getNode()->isElement() )
         return res;
-    lString16 value = p.getNode()->getAttributeValue("base");
+    lString32 value = p.getNode()->getAttributeValue("base");
     if (value.empty() || value[0] != '#')
         return res;
     res = pathById( value.c_str() + 1 );
     crtrace log;
-    log << "CRSkinContainer::getBasePath( " << lString16( path ) << " ) = " << res;
+    log << "CRSkinContainer::getBasePath( " << lString32( path ) << " ) = " << res;
     return res;
 }
 
@@ -268,35 +268,35 @@ class CRSkinImpl : public CRSkinContainer
 protected:
     LVContainerRef _container;
     LVAutoPtr<ldomDocument> _doc;
-    LVCacheMap<lString16,LVImageSourceRef> _imageCache;
-    LVCacheMap<lString16,CRRectSkinRef> _rectCache;
-    LVCacheMap<lString16,CRScrollSkinRef> _scrollCache;
-    LVCacheMap<lString16,CRWindowSkinRef> _windowCache;
-    LVCacheMap<lString16,CRMenuSkinRef> _menuCache;
-    LVCacheMap<lString16,CRPageSkinRef> _pageCache;
-    LVCacheMap<lString16,CRToolBarSkinRef> _toolbarCache;
+    LVCacheMap<lString32,LVImageSourceRef> _imageCache;
+    LVCacheMap<lString32,CRRectSkinRef> _rectCache;
+    LVCacheMap<lString32,CRScrollSkinRef> _scrollCache;
+    LVCacheMap<lString32,CRWindowSkinRef> _windowCache;
+    LVCacheMap<lString32,CRMenuSkinRef> _menuCache;
+    LVCacheMap<lString32,CRPageSkinRef> _pageCache;
+    LVCacheMap<lString32,CRToolBarSkinRef> _toolbarCache;
     CRPageSkinListRef _pageSkinList;
 public:
     /// returns scroll skin by path or #id
-    virtual CRScrollSkinRef getScrollSkin( const lChar16 * path );
+    virtual CRScrollSkinRef getScrollSkin( const lChar32 * path );
     /// returns rect skin by path or #id
-    virtual CRRectSkinRef getRectSkin( const lChar16 * path );
+    virtual CRRectSkinRef getRectSkin( const lChar32 * path );
     /// returns window skin by path or #id
-    virtual CRWindowSkinRef getWindowSkin( const lChar16 * path );
+    virtual CRWindowSkinRef getWindowSkin( const lChar32 * path );
     /// returns menu skin by path or #id
-    virtual CRMenuSkinRef getMenuSkin( const lChar16 * path );
+    virtual CRMenuSkinRef getMenuSkin( const lChar32 * path );
     /// returns book page skin by path or #id
-    virtual CRPageSkinRef getPageSkin( const lChar16 * path );
+    virtual CRPageSkinRef getPageSkin( const lChar32 * path );
     /// returns book page skin list
     virtual CRPageSkinListRef getPageSkinList();
     /// return ToolBar skin by path or #id
-	virtual CRToolBarSkinRef getToolBarSkin( const lChar16 * path );
+	virtual CRToolBarSkinRef getToolBarSkin( const lChar32 * path );
     /// get DOM path by id
-    virtual lString16 pathById( const lChar16 * id );
+    virtual lString32 pathById( const lChar32 * id );
     /// gets image from container
-    virtual LVImageSourceRef getImage( const lChar16 * filename );
+    virtual LVImageSourceRef getImage( const lChar32 * filename );
     /// gets doc pointer by asolute path
-    virtual ldomXPointer getXPointer( const lString16 & xPointerStr ) { return _doc->createXPointer( xPointerStr ); }
+    virtual ldomXPointer getXPointer( const lString32 & xPointerStr ) { return _doc->createXPointer( xPointerStr ); }
     /// garbage collection
     virtual void gc()
     {
@@ -435,21 +435,21 @@ static const char *menu_shortcut_background[] = {
 
 
 typedef struct {
-    const lChar16 * filename;
+    const lChar32 * filename;
     const char * * xpm;
 } standard_image_item_t;
 
 static standard_image_item_t standard_images [] = {
-    { L"std_menu_shortcut_background.xpm", menu_shortcut_background },
-    { L"std_menu_item_background.xpm", menu_item_background },
+    { U"std_menu_shortcut_background.xpm", menu_shortcut_background },
+    { U"std_menu_item_background.xpm", menu_item_background },
     { NULL, NULL }
 };
 
 /// gets image from container
-LVImageSourceRef CRSkinImpl::getImage(  const lChar16 * filename  )
+LVImageSourceRef CRSkinImpl::getImage(  const lChar32 * filename  )
 {
     LVImageSourceRef res;
-    lString16 fn( filename );
+    lString32 fn( filename );
     if ( _imageCache.get( fn, res ) )
         return res; // found in cache
 
@@ -480,7 +480,7 @@ bool CRSkinImpl::open( LVContainerRef container )
 {
     if ( container.isNull() )
         return false;
-    LVStreamRef stream = container->OpenStream( L"cr3skin.xml", LVOM_READ );
+    LVStreamRef stream = container->OpenStream( U"cr3skin.xml", LVOM_READ );
     if ( stream.isNull() ) {
         CRLog::error("cannot open skin: cr3skin.xml not found");
         return false;
@@ -508,25 +508,25 @@ bool CRSkinImpl::open( lString8 simpleXml )
 }
 
 /// reads string value from attrname attribute of element specified by path, returns empty string if not found
-lString16 CRSkinContainer::readString( const lChar16 * path, const lChar16 * attrname, bool * res )
+lString32 CRSkinContainer::readString( const lChar32 * path, const lChar32 * attrname, bool * res )
 {
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr )
-        return lString16::empty_str;
+        return lString32::empty_str;
     if ( !ptr.getNode()->isElement() )
-        return lString16::empty_str;
-	//lString16 pnname = ptr.getNode()->getParentNode()->getNodeName();
-	//lString16 nname = ptr.getNode()->getNodeName();
-    lString16 value = ptr.getNode()->getAttributeValue(attrname);
+        return lString32::empty_str;
+	//lString32 pnname = ptr.getNode()->getParentNode()->getNodeName();
+	//lString32 nname = ptr.getNode()->getNodeName();
+    lString32 value = ptr.getNode()->getAttributeValue(attrname);
 	if ( res )
 		*res = true;
     return value;
 }
 
 /// reads string value from attrname attribute of element specified by path, returns defValue if not found
-lString16 CRSkinContainer::readString( const lChar16 * path, const lChar16 * attrname, const lString16 & defValue, bool * res )
+lString32 CRSkinContainer::readString( const lChar32 * path, const lChar32 * attrname, const lString32 & defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
 	if ( res )
@@ -535,9 +535,9 @@ lString16 CRSkinContainer::readString( const lChar16 * path, const lChar16 * att
 }
 
 /// reads color value from attrname attribute of element specified by path, returns defValue if not found
-lUInt32 CRSkinContainer::readColor( const lChar16 * path, const lChar16 * attrname, lUInt32 defValue, bool * res  )
+lUInt32 CRSkinContainer::readColor( const lChar32 * path, const lChar32 * attrname, lUInt32 defValue, bool * res  )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
     css_length_t cv;
@@ -551,13 +551,13 @@ lUInt32 CRSkinContainer::readColor( const lChar16 * path, const lChar16 * attrna
 }
 
 /// reads rect value from attrname attribute of element specified by path, returns defValue if not found
-lvRect CRSkinContainer::readRect( const lChar16 * path, const lChar16 * attrname, lvRect defValue, bool * res )
+lvRect CRSkinContainer::readRect( const lChar32 * path, const lChar32 * attrname, lvRect defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
     lvRect p = defValue;
-    lString16 s1, s2, s3, s4, s;
+    lString32 s1, s2, s3, s4, s;
     s = value;
     if ( !s.split2(",", s1, s2) )
         return p;
@@ -591,9 +591,9 @@ lvRect CRSkinContainer::readRect( const lChar16 * path, const lChar16 * attrname
 }
 
 /// reads boolean value from attrname attribute of element specified by path, returns defValue if not found
-bool CRSkinContainer::readBool( const lChar16 * path, const lChar16 * attrname, bool defValue, bool * res )
+bool CRSkinContainer::readBool( const lChar32 * path, const lChar32 * attrname, bool defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if (value.empty())
         return defValue;
     if (value == "true" || value == "yes")
@@ -606,9 +606,9 @@ bool CRSkinContainer::readBool( const lChar16 * path, const lChar16 * attrname, 
 }
 
 /// reads image transform value from attrname attribute of element specified by path, returns defValue if not found
-ImageTransform CRSkinContainer::readTransform( const lChar16 * path, const lChar16 * attrname, ImageTransform defValue, bool * res )
+ImageTransform CRSkinContainer::readTransform( const lChar32 * path, const lChar32 * attrname, ImageTransform defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
     value.lowercase();
@@ -637,9 +637,9 @@ ImageTransform CRSkinContainer::readTransform( const lChar16 * path, const lChar
 }
 
 /// reads h align value from attrname attribute of element specified by path, returns defValue if not found
-int CRSkinContainer::readHAlign( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res )
+int CRSkinContainer::readHAlign( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if (value.empty())
         return defValue;
     if (value == "left") {
@@ -662,9 +662,9 @@ int CRSkinContainer::readHAlign( const lChar16 * path, const lChar16 * attrname,
 }
 
 /// reads h align value from attrname attribute of element specified by path, returns defValue if not found
-int CRSkinContainer::readVAlign( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res )
+int CRSkinContainer::readVAlign( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if (value.empty())
         return defValue;
     if (value == "top") {
@@ -687,9 +687,9 @@ int CRSkinContainer::readVAlign( const lChar16 * path, const lChar16 * attrname,
 }
 
 /// reads int value from attrname attribute of element specified by path, returns defValue if not found
-int CRSkinContainer::readInt( const lChar16 * path, const lChar16 * attrname, int defValue, bool * res )
+int CRSkinContainer::readInt( const lChar32 * path, const lChar32 * attrname, int defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
     value.trim();
@@ -697,13 +697,13 @@ int CRSkinContainer::readInt( const lChar16 * path, const lChar16 * attrname, in
 }
 
 /// reads point(size) value from attrname attribute of element specified by path, returns defValue if not found
-lvPoint CRSkinContainer::readSize( const lChar16 * path, const lChar16 * attrname, lvPoint defValue, bool * res )
+lvPoint CRSkinContainer::readSize( const lChar32 * path, const lChar32 * attrname, lvPoint defValue, bool * res )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() )
         return defValue;
     lvPoint p = defValue;
-    lString16 s1, s2;
+    lString32 s1, s2;
     if ( !value.split2(",", s1, s2) )
         return p;
     s1.trim();
@@ -721,9 +721,9 @@ lvPoint CRSkinContainer::readSize( const lChar16 * path, const lChar16 * attrnam
 }
 
 /// reads rect value from attrname attribute of element specified by path, returns null ref if not found
-LVImageSourceRef CRSkinContainer::readImage( const lChar16 * path, const lChar16 * attrname, bool * r )
+LVImageSourceRef CRSkinContainer::readImage( const lChar32 * path, const lChar32 * attrname, bool * r )
 {
-    lString16 value = readString( path, attrname );
+    lString32 value = readString( path, attrname );
     if ( value.empty() ) {
 #ifdef TRACE_SKIN_ERRORS
         crtrace log;
@@ -745,11 +745,11 @@ LVImageSourceRef CRSkinContainer::readImage( const lChar16 * path, const lChar16
 }
 
 /// reads rect value from attrname attribute of element specified by path, returns null ref if not found
-CRIconListRef CRSkinContainer::readIcons( const lChar16 * path, bool * r )
+CRIconListRef CRSkinContainer::readIcons( const lChar32 * path, bool * r )
 {
     CRIconListRef list = CRIconListRef(new CRIconList() );
     for ( int i=1; i<16; i++ ) {
-        lString16 p = lString16(path) << "[" << fmt::decimal(i) << "]";
+        lString32 p = lString32(path) << "[" << fmt::decimal(i) << "]";
         CRIconSkin * icon = new CRIconSkin();
         if ( readIconSkin(p.c_str(), icon ) )
             list->add( CRIconSkinRef(icon) );
@@ -782,7 +782,7 @@ CRSkinRef LVOpenSimpleSkin( const lString8 & xml )
 }
 
 /// opens skin from directory or .zip file
-CRSkinRef LVOpenSkin( const lString16 & pathname )
+CRSkinRef LVOpenSkin( const lString32 & pathname )
 {
     LVContainerRef container = LVOpenDirectory( pathname.c_str() );
     if ( !container ) {
@@ -870,7 +870,7 @@ CRSkinnedItem::CRSkinnedItem()
 {
 }
 
-void CRSkinnedItem::setFontFace( lString16 face )
+void CRSkinnedItem::setFontFace( lString32 face )
 {
     if ( _fontFace != face ) {
         _fontFace = face;
@@ -910,16 +910,16 @@ LVFontRef CRSkinnedItem::getFont()
     return _font;
 }
 
-lvPoint CRSkinnedItem::measureText( lString16 text )
+lvPoint CRSkinnedItem::measureText( lString32 text )
 {
     int th = getFont()->getHeight();
     int tw = getFont()->getTextWidth( text.c_str(), text.length() );
     return lvPoint( tw, th );
 }
 
-static void wrapLine( lString16Collection & dst, lString16 stringToSplit, int maxWidth, LVFontRef font )
+static void wrapLine( lString32Collection & dst, lString32 stringToSplit, int maxWidth, LVFontRef font )
 {
-    lString16 str = stringToSplit;
+    lString32 str = stringToSplit;
     int w = font->getTextWidth( str.c_str(), str.length() );
     if ( w<=maxWidth ) {
         dst.add( str );
@@ -929,10 +929,10 @@ static void wrapLine( lString16Collection & dst, lString16 stringToSplit, int ma
         int wpos = 1;
         int wquality = 0;
         for ( int i=str.length(); i>=0; i-- ) {
-            lChar16 ch = str[i];
+            lChar32 ch = str[i];
             if ( ch!=' ' && ch!=0 && wpos>1 )
                 continue;
-            lChar16 prevChar = i>0 ? str[i-1] : 0;
+            lChar32 prevChar = i>0 ? str[i-1] : 0;
             w = font->getTextWidth( str.c_str(), i );
             int q = 0;
             if ( ch!=' ' && ch!=0 )
@@ -948,7 +948,7 @@ static void wrapLine( lString16Collection & dst, lString16 stringToSplit, int ma
             if ( wquality>1 && w<=maxWidth*2/3 )
                 break;
         }
-        lString16 s = str.substr(0, wpos);
+        lString32 s = str.substr(0, wpos);
         s.trim();
         if ( s.length()>0 )
             dst.add( s );
@@ -957,7 +957,7 @@ static void wrapLine( lString16Collection & dst, lString16 stringToSplit, int ma
     }
 }
 
-lvPoint CRRectSkin::measureTextItem( lString16 text )
+lvPoint CRRectSkin::measureTextItem( lString32 text )
 {
     lvPoint sz = CRSkinnedItem::measureText( text );
     sz.x += _margins.left + _margins.right;
@@ -969,28 +969,28 @@ lvPoint CRRectSkin::measureTextItem( lString16 text )
     return sz;
 }
 
-void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags )
+void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font, lUInt32 textColor, lUInt32 bgColor, int flags )
 {
     SAVE_DRAW_STATE( buf );
     if ( font.isNull() )
         font = getFont();
     if ( font.isNull() )
         return;
-    lString16Collection lines;
-    lString16 tabText;
+    lString32Collection lines;
+    lString32 tabText;
     int tabPos = text.pos("\t");
     if ( tabPos>=0 ) {
         if ( flags & SKIN_EXTEND_TAB ) {
             tabText = text.substr( tabPos+1 );
             text = text.substr( 0, tabPos );
         } else {
-            text[tabPos] = L' ';
+            text[tabPos] = U' ';
         }
     }
-    lString16 cr("\n");
+    lString32 cr("\n");
     if ( flags & SKIN_WORD_WRAP ) {
-        lString16Collection crlines;
-        lString16 s1, s2;
+        lString32Collection crlines;
+        lString32 s1, s2;
         while ( text.split2( cr, s1, s2 ) ) {
             crlines.add(s1);
             text = s2;
@@ -1000,8 +1000,8 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text
             wrapLine( lines, crlines[i], rc.width(), font );
         }
     } else {
-        lString16 s = text;
-        while ( s.replace( cr, cs16(" ") ) )
+        lString32 s = text;
+        while ( s.replace( cr, cs32(" ") ) )
             ;
         lines.add( s );
     }
@@ -1026,7 +1026,7 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text
         y += dy;
 
     for ( int i=0; i<lines.length(); i++ ) {
-        lString16 s = lines[i];
+        lString32 s = lines[i];
         int tw = font->getTextWidth( s.c_str(), s.length() );
         int x = txtrc.left;
         int dx = txtrc.width() - tw;
@@ -1036,9 +1036,9 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text
             x += dx;
 
 
-        font->DrawTextString( &buf, x, y, s.c_str(), s.length(), L'?', NULL, false, 0 );
+        font->DrawTextString( &buf, x, y, s.c_str(), s.length(), U'?', NULL, false, 0 );
         if ( !tabText.empty() ) {
-            font->DrawTextString( &buf, txtrc.right-ttw, y, tabText.c_str(), tabText.length(), L'?', NULL, false, 0 );
+            font->DrawTextString( &buf, txtrc.right-ttw, y, tabText.c_str(), tabText.length(), U'?', NULL, false, 0 );
             tabText.clear();
         }
         y = y + lh;
@@ -1046,12 +1046,12 @@ void CRSkinnedItem::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text
     buf.SetClipRect( &oldRc );
 }
 
-void CRRectSkin::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text, LVFontRef font )
+void CRRectSkin::drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text, LVFontRef font )
 {
     lvRect rect = getClientRect( rc );
     CRSkinnedItem::drawText( buf, rect, text, font );
 }
-void CRRectSkin::drawText( LVDrawBuf & buf, const lvRect & rc, lString16 text )
+void CRRectSkin::drawText( LVDrawBuf & buf, const lvRect & rc, lString32 text )
 {
     lvRect rect = CRRectSkin::getClientRect( rc );
     CRSkinnedItem::drawText( buf, rect, text );
@@ -1115,7 +1115,7 @@ void CRScrollSkin::drawScroll( LVDrawBuf & buf, const lvRect & rect, bool vertic
                 r.right = r.left + tabwidth;
                 if ( i+1!=page ) {
                     _bottomTabSkin->draw(buf, r);
-                    lString16 label = lString16::itoa(i+1);
+                    lString32 label = lString32::itoa(i+1);
                     _bottomTabSkin->drawText(buf, r, label);
                 }
                 r.left += tabwidth - r.height()/6;
@@ -1127,7 +1127,7 @@ void CRScrollSkin::drawScroll( LVDrawBuf & buf, const lvRect & rect, bool vertic
                 r.right = r.left + tabwidth;
                 if ( i+1==page ) {
                     _bottomActiveTabSkin->draw(buf, r);
-                    lString16 label = lString16::itoa(i+1);
+                    lString32 label = lString32::itoa(i+1);
                     _bottomActiveTabSkin->drawText(buf, r, label);
                 }
                 r.left += tabwidth - r.height()/6;
@@ -1156,7 +1156,7 @@ void CRScrollSkin::drawScroll( LVDrawBuf & buf, const lvRect & rect, bool vertic
 
     if ( _hBody.isNull() ) {
         // text label with optional arrows
-        lString16 label;
+        lString32 label;
         label << fmt::decimal(page) << " / " << fmt::decimal(pages);
         // calc label width
         int w = getFont()->getTextWidth( label.c_str(), label.length() );
@@ -1235,7 +1235,7 @@ void CRScrollSkin::drawScroll( LVDrawBuf & buf, const lvRect & rect, bool vertic
             sliderRect.width(), sliderRect.height() );
         buf.Draw( img, sliderRect.left, sliderRect.top, sliderRect.width(), sliderRect.height(), false );
         if ( this->getShowPageNumbers() ) {
-            lString16 label;
+            lString32 label;
             label << fmt::decimal(page) << " / " << fmt::decimal(pages);
             drawText( buf, sliderRect, label );
         }
@@ -1414,10 +1414,10 @@ public:
         _titleSkin->setFontBold( true );
         _titleSkin->setFontSize( 28 );
         _itemSkin = CRRectSkinRef( new CRRectSkin() );
-        _itemSkin->setBackgroundImage( skin->getImage( L"std_menu_item_background.xpm" ) );
+        _itemSkin->setBackgroundImage( skin->getImage( U"std_menu_item_background.xpm" ) );
         _itemSkin->setBorderWidths( lvRect( 8, 8, 8, 8 ) );
         _itemShortcutSkin = CRRectSkinRef( new CRRectSkin() );
-        _itemShortcutSkin->setBackgroundImage( skin->getImage( L"std_menu_shortcut_background.xpm" ) );
+        _itemShortcutSkin->setBackgroundImage( skin->getImage( U"std_menu_shortcut_background.xpm" ) );
         _itemShortcutSkin->setBorderWidths( lvRect( 12, 8, 8, 8 ) );
         _itemShortcutSkin->setTextColor( 0x555555 );
         _itemShortcutSkin->setTextHAlign( SKIN_HALIGN_CENTER );
@@ -1427,17 +1427,17 @@ public:
 
 CRButtonSkin::CRButtonSkin() { }
 
-bool CRSkinContainer::readButtonSkin(  const lChar16 * path, CRButtonSkin * res )
+bool CRSkinContainer::readButtonSkin(  const lChar32 * path, CRButtonSkin * res )
 {
     bool flg = false;
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readButtonSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1448,10 +1448,10 @@ bool CRSkinContainer::readButtonSkin(  const lChar16 * path, CRButtonSkin * res 
     }
 
     flg = readRectSkin( path, res ) || flg;
-    res->setNormalImage( readImage( path, L"normal", &flg ) );
-    res->setDisabledImage( readImage( path, L"disabled", &flg ) );
-    res->setPressedImage( readImage( path, L"pressed", &flg ) );
-    res->setSelectedImage( readImage( path, L"selected", &flg ) );
+    res->setNormalImage( readImage( path, U"normal", &flg ) );
+    res->setDisabledImage( readImage( path, U"disabled", &flg ) );
+    res->setPressedImage( readImage( path, U"pressed", &flg ) );
+    res->setSelectedImage( readImage( path, U"selected", &flg ) );
 
     LVImageSourceRef img = res->getNormalImage();
     lvRect margins = res->getBorderWidths();
@@ -1472,17 +1472,17 @@ bool CRSkinContainer::readButtonSkin(  const lChar16 * path, CRButtonSkin * res 
 
 CRScrollSkin::CRScrollSkin() : _autohide(false), _showPageNumbers(true), _location(CRScrollSkin::Status) { }
 
-bool CRSkinContainer::readScrollSkin(  const lChar16 * path, CRScrollSkin * res )
+bool CRSkinContainer::readScrollSkin(  const lChar32 * path, CRScrollSkin * res )
 {
     bool flg = false;
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readScrollSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1496,9 +1496,9 @@ bool CRSkinContainer::readScrollSkin(  const lChar16 * path, CRScrollSkin * res 
 
     flg = readRectSkin( path, res ) || flg;
 
-    res->setAutohide( readBool( (p).c_str(), L"autohide", res->getAutohide()) );
-    res->setShowPageNumbers( readBool( (p).c_str(), L"show-page-numbers", res->getShowPageNumbers()) );
-    lString16 l = readString( (p).c_str(), L"location", lString16::empty_str );
+    res->setAutohide( readBool( (p).c_str(), U"autohide", res->getAutohide()) );
+    res->setShowPageNumbers( readBool( (p).c_str(), U"show-page-numbers", res->getShowPageNumbers()) );
+    lString32 l = readString( (p).c_str(), U"location", lString32::empty_str );
     if ( !l.empty() ) {
         l.lowercase();
         if (l == "title")
@@ -1546,16 +1546,16 @@ bool CRSkinContainer::readScrollSkin(  const lChar16 * path, CRScrollSkin * res 
         flg = true;
     }
 
-    LVImageSourceRef hf = readImage( (p + "/hbody").c_str(), L"frame", &flg );
+    LVImageSourceRef hf = readImage( (p + "/hbody").c_str(), U"frame", &flg );
     if ( !hf.isNull() )
         res->setHBody( hf );
-    LVImageSourceRef hs = readImage( (p + "/hbody").c_str(), L"slider", &flg );
+    LVImageSourceRef hs = readImage( (p + "/hbody").c_str(), U"slider", &flg );
     if ( !hs.isNull() )
         res->setHSlider( hs );
-    LVImageSourceRef vf = readImage( (p + "/vbody").c_str(), L"frame", &flg );
+    LVImageSourceRef vf = readImage( (p + "/vbody").c_str(), U"frame", &flg );
     if ( !vf.isNull() )
         res->setVBody( vf );
-    LVImageSourceRef vs = readImage( (p + "/vbody").c_str(), L"slider", &flg );
+    LVImageSourceRef vs = readImage( (p + "/vbody").c_str(), U"slider", &flg );
     if ( !vs.isNull() )
         res->setVSlider(vs );
 
@@ -1567,16 +1567,16 @@ bool CRSkinContainer::readScrollSkin(  const lChar16 * path, CRScrollSkin * res 
     return flg;
 }
 
-bool CRSkinContainer::readIconSkin(  const lChar16 * path, CRIconSkin * res )
+bool CRSkinContainer::readIconSkin(  const lChar32 * path, CRIconSkin * res )
 {
     bool flg = false;
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readIconSkin( base.c_str(), res ) || flg;
     }
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1585,32 +1585,32 @@ bool CRSkinContainer::readIconSkin(  const lChar16 * path, CRIconSkin * res )
 #endif
         return false;
     }
-    LVImageSourceRef image = readImage( path, L"image", &flg );
+    LVImageSourceRef image = readImage( path, U"image", &flg );
     if ( !image.isNull() )
         res->setImage( image );
-    res->setHAlign( readHAlign( path, L"halign", res->getHAlign(), &flg) );
-    res->setVAlign( readVAlign( path, L"valign", res->getVAlign(), &flg) );
-    res->setBgColor( readColor( path, L"color", res->getBgColor(), &flg) );
-    res->setHTransform( readTransform( path, L"htransform", res->getHTransform(), &flg) );
-    res->setVTransform( readTransform( path, L"vtransform", res->getVTransform(), &flg) );
-    res->setSplitPoint( readSize( path, L"split", res->getSplitPoint(), &flg) );
-    res->setPos( readSize( path, L"pos", res->getPos(), &flg) );
-    res->setSize( readSize( path, L"size", res->getSize(), &flg) );
+    res->setHAlign( readHAlign( path, U"halign", res->getHAlign(), &flg) );
+    res->setVAlign( readVAlign( path, U"valign", res->getVAlign(), &flg) );
+    res->setBgColor( readColor( path, U"color", res->getBgColor(), &flg) );
+    res->setHTransform( readTransform( path, U"htransform", res->getHTransform(), &flg) );
+    res->setVTransform( readTransform( path, U"vtransform", res->getVTransform(), &flg) );
+    res->setSplitPoint( readSize( path, U"split", res->getSplitPoint(), &flg) );
+    res->setPos( readSize( path, U"pos", res->getPos(), &flg) );
+    res->setSize( readSize( path, U"size", res->getSize(), &flg) );
     return flg;
 }
 
-bool CRSkinContainer::readRectSkin(  const lChar16 * path, CRRectSkin * res )
+bool CRSkinContainer::readRectSkin(  const lChar32 * path, CRRectSkin * res )
 {
     bool flg = false;
 
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readRectSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1620,10 +1620,10 @@ bool CRSkinContainer::readRectSkin(  const lChar16 * path, CRRectSkin * res )
         return false;
     }
 
-    lString16 bgpath = p + "/background";
-    lString16 borderpath = p + "/border";
-    lString16 textpath = p + "/text";
-    lString16 sizepath = p + "/size";
+    lString32 bgpath = p + "/background";
+    lString32 borderpath = p + "/border";
+    lString32 textpath = p + "/text";
+    lString32 sizepath = p + "/size";
 
     CRIconListRef icons;
     bool bgIconsFlag = false;
@@ -1632,23 +1632,23 @@ bool CRSkinContainer::readRectSkin(  const lChar16 * path, CRRectSkin * res )
         res->setBgIcons( icons );
         flg = true;
     }
-    //res->setBackgroundColor( readColor( bgpath.c_str(), L"color", res->getBackgroundColor(), &flg ) );
-    res->setBorderWidths( readRect( borderpath.c_str(), L"widths", res->getBorderWidths(), &flg ) );
-    res->setMinSize( readSize( sizepath.c_str(), L"minvalue", res->getMinSize(), &flg ) );
-    res->setMaxSize( readSize( sizepath.c_str(), L"maxvalue", res->getMaxSize(), &flg ) );
-    res->setFontFace( readString( textpath.c_str(), L"face", res->getFontFace(), &flg ) );
-    res->setTextColor( readColor( textpath.c_str(), L"color", res->getTextColor(), &flg ) );
-    res->setFontBold( readBool( textpath.c_str(), L"bold", res->getFontBold(), &flg ) );
-    res->setWordWrap( readBool( textpath.c_str(), L"wordwrap", res->getWordWrap(), &flg ) );
-    res->setFontItalic( readBool( textpath.c_str(), L"italic", res->getFontItalic(), &flg ) );
-    res->setFontSize( readInt( textpath.c_str(), L"size", res->getFontSize(), &flg ) );
-    res->setTextHAlign( readHAlign( textpath.c_str(), L"halign", res->getTextHAlign(), &flg) );
-    res->setTextVAlign( readVAlign( textpath.c_str(), L"valign", res->getTextVAlign(), &flg) );
+    //res->setBackgroundColor( readColor( bgpath.c_str(), U"color", res->getBackgroundColor(), &flg ) );
+    res->setBorderWidths( readRect( borderpath.c_str(), U"widths", res->getBorderWidths(), &flg ) );
+    res->setMinSize( readSize( sizepath.c_str(), U"minvalue", res->getMinSize(), &flg ) );
+    res->setMaxSize( readSize( sizepath.c_str(), U"maxvalue", res->getMaxSize(), &flg ) );
+    res->setFontFace( readString( textpath.c_str(), U"face", res->getFontFace(), &flg ) );
+    res->setTextColor( readColor( textpath.c_str(), U"color", res->getTextColor(), &flg ) );
+    res->setFontBold( readBool( textpath.c_str(), U"bold", res->getFontBold(), &flg ) );
+    res->setWordWrap( readBool( textpath.c_str(), U"wordwrap", res->getWordWrap(), &flg ) );
+    res->setFontItalic( readBool( textpath.c_str(), U"italic", res->getFontItalic(), &flg ) );
+    res->setFontSize( readInt( textpath.c_str(), U"size", res->getFontSize(), &flg ) );
+    res->setTextHAlign( readHAlign( textpath.c_str(), U"halign", res->getTextHAlign(), &flg) );
+    res->setTextVAlign( readVAlign( textpath.c_str(), U"valign", res->getTextVAlign(), &flg) );
 
-    res->setHAlign( readHAlign( path, L"halign", res->getHAlign(), &flg) );
-    res->setVAlign( readVAlign( path, L"valign", res->getVAlign(), &flg) );
-    res->setPos( readSize( path, L"pos", res->getPos(), &flg) );
-    res->setSize( readSize( path, L"size", res->getSize(), &flg) );
+    res->setHAlign( readHAlign( path, U"halign", res->getHAlign(), &flg) );
+    res->setVAlign( readVAlign( path, U"valign", res->getVAlign(), &flg) );
+    res->setPos( readSize( path, U"pos", res->getPos(), &flg) );
+    res->setSize( readSize( path, U"size", res->getSize(), &flg) );
 
     if ( !flg ) {
         crtrace log;
@@ -1664,18 +1664,18 @@ lvPoint CRWindowSkin::getTitleSize()
     return minsize;
 }
 
-bool CRSkinContainer::readPageSkin(  const lChar16 * path, CRPageSkin * res )
+bool CRSkinContainer::readPageSkin(  const lChar32 * path, CRPageSkin * res )
 {
     bool flg = false;
 
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readPageSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1685,7 +1685,7 @@ bool CRSkinContainer::readPageSkin(  const lChar16 * path, CRPageSkin * res )
         return false;
     }
 
-    lString16 name = ptr.getNode()->getAttributeValue(ptr.getNode()->getDocument()->getAttrNameIndex("name"));
+    lString32 name = ptr.getNode()->getAttributeValue(ptr.getNode()->getDocument()->getAttrNameIndex("name"));
     if ( !name.empty() )
         res->setName(name);
 
@@ -1702,18 +1702,18 @@ bool CRSkinContainer::readPageSkin(  const lChar16 * path, CRPageSkin * res )
     return flg;
 }
 
-bool CRSkinContainer::readWindowSkin(  const lChar16 * path, CRWindowSkin * res )
+bool CRSkinContainer::readWindowSkin(  const lChar32 * path, CRWindowSkin * res )
 {
     bool flg = false;
 
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readWindowSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1723,7 +1723,7 @@ bool CRSkinContainer::readWindowSkin(  const lChar16 * path, CRWindowSkin * res 
         return false;
     }
 
-    res->setFullScreen(readBool(path, L"fullscreen", res->getFullScreen(), &flg));
+    res->setFullScreen(readBool(path, U"fullscreen", res->getFullScreen(), &flg));
 
     flg = readRectSkin(  path, res ) || flg;
     CRRectSkinRef titleSkin( new CRRectSkin() );
@@ -1764,18 +1764,18 @@ bool CRSkinContainer::readWindowSkin(  const lChar16 * path, CRWindowSkin * res 
     return flg;
 }
 
-bool CRSkinContainer::readMenuSkin(  const lChar16 * path, CRMenuSkin * res )
+bool CRSkinContainer::readMenuSkin(  const lChar32 * path, CRMenuSkin * res )
 {
     bool flg = false;
 
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readMenuSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1844,18 +1844,18 @@ bool CRSkinContainer::readMenuSkin(  const lChar16 * path, CRMenuSkin * res )
     if ( b )
         res->setEvenSelItemShortcutSkin( evenshortcutSelSkin );
 
-    res->setMinItemCount( readInt( path, L"min-item-count", res->getMinItemCount()) );
-    res->setMaxItemCount( readInt( path, L"max-item-count", res->getMaxItemCount()) );
-    res->setShowShortcuts( readBool( path, L"show-shortcuts", res->getShowShortcuts() ) );
+    res->setMinItemCount( readInt( path, U"min-item-count", res->getMinItemCount()) );
+    res->setMaxItemCount( readInt( path, U"max-item-count", res->getMaxItemCount()) );
+    res->setShowShortcuts( readBool( path, U"show-shortcuts", res->getShowShortcuts() ) );
 
     return flg;
 }
 
-CRButtonListRef CRSkinContainer::readButtons( const lChar16 * path, bool * res )
+CRButtonListRef CRSkinContainer::readButtons( const lChar32 * path, bool * res )
 {
     CRButtonListRef list = CRButtonListRef(new CRButtonList() );
     for ( int i=1; i<64; i++ ) {
-        lString16 p = lString16(path) << "[" << fmt::decimal(i) << "]";
+        lString32 p = lString32(path) << "[" << fmt::decimal(i) << "]";
         CRButtonSkin * button = new CRButtonSkin();
         if ( readButtonSkin(p.c_str(), button ) )
             list->add( LVRef<CRButtonSkin>(button) );
@@ -1878,17 +1878,17 @@ CRButtonListRef CRSkinContainer::readButtons( const lChar16 * path, bool * res )
     return list;	
 }
 
-bool CRSkinContainer::readToolBarSkin(  const lChar16 * path, CRToolBarSkin * res )
+bool CRSkinContainer::readToolBarSkin(  const lChar32 * path, CRToolBarSkin * res )
 {
     bool flg = false;
-    lString16 base = getBasePath( path );
+    lString32 base = getBasePath( path );
     RecursionLimit limit;
     if ( !base.empty() && limit.test() ) {
         // read base skin first
         flg = readToolBarSkin( base.c_str(), res ) || flg;
     }
 
-    lString16 p( path );
+    lString32 p( path );
     ldomXPointer ptr = getXPointer( path );
     if ( !ptr ) {
 #ifdef TRACE_SKIN_ERRORS
@@ -1899,7 +1899,7 @@ bool CRSkinContainer::readToolBarSkin(  const lChar16 * path, CRToolBarSkin * re
     }
     flg = readRectSkin( path, res ) || flg;
 
-    lString16 buttonspath = p + "/button";
+    lString32 buttonspath = p + "/button";
     bool buttonsFlag = false;
     CRButtonListRef buttons = readButtons( buttonspath.c_str(), &buttonsFlag);
     if ( buttonsFlag ) {
@@ -1909,18 +1909,18 @@ bool CRSkinContainer::readToolBarSkin(  const lChar16 * path, CRToolBarSkin * re
 	return flg;
 }
 
-lString16 CRSkinImpl::pathById( const lChar16 * id )
+lString32 CRSkinImpl::pathById( const lChar32 * id )
 {
     ldomNode * elem = _doc->getElementById( id );
     if ( !elem )
-        return lString16::empty_str;
+        return lString32::empty_str;
     return ldomXPointer(elem, -1).toString();
 }
 
 /// returns rect skin
-CRRectSkinRef CRSkinImpl::getRectSkin( const lChar16 * path )
+CRRectSkinRef CRSkinImpl::getRectSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRRectSkinRef res;
     if ( _rectCache.get( p, res ) )
         return res; // found in cache
@@ -1931,14 +1931,14 @@ CRRectSkinRef CRSkinImpl::getRectSkin( const lChar16 * path )
     // create new one
     res = CRRectSkinRef( new CRRectSkin() );
     readRectSkin( p.c_str(), res.get() );
-    _rectCache.set( lString16(path), res );
+    _rectCache.set( lString32(path), res );
     return res;
 }
 
 /// returns scroll skin by path or #id
-CRScrollSkinRef CRSkinImpl::getScrollSkin( const lChar16 * path )
+CRScrollSkinRef CRSkinImpl::getScrollSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRScrollSkinRef res;
     if ( _scrollCache.get( p, res ) )
         return res; // found in cache
@@ -1949,7 +1949,7 @@ CRScrollSkinRef CRSkinImpl::getScrollSkin( const lChar16 * path )
     // create new one
     res = CRScrollSkinRef( new CRScrollSkin() );
     readScrollSkin( p.c_str(), res.get() );
-    _scrollCache.set( lString16(path), res );
+    _scrollCache.set( lString32(path), res );
     return res;
 }
 
@@ -1959,8 +1959,8 @@ CRPageSkinListRef CRSkinImpl::getPageSkinList()
     if ( _pageSkinList.isNull() ) {
         _pageSkinList = CRPageSkinListRef( new CRPageSkinList() );
         for ( int i=0; i<32; i++ ) {
-            lString16 path("/CR3Skin/page-skins/page-skin[");
-            path << (i+1) << L"]";
+            lString32 path("/CR3Skin/page-skins/page-skin[");
+            path << (i+1) << U"]";
             CRPageSkinRef skin = CRPageSkinRef( new CRPageSkin() );
             if ( readPageSkin(path.c_str(), skin.get() ) ) {
                 _pageSkinList->add( skin );
@@ -1973,9 +1973,9 @@ CRPageSkinListRef CRSkinImpl::getPageSkinList()
 }
 
 /// returns book page skin by path or #id
-CRPageSkinRef CRSkinImpl::getPageSkin( const lChar16 * path )
+CRPageSkinRef CRSkinImpl::getPageSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRPageSkinRef res;
     if ( _pageCache.get( p, res ) )
         return res; // found in cache
@@ -1986,14 +1986,14 @@ CRPageSkinRef CRSkinImpl::getPageSkin( const lChar16 * path )
     // create new one
     res = CRPageSkinRef( new CRPageSkin() );
     readPageSkin( p.c_str(), res.get() );
-    _pageCache.set( lString16(path), res );
+    _pageCache.set( lString32(path), res );
     return res;
 }
 
 /// returns window skin
-CRWindowSkinRef CRSkinImpl::getWindowSkin( const lChar16 * path )
+CRWindowSkinRef CRSkinImpl::getWindowSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRWindowSkinRef res;
     if ( _windowCache.get( p, res ) )
         return res; // found in cache
@@ -2004,14 +2004,14 @@ CRWindowSkinRef CRSkinImpl::getWindowSkin( const lChar16 * path )
     // create new one
     res = CRWindowSkinRef( new CRWindowSkin() );
     readWindowSkin( p.c_str(), res.get() );
-    _windowCache.set( lString16(path), res );
+    _windowCache.set( lString32(path), res );
     return res;
 }
 
 /// returns menu skin
-CRMenuSkinRef CRSkinImpl::getMenuSkin( const lChar16 * path )
+CRMenuSkinRef CRSkinImpl::getMenuSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRMenuSkinRef res;
     if ( _menuCache.get( p, res ) )
         return res; // found in cache
@@ -2022,13 +2022,13 @@ CRMenuSkinRef CRSkinImpl::getMenuSkin( const lChar16 * path )
     // create new one
     res = CRMenuSkinRef( new CRMenuSkin() );
     readMenuSkin( p.c_str(), res.get() );
-    _menuCache.set( lString16(path), res );
+    _menuCache.set( lString32(path), res );
     return res;
 }
 
-CRToolBarSkinRef CRSkinImpl::getToolBarSkin( const lChar16 * path )
+CRToolBarSkinRef CRSkinImpl::getToolBarSkin( const lChar32 * path )
 {
-    lString16 p(path);
+    lString32 p(path);
     CRToolBarSkinRef res;
     if ( _toolbarCache.get( p, res ) )
         return res; // found in cache
@@ -2038,11 +2038,11 @@ CRToolBarSkinRef CRSkinImpl::getToolBarSkin( const lChar16 * path )
     }
     res = CRToolBarSkinRef( new CRToolBarSkin() );
     readToolBarSkin( p.c_str(), res.get() );
-    _toolbarCache.set( lString16(path), res );
+    _toolbarCache.set( lString32(path), res );
     return res;
 }
 
-CRSkinListItem * CRSkinList::findByName( const lString16 & name )
+CRSkinListItem * CRSkinList::findByName( const lString32 & name )
 {
     for ( int i=0; i<length(); i++ )
         if ( get(i)->getName()==name )
@@ -2050,7 +2050,7 @@ CRSkinListItem * CRSkinList::findByName( const lString16 & name )
     return NULL;
 }
 
-CRSkinListItem * CRSkinListItem::init( lString16 baseDir, lString16 fileName )
+CRSkinListItem * CRSkinListItem::init( lString32 baseDir, lString32 fileName )
 {
     CRSkinRef skin = LVOpenSkin( baseDir + fileName );
     if ( skin.isNull() )
@@ -2067,7 +2067,7 @@ CRSkinRef CRSkinListItem::getSkin()
     return LVOpenSkin( getDirName() + getFileName() );
 }
 
-bool CRLoadSkinList( lString16 baseDir, CRSkinList & list )
+bool CRLoadSkinList( lString32 baseDir, CRSkinList & list )
 {
     return false;
 }

--- a/crengine/src/crtest.cpp
+++ b/crengine/src/crtest.cpp
@@ -10,11 +10,11 @@ protected:
     LVStreamRef m_base_stream1;
     LVStreamRef m_base_stream2;
 public:
-    virtual const lChar16 * GetName()
+    virtual const lChar32 * GetName()
             {
-                static lChar16 buf[1024];
-                lString16 res1 = m_base_stream1->GetName();
-                lString16 res2 = m_base_stream2->GetName();
+                static lChar32 buf[1024];
+                lString32 res1 = m_base_stream1->GetName();
+                lString32 res2 = m_base_stream2->GetName();
                 MYASSERT( res1==res2, "getName, res");
                 lStr_cpy( buf, res1.c_str());
                 return buf;

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -17,7 +17,7 @@
 #include <string.h>
 #include <stdio.h>
 
-static const lChar16 __cp737[128] = {
+static const lChar32 __cp737[128] = {
   /* 0x80 */
   0x0391, 0x0392, 0x0393, 0x0394, 0x0395, 0x0396, 0x0397, 0x0398,
   0x0399, 0x039a, 0x039b, 0x039c, 0x039d, 0x039e, 0x039f, 0x03a0,
@@ -44,7 +44,7 @@ static const lChar16 __cp737[128] = {
   0x00b0, 0x2219, 0x00b7, 0x221a, 0x207f, 0x00b2, 0x25a0, 0x00a0,
 };
 
-static const lChar16 __cp1253[128] = {
+static const lChar32 __cp1253[128] = {
   /* 0x80 */
   0x20ac, 0xfffd, 0x201a, 0x0192, 0x201e, 0x2026, 0x2020, 0x2021,
   0xfffd, 0x2030, 0xfffd, 0x2039, 0xfffd, 0xfffd, 0xfffd, 0xfffd,
@@ -71,7 +71,7 @@ static const lChar16 __cp1253[128] = {
   0x03c8, 0x03c9, 0x03ca, 0x03cb, 0x03cc, 0x03cd, 0x03ce, 0xfffd,
 };
 
-static const lChar16 __cp775[128] = {
+static const lChar32 __cp775[128] = {
   /* 0x80 */
   0x0106, 0x00fc, 0x00e9, 0x0101, 0x00e4, 0x0123, 0x00e5, 0x0107,
   0x0142, 0x0113, 0x0156, 0x0157, 0x012b, 0x0179, 0x00c4, 0x00c5,
@@ -102,7 +102,7 @@ static const lChar16 __cp775[128] = {
  * CP852
  */
 
-static const lChar16 __cp852[128] = {
+static const lChar32 __cp852[128] = {
   /* 0x80 */
   0x00c7, 0x00fc, 0x00e9, 0x00e2, 0x00e4, 0x016f, 0x0107, 0x00e7,
   0x0142, 0x00eb, 0x0150, 0x0151, 0x00ee, 0x0179, 0x00c4, 0x0106,
@@ -133,7 +133,7 @@ static const lChar16 __cp852[128] = {
  * ISO-8859-2
  */
 
-static const lChar16 __iso8859_2[128] = {
+static const lChar32 __iso8859_2[128] = {
   /* 0x80*/
   0x0402, 0x0403, 0x201a, 0x0453, 0x201e, 0x2026, 0x2020, 0x2021,
   0x20ac, 0x2030, 0x0409, 0x2039, 0x040a, 0x040c, 0x040b, 0x040f,
@@ -164,7 +164,7 @@ static const lChar16 __iso8859_2[128] = {
  * ISO-8859-16
  */
 
-static const lChar16 __iso8859_16[128] = {
+static const lChar32 __iso8859_16[128] = {
     /* 0x80*/
     0x0402, 0x0403, 0x201a, 0x0453, 0x201e, 0x2026, 0x2020, 0x2021,
     0x20ac, 0x2030, 0x0409, 0x2039, 0x040a, 0x040c, 0x040b, 0x040f,
@@ -191,7 +191,7 @@ static const lChar16 __iso8859_16[128] = {
     0x0171, 0x00f9, 0x00fa, 0x00fb, 0x00fc, 0x0119, 0x021b, 0x00ff,
 };
 
-static const lChar16 __cp1257[128] = {
+static const lChar32 __cp1257[128] = {
   /* 0x80 */
   0x20ac, 0xfffd, 0x201a, 0xfffd, 0x201e, 0x2026, 0x2020, 0x2021,
   0xfffd, 0x2030, 0xfffd, 0x2039, 0xfffd, 0x00a8, 0x02c7, 0x00b8,
@@ -218,7 +218,7 @@ static const lChar16 __cp1257[128] = {
   0x0173, 0x0142, 0x015b, 0x016b, 0x00fc, 0x017c, 0x017e, 0x02d9,
 };
 
-static const lChar16 __cp1251[128] = {
+static const lChar32 __cp1251[128] = {
     /* 0x80*/
     0x0402, 0x0403, 0x201a, 0x0453,
     0x201e, 0x2026, 0x2020, 0x2021,
@@ -261,7 +261,7 @@ static const lChar16 __cp1251[128] = {
     0x044c, 0x044d, 0x044e, 0x044f,
 };
 
-static const lChar16 __cp1252[128] = {
+static const lChar32 __cp1252[128] = {
     /* 0x80*/
     0x0402, 0x0403, 0x201a, 0x0453,
     0x201e, 0x2026, 0x2020, 0x2021,
@@ -304,7 +304,7 @@ static const lChar16 __cp1252[128] = {
     0x00fc, 0x00fd, 0x00fe, 0x00ff,
 };
 
-static const lChar16 __cp1254[128] = {
+static const lChar32 __cp1254[128] = {
     /* 0x80 */
     0x20ac, 0xfffd, 0x201a, 0x0192,
     0x201e, 0x2026, 0x2020, 0x2021,
@@ -347,7 +347,7 @@ static const lChar16 __cp1254[128] = {
     0x00fc, 0x0131, 0x015f, 0x00ff,
 };
 
-static const lChar16 __cp866[128] = {
+static const lChar32 __cp866[128] = {
     /* 0x80*/
     0x0410, 0x0411, 0x0412, 0x0413,
     0x0414, 0x0415, 0x0416, 0x0417,
@@ -390,7 +390,7 @@ static const lChar16 __cp866[128] = {
     0x2116, 0x00a4, 0x25a0, 0x00a0,
 };
 
-static const lChar16 __koi8r[128] = {
+static const lChar32 __koi8r[128] = {
     /* 0x80*/
     0x2500, 0x2502, 0x250c, 0x2510,
     0x2514, 0x2518, 0x251c, 0x2524,
@@ -433,7 +433,7 @@ static const lChar16 __koi8r[128] = {
     0x042d, 0x0429, 0x0427, 0x042a,
 };
 
-static const lChar16 __cp1250[128] = {
+static const lChar32 __cp1250[128] = {
     /* 0x80*/
     0x20ac, 0x0000, 0x201a, 0x0000,
     0x201e, 0x2026, 0x2020, 0x2021,
@@ -476,7 +476,7 @@ static const lChar16 __cp1250[128] = {
     0x00fc, 0x00fd, 0x0163, 0x02d9,
 };
 
-static const lChar16 __cp850[128] = {
+static const lChar32 __cp850[128] = {
     /* 0x80*/
     0x00c7, 0x00fc, 0x00e9, 0x00e2,
     0x00e4, 0x00e0, 0x00e5, 0x00e7,
@@ -538,7 +538,7 @@ static const lChar16 __cp850[128] = {
 /// add other encodings here
 static struct {
     const char * name;
-    const lChar16 * table;
+    const lChar32 * table;
     int id;
 } _enc_table[] = {
     {"windows-1250", __cp1250, CRENC_ID_CP1250},
@@ -582,11 +582,11 @@ static struct {
     {NULL, NULL, 0}
 };
 
-int CREncodingNameToId( const lChar16 * enc_name )
+int CREncodingNameToId( const lChar32 * enc_name )
 {
-    lString16 s( enc_name );
+    lString32 s( enc_name );
     s.lowercase();
-    const lChar16 * encoding_name = s.c_str();
+    const lChar32 * encoding_name = s.c_str();
     if ( !lStr_cmp(encoding_name, "utf-8") )
         return CRENC_ID_UTF8;
     else if ( !lStr_cmp(encoding_name, "utf-16") )
@@ -635,11 +635,11 @@ const char * CREncodingIdToName( int id )
     return NULL; // not found
 }
 
-const lChar16 * GetCharsetByte2UnicodeTable( const lChar16 * enc_name )
+const lChar32 * GetCharsetByte2UnicodeTable( const lChar32 * enc_name )
 {
-    lString16 s( enc_name );
+    lString32 s( enc_name );
     s.lowercase();
-    const lChar16 * encoding_name = s.c_str();
+    const lChar32 * encoding_name = s.c_str();
     for (int i=0; _enc_table[i].name!=NULL; i++)
     {
         if ( !lStr_cmp(encoding_name, _enc_table[i].name) )
@@ -650,7 +650,7 @@ const lChar16 * GetCharsetByte2UnicodeTable( const lChar16 * enc_name )
     return NULL; // not found
 }
 
-const lChar16 * GetCharsetByte2UnicodeTableById( int id )
+const lChar32 * GetCharsetByte2UnicodeTableById( int id )
 {
     for (int i=0; _enc_table[i].name!=NULL; i++)
     {
@@ -1224,7 +1224,7 @@ const char* langToLanguage( int lang )
     }
 }
 
-const lChar16 * GetCharsetByte2UnicodeTable( int codepage )
+const lChar32 * GetCharsetByte2UnicodeTable( int codepage )
 {
     switch ( codepage )
     {
@@ -1249,26 +1249,26 @@ const lChar16 * GetCharsetByte2UnicodeTable( int codepage )
     }
 }
 
-const lChar16 * GetCharsetName( int codepage )
+const lChar32 * GetCharsetName( int codepage )
 {
     switch ( codepage )
     {
     case 1251:
-        return L"cp1251";
+        return U"cp1251";
     case 1257:
-        return L"cp1257";
+        return U"cp1257";
     case 204:
-        return L"cp1251";
+        return U"cp1251";
     case 1252:
-        return L"cp1252";
+        return U"cp1252";
     case 1253:
-        return L"cp1253";
+        return U"cp1253";
     case 737:
-        return L"cp737";
-    case 1250: return L"cp1250";
-    case 866:  return L"cp866";
-    case 850:  return L"cp850";
-    default:   return L"cp1252";
+        return U"cp737";
+    case 1250: return U"cp1250";
+    case 866:  return U"cp866";
+    case 850:  return U"cp850";
+    default:   return U"cp1252";
     }
 }
 
@@ -1410,11 +1410,11 @@ static struct {
     {NULL, NULL}
 };
 
-const lChar8 ** GetCharsetUnicode2ByteTable( const lChar16 * enc_name )
+const lChar8 ** GetCharsetUnicode2ByteTable( const lChar32 * enc_name )
 {
-    lString16 s( enc_name );
+    lString32 s( enc_name );
     s.lowercase();
-    const lChar16 * encoding_name = s.c_str();
+    const lChar32 * encoding_name = s.c_str();
     for (int i=0; _uni2byte_enc_table[i].name!=NULL; i++)
     {
         if ( !lStr_cmp(encoding_name, _uni2byte_enc_table[i].name) )

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -9,13 +9,13 @@
 #define DOCX_TAG_CHILD(itm) { DOCX_TAG_ID(itm), DOCX_TAG_NAME(itm) }
 #define DOCX_LAST_ITEM { -1, NULL }
 
-static const lChar16* const docx_DocumentContentType   = L"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
-static const lChar16* const docx_NumberingContentType  = L"application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml";
-static const lChar16* const docx_StylesContentType     = L"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml";
-static const lChar16* const docx_ImageRelationship     = L"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
-static const lChar16* const docx_HyperlinkRelationship = L"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
-static const lChar16* const docx_FootNotesRelationShip = L"http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes";
-static const lChar16* const docx_EndNotesRelationShip  = L"http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes";
+static const lChar32* const docx_DocumentContentType   = U"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+static const lChar32* const docx_NumberingContentType  = U"application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml";
+static const lChar32* const docx_StylesContentType     = U"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml";
+static const lChar32* const docx_ImageRelationship     = U"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+static const lChar32* const docx_HyperlinkRelationship = U"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
+static const lChar32* const docx_FootNotesRelationShip = U"http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes";
+static const lChar32* const docx_EndNotesRelationShip  = U"http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes";
 
 enum {
 #define DOCX_NUM_FMT(itm)
@@ -26,7 +26,7 @@ enum {
 };
 
 #define DOCX_NUM_FMT(itm)
-#define DOCX_TAG(itm) static const lChar16 * const DOCX_TAG_NAME(itm) = L ## #itm;
+#define DOCX_TAG(itm) static const lChar32 * const DOCX_TAG_NAME(itm) = U ## #itm;
     #include "docxdtd.inc"
 
 const struct item_def_t styles_elements[] = {
@@ -219,53 +219,53 @@ const struct item_def_t no_elements[] = {
 };
 
 const struct item_def_t jc_attr_values[] = {
-    { css_ta_left, L"left"},
-    { css_ta_right, L"right" },
-    { css_ta_center, L"center" },
-    { css_ta_justify, L"both" },
+    { css_ta_left, U"left"},
+    { css_ta_right, U"right" },
+    { css_ta_center, U"center" },
+    { css_ta_justify, U"both" },
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t vertAlign_attr_values[] = {
-    { css_va_baseline, L"baseline"},
-    { css_va_super, L"superscript" },
-    { css_va_sub, L"subscript" },
+    { css_va_baseline, U"baseline"},
+    { css_va_super, U"superscript" },
+    { css_va_sub, U"subscript" },
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t textAlignment_attr_values[] = {
-    { css_va_inherit, L"auto" },
-    { css_va_baseline, L"baseline"},
-    { css_va_bottom, L"bottom"},
-    { css_va_middle, L"center" },
-    { css_va_top, L"top" },
+    { css_va_inherit, U"auto" },
+    { css_va_baseline, U"baseline"},
+    { css_va_bottom, U"bottom"},
+    { css_va_middle, U"center" },
+    { css_va_top, U"top" },
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t lineRule_attr_values[] = {
-    { odx_lineRule_atLeast, L"atLeast" },
-    { odx_lineRule_auto, L"auto"},
-    { odx_lineRule_exact, L"exact"},
+    { odx_lineRule_atLeast, U"atLeast" },
+    { odx_lineRule_auto, U"auto"},
+    { odx_lineRule_exact, U"exact"},
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t styleType_attr_values[] = {
-    { odx_paragraph_style, L"paragraph" },
-    { odx_character_style, L"character"},
-    { odx_numbering_style, L"numbering"},
-    { odx_table_style, L"table"},
+    { odx_paragraph_style, U"paragraph" },
+    { odx_character_style, U"character"},
+    { odx_numbering_style, U"numbering"},
+    { odx_table_style, U"table"},
     DOCX_LAST_ITEM
 };
 
 const struct item_def_t lvlSuff_attr_values[] = {
-    { docx_level_suffix_tab, L"tab" },
-    { docx_level_suffix_space, L"space" },
-    { docx_level_suffix_nothing, L"nothing" },
+    { docx_level_suffix_tab, U"tab" },
+    { docx_level_suffix_space, U"space" },
+    { docx_level_suffix_nothing, U"nothing" },
     DOCX_LAST_ITEM
 };
 
 #define DOCX_TAG(itm)
-#define DOCX_NUM_FMT(itm) { docx_numFormat_##itm , L ## #itm },
+#define DOCX_NUM_FMT(itm) { docx_numFormat_##itm , U ## #itm },
 const struct item_def_t numFmt_attr_values[] = {
     #include "docxdtd.inc"
     DOCX_LAST_ITEM
@@ -291,12 +291,12 @@ private:
     css_text_align_t m_lvlJc;
     css_length_t m_ilvl;
     css_length_t m_lvlRestart;
-    lString16 m_lvlText;
+    lString32 m_lvlText;
     bool m_lvlTextNull;
     docx_numFormat_type m_lvlNumFormat;
     odx_pPr m_pPr;
     odx_rPr m_rPr;
-    lString16 m_pStyle;
+    lString32 m_pStyle;
     css_length_t m_lvlStart;
     docx_LevelSuffix_type m_suffix;
 public:
@@ -313,14 +313,14 @@ public:
     inline void setLevel(const css_length_t &value) { m_ilvl = value; }
     inline css_length_t getLevelRestart() const { return m_lvlRestart; }
     inline void setLevelRestart(const css_length_t &value) { m_lvlRestart = value; }
-    inline lString16 getLevelText() const { return m_lvlText; }
-    inline void setLevelText(const lString16 value) { m_lvlText = value; }
+    inline lString32 getLevelText() const { return m_lvlText; }
+    inline void setLevelText(const lString32 value) { m_lvlText = value; }
     inline bool getLevelTextNull() const { return m_lvlTextNull; }
     inline void setLevelTextNull(const bool value) { m_lvlTextNull = value; }
     inline docx_numFormat_type getNumberFormat() const { return m_lvlNumFormat; }
     inline void setNumberFormat(const docx_numFormat_type value) { m_lvlNumFormat = value; }
-    inline lString16 getReferencedStyleId() const { return m_pStyle; }
-    inline void setReferencedStyleId(const lString16 value) { m_pStyle = value; }
+    inline lString32 getReferencedStyleId() const { return m_pStyle; }
+    inline void setReferencedStyleId(const lString32 value) { m_pStyle = value; }
     inline css_length_t getLevelStart() const { return m_lvlStart; }
     inline void setLevelStart(const css_length_t &value) { m_lvlStart = value; }
     inline docx_LevelSuffix_type getLevelSuffix() const { return m_suffix; }
@@ -389,25 +389,25 @@ public:
     void addAbstractNum(docxAbstractNumRef abstractNum );
     docxNumRef getNum(lUInt32 id) { return m_Numbers.get(id); }
     docxAbstractNumRef getAbstractNum(lUInt32 id) { return m_abstractNumbers.get(id); }
-    lString16 getImageTarget(lString16 id) {
+    lString32 getImageTarget(lString32 id) {
         return getRelationTarget(docx_ImageRelationship, id);
     }
-    lString16 getLinkTarget(lString16 id) {
+    lString32 getLinkTarget(lString32 id) {
         return getRelationTarget(docx_HyperlinkRelationship, id);
     }
-    lString16 getRelationTarget(const lChar16 * const relationType, lString16 id) {
+    lString32 getRelationTarget(const lChar32 * const relationType, lString32 id) {
         if ( !m_relatedPart.isNull() )
             return m_relatedPart->getRelatedPartName(relationType, id);
         return m_docPart->getRelatedPartName(relationType, id);
     }
-    LVStreamRef openContentPart(const lChar16 * const contentType);
-    LVStreamRef openRelatedPart(const lChar16 * const relationshipType);
+    LVStreamRef openContentPart(const lChar32 * const contentType);
+    LVStreamRef openRelatedPart(const lChar32 * const relationshipType);
     void closeRelatedPart();
     void openList(int level, int numid, ldomDocumentWriter *writer);
     void closeList(int level, ldomDocumentWriter *writer);
     inline int getListLevel() { return m_ListLevels.length(); }
     inline bool isInList() { return m_ListLevels.length() != 0; }
-    lString16 m_footNoteId;
+    lString32 m_footNoteId;
     int m_footNoteCount;
     int m_endNoteCount;
     bool m_inField;
@@ -420,8 +420,8 @@ class docx_ElementHandler : public xml_ElementHandler
 protected:
     docxImportContext *m_importContext;
 protected:
-    static bool parse_OnOff_attribute(const lChar16 * attrValue);
-    void generateLink(const lChar16 * target, const lChar16 * type, const lChar16 *text);
+    static bool parse_OnOff_attribute(const lChar32 * attrValue);
+    void generateLink(const lChar32 * target, const lChar32 * type, const lChar32 *text);
     docx_ElementHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context,
                         int element, const struct item_def_t *children) : xml_ElementHandler(reader, writer, element, children),
         m_importContext(context)
@@ -440,7 +440,7 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
     void start(odx_rPr *rPr);
     void reset();
 };
@@ -455,8 +455,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset() { m_level = 1; }
 };
 
@@ -467,12 +467,12 @@ private:
     odx_rPr m_rPr;
     docx_pHandler* m_pHandler;
     docx_rPrHandler m_rPrHandler;
-    lString16 m_footnoteId;
-    lString16 m_instruction;
+    lString32 m_footnoteId;
+    lString32 m_instruction;
     docx_drawingHandler m_drawingHandler;
     bool m_content;
 private:
-    void handleInstruction(lString16& instruction, lString16 parameters);
+    void handleInstruction(lString32& instruction, lString32 parameters);
 public:
     docx_rHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_pHandler* pHandler) :
         docx_ElementHandler(reader, writer, context, docx_el_r, r_elements), m_pHandler(pHandler),
@@ -482,9 +482,9 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleText( const lChar16 * text, int len, lUInt32 flags );
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleText( const lChar32 * text, int len, lUInt32 flags );
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset();
 };
 
@@ -498,8 +498,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void start(odx_pPr *pPr);
     void reset();
 };
@@ -507,7 +507,7 @@ public:
 class docx_hyperlinkHandler  : public docx_ElementHandler
 {
     docx_rHandler m_rHandler;
-    lString16 m_target;
+    lString32 m_target;
     int m_runCount;
 public:
     docx_hyperlinkHandler(docXMLreader * reader, ldomDocumentWriter *writer, docxImportContext *context, docx_pHandler* pHandler) :
@@ -516,8 +516,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset() { m_target.clear(); m_rHandler.reset(); m_runCount = 0; }
 };
 
@@ -543,8 +543,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset();
 };
 
@@ -585,8 +585,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset();
 };
 
@@ -605,8 +605,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
 };
 
 class docx_documentHandler : public docx_ElementHandler
@@ -624,8 +624,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
 };
 
 class docx_styleHandler : public docx_ElementHandler
@@ -644,8 +644,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void start();
 };
 
@@ -666,7 +666,7 @@ public:
     }
     /// destructor
     ldomNode * handleTagOpen(int tagId);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void reset();
 };
 
@@ -688,7 +688,7 @@ public:
         m_lvl = level;
         docx_ElementHandler::start();
     }
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
     ldomNode * handleTagOpen(int tagId);
     void reset();
 };
@@ -704,9 +704,9 @@ public:
         m_lvlHandler(reader, writer, context)
     {
     }
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
     ldomNode * handleTagOpen(int tagId);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void start();
 };
 
@@ -721,9 +721,9 @@ public:
         m_lvlHandler(reader, writer, context)
     {
     }
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
     ldomNode * handleTagOpen(int tagId);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
     void start();
 };
 
@@ -741,7 +741,7 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
 };
 
 
@@ -782,7 +782,7 @@ css_list_style_type_t docxNumLevel::getListType() const
     case docx_numFormat_upperRoman:
         return css_lst_upper_roman;
     case docx_numFormat_bullet:
-        if ( getLevelText() == L"\xf0a7" )
+        if ( getLevelText() == U"\xf0a7" )
             return css_lst_square;
         return css_lst_disc;
     case docx_numFormat_decimal:
@@ -792,39 +792,39 @@ css_list_style_type_t docxNumLevel::getListType() const
     }
 }
 
-bool docx_ElementHandler::parse_OnOff_attribute(const lChar16 * attrValue)
+bool docx_ElementHandler::parse_OnOff_attribute(const lChar32 * attrValue)
 {
     if ( !lStr_cmp(attrValue, "1") || !lStr_cmp(attrValue, "on") || !lStr_cmp(attrValue, "true") )
         return true;
     return false;
 }
 
-void docx_ElementHandler::generateLink(const lChar16 *target, const lChar16 *type, const lChar16 *text)
+void docx_ElementHandler::generateLink(const lChar32 *target, const lChar32 *type, const lChar32 *text)
 {
-    m_writer->OnTagOpen(L"", L"a");
-    m_writer->OnAttribute(L"", L"href", target );
+    m_writer->OnTagOpen(U"", U"a");
+    m_writer->OnAttribute(U"", U"href", target );
     if(type)
-        m_writer->OnAttribute(L"", L"type", type);
+        m_writer->OnAttribute(U"", U"type", type);
     // Add classic role=doc-noteref attribute to allow popup/in-page footnotes
-    m_writer->OnAttribute(L"", L"role", L"doc-noteref");
+    m_writer->OnAttribute(U"", U"role", U"doc-noteref");
     m_writer->OnTagBody();
 #ifndef ODX_CRENGINE_IN_PAGE_FOOTNOTES
     if( !lStr_cmp(type, "note") ) {
         // For footnotes (but not endnotes), wrap in <sup> (to get the
         // same effect as the following in docx.css:
         //   a[type="note"] { vertical-align: super; font-size: 70%; }
-        m_writer->OnTagOpen(L"", L"sup");
+        m_writer->OnTagOpen(U"", U"sup");
         m_writer->OnTagBody();
     }
 #endif
-    lString16 t(text);
+    lString32 t(text);
     m_writer->OnText(t.c_str(), t.length(), 0);
 #ifndef ODX_CRENGINE_IN_PAGE_FOOTNOTES
     if( !lStr_cmp(type, "note") ) {
-        m_writer->OnTagClose(L"", L"sup");
+        m_writer->OnTagClose(U"", U"sup");
     }
 #endif
-    m_writer->OnTagClose(L"", L"a");
+    m_writer->OnTagClose(U"", U"a");
 }
 
 ldomNode * docx_rPrHandler::handleTagOpen(int tagId)
@@ -852,7 +852,7 @@ ldomNode * docx_rPrHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_rPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue)
+void docx_rPrHandler::handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue)
 {
     int attr_value;
     switch(m_state) {
@@ -927,16 +927,16 @@ void docx_rPrHandler::start(odx_rPr * const rPr)
     docx_ElementHandler::start();
 }
 
-void docx_rHandler::handleInstruction(lString16 &instruction, lString16 parameters)
+void docx_rHandler::handleInstruction(lString32 &instruction, lString32 parameters)
 {
-    if( instruction == cs16("REF") || instruction == cs16("NOTEREF") || instruction == cs16("PAGEREF") ) {
-        lString16 argument, switches;
-        if( parameters.split2( cs16(" "), argument, switches) && !argument.empty() )
+    if( instruction == cs32("REF") || instruction == cs32("NOTEREF") || instruction == cs32("PAGEREF") ) {
+        lString32 argument, switches;
+        if( parameters.split2( cs32(" "), argument, switches) && !argument.empty() )
         {
-            m_importContext->m_linkNode = m_writer->OnTagOpen(L"", L"a");
-            lString16 target = L"#";
+            m_importContext->m_linkNode = m_writer->OnTagOpen(U"", U"a");
+            lString32 target = U"#";
             target  << argument;
-            m_writer->OnAttribute(L"", L"href", target.c_str());
+            m_writer->OnAttribute(U"", U"href", target.c_str());
             m_writer->OnTagBody();
         }
     }
@@ -978,7 +978,7 @@ ldomNode *docx_rHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_rHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_rHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     if( (docx_el_footnoteReference == m_state || docx_el_endnoteReference == m_state) &&
        !lStr_cmp(attrname, "id") ) {
@@ -989,7 +989,7 @@ void docx_rHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attr
             m_importContext->m_inField = true;
         } else if( !lStr_cmp(attrvalue, "end") ) {
             if( m_importContext->m_linkNode ) {
-                m_writer->OnTagClose(L"", L"a");
+                m_writer->OnTagClose(U"", U"a");
                 m_importContext->m_linkNode = NULL;
             }
             m_importContext->m_inField = false;
@@ -997,7 +997,7 @@ void docx_rHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attr
     }
 }
 
-void docx_rHandler::handleText(const lChar16 *text, int len, lUInt32 flags)
+void docx_rHandler::handleText(const lChar32 *text, int len, lUInt32 flags)
 {
     switch(m_state) {
     case docx_el_t:
@@ -1011,14 +1011,14 @@ void docx_rHandler::handleText(const lChar16 *text, int len, lUInt32 flags)
     }
 }
 
-void docx_rHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_rHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
-    lChar16 nobsp = 0x00A0;
+    lChar32 nobsp = 0x00A0;
     CR_UNUSED2(nsname, tagname);
 
     switch(m_state) {
     case docx_el_br:
-        m_writer->OnTagOpenAndClose(L"", L"br");
+        m_writer->OnTagOpenAndClose(U"", U"br");
         m_state = docx_el_r;
         break;
     case docx_el_r:
@@ -1031,9 +1031,9 @@ void docx_rHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname
     case docx_el_footnoteReference:
         if( !m_footnoteId.empty() ) {
             m_importContext->m_footNoteCount++;
-            lString16 target = L"#n_";
+            lString32 target = U"#n_";
             target  << m_footnoteId;
-            generateLink(target.c_str(), L"note", m_footnoteId.c_str());
+            generateLink(target.c_str(), U"note", m_footnoteId.c_str());
         }
         m_state = docx_el_r;
         break;
@@ -1041,8 +1041,8 @@ void docx_rHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname
         if( m_importContext->m_inField ) {
             m_instruction.trim();
             if ( !m_instruction.empty() ) {
-                lString16 instruction, parameters;
-                if ( m_instruction.split2(cs16(" "), instruction, parameters) )
+                lString32 instruction, parameters;
+                if ( m_instruction.split2(cs32(" "), instruction, parameters) )
                     handleInstruction(instruction, parameters);
             }
         }
@@ -1051,19 +1051,19 @@ void docx_rHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname
     case docx_el_endnoteReference:
         if( !m_footnoteId.empty() ) {
             m_importContext->m_endNoteCount++;
-            lString16 target = L"#c_";
+            lString32 target = U"#c_";
             target  << m_footnoteId;
-            generateLink(target.c_str(), L"comment", m_footnoteId.c_str());
+            generateLink(target.c_str(), U"comment", m_footnoteId.c_str());
         }
         m_state = docx_el_r;
         break;
     case docx_el_footnoteRef:
     case docx_el_endnoteRef:
         if(!m_importContext->m_footNoteId.empty()) {
-            m_writer->OnTagOpen(L"", L"sup");
+            m_writer->OnTagOpen(U"", U"sup");
             m_writer->OnTagBody();
             m_writer->OnText(m_importContext->m_footNoteId.c_str(), m_importContext->m_footNoteId.length(), 0);
-            m_writer->OnTagClose(L"", L"sup");
+            m_writer->OnTagClose(U"", U"sup");
         }
     default:
         m_state = docx_el_r;
@@ -1108,7 +1108,7 @@ ldomNode * docx_pPrHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_pPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue)
+void docx_pPrHandler::handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue)
 {
     switch(m_state) {
     case docx_el_pStyle:
@@ -1192,7 +1192,7 @@ void docx_pPrHandler::handleAttribute(const lChar16 * attrname, const lChar16 * 
     }
 }
 
-void docx_pPrHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docx_pPrHandler::handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
 {
     switch(m_state) {
     case docx_el_ilvl:
@@ -1240,19 +1240,19 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
                 else if( level < m_importContext->getListLevel() )
                     m_importContext->closeList(level, m_writer);
                 else
-                    m_writer->OnTagClose(L"", L"li");
-                m_writer->OnTagOpen(L"", L"li");
+                    m_writer->OnTagClose(U"", U"li");
+                m_writer->OnTagOpen(U"", U"li");
             } else {
                 if( m_importContext->isInList() )
                     m_importContext->closeList(0, m_writer);
                 if( m_inTitle )
                     m_titleHandler->onTitleStart(outlineLevel.value + 1);
                 else
-                    m_writer->OnTagOpen(L"", L"p");
+                    m_writer->OnTagOpen(U"", U"p");
             }
-            lString16 style = m_pPr.getCss();
+            lString32 style = m_pPr.getCss();
             if( !style.empty() )
-                m_writer->OnAttribute(L"", L"style", style.c_str());
+                m_writer->OnAttribute(U"", U"style", style.c_str());
             m_writer->OnTagBody();
         }
         if(docx_el_r == tagId)
@@ -1275,17 +1275,17 @@ ldomNode * docx_pHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_pHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_pHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     if( docx_el_bookmarkStart == m_state && !lStr_cmp(attrname, "name") ) {
-        m_writer->OnTagOpen(L"", L"a");
-        m_writer->OnAttribute(L"", L"id", attrvalue);
+        m_writer->OnTagOpen(U"", U"a");
+        m_writer->OnAttribute(U"", U"id", attrvalue);
         m_writer->OnTagBody();
-        m_writer->OnTagClose(L"", L"a");
+        m_writer->OnTagClose(U"", U"a");
     }
 }
 
-void docx_pHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docx_pHandler::handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
 {
     CR_UNUSED2(nsname, tagname);
 
@@ -1294,7 +1294,7 @@ void docx_pHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagn
         closeStyleTags(m_writer);
         if( m_pPr.getNumberingId() == 0 ) {
             if( !m_inTitle ) {
-                m_writer->OnTagClose(L"", L"p");
+                m_writer->OnTagClose(U"", U"p");
             }
         }
         stop();
@@ -1339,13 +1339,13 @@ ldomNode * docx_documentHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_documentHandler::handleAttribute(const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue)
+void docx_documentHandler::handleAttribute(const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue)
 {
     if (m_state == docx_el_document && !lStr_cmp(nsname, "xmlns") )
         CRLog::debug("namespace declaration %s:%s",  LCSTR(attrname), LCSTR(attrvalue));
 }
 
-void docx_documentHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docx_documentHandler::handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
 {
     switch(m_state) {
     case docx_el_body:
@@ -1378,7 +1378,7 @@ ldomNode * docx_styleHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_styleHandler::handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue)
+void docx_styleHandler::handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue)
 {
     switch(m_state) {
     case docx_el_style:
@@ -1405,7 +1405,7 @@ void docx_styleHandler::handleAttribute(const lChar16 * attrname, const lChar16 
     }
 }
 
-void docx_styleHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docx_styleHandler::handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
 {
     CR_UNUSED2(nsname, tagname);
 
@@ -1451,7 +1451,7 @@ ldomNode * docx_stylesHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_stylesHandler::handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+void docx_stylesHandler::handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
 {
     switch(m_state) {
     case docx_el_rPrDefault:
@@ -1531,11 +1531,11 @@ void parseFootnotes(ldomDocumentWriter& writer, docxImportContext& context, int 
 
         if(parser.Parse())
 #ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
-            writer.OnTagClose(L"", docx_el_body_name);
+            writer.OnTagClose(U"", docx_el_body_name);
 #else
             // We didn't add <body name=notes> to not trigger crengine auto-in-page-foonotes
             // mechanism, so we can tweak them with style tweaks. We used a simple <div> instead.
-            writer.OnTagClose(L"", L"div");
+            writer.OnTagClose(U"", U"div");
 #endif
     }
     context.closeRelatedPart();
@@ -1643,7 +1643,7 @@ void docxImportContext::addAbstractNum(docxAbstractNumRef abstractNum)
     }
 }
 
-LVStreamRef docxImportContext::openContentPart(const lChar16 * const contentType)
+LVStreamRef docxImportContext::openContentPart(const lChar32 * const contentType)
 {
     m_docPart = m_package->getContentPart(contentType);
     if( !m_docPart.isNull() ) {
@@ -1652,7 +1652,7 @@ LVStreamRef docxImportContext::openContentPart(const lChar16 * const contentType
     return LVStreamRef();
 }
 
-LVStreamRef docxImportContext::openRelatedPart(const lChar16 * const relationshipType)
+LVStreamRef docxImportContext::openRelatedPart(const lChar32 * const relationshipType)
 {
     if ( !m_docPart.isNull() ) {
         m_relatedPart = m_docPart->getRelatedPart(relationshipType);
@@ -1680,20 +1680,20 @@ void docxImportContext::openList(int level, int numid, ldomDocumentWriter *write
             listLevel = num->getDocxLevel(const_cast<docxImportContext&>(*this), level - 1);
         if (listLevel)
             listType = listLevel->getListType();
-        writer->OnTagOpen(L"", L"ol");
+        writer->OnTagOpen(U"", U"ol");
         m_ListLevels.add(listType);
-        writer->OnAttribute(L"", L"style", getListStyleCss(listType).c_str());
+        writer->OnAttribute(U"", U"style", getListStyleCss(listType).c_str());
         writer->OnTagBody();
         if ( i != level - 1 )
-            writer->OnTagOpenNoAttr(L"", L"li");
+            writer->OnTagOpenNoAttr(U"", U"li");
     }
 }
 
 void docxImportContext::closeList(int level, ldomDocumentWriter *writer)
 {
     for(int i = getListLevel(); i > level; i--) {
-        writer->OnTagClose(L"", L"li");
-        writer->OnTagClose(L"", L"ol");
+        writer->OnTagClose(U"", U"li");
+        writer->OnTagClose(U"", U"ol");
         m_ListLevels.remove(getListLevel() - 1);
     }
 }
@@ -1723,7 +1723,7 @@ ldomNode * docx_lvlHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_lvlHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_lvlHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     css_length_t result;
 
@@ -1788,11 +1788,11 @@ ldomNode *docx_footnotesHandler::handleTagOpen(int tagId)
     case docx_el_p:
         if( m_normal && !m_importContext->m_footNoteId.empty() ) {
             if( m_pCount == 0 ) {
-                m_writer->OnTagOpen(L"", L"section");
-                lString16 id = isEndNote() ? L"c_" : L"n_";
+                m_writer->OnTagOpen(U"", U"section");
+                lString32 id = isEndNote() ? U"c_" : U"n_";
                 id << m_importContext->m_footNoteId.c_str();
-                m_writer->OnAttribute(L"", L"id", id.c_str());
-                m_writer->OnAttribute(L"", L"role", isEndNote() ? L"doc-rearnote" : L"doc-footnote");
+                m_writer->OnAttribute(U"", U"id", id.c_str());
+                m_writer->OnAttribute(U"", U"role", isEndNote() ? U"doc-rearnote" : U"doc-footnote");
                 m_writer->OnTagBody();
             }
             paragraphHandler.start();
@@ -1811,23 +1811,23 @@ ldomNode *docx_footnotesHandler::handleTagOpen(int tagId)
     case docx_el_footnotes:
     case docx_el_endnotes:
 #ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
-        m_writer->OnTagOpen(L"", docx_el_body_name);
+        m_writer->OnTagOpen(U"", docx_el_body_name);
         if(isEndNote()) {
-            m_writer->OnAttribute(L"", L"name", L"comments");
+            m_writer->OnAttribute(U"", U"name", U"comments");
             m_writer->OnTagBody();
-            m_writer->OnTagOpen(L"", L"subtitle");
+            m_writer->OnTagOpen(U"", U"subtitle");
             m_writer->OnTagBody();
-            m_writer->OnText(L"* * *", 5, 0);
-            m_writer->OnTagClose(L"", L"subtitle");
+            m_writer->OnText(U"* * *", 5, 0);
+            m_writer->OnTagClose(U"", U"subtitle");
         } else {
-            m_writer->OnAttribute(L"", L"name", L"notes");
+            m_writer->OnAttribute(U"", U"name", U"notes");
             m_writer->OnTagBody();
         }
 #else
         // We don't add <body name=notes> to not trigger crengine auto-in-page-foonotes
         // mechanism, so we can tweak them with style tweaks. We use a simple <div> instead.
-        m_writer->OnTagOpen(L"", L"div");
-        m_writer->OnAttribute(L"", L"style", L"page-break-before: always");
+        m_writer->OnTagOpen(U"", U"div");
+        m_writer->OnAttribute(U"", U"style", U"page-break-before: always");
         m_writer->OnTagBody();
 #endif
         //fallthrough
@@ -1838,7 +1838,7 @@ ldomNode *docx_footnotesHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_footnotesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_footnotesHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     switch(m_state) {
     case docx_el_footnote:
@@ -1854,7 +1854,7 @@ void docx_footnotesHandler::handleAttribute(const lChar16 *attrname, const lChar
     }
 }
 
-void docx_footnotesHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_footnotesHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     switch (m_state) {
     case docx_el_p:
@@ -1862,7 +1862,7 @@ void docx_footnotesHandler::handleTagClose(const lChar16 *nsname, const lChar16 
         break;
     case docx_el_endnote:
     case docx_el_footnote:
-        m_writer->OnTagClose(L"", L"section");
+        m_writer->OnTagClose(U"", U"section");
     default:
         docx_ElementHandler::handleTagClose(nsname, tagname);
         break;
@@ -1874,8 +1874,8 @@ ldomNode *docx_hyperlinkHandler::handleTagOpen(int tagId)
     switch(tagId) {
     case docx_el_r:
         if ( !m_target.empty() && 0 == m_runCount ) {
-            m_writer->OnTagOpen(L"", L"a");
-            m_writer->OnAttribute(L"", L"href", m_target.c_str());
+            m_writer->OnTagOpen(U"", U"a");
+            m_writer->OnAttribute(U"", U"href", m_target.c_str());
             m_writer->OnTagBody();
         }
         m_runCount++;
@@ -1888,23 +1888,23 @@ ldomNode *docx_hyperlinkHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_hyperlinkHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_hyperlinkHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     if( docx_el_hyperlink == m_state) {
         if ( !lStr_cmp(attrname, "id") ) {
-            m_target = m_importContext->getLinkTarget(lString16(attrvalue));
+            m_target = m_importContext->getLinkTarget(lString32(attrvalue));
         } else if (!lStr_cmp(attrname, "anchor") && m_target.empty()) {
-            m_target = cs16("#") + lString16(attrvalue);
+            m_target = cs32("#") + lString32(attrvalue);
         }
     }
 }
 
-void docx_hyperlinkHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_hyperlinkHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     switch (m_state) {
     case docx_el_hyperlink:
         if ( !m_target.empty() ) {
-            m_writer->OnTagClose(L"", L"a");
+            m_writer->OnTagClose(U"", U"a");
         }
     default:
         docx_ElementHandler::handleTagClose(nsname, tagname);
@@ -1919,20 +1919,20 @@ ldomNode *docx_drawingHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_drawingHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_drawingHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     if( m_state == docx_el_blip && !lStr_cmp(attrname, "embed") ) {
-        lString16 imgPath = m_importContext->getImageTarget(lString16(attrvalue));
+        lString32 imgPath = m_importContext->getImageTarget(lString32(attrvalue));
         if( !imgPath.empty() ) {
-            m_writer->OnTagOpen(L"", L"img");
-            m_writer->OnAttribute(L"", L"src",  imgPath.c_str());
+            m_writer->OnTagOpen(U"", U"img");
+            m_writer->OnAttribute(U"", U"src",  imgPath.c_str());
             m_writer->OnTagBody();
-            m_writer->OnTagClose(L"", L"img", true);
+            m_writer->OnTagClose(U"", U"img", true);
         }
     }
 }
 
-void docx_drawingHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_drawingHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     CR_UNUSED2(nsname, tagname);
 
@@ -1948,8 +1948,8 @@ void docx_tblHandler::endRowSpan(int column)
         CRLog::warn("Row span on column: %d, end: %d", column, rowSpan.rows);
         if( rowSpan.column ) {
             rowSpan.column->setAttributeValue(LXML_NS_NONE,
-                                              rowSpan.column->getDocument()->getAttrNameIndex(L"rowspan"),
-                                              lString16::itoa(rowSpan.rows).c_str());
+                                              rowSpan.column->getDocument()->getAttrNameIndex(U"rowspan"),
+                                              lString32::itoa(rowSpan.rows).c_str());
         } else {
             CRLog::error("No column node");
         }
@@ -1974,7 +1974,7 @@ ldomNode *docx_tblHandler::handleTagOpen(int tagId)
         break;
     case docx_el_tr:
         m_column = 0;
-        m_writer->OnTagOpenNoAttr(L"", L"tr");
+        m_writer->OnTagOpenNoAttr(U"", U"tr");
         break;
     default:
         break;
@@ -1986,33 +1986,33 @@ ldomNode *docx_tblHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_tblHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_tblHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     if( m_state == docx_el_gridSpan && !lStr_cmp( attrname, "val" ) ) {
-        m_colSpan = lString16(attrvalue).atoi();
+        m_colSpan = lString32(attrvalue).atoi();
     } else if( m_state == docx_el_vMerge && !lStr_cmp( attrname, "val" ) ) {
         if( !lStr_cmp( attrvalue, "restart" ) )
             m_vMergeState = VMERGE_RESET;
     }
 }
 
-void docx_tblHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_tblHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     CR_UNUSED2(nsname, tagname);
 
     if( !m_levels.empty() ) {
         switch(m_state) {
         case docx_el_tblPr:
-            m_writer->OnTagOpenNoAttr(L"", L"table");
+            m_writer->OnTagOpenNoAttr(U"", U"table");
             break;
         case docx_el_tr:
-            m_writer->OnTagClose(L"", L"tr");
+            m_writer->OnTagClose(U"", U"tr");
             m_rowCount++;
             break;
         case docx_el_tc:
             m_column++;
             if( m_pHandler_ == &m_pHandler )
-                m_writer->OnTagClose(L"", L"td");
+                m_writer->OnTagClose(U"", U"td");
             break;
         case docx_el_gridCol:
             m_columnCount++;
@@ -2024,7 +2024,7 @@ void docx_tblHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagna
         case docx_el_tcPr:
             if( VMERGE_NONE == m_vMergeState || VMERGE_RESET == m_vMergeState) {
                 m_pHandler_ = &m_pHandler;
-                ldomNode *columnNode = m_writer->OnTagOpen(L"", L"td");
+                ldomNode *columnNode = m_writer->OnTagOpen(U"", U"td");
                 for(int i = 0; i < m_colSpan; i++) {
                     if( m_column + i >= m_columnCount )
                         break; // shouldn't happen
@@ -2032,7 +2032,7 @@ void docx_tblHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagna
                 }
                 m_rowSpaninfo[m_column] = docx_row_span_info(columnNode);
                 if( m_colSpan > 1)
-                    m_writer->OnAttribute(L"", L"colspan", lString16::itoa(m_colSpan).c_str() );
+                    m_writer->OnAttribute(U"", U"colspan", lString32::itoa(m_colSpan).c_str() );
                 m_writer->OnTagBody();
             } else if ( VMERGE_CONTINUE == m_vMergeState ) {
                 m_pHandler_ = &m_skipHandler;
@@ -2053,7 +2053,7 @@ void docx_tblHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagna
         for(int i = 0; i < m_columnCount; i++) {
             endRowSpan(i);
         }
-        m_writer->OnTagClose(L"", L"table");
+        m_writer->OnTagClose(U"", U"table");
         stop();
     }
 
@@ -2082,7 +2082,7 @@ ldomNode *docx_numberingHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_numberingHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_numberingHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     switch(m_state) {
     case docx_el_num:
@@ -2113,19 +2113,19 @@ ldomNode *docx_abstractNumHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_abstractNumHandler::handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue)
+void docx_abstractNumHandler::handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue)
 {
     switch(m_state) {
     case docx_el_abstractNum:
         if ( !lStr_cmp(attrname, "abstractNumId") )
-            m_abstractNumRef->setId(lString16(attrvalue).atoi());
+            m_abstractNumRef->setId(lString32(attrvalue).atoi());
         break;
     default:
         break;
     }
 }
 
-void docx_abstractNumHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_abstractNumHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     CR_UNUSED2(nsname, tagname);
 
@@ -2149,16 +2149,16 @@ void docx_abstractNumHandler::start()
     docx_ElementHandler::start();
 }
 
-void docx_numHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void docx_numHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     switch(m_state) {
     case docx_el_num:
         if ( !lStr_cmp(attrname, "numId") )
-            m_numRef->setId( lString16(attrvalue).atoi() );
+            m_numRef->setId( lString32(attrvalue).atoi() );
         break;
     case docx_el_abstractNumId:
         if ( !lStr_cmp(attrname, "val") )
-            m_numRef->setBaseId( lString16(attrvalue).atoi() );
+            m_numRef->setBaseId( lString32(attrvalue).atoi() );
         break;
     default:
         break;
@@ -2180,7 +2180,7 @@ ldomNode *docx_numHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void docx_numHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void docx_numHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     CR_UNUSED2(nsname, tagname);
 

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -3,10 +3,10 @@
 
 class EpubItem {
 public:
-    lString16 href;
-    lString16 mediaType;
-    lString16 id;
-    lString16 title;
+    lString32 href;
+    lString32 mediaType;
+    lString32 id;
+    lString32 title;
     EpubItem()
     { }
     EpubItem( const EpubItem & v )
@@ -23,7 +23,7 @@ public:
 
 class EpubItems : public LVPtrVector<EpubItem> {
 public:
-    EpubItem * findById( const lString16 & id )
+    EpubItem * findById( const lString32 & id )
     {
         if ( id.empty() )
             return NULL;
@@ -35,15 +35,15 @@ public:
 };
 
 //static void dumpZip( LVContainerRef arc ) {
-//    lString16 arcName = LVExtractFilenameWithoutExtension( arc->GetName() );
+//    lString32 arcName = LVExtractFilenameWithoutExtension( arc->GetName() );
 //    if ( arcName.empty() )
 //        arcName = "unziparc";
-//    lString16 outDir = cs16("/tmp/") + arcName;
+//    lString32 outDir = cs32("/tmp/") + arcName;
 //    LVCreateDirectory(outDir);
 //    for ( int i=0; i<arc->GetObjectCount(); i++ ) {
 //        const LVContainerItemInfo * info = arc->GetObjectInfo(i);
 //        if ( !info->IsContainer() ) {
-//            lString16 outFileName = outDir + "/" + info->GetName();
+//            lString32 outFileName = outDir + "/" + info->GetName();
 //            LVCreateDirectory(LVExtractPath(outFileName));
 //            LVStreamRef in = arc->OpenStream(info->GetName(), LVOM_READ);
 //            LVStreamRef out = LVOpenFileStream(outFileName.c_str(), LVOM_WRITE);
@@ -66,9 +66,9 @@ bool DetectEpubFormat( LVStreamRef stream )
     //dumpZip( m_arc );
 
     // read "mimetype" file contents from root of archive
-    lString16 mimeType;
+    lString32 mimeType;
     {
-        LVStreamRef mtStream = m_arc->OpenStream(L"mimetype", LVOM_READ );
+        LVStreamRef mtStream = m_arc->OpenStream(U"mimetype", LVOM_READ );
         if ( !mtStream.isNull() ) {
             lvsize_t size = mtStream->GetSize();
             if ( size>4 && size<100 ) {
@@ -85,7 +85,7 @@ bool DetectEpubFormat( LVStreamRef stream )
         }
     }
 
-    if ( mimeType != L"application/epub+zip" )
+    if ( mimeType != U"application/epub+zip" )
         return false;
     return true;
 }
@@ -93,10 +93,10 @@ bool DetectEpubFormat( LVStreamRef stream )
 void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, ldomDocumentFragmentWriter & appender ) {
     if ( !mapRoot || !baseToc)
         return;
-    lUInt16 navPoint_id = mapRoot->getDocument()->getElementNameIndex(L"navPoint");
-    lUInt16 navLabel_id = mapRoot->getDocument()->getElementNameIndex(L"navLabel");
-    lUInt16 content_id = mapRoot->getDocument()->getElementNameIndex(L"content");
-    lUInt16 text_id = mapRoot->getDocument()->getElementNameIndex(L"text");
+    lUInt16 navPoint_id = mapRoot->getDocument()->getElementNameIndex(U"navPoint");
+    lUInt16 navLabel_id = mapRoot->getDocument()->getElementNameIndex(U"navLabel");
+    lUInt16 content_id = mapRoot->getDocument()->getElementNameIndex(U"content");
+    lUInt16 text_id = mapRoot->getDocument()->getElementNameIndex(U"text");
     for ( int i=0; i<EPUB_TOC_MAX_ITER; i++ ) {
         ldomNode * navPoint = mapRoot->findChildElement(LXML_NS_ANY, navPoint_id, i);
         if ( !navPoint )
@@ -110,8 +110,8 @@ void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
         ldomNode * content = navPoint->findChildElement(LXML_NS_ANY, content_id, -1);
         if ( !content )
             continue;
-        lString16 href = content->getAttributeValue("src");
-        lString16 title = text->getText(' ');
+        lString32 href = content->getAttributeValue("src");
+        lString32 title = text->getText(' ');
         title.trimDoubleSpaces(false, false, false);
         if ( href.empty() || title.empty() )
             continue;
@@ -125,7 +125,7 @@ void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
         if ( !target )
             continue;
         ldomXPointer ptr(target, 0);
-        LVTocItem * tocItem = baseToc->addChild(title, ptr, lString16::empty_str);
+        LVTocItem * tocItem = baseToc->addChild(title, ptr, lString32::empty_str);
         ReadEpubNcxToc( doc, navPoint, tocItem, appender );
     }
 }
@@ -142,10 +142,10 @@ void ReadEpubNcxPageList( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pa
     // Also see http://kb.daisy.org/publishing/docs/navigation/pagelist.html
     if ( !mapRoot || !pageMap)
         return;
-    lUInt16 pageTarget_id = mapRoot->getDocument()->getElementNameIndex(L"pageTarget");
-    lUInt16 navLabel_id = mapRoot->getDocument()->getElementNameIndex(L"navLabel");
-    lUInt16 content_id = mapRoot->getDocument()->getElementNameIndex(L"content");
-    lUInt16 text_id = mapRoot->getDocument()->getElementNameIndex(L"text");
+    lUInt16 pageTarget_id = mapRoot->getDocument()->getElementNameIndex(U"pageTarget");
+    lUInt16 navLabel_id = mapRoot->getDocument()->getElementNameIndex(U"navLabel");
+    lUInt16 content_id = mapRoot->getDocument()->getElementNameIndex(U"content");
+    lUInt16 text_id = mapRoot->getDocument()->getElementNameIndex(U"text");
     for ( int i=0; i<EPUB_ITEM_MAX_ITER; i++ ) {
         ldomNode * pageTarget = mapRoot->findChildElement(LXML_NS_ANY, pageTarget_id, i);
         if ( !pageTarget )
@@ -159,8 +159,8 @@ void ReadEpubNcxPageList( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pa
         ldomNode * content = pageTarget->findChildElement(LXML_NS_ANY, content_id, -1);
         if ( !content )
             continue;
-        lString16 href = content->getAttributeValue("src");
-        lString16 title = text->getText(' ');
+        lString32 href = content->getAttributeValue("src");
+        lString32 title = text->getText(' ');
         title.trimDoubleSpaces(false, false, false);
         if ( href.empty() || title.empty() )
             continue;
@@ -172,7 +172,7 @@ void ReadEpubNcxPageList( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pa
         if ( !target )
             continue;
         ldomXPointer ptr(target, 0);
-        pageMap->addPage(title, ptr, lString16::empty_str);
+        pageMap->addPage(title, ptr, lString32::empty_str);
     }
 }
 
@@ -180,10 +180,10 @@ void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
     // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
     if ( !mapRoot || !baseToc)
         return;
-    lUInt16 ol_id = mapRoot->getDocument()->getElementNameIndex(L"ol");
-    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(L"li");
-    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(L"a");
-    lUInt16 span_id = mapRoot->getDocument()->getElementNameIndex(L"span");
+    lUInt16 ol_id = mapRoot->getDocument()->getElementNameIndex(U"ol");
+    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(U"li");
+    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(U"a");
+    lUInt16 span_id = mapRoot->getDocument()->getElementNameIndex(U"span");
     for ( int i=0; i<EPUB_TOC_MAX_ITER; i++ ) {
         ldomNode * li = mapRoot->findChildElement(LXML_NS_ANY, li_id, i);
         if ( !li )
@@ -191,8 +191,8 @@ void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
         LVTocItem * tocItem = NULL;
         ldomNode * a = li->findChildElement(LXML_NS_ANY, a_id, -1);
         if ( a ) {
-            lString16 href = a->getAttributeValue("href");
-            lString16 title = a->getText(' ');
+            lString32 href = a->getAttributeValue("href");
+            lString32 title = a->getText(' ');
             if ( title.empty() ) {
                 // "If the a element contains [...] that do not provide intrinsic text alternatives,
                 // it must also include a title attribute with an alternate text rendition of the
@@ -207,7 +207,7 @@ void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
                     ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
                     if ( target ) {
                         ldomXPointer ptr(target, 0);
-                        tocItem = baseToc->addChild(title, ptr, lString16::empty_str);
+                        tocItem = baseToc->addChild(title, ptr, lString32::empty_str);
                         // Report xpointer to upper parent(s) that didn't have
                         // one (no <a>) - but stop before the root node
                         LVTocItem * tmp = baseToc;
@@ -228,14 +228,14 @@ void ReadEpubNavToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
             if ( !tocItem ) {
                 // Make a LVTocItem to contain sub items
                 // There can be a <span>, with no href: children will set it to its own xpointer
-                lString16 title;
+                lString32 title;
                 ldomNode * span = li->findChildElement(LXML_NS_ANY, span_id, -1);
                 if ( span ) {
                     title = span->getText(' ');
                     title.trimDoubleSpaces(false, false, false);
                 }
                 // If none, let title empty
-                tocItem = baseToc->addChild(title, ldomXPointer(), lString16::empty_str);
+                tocItem = baseToc->addChild(title, ldomXPointer(), lString32::empty_str);
             }
             ReadEpubNavToc( doc, ol, tocItem, appender );
         }
@@ -246,16 +246,16 @@ void ReadEpubNavPageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pag
     // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
     if ( !mapRoot || !pageMap)
         return;
-    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(L"li");
-    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(L"a");
+    lUInt16 li_id = mapRoot->getDocument()->getElementNameIndex(U"li");
+    lUInt16 a_id = mapRoot->getDocument()->getElementNameIndex(U"a");
     for ( int i=0; i<EPUB_ITEM_MAX_ITER; i++ ) {
         ldomNode * li = mapRoot->findChildElement(LXML_NS_ANY, li_id, i);
         if ( !li )
             break;
         ldomNode * a = li->findChildElement(LXML_NS_ANY, a_id, -1);
         if ( a ) {
-            lString16 href = a->getAttributeValue("href");
-            lString16 title = a->getText(' ');
+            lString32 href = a->getAttributeValue("href");
+            lString32 title = a->getText(' ');
             if ( title.empty() ) {
                 title = a->getAttributeValue("title");
             }
@@ -267,7 +267,7 @@ void ReadEpubNavPageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pag
                     ldomNode * target = doc->getNodeById(doc->getAttrValueIndex(href.substr(1).c_str()));
                     if ( target ) {
                         ldomXPointer ptr(target, 0);
-                        pageMap->addPage(title, ptr, lString16::empty_str);
+                        pageMap->addPage(title, ptr, lString32::empty_str);
                     }
                 }
             }
@@ -279,13 +279,13 @@ void ReadEpubAdobePageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * p
     // https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page-map
     if ( !mapRoot || !pageMap)
         return;
-    lUInt16 page_id = mapRoot->getDocument()->getElementNameIndex(L"page");
+    lUInt16 page_id = mapRoot->getDocument()->getElementNameIndex(U"page");
     for ( int i=0; i<EPUB_ITEM_MAX_ITER; i++ ) {
         ldomNode * page = mapRoot->findChildElement(LXML_NS_ANY, page_id, i);
         if ( !page )
             break;
-        lString16 href = page->getAttributeValue("href");
-        lString16 title = page->getAttributeValue("name");
+        lString32 href = page->getAttributeValue("href");
+        lString32 title = page->getAttributeValue("name");
         title.trimDoubleSpaces(false, false, false);
         if ( href.empty() || title.empty() )
             continue;
@@ -297,22 +297,22 @@ void ReadEpubAdobePageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * p
         if ( !target )
             continue;
         ldomXPointer ptr(target, 0);
-        pageMap->addPage(title, ptr, lString16::empty_str);
+        pageMap->addPage(title, ptr, lString32::empty_str);
     }
 }
 
-lString16 EpubGetRootFilePath(LVContainerRef m_arc)
+lString32 EpubGetRootFilePath(LVContainerRef m_arc)
 {
     // check root media type
-    lString16 rootfilePath;
-    lString16 rootfileMediaType;
+    lString32 rootfilePath;
+    lString32 rootfileMediaType;
     // read container.xml
     {
-        LVStreamRef container_stream = m_arc->OpenStream(L"META-INF/container.xml", LVOM_READ);
+        LVStreamRef container_stream = m_arc->OpenStream(U"META-INF/container.xml", LVOM_READ);
         if ( !container_stream.isNull() ) {
             ldomDocument * doc = LVParseXMLStream( container_stream );
             if ( doc ) {
-                ldomNode * rootfile = doc->nodeFromXPath( cs16("container/rootfiles/rootfile") );
+                ldomNode * rootfile = doc->nodeFromXPath( cs32("container/rootfiles/rootfile") );
                 if ( rootfile && rootfile->isElement() ) {
                     rootfilePath = rootfile->getAttributeValue("full-path");
                     rootfileMediaType = rootfile->getAttributeValue("media-type");
@@ -323,7 +323,7 @@ lString16 EpubGetRootFilePath(LVContainerRef m_arc)
     }
 
     if (rootfilePath.empty() || rootfileMediaType != "application/oebps-package+xml")
-        return lString16::empty_str;
+        return lString32::empty_str;
     return rootfilePath;
 }
 
@@ -350,9 +350,9 @@ public:
 
 class EncryptedItem {
 public:
-    lString16 _uri;
-    lString16 _method;
-    EncryptedItem(lString16 uri, lString16 method) : _uri(uri), _method(method) {
+    lString32 _uri;
+    lString32 _method;
+    EncryptedItem(lString32 uri, lString32 method) : _uri(uri), _method(method) {
 
     }
 };
@@ -372,7 +372,7 @@ class EncCallback : public LVXMLParserCallback {
     bool insideCipherReference;
 public:
     /// called on opening tag <
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname) {
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname) {
         CR_UNUSED(nsname);
         if (!lStr_cmp(tagname, "encryption"))
             insideEncryption = true;
@@ -387,7 +387,7 @@ public:
         return NULL;
     }
     /// called on tag close
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false ) {
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false ) {
         CR_UNUSED(nsname);
         if (!lStr_cmp(tagname, "encryption"))
             insideEncryption = false;
@@ -404,7 +404,7 @@ public:
             insideCipherReference = false;
     }
     /// called on element attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue ) {
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue ) {
         CR_UNUSED2(nsname, attrvalue);
         if (!lStr_cmp(attrname, "URI") && insideCipherReference)
             insideEncryption = false;
@@ -412,11 +412,11 @@ public:
             insideEncryptedData = false;
     }
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags ) {
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags ) {
         CR_UNUSED3(text,len,flags);
     }
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) {
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) {
         CR_UNUSED3(name,data,size);
         return false;
     }
@@ -426,8 +426,8 @@ public:
     virtual void OnTagBody() { }
 
     EncryptedItemCallback * _container;
-    lString16 algorithm;
-    lString16 uri;
+    lString32 algorithm;
+    lString32 uri;
     /// destructor
     EncCallback(EncryptedItemCallback * container) : _container(container) {
         insideEncryption = false;
@@ -448,14 +448,14 @@ public:
     }
 
     virtual LVContainer * GetParentContainer() { return _container->GetParentContainer(); }
-    //virtual const LVContainerItemInfo * GetObjectInfo(const wchar_t * pname);
+    //virtual const LVContainerItemInfo * GetObjectInfo(const lChar32 * pname);
     virtual const LVContainerItemInfo * GetObjectInfo(int index) { return _container->GetObjectInfo(index); }
     virtual int GetObjectCount() const { return _container->GetObjectCount(); }
     /// returns object size (file size or directory entry count)
     virtual lverror_t GetSize( lvsize_t * pSize ) { return _container->GetSize(pSize); }
 
 
-    virtual LVStreamRef OpenStream( const lChar16 * fname, lvopen_mode_t mode ) {
+    virtual LVStreamRef OpenStream( const lChar32 * fname, lvopen_mode_t mode ) {
 
         LVStreamRef res = _container->OpenStream(fname, mode);
         if (res.isNull())
@@ -466,12 +466,12 @@ public:
     }
 
     /// returns stream/container name, may be NULL if unknown
-    virtual const lChar16 * GetName()
+    virtual const lChar32 * GetName()
     {
         return _container->GetName();
     }
     /// sets stream/container name, may be not implemented for some objects
-    virtual void SetName(const lChar16 * name)
+    virtual void SetName(const lChar32 * name)
     {
         _container->SetName(name);
     }
@@ -481,13 +481,13 @@ public:
         _list.add(item);
     }
 
-    EncryptedItem * findEncryptedItem(const lChar16 * name) {
-        lString16 n;
+    EncryptedItem * findEncryptedItem(const lChar32 * name) {
+        lString32 n;
         if (name[0] != '/' && name[0] != '\\')
             n << "/";
         n << name;
         for (int i=0; i<_list.length(); i++) {
-            lString16 s = _list[i]->_uri;
+            lString32 s = _list[i]->_uri;
             if (s[0]!='/' && s[i]!='\\')
                 s = "/" + s;
             if (_list[i]->_uri == s)
@@ -496,13 +496,13 @@ public:
         return NULL;
     }
 
-    bool isEncryptedItem(const lChar16 * name) {
+    bool isEncryptedItem(const lChar32 * name) {
         return findEncryptedItem(name) != NULL;
     }
 
     LVArray<lUInt8> _fontManglingKey;
 
-    bool setManglingKey(lString16 key) {
+    bool setManglingKey(lString32 key) {
         if (key.startsWith("urn:uuid:"))
             key = key.substr(9);
         _fontManglingKey.clear();
@@ -525,7 +525,7 @@ public:
 
     bool hasUnsupportedEncryption() {
         for (int i=0; i<_list.length(); i++) {
-            lString16 method = _list[i]->_method;
+            lString32 method = _list[i]->_method;
             if (method != "http://ns.adobe.com/pdf/enc#RC") {
                 CRLog::debug("unsupported encryption method: %s", LCSTR(method));
                 return true;
@@ -535,7 +535,7 @@ public:
     }
 
     bool open() {
-        LVStreamRef stream = _container->OpenStream(L"META-INF/encryption.xml", LVOM_READ);
+        LVStreamRef stream = _container->OpenStream(U"META-INF/encryption.xml", LVOM_READ);
         if (stream.isNull())
             return false;
         EncCallback enccallback(this);
@@ -551,43 +551,43 @@ public:
 void createEncryptedEpubWarningDocument(ldomDocument * m_doc) {
     CRLog::error("EPUB document contains encrypted items");
     ldomDocumentWriter writer(m_doc);
-    writer.OnTagOpenNoAttr(NULL, L"body");
-    writer.OnTagOpenNoAttr(NULL, L"h3");
-    lString16 hdr("Encrypted content");
+    writer.OnTagOpenNoAttr(NULL, U"body");
+    writer.OnTagOpenNoAttr(NULL, U"h3");
+    lString32 hdr("Encrypted content");
     writer.OnText(hdr.c_str(), hdr.length(), 0);
-    writer.OnTagClose(NULL, L"h3");
+    writer.OnTagClose(NULL, U"h3");
 
-    writer.OnTagOpenAndClose(NULL, L"hr");
+    writer.OnTagOpenAndClose(NULL, U"hr");
 
-    writer.OnTagOpenNoAttr(NULL, L"p");
-    lString16 txt("This document is encrypted (has DRM protection).");
+    writer.OnTagOpenNoAttr(NULL, U"p");
+    lString32 txt("This document is encrypted (has DRM protection).");
     writer.OnText(txt.c_str(), txt.length(), 0);
-    writer.OnTagClose(NULL, L"p");
+    writer.OnTagClose(NULL, U"p");
 
-    writer.OnTagOpenNoAttr(NULL, L"p");
-    lString16 txt2("Cool Reader doesn't support reading of DRM protected books.");
+    writer.OnTagOpenNoAttr(NULL, U"p");
+    lString32 txt2("Cool Reader doesn't support reading of DRM protected books.");
     writer.OnText(txt2.c_str(), txt2.length(), 0);
-    writer.OnTagClose(NULL, L"p");
+    writer.OnTagClose(NULL, U"p");
 
-    writer.OnTagOpenNoAttr(NULL, L"p");
-    lString16 txt3("To read this book, please use software recommended by book seller.");
+    writer.OnTagOpenNoAttr(NULL, U"p");
+    lString32 txt3("To read this book, please use software recommended by book seller.");
     writer.OnText(txt3.c_str(), txt3.length(), 0);
-    writer.OnTagClose(NULL, L"p");
+    writer.OnTagClose(NULL, U"p");
 
-    writer.OnTagOpenAndClose(NULL, L"hr");
+    writer.OnTagOpenAndClose(NULL, U"hr");
 
-    writer.OnTagOpenNoAttr(NULL, L"p");
-    lString16 txt4("");
+    writer.OnTagOpenNoAttr(NULL, U"p");
+    lString32 txt4("");
     writer.OnText(txt4.c_str(), txt4.length(), 0);
-    writer.OnTagClose(NULL, L"p");
+    writer.OnTagClose(NULL, U"p");
 
-    writer.OnTagClose(NULL, L"body");
+    writer.OnTagClose(NULL, U"body");
 }
 
 LVStreamRef GetEpubCoverpage(LVContainerRef arc)
 {
     // check root media type
-    lString16 rootfilePath = EpubGetRootFilePath(arc);
+    lString32 rootfilePath = EpubGetRootFilePath(arc);
     if ( rootfilePath.empty() )
         return LVStreamRef();
 
@@ -598,7 +598,7 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
 
     LVContainerRef m_arc = LVContainerRef(decryptor);
 
-    lString16 codeBase = LVExtractPath(rootfilePath, false);
+    lString32 codeBase = LVExtractPath(rootfilePath, false);
     CRLog::trace("codeBase=%s", LCSTR(codeBase));
 
     LVStreamRef content_stream = m_arc->OpenStream(rootfilePath.c_str(), LVOM_READ);
@@ -609,18 +609,18 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
     LVStreamRef coverPageImageStream;
     // reading content stream
     {
-        lString16 coverId;
+        lString32 coverId;
         ldomDocument * doc = LVParseXMLStream( content_stream );
         if ( !doc )
             return LVStreamRef();
 
         for ( size_t i=1; i<=EPUB_META_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/meta[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/meta[") << fmt::decimal(i) << "]");
             if ( !item )
                 break;
-            lString16 name = item->getAttributeValue("name");
+            lString32 name = item->getAttributeValue("name");
             if (name == "cover") {
-                lString16 content = item->getAttributeValue("content");
+                lString32 content = item->getAttributeValue("content");
                 coverId = content;
                 // We're done
                 break;
@@ -629,16 +629,16 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
 
         // items
         for ( size_t i=1; i<=EPUB_ITEM_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/manifest/item[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/manifest/item[") << fmt::decimal(i) << "]");
             if ( !item )
                 break;
-            lString16 href = item->getAttributeValue("href");
-            lString16 id = item->getAttributeValue("id");
+            lString32 href = item->getAttributeValue("href");
+            lString32 id = item->getAttributeValue("id");
             if ( !href.empty() && !id.empty() ) {
                 if (id == coverId) {
                     // coverpage file
                     href = DecodeHTMLUrlString(href);
-                    lString16 coverFileName = LVCombinePaths(codeBase, href);
+                    lString32 coverFileName = LVCombinePaths(codeBase, href);
                     CRLog::info("EPUB coverpage file: %s", LCSTR(coverFileName));
                     coverPageImageStream = m_arc->OpenStream(coverFileName.c_str(), LVOM_READ);
                     // We're done
@@ -655,13 +655,13 @@ LVStreamRef GetEpubCoverpage(LVContainerRef arc)
 
 class EmbeddedFontStyleParser {
     LVEmbeddedFontList & _fontList;
-    lString16 _basePath;
+    lString32 _basePath;
     int _state;
     lString8 _face;
     lString8 islocal;
     bool _italic;
     bool _bold;
-    lString16 _url;
+    lString32 _url;
 public:
     EmbeddedFontStyleParser(LVEmbeddedFontList & fontList) : _fontList(fontList) { }
     void onToken(char token) {
@@ -707,7 +707,7 @@ public:
                     if (islocal.length()==5 && _basePath.length()!=0)
                         _url = _url.substr((_basePath.length()+1), (_url.length()-_basePath.length()));
                     if (_fontList.findByUrl(_url))
-                        _url=_url.append(lString16(" ")); //avoid add() replaces existing local name
+                        _url=_url.append(lString32(" ")); //avoid add() replaces existing local name
                     _fontList.add(_url, _face, _bold, _italic);
                 }
             }
@@ -717,7 +717,7 @@ public:
             if (_state == 2) {
                 if (!_url.empty()) {
                       if (islocal.length() == 5 && _basePath.length()!=0) _url=(_url.substr((_basePath.length()+1),(_url.length()-_basePath.length())));
-                        if (_fontList.findByUrl(_url)) _url=_url.append(lString16(" "));
+                        if (_fontList.findByUrl(_url)) _url=_url.append(lString32(" "));
                     _fontList.add(_url, _face, _bold, _italic);
                 }
                 _state = 11;
@@ -783,8 +783,8 @@ public:
         //CRLog::trace("state==%d: \"%s\"", _state, token.c_str());
         if (_state == 11 || _state == 13) {
             if (!token.empty()) {
-                lString16 ltoken = Utf8ToUnicode(token);
-                if (ltoken.startsWithNoCase(lString16("res://")) || ltoken.startsWithNoCase(lString16("file://")) )
+                lString32 ltoken = Utf8ToUnicode(token);
+                if (ltoken.startsWithNoCase(lString32("res://")) || ltoken.startsWithNoCase(lString32("file://")) )
                     _url = ltoken;
                 else
                     _url = LVCombinePaths(_basePath, ltoken);
@@ -851,7 +851,7 @@ public:
         }
         return tmp;
     }
-    void parse(lString16 basePath, const lString8 & css) {
+    void parse(lString32 basePath, const lString8 & css) {
         _state = 0;
         _basePath = basePath;
         lString8 token;
@@ -895,7 +895,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         return false; // not a ZIP archive
 
     // check root media type
-    lString16 rootfilePath = EpubGetRootFilePath(arc);
+    lString32 rootfilePath = EpubGetRootFilePath(arc);
     if ( rootfilePath.empty() )
         return false;
 
@@ -921,8 +921,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     EpubItems epubItems;
     //EpubItem * epubToc = NULL; //TODO
     LVArray<EpubItem*> spineItems;
-    lString16 codeBase;
-    //lString16 css;
+    lString32 codeBase;
+    //lString32 css;
 
     //
     {
@@ -936,12 +936,12 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 
 
     bool isEpub3 = false;
-    lString16 epubVersion;
-    lString16 navHref; // epub3 TOC
-    lString16 ncxHref; // epub2 TOC
-    lString16 pageMapHref; // epub2 Adobe page-map
-    lString16 pageMapSource;
-    lString16 coverId;
+    lString32 epubVersion;
+    lString32 navHref; // epub3 TOC
+    lString32 ncxHref; // epub2 TOC
+    lString32 pageMapHref; // epub2 Adobe page-map
+    lString32 pageMapSource;
+    lString32 coverId;
 
     LVEmbeddedFontList fontList;
     EmbeddedFontStyleParser styleParser(fontList);
@@ -959,7 +959,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 //            doc->saveToStream(out, NULL, true);
 //        }
 
-        ldomNode * package = doc->nodeFromXPath(lString16("package"));
+        ldomNode * package = doc->nodeFromXPath(lString32("package"));
         if ( package ) {
             epubVersion = package->getAttributeValue("version");
             if ( !epubVersion.empty() && epubVersion[0] >= '3' )
@@ -967,11 +967,11 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         }
 
         CRPropRef m_doc_props = m_doc->getProps();
-        // lString16 authors = doc->textFromXPath( cs16("package/metadata/creator"));
-        lString16 title = doc->textFromXPath( cs16("package/metadata/title"));
-        lString16 language = doc->textFromXPath( cs16("package/metadata/language"));
-        lString16 description = doc->textFromXPath( cs16("package/metadata/description"));
-        pageMapSource = doc->textFromXPath( cs16("package/metadata/source"));
+        // lString32 authors = doc->textFromXPath( cs32("package/metadata/creator"));
+        lString32 title = doc->textFromXPath( cs32("package/metadata/title"));
+        lString32 language = doc->textFromXPath( cs32("package/metadata/language"));
+        lString32 description = doc->textFromXPath( cs32("package/metadata/description"));
+        pageMapSource = doc->textFromXPath( cs32("package/metadata/source"));
         // m_doc_props->setString(DOC_PROP_AUTHORS, authors);
         m_doc_props->setString(DOC_PROP_TITLE, title);
         m_doc_props->setString(DOC_PROP_LANGUAGE, language);
@@ -982,12 +982,12 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // as a single doc_props string with values separated by \n.
         // (these \n can be replaced on the lua side for the most appropriate display)
         bool authors_set = false;
-        lString16 authors;
+        lString32 authors;
         for ( size_t i=1; i<=EPUB_META_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/creator[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/creator[") << fmt::decimal(i) << "]");
             if (!item)
                 break;
-            lString16 author = item->getText().trim();
+            lString32 author = item->getText().trim();
             if (authors_set) {
                 authors << "\n" << author;
             }
@@ -1000,12 +1000,12 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 
         // There may be multiple <dc:subject> tags, which are usually used for keywords, categories
         bool subjects_set = false;
-        lString16 subjects;
+        lString32 subjects;
         for ( size_t i=1; i<=EPUB_META_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/subject[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/subject[") << fmt::decimal(i) << "]");
             if (!item)
                 break;
-            lString16 subject = item->getText().trim();
+            lString32 subject = item->getText().trim();
             if (subjects_set) {
                 subjects << "\n" << subject;
             }
@@ -1017,10 +1017,10 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc_props->setString(DOC_PROP_KEYWORDS, subjects);
 
         for ( size_t i=1; i<=EPUB_META_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/identifier[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/identifier[") << fmt::decimal(i) << "]");
             if (!item)
                 break;
-            lString16 key = item->getText().trim();
+            lString32 key = item->getText().trim();
             if (decryptor->setManglingKey(key)) {
                 CRLog::debug("Using font mangling key %s", LCSTR(key));
                 break;
@@ -1059,23 +1059,23 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 break;
             }
 
-            ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/meta[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/meta[") << fmt::decimal(i) << "]");
             if ( !item )
                 break;
 
-            lString16 name = item->getAttributeValue("name");
+            lString32 name = item->getAttributeValue("name");
             // Might come before or after the series stuff
             // (e.g., while you might think it'd come early, Calibre appends it during the Send To Device process).
             // Fun fact: this isn't part of *either* version of the ePub specs.
             // It's simply an agreed-upon convention, given how utterly terrible the actual specs are.
             if (coverId.empty() && name == "cover") {
-                lString16 content = item->getAttributeValue("content");
+                lString32 content = item->getAttributeValue("content");
                 coverId = content;
                 continue;
             }
             // Has to come before calibre:series_index
             if (!hasSeriesMeta && name == "calibre:series") {
-                lString16 content = item->getAttributeValue("content");
+                lString32 content = item->getAttributeValue("content");
                 PreProcessXmlString(content, 0);
                 m_doc_props->setString(DOC_PROP_SERIES_NAME, content);
                 hasSeriesMeta = true;
@@ -1083,7 +1083,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             }
             // Has to come after calibre:series
             if (hasSeriesMeta && name == "calibre:series_index") {
-                lString16 content = item->getAttributeValue("content");
+                lString32 content = item->getAttributeValue("content");
                 PreProcessXmlString(content, 0);
                 m_doc_props->setString(DOC_PROP_SERIES_NUMBER, content);
                 hasSeriesIdMeta = true;
@@ -1094,14 +1094,14 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // Fallback to the ePub 3 spec for cover-image, c.f. https://www.w3.org/publishing/epub3/epub-packages.html#sec-cover-image
         if (isEpub3 && coverId.empty()) {
             for ( size_t i=1; i<=EPUB_ITEM_MAX_ITER; i++ ) {
-                ldomNode * item = doc->nodeFromXPath(lString16("package/manifest/item[") << fmt::decimal(i) << "]");
+                ldomNode * item = doc->nodeFromXPath(lString32("package/manifest/item[") << fmt::decimal(i) << "]");
                 if ( !item )
                     break;
 
                 // NOTE: Yes, plural, not a typo... -_-"
-                lString16 props = item->getAttributeValue("properties");
+                lString32 props = item->getAttributeValue("properties");
                 if (!props.empty() && props == "cover-image") {
-                    lString16 id = item->getAttributeValue("id");
+                    lString32 id = item->getAttributeValue("id");
                     coverId = id;
                     // Can only be one (or none), we're done!
                     break;
@@ -1119,13 +1119,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         //       That thankfully seems to have been relegated to the past, despite title-type still supporting a collection type:
         //       https://www.w3.org/publishing/epub32/epub-packages.html#sec-title-type
         if (isEpub3 && !hasSeriesMeta) {
-            lString16 seriesId;
+            lString32 seriesId;
             for ( size_t i=1; i<=EPUB_META_MAX_ITER; i++ ) {
-                ldomNode * item = doc->nodeFromXPath(lString16("package/metadata/meta[") << fmt::decimal(i) << "]");
+                ldomNode * item = doc->nodeFromXPath(lString32("package/metadata/meta[") << fmt::decimal(i) << "]");
                 if ( !item )
                     break;
 
-                lString16 property = item->getAttributeValue("property");
+                lString32 property = item->getAttributeValue("property");
 
                 // If we don't have a collection yet, try to find one
                 // NOTE: The specs say that collections *MAY* be nested (i.e., a belongs-to-collection node may refine another one).
@@ -1134,7 +1134,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 //       or the most deeply nested one, depending on what made the most sense, but I don't, so, KISS ;).
                 if (!hasSeriesMeta) {
                     if (property == "belongs-to-collection") {
-                        lString16 content = item->getText().trim();
+                        lString32 content = item->getText().trim();
                         PreProcessXmlString(content, 0);
                         m_doc_props->setString(DOC_PROP_SERIES_NAME, content);
                         hasSeriesMeta = true;
@@ -1150,9 +1150,9 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     /*
                     if (property == "collection-type") {
                         // Only support valid types (series or set)
-                        lString16 content = item->getText().trim();
+                        lString32 content = item->getText().trim();
                         if (content == "series" || content == "set") {
-                            lString16 id = item->getAttributeValue("refines");
+                            lString32 id = item->getAttributeValue("refines");
                             // Strip the anchor to match against seriesId
                             if (id.startsWith("#")) {
                                 id = id.substr(1, id.length() - 1);
@@ -1165,14 +1165,14 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     }
                     */
                     if (property == "group-position") {
-                        lString16 id = item->getAttributeValue("refines");
+                        lString32 id = item->getAttributeValue("refines");
                         // Strip the anchor to match against seriesId
                         if (id.startsWith("#")) {
                             id = id.substr(1, id.length() - 1);
                         }
                         // If we've got a match, that's our position in the series!
                         if (id == seriesId) {
-                            lString16 content = item->getText().trim();
+                            lString32 content = item->getText().trim();
                             PreProcessXmlString(content, 0);
                             // NOTE: May contain decimal values (much like calibre:series_index).
                             //       c.f., https://github.com/koreader/crengine/pull/346#discussion_r436190907
@@ -1197,17 +1197,17 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // items
         CRLog::debug("opf: reading items");
         for ( size_t i=1; i<=EPUB_ITEM_MAX_ITER; i++ ) {
-            ldomNode * item = doc->nodeFromXPath(lString16("package/manifest/item[") << fmt::decimal(i) << "]");
+            ldomNode * item = doc->nodeFromXPath(lString32("package/manifest/item[") << fmt::decimal(i) << "]");
             if ( !item )
                 break;
-            lString16 href = item->getAttributeValue("href");
-            lString16 mediaType = item->getAttributeValue("media-type");
-            lString16 id = item->getAttributeValue("id");
+            lString32 href = item->getAttributeValue("href");
+            lString32 mediaType = item->getAttributeValue("media-type");
+            lString32 id = item->getAttributeValue("id");
             if ( !href.empty() && !id.empty() ) {
                 href = DecodeHTMLUrlString(href);
                 if ( id==coverId ) {
                     // coverpage file
-                    lString16 coverFileName = LVCombinePaths(codeBase, href);
+                    lString32 coverFileName = LVCombinePaths(codeBase, href);
                     CRLog::info("EPUB coverpage file: %s", LCSTR(coverFileName));
                     LVStreamRef stream = m_arc->OpenStream(coverFileName.c_str(), LVOM_READ);
                     if ( !stream.isNull() ) {
@@ -1230,28 +1230,28 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 epubItems.add( epubItem );
 
                 if ( isEpub3 && navHref.empty() ) {
-                    lString16 properties = item->getAttributeValue("properties");
+                    lString32 properties = item->getAttributeValue("properties");
                     // We met properties="nav scripted"...
-                    if ( properties == L"nav" || properties.startsWith(L"nav ")
-                            || properties.endsWith(L" nav") || properties.pos(L" nav ") >= 0 ) {
+                    if ( properties == U"nav" || properties.startsWith(U"nav ")
+                            || properties.endsWith(U" nav") || properties.pos(U" nav ") >= 0 ) {
                         navHref = href;
                     }
                 }
 
 //                // register embedded document fonts
-//                if (mediaType == L"application/vnd.ms-opentype"
-//                        || mediaType == L"application/x-font-otf"
-//                        || mediaType == L"application/x-font-ttf") { // TODO: more media types?
+//                if (mediaType == U"application/vnd.ms-opentype"
+//                        || mediaType == U"application/x-font-otf"
+//                        || mediaType == U"application/x-font-ttf") { // TODO: more media types?
 //                    // TODO:
 //                    fontList.add(codeBase + href);
 //                }
             }
             if (mediaType == "text/css") {
-                lString16 name = LVCombinePaths(codeBase, href);
+                lString32 name = LVCombinePaths(codeBase, href);
                 LVStreamRef cssStream = m_arc->OpenStream(name.c_str(), LVOM_READ);
                 if (!cssStream.isNull()) {
                     lString8 cssFile = UnicodeToUtf8(LVReadTextFile(cssStream));
-                    lString16 base = name;
+                    lString32 base = name;
                     LVExtractLastPathElement(base);
                     //CRLog::trace("style: %s", cssFile.c_str());
                     styleParser.parse(base, cssFile);
@@ -1270,7 +1270,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // spine == itemrefs
         if ( epubItems.length()>0 ) {
             CRLog::debug("opf: reading spine");
-            ldomNode * spine = doc->nodeFromXPath( cs16("package/spine") );
+            ldomNode * spine = doc->nodeFromXPath( cs32("package/spine") );
             if ( spine ) {
 
                 // <spine toc="ncx" page-map="page-map">
@@ -1282,7 +1282,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     pageMapHref = LVCombinePaths(codeBase, page_map->href);
 
                 for ( size_t i=1; i<=EPUB_ITEM_MAX_ITER; i++ ) {
-                    ldomNode * item = doc->nodeFromXPath(lString16("package/spine/itemref[") << fmt::decimal(i) << "]");
+                    ldomNode * item = doc->nodeFromXPath(lString32("package/spine/itemref[") << fmt::decimal(i) << "]");
                     if ( !item )
                         break;
                     EpubItem * epubItem = epubItems.findById( item->getAttributeValue("idref") );
@@ -1326,15 +1326,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc->registerEmbeddedFonts();
     }
 
-    ldomDocumentFragmentWriter appender(&writer, cs16("body"), cs16("DocFragment"), lString16::empty_str );
+    ldomDocumentFragmentWriter appender(&writer, cs32("body"), cs32("DocFragment"), lString32::empty_str );
     writer.OnStart(NULL);
-    writer.OnTagOpenNoAttr(L"", L"body");
+    writer.OnTagOpenNoAttr(U"", U"body");
     int fragmentCount = 0;
     size_t spineItemsNb = spineItems.length();
     for ( size_t i=0; i<spineItemsNb; i++ ) {
         if (spineItems[i]->mediaType == "application/xhtml+xml") {
-            lString16 name = LVCombinePaths(codeBase, spineItems[i]->href);
-            lString16 subst = cs16("_doc_fragment_") + fmt::decimal(i);
+            lString32 name = LVCombinePaths(codeBase, spineItems[i]->href);
+            lString32 subst = cs32("_doc_fragment_") + fmt::decimal(i);
             appender.addPathSubstitution( name, subst );
             //CRLog::trace("subst: %s => %s", LCSTR(name), LCSTR(subst));
         }
@@ -1349,13 +1349,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             }
         }
         if (spineItems[i]->mediaType == "application/xhtml+xml") {
-            lString16 name = LVCombinePaths(codeBase, spineItems[i]->href);
+            lString32 name = LVCombinePaths(codeBase, spineItems[i]->href);
             {
                 CRLog::debug("Checking fragment: %s", LCSTR(name));
                 LVStreamRef stream = m_arc->OpenStream(name.c_str(), LVOM_READ);
                 if ( !stream.isNull() ) {
                     appender.setCodeBase( name );
-                    lString16 base = name;
+                    lString32 base = name;
                     LVExtractLastPathElement(base);
                     //CRLog::trace("base: %s", LCSTR(base));
                     //LVXMLParser
@@ -1389,15 +1389,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         // http://idpf.org/epub/30/spec/epub30-contentdocs.html#sec-xhtml-nav-def
         navHref = LVCombinePaths(codeBase, navHref);
         LVStreamRef stream = m_arc->OpenStream(navHref.c_str(), LVOM_READ);
-        lString16 codeBase = LVExtractPath( navHref );
+        lString32 codeBase = LVExtractPath( navHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * navDoc = LVParseXMLStream( stream );
             if ( navDoc!=NULL ) {
                 // Find <nav epub:type="toc">
-                lUInt16 nav_id = navDoc->getElementNameIndex(L"nav");
+                lUInt16 nav_id = navDoc->getElementNameIndex(U"nav");
                 ldomNode * navDocRoot = navDoc->getRootNode();
                 ldomNode * n = navDocRoot;
                 // Kobo falls back to other <nav type=> when no <nav type=toc> is found,
@@ -1413,14 +1413,14 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                         // and not when we get back to it from a child to process next sibling
                         if (nextChildIndex == 0) {
                             if ( n->isElement() && n->getNodeId() == nav_id ) {
-                                lString16 type = n->getAttributeValue("type");
-                                if ( type == L"toc") {
+                                lString32 type = n->getAttributeValue("type");
+                                if ( type == U"toc") {
                                     n_toc = n;
                                 }
-                                else if ( type == L"landmarks") {
+                                else if ( type == U"landmarks") {
                                     n_landmarks = n;
                                 }
-                                else if ( type == L"page-list") {
+                                else if ( type == U"page-list") {
                                     n_page_list = n;
                                 }
                             }
@@ -1456,12 +1456,12 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     // we could just add it as a top container item for the others, which will
                     // be useless (and bothering), so let's just ignore it.
                     // Get its first and single <OL> child
-                    ldomNode * ol_root = n_toc->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(L"ol"), -1 );
+                    ldomNode * ol_root = n_toc->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(U"ol"), -1 );
                     if ( ol_root )
                         ReadEpubNavToc( m_doc, ol_root, m_doc->getToc(), appender );
                 }
                 if ( n_page_list ) {
-                    ldomNode * ol_root = n_page_list->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(L"ol"), -1 );
+                    ldomNode * ol_root = n_page_list->findChildElement( LXML_NS_ANY, navDoc->getElementNameIndex(U"ol"), -1 );
                     if ( ol_root )
                         ReadEpubNavPageMap( m_doc, ol_root, m_doc->getPageMap(), appender );
                 }
@@ -1477,21 +1477,21 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     // We may also find in the ncx a <pageList> list
     if ( ( !has_toc || !has_pagemap ) && !ncxHref.empty() ) {
         LVStreamRef stream = m_arc->OpenStream(ncxHref.c_str(), LVOM_READ);
-        lString16 codeBase = LVExtractPath( ncxHref );
+        lString32 codeBase = LVExtractPath( ncxHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * ncxdoc = LVParseXMLStream( stream );
             if ( ncxdoc!=NULL ) {
                 if ( !has_toc ) {
-                    ldomNode * navMap = ncxdoc->nodeFromXPath( cs16("ncx/navMap"));
+                    ldomNode * navMap = ncxdoc->nodeFromXPath( cs32("ncx/navMap"));
                     if ( navMap!=NULL )
                         ReadEpubNcxToc( m_doc, navMap, m_doc->getToc(), appender );
                 }
                 // http://blog.epubbooks.com/346/marking-up-page-numbers-in-the-epub-ncx/
                 if ( !has_pagemap ) {
-                    ldomNode * pageList = ncxdoc->nodeFromXPath( cs16("ncx/pageList"));
+                    ldomNode * pageList = ncxdoc->nodeFromXPath( cs32("ncx/pageList"));
                     if ( pageList!=NULL )
                         ReadEpubNcxPageList( m_doc, pageList, m_doc->getPageMap(), appender );
                 }
@@ -1508,15 +1508,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         LVTocItem * baseToc = m_doc->getToc();
         for ( size_t i=0; i<spineItemsNb; i++ ) {
             if (spineItems[i]->mediaType == "application/xhtml+xml") {
-                lString16 title = spineItems[i]->id; // nothing much else to use
-                lString16 href = appender.convertHref(spineItems[i]->id);
+                lString32 title = spineItems[i]->id; // nothing much else to use
+                lString32 href = appender.convertHref(spineItems[i]->id);
                 if ( href.empty() || href[0]!='#' )
                     continue;
                 ldomNode * target = m_doc->getNodeById(m_doc->getAttrValueIndex(href.substr(1).c_str()));
                 if ( !target )
                     continue;
                 ldomXPointer ptr(target, 0);
-                baseToc->addChild(title, ptr, lString16::empty_str);
+                baseToc->addChild(title, ptr, lString32::empty_str);
             }
         }
     }
@@ -1525,15 +1525,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     // https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page-map
     if ( !has_pagemap && !pageMapHref.empty() ) {
         LVStreamRef stream = m_arc->OpenStream(pageMapHref.c_str(), LVOM_READ);
-        lString16 codeBase = LVExtractPath( pageMapHref );
+        lString32 codeBase = LVExtractPath( pageMapHref );
         if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
-            codeBase.append(1, L'/');
+            codeBase.append(1, U'/');
         appender.setCodeBase(codeBase);
         if ( !stream.isNull() ) {
             ldomDocument * pagemapdoc = LVParseXMLStream( stream );
             if ( pagemapdoc!=NULL ) {
                 if ( !has_pagemap ) {
-                    ldomNode * pageMap = pagemapdoc->nodeFromXPath( cs16("page-map"));
+                    ldomNode * pageMap = pagemapdoc->nodeFromXPath( cs32("page-map"));
                     if ( pageMap!=NULL )
                         ReadEpubAdobePageMap( m_doc, pageMap, m_doc->getPageMap(), appender );
                 }
@@ -1545,7 +1545,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     if ( m_doc->getPageMap()->getChildCount() > 0 && !pageMapSource.empty() )
         m_doc->getPageMap()->setSource(pageMapSource);
 
-    writer.OnTagClose(L"", L"body");
+    writer.OnTagClose(U"", U"body");
     writer.OnStop();
     CRLog::debug("EPUB: %d documents merged", fragmentCount);
 
@@ -1589,7 +1589,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
     }
 #endif
 #if 0
-    LVStreamRef out = LVOpenFileStream( L"c:\\doc.xml" , LVOM_WRITE );
+    LVStreamRef out = LVOpenFileStream( U"c:\\doc.xml" , LVOM_WRITE );
     if ( !out.isNull() )
         m_doc->saveToStream( out, "utf-8" );
 #endif

--- a/crengine/src/fb3fmt.cpp
+++ b/crengine/src/fb3fmt.cpp
@@ -2,10 +2,10 @@
 #include "../include/lvtinydom.h"
 #include "../include/fb2def.h"
 
-static const lChar16 * const fb3_BodyContentType = L"application/fb3-body+xml";
-static const lChar16 * const fb3_DescriptionContentType = L"application/fb3-description+xml";
-static const lChar16 * const fb3_CoverRelationship = L"http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail";
-static const lChar16 * const fb3_ImageRelationship = L"http://www.fictionbook.org/FictionBook3/relationships/image";
+static const lChar32 * const fb3_BodyContentType = U"application/fb3-body+xml";
+static const lChar32 * const fb3_DescriptionContentType = U"application/fb3-description+xml";
+static const lChar32 * const fb3_CoverRelationship = U"http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail";
+static const lChar32 * const fb3_ImageRelationship = U"http://www.fictionbook.org/FictionBook3/relationships/image";
 
 bool DetectFb3Format( LVStreamRef stream )
 {
@@ -34,19 +34,19 @@ public:
     }
     // LVXMLParserCallback interface
 public:
-    ldomNode *OnTagOpen(const lChar16 *nsname, const lChar16 *tagname);
+    ldomNode *OnTagOpen(const lChar32 *nsname, const lChar32 *tagname);
     /// called on closing tag
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+    void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false );
     void OnTagBody();
-    void OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue);
+    void OnAttribute(const lChar32 *nsname, const lChar32 *attrname, const lChar32 *attrvalue);
 
     lUInt32 getFlags() { return m_parent->getFlags(); }
     void setFlags(lUInt32 flags) { m_parent->setFlags(flags); }
-    void OnEncoding(const lChar16 *name, const lChar16 *table) { m_parent->OnEncoding(name, table); }
+    void OnEncoding(const lChar32 *name, const lChar32 *table) { m_parent->OnEncoding(name, table); }
     void OnStart(LVFileFormatParser *parser) { m_parent->OnStart(parser); }
     void OnStop() { m_parent->OnStop(); }
-    void OnText(const lChar16 *text, int len, lUInt32 flags) {  m_parent->OnText(text, len, flags); }
-    bool OnBlob(lString16 name, const lUInt8 *data, int size) { return m_parent->OnBlob(name, data, size); }
+    void OnText(const lChar32 *text, int len, lUInt32 flags) {  m_parent->OnText(text, len, flags); }
+    bool OnBlob(lString32 name, const lUInt8 *data, int size) { return m_parent->OnBlob(name, data, size); }
     void OnDocProperty(const char *name, lString8 value)  { m_parent->OnDocProperty(name, value);  }
 };
 
@@ -67,7 +67,7 @@ bool ImportFb3Document( LVStreamRef stream, ldomDocument * doc, LVDocViewCallbac
     ldomDocument * descDoc = context.getDescription();
 
     if ( descDoc ) {
-        lString16 language = descDoc->textFromXPath( cs16("fb3-description/lang") );
+        lString32 language = descDoc->textFromXPath( cs32("fb3-description/lang") );
         doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
     } else {
         CRLog::error("Couldn't parse description doc");
@@ -118,7 +118,7 @@ fb3ImportContext::~fb3ImportContext()
         delete  m_descDoc;
 }
 
-lString16 fb3ImportContext::geImageTarget(const lString16 relationId) {
+lString32 fb3ImportContext::geImageTarget(const lString32 relationId) {
     return m_bookPart->getRelatedPartName(fb3_ImageRelationship, relationId);
 }
 
@@ -143,53 +143,53 @@ ldomDocument *fb3ImportContext::getDescription()
 void fb3DomWriter::writeDescription()
 {
     //TODO extended FB3 description
-    m_parent->OnTagOpenNoAttr( NULL, L"description" );
-    m_parent->OnTagOpenNoAttr( NULL, L"title-info" );
-    m_parent->OnTagOpenNoAttr( NULL, L"book-title" );
-    m_parent->OnTagClose( NULL, L"book-title" );
+    m_parent->OnTagOpenNoAttr( NULL, U"description" );
+    m_parent->OnTagOpenNoAttr( NULL, U"title-info" );
+    m_parent->OnTagOpenNoAttr( NULL, U"book-title" );
+    m_parent->OnTagClose( NULL, U"book-title" );
     if ( !m_context->m_coverImage.empty() ) {
-        m_parent->OnTagOpenNoAttr( NULL, L"coverpage" );
-        m_parent->OnTagOpen(NULL, L"image");
-        m_parent->OnAttribute(L"l", L"href", m_context->m_coverImage.c_str());
-        m_parent->OnTagClose( NULL, L"image", true );
-        m_parent->OnTagClose( NULL, L"coverpage" );
+        m_parent->OnTagOpenNoAttr( NULL, U"coverpage" );
+        m_parent->OnTagOpen(NULL, U"image");
+        m_parent->OnAttribute(U"l", U"href", m_context->m_coverImage.c_str());
+        m_parent->OnTagClose( NULL, U"image", true );
+        m_parent->OnTagClose( NULL, U"coverpage" );
     }
-    m_parent->OnTagClose( NULL, L"title-info" );
-    m_parent->OnTagClose( NULL, L"description" );
+    m_parent->OnTagClose( NULL, U"title-info" );
+    m_parent->OnTagClose( NULL, U"description" );
 }
 
-ldomNode *fb3DomWriter::OnTagOpen(const lChar16 *nsname, const lChar16 *tagname)
+ldomNode *fb3DomWriter::OnTagOpen(const lChar32 *nsname, const lChar32 *tagname)
 {
     if( !lStr_cmp(tagname, "fb3-body") ) {
-        m_parent->OnTagOpenNoAttr(NULL, L"FictionBook");
+        m_parent->OnTagOpenNoAttr(NULL, U"FictionBook");
         writeDescription();
-        tagname = L"body";
+        tagname = U"body";
     } else if ( !lStr_cmp(tagname, "notes" )) {
-         m_parent->OnTagClose(NULL, L"body");
-         ldomNode *footnotesBody = m_parent->OnTagOpen(NULL,L"body");
-         m_parent->OnAttribute(NULL, L"name", L"notes");
+         m_parent->OnTagClose(NULL, U"body");
+         ldomNode *footnotesBody = m_parent->OnTagOpen(NULL,U"body");
+         m_parent->OnAttribute(NULL, U"name", U"notes");
          m_parent->OnTagBody();
          return footnotesBody;
     } else if( !lStr_cmp(tagname, "notebody") ) {
-        tagname = L"section";
+        tagname = U"section";
     } else if( !lStr_cmp(tagname, "note") ) {
         m_checkRole = true;
-        return m_parent->OnTagOpen(nsname, L"a");
+        return m_parent->OnTagOpen(nsname, U"a");
     }
     return m_parent->OnTagOpen(nsname, tagname);
 }
 
-void fb3DomWriter::OnTagClose(const lChar16 *nsname, const lChar16 *tagname, bool self_closing_tag)
+void fb3DomWriter::OnTagClose(const lChar32 *nsname, const lChar32 *tagname, bool self_closing_tag)
 {
     if ( !lStr_cmp(tagname, "fb3-body") ) {
-        m_parent->OnTagClose(NULL, L"body");
-        tagname = L"FictionBook";
+        m_parent->OnTagClose(NULL, U"body");
+        tagname = U"FictionBook";
     } else if ( !lStr_cmp(tagname, "notebody") ) {
-        tagname = L"section";
+        tagname = U"section";
     } else if( !lStr_cmp(tagname, "note") ) {
-        tagname = L"a";
+        tagname = U"a";
     } else if ( !lStr_cmp(tagname, "notes" )) {
-        tagname = L"body";
+        tagname = U"body";
     }
     m_parent->OnTagClose(nsname, tagname, self_closing_tag);
 }
@@ -200,25 +200,25 @@ void fb3DomWriter::OnTagBody()
     m_parent->OnTagBody();
 }
 
-void fb3DomWriter::OnAttribute(const lChar16 *nsname, const lChar16 *attrname, const lChar16 *attrvalue)
+void fb3DomWriter::OnAttribute(const lChar32 *nsname, const lChar32 *attrname, const lChar32 *attrvalue)
 {
     bool pass = true;
 
     if( !lStr_cmp(attrname, "href") ) {
-        lString16 href(attrvalue);
+        lString32 href(attrvalue);
 
         if ( href.pos(":") == -1 && href[0] != '#') {
-            href = cs16("#") + href;
+            href = cs32("#") + href;
             m_parent->OnAttribute(nsname, attrname, href.c_str());
             pass = false;
         }
     } else if ( m_checkRole && !lStr_cmp(attrname, "role") ) {
         if( !lStr_cmp(attrvalue, "footnote") )
-            m_parent->OnAttribute(NULL, L"type", L"note");
+            m_parent->OnAttribute(NULL, U"type", U"note");
         else
-            m_parent->OnAttribute(NULL, L"type", L"comment");
+            m_parent->OnAttribute(NULL, U"type", U"comment");
     } else if ( !lStr_cmp(attrname, "src") ) {
-        lString16 target = m_context->geImageTarget(attrvalue);
+        lString32 target = m_context->geImageTarget(attrvalue);
         if( !target.empty() ) {
             m_parent->OnAttribute(nsname, attrname, target.c_str());
             pass = false;

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -68,12 +68,12 @@ public:
     {
     }
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) {
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) {
         CR_UNUSED3(name, data, size);
         return true;
     }
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname)
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname)
     {
         CR_UNUSED(nsname);
         if ( lStr_cmp(tagname, "FictionBookMarks")==0 && state==in_xml ) {
@@ -114,7 +114,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBookMarks")==0 && state==in_fbm ) {
             state = in_xml;
@@ -163,7 +163,7 @@ public:
         }
     }
     /// called on element attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
     {
         CR_UNUSED(nsname);
         if ( lStr_cmp(attrname, "type")==0 && state==in_bm ) {
@@ -175,7 +175,7 @@ public:
                 }
             }
         } else if ( lStr_cmp(attrname, "shortcut")==0 && state==in_bm ) {
-            int n = lString16( attrvalue ).atoi();
+            int n = lString32( attrvalue ).atoi();
             _curr_bookmark->setShortcut( n );
         } else if ( lStr_cmp(attrname, "percent")==0 && state==in_bm ) {
             int n1=0, n2=0;
@@ -197,14 +197,14 @@ public:
                 n1 = n1*10 + (attrvalue[i]-'0');
             _curr_bookmark->setTimestamp( n1 );
         } else if (lStr_cmp(attrname, "page")==0 && state==in_bm) {
-            _curr_bookmark->setBookmarkPage(lString16( attrvalue ).atoi());
+            _curr_bookmark->setBookmarkPage(lString32( attrvalue ).atoi());
         }
     }
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags )
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
         CR_UNUSED(flags);
-        lString16 txt( text, len );
+        lString32 txt( text, len );
         switch (state) {
         case in_start_point:
             _curr_bookmark->setStartPos( txt );
@@ -262,7 +262,7 @@ bool CRFileHist::loadFromStream( LVStreamRef stream )
     return true;
 }
 
-static void putTagValue( LVStream * stream, int level, const char * tag, lString16 value )
+static void putTagValue( LVStream * stream, int level, const char * tag, lString32 value )
 {
     for ( int i=0; i<level; i++ )
         *stream << "  ";
@@ -315,7 +315,7 @@ bool CRFileHist::saveToStream( LVStream * targetStream )
         putTagValue( stream, 3, "doc-series", rec->getSeries() );
         putTagValue( stream, 3, "doc-filename", rec->getFileName() );
         putTagValue( stream, 3, "doc-filepath", rec->getFilePath() );
-        putTagValue( stream, 3, "doc-filesize", lString16::itoa( (unsigned int)rec->getFileSize() ) );
+        putTagValue( stream, 3, "doc-filesize", lString32::itoa( (unsigned int)rec->getFileSize() ) );
         putTag( stream, 2, "/file-info" );
         putTag( stream, 2, "bookmark-list" );
         putBookmark( stream, rec->getLastPos() );
@@ -331,12 +331,12 @@ bool CRFileHist::saveToStream( LVStream * targetStream )
     return true;
 }
 
-static void splitFName( lString16 pathname, lString16 & path, lString16 & name )
+static void splitFName( lString32 pathname, lString32 & path, lString32 & name )
 {
     //
     int spos = -1;
     for ( spos=pathname.length()-1; spos>=0; spos-- ) {
-        lChar16 ch = pathname[spos];
+        lChar32 ch = pathname[spos];
         if ( ch=='\\' || ch=='/' ) {
             break;
         }
@@ -406,7 +406,7 @@ int CRFileHistRecord::getFirstFreeShortcutBookmark()
     return -1;
 }
 
-int CRFileHist::findEntry( const lString16 & fname, const lString16 & fpath, lvsize_t sz )
+int CRFileHist::findEntry( const lString32 & fname, const lString32 & fpath, lvsize_t sz )
 {
     CR_UNUSED(fpath);
     for ( int i=0; i<_records.length(); i++ ) {
@@ -437,13 +437,13 @@ void CRFileHistRecord::setLastPos( CRBookmark * bmk )
     _lastpos = *bmk;
 }
 
-lString16 CRBookmark::getChapterName( ldomXPointer ptr )
+lString32 CRBookmark::getChapterName( ldomXPointer ptr )
 {
     //CRLog::trace("CRBookmark::getChapterName()");
-	lString16 chapter;
+	lString32 chapter;
 	int lastLevel = -1;
 	bool foundAnySection = false;
-    lUInt16 section_id = ptr.getNode()->getDocument()->getElementNameIndex( L"section" );
+    lUInt16 section_id = ptr.getNode()->getDocument()->getElementNameIndex( U"section" );
 	if ( !ptr.isNull() )
 	{
 		ldomXPointerEx p( ptr );
@@ -456,7 +456,7 @@ lString16 CRBookmark::getChapterName( ldomXPointer ptr )
             foundAnySection = foundAnySection || foundSection;
             if ( !foundSection && foundAnySection )
                 continue;
-			lString16 nname = p.getNode()->getNodeName();
+			lString32 nname = p.getNode()->getNodeName();
             if ( !nname.compare("title") || !nname.compare("h1") || !nname.compare("h2")  || !nname.compare("h3") ) {
 				if ( lastLevel!=-1 && p.getLevel()>=lastLevel )
 					continue;
@@ -472,15 +472,15 @@ lString16 CRBookmark::getChapterName( ldomXPointer ptr )
 	return chapter;
 }
 
-CRFileHistRecord * CRFileHist::savePosition( lString16 fpathname, size_t sz,
-                            const lString16 & title,
-                            const lString16 & author,
-                            const lString16 & series,
+CRFileHistRecord * CRFileHist::savePosition( lString32 fpathname, size_t sz,
+                            const lString32 & title,
+                            const lString32 & author,
+                            const lString32 & series,
                             ldomXPointer ptr )
 {
     //CRLog::trace("CRFileHist::savePosition");
-    lString16 name;
-	lString16 path;
+    lString32 name;
+	lString32 path;
     splitFName( fpathname, path, name );
     CRBookmark bmk( ptr );
     //CRLog::trace("Bookmark created");
@@ -507,10 +507,10 @@ CRFileHistRecord * CRFileHist::savePosition( lString16 fpathname, size_t sz,
     return rec;
 }
 
-ldomXPointer CRFileHist::restorePosition( ldomDocument * doc, lString16 fpathname, size_t sz )
+ldomXPointer CRFileHist::restorePosition( ldomDocument * doc, lString32 fpathname, size_t sz )
 {
-    lString16 name;
-    lString16 path;
+    lString32 name;
+    lString32 path;
     splitFName( fpathname, path, name );
     int index = findEntry( name, path, (lvsize_t)sz );
     if ( index>=0 ) {
@@ -521,14 +521,14 @@ ldomXPointer CRFileHist::restorePosition( ldomDocument * doc, lString16 fpathnam
 }
 
 CRBookmark::CRBookmark (ldomXPointer ptr )
-: _startpos(lString16::empty_str)
-, _endpos(lString16::empty_str)
+: _startpos(lString32::empty_str)
+, _endpos(lString32::empty_str)
 , _percent(0)
 , _type(0)
 , _shortcut(0)
-, _postext(lString16::empty_str)
-, _titletext(lString16::empty_str)
-, _commenttext(lString16::empty_str)
+, _postext(lString32::empty_str)
+, _titletext(lString32::empty_str)
+, _commenttext(lString32::empty_str)
 , _timestamp(time_t(0))
 , _page(0)
 {
@@ -537,7 +537,7 @@ CRBookmark::CRBookmark (ldomXPointer ptr )
         return;
 
     //CRLog::trace("CRBookmark::CRBookmark() started");
-    lString16 path;
+    lString32 path;
 
     //CRLog::trace("CRBookmark::CRBookmark() calling ptr.toPoint");
     lvPoint pt = ptr.toPoint();
@@ -563,7 +563,7 @@ CRBookmark::CRBookmark (ldomXPointer ptr )
 }
 
 
-lString16 CRFileHistRecord::getLastTimeString( bool longFormat )
+lString32 CRFileHistRecord::getLastTimeString( bool longFormat )
 {
 
     time_t t = getLastTime();
@@ -595,10 +595,10 @@ lString16 CRFileHistRecord::getLastTimeString( bool longFormat )
 #define POS_TEXT_TAG         "POSTEXT"
 #define COMMENT_TEXT_TAG     "COMMENTTEXT"
 
-static lString8 encodeText(lString16 text16) {
-    if (text16.empty())
+static lString8 encodeText(lString32 text32) {
+    if (text32.empty())
         return lString8::empty_str;
-    lString8 text = UnicodeToUtf8(text16);
+    lString8 text = UnicodeToUtf8(text32);
     lString8 buf;
     for (int i=0; i<text.length(); i++) {
         char ch = text[i];
@@ -623,9 +623,9 @@ static lString8 encodeText(lString16 text16) {
     return buf;
 }
 
-static lString16 decodeText(lString8 text) {
+static lString32 decodeText(lString8 text) {
     if (text.empty())
-        return lString16::empty_str;
+        return lString32::empty_str;
     lString8 buf;
     bool lastControl = false;
     for (int i=0; i<text.length(); i++) {
@@ -671,7 +671,7 @@ static int findBytes(lChar8 * buf, int start, int end, const lChar8 * pattern) {
     return -1;
 }
 
-ChangeInfo::ChangeInfo(CRBookmark * bookmark, lString16 fileName, bool deleted)
+ChangeInfo::ChangeInfo(CRBookmark * bookmark, lString32 fileName, bool deleted)
     : _bookmark(bookmark ? new CRBookmark(*bookmark) : NULL), _fileName(fileName), _deleted(deleted)
 {
     _timestamp = bookmark && bookmark->getTimestamp() > 0 ? bookmark->getTimestamp() : (time_t)time(0);

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -43,7 +43,7 @@
 
 #ifdef ANDROID
 
-#define _16(x) lString16(x)
+#define _32(x) lString32(x)
 
 #else
 
@@ -54,7 +54,7 @@
 int HyphMan::_LeftHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_RightHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_TrustSoftHyphens = HYPH_DEFAULT_TRUST_SOFT_HYPHENS;
-LVHashTable<lString16, HyphMethod*> HyphMan::_loaded_hyph_methods(16);
+LVHashTable<lString32, HyphMethod*> HyphMan::_loaded_hyph_methods(16);
 HyphDataLoader* HyphMan::_dataLoader = NULL;
 
 
@@ -76,13 +76,13 @@ class TexHyph : public HyphMethod
     lUInt32 _pattern_count;
 public:
     int largest_overflowed_word;
-    bool match( const lChar16 * str, char * mask );
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    bool match( const lChar32 * str, char * mask );
+    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     void addPattern( TexPattern * pattern );
-    TexHyph( lString16 id=HYPH_DICT_ID_DICTIONARY, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN, int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN );
+    TexHyph( lString32 id=HYPH_DICT_ID_DICTIONARY, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN, int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN );
     virtual ~TexHyph();
     bool load( LVStreamRef stream );
-    bool load( lString16 fileName );
+    bool load( lString32 fileName );
     virtual lUInt32 getHash() { return _hash; }
     virtual lUInt32 getCount() { return _pattern_count; }
     virtual lUInt32 getSize();
@@ -92,7 +92,7 @@ class AlgoHyph : public HyphMethod
 {
 public:
     AlgoHyph(): HyphMethod(HYPH_DICT_ID_ALGORITHM) {};
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     virtual ~AlgoHyph();
 };
 
@@ -100,7 +100,7 @@ class SoftHyphensHyph : public HyphMethod
 {
 public:
     SoftHyphensHyph(): HyphMethod(HYPH_DICT_ID_SOFTHYPHENS) {};
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     virtual ~SoftHyphensHyph();
 };
 
@@ -108,7 +108,7 @@ class NoHyph : public HyphMethod
 {
 public:
     NoHyph(): HyphMethod(HYPH_DICT_ID_NONE) {};
-    virtual bool hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
     {
         CR_UNUSED6(str, len, widths, flags, hyphCharWidth, maxWidth);
         return false;
@@ -147,7 +147,7 @@ class HyphDataLoaderFromFile: public HyphDataLoader
 public:
     HyphDataLoaderFromFile() : HyphDataLoader() {}
     virtual ~HyphDataLoaderFromFile() {}
-    virtual LVStreamRef loadData(lString16 id) {
+    virtual LVStreamRef loadData(lString32 id) {
         HyphDictionaryList* dictList = HyphMan::getDictList();
         HyphDictionary * p = dictList->find(id);
         if ( !p )
@@ -157,7 +157,7 @@ public:
                 p->getType() == HDT_SOFTHYPHENS ||
                 ( p->getType() != HDT_DICT_ALAN && p->getType() != HDT_DICT_TEX) )
             return LVStreamRef();
-        lString16 filename = p->getFilename();
+        lString32 filename = p->getFilename();
         return LVOpenFileStream( filename.c_str(), LVOM_READ );
     }
 };
@@ -169,8 +169,8 @@ void HyphMan::uninit()
     // Avoid existing frontend code to have to call it:
     TextLangMan::uninit();
     // Clean up _loaded_hyph_methods
-    LVHashTable<lString16, HyphMethod*>::iterator it = _loaded_hyph_methods.forwardIterator();
-    LVHashTable<lString16, HyphMethod*>::pair* pair;
+    LVHashTable<lString32, HyphMethod*>::iterator it = _loaded_hyph_methods.forwardIterator();
+    LVHashTable<lString32, HyphMethod*>::pair* pair;
     while ((pair = it.next())) {
         delete pair->value;
     }
@@ -189,7 +189,7 @@ void HyphMan::uninit()
     */
 }
 
-bool HyphMan::initDictionaries(lString16 dir, bool clear)
+bool HyphMan::initDictionaries(lString32 dir, bool clear)
 {
     if (clear && _dictList)
         delete _dictList;
@@ -198,11 +198,11 @@ bool HyphMan::initDictionaries(lString16 dir, bool clear)
     if (NULL == _dataLoader)
         _dataLoader = new HyphDataLoaderFromFile;
     if (_dictList->open(dir, clear)) {
-		if ( !_dictList->activate( lString16(DEF_HYPHENATION_DICT) ) )
-    			_dictList->activate( lString16(HYPH_DICT_ID_ALGORITHM) );
+		if ( !_dictList->activate( lString32(DEF_HYPHENATION_DICT) ) )
+    			_dictList->activate( lString32(HYPH_DICT_ID_ALGORITHM) );
 		return true;
 	} else {
-		_dictList->activate( lString16(HYPH_DICT_ID_ALGORITHM) );
+		_dictList->activate( lString32(HYPH_DICT_ID_ALGORITHM) );
 		return false;
 	}
 }
@@ -250,7 +250,7 @@ bool HyphMan::isEnabled() {
     */
 }
 
-bool HyphMan::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool HyphMan::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     return TextLangMan::getMainLangHyphMethod()->hyphenate( str, len, widths, flags, hyphCharWidth, maxWidth, flagSize );
     /* Obsolete:
@@ -259,12 +259,12 @@ bool HyphMan::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
 }
 
 HyphDictionary * HyphMan::getSelectedDictionary() {
-    lString16 id = TextLangMan::getTextLangCfg()->getHyphMethod()->getId();
+    lString32 id = TextLangMan::getTextLangCfg()->getHyphMethod()->getId();
     HyphDictionary * dict = _dictList->find( id );
     return dict;
 }
 
-HyphMethod * HyphMan::getHyphMethodForDictionary( lString16 id, int leftHyphenMin, int rightHyphenMin ) {
+HyphMethod * HyphMan::getHyphMethodForDictionary( lString32 id, int leftHyphenMin, int rightHyphenMin ) {
     if ( id.empty() || NULL == _dataLoader)
         return &NO_HYPH;
     HyphDictionary * p = _dictList->find(id);
@@ -353,7 +353,7 @@ bool HyphDictionary::activate()
     */
 }
 
-bool HyphDictionaryList::activate( lString16 id )
+bool HyphDictionaryList::activate( lString32 id )
 {
     CRLog::trace("HyphDictionaryList::activate(%s)", LCSTR(id));
 	HyphDictionary * p = find(id);
@@ -365,19 +365,19 @@ bool HyphDictionaryList::activate( lString16 id )
 
 void HyphDictionaryList::addDefault()
 {
-	if ( !find( lString16( HYPH_DICT_ID_NONE ) ) ) {
-		_list.add( new HyphDictionary( HDT_NONE, _16("[No Hyphenation]"), lString16(HYPH_DICT_ID_NONE), lString16(HYPH_DICT_ID_NONE) ) );
+	if ( !find( lString32( HYPH_DICT_ID_NONE ) ) ) {
+		_list.add( new HyphDictionary( HDT_NONE, _32("[No Hyphenation]"), lString32(HYPH_DICT_ID_NONE), lString32(HYPH_DICT_ID_NONE) ) );
 	}
-	if ( !find( lString16( HYPH_DICT_ID_ALGORITHM ) ) ) {
-		_list.add( new HyphDictionary( HDT_ALGORITHM, _16("[Algorithmic Hyphenation]"), lString16(HYPH_DICT_ID_ALGORITHM), lString16(HYPH_DICT_ID_ALGORITHM) ) );
+	if ( !find( lString32( HYPH_DICT_ID_ALGORITHM ) ) ) {
+		_list.add( new HyphDictionary( HDT_ALGORITHM, _32("[Algorithmic Hyphenation]"), lString32(HYPH_DICT_ID_ALGORITHM), lString32(HYPH_DICT_ID_ALGORITHM) ) );
 	}
-	if ( !find( lString16( HYPH_DICT_ID_SOFTHYPHENS ) ) ) {
-		_list.add( new HyphDictionary( HDT_SOFTHYPHENS, _16("[Soft-hyphens Hyphenation]"), lString16(HYPH_DICT_ID_SOFTHYPHENS), lString16(HYPH_DICT_ID_SOFTHYPHENS) ) );
+	if ( !find( lString32( HYPH_DICT_ID_SOFTHYPHENS ) ) ) {
+		_list.add( new HyphDictionary( HDT_SOFTHYPHENS, _32("[Soft-hyphens Hyphenation]"), lString32(HYPH_DICT_ID_SOFTHYPHENS), lString32(HYPH_DICT_ID_SOFTHYPHENS) ) );
 	}
 
 }
 
-HyphDictionary * HyphDictionaryList::find( const lString16& id )
+HyphDictionary * HyphDictionaryList::find( const lString32& id )
 {
 	for ( int i=0; i<_list.length(); i++ ) {
 		if ( _list[i]->getId() == id )
@@ -394,7 +394,7 @@ static int HyphDictionary_comparator(const HyphDictionary ** item1, const HyphDi
     return (int)((*item1)->getType() - (*item2)->getType());
 }
 
-bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
+bool HyphDictionaryList::open(lString32 hyphDirectory, bool clear)
 {
     CRLog::info("HyphDictionaryList::open(%s)", LCSTR(hyphDirectory) );
     if (clear) {
@@ -407,7 +407,7 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
     LVContainerRef container;
     LVStreamRef stream;
     if ( (hyphDirectory.endsWith("/") || hyphDirectory.endsWith("\\")) && LVDirectoryExists(hyphDirectory) ) {
-        container = LVOpenDirectory( hyphDirectory.c_str(), L"*.*" );
+        container = LVOpenDirectory( hyphDirectory.c_str(), U"*.*" );
     } else if ( LVFileExists(hyphDirectory) ) {
         stream = LVOpenFileStream( hyphDirectory.c_str(), LVOM_READ );
         if ( !stream.isNull() )
@@ -420,9 +420,9 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
         CRLog::info("%d items found in hyph directory", len);
 		for ( int i=0; i<len; i++ ) {
 			const LVContainerItemInfo * item = container->GetObjectInfo( i );
-			lString16 name = item->GetName();
-            lString16 suffix;
-            lString16 suffix2add;
+			lString32 name = item->GetName();
+            lString32 suffix;
+            lString32 suffix2add;
             HyphDictType t = HDT_NONE;
             if ( name.endsWith("_hyphen_(Alan).pdb") ) {
                 suffix = "_hyphen_(Alan).pdb";
@@ -436,9 +436,9 @@ bool HyphDictionaryList::open(lString16 hyphDirectory, bool clear)
 
 
 
-			lString16 filename = hyphDirectory + name;
-			lString16 id = name;
-			lString16 title = name;
+			lString32 filename = hyphDirectory + name;
+			lString32 id = name;
+			lString32 title = name;
 			if ( title.endsWith( suffix ) )
 				title.erase( title.length() - suffix.length(), suffix.length() );
 			if (!suffix2add.empty())
@@ -468,7 +468,7 @@ HyphMan::~HyphMan()
 // and AlgoHyph::hyphenate(): if soft hyphens are found in the
 // provided word, trust and use them; don't do the regular patterns
 // and algorithm matching.
-static bool softhyphens_hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+static bool softhyphens_hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     bool soft_hyphens_found = false;
     for ( int i = 0; i<len; i++ ) {
@@ -488,7 +488,7 @@ static bool softhyphens_hyphenate( const lChar16 * str, int len, lUInt16 * width
     return soft_hyphens_found;
 }
 
-bool SoftHyphensHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool SoftHyphensHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     return softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize);
 }
@@ -532,7 +532,7 @@ static int isCorrectHyphFile(LVStream * stream)
 
 class TexPattern {
 public:
-    lChar16 word[MAX_PATTERN_SIZE+1];
+    lChar32 word[MAX_PATTERN_SIZE+1];
     char attr[MAX_PATTERN_SIZE+2];
     int overflowed; // 0, or size of complete word if larger than MAX_PATTERN_SIZE
     TexPattern * next;
@@ -542,22 +542,22 @@ public:
         return lStr_cmp( word, v->word );
     }
 
-    static int hash( const lChar16 * s )
+    static int hash( const lChar32 * s )
     {
         return ((lUInt32)(((s[0] *31 + s[1])*31 + s[2]) * 31 + s[3])) % PATTERN_HASH_SIZE;
     }
 
-    static int hash3( const lChar16 * s )
+    static int hash3( const lChar32 * s )
     {
         return ((lUInt32)(((s[0] *31 + s[1])*31 + s[2]) * 31 + 0)) % PATTERN_HASH_SIZE;
     }
 
-    static int hash2( const lChar16 * s )
+    static int hash2( const lChar32 * s )
     {
         return ((lUInt32)(((s[0] *31 + s[1])*31 + 0) * 31 + 0)) % PATTERN_HASH_SIZE;
     }
 
-    static int hash1( const lChar16 * s )
+    static int hash1( const lChar32 * s )
     {
         return ((lUInt32)(((s[0] *31 + 0)*31 + 0) * 31 + 0)) % PATTERN_HASH_SIZE;
     }
@@ -567,7 +567,7 @@ public:
         return ((lUInt32)(((word[0] *31 + word[1])*31 + word[2]) * 31 + word[3])) % PATTERN_HASH_SIZE;
     }
 
-    bool match( const lChar16 * s, char * mask )
+    bool match( const lChar32 * s, char * mask )
     {
         TexPattern * p = this;
         bool found = false;
@@ -581,7 +581,7 @@ public:
             if ( res ) {
                 if ( p->word[0]==s[0] && (p->word[1]==0 || p->word[1]==s[1]) ) {
 #if DUMP_PATTERNS==1
-                    CRLog::debug("Pattern matched: %s %s on %s %s", LCSTR(lString16(p->word)), p->attr, LCSTR(lString16(s)), mask);
+                    CRLog::debug("Pattern matched: %s %s on %s %s", LCSTR(lString32(p->word)), p->attr, LCSTR(lString32(s)), mask);
 #endif
                     p->apply(mask);
                     found = true;
@@ -601,7 +601,7 @@ public:
         }
     }
 
-    TexPattern( const lString16 &s ) : next( NULL )
+    TexPattern( const lString32 &s ) : next( NULL )
     {
         overflowed = 0;
         memset( word, 0, sizeof(word) );
@@ -609,7 +609,7 @@ public:
         attr[sizeof(attr)-1] = 0;
         int n = 0;
         for ( int i=0; i<(int)s.length(); i++ ) {
-            lChar16 ch = s[i];
+            lChar32 ch = s[i];
             if (n > MAX_PATTERN_SIZE) {
                 if ( ch<'0' || ch>'9' ) {
                     overflowed = n++;
@@ -641,7 +641,7 @@ public:
             overflowed = overflowed + 1; // convert counter to number of things counted
     }
 
-    TexPattern( const unsigned char * s, int sz, const lChar16 * charMap )
+    TexPattern( const unsigned char * s, int sz, const lChar32 * charMap )
     {
         overflowed = 0;
         if ( sz > MAX_PATTERN_SIZE ) {
@@ -660,9 +660,9 @@ class HyphPatternReader : public LVXMLParserCallback
 {
 protected:
     bool insidePatternTag;
-    lString16Collection & data;
+    lString32Collection & data;
 public:
-    HyphPatternReader(lString16Collection & result) : insidePatternTag(false), data(result)
+    HyphPatternReader(lString32Collection & result) : insidePatternTag(false), data(result)
     {
         result.clear();
     }
@@ -671,7 +671,7 @@ public:
     /// called on opening tag end
     virtual void OnTagBody() {}
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname)
+    virtual ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname)
     {
         CR_UNUSED(nsname);
         if (!lStr_cmp(tagname, "pattern")) {
@@ -680,32 +680,32 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false )
     {
         CR_UNUSED2(nsname, tagname);
         insidePatternTag = false;
     }
     /// called on element attribute
-    virtual void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+    virtual void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
     {
         CR_UNUSED3(nsname, attrname, attrvalue);
     }
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags )
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
         CR_UNUSED(flags);
         if ( insidePatternTag )
-            data.add( lString16(text, len) );
+            data.add( lString32(text, len) );
     }
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 name, const lUInt8 * data, int size) {
+    virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) {
         CR_UNUSED3(name, data, size);
         return false;
     }
 
 };
 
-TexHyph::TexHyph(lString16 id, int leftHyphenMin, int rightHyphenMin) : HyphMethod(id, leftHyphenMin, rightHyphenMin)
+TexHyph::TexHyph(lString32 id, int leftHyphenMin, int rightHyphenMin) : HyphMethod(id, leftHyphenMin, rightHyphenMin)
 {
     memset( table, 0, sizeof(table) );
     _hash = 123456;
@@ -758,7 +758,7 @@ bool TexHyph::load( LVStreamRef stream )
         stream->SetPos(p);
         if ( stream->SetPos(p)!=p )
             return false;
-        lChar16 charMap[256] = { 0 };
+        lChar32 charMap[256] = { 0 };
         unsigned char buf[0x10000];
         // make char map table
         for (i=0; i<hyph_count; i++)
@@ -774,8 +774,8 @@ bool TexHyph::load( LVStreamRef stream )
             cnv.msf( hyph.wu );
             charMap[ (unsigned char)hyph.al ] = hyph.wl;
             charMap[ (unsigned char)hyph.au ] = hyph.wu;
-//            lChar16 ch = hyph.wl;
-//            CRLog::debug("wl=%s mask=%c%c", LCSTR(lString16(&ch, 1)), hyph.mask0[0], hyph.mask0[1]);
+//            lChar32 ch = hyph.wl;
+//            CRLog::debug("wl=%s mask=%c%c", LCSTR(lString32(&ch, 1)), hyph.mask0[0], hyph.mask0[1]);
             if (hyph.mask0[0]!='0'||hyph.mask0[1]!='0') {
                 unsigned char pat[4];
                 pat[0] = hyph.al;
@@ -784,11 +784,11 @@ bool TexHyph::load( LVStreamRef stream )
                 pat[3] = 0;
                 TexPattern * pattern = new TexPattern(pat, 1, charMap);
 #if DUMP_PATTERNS==1
-                CRLog::debug("Pattern: '%s' - %s", LCSTR(lString16(pattern->word)), pattern->attr );
+                CRLog::debug("Pattern: '%s' - %s", LCSTR(lString32(pattern->word)), pattern->attr );
 #endif
                 if (pattern->overflowed) {
                     // don't use truncated words
-                    CRLog::warn("Pattern overflowed (%d > %d) and ignored: '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(lString16(pattern->word)));
+                    CRLog::warn("Pattern overflowed (%d > %d) and ignored: '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(lString32(pattern->word)));
                     if (pattern->overflowed > largest_overflowed_word)
                         largest_overflowed_word = pattern->overflowed;
                     delete pattern;
@@ -822,11 +822,11 @@ bool TexHyph::load( LVStreamRef stream )
                     break;
                 TexPattern * pattern = new TexPattern( p, sz, charMap );
 #if DUMP_PATTERNS==1
-                CRLog::debug("Pattern: '%s' - %s", LCSTR(lString16(pattern->word)), pattern->attr);
+                CRLog::debug("Pattern: '%s' - %s", LCSTR(lString32(pattern->word)), pattern->attr);
 #endif
                 if (pattern->overflowed) {
                     // don't use truncated words
-                    CRLog::warn("Pattern overflowed (%d > %d) and ignored: '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(lString16(pattern->word)));
+                    CRLog::warn("Pattern overflowed (%d > %d) and ignored: '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(lString32(pattern->word)));
                     if (pattern->overflowed > largest_overflowed_word)
                         largest_overflowed_word = pattern->overflowed;
                     delete pattern;
@@ -842,7 +842,7 @@ bool TexHyph::load( LVStreamRef stream )
         return patternCount>0;
     } else {
         // tex xml format as for FBReader
-        lString16Collection data;
+        lString32Collection data;
         HyphPatternReader reader( data );
         LVXMLParser parser( stream, &reader );
         if ( !parser.CheckFormat() )
@@ -855,11 +855,11 @@ bool TexHyph::load( LVStreamRef stream )
             data[i].lowercase();
             TexPattern * pattern = new TexPattern( data[i] );
 #if DUMP_PATTERNS==1
-            CRLog::debug("Pattern: (%s) '%s' - %s", LCSTR(data[i]), LCSTR(lString16(pattern->word)), pattern->attr);
+            CRLog::debug("Pattern: (%s) '%s' - %s", LCSTR(data[i]), LCSTR(lString32(pattern->word)), pattern->attr);
 #endif
             if (pattern->overflowed) {
                 // don't use truncated words
-                CRLog::warn("Pattern overflowed (%d > %d) and ignored: (%s) '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(data[i]), LCSTR(lString16(pattern->word)));
+                CRLog::warn("Pattern overflowed (%d > %d) and ignored: (%s) '%s'", pattern->overflowed, MAX_PATTERN_SIZE, LCSTR(data[i]), LCSTR(lString32(pattern->word)));
                 if (pattern->overflowed > largest_overflowed_word)
                     largest_overflowed_word = pattern->overflowed;
                 delete pattern;
@@ -873,7 +873,7 @@ bool TexHyph::load( LVStreamRef stream )
     }
 }
 
-bool TexHyph::load( lString16 fileName )
+bool TexHyph::load( lString32 fileName )
 {
     LVStreamRef stream = LVOpenFileStream( fileName.c_str(), LVOM_READ );
     if ( stream.isNull() )
@@ -882,7 +882,7 @@ bool TexHyph::load( lString16 fileName )
 }
 
 
-bool TexHyph::match( const lChar16 * str, char * mask )
+bool TexHyph::match( const lChar32 * str, char * mask )
 {
     bool found = false;
     TexPattern * res = table[ TexPattern::hash( str ) ];
@@ -906,7 +906,7 @@ bool TexHyph::match( const lChar16 * str, char * mask )
 
 //TODO: do we need it?
 ///// returns false if there is rule disabling hyphenation at specified point
-//static bool checkHyphenRules( const lChar16 * str, int len, int pos )
+//static bool checkHyphenRules( const lChar32 * str, int len, int pos )
 //{
 //    if ( pos<1 || pos>len-3 )
 //        return false;
@@ -925,7 +925,7 @@ bool TexHyph::match( const lChar16 * str, char * mask )
 //    return true;
 //}
 
-bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool TexHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( HyphMan::_TrustSoftHyphens ) {
         if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize) )
@@ -935,7 +935,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
         return false;
     if ( len>=WORD_LENGTH )
         len = WORD_LENGTH - 2;
-    lChar16 word[WORD_LENGTH+4] = { 0 };
+    lChar32 word[WORD_LENGTH+4] = { 0 };
     char mask[WORD_LENGTH+4] = { 0 };
 
     // Make word from str, with soft-hyphens stripped out.
@@ -953,10 +953,10 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     if ( wlen<=3 )
         return false;
     lStr_lowercase(word+1, wlen);
-    // printf("word:%s => #%s# (%d => %d)\n", LCSTR(lString16(str, len)), LCSTR(lString16(word)), len, wlen);
+    // printf("word:%s => #%s# (%d => %d)\n", LCSTR(lString32(str, len)), LCSTR(lString32(word)), len, wlen);
 
 #if DUMP_HYPHENATION_WORDS==1
-    CRLog::trace("word to hyphenate: '%s'", LCSTR(lString16(word)));
+    CRLog::trace("word to hyphenate: '%s'", LCSTR(lString32(word)));
 #endif
 
     // Find matches from dict patterns, at any position in word.
@@ -970,26 +970,26 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
         return false;
 
 #if DUMP_HYPHENATION_WORDS==1
-    lString16 buf;
-    lString16 buf2;
+    lString32 buf;
+    lString32 buf2;
     bool boundFound = false;
     for ( int i=0; i<wlen; i++ ) {
         buf << word[i+1];
         buf2 << word[i+1];
-        buf2 << (lChar16)mask[i+2];
+        buf2 << (lChar32)mask[i+2];
         // This maxWidth check may be wrong here (in the dump only) because
         // of a +1 shift and possible more shifts due to soft-hyphens.
         int nw = widths[i]+hyphCharWidth;
         if ( (mask[i+2]&1) ) {
-            buf << (lChar16)'-';
-            buf2 << (lChar16)'-';
+            buf << (lChar32)'-';
+            buf2 << (lChar32)'-';
         }
         if ( nw>maxWidth && !boundFound ) {
-            buf << (lChar16)'|';
-            buf2 << (lChar16)'|';
+            buf << (lChar32)'|';
+            buf2 << (lChar32)'|';
             boundFound = true;
-//            buf << (lChar16)'-';
-//            buf2 << (lChar16)'-';
+//            buf << (lChar32)'-';
+//            buf2 << (lChar32)'-';
         }
     }
     CRLog::trace("Hyphenate: %s  %s", LCSTR(buf), LCSTR(buf2) );
@@ -1035,7 +1035,7 @@ bool TexHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 
     return res;
 }
 
-bool AlgoHyph::hyphenate( const lChar16 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool AlgoHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( HyphMan::_TrustSoftHyphens ) {
         if ( softhyphens_hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize) )

--- a/crengine/src/lstridmap.cpp
+++ b/crengine/src/lstridmap.cpp
@@ -17,7 +17,7 @@
 #include "../include/lvtinydom.h"
 #include <string.h>
 
-LDOMNameIdMapItem::LDOMNameIdMapItem(lUInt16 _id, const lString16 & _value, const css_elem_def_props_t * _data)
+LDOMNameIdMapItem::LDOMNameIdMapItem(lUInt16 _id, const lString32 & _value, const css_elem_def_props_t * _data)
     : id(_id), value(_value)
 {
 	if ( _data ) {
@@ -68,7 +68,7 @@ LDOMNameIdMapItem * LDOMNameIdMapItem::deserialize( SerialBuf & buf )
 	if ( !buf.checkMagic( id_map_item_magic ) )
         return NULL;
 	lUInt16 id;
-	lString16 value;
+	lString32 value;
 	lUInt8 flgData;
     buf >> id >> value >> flgData;
     if ( id>=MAX_TYPE_ID )
@@ -202,7 +202,7 @@ void LDOMNameIdMap::Sort()
     m_sorted = true;
 }
 
-const LDOMNameIdMapItem * LDOMNameIdMap::findItem( const lChar16 * name )
+const LDOMNameIdMapItem * LDOMNameIdMap::findItem( const lChar32 * name )
 {
     if (m_count==0 || !name || !*name)
         return NULL;
@@ -287,7 +287,7 @@ void LDOMNameIdMap::AddItem( LDOMNameIdMapItem * item )
     }
 }
 
-void LDOMNameIdMap::AddItem( lUInt16 id, const lString16 & value, const css_elem_def_props_t * data )
+void LDOMNameIdMap::AddItem( lUInt16 id, const lString32 & value, const css_elem_def_props_t * data )
 {
     if (id==0)
         return;
@@ -319,9 +319,9 @@ void LDOMNameIdMap::dumpUnknownItems( FILE * f, int start_id )
     }
 }
 
-lString16 LDOMNameIdMap::getUnknownItems( int start_id )
+lString32 LDOMNameIdMap::getUnknownItems( int start_id )
 {
-    lString16 items;
+    lString32 items;
     for (int i=start_id; i<m_size; i++) {
         if (m_by_id[i] != NULL) {
             if ( !items.empty() )

--- a/crengine/src/lvbmpbuf.cpp
+++ b/crengine/src/lvbmpbuf.cpp
@@ -383,7 +383,7 @@ void lvdrawbufDraw( draw_buf_t * buf, int x, int y, const lUInt8 * bitmap, int n
 */
 /*
 void lvdrawbufDrawText( draw_buf_t * buf, int x, int y, const lvfont_handle pfont, 
-                       const lChar16 * text, int len, lChar16 def_char )
+                       const lChar32 * text, int len, lChar32 def_char )
 {
    const lvfont_glyph_t * glyph;
    int baseline = lvfontGetHeader( pfont )->fontBaseline;
@@ -415,7 +415,7 @@ void lvdrawbufDrawText( draw_buf_t * buf, int x, int y, const lvfont_handle pfon
 }
 */
 void lvdrawbufDrawText( draw_buf_t * buf, int x, int y, const lvfont_handle pfont, 
-                       const lChar16 * text, int len, lChar16 def_char )
+                       const lChar32 * text, int len, lChar32 def_char )
 {
     static lUInt8 glyph_buf[16384];
     const lvfont_glyph_t * glyph;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -195,8 +195,8 @@ LVDocView::LVDocView(int bitsPerPixel, bool noDefaultDocument) :
 
     if (!noDefaultDocument)
         // NOLINTNEXTLINE: Call to virtual function during construction
-        createDefaultDocument(cs16("No document"), lString16(
-                    L"Welcome to CoolReader! Please select file to open"));
+        createDefaultDocument(cs32("No document"), lString32(
+                    U"Welcome to CoolReader! Please select file to open"));
 
     m_font_size = scaleFontSizeForDPI(m_requested_font_size);
     gRootFontSize = m_font_size; // stored as global (for 'rem' css unit)
@@ -266,14 +266,14 @@ void LVDocView::requestReload() {
 		CRFileHist * hist = getHistory();
 		if (!hist || hist->getRecords().length() <= 0)
 			return;
-        //lString16 fn = hist->getRecords()[0]->getFilePathName();
-        lString16 fn = m_filename;
+        //lString32 fn = hist->getRecords()[0]->getFilePathName();
+        lString32 fn = m_filename;
 		bool res = LoadDocument(fn.c_str());
 		if (res) {
 			//swapToCache();
 			restorePosition();
 		} else {
-            createDefaultDocument(lString16::empty_str, lString16(
+            createDefaultDocument(lString32::empty_str, lString32(
 					"Error while opening document ") + fn);
 		}
 		checkRender();
@@ -428,13 +428,13 @@ void LVDocView::setPageHeaderInfo(int hdrFlags) {
 	}
 }
 
-lString16 mergeCssMacros(CRPropRef props) {
+lString32 mergeCssMacros(CRPropRef props) {
     lString8 res = lString8::empty_str;
     for (int i=0; i<props->getCount(); i++) {
     	lString8 n(props->getName(i));
     	if (n.endsWith(".day") || n.endsWith(".night"))
     		continue;
-        lString16 v = props->getValue(i);
+        lString32 v = props->getValue(i);
         if (!v.empty()) {
             if (v.lastChar() != ';')
                 v.append(1, ';');
@@ -463,7 +463,7 @@ lString8 substituteCssMacros(lString8 src, CRPropRef props) {
             if (!err) {
                 // substitute variable
                 lString8 prop(s + 1, (lvsize_t)(s2 - s - 1));
-                lString16 v;
+                lString32 v;
                 // $styles.stylename.all will merge all properties like styles.stylename.*
                 if (prop.endsWith(".all")) {
                     // merge whole branch
@@ -767,7 +767,7 @@ bool LVDocView::exportWolFile(const char * fname, bool flgGray, int levels) {
 	return exportWolFile(stream.get(), flgGray, levels);
 }
 
-bool LVDocView::exportWolFile(const wchar_t * fname, bool flgGray, int levels) {
+bool LVDocView::exportWolFile(const lChar32 * fname, bool flgGray, int levels) {
 	LVStreamRef stream = LVOpenFileStream(fname, LVOM_WRITE);
 	if (!stream)
 		return false;
@@ -794,14 +794,14 @@ LVTocItem * LVDocView::getToc() {
 	return m_doc->getToc();
 }
 
-static lString16 getSectionHeader(ldomNode * section) {
-	lString16 header;
+static lString32 getSectionHeader(ldomNode * section) {
+	lString32 header;
 	if (!section || section->getChildCount() == 0)
 		return header;
-    ldomNode * child = section->getChildElementNode(0, L"title");
+    ldomNode * child = section->getChildElementNode(0, U"title");
     if (!child)
 		return header;
-	header = child->getText(L' ', 1024);
+	header = child->getText(U' ', 1024);
 	return header;
 }
 
@@ -829,7 +829,7 @@ int getSectionPage(ldomNode * section, LVRendPageList & pages) {
  {
  if ( !basesection || !parent )
  return;
- lString16 name = getSectionHeader( basesection );
+ lString32 name = getSectionHeader( basesection );
  if ( name.empty() )
  return; // section without header
  ldomXPointer ptr( basesection, 0 );
@@ -942,7 +942,7 @@ void LVDocView::updatePageMapInfo(LVPageMap * pagemap) {
 
 /// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
 /// path relative to document directory for non-container documents like HTML)
-LVStreamRef LVDocView::getDocumentFileStream( lString16 filePath ) {
+LVStreamRef LVDocView::getDocumentFileStream( lString32 filePath ) {
     if ( !filePath.empty() ) {
         LVContainerRef cont = m_doc->getContainer();
         if ( cont.isNull() ) // no real container
@@ -956,7 +956,7 @@ LVStreamRef LVDocView::getDocumentFileStream( lString16 filePath ) {
 
 /// returns cover page image stream, if any
 LVStreamRef LVDocView::getCoverPageImageStream() {
-    lString16 fileName;
+    lString32 fileName;
     //m_doc_props
 //    for ( int i=0; i<m_doc_props->getCount(); i++ ) {
 //        CRLog::debug("%s = %s", m_doc_props->getName(i), LCSTR(m_doc_props->getValue(i)));
@@ -1058,9 +1058,9 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
             css_ff_serif, cs8("Times New Roman")));
 	LVFontRef series_fnt(fontMan->GetFont(base_font_size - 3, 400, true,
             css_ff_serif, cs8("Times New Roman")));
-	lString16 authors = getAuthors();
-	lString16 title = getTitle();
-	lString16 series = getSeries();
+	lString32 authors = getAuthors();
+	lString32 title = getTitle();
+	lString32 series = getSeries();
 	if (title.empty())
         title = "no title";
 	LFormattedText txform;
@@ -1167,7 +1167,7 @@ bool LVDocView::exportWolFile(LVStream * stream, bool flgGray, int levels) {
 
 	//Render(dx, dy, &pages);
 
-	const lChar8 * * table = GetCharsetUnicode2ByteTable(L"windows-1251");
+	const lChar8 * * table = GetCharsetUnicode2ByteTable(U"windows-1251");
 
 	//ldomXPointer bm = getBookmark();
 	{
@@ -1216,9 +1216,9 @@ bool LVDocView::exportWolFile(LVStream * stream, bool flgGray, int levels) {
 		}
 
 		// add TOC
-		ldomNode * body = m_doc->nodeFromXPath(lString16(
+		ldomNode * body = m_doc->nodeFromXPath(lString32(
                 "/FictionBook/body[1]"));
-		lUInt16 section_id = m_doc->getElementNameIndex(L"section");
+		lUInt16 section_id = m_doc->getElementNameIndex(U"section");
 
 		if (body) {
 			int l1n = 0;
@@ -1324,7 +1324,7 @@ void LVDocView::getPageHeaderRectangle(int pageIndex, lvRect & headerRc) {
 }
 
 /// returns current time representation string
-lString16 LVDocView::getTimeString() {
+lString32 LVDocView::getTimeString() {
 	time_t t = (time_t) time(0);
 	tm * bt = localtime(&t);
 	char str[12];
@@ -1512,12 +1512,12 @@ LVArray<int> & LVDocView::getSectionBounds( bool for_external_update ) {
 	m_section_bounds.clear();
 	m_section_bounds.add(0);
     // Get sections from FB2 books
-    ldomNode * body = m_doc->nodeFromXPath(cs16("/FictionBook/body[1]"));
-	lUInt16 section_id = m_doc->getElementNameIndex(L"section");
+    ldomNode * body = m_doc->nodeFromXPath(cs32("/FictionBook/body[1]"));
+	lUInt16 section_id = m_doc->getElementNameIndex(U"section");
     if (body == NULL) {
         // Get sections from EPUB books
-        body = m_doc->nodeFromXPath(cs16("/body[1]"));
-        section_id = m_doc->getElementNameIndex(L"DocFragment");
+        body = m_doc->nodeFromXPath(cs32("/body[1]"));
+        section_id = m_doc->getElementNameIndex(U"DocFragment");
     }
 	int fh = GetFullHeight();
     int pc = getVisiblePageCount();
@@ -1652,22 +1652,22 @@ void LVDocView::setBatteryIcons(const LVRefVec<LVImageSource> & icons) {
 	m_batteryIcons = icons;
 }
 
-lString16 fitTextWidthWithEllipsis(lString16 text, LVFontRef font, int maxwidth) {
+lString32 fitTextWidthWithEllipsis(lString32 text, LVFontRef font, int maxwidth) {
 	int w = font->getTextWidth(text.c_str(), text.length());
 	if (w <= maxwidth)
 		return text;
 	int len;
 	for (len = text.length() - 1; len > 1; len--) {
-        lString16 s = text.substr(0, len) + "...";
+        lString32 s = text.substr(0, len) + "...";
 		w = font->getTextWidth(s.c_str(), s.length());
 		if (w <= maxwidth)
 			return s;
 	}
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 /// substitute page header with custom text (e.g. to be used while loading)
-void LVDocView::setPageHeaderOverride(lString16 s) {
+void LVDocView::setPageHeaderOverride(lString32 s) {
 	m_pageHeaderOverride = s;
 	clearImageCache();
 }
@@ -1764,7 +1764,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
             drawbuf->FillRect(x, gpos - 2 - sz/2, x + szx, gpos - 2 + sz/2 + 1, cl);
 	}
 
-	lString16 text;
+	lString32 text;
 	//int iy = info.top; // + (info.height() - m_infoFont->getHeight()) * 2 / 3;
         int iy = info.top + /*m_infoFont->getHeight() +*/ (info.height() - m_infoFont->getHeight()) / 2 - HEADER_MARGIN/2;
 
@@ -1823,7 +1823,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 				info.right = brc.left - info.height() / 2;
 			}
 		}
-		lString16 pageinfo;
+		lString32 pageinfo;
 		if (pageCount > 0) {
 			if (phi & PGHDR_PAGE_NUMBER)
                 pageinfo += fmt::decimal(pageIndex + 1);
@@ -1835,7 +1835,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
             if (phi & PGHDR_PERCENT) {
                 if ( !pageinfo.empty() )
                     pageinfo += "  ";
-                //pageinfo += lString16::itoa(percent/100)+L"%"; //+L"."+lString16::itoa(percent/10%10)+L"%";
+                //pageinfo += lString32::itoa(percent/100)+U"%"; //+U"."+lString32::itoa(percent/10%10)+U"%";
                 pageinfo += fmt::decimal(percent/100);
                 pageinfo += ",";
                 int pp = percent%100;
@@ -1851,23 +1851,23 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		if (!pageinfo.empty()) {
 			piw = m_infoFont->getTextWidth(pageinfo.c_str(), pageinfo.length());
 			m_infoFont->DrawTextString(drawbuf, info.right - piw, iy,
-					pageinfo.c_str(), pageinfo.length(), L' ', NULL, false);
+					pageinfo.c_str(), pageinfo.length(), U' ', NULL, false);
 			info.right -= piw + info.height() / 2;
 		}
 		if (phi & PGHDR_CLOCK) {
-			lString16 clock = getTimeString();
+			lString32 clock = getTimeString();
 			m_last_clock = clock;
 			int w = m_infoFont->getTextWidth(clock.c_str(), clock.length()) + 2;
 			m_infoFont->DrawTextString(drawbuf, info.right - w, iy,
-					clock.c_str(), clock.length(), L' ', NULL, false);
+					clock.c_str(), clock.length(), U' ', NULL, false);
 			info.right -= w + info.height() / 2;
 		}
 		int authorsw = 0;
-		lString16 authors;
+		lString32 authors;
 		if (phi & PGHDR_AUTHOR)
 			authors = getAuthors();
 		int titlew = 0;
-		lString16 title;
+		lString32 title;
 		if (phi & PGHDR_TITLE) {
 			title = getTitle();
 			if (title.empty() && authors.empty())
@@ -1879,7 +1879,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		}
 		if (phi & PGHDR_AUTHOR && !authors.empty()) {
 			if (!title.empty())
-				authors += L'.';
+				authors += U'.';
 			authorsw = m_infoFont->getTextWidth(authors.c_str(),
 					authors.length());
 		}
@@ -1902,7 +1902,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 	text = fitTextWidthWithEllipsis(text, m_infoFont, newcr.width());
 	if (!text.empty()) {
 		m_infoFont->DrawTextString(drawbuf, info.left, iy, text.c_str(),
-				text.length(), L' ', NULL, false);
+				text.length(), U' ', NULL, false);
 	}
 	drawbuf->SetClipRect(&oldcr);
 	//--------------
@@ -2059,7 +2059,7 @@ void LVDocView::drawPageTo(LVDrawBuf * drawbuf, LVRendPageInfo & page,
 #endif
 
 #if 0
-	lString16 pagenum = lString16::itoa( page.index+1 );
+	lString32 pagenum = lString32::itoa( page.index+1 );
 	m_font->DrawTextString(drawbuf, 5, 0 , pagenum.c_str(), pagenum.length(), '?', NULL, false); //drawbuf->GetHeight()-m_font->getHeight()
 #endif
 }
@@ -2681,10 +2681,10 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
 /// returns number of non-space characters on current page
 int LVDocView::getCurrentPageCharCount()
 {
-    lString16 text = getPageText(true);
+    lString32 text = getPageText(true);
     int count = 0;
     for (int i=0; i<text.length(); i++) {
-        lChar16 ch = text[i];
+        lChar32 ch = text[i];
         if (ch>='0')
             count++;
     }
@@ -2705,7 +2705,7 @@ int LVDocView::getCurrentPageImageCount()
         virtual void onText(ldomXRange *) { }
         /// called for each found node in range
         virtual bool onElement(ldomXPointerEx * ptr) {
-            lString16 nodeName = ptr->getNode()->getNodeName();
+            lString32 nodeName = ptr->getNode()->getNodeName();
             if (nodeName == "img" || nodeName == "image")
                 count++;
 			return true;
@@ -2719,10 +2719,10 @@ int LVDocView::getCurrentPageImageCount()
 }
 
 /// get page text, -1 for current page
-lString16 LVDocView::getPageText(bool, int pageIndex) {
+lString32 LVDocView::getPageText(bool, int pageIndex) {
 	LVLock lock(getMutex());
     CHECK_RENDER("getPageText()")
-	lString16 txt;
+	lString32 txt;
 	LVRef < ldomXRange > range = getPageDocumentRange(pageIndex);
 	if (!range.isNull())
 		txt = range->getRangeText();
@@ -3014,7 +3014,7 @@ bool LVDocView::getCursorRect(ldomXPointer ptr, lvRect & rc,
 }
 
 /// follow link, returns true if navigation was successful
-bool LVDocView::goLink(lString16 link, bool savePos) {
+bool LVDocView::goLink(lString32 link, bool savePos) {
 	CRLog::debug("goLink(%s)", LCSTR(link));
 	ldomNode * element = NULL;
 	if (link.empty()) {
@@ -3030,8 +3030,8 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 			return false;
 	}
 	if (link[0] != '#' || link.length() <= 1) {
-		lString16 filename = link;
-		lString16 id;
+		lString32 filename = link;
+		lString32 id;
         int p = filename.pos("#");
 		if (p >= 0) {
 			// split filename and anchor
@@ -3050,19 +3050,19 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 			CRLog::debug("Link to another file: %s   anchor=%s", UnicodeToUtf8(
 					filename).c_str(), UnicodeToUtf8(id).c_str());
 
-			lString16 baseDir = m_doc_props->getStringDef(DOC_PROP_FILE_PATH,
+			lString32 baseDir = m_doc_props->getStringDef(DOC_PROP_FILE_PATH,
 					".");
 			LVAppendPathDelimiter(baseDir);
-			lString16 fn = m_doc_props->getStringDef(DOC_PROP_FILE_NAME, "");
+			lString32 fn = m_doc_props->getStringDef(DOC_PROP_FILE_NAME, "");
 			CRLog::debug("Current path: %s   filename:%s", UnicodeToUtf8(
 					baseDir).c_str(), UnicodeToUtf8(fn).c_str());
 			baseDir = LVExtractPath(baseDir + fn);
-			//lString16 newPathName = LVMakeRelativeFilename( baseDir, filename );
-			lString16 newPathName = LVCombinePaths(baseDir, filename);
-			lString16 dir = LVExtractPath(newPathName);
-			lString16 filename = LVExtractFilename(newPathName);
+			//lString32 newPathName = LVMakeRelativeFilename( baseDir, filename );
+			lString32 newPathName = LVCombinePaths(baseDir, filename);
+			lString32 dir = LVExtractPath(newPathName);
+			lString32 filename = LVExtractFilename(newPathName);
 			LVContainerRef container = m_container;
-			lString16 arcname =
+			lString32 arcname =
 					m_doc_props->getStringDef(DOC_PROP_ARC_NAME, "");
 			if (arcname.empty()) {
 				container = LVOpenDirectory(dir.c_str());
@@ -3101,12 +3101,12 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 			m_doc_props->setString(DOC_PROP_FILE_PATH, dir);
 			m_doc_props->setString(DOC_PROP_FILE_NAME, filename);
 			m_doc_props->setString(DOC_PROP_CODE_BASE, LVExtractPath(filename));
-			m_doc_props->setString(DOC_PROP_FILE_SIZE, lString16::itoa(
+			m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa(
 					(int) stream->GetSize()));
             m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 			// TODO: load document from stream properly
 			if (!LoadDocument(stream)) {
-                createDefaultDocument(cs16("Load error"), lString16(
+                createDefaultDocument(cs32("Load error"), lString32(
                         "Cannot open file ") + filename);
 				return false;
 			}
@@ -3119,7 +3119,7 @@ bool LVDocView::goLink(lString16 link, bool savePos) {
 			// TODO: setup properties
 			// go to anchor
 			if (!id.empty())
-                goLink(cs16("#") + id);
+                goLink(cs32("#") + id);
 			clearImageCache();
 			requestRender();
 			return true;
@@ -3143,17 +3143,17 @@ bool LVDocView::goSelectedLink() {
 	ldomXRange * link = getCurrentPageSelectedLink();
 	if (!link)
 		return false;
-	lString16 href = link->getHRef();
+	lString32 href = link->getHRef();
 	if (href.empty())
 		return false;
 	return goLink(href);
 }
 
-#define NAVIGATION_FILENAME_SEPARATOR L":"
-bool splitNavigationPos(lString16 pos, lString16 & fname, lString16 & path) {
-	int p = pos.pos(lString16(NAVIGATION_FILENAME_SEPARATOR));
+#define NAVIGATION_FILENAME_SEPARATOR U":"
+bool splitNavigationPos(lString32 pos, lString32 & fname, lString32 & path) {
+	int p = pos.pos(lString32(NAVIGATION_FILENAME_SEPARATOR));
 	if (p <= 0) {
-        fname = lString16::empty_str;
+        fname = lString32::empty_str;
 		path = pos;
 		return false;
 	}
@@ -3163,20 +3163,20 @@ bool splitNavigationPos(lString16 pos, lString16 & fname, lString16 & path) {
 }
 
 /// packs current file path and name
-lString16 LVDocView::getNavigationPath() {
-	lString16 fname = m_doc_props->getStringDef(DOC_PROP_FILE_NAME, "");
-	lString16 fpath = m_doc_props->getStringDef(DOC_PROP_FILE_PATH, "");
+lString32 LVDocView::getNavigationPath() {
+	lString32 fname = m_doc_props->getStringDef(DOC_PROP_FILE_NAME, "");
+	lString32 fpath = m_doc_props->getStringDef(DOC_PROP_FILE_PATH, "");
 	LVAppendPathDelimiter(fpath);
-	lString16 s = fpath + fname;
+	lString32 s = fpath + fname;
 	if (!m_arc.isNull())
-        s = cs16("/") + s;
+        s = cs32("/") + s;
 	return s;
 }
 
 /// saves position to navigation history, to be able return back
-bool LVDocView::savePosToNavigationHistory(lString16 path) {
+bool LVDocView::savePosToNavigationHistory(lString32 path) {
     if (!path.empty()) {
-        lString16 s = getNavigationPath() + NAVIGATION_FILENAME_SEPARATOR
+        lString32 s = getNavigationPath() + NAVIGATION_FILENAME_SEPARATOR
                 + path;
         CRLog::debug("savePosToNavigationHistory(%s)",
                 UnicodeToUtf8(s).c_str());
@@ -3188,18 +3188,18 @@ bool LVDocView::savePosToNavigationHistory(lString16 path) {
 bool LVDocView::savePosToNavigationHistory() {
 	ldomXPointer bookmark = getBookmark();
 	if (!bookmark.isNull()) {
-		lString16 path = bookmark.toString();
+		lString32 path = bookmark.toString();
         return savePosToNavigationHistory(path);
 	}
 	return false;
 }
 
 /// navigate to history path URL
-bool LVDocView::navigateTo(lString16 historyPath) {
+bool LVDocView::navigateTo(lString32 historyPath) {
 	CRLog::debug("navigateTo(%s)", LCSTR(historyPath));
-	lString16 fname, path;
+	lString32 fname, path;
 	if (splitNavigationPos(historyPath, fname, path)) {
-		lString16 curr_fname = getNavigationPath();
+		lString32 curr_fname = getNavigationPath();
 		if (curr_fname != fname) {
 			CRLog::debug(
 					"navigateTo() : file name doesn't match: current=%s %s, new=%s %s",
@@ -3232,7 +3232,7 @@ bool LVDocView::canGoForward() {
 bool LVDocView::goBack() {
 	if (_navigationHistory.forwardCount() == 0 && savePosToNavigationHistory())
 		_navigationHistory.back();
-	lString16 s = _navigationHistory.back();
+	lString32 s = _navigationHistory.back();
 	if (s.empty())
 		return false;
 	return navigateTo(s);
@@ -3240,7 +3240,7 @@ bool LVDocView::goBack() {
 
 /// go forward. returns true if navigation was successful
 bool LVDocView::goForward() {
-	lString16 s = _navigationHistory.forward();
+	lString32 s = _navigationHistory.forward();
 	if (s.empty())
 		return false;
 	return navigateTo(s);
@@ -3325,7 +3325,7 @@ void LVDocView::updateBookMarksRanges()
                 CRBookmark * bmk = bookmarks[i];
                 if (bmk->getType() != bmkt_comment && bmk->getType() != bmkt_correction)
                     continue;
-                lString16 pos = bmk->getStartPos();
+                lString32 pos = bmk->getStartPos();
                 ldomXPointer p = m_doc->createXPointer(pos);
                 if (p.isNull())
                     continue;
@@ -3361,10 +3361,10 @@ void LVDocView::updateBookMarksRanges()
                 if ((bmk->getType() != bmkt_comment && bmk->getType() != bmkt_correction) ||
                     bmk->getPercent() != bmi->get(i))
                     continue;
-                lString16 epos = bmk->getEndPos();
+                lString32 epos = bmk->getEndPos();
                 ldomXPointer ep = m_doc->createXPointer(epos);
                 if (!ep.isNull()) {
-                    lString16 spos = bmk->getStartPos();
+                    lString32 spos = bmk->getStartPos();
                     ldomXPointer sp = m_doc->createXPointer(spos);
                     if (!sp.isNull()) {
                         ldomXRange bmk_range(sp, ep);
@@ -3658,7 +3658,7 @@ void SaveBase64Objects( ldomNode * node )
 {
 	if ( !node->isElement() || node->getNodeId()!=el_binary )
 	return;
-	lString16 name = node->getAttributeValue(attr_id);
+	lString32 name = node->getAttributeValue(attr_id);
 	if ( name.empty() )
 	return;
 	fprintf( stderr, "opening base64 stream...\n" );
@@ -3696,12 +3696,12 @@ CRFileHistRecord * LVDocView::getCurrentFileHistRecord() {
 		return NULL;
 	//CRLog::trace("LVDocView::getCurrentFileHistRecord()");
 	//CRLog::trace("get title, authors, series");
-	lString16 title = getTitle();
-	lString16 authors = getAuthors();
-	lString16 series = getSeries();
+	lString32 title = getTitle();
+	lString32 authors = getAuthors();
+	lString32 series = getSeries();
 	//CRLog::trace("get bookmark");
 	ldomXPointer bmk = getBookmark();
-    lString16 fn = m_filename;
+    lString32 fn = m_filename;
 #ifdef ORIGINAL_FILENAME_PATCH
     if ( !m_originalFilename.empty() )
         fn = m_originalFilename;
@@ -3725,7 +3725,7 @@ void LVDocView::restorePosition() {
 		return;
 	LVLock lock(getMutex());
 	//checkRender();
-    lString16 fn = m_filename;
+    lString32 fn = m_filename;
 #ifdef ORIGINAL_FILENAME_PATCH
     if ( !m_originalFilename.empty() )
         fn = m_originalFilename;
@@ -3747,7 +3747,7 @@ void LVDocView::restorePosition() {
 }
 
 static void FileToArcProps(CRPropRef props) {
-	lString16 s = props->getStringDef(DOC_PROP_FILE_NAME);
+	lString32 s = props->getStringDef(DOC_PROP_FILE_NAME);
 	if (!s.empty())
 		props->setString(DOC_PROP_ARC_NAME, s);
 	s = props->getStringDef(DOC_PROP_FILE_PATH);
@@ -3756,27 +3756,27 @@ static void FileToArcProps(CRPropRef props) {
 	s = props->getStringDef(DOC_PROP_FILE_SIZE);
 	if (!s.empty())
 		props->setString(DOC_PROP_ARC_SIZE, s);
-    props->setString(DOC_PROP_FILE_NAME, lString16::empty_str);
-    props->setString(DOC_PROP_FILE_PATH, lString16::empty_str);
-    props->setString(DOC_PROP_FILE_SIZE, lString16::empty_str);
+    props->setString(DOC_PROP_FILE_NAME, lString32::empty_str);
+    props->setString(DOC_PROP_FILE_PATH, lString32::empty_str);
+    props->setString(DOC_PROP_FILE_SIZE, lString32::empty_str);
 	props->setHex(DOC_PROP_FILE_CRC32, 0);
 }
 
 /// load document from file
-bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
+bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 	if (!fname || !fname[0])
 		return false;
 
 	Clear();
 
-    CRLog::debug("LoadDocument(%s) textMode=%s", LCSTR(lString16(fname)), getTextFormatOptions()==txt_format_pre ? "pre" : "autoformat");
+    CRLog::debug("LoadDocument(%s) textMode=%s", LCSTR(lString32(fname)), getTextFormatOptions()==txt_format_pre ? "pre" : "autoformat");
 
 	// split file path and name
-	lString16 filename16(fname);
+	lString32 filename32(fname);
 
-	lString16 arcPathName;
-	lString16 arcItemPathName;
-	bool isArchiveFile = LVSplitArcName(filename16, arcPathName,
+	lString32 arcPathName;
+	lString32 arcItemPathName;
+	bool isArchiveFile = LVSplitArcName(filename32, arcPathName,
 			arcItemPathName);
 	if (isArchiveFile) {
 		// load from archive, using @/ separated arhive/file pathname
@@ -3798,23 +3798,23 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 		stream = m_container->OpenStream(arcItemPathName.c_str(), LVOM_READ);
 		if (stream.isNull()) {
 			CRLog::error("Cannot open archive file item stream %s", LCSTR(
-					filename16));
+					filename32));
 			return false;
 		}
 
-		lString16 fn = LVExtractFilename(arcPathName);
-		lString16 dir = LVExtractPath(arcPathName);
+		lString32 fn = LVExtractFilename(arcPathName);
+		lString32 dir = LVExtractPath(arcPathName);
 
 		m_doc_props->setString(DOC_PROP_ARC_NAME, fn);
 		m_doc_props->setString(DOC_PROP_ARC_PATH, dir);
-		m_doc_props->setString(DOC_PROP_ARC_SIZE, lString16::itoa(arcsize));
-		m_doc_props->setString(DOC_PROP_FILE_SIZE, lString16::itoa(
+		m_doc_props->setString(DOC_PROP_ARC_SIZE, lString32::itoa(arcsize));
+		m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa(
 				(int) stream->GetSize()));
 		m_doc_props->setString(DOC_PROP_FILE_NAME, arcItemPathName);
         m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 		// loading document
 		if (LoadDocument(stream, metadataOnly)) {
-			m_filename = lString16(fname);
+			m_filename = lString32(fname);
 			m_stream.Clear();
 			return true;
 		}
@@ -3822,29 +3822,29 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 		return false;
 	}
 
-	lString16 fn = LVExtractFilename(filename16);
-	lString16 dir = LVExtractPath(filename16);
+	lString32 fn = LVExtractFilename(filename32);
+	lString32 dir = LVExtractPath(filename32);
 
-	CRLog::info("Loading document %s : fn=%s, dir=%s", LCSTR(filename16),
+	CRLog::info("Loading document %s : fn=%s, dir=%s", LCSTR(filename32),
 			LCSTR(fn), LCSTR(dir));
 #if 0
 	int i;
 	int last_slash = -1;
-	lChar16 slash_char = 0;
+	lChar32 slash_char = 0;
 	for ( i=0; fname[i]; i++ ) {
 		if ( fname[i]=='\\' || fname[i]=='/' ) {
 			last_slash = i;
 			slash_char = fname[i];
 		}
 	}
-	lString16 dir;
+	lString32 dir;
 	if ( last_slash==-1 )
         dir = ".";
 	else if ( last_slash == 0 )
         dir << slash_char;
 	else
-        dir = lString16( fname, last_slash );
-	lString16 fn( fname + last_slash + 1 );
+        dir = lString32( fname, last_slash );
+	lString32 fn( fname + last_slash + 1 );
 #endif
 
 	m_doc_props->setString(DOC_PROP_FILE_PATH, dir);
@@ -3855,12 +3855,12 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 	if (!stream)
 		return false;
     m_doc_props->setString(DOC_PROP_FILE_NAME, fn);
-	m_doc_props->setString(DOC_PROP_FILE_SIZE, lString16::itoa(
+	m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa(
 			(int) stream->GetSize()));
     m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
 	if (LoadDocument(stream, metadataOnly)) {
-		m_filename = lString16(fname);
+		m_filename = lString32(fname);
 		m_stream.Clear();
 
 #define DUMP_OPENED_DOCUMENT_SENTENCES 0 // debug XPointer navigation
@@ -3878,7 +3878,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
                         ldomXPointerEx ptr2(ptr);
                         ptr2.thisSentenceEnd();
                         ldomXRange range(ptr, ptr2);
-                        lString16 str = range.getRangeText();
+                        lString32 str = range.getRangeText();
                         *out << ">sentence: " << UnicodeToUtf8(str) << "\n";
                         if ( !ptr.nextSentenceStart() )
                             break;
@@ -3895,7 +3895,7 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
                         ldomXPointerEx ptr2(ptr);
                         ptr2.thisSentenceEnd();
                         ldomXRange range(ptr, ptr2);
-                        lString16 str = range.getRangeText();
+                        lString32 str = range.getRangeText();
                         *out << "<sentence: " << UnicodeToUtf8(str) << "\n";
                         if ( !ptr.prevSentenceStart() )
                             break;
@@ -3914,12 +3914,12 @@ bool LVDocView::LoadDocument(const lChar16 * fname, bool metadataOnly) {
 void LVDocView::close() {
     if ( m_doc )
         m_doc->updateMap(m_callback); // show save cache file progress
-    createDefaultDocument(lString16::empty_str, lString16::empty_str);
+    createDefaultDocument(lString32::empty_str, lString32::empty_str);
 }
 
 
 /// create empty document with specified message (to show errors)
-void LVDocView::createHtmlDocument(lString16 code) {
+void LVDocView::createHtmlDocument(lString32 code) {
     Clear();
     m_showCover = false;
     createEmptyDocument();
@@ -3932,7 +3932,7 @@ void LVDocView::createHtmlDocument(lString16 code) {
     _page = 0;
 
 
-    lString8 s = UnicodeToUtf8(lString16(L"\xFEFF<html><body>") + code + "</body>");
+    lString8 s = UnicodeToUtf8(lString32(U"\xFEFF<html><body>") + code + "</body>");
     setDocFormat( doc_format_html);
     LVStreamRef stream = LVCreateMemoryStream();
     stream->Write(s.c_str(), s.length(), NULL);
@@ -3946,56 +3946,56 @@ void LVDocView::createHtmlDocument(lString16 code) {
     REQUEST_RENDER("resize")
 }
 
-void LVDocView::createDefaultDocument(lString16 title, lString16 message) {
+void LVDocView::createDefaultDocument(lString32 title, lString32 message) {
     Clear();
     m_showCover = false;
     createEmptyDocument();
 
     ldomDocumentWriter writer(m_doc);
-    lString16Collection lines;
-    lines.split(message, lString16("\n"));
+    lString32Collection lines;
+    lines.split(message, lString32("\n"));
 
     _pos = 0;
     _page = 0;
 
     // make fb2 document structure
-    writer.OnTagOpen(NULL, L"?xml");
-    writer.OnAttribute(NULL, L"version", L"1.0");
-    writer.OnAttribute(NULL, L"encoding", L"utf-8");
-    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagOpen(NULL, U"?xml");
+    writer.OnAttribute(NULL, U"version", U"1.0");
+    writer.OnAttribute(NULL, U"encoding", U"utf-8");
+    writer.OnEncoding(U"utf-8", NULL);
     writer.OnTagBody();
-    writer.OnTagClose(NULL, L"?xml");
-    writer.OnTagOpenNoAttr(NULL, L"FictionBook");
+    writer.OnTagClose(NULL, U"?xml");
+    writer.OnTagOpenNoAttr(NULL, U"FictionBook");
     // DESCRIPTION
-    writer.OnTagOpenNoAttr(NULL, L"description");
-    writer.OnTagOpenNoAttr(NULL, L"title-info");
-    writer.OnTagOpenNoAttr(NULL, L"book-title");
-    writer.OnTagOpenNoAttr(NULL, L"lang");
+    writer.OnTagOpenNoAttr(NULL, U"description");
+    writer.OnTagOpenNoAttr(NULL, U"title-info");
+    writer.OnTagOpenNoAttr(NULL, U"book-title");
+    writer.OnTagOpenNoAttr(NULL, U"lang");
     writer.OnText(title.c_str(), title.length(), 0);
-    writer.OnTagClose(NULL, L"book-title");
-    writer.OnTagOpenNoAttr(NULL, L"title-info");
-    writer.OnTagClose(NULL, L"description");
+    writer.OnTagClose(NULL, U"book-title");
+    writer.OnTagOpenNoAttr(NULL, U"title-info");
+    writer.OnTagClose(NULL, U"description");
     // BODY
-    writer.OnTagOpenNoAttr(NULL, L"body");
-    //m_callback->OnTagOpen( NULL, L"section" );
+    writer.OnTagOpenNoAttr(NULL, U"body");
+    //m_callback->OnTagOpen( NULL, U"section" );
     // process text
     if (title.length()) {
-        writer.OnTagOpenNoAttr(NULL, L"title");
-        writer.OnTagOpenNoAttr(NULL, L"p");
+        writer.OnTagOpenNoAttr(NULL, U"title");
+        writer.OnTagOpenNoAttr(NULL, U"p");
         writer.OnText(title.c_str(), title.length(), 0);
-        writer.OnTagClose(NULL, L"p");
-        writer.OnTagClose(NULL, L"title");
+        writer.OnTagClose(NULL, U"p");
+        writer.OnTagClose(NULL, U"title");
     }
-    lString16Collection messageLines;
-    messageLines.split(message, lString16("\n"));
+    lString32Collection messageLines;
+    messageLines.split(message, lString32("\n"));
     for (int i = 0; i < messageLines.length(); i++) {
-        writer.OnTagOpenNoAttr(NULL, L"p");
+        writer.OnTagOpenNoAttr(NULL, U"p");
         writer.OnText(messageLines[i].c_str(), messageLines[i].length(), 0);
-        writer.OnTagClose(NULL, L"p");
+        writer.OnTagClose(NULL, U"p");
     }
-    //m_callback->OnTagClose( NULL, L"section" );
-    writer.OnTagClose(NULL, L"body");
-    writer.OnTagClose(NULL, L"FictionBook");
+    //m_callback->OnTagClose( NULL, U"section" );
+    writer.OnTagClose(NULL, U"body");
+    writer.OnTagClose(NULL, U"FictionBook");
 
     // set stylesheet
     updateDocStyleSheet();
@@ -4057,9 +4057,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportPDBDocument( m_stream, m_doc, m_callback, this, contentFormat );
             if ( !res ) {
                 setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading PDB format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading PDB format"), cs32("Cannot open document") );
                 if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading PDB document") );
+                    m_callback->OnLoadFileError( cs32("Error reading PDB document") );
                 }
                 return false;
             } else {
@@ -4088,9 +4088,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportEpubDocument( m_stream, m_doc, m_callback, this, metadataOnly );
 			if ( !res ) {
 				setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading EPUB format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading EPUB format"), cs32("Cannot open document") );
 				if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading EPUB document") );
+                    m_callback->OnLoadFileError( cs32("Error reading EPUB document") );
 				}
 				return false;
 			} else {
@@ -4126,9 +4126,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportFb3Document( m_stream, m_doc, m_callback, this );
             if ( !res ) {
                 setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading FB3 format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading FB3 format"), cs32("Cannot open document") );
                 if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading FB3 document") );
+                    m_callback->OnLoadFileError( cs32("Error reading FB3 document") );
                 }
                 return false;
             } else {
@@ -4158,9 +4158,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportDocXDocument( m_stream, m_doc, m_callback, this );
             if ( !res ) {
                 setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading DOCX format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading DOCX format"), cs32("Cannot open document") );
                 if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading DOCX document") );
+                    m_callback->OnLoadFileError( cs32("Error reading DOCX document") );
                 }
                 return false;
             } else {
@@ -4190,9 +4190,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportOpenDocument(m_stream, m_doc, m_callback, this );
             if ( !res ) {
                 setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading DOCX format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading DOCX format"), cs32("Cannot open document") );
                 if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading DOCX document") );
+                    m_callback->OnLoadFileError( cs32("Error reading DOCX document") );
                 }
                 return false;
             } else {
@@ -4224,9 +4224,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportCHMDocument( m_stream, m_doc, m_callback, this );
 			if ( !res ) {
 				setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading CHM format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading CHM format"), cs32("Cannot open document") );
 				if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading CHM document") );
+                    m_callback->OnLoadFileError( cs32("Error reading CHM document") );
 				}
 				return false;
 			} else {
@@ -4257,9 +4257,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
             bool res = ImportWordDocument( m_stream, m_doc, m_callback, this );
             if ( !res ) {
                 setDocFormat( doc_format_none );
-                createDefaultDocument( cs16("ERROR: Error reading DOC format"), cs16("Cannot open document") );
+                createDefaultDocument( cs32("ERROR: Error reading DOC format"), cs32("Cannot open document") );
                 if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("Error reading DOC document") );
+                    m_callback->OnLoadFileError( cs32("Error reading DOC document") );
                 }
                 return false;
             } else {
@@ -4291,8 +4291,8 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 			int txtCount = 0;
 			int fbdCount = 0;
             int pmlCount = 0;
-			lString16 defHtml;
-			lString16 firstGood;
+			lString32 defHtml;
+			lString32 firstGood;
 			for (int i=0; i<m_arc->GetObjectCount(); i++)
 			{
 				const LVContainerItemInfo * item = m_arc->GetObjectInfo(i);
@@ -4300,13 +4300,13 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 				{
 					if ( !item->IsContainer() )
 					{
-						lString16 name( item->GetName() );
+						lString32 name( item->GetName() );
 						CRLog::debug("arc item[%d] : %s", i, LCSTR(name) );
-						lString16 s = name;
+						lString32 s = name;
 						s.lowercase();
 						bool nameIsOk = true;
                         if ( s.endsWith(".htm") || s.endsWith(".html") ) {
-							lString16 nm = LVExtractFilenameWithoutExtension( s );
+							lString32 nm = LVExtractFilenameWithoutExtension( s );
                             if ( nm == "index" || nm == "default" )
 							defHtml = name;
 							htmCount++;
@@ -4330,7 +4330,7 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 						if ( name.length() >= 5 )
 						{
 							name.lowercase();
-							const lChar16 * pext = name.c_str() + name.length() - 4;
+							const lChar32 * pext = name.c_str() + name.length() - 4;
                             if (!lStr_cmp(pext, ".fb2"))
                                 nameIsOk = true;
                             else if (!lStr_cmp(pext, ".txt"))
@@ -4343,14 +4343,14 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 					}
 				}
 			}
-			lString16 fn = !defHtml.empty() ? defHtml : firstGood;
+			lString32 fn = !defHtml.empty() ? defHtml : firstGood;
 			if ( !fn.empty() ) {
 				m_stream = m_arc->OpenStream( fn.c_str(), LVOM_READ );
 				if ( !m_stream.isNull() ) {
 					CRLog::debug("Opened archive stream %s", LCSTR(fn) );
 					m_doc_props->setString(DOC_PROP_FILE_NAME, fn);
 					m_doc_props->setString(DOC_PROP_CODE_BASE, LVExtractPath(fn) );
-					m_doc_props->setString(DOC_PROP_FILE_SIZE, lString16::itoa((int)m_stream->GetSize()));
+					m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa((int)m_stream->GetSize()));
                     m_doc_props->setHex(DOC_PROP_FILE_CRC32, m_stream->getcrc32());
 					found = true;
 				}
@@ -4360,7 +4360,7 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 			{
 				Clear();
 				if ( m_callback ) {
-                    m_callback->OnLoadFileError( cs16("File with supported extension not found in archive.") );
+                    m_callback->OnLoadFileError( cs32("File with supported extension not found in archive.") );
 				}
 				return false;
 			}
@@ -4427,39 +4427,39 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 	}
 }
 
-const lChar16 * getDocFormatName(doc_format_t fmt) {
+const lChar32 * getDocFormatName(doc_format_t fmt) {
 	switch (fmt) {
 	case doc_format_fb2:
-		return L"FictionBook (FB2)";
+		return U"FictionBook (FB2)";
 	case doc_format_fb3:
-		return L"FictionBook (FB3)";
+		return U"FictionBook (FB3)";
 	case doc_format_txt:
-		return L"Plain text (TXT)";
+		return U"Plain text (TXT)";
 	case doc_format_rtf:
-		return L"Rich text (RTF)";
+		return U"Rich text (RTF)";
 	case doc_format_epub:
-		return L"EPUB";
+		return U"EPUB";
 	case doc_format_chm:
-		return L"CHM";
+		return U"CHM";
 	case doc_format_html:
-		return L"HTML";
+		return U"HTML";
 	case doc_format_txt_bookmark:
-		return L"CR3 TXT Bookmark";
+		return U"CR3 TXT Bookmark";
 	case doc_format_doc:
-		return L"DOC";
+		return U"DOC";
 	case doc_format_docx:
-		return L"DOCX";
+		return U"DOCX";
     case doc_format_odt:
-        return L"OpenDocument (ODT)";
+        return U"OpenDocument (ODT)";
 	default:
-		return L"Unknown format";
+		return U"Unknown format";
 	}
 }
 
 /// sets current document format
 void LVDocView::setDocFormat(doc_format_t fmt) {
 	m_doc_format = fmt;
-	lString16 desc(getDocFormatName(fmt));
+	lString32 desc(getDocFormatName(fmt));
 	m_doc_props->setString(DOC_PROP_FILE_FORMAT, desc);
 	m_doc_props->setInt(DOC_PROP_FILE_FORMAT_ID, (int) fmt);
 }
@@ -4555,8 +4555,8 @@ bool LVDocView::ParseDocument() {
 	if (m_stream->GetSize() > DOCUMENT_CACHING_MIN_SIZE) {
 		// try loading from cache
 
-		//lString16 fn( m_stream->GetName() );
-		lString16 fn =
+		//lString32 fn( m_stream->GetName() );
+		lString32 fn =
 				m_doc_props->getStringDef(DOC_PROP_FILE_NAME, "untitled");
 		fn = LVExtractFilename(fn);
 		lUInt32 crc = 0;
@@ -4574,7 +4574,7 @@ bool LVDocView::ParseDocument() {
 			CRLog::info("Document is found in cache, will reuse");
 
 
-			//            lString16 docstyle = m_doc->createXPointer(L"/FictionBook/stylesheet").getText();
+			//            lString32 docstyle = m_doc->createXPointer(U"/FictionBook/stylesheet").getText();
 			//            if ( !docstyle.empty() && m_doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
 			//                //m_doc->getStyleSheet()->parse(UnicodeToUtf8(docstyle).c_str());
 			//                m_doc->setStyleSheet( UnicodeToUtf8(docstyle).c_str(), false );
@@ -4674,11 +4674,11 @@ bool LVDocView::ParseDocument() {
         // unknown format (never reached)
         if (!parser) {
             setDocFormat( doc_format_none);
-            createDefaultDocument(cs16("ERROR: Unknown document format"),
-                    cs16("Cannot open document"));
+            createDefaultDocument(cs32("ERROR: Unknown document format"),
+                    cs32("Cannot open document"));
             if (m_callback) {
                 m_callback->OnLoadFileError(
-                        cs16("Unknown document format"));
+                        cs32("Unknown document format"));
             }
             return false;
         }
@@ -4699,10 +4699,10 @@ bool LVDocView::ParseDocument() {
 		if (!parser->Parse()) {
 			delete parser;
 			if (m_callback) {
-                m_callback->OnLoadFileError(cs16("Bad document format"));
+                m_callback->OnLoadFileError(cs32("Bad document format"));
 			}
-            createDefaultDocument(cs16("ERROR: Bad document format"),
-                    cs16("Cannot open document"));
+            createDefaultDocument(cs32("ERROR: Bad document format"),
+                    cs32("Cannot open document"));
 			return false;
 		}
 		delete parser;
@@ -4719,14 +4719,14 @@ bool LVDocView::ParseDocument() {
 			if (rootNode)
 				el = rootNode->findChildElement(path);
 			if (el != NULL) {
-                lString16 s = el->getText(L' ', 1024);
+                lString32 s = el->getText(U' ', 1024);
 				if (!s.empty()) {
 					m_doc_props->setString(DOC_PROP_TITLE, s);
 				}
 			}
 		}
 
-		//        lString16 docstyle = m_doc->createXPointer(L"/FictionBook/stylesheet").getText();
+		//        lString32 docstyle = m_doc->createXPointer(U"/FictionBook/stylesheet").getText();
 		//        if ( !docstyle.empty() && m_doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
 		//            //m_doc->getStyleSheet()->parse(UnicodeToUtf8(docstyle).c_str());
 		//            m_doc->setStyleSheet( UnicodeToUtf8(docstyle).c_str(), false );
@@ -4752,9 +4752,9 @@ bool LVDocView::ParseDocument() {
 			m_doc_props->setString(DOC_PROP_KEYWORDS, extractDocKeywords(m_doc));
 			m_doc_props->setString(DOC_PROP_DESCRIPTION, extractDocDescription(m_doc));
             int seriesNumber = -1;
-            lString16 seriesName = extractDocSeries(m_doc, &seriesNumber);
+            lString32 seriesName = extractDocSeries(m_doc, &seriesNumber);
             m_doc_props->setString(DOC_PROP_SERIES_NAME, seriesName);
-            m_doc_props->setString(DOC_PROP_SERIES_NUMBER, seriesNumber>0 ? lString16::itoa(seriesNumber) :lString16::empty_str);
+            m_doc_props->setString(DOC_PROP_SERIES_NUMBER, seriesNumber>0 ? lString32::itoa(seriesNumber) :lString32::empty_str);
         }
 	}
 	//m_doc->persist();
@@ -4779,7 +4779,7 @@ bool LVDocView::ParseDocument() {
 	}
 #endif
 #if 0// test swap to disk
-    lString16 cacheFile = cs16("/tmp/cr3swap.bin");
+    lString32 cacheFile = cs32("/tmp/cr3swap.bin");
 	bool res = m_doc->swapToCacheFile( cacheFile );
 	if ( !res ) {
 		CRLog::error( "Failed to swap to disk" );
@@ -4801,7 +4801,7 @@ bool LVDocView::ParseDocument() {
 #endif
 #if 0
 	{
-		LVStreamRef ostream = LVOpenFileStream(L"out.xml", LVOM_WRITE );
+		LVStreamRef ostream = LVOpenFileStream(U"out.xml", LVOM_WRITE );
 		if ( !ostream.isNull() )
 		m_doc->saveToStream( ostream, "utf-8" );
 	}
@@ -4984,17 +4984,17 @@ ldomXPointer LVDocView::getPageBookmark(int page) {
 }
 
 /// get bookmark position text
-bool LVDocView::getBookmarkPosText(ldomXPointer bm, lString16 & titleText,
-		lString16 & posText) {
+bool LVDocView::getBookmarkPosText(ldomXPointer bm, lString32 & titleText,
+		lString32 & posText) {
 	LVLock lock(getMutex());
 	checkRender();
-    titleText = posText = lString16::empty_str;
+    titleText = posText = lString32::empty_str;
 	if (bm.isNull())
 		return false;
 	ldomNode * el = bm.getNode();
 	CRLog::trace("getBookmarkPosText() : getting position text");
 	if (el->isText()) {
-        lString16 txt = bm.getNode()->getText();
+        lString32 txt = bm.getNode()->getText();
 		int startPos = bm.getOffset();
 		int len = txt.length() - startPos;
 		if (len > 0)
@@ -5004,7 +5004,7 @@ bool LVDocView::getBookmarkPosText(ldomXPointer bm, lString16 & titleText,
         posText += txt;
 		el = el->getParentNode();
 	} else {
-        posText = el->getText(L' ', 1024);
+        posText = el->getText(U' ', 1024);
 	}
     bool inTitle = false;
 	do {
@@ -5025,8 +5025,8 @@ bool LVDocView::getBookmarkPosText(ldomXPointer bm, lString16 & titleText,
 			}
 			if (el->getNodeId() == el_body && !titleText.empty())
 				break;
-			lString16 txt = getSectionHeader(el);
-			lChar16 lastch = !txt.empty() ? txt[txt.length() - 1] : 0;
+			lString32 txt = getSectionHeader(el);
+			lChar32 lastch = !txt.empty() ? txt[txt.length() - 1] : 0;
 			if (!titleText.empty()) {
 				if (lastch != '.' && lastch != '?' && lastch != '!')
                     txt += ".";
@@ -5086,7 +5086,7 @@ void LVDocView::updateScroll() {
 		m_scrollinfo.scale = shift;
 		char str[32];
 		sprintf(str, "%d%%", (int) (fh > 0 ? (100 * npos / fh) : 0));
-		m_scrollinfo.posText = lString16(str);
+		m_scrollinfo.posText = lString32(str);
 	} else {
 		int page = getCurPage();
 		int vpc = getVisiblePageCount();
@@ -5101,7 +5101,7 @@ void LVDocView::updateScroll() {
 			} else
 				sprintf(str, "%d / %d", page, m_pages.length() - 1);
 		}
-		m_scrollinfo.posText = lString16(str);
+		m_scrollinfo.posText = lString32(str);
 	}
 }
 
@@ -5306,7 +5306,7 @@ bool LVDocView::moveByChapter(int delta) {
 
 /// saves new bookmark
 CRBookmark * LVDocView::saveRangeBookmark(ldomXRange & range, bmk_type type,
-		lString16 comment) {
+		lString32 comment) {
 	if (range.isNull())
 		return NULL;
 	if (range.getStart().isNull())
@@ -5327,7 +5327,7 @@ CRBookmark * LVDocView::saveRangeBookmark(ldomXRange & range, bmk_type type,
 	if (percent > 10000)
 		percent = 10000;
 	bmk->setPercent(percent);
-	lString16 postext = range.getRangeText();
+	lString32 postext = range.getRangeText();
 	bmk->setPosText(postext);
 	bmk->setCommentText(comment);
 	bmk->setTitleText(CRBookmark::getChapterName(range.getStart()));
@@ -5393,11 +5393,11 @@ bool LVDocView::removeBookmark(CRBookmark * bm) {
 
 #define MAX_EXPORT_BOOKMARKS_SIZE 200000
 /// export bookmarks to text file
-bool LVDocView::exportBookmarks(lString16 filename) {
+bool LVDocView::exportBookmarks(lString32 filename) {
 	if (m_filename.empty())
 		return true; // no document opened
-	lChar16 lastChar = filename.lastChar();
-	lString16 dir;
+	lChar32 lastChar = filename.lastChar();
+	lString32 dir;
 	CRLog::trace("exportBookmarks(%s)", UnicodeToUtf8(filename).c_str());
 	if (lastChar == '/' || lastChar == '\\') {
 		dir = filename;
@@ -5408,13 +5408,13 @@ bool LVDocView::exportBookmarks(lString16 filename) {
 	}
 	if (filename.empty()) {
 		CRPropRef props = getDocProps();
-		lString16 arcname = props->getStringDef(DOC_PROP_ARC_NAME);
-		lString16 arcpath = props->getStringDef(DOC_PROP_ARC_PATH);
+		lString32 arcname = props->getStringDef(DOC_PROP_ARC_NAME);
+		lString32 arcpath = props->getStringDef(DOC_PROP_ARC_PATH);
 		int arcFileCount = props->getIntDef(DOC_PROP_ARC_FILE_COUNT, 0);
 		if (!arcpath.empty())
 			LVAppendPathDelimiter(arcpath);
-		lString16 fname = props->getStringDef(DOC_PROP_FILE_NAME);
-		lString16 fpath = props->getStringDef(DOC_PROP_FILE_PATH);
+		lString32 fname = props->getStringDef(DOC_PROP_FILE_NAME);
+		lString32 fpath = props->getStringDef(DOC_PROP_FILE_PATH);
 		if (!fpath.empty())
 			LVAppendPathDelimiter(fpath);
 		if (!arcname.empty()) {
@@ -5479,7 +5479,7 @@ bool LVDocView::exportBookmarks(lString16 filename) {
 		}
 		char pos[16];
 		int percent = bmk->getPercent();
-		lString16 title = bmk->getTitleText();
+		lString32 title = bmk->getTitleText();
 		sprintf(pos, "%d.%02d%%", percent / 100, percent % 100);
 		newContent << "## " << pos << " - "
 				<< (bmk->getType() == bmkt_comment ? "comment" : "correction")
@@ -5528,8 +5528,8 @@ CRBookmark * LVDocView::saveCurrentPageShortcutBookmark(int number) {
 		return NULL;
 	}
 	CRBookmark * bm = rec->setShortcutBookmark(number, p);
-	lString16 titleText;
-	lString16 posText;
+	lString32 titleText;
+	lString32 posText;
 	if (bm && getBookmarkPosText(p, titleText, posText)) {
 		bm->setTitleText(titleText);
 		bm->setPosText(posText);
@@ -5539,7 +5539,7 @@ CRBookmark * LVDocView::saveCurrentPageShortcutBookmark(int number) {
 }
 
 /// saves current page bookmark under numbered shortcut
-CRBookmark * LVDocView::saveCurrentPageBookmark(lString16 comment) {
+CRBookmark * LVDocView::saveCurrentPageBookmark(lString32 comment) {
 	CRFileHistRecord * rec = getCurrentFileHistRecord();
 	if (!rec)
 		return NULL;
@@ -5547,8 +5547,8 @@ CRBookmark * LVDocView::saveCurrentPageBookmark(lString16 comment) {
 	if (p.isNull())
 		return NULL;
 	CRBookmark * bm = new CRBookmark(p);
-	lString16 titleText;
-	lString16 posText;
+	lString32 titleText;
+	lString32 posText;
 	bm->setType(bmkt_pos);
 	if (getBookmarkPosText(p, titleText, posText)) {
 		bm->setTitleText(titleText);
@@ -5577,7 +5577,7 @@ bool LVDocView::goToPageShortcutBookmark(int number) {
 	CRBookmark * bmk = rec->getShortcutBookmark(number);
 	if (!bmk)
 		return false;
-	lString16 pos = bmk->getStartPos();
+	lString32 pos = bmk->getStartPos();
 	ldomXPointer p = m_doc->createXPointer(pos);
 	if (p.isNull())
 		return false;
@@ -5860,7 +5860,7 @@ int LVDocView::doCommand(LVDocCmd cmd, int param) {
                         ldomXPointerEx ptr2(ptr);
                         ptr2.thisSentenceEnd();
                         ldomXRange range(ptr, ptr2);
-                        lString16 str = range.getRangeText();
+                        lString32 str = range.getRangeText();
                         *out << ">sentence: " << UnicodeToUtf8(str) << "\n";
                         if ( !ptr.nextSentenceStart() )
                             break;
@@ -6074,7 +6074,7 @@ static const char * def_style_macros[] = {
 
 /// sets default property values if properties not found, checks ranges
 void LVDocView::propsUpdateDefaults(CRPropRef props) {
-	lString16Collection list;
+	lString32Collection list;
 	fontMan->getFaceList(list);
 	static int def_aa_props[] = { 2, 1, 0 };
 
@@ -6098,7 +6098,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	static const char * goodFonts[] = { "DejaVu Sans", "FreeSans",
 			"Liberation Sans", "Arial", "Verdana", NULL };
 	for (int i = 0; goodFonts[i]; i++) {
-		if (list.contains(lString16(goodFonts[i]))) {
+		if (list.contains(lString32(goodFonts[i]))) {
 			defFontFace = lString8(goodFonts[i]);
 			break;
 		}
@@ -6168,14 +6168,14 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
     else if (fs > MAX_STATUS_FONT_SIZE)
         fs = MAX_STATUS_FONT_SIZE;
 	props->setIntDef(PROP_STATUS_FONT_SIZE, fs);
-	lString16 hyph = props->getStringDef(PROP_HYPHENATION_DICT,
+	lString32 hyph = props->getStringDef(PROP_HYPHENATION_DICT,
 			DEF_HYPHENATION_DICT);
 	HyphDictionaryList * dictlist = HyphMan::getDictList();
 	if (dictlist) {
 		if (dictlist->find(hyph))
 			props->setStringDef(PROP_HYPHENATION_DICT, hyph);
 		else
-			props->setStringDef(PROP_HYPHENATION_DICT, lString16(
+			props->setStringDef(PROP_HYPHENATION_DICT, lString32(
 					HYPH_DICT_ID_ALGORITHM));
 	}
 	props->setIntDef(PROP_STATUS_LINE, 0);
@@ -6280,7 +6280,7 @@ void LVDocView::setStatusMode(int newMode, bool showClock, bool showTitle,
 #endif
 }
 
-bool LVDocView::propApply(lString8 name, lString16 value) {
+bool LVDocView::propApply(lString8 name, lString32 value) {
     CRPropRef props = LVCreatePropsContainer();
     props->setString(name.c_str(), value);
     CRPropRef unknown = propsApply( props );
@@ -6293,7 +6293,7 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
     CRPropRef unknown = LVCreatePropsContainer();
     for (int i = 0; i < props->getCount(); i++) {
         lString8 name(props->getName(i));
-        lString16 value = props->getValue(i);
+        lString32 value = props->getValue(i);
         if (name == PROP_FONT_ANTIALIASING) {
             int antialiasingMode = props->getIntDef(PROP_FONT_ANTIALIASING, 2);
             fontMan->SetAntialiasMode(antialiasingMode);
@@ -6302,7 +6302,7 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             REQUEST_RENDER("propsApply - styles.*")
         } else if (name == PROP_FONT_GAMMA) {
             double gamma = 1.0;
-            lString16 s = props->getStringDef(PROP_FONT_GAMMA, "1.0");
+            lString32 s = props->getStringDef(PROP_FONT_GAMMA, "1.0");
             lString8 s8 = UnicodeToUtf8(s);
             if ( sscanf(s8.c_str(), "%lf", &gamma)==1 ) {
                 fontMan->SetGamma(gamma);
@@ -6428,11 +6428,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                           m_props->getBoolDef(PROP_SHOW_PAGE_COUNT, true)
                           );
             //} else if ( name==PROP_BOOKMARK_ICONS ) {
-            //    enableBookmarkIcons( value==L"1" );
+            //    enableBookmarkIcons( value==U"1" );
         } else if (name == PROP_FONT_SIZE) {
             int fontSize = props->getIntDef(PROP_FONT_SIZE, m_font_sizes[0]);
             setFontSize(fontSize);//cr_font_sizes
-            value = lString16::itoa(m_requested_font_size);
+            value = lString32::itoa(m_requested_font_size);
         } else if (name == PROP_STATUS_FONT_SIZE) {
             int fontSize = props->getIntDef(PROP_STATUS_FONT_SIZE,
                                             INFO_FONT_SIZE);
@@ -6441,10 +6441,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             else if (fontSize > MAX_STATUS_FONT_SIZE)
                 fontSize = MAX_STATUS_FONT_SIZE;
             setStatusFontSize(fontSize);//cr_font_sizes
-            value = lString16::itoa(fontSize);
+            value = lString32::itoa(fontSize);
         } else if (name == PROP_HYPHENATION_DICT) {
             // hyphenation dictionary
-            lString16 id = props->getStringDef(PROP_HYPHENATION_DICT,
+            lString32 id = props->getStringDef(PROP_HYPHENATION_DICT,
                                                DEF_HYPHENATION_DICT);
             CRLog::debug("PROP_HYPHENATION_DICT = %s", LCSTR(id));
             HyphDictionaryList * list = HyphMan::getDictList();
@@ -6477,7 +6477,7 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 REQUEST_RENDER("propsApply hyphenation trust_soft_hyphens")
             }
         } else if (name == PROP_TEXTLANG_MAIN_LANG) {
-            lString16 lang = props->getStringDef(PROP_TEXTLANG_MAIN_LANG, TEXTLANG_DEFAULT_MAIN_LANG);
+            lString32 lang = props->getStringDef(PROP_TEXTLANG_MAIN_LANG, TEXTLANG_DEFAULT_MAIN_LANG);
             if ( lang != TextLangMan::getMainLang() ) {
                 TextLangMan::setMainLang( lang );
                 REQUEST_RENDER("propsApply textlang main_lang")
@@ -6510,12 +6510,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             int interlineSpace = props->getIntDef(PROP_INTERLINE_SPACE,
                                                   cr_interline_spaces[0]);
             setDefaultInterlineSpace(interlineSpace);//cr_font_sizes
-            value = lString16::itoa(m_def_interline_space);
+            value = lString32::itoa(m_def_interline_space);
 #if CR_INTERNAL_PAGE_ORIENTATION==1
         } else if ( name==PROP_ROTATE_ANGLE ) {
             cr_rotate_angle_t angle = (cr_rotate_angle_t) (props->getIntDef( PROP_ROTATE_ANGLE, 0 )&3);
             SetRotateAngle( angle );
-            value = lString16::itoa( m_rotateAngle );
+            value = lString32::itoa( m_rotateAngle );
 #endif
         } else if (name == PROP_EMBEDDED_STYLES) {
             bool value = props->getBoolDef(PROP_EMBEDDED_STYLES, true);
@@ -6666,7 +6666,7 @@ void LVPageWordSelector::selectWord(int x, int y)
 }
 
 // append chars to search pattern
-ldomWordEx * LVPageWordSelector::appendPattern( lString16 chars )
+ldomWordEx * LVPageWordSelector::appendPattern( lString32 chars )
 {
     ldomWordEx * res = _words.appendPattern(chars);
     if ( res )
@@ -6683,7 +6683,7 @@ ldomWordEx * LVPageWordSelector::reducePattern()
     return res;
 }
 
-SimpleTitleFormatter::SimpleTitleFormatter(lString16 text, lString8 fontFace, bool bold, bool italic, lUInt32 color, int maxWidth, int maxHeight, int fntSize) : _text(text), _fontFace(fontFace), _bold(bold), _italic(italic), _color(color), _maxWidth(maxWidth), _maxHeight(maxHeight), _fntSize(fntSize) {
+SimpleTitleFormatter::SimpleTitleFormatter(lString32 text, lString8 fontFace, bool bold, bool italic, lUInt32 color, int maxWidth, int maxHeight, int fntSize) : _text(text), _fontFace(fontFace), _bold(bold), _italic(italic), _color(color), _maxWidth(maxWidth), _maxHeight(maxHeight), _fntSize(fntSize) {
     if (_text.length() > 80)
         _text = _text.substr(0, 80) + "...";
     if (findBestSize())
@@ -6705,7 +6705,7 @@ bool SimpleTitleFormatter::measure() {
     _width = 0;
     _height = 0;
     for (int i=_lines.length() - 1; i >= 0; i--) {
-        lString16 line = _lines[i].trim();
+        lString32 line = _lines[i].trim();
         int w = _font->getTextWidth(line.c_str(), line.length());
         if (w > _width)
             _width = w;
@@ -6714,13 +6714,13 @@ bool SimpleTitleFormatter::measure() {
     return _width < _maxWidth && _height < _maxHeight;
 }
 bool SimpleTitleFormatter::splitLines(const char * delimiter) {
-    lString16 delim16(delimiter);
+    lString32 delim32(delimiter);
     int bestpos = -1;
     int bestdist = -1;
     int start = 0;
     bool skipDelimiter = *delimiter == '|';
     for (;;) {
-        int p = _text.pos(delim16, start);
+        int p = _text.pos(delim32, start);
         if (p < 0)
             break;
         int dist = _text.length() / 2 - p;
@@ -6734,8 +6734,8 @@ bool SimpleTitleFormatter::splitLines(const char * delimiter) {
     }
     if (bestpos < 0)
         return false;
-    _lines.add(_text.substr(0, bestpos + (skipDelimiter ? 0 : delim16.length())).trim());
-    _lines.add(_text.substr(bestpos + delim16.length()).trim());
+    _lines.add(_text.substr(0, bestpos + (skipDelimiter ? 0 : delim32.length())).trim());
+    _lines.add(_text.substr(bestpos + delim32.length()).trim());
     return measure();
 }
 bool SimpleTitleFormatter::format(int fontSize) {
@@ -6795,7 +6795,7 @@ bool SimpleTitleFormatter::findBestSize() {
     }
     return false;
 }
-void SimpleTitleFormatter::draw(LVDrawBuf & buf, lString16 str, int x, int y, int align) {
+void SimpleTitleFormatter::draw(LVDrawBuf & buf, lString32 str, int x, int y, int align) {
     int w = _font->getTextWidth(str.c_str(), str.length());
     if (align == 0)
         x -= w / 2; // center
@@ -6855,7 +6855,7 @@ static cover_palette_t series_palette[8] = {
     {0x00C0D0C0, 0x20E8E8D8, 0xC0FFC040, 0xD0F0E0E0, 0x00400040, 0x00000080, 0x00402040, 0x80FFFFFF},
 };
 
-void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString16 title, lString16 authors, lString16 seriesName, int seriesNumber) {
+void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber) {
     CR_UNUSED(seriesNumber);
     bool isGray = buf.GetBitsPerPixel() <= 8;
     cover_palette_t * palette = NULL;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -113,6 +113,15 @@ static css_font_family_t DEFAULT_FONT_FAMILY = css_ff_sans_serif;
 #define MAX_STATUS_FONT_SIZE 255
 #endif
 
+// Fallback defines, see crsetup.h
+#ifndef SCREEN_SIZE_MIN
+#define SCREEN_SIZE_MIN 80
+#endif
+
+#ifndef SCREEN_SIZE_MAX
+#define SCREEN_SIZE_MAX 32767
+#endif
+
 #if defined(__SYMBIAN32__)
 #include <e32std.h>
 #define DEFAULT_PAGE_MARGIN 2
@@ -3612,10 +3621,14 @@ void LVDocView::SetRotateAngle( cr_rotate_angle_t angle )
 void LVDocView::Resize(int dx, int dy) {
 	//LVCHECKPOINT("Resize");
 	CRLog::trace("LVDocView:Resize(%dx%d)", dx, dy);
-	if (dx < 80 || dx > 32767)
-		dx = 80;
-	if (dy < 80 || dy > 32767)
-		dy = 80;
+	if (dx < SCREEN_SIZE_MIN)
+		dx = SCREEN_SIZE_MIN;
+	else if (dx > SCREEN_SIZE_MAX)
+		dx = SCREEN_SIZE_MAX;
+	if (dy < SCREEN_SIZE_MIN)
+		dy = SCREEN_SIZE_MIN;
+	else if (dy > SCREEN_SIZE_MAX)
+		dy = SCREEN_SIZE_MAX;
 #if CR_INTERNAL_PAGE_ORIENTATION==1
 	if ( m_rotateAngle==CR_ROTATE_ANGLE_90 || m_rotateAngle==CR_ROTATE_ANGLE_270 ) {
 		CRLog::trace("Screen is rotated, swapping dimensions");

--- a/crengine/src/lvfnt.cpp
+++ b/crengine/src/lvfnt.cpp
@@ -20,7 +20,7 @@
 #define MAX_FONT_SIZE 0x100000
 
 #ifndef __cplusplus
-int lvfontIsUnicodeSpace( lChar16 code )
+int lvfontIsUnicodeSpace( lChar32 code )
 {
     /* TODO: add other space codes here */
     return (code==0x0020);
@@ -127,11 +127,11 @@ void lvfontClose( lvfont_handle pfont )
 }
 
 lUInt16 lvfontMeasureText( const lvfont_handle pfont, 
-                    const lChar16 * text, int len, 
+                    const lChar32 * text, int len, 
                     lUInt16 * widths,
                     lUInt8 * flags,
                     int max_width,
-                    lChar16 def_char
+                    lChar32 def_char
                  )
 {
     lUInt16 wsum = 0;
@@ -141,7 +141,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
     lUInt16 hyphwidth = 0;
     lUInt8 bflags;
     int isSpace;
-    lChar16 ch;
+    lChar32 ch;
     int hwStart, hwEnd;
 
     glyph = lvfontGetGlyph( pfont, UNICODE_SOFT_HYPHEN_CODE );
@@ -180,7 +180,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
     }
     for (hwEnd=nchars; hwEnd<len; hwEnd++)
     {
-        lChar16 ch = text[hwEnd];
+        lChar32 ch = text[hwEnd];
         if (lvfontIsUnicodeSpace(ch))
             break;
         if (flags[hwEnd-1]&LCHAR_ALLOW_WRAP_AFTER)

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2523,13 +2523,14 @@ public:
                 return NULL;  /* ignore errors */
             }
 
-            if (_embolden) { // Embolden and render
-                // See setEmbolden() for details
-                FT_GlyphSlot_Embolden(_slot);
-                FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
+            if (_embolden) {
+                FT_GlyphSlot_Embolden(_slot); // See setEmbolden() for details
             }
-            if (_italic == 2) { // Obliquen and render
+            if (_italic == 2) {
                 FT_GlyphSlot_Oblique(_slot);
+            }
+            if (_embolden || _italic==2) {
+                // Render now that transformations are applied
                 FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
             }
 
@@ -2578,16 +2579,18 @@ public:
                 return NULL;  /* ignore errors */
             }
 
-            if (_embolden) { // Embolden and render
-                // See setEmbolden() for details
+            if (_embolden) {
                 if ( _slot->format == FT_GLYPH_FORMAT_OUTLINE ) {
+                    // See setEmbolden() for details
                     FT_Outline_Embolden(&_slot->outline, 2*_embolden_half_strength);
                     FT_Outline_Translate(&_slot->outline, -_embolden_half_strength, -_embolden_half_strength);
                 }
-                FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
             }
-            if (_italic==2) { // Obliquen and render
+            if (_italic==2) {
                 FT_GlyphSlot_Oblique(_slot);
+            }
+            if (_embolden || _italic==2) {
+                // Render now that transformations are applied
                 FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
             }
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -102,13 +102,13 @@ lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_f
     lString8Collection list;
     splitPropertyValueList(commaSeparatedFaceList.c_str(), list);
     // faces we have
-    lString16Collection faces;
+    lString32Collection faces;
     getFaceList(faces);
     // find first matched
     for (int i = 0; i < list.length(); i++) {
         lString8 wantFace = list[i];
         for (int j = 0; j < faces.length(); j++) {
-            lString16 haveFace = faces[j];
+            lString32 haveFace = faces[j];
             if (wantFace == haveFace)
                 return wantFace;
         }
@@ -200,7 +200,7 @@ bool LVEmbeddedFontDef::deserialize(SerialBuf & buf) {
 ////////////////////////////////////////////////////////////////////
 // LVEmbeddedFontList
 ////////////////////////////////////////////////////////////////////
-LVEmbeddedFontDef * LVEmbeddedFontList::findByUrl(lString16 url) {
+LVEmbeddedFontDef * LVEmbeddedFontList::findByUrl(lString32 url) {
     for (int i=0; i<length(); i++) {
         if (get(i)->getUrl() == url)
             return get(i);
@@ -217,7 +217,7 @@ bool LVEmbeddedFontList::addAll(LVEmbeddedFontList & list) {
     return changed;
 }
 
-bool LVEmbeddedFontList::add(lString16 url, lString8 face, bool bold, bool italic) {
+bool LVEmbeddedFontList::add(lString32 url, lString8 face, bool bold, bool italic) {
     LVEmbeddedFontDef * def = findByUrl(url);
     if (def) {
         bool changed = false;
@@ -279,8 +279,8 @@ bool LVEmbeddedFontList::deserialize(SerialBuf & buf) {
 int LVFont::getVisualAligmentWidth() {
     FONT_GUARD
     if ( _visual_alignment_width==-1 ) {
-        lChar16 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';',
-                    (lChar16)L'，', (lChar16)L'。', (lChar16)L'！', 0 };
+        lChar32 chars[] = { getHyphChar(), ',', '.', '!', '?', ':', ';',
+                    (lChar32)U'，', (lChar32)U'。', (lChar32)U'！', 0 };
         int maxw = 0;
         for ( int i=0; chars[i]; i++ ) {
             int w = getCharWidth( chars[i] );
@@ -292,7 +292,7 @@ int LVFont::getVisualAligmentWidth() {
     return _visual_alignment_width;
 }
 
-static lChar16 getReplacementChar( lUInt32 code ) {
+static lChar32 getReplacementChar( lUInt32 code ) {
     switch (code) {
     case UNICODE_SOFT_HYPHEN_CODE:
         return '-';
@@ -537,36 +537,36 @@ public:
         }
         return 0;
     }
-    virtual void getFaceList( lString16Collection & list )
+    virtual void getFaceList( lString32Collection & list )
     {
         list.clear();
         for ( int i=0; i<_registered_list.length(); i++ ) {
             if (_registered_list[i]->getDef()->getDocumentId() != -1)
                 continue;
-            lString16 name = Utf8ToUnicode( _registered_list[i]->getDef()->getTypeFace() );
+            lString32 name = Utf8ToUnicode( _registered_list[i]->getDef()->getTypeFace() );
             if ( !list.contains(name) )
                 list.add( name );
         }
         list.sort();
     }
-    virtual void getFontFileNameList(lString16Collection &list)
+    virtual void getFontFileNameList(lString32Collection &list)
     {
         list.clear();
         for ( int i=0; i<_registered_list.length(); i++ ) {
             if (_registered_list[i]->getDef()->getDocumentId() == -1) {
-                lString16 name = Utf8ToUnicode(_registered_list[i]->getDef()->getName());
+                lString32 name = Utf8ToUnicode(_registered_list[i]->getDef()->getName());
                 if (!list.contains(name))
                     list.add(name);
             }
         }
         list.sort();
     }
-    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index )
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index )
     {
         for ( int i=0; i<_registered_list.length(); i++ ) {
             if (_registered_list[i]->getDef()->getDocumentId() == -1) {
                 LVFontDef * fdef = _registered_list[i]->getDef();
-                lString16 facename = Utf8ToUnicode( fdef->getTypeFace() );
+                lString32 facename = Utf8ToUnicode( fdef->getTypeFace() );
                 if (facename != name )
                     continue;
                 if ( (bold && fdef->getWeight() < 650) || (!bold && fdef->getWeight() >= 650) )
@@ -614,7 +614,7 @@ private:
     static const int COUNT = 360;
     lUInt16 * ptrs[COUNT]; //support up to 0X2CFFF=360*512-1
 public:
-    lUInt16 get( lChar16 ch )
+    lUInt16 get( lChar32 ch )
     {
         FONT_GLYPH_CACHE_GUARD
         int inx = (ch>>9) & 0x1ff;
@@ -624,7 +624,7 @@ public:
             return CACHED_UNSIGNED_METRIC_NOT_SET;
         return ptr[ch & 0x1FF ];
     }
-    void put( lChar16 ch, lUInt16 m )
+    void put( lChar32 ch, lUInt16 m )
     {
         FONT_GLYPH_CACHE_GUARD
         int inx = (ch>>9) & 0x1ff;
@@ -661,11 +661,11 @@ public:
 class LVFontGlyphSignedMetricCache : public LVFontGlyphUnsignedMetricCache
 {
 public:
-    lInt16 get( lChar16 ch )
+    lInt16 get( lChar32 ch )
     {
         return (lInt16) ( LVFontGlyphUnsignedMetricCache::get(ch) - CACHED_SIGNED_METRIC_SHIFT );
     }
-    void put( lChar16 ch, lInt16 m )
+    void put( lChar32 ch, lInt16 m )
     {
         LVFontGlyphUnsignedMetricCache::put(ch, (lUInt16)( m + CACHED_SIGNED_METRIC_SHIFT) );
     }
@@ -673,7 +673,7 @@ public:
 
 class LVFreeTypeFace;
 
-static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar16 ch, FT_GlyphSlot slot ) // , bool drawMonochrome
+static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar32 ch, FT_GlyphSlot slot ) // , bool drawMonochrome
 {
     FONT_LOCAL_GLYPH_CACHE_GUARD
     FT_Bitmap*  bitmap = &slot->bitmap;
@@ -812,7 +812,7 @@ void LVFontLocalGlyphCache::clear()
 #endif
 }
 
-LVFontGlyphCacheItem * LVFontLocalGlyphCache::getByChar(lChar16 ch)
+LVFontGlyphCacheItem * LVFontLocalGlyphCache::getByChar(lChar32 ch)
 {
     FONT_LOCAL_GLYPH_CACHE_GUARD
 #if USE_GLYPHCACHE_HASHTABLE == 1
@@ -1012,9 +1012,9 @@ static lUInt16 char_flags[] = {
 // For use with Harfbuzz light
 struct LVCharTriplet
 {
-    lChar16 prevChar;
-    lChar16 Char;
-    lChar16 nextChar;
+    lChar32 prevChar;
+    lChar32 Char;
+    lChar32 nextChar;
     bool operator == (const struct LVCharTriplet& other) {
         return prevChar == other.prevChar && Char == other.Char && nextChar == other.nextChar;
     }
@@ -1630,7 +1630,7 @@ public:
 
 #if USE_HARFBUZZ==1
     // Used by Harfbuzz full
-    lChar16 filterChar(lChar16 code, lChar16 def_char=0) {
+    lChar32 filterChar(lChar32 code, lChar32 def_char=0) {
         if (code == '\t')    // (FreeSerif doesn't have \t, get a space
             code = ' ';      // rather than a '?')
 
@@ -1652,7 +1652,7 @@ public:
                 }
             }
         }
-        lChar16 res = getReplacementChar(code);
+        lChar32 res = getReplacementChar(code);
         if (res != 0)
             return res;
         if (def_char != 0)
@@ -1661,7 +1661,7 @@ public:
         return code;
     }
 
-    bool hbCalcCharWidth(struct LVCharPosInfo* posInfo, const struct LVCharTriplet& triplet, lChar16 def_char) {
+    bool hbCalcCharWidth(struct LVCharPosInfo* posInfo, const struct LVCharTriplet& triplet, lChar32 def_char) {
         if (!posInfo)
             return false;
         unsigned int segLen = 0;
@@ -1720,7 +1720,7 @@ public:
     }
 #endif // USE_HARFBUZZ==1
 
-    FT_UInt getCharIndex( lChar16 code, lChar16 def_char ) {
+    FT_UInt getCharIndex( lChar32 code, lChar32 def_char ) {
         if ( code=='\t' )
             code = ' ';
         FT_UInt ch_glyph_index = FT_Get_Char_Index( _face, code );
@@ -1748,7 +1748,7 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false ) {
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false ) {
         //FONT_GUARD
         int glyph_index = getCharIndex( code, 0 );
         if ( glyph_index==0 ) {
@@ -1867,7 +1867,7 @@ public:
     }
 #if 0
     // USE GET_CHAR_FLAGS instead
-    inline int calcCharFlags( lChar16 ch )
+    inline int calcCharFlags( lChar32 ch )
     {
         switch ( ch ) {
         case 0x0020:
@@ -1896,12 +1896,12 @@ public:
         \return number of characters before max_width reached
     */
     virtual lUInt16 measureText(
-                        const lChar16 * text,
+                        const lChar32 * text,
                         int len,
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg = NULL,
                         int letter_spacing = 0,
                         bool allow_hyphenation = true,
@@ -2279,7 +2279,7 @@ public:
             struct LVCharPosInfo posInfo;
             triplet.Char = 0;
             for ( i=0; i<len; i++) {
-                lChar16 ch = text[i];
+                lChar32 ch = text[i];
                 bool isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
                 if (isHyphen) {
                     // do just what would be done below if zero width (no change
@@ -2336,7 +2336,7 @@ public:
         int use_kerning = _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
         #endif
         for ( i=0; i<len; i++) {
-            lChar16 ch = text[i];
+            lChar32 ch = text[i];
             bool isHyphen = (ch==UNICODE_SOFT_HYPHEN_CODE);
             if (isHyphen) {
                 // do just what would be done below if zero width (no change
@@ -2448,7 +2448,7 @@ public:
         \param len is number of characters to measure
         \return width of specified string
     */
-    virtual lUInt32 getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL) {
+    virtual lUInt32 getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL) {
         static lUInt16 widths[MAX_LINE_CHARS+1];
         static lUInt8 flags[MAX_LINE_CHARS+1];
         if ( len>MAX_LINE_CHARS )
@@ -2460,7 +2460,7 @@ public:
                         widths,
                         flags,
                         MAX_LINE_WIDTH,
-                        L' ',  // def_char
+                        U' ',  // def_char
                         lang_cfg
                      );
         if ( res>0 && res<MAX_LINE_CHARS )
@@ -2480,7 +2480,7 @@ public:
         \param code is unicode character
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0, bool is_fallback=false) {
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, bool is_fallback=false) {
         //FONT_GUARD
         FT_UInt ch_glyph_index = getCharIndex( ch, 0 );
         if ( ch_glyph_index==0 ) {
@@ -2542,7 +2542,7 @@ public:
                 FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
             }
 
-            item = newItem( &_glyph_cache, (lChar16)ch, _slot ); //, _drawMonochrome
+            item = newItem( &_glyph_cache, (lChar32)ch, _slot ); //, _drawMonochrome
             if (item)
                 _glyph_cache.put( item );
         }
@@ -2613,7 +2613,7 @@ public:
 //        \param buf is buffer [width*height] to place glyph data
 //        \return true if glyph was found
 //    */
-//    virtual bool getGlyphImage(lUInt16 ch, lUInt8 * bmp, lChar16 def_char=0)
+//    virtual bool getGlyphImage(lUInt16 ch, lUInt8 * bmp, lChar32 def_char=0)
 //    {
 //        LVFontGlyphCacheItem * item = getGlyph(ch);
 //        if ( item )
@@ -2640,7 +2640,7 @@ public:
     }
 
     /// returns char glyph advance width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char='?' )
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char='?' )
     {
         int w = _wcache.get(ch);
         if ( w == CACHED_UNSIGNED_METRIC_NOT_SET ) {
@@ -2657,7 +2657,7 @@ public:
     }
 
     /// returns char glyph left side bearing
-    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false )
+    virtual int getLeftSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false )
     {
         if ( italic_only && !getItalic() )
             return 0;
@@ -2678,7 +2678,7 @@ public:
     }
 
     /// returns char glyph right side bearing
-    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false )
+    virtual int getRightSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false )
     {
         if ( italic_only && !getItalic() )
             return 0;
@@ -2731,8 +2731,8 @@ public:
 
     /// draws text string (returns x advance)
     virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette, bool addHyphen,
                        TextLangCfg * lang_cfg,
                        lUInt32 flags, int letter_spacing, int width,
                        int text_decoration_back_gap )
@@ -2754,7 +2754,7 @@ public:
 
         unsigned int i;
         //lUInt16 prev_width = 0;
-        lChar16 ch;
+        lChar32 ch;
         // measure character widths
         bool isHyphen = false;
         int x0 = x;
@@ -2966,7 +2966,7 @@ public:
                     // Adjust fallback y so baselines of both fonts match
                     int fb_y = y + _baseline - fallback->getBaseline();
                     bool fb_addHyphen = false; // will be added by main font
-                    const lChar16 * fb_text = text + fb_t_start;
+                    const lChar32 * fb_text = text + fb_t_start;
                     int fb_len = fb_t_end - fb_t_start;
                     // (width and text_decoration_back_gap are only used for
                     // text decoration, that we dropped: no update needed)
@@ -3265,7 +3265,7 @@ public:
     }
 
     /// hyphenation character
-    virtual lChar16 getHyphChar() { return UNICODE_SOFT_HYPHEN_CODE; }
+    virtual lChar32 getHyphChar() { return UNICODE_SOFT_HYPHEN_CODE; }
 
     /// hyphen width
     virtual int getHyphenWidth() {
@@ -3279,7 +3279,7 @@ public:
         \param glyph is pointer to glyph_info_t struct to place retrieved info
         \return true if glyh was found
     */
-    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar16 def_char=0, bool is_fallback=false  )
+    virtual bool getGlyphInfo( lUInt32 code, glyph_info_t * glyph, lChar32 def_char=0, bool is_fallback=false  )
     {
         bool res = _baseFont->getGlyphInfo( code, glyph, def_char, is_fallback );
         if ( !res )
@@ -3300,11 +3300,11 @@ public:
         \return number of characters before max_width reached
     */
     virtual lUInt16 measureText(
-                        const lChar16 * text, int len,
+                        const lChar32 * text, int len,
                         lUInt16 * widths,
                         lUInt8 * flags,
                         int max_width,
-                        lChar16 def_char,
+                        lChar32 def_char,
                         TextLangCfg * lang_cfg = NULL,
                         int letter_spacing=0,
                         bool allow_hyphenation=true,
@@ -3336,7 +3336,7 @@ public:
         \param len is number of characters to measure
         \return width of specified string
     */
-    virtual lUInt32 getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL) {
+    virtual lUInt32 getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL) {
         static lUInt16 widths[MAX_LINE_CHARS+1];
         static lUInt8 flags[MAX_LINE_CHARS+1];
         if ( len>MAX_LINE_CHARS )
@@ -3348,7 +3348,7 @@ public:
                         widths,
                         flags,
                         MAX_LINE_WIDTH,
-                        L' ',  // def_char
+                        U' ',  // def_char
                         lang_cfg
                      );
         if ( res>0 && res<MAX_LINE_CHARS )
@@ -3360,7 +3360,7 @@ public:
         \param code is unicode character
         \return glyph pointer if glyph was found, NULL otherwise
     */
-    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar16 def_char=0, bool is_fallback=false) {
+    virtual LVFontGlyphCacheItem * getGlyph(lUInt32 ch, lChar32 def_char=0, bool is_fallback=false) {
 
         LVFontGlyphCacheItem * item = _glyph_cache.getByChar( ch );
         if ( item )
@@ -3375,7 +3375,7 @@ public:
         int dx = oldx ? oldx + _hShift : 0;
         int dy = oldy ? oldy + _vShift : 0;
 
-        item = LVFontGlyphCacheItem::newItem( &_glyph_cache, (lChar16)ch, dx, dy ); //, _drawMonochrome
+        item = LVFontGlyphCacheItem::newItem( &_glyph_cache, (lChar32)ch, dx, dy ); //, _drawMonochrome
         if (item) {
             item->advance = olditem->advance + _hShift;
             item->origin_x = olditem->origin_x;
@@ -3411,7 +3411,7 @@ public:
         \param buf is buffer [width*height] to place glyph data
         \return true if glyph was found
     */
-//    virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char=0 )
+//    virtual bool getGlyphImage(lUInt16 code, lUInt8 * buf, lChar32 def_char=0 )
 //    {
 //        LVFontGlyphCacheItem * item = getGlyph( code, def_char );
 //        if ( !item )
@@ -3480,20 +3480,20 @@ public:
     }
 
     /// returns char glyph advance width
-    virtual int getCharWidth( lChar16 ch, lChar16 def_char=0 )
+    virtual int getCharWidth( lChar32 ch, lChar32 def_char=0 )
     {
         int w = _baseFont->getCharWidth( ch, def_char ) + _hShift;
         return w;
     }
 
     /// returns char glyph left side bearing
-    virtual int getLeftSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false )
+    virtual int getLeftSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false )
     {
         return _baseFont->getLeftSideBearing( ch, negative_only, italic_only );
     }
 
     /// returns char glyph right side bearing
-    virtual int getRightSideBearing( lChar16 ch, bool negative_only=false, bool italic_only=false )
+    virtual int getRightSideBearing( lChar32 ch, bool negative_only=false, bool italic_only=false )
     {
         return _baseFont->getRightSideBearing( ch, negative_only, italic_only );
     }
@@ -3518,8 +3518,8 @@ public:
 
     /// draws text string (returns x advance)
     virtual int DrawTextString( LVDrawBuf * buf, int x, int y,
-                       const lChar16 * text, int len,
-                       lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                       const lChar32 * text, int len,
+                       lChar32 def_char, lUInt32 * palette, bool addHyphen,
                        TextLangCfg * lang_cfg,
                        lUInt32 flags, int letter_spacing, int width,
                        int text_decoration_back_gap )
@@ -3542,7 +3542,7 @@ public:
         int i;
 
         //lUInt16 prev_width = 0;
-        lChar16 ch;
+        lChar32 ch;
         // measure character widths
         bool isHyphen = false;
         int x0 = x;
@@ -3675,7 +3675,7 @@ private:
     LVFontCache _cache;
     FT_Library  _library;
     LVFontGlobalGlyphCache _globalCache;
-    lString16 _requiredChars;
+    lString32 _requiredChars;
     #if (DEBUG_FONT_MAN==1)
     FILE * _log;
     #endif
@@ -3896,7 +3896,7 @@ public:
         #elif (USE_FONTCONFIG==1)
         {
             CRLog::info("Reading list of system fonts using FONTCONFIG");
-            lString16Collection fonts;
+            lString32Collection fonts;
 
             int facesFound = 0;
 
@@ -3933,10 +3933,10 @@ public:
                     continue;
                 }
                 lString8 fn( (const char *)s );
-                lString16 fn16( fn.c_str() );
-                fn16.lowercase();
-                if (!fn16.endsWith(".ttf") && !fn16.endsWith(".odf") && !fn16.endsWith(".otf") &&
-                                              !fn16.endsWith(".pfb") && !fn16.endsWith(".pfa") ) {
+                lString32 fn32( fn.c_str() );
+                fn32.lowercase();
+                if (!fn32.endsWith(".ttf") && !fn32.endsWith(".odf") && !fn32.endsWith(".otf") &&
+                                              !fn32.endsWith(".pfb") && !fn32.endsWith(".pfa") ) {
                     continue;
                 }
                 int weight = FC_WEIGHT_MEDIUM;
@@ -4028,13 +4028,13 @@ public:
                 //     default: cr_weight=300; break;
                 // }
                 css_font_family_t fontFamily = css_ff_sans_serif;
-                lString16 face16((const char *)family);
-                face16.lowercase();
+                lString32 face32((const char *)family);
+                face32.lowercase();
                 if ( spacing==FC_MONO )
                     fontFamily = css_ff_monospace;
-                else if (face16.pos("sans") >= 0)
+                else if (face32.pos("sans") >= 0)
                     fontFamily = css_ff_sans_serif;
-                else if (face16.pos("serif") >= 0)
+                else if (face32.pos("serif") >= 0)
                     fontFamily = css_ff_serif;
 
                 //css_ff_inherit,
@@ -4046,11 +4046,11 @@ public:
                 bool italic = (slant!=FC_SLANT_ROMAN);
 
                 lString8 face((const char*)family);
-                lString16 style16((const char*)style);
-                style16.lowercase();
-                if (style16.pos("condensed") >= 0)
+                lString32 style32((const char*)style);
+                style32.lowercase();
+                if (style32.pos("condensed") >= 0)
                     face << " Condensed";
-                else if (style16.pos("extralight") >= 0)
+                else if (style32.pos("extralight") >= 0)
                     face << " Extra Light";
 
                 LVFontDef def(
@@ -4137,11 +4137,11 @@ public:
                 fprintf(_log, "=========================== LOGGING STARTED ===================\n");
             }
         #endif
-        // _requiredChars = L"azAZ09";//\x0410\x042F\x0430\x044F";
+        // _requiredChars = U"azAZ09";//\x0410\x042F\x0430\x044F";
         // Some fonts come without any of these (ie. NotoSansMyanmar.ttf), there's
         // no reason to prevent them from being used.
         // So, check only for the presence of the space char, hoping it's there in any font.
-        _requiredChars = L" ";
+        _requiredChars = U" ";
     }
 
     virtual void gc() // garbage collector
@@ -4160,20 +4160,20 @@ public:
     }
 
     /// returns available typefaces
-    virtual void getFaceList( lString16Collection & list )
+    virtual void getFaceList( lString32Collection & list )
     {
         FONT_MAN_GUARD
         _cache.getFaceList( list );
     }
 
     /// returns registered font files
-    virtual void getFontFileNameList( lString16Collection & list )
+    virtual void getFontFileNameList( lString32Collection & list )
     {
         FONT_MAN_GUARD
         _cache.getFontFileNameList(list);
     }
 
-    virtual bool getFontFileNameAndFaceIndex( lString16 name, bool bold, bool italic, lString8 & filename, int & index )
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index )
     {
         FONT_MAN_GUARD
         return _cache.getFontFileNameAndFaceIndex(name, bold, italic, filename, index);
@@ -4451,7 +4451,7 @@ public:
         if (face==NULL)
             return false; // invalid face
         for ( int i=0; i<_requiredChars.length(); i++ ) {
-            lChar16 ch = _requiredChars[i];
+            lChar32 ch = _requiredChars[i];
             FT_UInt ch_glyph_index = FT_Get_Char_Index( face, ch );
             if ( ch_glyph_index==0 ) {
                 CRLog::debug("Required char not found in font: %04x", ch);
@@ -4467,7 +4467,7 @@ public:
         // TODO: check existance of required characters (e.g. cyrillic)
         if (face==NULL)
             return false; // invalid face
-        lChar16 ch1 = 'i';
+        lChar32 ch1 = 'i';
         FT_UInt ch_glyph_index1 = FT_Get_Char_Index( face, ch1 );
         if ( ch_glyph_index1==0 )
             return false; // no required char!!!
@@ -4487,7 +4487,7 @@ public:
         else
             w2 = (face->glyph->metrics.horiAdvance >> 6);
 
-        lChar16 ch2 = 'W';
+        lChar32 ch2 = 'W';
         FT_UInt ch_glyph_index2 = FT_Get_Char_Index( face, ch2 );
         if ( ch_glyph_index2==0 )
             return false; // no required char!!!
@@ -4499,7 +4499,7 @@ public:
     // Note: publishers can specify font-variant/font-feature-settings/font-variation-settings
     // in the @font-face declaration.
     // todo: parse it and pass it here, and set it on the non-instantiated font (instead of -1)
-    virtual bool RegisterDocumentFont(int documentId, LVContainerRef container, lString16 name, lString8 faceName, bool bold, bool italic) {
+    virtual bool RegisterDocumentFont(int documentId, LVContainerRef container, lString32 name, lString8 faceName, bool bold, bool italic) {
         FONT_MAN_GUARD
         lString8 name8 = UnicodeToUtf8(name);
         CRLog::debug("RegisterDocumentFont(documentId=%d, path=%s)", documentId, name8.c_str());
@@ -4608,10 +4608,10 @@ public:
         _cache.removeDocumentFonts(documentId);
     }
 
-    virtual bool RegisterExternalFont( lString16 name, lString8 family_name, bool bold, bool italic) {
-        if (name.startsWithNoCase(lString16("res://")))
+    virtual bool RegisterExternalFont( lString32 name, lString8 family_name, bool bold, bool italic) {
+        if (name.startsWithNoCase(lString32("res://")))
             name = name.substr(6);
-        else if (name.startsWithNoCase(lString16("file://")))
+        else if (name.startsWithNoCase(lString32("file://")))
             name = name.substr(7);
         lString8 fname = UnicodeToUtf8(name);
 
@@ -4936,7 +4936,7 @@ public:
         return res;
     }
     /// returns registered font files
-    virtual void getFontFileNameList( lString16Collection & list )
+    virtual void getFontFileNameList( lString32Collection & list )
     {
         FONT_MAN_GUARD
         _cache.getFontFileNameList(list);
@@ -5096,12 +5096,12 @@ public:
         return res!=0;
     }
 
-    virtual void getFaceList( lString16Collection & list )
+    virtual void getFaceList( lString32Collection & list )
     {
         _cache.getFaceList(list);
     }
     /// returns registered font files
-    virtual void getFontFileNameList( lString16Collection & list )
+    virtual void getFontFileNameList( lString32Collection & list )
     {
         FONT_MAN_GUARD
         _cache.getFontFileNameList(list);
@@ -5128,11 +5128,11 @@ int CALLBACK LVWin32FontEnumFontFamExProc(
         if ( fnt.Create( *lf ) )
         {
             //
-            static lChar16 chars[] = {0, 0xBF, 0xE9, 0x106, 0x410, 0x44F, 0 };
+            static lChar32 chars[] = {0, 0xBF, 0xE9, 0x106, 0x410, 0x44F, 0 };
             for (int i=0; chars[i]; i++)
             {
                 LVFont::glyph_info_t glyph;
-                if (!fnt.getGlyphInfo( chars[i], &glyph, L' ' )) //def_char
+                if (!fnt.getGlyphInfo( chars[i], &glyph, U' ' )) //def_char
                     return 1;
             }
             fontman->RegisterFont( lf ); //&lpelfe->elfLogFont
@@ -5348,8 +5348,8 @@ int LVFontDef::CalcFallbackMatch( lString8 face, int size ) const
 
 /// draws text string (returns x advance)
 int LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
-                   const lChar16 * text, int len,
-                   lChar16 def_char, lUInt32 * palette, bool addHyphen, TextLangCfg * lang_cfg, lUInt32 , int , int, int )
+                   const lChar32 * text, int len,
+                   lChar32 def_char, lUInt32 * palette, bool addHyphen, TextLangCfg * lang_cfg, lUInt32 , int , int, int )
 {
     //static lUInt8 glyph_buf[16384];
     //LVFont::glyph_info_t info;
@@ -5357,7 +5357,7 @@ int LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
     int x0 = x;
     while (len>=(addHyphen?0:1)) {
         if (len<=1 || *text != UNICODE_SOFT_HYPHEN_CODE) {
-            lChar16 ch = ((len==0)?UNICODE_SOFT_HYPHEN_CODE:*text);
+            lChar32 ch = ((len==0)?UNICODE_SOFT_HYPHEN_CODE:*text);
 
             LVFontGlyphCacheItem * item = getGlyph(ch, def_char);
             int w  = 0;
@@ -5403,7 +5403,7 @@ int LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
 }
 
 #if (USE_BITMAP_FONTS==1)
-bool LBitmapFont::getGlyphInfo( lUInt32 code, LVFont::glyph_info_t * glyph, lChar16 def_char, bool is_fallback )
+bool LBitmapFont::getGlyphInfo( lUInt32 code, LVFont::glyph_info_t * glyph, lChar32 def_char, bool is_fallback )
 {
     const lvfont_glyph_t * ptr = lvfontGetGlyph( m_font, code );
     if (!ptr)
@@ -5417,11 +5417,11 @@ bool LBitmapFont::getGlyphInfo( lUInt32 code, LVFont::glyph_info_t * glyph, lCha
 }
 
 lUInt16 LBitmapFont::measureText(
-                    const lChar16 * text, int len,
+                    const lChar32 * text, int len,
                     lUInt16 * widths,
                     lUInt8 * flags,
                     int max_width,
-                    lChar16 def_char,
+                    lChar32 def_char,
                     TextLangCfg * lang_cfg,
                     int letter_spacing,
                     bool allow_hyphenation,
@@ -5431,7 +5431,7 @@ lUInt16 LBitmapFont::measureText(
     return lvfontMeasureText( m_font, text, len, widths, flags, max_width, def_char );
 }
 
-lUInt32 LBitmapFont::getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg )
+lUInt32 LBitmapFont::getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg )
 {
     static lUInt16 widths[MAX_LINE_CHARS+1];
     static lUInt8 flags[MAX_LINE_CHARS+1];
@@ -5444,7 +5444,7 @@ lUInt32 LBitmapFont::getTextWidth( const lChar16 * text, int len, TextLangCfg * 
                     widths,
                     flags,
                     MAX_LINE_WIDTH,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -5464,7 +5464,7 @@ int LBitmapFont::getHeight() const
     const lvfont_header_t * hdr = lvfontGetHeader( m_font );
     return hdr->fontHeight;
 }
-bool LBitmapFont::getGlyphImage(lUInt32 code, lUInt8 * buf, lChar16 def_char)
+bool LBitmapFont::getGlyphImage(lUInt32 code, lUInt8 * buf, lChar32 def_char)
 {
     const lvfont_glyph_t * ptr = lvfontGetGlyph( m_font, code );
     if (!ptr)
@@ -5768,20 +5768,20 @@ bool LVBaseWin32Font::Create(int size, int weight, bool italic, css_font_family_
     \param glyph is pointer to glyph_info_t struct to place retrieved info
     \return true if glyh was found
 */
-bool LVWin32DrawFont::getGlyphInfo( lUInt16 code, glyph_info_t * glyph, lChar16 def_char, bool is_fallback=false )
+bool LVWin32DrawFont::getGlyphInfo( lUInt16 code, glyph_info_t * glyph, lChar32 def_char, bool is_fallback=false )
 {
     return false;
 }
 
 /// returns char width
-int LVWin32DrawFont::getCharWidth( lChar16 ch, lChar16 def_char )
+int LVWin32DrawFont::getCharWidth( lChar32 ch, lChar32 def_char )
 {
     if (_hfont==NULL)
         return 0;
     // measure character widths
     GCP_RESULTSW gcpres = { 0 };
     gcpres.lStructSize = sizeof(gcpres);
-    lChar16 str[2];
+    lChar32 str[2];
     str[0] = ch;
     str[1] = 0;
     int dx[2];
@@ -5806,7 +5806,7 @@ int LVWin32DrawFont::getCharWidth( lChar16 ch, lChar16 def_char )
     return dx[0];
 }
 
-lUInt32 LVWin32DrawFont::getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL )
+lUInt32 LVWin32DrawFont::getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL )
 {
     //
     static lUInt16 widths[MAX_LINE_CHARS+1];
@@ -5820,7 +5820,7 @@ lUInt32 LVWin32DrawFont::getTextWidth( const lChar16 * text, int len, TextLangCf
                     widths,
                     flags,
                     MAX_LINE_WIDTH,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -5833,11 +5833,11 @@ lUInt32 LVWin32DrawFont::getTextWidth( const lChar16 * text, int len, TextLangCf
     \return true if glyph was found
 */
 lUInt16 LVWin32DrawFont::measureText(
-                    const lChar16 * text, int len,
+                    const lChar32 * text, int len,
                     lUInt16 * widths,
                     lUInt8 * flags,
                     int max_width,
-                    lChar16 def_char,
+                    lChar32 def_char,
                     TextLangCfg * lang_cfg = NULL,
                     int letter_spacing,
                     bool allow_hyphenation,
@@ -5847,10 +5847,10 @@ lUInt16 LVWin32DrawFont::measureText(
     if (_hfont==NULL)
         return 0;
 
-    lString16 str(text, len);
+    lString32 str(text, len);
     assert(str[len]==0);
-    //str += L"         ";
-    lChar16 * pstr = str.modify();
+    //str += U"         ";
+    lChar32 * pstr = str.modify();
     assert(pstr[len]==0);
     // substitute soft hyphens with zero width spaces
     for (int i=0; i<len; i++)
@@ -5890,7 +5890,7 @@ lUInt16 LVWin32DrawFont::measureText(
     lUInt16 gwidth = 0;
     lUInt8 bflags;
     int isSpace;
-    lChar16 ch;
+    lChar32 ch;
     int hwStart, hwEnd;
 
     assert(pstr[len]==0);
@@ -5925,7 +5925,7 @@ lUInt16 LVWin32DrawFont::measureText(
     }
     for (hwEnd=nchars; hwEnd<len; hwEnd++)
     {
-        lChar16 ch = text[hwEnd];
+        lChar32 ch = text[hwEnd];
         if (lvfontIsUnicodeSpace(ch))
             break;
         if (flags[hwEnd-1]&LCHAR_ALLOW_WRAP_AFTER)
@@ -5944,8 +5944,8 @@ lUInt16 LVWin32DrawFont::measureText(
 
 /// draws text string (returns x advance)
 int LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
-                   const lChar16 * text, int len,
-                   lChar16 def_char, lUInt32 * palette, bool addHyphen,
+                   const lChar32 * text, int len,
+                   lChar32 def_char, lUInt32 * palette, bool addHyphen,
                    TextLangCfg * lang_cfg,
                    lUInt32 flags, int letter_spacing, int width,
                    int text_decoration_back_gap )
@@ -5953,12 +5953,12 @@ int LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
     if (_hfont==NULL)
         return 0;
 
-    lString16 str(text, len);
+    lString32 str(text, len);
     // substitute soft hyphens with zero width spaces
     if (addHyphen)
         str += UNICODE_SOFT_HYPHEN_CODE;
-    //str += L"       ";
-    lChar16 * pstr = str.modify();
+    //str += U"       ";
+    lChar32 * pstr = str.modify();
     for (int i=0; i<len-1; i++)
     {
         if (pstr[i]==UNICODE_SOFT_HYPHEN_CODE)
@@ -6014,7 +6014,7 @@ int LVWin32DrawFont::DrawTextString( LVDrawBuf * buf, int x, int y,
     \param buf is buffer [width*height] to place glyph data
     \return true if glyph was found
 */
-bool LVWin32DrawFont::getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char)
+bool LVWin32DrawFont::getGlyphImage(lUInt16 code, lUInt8 * buf, lChar32 def_char)
 {
     return false;
 }
@@ -6051,7 +6051,7 @@ int LVWin32Font::GetGlyphIndex( HDC hdc, wchar_t code )
 }
 
 
-glyph_t * LVWin32Font::GetGlyphRec( lChar16 ch )
+glyph_t * LVWin32Font::GetGlyphRec( lChar32 ch )
 {
     glyph_t * p = _cache.get( ch );
     if (p->flgNotExists)
@@ -6163,7 +6163,7 @@ glyph_t * LVWin32Font::GetGlyphRec( lChar16 ch )
     \param glyph is pointer to glyph_info_t struct to place retrieved info
     \return true if glyh was found
 */
-bool LVWin32Font::getGlyphInfo( lUInt16 code, glyph_info_t * glyph, lChar16 def_char, bool is_fallback=false )
+bool LVWin32Font::getGlyphInfo( lUInt16 code, glyph_info_t * glyph, lChar32 def_char, bool is_fallback=false )
 {
     if (_hfont==NULL)
         return false;
@@ -6174,7 +6174,7 @@ bool LVWin32Font::getGlyphInfo( lUInt16 code, glyph_info_t * glyph, lChar16 def_
     return true;
 }
 
-lUInt32 LVWin32Font::getTextWidth( const lChar16 * text, int len, TextLangCfg * lang_cfg=NULL )
+lUInt32 LVWin32Font::getTextWidth( const lChar32 * text, int len, TextLangCfg * lang_cfg=NULL )
 {
     //
     static lUInt16 widths[MAX_LINE_CHARS+1];
@@ -6188,7 +6188,7 @@ lUInt32 LVWin32Font::getTextWidth( const lChar16 * text, int len, TextLangCfg * 
                     widths,
                     flags,
                     MAX_LINE_WIDTH,
-                    L' ',  // def_char
+                    U' ',  // def_char
                     lang_cfg
                  );
     if ( res>0 && res<MAX_LINE_CHARS )
@@ -6201,11 +6201,11 @@ lUInt32 LVWin32Font::getTextWidth( const lChar16 * text, int len, TextLangCfg * 
     \return true if glyph was found
 */
 lUInt16 LVWin32Font::measureText(
-                    const lChar16 * text, int len,
+                    const lChar32 * text, int len,
                     lUInt16 * widths,
                     lUInt8 * flags,
                     int max_width,
-                    lChar16 def_char,
+                    lChar32 def_char,
                     TextLangCfg * lang_cfg = NULL,
                     int letter_spacing,
                     bool allow_hyphenation,
@@ -6217,12 +6217,12 @@ lUInt16 LVWin32Font::measureText(
 
     lUInt16 wsum = 0;
     lUInt16 nchars = 0;
-    glyph_t * glyph; //GetGlyphRec( lChar16 ch )
+    glyph_t * glyph; //GetGlyphRec( lChar32 ch )
     lUInt16 gwidth = 0;
     lUInt16 hyphwidth = 0;
     lUInt8 bflags;
     int isSpace;
-    lChar16 ch;
+    lChar32 ch;
     int hwStart, hwEnd;
 
     glyph = GetGlyphRec( UNICODE_SOFT_HYPHEN_CODE );
@@ -6260,7 +6260,7 @@ lUInt16 LVWin32Font::measureText(
     }
     for (hwEnd=nchars; hwEnd<len; hwEnd++)
     {
-        lChar16 ch = text[hwEnd];
+        lChar32 ch = text[hwEnd];
         if (lvfontIsUnicodeSpace(ch))
             break;
         if (flags[hwEnd-1]&LCHAR_ALLOW_WRAP_AFTER)
@@ -6282,7 +6282,7 @@ lUInt16 LVWin32Font::measureText(
     \param buf is buffer [width*height] to place glyph data
     \return true if glyph was found
 */
-bool LVWin32Font::getGlyphImage(lUInt16 code, lUInt8 * buf, lChar16 def_char)
+bool LVWin32Font::getGlyphImage(lUInt16 code, lUInt8 * buf, lChar32 def_char)
 {
     if (_hfont==NULL)
         return false;

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1931,15 +1931,15 @@ LVImageSourceRef LVCreateNodeImageSource( ldomNode * node )
     if (stream.isNull())
         return ref;
 //    if ( CRLog::isDebugEnabled() ) {
-//        lUInt16 attr_id = node->getDocument()->getAttrNameIndex(L"id");
-//        lString16 id = node->getAttributeValue(attr_id);
+//        lUInt16 attr_id = node->getDocument()->getAttrNameIndex(U"id");
+//        lString32 id = node->getAttributeValue(attr_id);
 //        CRLog::debug("Opening node image id=%s", LCSTR(id));
 //    }
     return LVCreateStreamImageSource( stream );
 }
 
 /// creates image source as memory copy of file contents
-LVImageSourceRef LVCreateFileCopyImageSource( lString16 fname )
+LVImageSourceRef LVCreateFileCopyImageSource( lString32 fname )
 {
     return LVCreateStreamImageSource( LVCreateMemoryStream(fname) );
 }
@@ -2551,11 +2551,11 @@ void LVDrawBatteryIcon( LVDrawBuf * drawbuf, const lvRect & batteryRc, int perce
 
     if ( drawText ) {
         // rc is rectangle to draw text to
-        lString16 txt;
+        lString32 txt;
         if ( charging )
             txt = "+++";
         else
-            txt = lString16::itoa(percent); // + L"%";
+            txt = lString32::itoa(percent); // + U"%";
         int w = font->getTextWidth(txt.c_str(), txt.length());
         int h = font->getHeight();
         int x = (rc.left + rc.right - w)/2;

--- a/crengine/src/lvmemman.cpp
+++ b/crengine/src/lvmemman.cpp
@@ -67,6 +67,8 @@ void crSetSignalHandler()
 void lvDefFatalErrorHandler (int errorCode, const char * errorText )
 {
     fprintf( stderr, "FATAL ERROR #%d: %s\n", errorCode, errorText );
+    // Uncomment to force a real crash when using gdb and wanting to see a backtrce
+    // int * a = 0; *a = 1;
     exit( errorCode );
 }
 

--- a/crengine/src/lvopc.cpp
+++ b/crengine/src/lvopc.cpp
@@ -1,7 +1,7 @@
 #include "../include/lvopc.h"
 #include "../include/lvtinydom.h"
 
-static const lChar16 * const OPC_PropertiesContentType = L"application/vnd.openxmlformats-package.core-properties+xml";
+static const lChar32 * const OPC_PropertiesContentType = U"application/vnd.openxmlformats-package.core-properties+xml";
 
 OpcPart::~OpcPart()
 {
@@ -13,17 +13,17 @@ LVStreamRef OpcPart::open()
     return m_package->open(m_name);
 }
 
-lString16 OpcPart::getRelatedPartName(const lChar16 * const relationType, const lString16 id)
+lString32 OpcPart::getRelatedPartName(const lChar32 * const relationType, const lString32 id)
 {
     if( !m_relationsValid ) {
         readRelations();
         m_relationsValid = true;
     }
-    LVHashTable<lString16, lString16> *relationsTable = m_relations.get(relationType);
+    LVHashTable<lString32, lString32> *relationsTable = m_relations.get(relationType);
     if( relationsTable ) {
         if( id.empty() ) {
-            LVHashTable<lString16, lString16>::iterator it = relationsTable->forwardIterator();
-            LVHashTable<lString16, lString16>::pair *p = it.next();
+            LVHashTable<lString32, lString32>::iterator it = relationsTable->forwardIterator();
+            LVHashTable<lString32, lString32>::pair *p = it.next();
             if( p ) {
                 return p->value; // return first value
             }
@@ -31,37 +31,37 @@ lString16 OpcPart::getRelatedPartName(const lChar16 * const relationType, const 
             return relationsTable->get(id);
         }
     }
-    return lString16();
+    return lString32();
 }
 
-OpcPartRef OpcPart::getRelatedPart(const lChar16 * const relationType, const lString16 id)
+OpcPartRef OpcPart::getRelatedPart(const lChar32 * const relationType, const lString32 id)
 {
     return m_package->getPart( getRelatedPartName(relationType, id) );
 }
 
 void OpcPart::readRelations()
 {
-    lString16 relsPath = LVExtractPath(m_name) + cs16("_rels/") + LVExtractFilename(m_name) + cs16(".rels");
+    lString32 relsPath = LVExtractPath(m_name) + cs32("_rels/") + LVExtractFilename(m_name) + cs32(".rels");
     LVStreamRef container_stream = m_package->open(relsPath);
 
     if ( !container_stream.isNull() ) {
         ldomDocument * doc = LVParseXMLStream( container_stream );
-        lString16 srcPath = LVExtractPath(m_name);
+        lString32 srcPath = LVExtractPath(m_name);
 
         if ( doc ) {
-            ldomNode *root = doc->nodeFromXPath(cs16("Relationships"));
+            ldomNode *root = doc->nodeFromXPath(cs32("Relationships"));
             if( root ) {
                 for(int i = 0; i < root->getChildCount(); i++) {
                     ldomNode * relationshipNode = root->getChildNode((lUInt32)i);
-                    const lString16 relType = relationshipNode->getAttributeValue(L"Type");
-                    LVHashTable<lString16, lString16> *relationsTable = m_relations.get(relType);
+                    const lString32 relType = relationshipNode->getAttributeValue(U"Type");
+                    LVHashTable<lString32, lString32> *relationsTable = m_relations.get(relType);
                     if( !relationsTable ) {
-                        relationsTable = new LVHashTable<lString16, lString16>(16);
+                        relationsTable = new LVHashTable<lString32, lString32>(16);
                         m_relations.set(relType, relationsTable);
                     }
-                    const lString16 id = relationshipNode->getAttributeValue(L"Id");
-                    relationsTable->set( id, getTargetPath(srcPath, relationshipNode->getAttributeValue(L"TargetMode"),
-                                                           relationshipNode->getAttributeValue(L"Target")) );
+                    const lString32 id = relationshipNode->getAttributeValue(U"Id");
+                    relationsTable->set( id, getTargetPath(srcPath, relationshipNode->getAttributeValue(U"TargetMode"),
+                                                           relationshipNode->getAttributeValue(U"Target")) );
                 }
             }
             delete doc;
@@ -69,10 +69,10 @@ void OpcPart::readRelations()
     }
 }
 
-lString16 OpcPart::getTargetPath(const lString16 srcPath, const lString16 targetMode, lString16 target)
+lString32 OpcPart::getTargetPath(const lString32 srcPath, const lString32 targetMode, lString32 target)
 {
     if( !target.empty() ) {
-        if ( targetMode == L"External" || target.pos(L":") != -1 )
+        if ( targetMode == U"External" || target.pos(U":") != -1 )
             return target;
 
         if( !LVIsAbsolutePath(target) ) {
@@ -85,7 +85,7 @@ lString16 OpcPart::getTargetPath(const lString16 srcPath, const lString16 target
     return target;
 }
 
-lString16 OpcPackage::getContentPartName(const lChar16 *contentType)
+lString32 OpcPackage::getContentPartName(const lChar32 *contentType)
 {
     if ( !m_contentTypesValid ) {
         readContentTypes();
@@ -94,12 +94,12 @@ lString16 OpcPackage::getContentPartName(const lChar16 *contentType)
     return m_contentTypes.get(contentType);
 }
 
-OpcPartRef OpcPackage::getPart(const lString16 partName)
+OpcPartRef OpcPackage::getPart(const lString32 partName)
 {
     return OpcPartRef(createPart(this, partName));
 }
 
-bool OpcPackage::partExist(const lString16 partName)
+bool OpcPackage::partExist(const lString32 partName)
 {
     LVStreamRef partStream = open(partName);
     return !partStream.isNull();
@@ -112,10 +112,10 @@ void OpcPackage::readCoreProperties(CRPropRef doc_props)
     if ( !propStream.isNull() ) {
         ldomDocument * propertiesDoc = LVParseXMLStream( propStream );
         if ( propertiesDoc ) {
-            lString16 author = propertiesDoc->textFromXPath( cs16("coreProperties/creator") );
-            lString16 title = propertiesDoc->textFromXPath( cs16("coreProperties/title") );
-            lString16 language = propertiesDoc->textFromXPath( cs16("coreProperties/language") );
-            lString16 description = propertiesDoc->textFromXPath( cs16("coreProperties/description") );
+            lString32 author = propertiesDoc->textFromXPath( cs32("coreProperties/creator") );
+            lString32 title = propertiesDoc->textFromXPath( cs32("coreProperties/title") );
+            lString32 language = propertiesDoc->textFromXPath( cs32("coreProperties/language") );
+            lString32 description = propertiesDoc->textFromXPath( cs32("coreProperties/description") );
             doc_props->setString(DOC_PROP_TITLE, title);
             doc_props->setString(DOC_PROP_AUTHORS, author );
             doc_props->setString(DOC_PROP_LANGUAGE, language );
@@ -131,18 +131,18 @@ void OpcPackage::readCoreProperties(CRPropRef doc_props)
 
 void OpcPackage::readContentTypes()
 {
-    LVStreamRef mtStream = m_container->OpenStream(L"[Content_Types].xml", LVOM_READ );
+    LVStreamRef mtStream = m_container->OpenStream(U"[Content_Types].xml", LVOM_READ );
     if ( !mtStream.isNull() ) {
         ldomDocument * doc = LVParseXMLStream( mtStream );
         if( doc ) {
-            ldomNode *root = doc->nodeFromXPath(cs16("Types"));
+            ldomNode *root = doc->nodeFromXPath(cs32("Types"));
             if(root) {
                 for(int i = 0; i < root->getChildCount(); i++) {
                     ldomNode * typeNode = root->getChildNode(i);
 
-                    if(typeNode->getNodeName() == cs16("Override")) //Don't care about Extensions
-                        m_contentTypes.set( typeNode->getAttributeValue(L"ContentType"),
-                                            typeNode->getAttributeValue(L"PartName") );
+                    if(typeNode->getNodeName() == cs32("Override")) //Don't care about Extensions
+                        m_contentTypes.set( typeNode->getAttributeValue(U"ContentType"),
+                                            typeNode->getAttributeValue(U"PartName") );
                 }
             }
             delete doc;

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -85,7 +85,7 @@ int LVRendPageContext::getCurrentLinksCount()
 }
 
 /// append or insert footnote link to last added line
-void LVRendPageContext::addLink( lString16 id, int pos )
+void LVRendPageContext::addLink( lString32 id, int pos )
 {
     if ( !gather_lines ) {
         if ( pos >= 0 ) // insert at pos
@@ -101,7 +101,7 @@ void LVRendPageContext::addLink( lString16 id, int pos )
 }
 
 /// mark start of foot note
-void LVRendPageContext::enterFootNote( lString16 id )
+void LVRendPageContext::enterFootNote( lString32 id )
 {
     if ( !page_list )
         return;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8666,19 +8666,23 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     lUInt32 txt_flags = is_rtl ? LTEXT_ALIGN_RIGHT : 0;
                     int list_marker_width;
                     lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
+                    /*
                     lUInt32 h = txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
                     if (doc_y + y0 + h <= clip.bottom) { // draw only if marker fully fits on page
-                        // In both LTR and RTL, for erm_block, we draw the marker inside 'width',
-                        // (only the child elements got their width shrinked by list_marker_width).
-                        if ( is_rtl ) {
-                            txform->Draw( &drawbuf, doc_x+x0 + width + shift_x - list_marker_width, doc_y+y0 + padding_top );
-                        }
-                        else {
-                            // (Don't shift by padding left, the list marker is outside padding left)
-                            txform->Draw( &drawbuf, doc_x+x0 + shift_x, doc_y+y0 + padding_top );
-                        }
+                    */
+                    // Better to draw it, even if it slightly overflows, or we might lose some
+                    // list item number for no real reason
+                    txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
+                    // In both LTR and RTL, for erm_block, we draw the marker inside 'width',
+                    // (only the child elements got their width shrinked by list_marker_width).
+                    if ( is_rtl ) {
+                        txform->Draw( &drawbuf, doc_x+x0 + width + shift_x - list_marker_width, doc_y+y0 + padding_top );
+                    }
+                    else {
+                        // (Don't shift by padding left, the list marker is outside padding left)
+                        txform->Draw( &drawbuf, doc_x+x0 + shift_x, doc_y+y0 + padding_top );
                     }
                 }
 
@@ -8837,18 +8841,22 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     lUInt32 txt_flags = is_rtl ? LTEXT_ALIGN_RIGHT : 0;
                     int list_marker_width;
                     lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
+                    /*
                     lUInt32 h = txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
                     if (doc_y + y0 + h <= clip.bottom) { // draw only if marker fully fits on page
-                        // In both LTR and RTL, for erm_final, we draw the marker outside 'width',
-                        // as 'width' has already been shrinked by list_marker_width.
-                        if ( is_rtl ) {
-                            txform->Draw( &drawbuf, doc_x+x0 + width + shift_x, doc_y+y0 + padding_top, NULL, NULL );
-                        }
-                        else {
-                            txform->Draw( &drawbuf, doc_x+x0 + shift_x - list_marker_width, doc_y+y0 + padding_top, NULL, NULL );
-                        }
+                    */
+                    // Better to draw it, even if it slightly overflows, or we might lose some
+                    // list item number for no real reason
+                    txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
+                    // In both LTR and RTL, for erm_final, we draw the marker outside 'width',
+                    // as 'width' has already been shrinked by list_marker_width.
+                    if ( is_rtl ) {
+                        txform->Draw( &drawbuf, doc_x+x0 + width + shift_x, doc_y+y0 + padding_top, NULL, NULL );
+                    }
+                    else {
+                        txform->Draw( &drawbuf, doc_x+x0 + shift_x - list_marker_width, doc_y+y0 + padding_top, NULL, NULL );
                     }
                     // Note: if there's a float on the left of the list item, we let
                     // the marker where it would be if there were no float, while Firefox

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -84,7 +84,7 @@ public:
     simpleLogFile & operator << ( const char * str ) { fprintf( f, "%s", str ); fflush( f ); return *this; }
     //simpleLogFile & operator << ( int d ) { fprintf( f, "%d(0x%X) ", d, d ); fflush( f ); return *this; }
     simpleLogFile & operator << ( int d ) { fprintf( f, "%d ", d ); fflush( f ); return *this; }
-    simpleLogFile & operator << ( const wchar_t * str )
+    simpleLogFile & operator << ( const lChar32 * str )
     {
         if (str)
         {
@@ -96,7 +96,7 @@ public:
         fflush( f );
         return *this;
     }
-    simpleLogFile & operator << ( const lString16 &str ) { return operator << (str.c_str()); }
+    simpleLogFile & operator << ( const lString32 &str ) { return operator << (str.c_str()); }
 };
 
 simpleLogFile logfile("/tmp/logfile.log");
@@ -109,8 +109,8 @@ class simpleLogFile
 public:
     simpleLogFile & operator << ( const char * ) { return *this; }
     simpleLogFile & operator << ( int ) { return *this; }
-    simpleLogFile & operator << ( const wchar_t * ) { return *this; }
-    simpleLogFile & operator << ( const lString16 & ) { return *this; }
+    simpleLogFile & operator << ( const lChar32 * ) { return *this; }
+    simpleLogFile & operator << ( const lString32 & ) { return *this; }
 };
 
 simpleLogFile logfile;
@@ -182,7 +182,7 @@ public:
     int y;
     int numcols; // sum of colspan
     int linkindex;
-    lString16Collection links;
+    lString32Collection links;
     ldomNode * elem;
     LVPtrVector<CCRTableCell> cells;
     CCRTableRowGroup * rowgroup;
@@ -249,8 +249,8 @@ public:
     in: string      25   35%
     out:            25   -35
 */
-int StrToIntPercent( const wchar_t * s, int digitwidth=0 );
-int StrToIntPercent( const wchar_t * s, int digitwidth )
+int StrToIntPercent( const lChar32 * s, int digitwidth=0 );
+int StrToIntPercent( const lChar32 * s, int digitwidth )
 {
     int n=0;
     if (!s || !s[0]) return 0;
@@ -345,7 +345,7 @@ public:
 
                 int item_direction = elem_direction;
                 if ( item->hasAttribute( attr_dir ) ) {
-                    lString16 dir = item->getAttributeValue( attr_dir );
+                    lString32 dir = item->getAttributeValue( attr_dir );
                     dir = dir.lowercase();
                     if ( dir.compare("rtl") == 0 ) {
                         item_direction = REND_DIRECTION_RTL;
@@ -421,7 +421,7 @@ public:
                         // It's not mentionned in any HTML or FB2 spec,
                         // and row->linkindex is never used.
                         if (row->elem->hasAttribute(LXML_NS_ANY, attr_link)) {
-                            lString16 lnk=row->elem->getAttributeValue(attr_link);
+                            lString32 lnk=row->elem->getAttributeValue(attr_link);
                             row->linkindex = lnk.atoi();
                         }
                         // recursion: search for inner elements
@@ -436,7 +436,7 @@ public:
                         CCRTableCol * col = cols[colindex];
                         col->elem = item;
                         /*
-                        lString16 w = item->getAttributeValue(attr_width);
+                        lString32 w = item->getAttributeValue(attr_width);
                         if (!w.empty()) {
                             // TODO: px, em, and other length types support
                             int wn = StrToIntPercent(w.c_str(), digitwidth);
@@ -498,7 +498,7 @@ public:
                         }
                         /*
                         // "width"
-                        lString16 w = item->getAttributeValue(attr_width);
+                        lString32 w = item->getAttributeValue(attr_width);
                         if (!w.empty()) {
                             int wn = StrToIntPercent(w.c_str(), digitwidth);
                             if (wn<0)
@@ -507,13 +507,13 @@ public:
                                 cell->width = wn;
                         }
                         // "align"
-                        lString16 halign = item->getAttributeValue(attr_align);
+                        lString32 halign = item->getAttributeValue(attr_align);
                         if (halign == "center")
                             cell->halign = 1; // center
                         else if (halign == "right")
                             cell->halign = 2; // right
                         // "valign"
-                        lString16 valign = item->getAttributeValue(attr_valign);
+                        lString32 valign = item->getAttributeValue(attr_valign);
                         if (valign == "center")
                             cell->valign = 2; // middle
                         else if (valign == "bottom")
@@ -1670,7 +1670,7 @@ public:
                                             while (parent && parent->getNodeId() != el_a)
                                                 parent = parent->getParentNode();
                                             if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                                lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                                lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                                 if ( href.length()>0 && href.at(0)=='#' ) {
                                                     href.erase(0,1);
                                                     if ( is_single_column )
@@ -1733,7 +1733,7 @@ public:
                         }
                         if ( !is_single_column ) {
                             // Gather footnotes links accumulated by cell_context
-                            lString16Collection * link_ids = cell_context->getLinkIds();
+                            lString32Collection * link_ids = cell_context->getLinkIds();
                             if (link_ids->length() > 0) {
                                 for ( int n=0; n<link_ids->length(); n++ ) {
                                     row->links.add( link_ids->at(n) );
@@ -2442,16 +2442,16 @@ int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_
     return px;
 }
 
-void SplitLines( const lString16 & str, lString16Collection & lines )
+void SplitLines( const lString32 & str, lString32Collection & lines )
 {
-    const lChar16 * s = str.c_str();
-    const lChar16 * start = s;
+    const lChar32 * s = str.c_str();
+    const lChar32 * start = s;
     for ( ; *s; s++ ) {
         if ( *s=='\r' || *s=='\n' ) {
             //if ( s > start )
-            //    lines.add( cs16("*") + lString16( start, s-start ) + cs16("<") );
+            //    lines.add( cs32("*") + lString32( start, s-start ) + cs32("<") );
             //else
-            //    lines.add( cs16("#") );
+            //    lines.add( cs32("#") );
             if ( (s[1] =='\r' || s[1]=='\n') && (s[1]!=s[0]) )
                 s++;
             start = s+1;
@@ -2460,15 +2460,15 @@ void SplitLines( const lString16 & str, lString16Collection & lines )
     while ( *start=='\r' || *start=='\n' )
         start++;
     if ( s > start )
-        lines.add( lString16( start, (lvsize_t)(s-start) ) );
+        lines.add( lString32( start, (lvsize_t)(s-start) ) );
 }
 
 // Returns the marker for a list item node. If txform is supplied render the marker, too.
 // marker_width is updated and can be used to add indent or padding necessary to make
 // room for the marker (what and how to do it depending of list-style_position (inside/outside)
 // is left to the caller)
-lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormattedText * txform, int line_h, lUInt32 flags ) {
-    lString16 marker;
+lString32 renderListItemMarker( ldomNode * enode, int & marker_width, LFormattedText * txform, int line_h, lUInt32 flags ) {
+    lString32 marker;
     marker_width = 0;
     ldomDocument* doc = enode->getDocument();
     // The UL > LI parent-child chain may have had some of our boxing elements inserted
@@ -2480,7 +2480,7 @@ lString16 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
         int maxWidth = 0;
         ldomNode * sibling = parent->getUnboxedFirstChild(true);
         while ( sibling ) {
-            lString16 marker;
+            lString32 marker;
             int markerWidth = 0;
             if ( sibling->getNodeListMarker( counterValue, marker, markerWidth ) ) {
                 if ( markerWidth > maxWidth )
@@ -2597,7 +2597,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             return; // don't draw invisible
 
         if ( enode->hasAttribute( attr_lang ) ) {
-            lString16 lang_tag = enode->getAttributeValue( attr_lang );
+            lString32 lang_tag = enode->getAttributeValue( attr_lang );
             if ( !lang_tag.empty() )
                 lang_cfg = TextLangMan::getTextLangCfg( lang_tag );
         }
@@ -3052,7 +3052,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
         if ( style->display == css_d_list_item_legacy ) { // obsolete (used only when gDOMVersionRequested < 20180524)
             // put item number/marker to list
-            lString16 marker;
+            lString32 marker;
             int marker_width = 0;
 
             ListNumberingPropsRef listProps =  enode->getDocument()->getNodeNumberingProps( enode->getParentNode()->getDataIndex() );
@@ -3062,7 +3062,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 int maxWidth = 0;
                 ldomNode * sibling = enode->getUnboxedParent()->getUnboxedFirstChild(true);
                 while ( sibling ) {
-                    lString16 marker;
+                    lString32 marker;
                     int markerWidth = 0;
                     if ( sibling->getNodeListMarker( counterValue, marker, markerWidth ) ) {
                         if ( markerWidth > maxWidth )
@@ -3098,7 +3098,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // (we don't draw anything when list-style-type=none)
             if ( renderAsListStylePositionInside(style, is_rtl) && style->list_style_type != css_lst_none ) {
                 int marker_width;
-                lString16 marker = renderListItemMarker( enode, marker_width, txform, line_h, flags );
+                lString32 marker = renderListItemMarker( enode, marker_width, txform, line_h, flags );
                 if ( marker.length() ) {
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH;
                 }
@@ -3117,7 +3117,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             if ( listPropNodeIndex ) {
                 ldomNode * list_item_block_parent = enode->getDocument()->getTinyNode( listPropNodeIndex );
                 int marker_width;
-                lString16 marker = renderListItemMarker( list_item_block_parent, marker_width, txform, line_h, flags );
+                lString32 marker = renderListItemMarker( list_item_block_parent, marker_width, txform, line_h, flags );
                 if ( marker.length() ) {
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH;
                 }
@@ -3132,32 +3132,32 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             if ( isBlock ) {
                 // If block image, forget any current flags and start from baseflags (?)
                 lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
-                //txform->AddSourceLine(L"title", 5, 0x000000, 0xffffff, font, baseflags, interval, margin, NULL, 0, 0);
+                //txform->AddSourceLine(U"title", 5, 0x000000, 0xffffff, font, baseflags, interval, margin, NULL, 0, 0);
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
-                lString16 title;
+                lString32 title;
                 //txform->AddSourceLine( title.c_str(), title.length(), cl, bgcl, font, LTEXT_FLAG_OWNTEXT|LTEXT_FLAG_NEWLINE, line_h, 0, NULL );
                 //baseflags
                 title = enode->getAttributeValue(attr_suptitle);
                 if ( !title.empty() ) {
-                    lString16Collection lines;
-                    lines.parse(title, cs16("\\n"), true);
+                    lString32Collection lines;
+                    lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
                         txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
                 }
                 txform->AddSourceObject(flags, line_h, valign_dy, indent, enode, lang_cfg );
                 title = enode->getAttributeValue(attr_subtitle);
                 if ( !title.empty() ) {
-                    lString16Collection lines;
-                    lines.parse(title, cs16("\\n"), true);
+                    lString32Collection lines;
+                    lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
                         txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
                 }
                 title = enode->getAttributeValue(attr_title);
                 if ( !title.empty() ) {
-                    lString16Collection lines;
-                    lines.parse(title, cs16("\\n"), true);
+                    lString32Collection lines;
+                    lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
                         txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
                 }
@@ -3263,7 +3263,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // When meeting them, we add the equivalent unicode opening and closing chars so
                 // that fribidi (working on text only) can ensure what's specified with HTML tags.
                 // See http://unicode.org/reports/tr9/#Markup_And_Formatting
-                lString16 dir = enode->getAttributeValue( attr_dir );
+                lString32 dir = enode->getAttributeValue( attr_dir );
                 dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
                 if ( nodeElementId == el_bdo ) {
                     // <bdo> (bidirectional override): prevents the bidirectional algorithm from
@@ -3277,16 +3277,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  leaving  => PDF PDI
                     // but it then doesn't have the intended effect (fribidi bug or limitation?)
                     if ( dir.compare("rtl") == 0 ) {
-                        // txform->AddSourceLine( L"\x2068\x202E", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        // txform->AddSourceLine( U"\x2068\x202E", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         // closeWithPDFPDI = true;
-                        txform->AddSourceLine( L"\x202E", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x202E", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         closeWithPDF = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( dir.compare("ltr") == 0 ) {
-                        // txform->AddSourceLine( L"\x2068\x202D", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        // txform->AddSourceLine( U"\x2068\x202D", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         // closeWithPDFPDI = true;
-                        txform->AddSourceLine( L"\x202D", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x202D", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         closeWithPDF = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
@@ -3299,17 +3299,17 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  dir=auto => FSI     U+2068  FIRST STRONG ISOLATE
                     //  leaving  => PDI     U+2069  POP DIRECTIONAL ISOLATE
                     if ( dir.compare("rtl") == 0 ) {
-                        txform->AddSourceLine( L"\x2067", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2067", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( dir.compare("ltr") == 0 ) {
-                        txform->AddSourceLine( L"\x2066", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2066", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( nodeElementId == el_bdi || dir.compare("auto") == 0 ) {
-                        txform->AddSourceLine( L"\x2068", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2068", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
@@ -3334,7 +3334,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // (if <q dir="rtl">...</q>, the added quote (first child pseudo element)
                 // should be inside the RTL bidi isolation.
                 if ( nodeElementId == el_pseudoElem ) {
-                    lString16 content = get_applied_content_property(enode);
+                    lString32 content = get_applied_content_property(enode);
                     if ( !content.empty() ) {
                         int em = font->getSize();
                         int letter_spacing = lengthToPx(style->letter_spacing, em, em);
@@ -3364,15 +3364,15 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
                 // See comment above: these are the closing counterpart
                 if ( closeWithPDI ) {
-                    txform->AddSourceLine( L"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
                 else if ( closeWithPDFPDI ) {
-                    txform->AddSourceLine( L"\x202C\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x202C\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
                 else if ( closeWithPDF ) {
-                    txform->AddSourceLine( L"\x202C", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x202C", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
             }
@@ -3387,13 +3387,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 css_style_ref_t style = enode->getStyle();
                 lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
-                txform->AddSourceLine( L" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
+                txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
                 /*
                 // We used to specify two UNICODE_NO_BREAK_SPACE (that would not collapse)
                 // mostly so we were able to detect them in lvtextfm.cpp and avoid this
                 // spacing to change width with text justification.
-                lChar16 delimiter[] = {UNICODE_NO_BREAK_SPACE, UNICODE_NO_BREAK_SPACE}; //160
-                txform->AddSourceLine( delimiter, sizeof(delimiter)/sizeof(lChar16), cl, bgcl, font.get(), lang_cfg,
+                lChar32 delimiter[] = {UNICODE_NO_BREAK_SPACE, UNICODE_NO_BREAK_SPACE}; //160
+                txform->AddSourceLine( delimiter, sizeof(delimiter)/sizeof(lChar32), cl, bgcl, font.get(), lang_cfg,
                                             LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
                 // Users who would like more spacing can use:
                 //   body[name="notes"] section title:after,
@@ -3438,7 +3438,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
                 lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
-                txform->AddSourceLine( L" ", 1, cl, bgcl, font.get(), lang_cfg,
+                txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                                         baseflags | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                                         line_h, valign_dy);
                 // baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
@@ -3499,14 +3499,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             LVFontRef font = enode->getFont();
             lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
             lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
-            txform->AddSourceLine( L" ", 1, cl, bgcl, font.get(), lang_cfg,
+            txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                             baseflags | LTEXT_SRC_IS_CLEAR_LAST | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                             line_h, valign_dy);
         }
     }
     else if ( enode->isText() ) {
         // text nodes
-        lString16 txt = enode->getText();
+        lString32 txt = enode->getText();
         if ( !txt.empty() ) {
             #ifdef DEBUG_DUMP_ENABLED
                 for (int i=0; i<enode->getNodeLevel(); i++)
@@ -3520,7 +3520,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // if ( parent->getNodeId() == el_a ) // "123" in <a href=><sup>123</sup></a> would not be flagged
             if (is_link_start && *is_link_start) { // was propagated from some outer <A>
                 tflags |= LTEXT_IS_LINK; // used to gather in-page footnotes
-                lString16 tmp = lString16(txt);
+                lString32 tmp = lString32(txt);
                 if (!tmp.trim().empty()) // non empty text, will make out a word
                     *is_link_start = false;
                     // reset to false, so next text nodes in that link are not
@@ -3570,10 +3570,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             /*
             if ( baseflags & LTEXT_FLAG_PREFORMATTED ) {
                 int flags = baseflags | tflags;
-                lString16Collection lines;
+                lString32Collection lines;
                 SplitLines( txt, lines );
                 for ( int k=0; k<lines.length(); k++ ) {
-                    lString16 str = lines[k];
+                    lString32 str = lines[k];
                     txform->AddSourceLine( str.c_str(), str.length(), cl, bgcl,
                         font, flags, line_h, 0, node, 0, letter_spacing );
                     flags &= ~LTEXT_FLAG_NEWLINE;
@@ -3604,7 +3604,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     line_h, valign_dy, indent, enode, 0, letter_spacing );
                 baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 // To show the lang tag for the lang used for this text node AFTER it:
-                // lString16 lang_tag_txt = L"[" + (lang_cfg ? lang_cfg->getLangTag() : lString16("??")) + L"]";
+                // lString32 lang_tag_txt = U"[" + (lang_cfg ? lang_cfg->getLangTag() : lString32("??")) + U"]";
                 // txform->AddSourceLine( lang_tag_txt.c_str(), lang_tag_txt.length(), cl, bgcl, font,
                 //          lang_cfg, baseflags|tflags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
             }
@@ -3954,7 +3954,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
     {
         css_style_ref_t style = enode->getStyle();
         bool isFootNoteBody = false;
-        lString16 footnoteId;
+        lString32 footnoteId;
         // Allow displaying footnote content at the bottom of all pages that contain a link
         // to it, when -cr-hint: footnote-inpage is set on the footnote block container.
         if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) &&
@@ -4250,7 +4250,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                         // Get marker width and height
                         LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
                         int list_marker_width;
-                        lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, 0);
+                        lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, 0);
                         list_marker_height = txform->Format( (lUInt16)(width - list_marker_width), (lUInt16)enode->getDocument()->getPageHeight() );
                         if ( style->list_style_position == css_lsp_outside &&
                             style->text_align != css_ta_center && style->text_align != css_ta_right) {
@@ -4294,7 +4294,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                         if ( child->isText() ) {
                             // We may occasionally let empty text nodes among block elements,
                             // just skip them
-                            lString16 s = child->getText();
+                            lString32 s = child->getText();
                             if ( IsEmptySpace(s.c_str(), s.length() ) )
                                 continue;
                             crFatalError(144, "Attempting to render non-empty Text node");
@@ -4358,7 +4358,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                             // When list_style_position = outside, we have to shift the final block
                             // to the right and reduce its width
                             int list_marker_width;
-                            lString16 marker = renderListItemMarker( enode, list_marker_width, NULL, -1, 0 );
+                            lString32 marker = renderListItemMarker( enode, list_marker_width, NULL, -1, 0 );
                             fmt.setX( fmt.getX() + list_marker_width );
                             width -= list_marker_width;
                         }
@@ -4420,7 +4420,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                 inside = getPageBreakInside( enode );
 
 //                if (before!=css_pb_auto) {
-//                    CRLog::trace("page break before node %s class=%s text=%s", LCSTR(enode->getNodeName()), LCSTR(enode->getAttributeValue(L"class")), LCSTR(enode->getText(' ', 120) ));
+//                    CRLog::trace("page break before node %s class=%s text=%s", LCSTR(enode->getNodeName()), LCSTR(enode->getAttributeValue(U"class")), LCSTR(enode->getText(' ', 120) ));
 //                }
 
                 //getPageBreakStyle( enode, before, inside, after );
@@ -4485,7 +4485,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                             // but we want to be able to gather in-page footnotes by only
                                             // specifying a -cr-hint: to the footnote target, with no need
                                             // to set one to the link itself
-                                        lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
@@ -4520,7 +4520,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
                                     if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                        lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
@@ -6308,7 +6308,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // See if dir= attribute or CSS specified direction
     int direction = flow->getDirection();
     if ( enode->hasAttribute( attr_dir ) ) {
-        lString16 dir = enode->getAttributeValue( attr_dir );
+        lString32 dir = enode->getAttributeValue( attr_dir );
         dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
         if ( dir.compare("rtl") == 0 ) {
             direction = REND_DIRECTION_RTL;
@@ -6338,7 +6338,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     if ( enode->hasAttribute( attr_lang ) && !enode->getAttributeValue( attr_lang ).empty() ) {
         // We'll probably have to check it is a valid lang specification
         // before overriding the upper one.
-        //   lString16 lang = enode->getAttributeValue( attr_lang );
+        //   lString32 lang = enode->getAttributeValue( attr_lang );
         //   LangManager->check(lang)...
         // In here, we don't care about the language, we just need to
         // know if this node specifies one, so children final blocks
@@ -6348,7 +6348,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // See if this block is a footnote container, so we can deal with it accordingly
     bool isFootNoteBody = false;
-    lString16 footnoteId;
+    lString32 footnoteId;
     // Allow displaying footnote content at the bottom of all pages that contain a link
     // to it, when -cr-hint: footnote-inpage is set on the footnote block container.
     if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) &&
@@ -7078,7 +7078,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     // Get marker width and height
                     LFormattedTextRef txform( enode->getDocument()->createFormattedText() );
                     int list_marker_width;
-                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, 0);
+                    lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, 0);
                     list_marker_height = txform->Format( (lUInt16)(width - list_marker_width), (lUInt16)enode->getDocument()->getPageHeight(), direction );
                     if ( ! renderAsListStylePositionInside(style, is_rtl) ) {
                         // When list_style_position = outside, we have to shift the whole block
@@ -7168,7 +7168,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     if ( child->isText() ) {
                         // We may occasionally let empty text nodes among block elements,
                         // just skip them
-                        lString16 s = child->getText();
+                        lString32 s = child->getText();
                         if ( IsEmptySpace(s.c_str(), s.length() ) )
                             continue;
                         crFatalError(144, "Attempting to render non-empty Text node");
@@ -7214,7 +7214,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                     0, width - list_marker_padding - padding_left - padding_right, 0, 0, direction );
                         flow->addFloat(child, child_clear, is_right, flt_vertical_margin);
                         // Gather footnotes links accumulated by alt_context
-                        lString16Collection * link_ids = alt_context.getLinkIds();
+                        lString32Collection * link_ids = alt_context.getLinkIds();
                         if (link_ids->length() > 0) {
                             for ( int n=0; n<link_ids->length(); n++ ) {
                                 flow->getPageContext()->addLink( link_ids->at(n) );
@@ -7386,7 +7386,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     if ( ! renderAsListStylePositionInside(style, is_rtl) ) {
                         // When list_style_position = outside, we have to shift the final block
                         // to the right (or to the left if RTL) and reduce its width
-                        lString16 marker = renderListItemMarker( enode, list_marker_padding, NULL, -1, 0 );
+                        lString32 marker = renderListItemMarker( enode, list_marker_padding, NULL, -1, 0 );
                         // With css_lsp_outside, the marker is outside: it shifts x left and reduces width
                         width -= list_marker_padding;
                         fmt.setWidth( width );
@@ -7663,7 +7663,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                             // but we want to be able to gather in-page footnotes by only
                                             // specifying a -cr-hint: to the footnote target, with no need
                                             // to set one to the link itself
-                                        lString16 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
                                         if ( href.length()>0 && href.at(0)=='#' ) {
                                             href.erase(0,1);
                                             flow->getPageContext()->addLink( href, link_insert_pos );
@@ -8241,7 +8241,7 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
     // (The provided width and height gives the area we have to draw the background image on)
     css_style_ref_t style=enode->getStyle();
     if (!style->background_image.empty()) {
-        lString16 filepath = lString16(style->background_image.c_str());
+        lString32 filepath = lString32(style->background_image.c_str());
         LVImageSourceRef img = enode->getParentNode()->getDocument()->getObjectImageSource(filepath);
         if (!img.isNull()) {
             // Native image size
@@ -8665,7 +8665,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     // If RTL, have the marker aligned to the right inside list_marker_width
                     lUInt32 txt_flags = is_rtl ? LTEXT_ALIGN_RIGHT : 0;
                     int list_marker_width;
-                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
+                    lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
                     lUInt32 h = txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
@@ -8836,7 +8836,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                     // If RTL, have the marker aligned to the right inside list_marker_width
                     lUInt32 txt_flags = is_rtl ? LTEXT_ALIGN_RIGHT : 0;
                     int list_marker_width;
-                    lString16 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
+                    lString32 marker = renderListItemMarker( enode, list_marker_width, txform.get(), -1, txt_flags);
                     lUInt32 h = txform->Format( (lUInt16)list_marker_width, (lUInt16)page_height, direction );
                     lvRect clip;
                     drawbuf.GetClipRect( &clip );
@@ -9090,9 +9090,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // apply node style= attribute
     //////////////////////////////////////////////////////
     if ( doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasAttribute( LXML_NS_ANY, attr_style ) ) {
-        lString16 nodeStyle = enode->getAttributeValue( LXML_NS_ANY, attr_style );
+        lString32 nodeStyle = enode->getAttributeValue( LXML_NS_ANY, attr_style );
         if ( !nodeStyle.empty() ) {
-            nodeStyle = cs16("{") + nodeStyle + "}";
+            nodeStyle = cs32("{") + nodeStyle + "}";
             LVCssDeclaration decl;
             lString8 s8 = UnicodeToUtf8(nodeStyle);
             const char * s = s8.c_str();
@@ -9577,7 +9577,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     if ( pstyle->pseudo_elem_before_style ) {
         if ( pstyle->pseudo_elem_before_style->display != css_d_none
                 && pstyle->pseudo_elem_before_style->content.length() > 0
-                && pstyle->pseudo_elem_before_style->content[0] != L'X' ) {
+                && pstyle->pseudo_elem_before_style->content[0] != U'X' ) {
             // Not "display: none" and with "content:" different than "none":
             // this pseudo element can be generated
             requires_pseudo_element_before = true;
@@ -9588,7 +9588,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     if ( pstyle->pseudo_elem_after_style ) {
         if ( pstyle->pseudo_elem_after_style->display != css_d_none
                 && pstyle->pseudo_elem_after_style->content.length() > 0
-                && pstyle->pseudo_elem_after_style->content[0] != L'X' ) {
+                && pstyle->pseudo_elem_after_style->content[0] != U'X' ) {
             // Not "display: none" and with "content:" different than "none":
             // this pseudo element can be generated
             requires_pseudo_element_after = true;
@@ -9677,7 +9677,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             lang_cfg = TextLangMan::getTextLangCfg( node ); // Fetch it from node or its parents
         }
         else if ( node->hasAttribute( attr_lang ) ) {
-            lString16 lang_tag = node->getAttributeValue( attr_lang );
+            lString32 lang_tag = node->getAttributeValue( attr_lang );
             if ( !lang_tag.empty() )
                 lang_cfg = TextLangMan::getTextLangCfg( lang_tag );
         }
@@ -9831,7 +9831,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         bool list_marker_width_as_padding = false;
         if ( style->display == css_d_list_item_block ) {
             LFormattedTextRef txform( node->getDocument()->createFormattedText() );
-            lString16 marker = renderListItemMarker( node, list_marker_width, txform.get(), -1, 0);
+            lString32 marker = renderListItemMarker( node, list_marker_width, txform.get(), -1, 0);
             #ifdef DEBUG_GETRENDEREDWIDTHS
                 printf("GRW: list_marker_width: %d\n", list_marker_width);
             #endif
@@ -10296,7 +10296,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             minWidth = _minWidth;
     }
     else { // text or pseudoElem
-        lString16 text;
+        lString32 text;
         int start = 0;
         int len = 0;
         ldomNode * parent;
@@ -10363,7 +10363,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         #define fit_glyphs true
 
         // measure text
-        const lChar16 * txt = text.c_str();
+        const lChar32 * txt = text.c_str();
         #ifdef DEBUG_GETRENDEREDWIDTHS
             printf("GRW text: |%s|\n", UnicodeToLocal(text).c_str());
             printf("GRW text:  (dumb text size=%d)\n", font->getTextWidth(txt, len));
@@ -10406,8 +10406,8 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 if ( (flags[i] & LCHAR_IS_SPACE) && (space_width_scale_percent != 100) ) {
                     w = w * space_width_scale_percent / 100;
                 }
-                lChar16 c = *(txt + start + i);
-                lChar16 next_c = *(txt + start + i + 1); // might be 0 at end of string
+                lChar32 c = *(txt + start + i);
+                lChar32 next_c = *(txt + start + i + 1); // might be 0 at end of string
                 if ( lang_cfg->hasLBCharSubFunc() ) {
                     next_c = lang_cfg->getLBCharSubFunc()(&lbCtx, txt+start, i+1, len-1 - (i+1));
                 }
@@ -10430,7 +10430,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                         if (fit_glyphs && curWordWidth > 0) { // there was a word before this space
                             if (start+i > 0) {
                                 // adjust for last word's last char overflow (italic, letter f...)
-                                lChar16 prevc = *(txt + start + i - 1);
+                                lChar32 prevc = *(txt + start + i - 1);
                                 int right_overflow = - font->getRightSideBearing(prevc, true);
                                 curWordWidth += right_overflow;
                             }
@@ -10446,7 +10446,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                         if (fit_glyphs && curWordWidth > 0) { // there was a word or CJK char before this CJK char
                             if (start+i > 0) {
                                 // adjust for last word's last char or previous CJK char right overflow
-                                lChar16 prevc = *(txt + start + i - 1);
+                                lChar32 prevc = *(txt + start + i - 1);
                                 int right_overflow = - font->getRightSideBearing(prevc, true);
                                 curWordWidth += right_overflow;
                             }
@@ -10468,7 +10468,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     if (fit_glyphs && curWordWidth > 0) { // we end with a word
                         if (start+i > 0) {
                             // adjust for last word's last char or previous CJK char right overflow
-                            lChar16 prevc = *(txt + start + i - 1);
+                            lChar32 prevc = *(txt + start + i - 1);
                             int right_overflow = - font->getRightSideBearing(prevc, true);
                             curWordWidth += right_overflow;
                             curMaxWidth += right_overflow;
@@ -10519,7 +10519,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             (void)nowrap; // avoid clang warning: value stored is never read
             for (int i=0; i<chars_measured; i++) {
                 int w = widths[i] - (i>0 ? widths[i-1] : 0);
-                lChar16 c = *(txt + start + i);
+                lChar32 c = *(txt + start + i);
                 if ( (flags[i] & LCHAR_IS_SPACE) && (space_width_scale_percent != 100) ) {
                     w = w * space_width_scale_percent / 100;
                 }
@@ -10542,7 +10542,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     if (fit_glyphs && curWordWidth > 0) { // there was a word before this space
                         if (start+i > 0) {
                             // adjust for last word's last char overflow (italic, letter f...)
-                            lChar16 prevc = *(txt + start + i - 1);
+                            lChar32 prevc = *(txt + start + i - 1);
                             int right_overflow = - font->getRightSideBearing(prevc, true);
                             curWordWidth += right_overflow;
                         }
@@ -10558,7 +10558,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     if (fit_glyphs && curWordWidth > 0) { // there was a word or CJK char before this CJK char
                         if (start+i > 0) {
                             // adjust for last word's last char or previous CJK char right overflow
-                            lChar16 prevc = *(txt + start + i - 1);
+                            lChar32 prevc = *(txt + start + i - 1);
                             int right_overflow = - font->getRightSideBearing(prevc, true);
                             curWordWidth += right_overflow;
                         }
@@ -10602,7 +10602,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 if (fit_glyphs && curWordWidth > 0) { // we end with a word
                     if (start+len > 0) {
                         // adjust for word last char right overflow
-                        lChar16 prevc = *(txt + start + len - 1);
+                        lChar32 prevc = *(txt + start + len - 1);
                         int right_overflow = - font->getRightSideBearing(prevc, true);
                         curWordWidth += right_overflow;
                         curMaxWidth += right_overflow; // also add it to max width

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7158,8 +7158,15 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
                 // Enter footnote body only after padding, to get rid of it
                 // and have lean in-page footnotes
-                if ( isFootNoteBody )
+                if ( isFootNoteBody ) {
+                    // If no padding were added, add an explicite 0-padding so that
+                    // any accumulated vertical margin is pushed here, and not
+                    // part of the footnote
+                    if (padding_top==0) {
+                        flow->addContentLine(0, RN_SPLIT_AFTER_AVOID, 0, true);
+                    }
                     flow->getPageContext()->enterFootNote( footnoteId );
+                }
 
                 // recurse all sub-blocks for blocks
                 int cnt = enode->getChildCount();
@@ -7591,8 +7598,15 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
                 // Enter footnote body after padding, to get rid of it
                 // and have lean in-page footnotes
-                if ( isFootNoteBody )
+                if ( isFootNoteBody ) {
+                    // If no padding were added, add an explicite 0-padding so that
+                    // any accumulated vertical margin is pushed here, and not
+                    // part of the footnote
+                    if (padding_top==0) {
+                        flow->addContentLine(0, RN_SPLIT_AFTER_AVOID, 0, true);
+                    }
                     flow->getPageContext()->enterFootNote( footnoteId );
+                }
 
                 // We have lines of text in 'txform', that we should register
                 // into flow/context for later page splitting.

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -81,16 +81,16 @@ void LVSetAssetContainerFactory(LVAssetContainerFactory * asset) {
 	_assetContainerFactory = asset;
 }
 
-lString16 LVExtractAssetPath(lString16 fn) {
+lString32 LVExtractAssetPath(lString32 fn) {
 	if (fn.length() < 2 || fn[0] != ASSET_PATH_PREFIX)
-		return lString16();
+		return lString32();
 	if (fn[1] == '/' || fn[1] == '\\')
 		return fn.substr(2);
 	return fn.substr(1);
 }
 
 // LVStorageObject stubs
-const lChar16 * LVStorageObject::GetName()
+const lChar32 * LVStorageObject::GetName()
 {
     return NULL;
 }
@@ -100,7 +100,7 @@ LVContainer * LVStorageObject::GetParentContainer()
     return NULL;
 }
 
-void LVStorageObject::SetName(const lChar16 *)
+void LVStorageObject::SetName(const lChar32 *)
 {
 }
 
@@ -138,23 +138,23 @@ lverror_t LVNamedStream::getcrc32( lUInt32 & dst )
     }
 }
 /// returns stream/container name, may be NULL if unknown
-const lChar16 * LVNamedStream::GetName()
+const lChar32 * LVNamedStream::GetName()
 {
     if (m_fname.empty())
         return NULL;
     return m_fname.c_str();
 }
 /// sets stream/container name, may be not implemented for some objects
-void LVNamedStream::SetName(const lChar16 * name)
+void LVNamedStream::SetName(const lChar32 * name)
 {
     m_fname = name;
     m_filename.clear();
     m_path.clear();
     if (m_fname.empty())
         return;
-    const lChar16 * fn = m_fname.c_str();
+    const lChar32 * fn = m_fname.c_str();
 
-    const lChar16 * p = fn + m_fname.length() - 1;
+    const lChar32 * p = fn + m_fname.length() - 1;
     for ( ;p>fn; p--) {
         if (p[-1] == '/' || p[-1]=='\\')
             break;
@@ -565,7 +565,7 @@ public:
         return (m_pos >= m_size);
     }
 
-    static LVFileMappedStream * CreateFileStream( lString16 fname, lvopen_mode_t mode, int minSize )
+    static LVFileMappedStream * CreateFileStream( lString32 fname, lvopen_mode_t mode, int minSize )
     {
         LVFileMappedStream * f = new LVFileMappedStream();
         if ( f->OpenFile( fname, mode, minSize )==LVERR_OK ) {
@@ -699,7 +699,7 @@ public:
         return LVERR_OK;
     }
 
-    lverror_t OpenFile( lString16 fname, lvopen_mode_t mode, lvsize_t minSize = (lvsize_t)-1 )
+    lverror_t OpenFile( lString32 fname, lvopen_mode_t mode, lvsize_t minSize = (lvsize_t)-1 )
     {
         m_mode = mode;
         if ( mode!=LVOM_READ && mode!=LVOM_APPEND )
@@ -840,7 +840,7 @@ public:
 */
 LVStreamRef LVMapFileStream( const lChar8 * pathname, lvopen_mode_t mode, lvsize_t minSize )
 {
-	lString16 fn = LocalToUnicode( lString8(pathname) );
+	lString32 fn = LocalToUnicode( lString8(pathname) );
 	return LVMapFileStream( fn.c_str(), mode, minSize );
 }
 
@@ -929,7 +929,7 @@ public:
     {
         return feof(m_file)!=0;
     }
-    static LVFileStream * CreateFileStream( lString16 fname, lvopen_mode_t mode )
+    static LVFileStream * CreateFileStream( lString32 fname, lvopen_mode_t mode )
     {
         LVFileStream * f = new LVFileStream;
         if (f->OpenFile( fname, mode )==LVERR_OK) {
@@ -939,7 +939,7 @@ public:
             return NULL;
         }
     }
-    lverror_t OpenFile( lString16 fname, lvopen_mode_t mode )
+    lverror_t OpenFile( lString32 fname, lvopen_mode_t mode )
     {
         m_mode = mode;
         m_file = NULL;
@@ -1242,7 +1242,7 @@ public:
         SetName(NULL);
         return LVERR_OK;
     }
-    static LVFileStream * CreateFileStream( lString16 fname, lvopen_mode_t mode )
+    static LVFileStream * CreateFileStream( lString32 fname, lvopen_mode_t mode )
     {
         LVFileStream * f = new LVFileStream;
         if (f->OpenFile( fname, mode )==LVERR_OK) {
@@ -1252,7 +1252,7 @@ public:
             return NULL;
         }
     }
-    lverror_t OpenFile( lString16 fname, int mode )
+    lverror_t OpenFile( lString32 fname, int mode )
     {
         mode = mode & LVOM_MASK;
 #if defined(_WIN32)
@@ -1359,7 +1359,7 @@ public:
 #endif
 
 /// tries to split full path name into archive name and file name inside archive using separator "@/" or "@\"
-bool LVSplitArcName( lString16 fullPathName, lString16 & arcPathName, lString16 & arcItemPathName )
+bool LVSplitArcName( lString32 fullPathName, lString32 & arcPathName, lString32 & arcItemPathName )
 {
     int p = fullPathName.pos("@/");
     if ( p<0 )
@@ -1385,13 +1385,13 @@ bool LVSplitArcName( lString8 fullPathName, lString8 & arcPathName, lString8 & a
 }
 
 // facility functions
-LVStreamRef LVOpenFileStream( const lChar16 * pathname, int mode )
+LVStreamRef LVOpenFileStream( const lChar32 * pathname, int mode )
 {
-    lString16 fn(pathname);
+    lString32 fn(pathname);
     if (fn.length() > 1 && fn[0] == ASSET_PATH_PREFIX) {
     	if (!_assetContainerFactory || mode != LVOM_READ)
     		return LVStreamRef();
-    	lString16 assetPath = LVExtractAssetPath(fn);
+    	lString32 assetPath = LVExtractAssetPath(fn);
     	return _assetContainerFactory->openAssetStream(assetPath);
     }
 #if 0
@@ -1416,7 +1416,7 @@ LVStreamRef LVOpenFileStream( const lChar16 * pathname, int mode )
 
 LVStreamRef LVOpenFileStream( const lChar8 * pathname, int mode )
 {
-    lString16 fn = Utf8ToUnicode(lString8(pathname));
+    lString32 fn = Utf8ToUnicode(lString8(pathname));
     return LVOpenFileStream( fn.c_str(), mode );
 }
 
@@ -1477,7 +1477,7 @@ class LVDirectoryContainer : public LVNamedContainer
 protected:
     LVDirectoryContainer * m_parent;
 public:
-    virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t mode )
+    virtual LVStreamRef OpenStream( const char32_t * fname, lvopen_mode_t mode )
     {
         int found_index = -1;
         for (int i=0; i<m_list.length(); i++) {
@@ -1491,10 +1491,10 @@ public:
             }
         }
         // make filename
-        lString16 fn = m_fname;
+        lString32 fn = m_fname;
         fn << fname;
         //const char * fb8 = UnicodeToUtf8( fn ).c_str();
-        //printf("Opening directory container file %s : %s fname=%s path=%s\n", UnicodeToUtf8( lString16(fname) ).c_str(), UnicodeToUtf8( fn ).c_str(), UnicodeToUtf8( m_fname ).c_str(), UnicodeToUtf8( m_path ).c_str());
+        //printf("Opening directory container file %s : %s fname=%s path=%s\n", UnicodeToUtf8( lString32(fname) ).c_str(), UnicodeToUtf8( fn ).c_str(), UnicodeToUtf8( m_fname ).c_str(), UnicodeToUtf8( m_path ).c_str());
         LVStreamRef stream( LVOpenFileStream( fn.c_str(), mode ) );
         if (!stream) {
             return stream;
@@ -1538,7 +1538,7 @@ public:
         SetName(NULL);
         Clear();
     }
-    static LVDirectoryContainer * OpenDirectory( const wchar_t * path, const wchar_t * mask = L"*.*" )
+    static LVDirectoryContainer * OpenDirectory( const char32_t * path, const char32_t * mask = U"*.*" )
     {
         if (!path || !path[0])
             return NULL;
@@ -1548,8 +1548,8 @@ public:
         LVDirectoryContainer * dir = new LVDirectoryContainer;
 
         // make filename
-        lString16 fn( path );
-        lChar16 lastch = 0;
+        lString32 fn( path );
+        lChar32 lastch = 0;
         if ( !fn.empty() )
             lastch = fn[fn.length()-1];
         if ( lastch!='\\' && lastch!='/' )
@@ -1593,7 +1593,7 @@ public:
 
                 if ( (dwAttrs & FILE_ATTRIBUTE_DIRECTORY) ) {
                     // directory
-                    if (!lStr_cmp(pfn, L"..") || !lStr_cmp(pfn, L".")) {
+                    if (!lStr_cmp(pfn, U"..") || !lStr_cmp(pfn, U".")) {
                         // .. or .
                     } else {
                         // normal directory
@@ -1658,7 +1658,7 @@ public:
         FindClose( hFind );
 #else
         // POSIX
-        lString16 p( fn );
+        lString32 p( fn );
         p.erase( p.length()-1, 1 );
         lString8 p8 = UnicodeToLocal( p );
         if ( p8.empty() )
@@ -2220,7 +2220,7 @@ private:
             {
                 //check CRC
                 if ( m_CRC != m_originalCRC ) {
-                    CRLog::error("ZIP stream '%s': CRC doesn't match", LCSTR(lString16(GetName())) );
+                    CRLog::error("ZIP stream '%s': CRC doesn't match", LCSTR(lString32(GetName())) );
                     return -1; // CRC error
                 }
             }
@@ -2446,7 +2446,7 @@ public:
     {
         return LVERR_NOTIMPL;
     }
-    static LVStream * Create( LVStreamRef stream, lvpos_t pos, lString16 name, lUInt32 srcPackSize, lUInt32 srcUnpSize )
+    static LVStream * Create( LVStreamRef stream, lvpos_t pos, lString32 name, lUInt32 srcPackSize, lUInt32 srcUnpSize )
     {
         ZipLocalFileHdr hdr;
         unsigned hdr_size = 0x1E; //sizeof(hdr);
@@ -2501,7 +2501,7 @@ public:
     bool usedAltReadingMethod() { return m_alt_reading_method; }
     void useAltReadingMethod() { m_alt_reading_method = true; }
 
-    virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t /*mode*/ )
+    virtual LVStreamRef OpenStream( const char32_t * fname, lvopen_mode_t /*mode*/ )
     {
         if ( fname[0]=='/' )
             fname++;
@@ -2519,7 +2519,7 @@ public:
         if (found_index<0)
             return LVStreamRef(); // not found
         // make filename
-        lString16 fn = fname;
+        lString32 fn = fname;
         LVStreamRef strm = m_stream; // fix strange arm-linux-g++ bug
         LVStreamRef stream(
 		LVZipDecodeStream::Create(
@@ -2717,7 +2717,7 @@ public:
             NextPosition += SeekLen;
             m_stream->Seek(NextPosition, LVSEEK_SET, NULL);
 
-            lString16 fName;
+            lString32 fName;
             if (ZipHeader.PackVer >= 63 && (ZipHeader.Flags & 0x0800) == 0x0800) {
                 // Language encoding flag (EFS).  If this bit is set,
                 // the filename and comment fields for this file
@@ -2734,9 +2734,9 @@ public:
                     //  "Win32","SMS/QDOS","Acorn RISC OS","Win32 VFAT","MVS",
                     //  "BeOS","Tandem"};
                     // TODO: try to detect proper charset using 0x0008 Extra Field (InfoZip APPNOTE-6.3.5, Appendix D.4).
-                    const lChar16 * enc_name = (ZipHeader.PackOS==0) ? L"cp866" : L"cp1251";
+                    const lChar32 * enc_name = (ZipHeader.PackOS==0) ? U"cp866" : U"cp1251";
                     //CRLog::trace("detected encoding %s", LCSTR(enc_name));
-                    const lChar16 * table = GetCharsetByte2UnicodeTable( enc_name );
+                    const lChar32 * table = GetCharsetByte2UnicodeTable( enc_name );
                     fName = ByteToUnicode( lString8(fnbuf), table );
                 }
             }
@@ -2797,7 +2797,7 @@ class LVRarArc : public LVArcContainerBase
 {
 public:
 
-    virtual LVStreamRef OpenStream( const wchar_t * fname, lvopen_mode_t mode )
+    virtual LVStreamRef OpenStream( const char32_t * fname, lvopen_mode_t mode )
     {
         int found_index = -1;
         for (int i=0; i<m_list.length(); i++) {
@@ -2817,7 +2817,7 @@ public:
         return LVStreamRef(); // not found
 /*
         // make filename
-        lString16 fn = fname;
+        lString32 fn = fname;
         LVStreamRef strm = m_stream; // fix strange arm-linux-g++ bug
         LVStreamRef stream(
 		LVZipDecodeStream::Create(
@@ -3158,7 +3158,7 @@ LVStreamRef LVCreateStringStream( lString8 data )
 }
 
 /// Creates memory stream as copy of string contents
-LVStreamRef LVCreateStringStream( lString16 data )
+LVStreamRef LVCreateStringStream( lString32 data )
 {
     return LVCreateStringStream( UnicodeToUtf8( data ) );
 }
@@ -3186,7 +3186,7 @@ LVStreamRef LVCreateMemoryStream( LVStreamRef srcStream )
 }
 
 /// Creates memory stream as copy of file contents.
-LVStreamRef LVCreateMemoryStream( lString16 filename )
+LVStreamRef LVCreateMemoryStream( lString32 filename )
 {
     LVStreamRef fs = LVOpenFileStream( filename.c_str(), LVOM_READ );
     if ( fs.isNull() )
@@ -3234,28 +3234,28 @@ bool LVDirectoryIsEmpty(const lString8& path) {
     return LVDirectoryIsEmpty(Utf8ToUnicode(path));
 }
 
-bool LVDirectoryIsEmpty(const lString16& path) {
+bool LVDirectoryIsEmpty(const lString32& path) {
     LVContainerRef dir = LVOpenDirectory(path);
     if (dir.isNull())
         return false;
     return dir->GetObjectCount() == 0;
 }
 
-LVContainerRef LVOpenDirectory(const lString16& path, const wchar_t * mask) {
+LVContainerRef LVOpenDirectory(const lString32& path, const char32_t * mask) {
 	return LVOpenDirectory(path.c_str(), mask);
 }
 
-LVContainerRef LVOpenDirectory(const lString8& path, const wchar_t * mask) {
+LVContainerRef LVOpenDirectory(const lString8& path, const char32_t * mask) {
 	return LVOpenDirectory(Utf8ToUnicode(path).c_str(), mask);
 }
 
-LVContainerRef LVOpenDirectory( const wchar_t * path, const wchar_t * mask )
+LVContainerRef LVOpenDirectory( const char32_t * path, const char32_t * mask )
 {
-	lString16 pathname(path);
+	lString32 pathname(path);
     if (pathname.length() > 1 && pathname[0] == ASSET_PATH_PREFIX) {
     	if (!_assetContainerFactory)
     		return LVContainerRef();
-    	lString16 assetPath = LVExtractAssetPath(pathname);
+    	lString32 assetPath = LVExtractAssetPath(pathname);
     	return _assetContainerFactory->openAssetContainer(assetPath);
     }
     LVContainerRef dir(LVDirectoryContainer::OpenDirectory(path, mask));
@@ -3600,7 +3600,7 @@ lString8 LVExtractPath( lString8 pathName, bool appendEmptyPath) {
 }
 
 /// returns path part of pathname (appended with / or \ delimiter)
-lString16 LVExtractPath( lString16 pathName, bool appendEmptyPath )
+lString32 LVExtractPath( lString32 pathName, bool appendEmptyPath )
 {
     int last_delim_pos = -1;
     for ( int i=0; i<pathName.length(); i++ )
@@ -3608,9 +3608,9 @@ lString16 LVExtractPath( lString16 pathName, bool appendEmptyPath )
             last_delim_pos = i;
     if ( last_delim_pos==-1 )
 #ifdef _LINUX
-        return lString16(appendEmptyPath ? L"./" : L"");
+        return lString32(appendEmptyPath ? U"./" : U"");
 #else
-        return lString16(appendEmptyPath ? L".\\" : L"");
+        return lString32(appendEmptyPath ? U".\\" : U"");
 #endif
     return pathName.substr( 0, last_delim_pos+1 );
 }
@@ -3621,7 +3621,7 @@ lString8 LVExtractFilename( lString8 pathName ) {
 }
 
 /// returns filename part of pathname
-lString16 LVExtractFilename( lString16 pathName )
+lString32 LVExtractFilename( lString32 pathName )
 {
     int last_delim_pos = -1;
     for ( int i=0; i<pathName.length(); i++ )
@@ -3633,9 +3633,9 @@ lString16 LVExtractFilename( lString16 pathName )
 }
 
 /// returns filename part of pathname without extension
-lString16 LVExtractFilenameWithoutExtension( lString16 pathName )
+lString32 LVExtractFilenameWithoutExtension( lString32 pathName )
 {
-    lString16 s = LVExtractFilename( pathName );
+    lString32 s = LVExtractFilename( pathName );
     int lastDot = -1;
     for ( int i=0; i<s.length(); i++ )
         if ( s[i]=='.' )
@@ -3646,11 +3646,11 @@ lString16 LVExtractFilenameWithoutExtension( lString16 pathName )
 }
 
 /// returns true if absolute path is specified
-bool LVIsAbsolutePath( lString16 pathName )
+bool LVIsAbsolutePath( lString32 pathName )
 {
     if ( pathName.empty() )
         return false;
-    lChar16 c = pathName[0];
+    lChar32 c = pathName[0];
     if ( c=='\\' || c=='/' )
         return true;
 #ifdef _WIN32
@@ -3662,10 +3662,10 @@ bool LVIsAbsolutePath( lString16 pathName )
 }
 
 /// removes first path part from pathname and returns it
-lString16 LVExtractFirstPathElement( lString16 & pathName )
+lString32 LVExtractFirstPathElement( lString32 & pathName )
 {
     if ( pathName.empty() )
-        return lString16::empty_str;
+        return lString32::empty_str;
     if ( pathName[0]=='/' || pathName[0]=='\\' )
         pathName.erase(0, 1);
     int first_delim_pos = -1;
@@ -3675,21 +3675,21 @@ lString16 LVExtractFirstPathElement( lString16 & pathName )
             break;
         }
     if ( first_delim_pos==-1 ) {
-        lString16 res = pathName;
+        lString32 res = pathName;
         pathName.clear();
         return res;
     }
-    lString16 res = pathName.substr(0, first_delim_pos );
+    lString32 res = pathName.substr(0, first_delim_pos );
     pathName.erase(0, first_delim_pos+1 );
     return res;
 }
 
 /// appends path delimiter character to end of path, if absent
-void LVAppendPathDelimiter( lString16 & pathName )
+void LVAppendPathDelimiter( lString32 & pathName )
 {
     if ( pathName.empty() || (pathName.length() == 1 && pathName[0] == ASSET_PATH_PREFIX))
         return;
-    lChar16 delim = LVDetectPathDelimiter( pathName );
+    lChar32 delim = LVDetectPathDelimiter( pathName );
     if ( pathName[pathName.length()-1]!=delim )
         pathName << delim;
 }
@@ -3705,7 +3705,7 @@ void LVAppendPathDelimiter( lString8 & pathName )
 }
 
 /// removes path delimiter from end of path, if present
-void LVRemoveLastPathDelimiter( lString16 & pathName ) {
+void LVRemoveLastPathDelimiter( lString32 & pathName ) {
     if (pathName.empty() || (pathName.length() == 1 && pathName[0] == ASSET_PATH_PREFIX))
         return;
     if (pathName.endsWith("/") || pathName.endsWith("\\"))
@@ -3722,20 +3722,20 @@ void LVRemoveLastPathDelimiter( lString8 & pathName )
 }
 
 /// replaces any found / or \\ separator with specified one
-void LVReplacePathSeparator( lString16 & pathName, lChar16 separator )
+void LVReplacePathSeparator( lString32 & pathName, lChar32 separator )
 {
-    lChar16 * buf = pathName.modify();
+    lChar32 * buf = pathName.modify();
     for ( ; *buf; buf++ )
         if ( *buf=='/' || *buf=='\\' )
             *buf = separator;
 }
 
 // resolve relative links
-lString16 LVCombinePaths( lString16 basePath, lString16 newPath )
+lString32 LVCombinePaths( lString32 basePath, lString32 newPath )
 {
     if ( newPath[0]=='/' || newPath[0]=='\\' || (newPath.length()>0 && newPath[1]==':' && newPath[2]=='\\') )
         return newPath; // absolute path
-    lChar16 separator = 0;
+    lChar32 separator = 0;
     if (!basePath.empty())
         LVAppendPathDelimiter(basePath);
     for ( int i=0; i<basePath.length(); i++ ) {
@@ -3753,12 +3753,12 @@ lString16 LVCombinePaths( lString16 basePath, lString16 newPath )
         }
     if ( separator == 0 )
         separator = '/';
-    lString16 s = basePath;
+    lString32 s = basePath;
     LVAppendPathDelimiter( s );
     s += newPath;
     //LVAppendPathDelimiter( s );
     LVReplacePathSeparator( s, separator );
-    lString16 pattern;
+    lString32 pattern;
     pattern << separator << ".." << separator;
     bool changed;
     do {
@@ -3783,7 +3783,7 @@ lString16 LVCombinePaths( lString16 basePath, lString16 newPath )
     // Replace "/./" inside with "/"
     pattern.clear();
     pattern << separator << "." << separator;
-    lString16 replacement;
+    lString32 replacement;
     replacement << separator;
     while ( s.replace( pattern, replacement ) ) ;
     // Remove "./" at start
@@ -3794,11 +3794,11 @@ lString16 LVCombinePaths( lString16 basePath, lString16 newPath )
 
 
 /// removes last path part from pathname and returns it
-lString16 LVExtractLastPathElement( lString16 & pathName )
+lString32 LVExtractLastPathElement( lString32 & pathName )
 {
     int l = pathName.length();
     if ( l==0 )
-        return lString16::empty_str;
+        return lString32::empty_str;
     if ( pathName[l-1]=='/' || pathName[l-1]=='\\' )
         pathName.erase(l-1, 1);
     int last_delim_pos = -1;
@@ -3806,17 +3806,17 @@ lString16 LVExtractLastPathElement( lString16 & pathName )
         if ( pathName[i]=='/' || pathName[i]=='\\' )
             last_delim_pos = i;
     if ( last_delim_pos==-1 ) {
-        lString16 res = pathName;
+        lString32 res = pathName;
         pathName.clear();
         return res;
     }
-    lString16 res = pathName.substr( last_delim_pos + 1, pathName.length()-last_delim_pos-1 );
+    lString32 res = pathName.substr( last_delim_pos + 1, pathName.length()-last_delim_pos-1 );
     pathName.erase( last_delim_pos, pathName.length()-last_delim_pos );
     return res;
 }
 
 /// returns path delimiter character
-lChar16 LVDetectPathDelimiter( lString16 pathName )
+lChar32 LVDetectPathDelimiter( lString32 pathName )
 {
     for ( int i=0; i<pathName.length(); i++ )
         if ( pathName[i]=='/' || pathName[i]=='\\' )
@@ -3841,16 +3841,16 @@ char LVDetectPathDelimiter( lString8 pathName ) {
 }
 
 /// returns full path to file identified by pathName, with base directory == basePath
-lString16 LVMakeRelativeFilename( lString16 basePath, lString16 pathName )
+lString32 LVMakeRelativeFilename( lString32 basePath, lString32 pathName )
 {
     if ( LVIsAbsolutePath( pathName ) )
         return pathName;
-    lChar16 delim = LVDetectPathDelimiter( basePath );
-    lString16 path = LVExtractPath( basePath );
-    lString16 name = LVExtractFilename( pathName );
-    lString16 dstpath = LVExtractPath( pathName );
+    lChar32 delim = LVDetectPathDelimiter( basePath );
+    lString32 path = LVExtractPath( basePath );
+    lString32 name = LVExtractFilename( pathName );
+    lString32 dstpath = LVExtractPath( pathName );
     while ( !dstpath.empty() ) {
-        lString16 element = LVExtractFirstPathElement( dstpath );
+        lString32 element = LVExtractFirstPathElement( dstpath );
         if (element == ".") {
             // do nothing
         } else if (element == "..")
@@ -3864,7 +3864,7 @@ lString16 LVMakeRelativeFilename( lString16 basePath, lString16 pathName )
 }
 
 /// removes path delimiter character from end of path, if exists
-void LVRemovePathDelimiter( lString16 & pathName )
+void LVRemovePathDelimiter( lString32 & pathName )
 {
     int len = pathName.length();
     if ( len>0 && pathName != "/" && pathName != "\\" && !pathName.endsWith(":\\") && !pathName.endsWith("\\\\")) {
@@ -3889,13 +3889,13 @@ bool LVFileExists( const lString8 & pathName ) {
 }
 
 /// returns true if specified file exists
-bool LVFileExists( const lString16 & pathName )
+bool LVFileExists( const lString32 & pathName )
 {
-    lString16 fn(pathName);
+    lString32 fn(pathName);
     if (fn.length() > 1 && fn[0] == ASSET_PATH_PREFIX) {
     	if (!_assetContainerFactory)
     		return false;
-    	lString16 assetPath = LVExtractAssetPath(fn);
+    	lString32 assetPath = LVExtractAssetPath(fn);
     	return !_assetContainerFactory->openAssetStream(assetPath).isNull();
     }
 #ifdef _WIN32
@@ -3912,8 +3912,8 @@ bool LVFileExists( const lString16 & pathName )
 }
 
 /// returns true if directory exists and your app can write to directory
-bool LVDirectoryIsWritable(const lString16 & pathName) {
-    lString16 fn = pathName;
+bool LVDirectoryIsWritable(const lString32 & pathName) {
+    lString32 fn = pathName;
     LVAppendPathDelimiter(fn);
     fn << ".cr3_directory_write_test";
     bool res = false;
@@ -3934,13 +3934,13 @@ bool LVDirectoryIsWritable(const lString16 & pathName) {
 }
 
 /// returns true if specified directory exists
-bool LVDirectoryExists( const lString16 & pathName )
+bool LVDirectoryExists( const lString32 & pathName )
 {
-    lString16 fn(pathName);
+    lString32 fn(pathName);
     if (fn.length() > 1 && fn[0] == ASSET_PATH_PREFIX) {
     	if (!_assetContainerFactory)
     		return false;
-    	lString16 assetPath = LVExtractAssetPath(fn);
+    	lString32 assetPath = LVExtractAssetPath(fn);
     	return !_assetContainerFactory->openAssetContainer(assetPath).isNull();
     }
     LVContainerRef dir = LVOpenDirectory( pathName.c_str() );
@@ -3950,11 +3950,11 @@ bool LVDirectoryExists( const lString16 & pathName )
 /// returns true if specified directory exists
 bool LVDirectoryExists( const lString8 & pathName )
 {
-    lString16 fn(Utf8ToUnicode(pathName));
+    lString32 fn(Utf8ToUnicode(pathName));
     if (fn.length() > 1 && fn[0] == ASSET_PATH_PREFIX) {
     	if (!_assetContainerFactory)
     		return false;
-    	lString16 assetPath = LVExtractAssetPath(fn);
+    	lString32 assetPath = LVExtractAssetPath(fn);
     	return !_assetContainerFactory->openAssetContainer(assetPath).isNull();
     }
     LVContainerRef dir = LVOpenDirectory(fn);
@@ -3962,7 +3962,7 @@ bool LVDirectoryExists( const lString8 & pathName )
 }
 
 /// Create directory if not exist
-bool LVCreateDirectory( lString16 path )
+bool LVCreateDirectory( lString32 path )
 {
     CRLog::trace("LVCreateDirectory(%s)", UnicodeToUtf8(path).c_str() );
     //LVRemovePathDelimiter(path);
@@ -3976,7 +3976,7 @@ bool LVCreateDirectory( lString16 path )
     if ( dir.isNull() ) {
         CRLog::trace("Directory %s not found", UnicodeToUtf8(path).c_str());
         LVRemovePathDelimiter(path);
-        lString16 basedir = LVExtractPath( path );
+        lString32 basedir = LVExtractPath( path );
         CRLog::trace("Checking base directory %s", UnicodeToUtf8(basedir).c_str());
         if ( !LVCreateDirectory( basedir ) ) {
             CRLog::error("Failed to create directory %s", UnicodeToUtf8(basedir).c_str());
@@ -4006,7 +4006,7 @@ bool LVCreateDirectory( lString16 path )
         \param minSize is minimum file size for R/W mode
     \return reference to opened stream if success, NULL if error
 */
-LVStreamRef LVMapFileStream( const lChar16 * pathname, lvopen_mode_t mode, lvsize_t minSize )
+LVStreamRef LVMapFileStream( const lChar32 * pathname, lvopen_mode_t mode, lvsize_t minSize )
 {
 #if !defined(_WIN32) && !defined(_LINUX)
         // STUB for systems w/o mmap
@@ -4017,13 +4017,13 @@ LVStreamRef LVMapFileStream( const lChar16 * pathname, lvopen_mode_t mode, lvsiz
     }
     return LVStreamRef();
 #else
-        LVFileMappedStream * stream = LVFileMappedStream::CreateFileStream( lString16(pathname), mode, (int)minSize );
+        LVFileMappedStream * stream = LVFileMappedStream::CreateFileStream( lString32(pathname), mode, (int)minSize );
         return LVStreamRef(stream);
 #endif
 }
 
 /// delete file, return true if file found and successfully deleted
-bool LVDeleteFile( lString16 filename )
+bool LVDeleteFile( lString32 filename )
 {
 #ifdef _WIN32
     return DeleteFileW( filename.c_str() ) ? true : false;
@@ -4035,7 +4035,7 @@ bool LVDeleteFile( lString16 filename )
 }
 
 /// rename file
-bool LVRenameFile(lString16 oldname, lString16 newname) {
+bool LVRenameFile(lString32 oldname, lString32 newname) {
     return LVRenameFile(UnicodeToUtf8(oldname), UnicodeToUtf8(newname));
 }
 
@@ -4060,7 +4060,7 @@ bool LVDeleteFile( lString8 filename ) {
 }
 
 /// delete directory, return true if directory is found and successfully deleted
-bool LVDeleteDirectory( lString16 filename ) {
+bool LVDeleteDirectory( lString32 filename ) {
 #ifdef _WIN32
     return RemoveDirectoryW( filename.c_str() ) ? true : false;
 #else
@@ -4350,7 +4350,7 @@ public:
         Flush( true ); // NOLINT: Call to virtual function during destruction
     }
 
-    virtual const lChar16 * GetName()
+    virtual const lChar32 * GetName()
             { return _baseStream->GetName(); }
     virtual lvopen_mode_t GetMode()
             { return _baseStream->GetMode(); }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -50,9 +50,9 @@ static lChar8 empty_str_8[] = {0};
 static lstring8_chunk_t empty_chunk_8(empty_str_8);
 lstring8_chunk_t * lString8::EMPTY_STR_8 = &empty_chunk_8;
 
-static lChar16 empty_str_16[] = {0};
-static lstring16_chunk_t empty_chunk_16(empty_str_16);
-lstring16_chunk_t * lString16::EMPTY_STR_16 = &empty_chunk_16;
+static lChar32 empty_str_32[] = {0};
+static lstring32_chunk_t empty_chunk_32(empty_str_32);
+lstring32_chunk_t * lString32::EMPTY_STR_32 = &empty_chunk_32;
 
 //================================================================================
 // atomic string storages for string literals
@@ -87,58 +87,58 @@ const lString8 & cs8(const char * str) {
     return lString8::empty_str;
 }
 
-static const void * const_ptrs_16[CONST_STRING_BUFFER_SIZE] = {NULL};
-static lString16 values_16[CONST_STRING_BUFFER_SIZE];
-static int size_16 = 0;
+static const void * const_ptrs_32[CONST_STRING_BUFFER_SIZE] = {NULL};
+static lString32 values_32[CONST_STRING_BUFFER_SIZE];
+static int size_32 = 0;
 
-/// get reference to atomic constant wide string for string literal e.g. cs16("abc") -- fast and memory effective
-const lString16 & cs16(const char * str) {
+/// get reference to atomic constant wide string for string literal e.g. cs32("abc") -- fast and memory effective
+const lString32 & cs32(const char * str) {
     int index =  (int)(((ptrdiff_t)str * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK);
     for (;;) {
-        const void * p = const_ptrs_16[index];
+        const void * p = const_ptrs_32[index];
         if (p == str) {
-            return values_16[index];
+            return values_32[index];
         } else if (p == NULL) {
 #if DEBUG_STATIC_STRING_ALLOC == 1
-            CRLog::trace("allocating static string16 %s", str);
+            CRLog::trace("allocating static string32 %s", str);
 #endif
-            const_ptrs_16[index] = str;
-            size_16++;
-            values_16[index] = lString16(str);
-            values_16[index].addref();
-            return values_16[index];
+            const_ptrs_32[index] = str;
+            size_32++;
+            values_32[index] = lString32(str);
+            values_32[index].addref();
+            return values_32[index];
         }
-        if (size_16 > CONST_STRING_BUFFER_SIZE / 4) {
+        if (size_32 > CONST_STRING_BUFFER_SIZE / 4) {
             crFatalError(-1, "out of memory for const string8");
         }
         index = (index + 1) & CONST_STRING_BUFFER_MASK;
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
-/// get reference to atomic constant wide string for string literal e.g. cs16(L"abc") -- fast and memory effective
-const lString16 & cs16(const lChar16 * str) {
+/// get reference to atomic constant wide string for string literal e.g. cs32(U"abc") -- fast and memory effective
+const lString32 & cs32(const lChar32 * str) {
     int index = (((int)((ptrdiff_t)str)) * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK;
     for (;;) {
-        const void * p = const_ptrs_16[index];
+        const void * p = const_ptrs_32[index];
         if (p == str) {
-            return values_16[index];
+            return values_32[index];
         } else if (p == NULL) {
 #if DEBUG_STATIC_STRING_ALLOC == 1
-            CRLog::trace("allocating static string16 %s", LCSTR(str));
+            CRLog::trace("allocating static string32 %s", LCSTR(str));
 #endif
-            const_ptrs_16[index] = str;
-            size_16++;
-            values_16[index] = lString16(str);
-            values_16[index].addref();
-            return values_16[index];
+            const_ptrs_32[index] = str;
+            size_32++;
+            values_32[index] = lString32(str);
+            values_32[index].addref();
+            return values_32[index];
         }
-        if (size_16 > CONST_STRING_BUFFER_SIZE / 4) {
+        if (size_32 > CONST_STRING_BUFFER_SIZE / 4) {
             crFatalError(-1, "out of memory for const string8");
         }
         index = (index + 1) & CONST_STRING_BUFFER_MASK;
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 
@@ -173,10 +173,10 @@ struct lstring_chunk_slice_t {
         pFree = (lstring8_chunk_t *)res->buf8;
         return res;
     }
-    inline lstring16_chunk_t * alloc_chunk16()
+    inline lstring32_chunk_t * alloc_chunk32()
     {
-        lstring16_chunk_t * res = (lstring16_chunk_t *)pFree;
-        pFree = (lstring8_chunk_t *)res->buf16;
+        lstring32_chunk_t * res = (lstring32_chunk_t *)pFree;
+        pFree = (lstring8_chunk_t *)res->buf32;
         return res;
     }
     inline bool free_chunk( lstring8_chunk_t * pChunk )
@@ -196,7 +196,7 @@ struct lstring_chunk_slice_t {
         pFree = pChunk;
         return true;
     }
-    inline bool free_chunk16(lstring16_chunk_t * pChunk)
+    inline bool free_chunk32(lstring32_chunk_t * pChunk)
     {
         if ((lstring8_chunk_t *)pChunk < pChunks || (lstring8_chunk_t *)pChunk >= pEnd)
             return false; // chunk does not belong to this slice
@@ -209,7 +209,7 @@ struct lstring_chunk_slice_t {
         pChunk->size = 0;
 #endif
 */
-        pChunk->buf16 = (lChar16 *)pFree;
+        pChunk->buf32 = (lChar32 *)pFree;
         pFree = (lstring8_chunk_t *)pChunk;
         return true;
     }
@@ -271,7 +271,7 @@ void lstring8_chunk_t::free( lstring8_chunk_t * pChunk )
     crFatalError(); // wrong pointer!!!
 }
 
-lstring16_chunk_t * lstring16_chunk_t::alloc()
+lstring32_chunk_t * lstring32_chunk_t::alloc()
 {
     if (!slices_initialized)
         init_ls_storage();
@@ -279,21 +279,21 @@ lstring16_chunk_t * lstring16_chunk_t::alloc()
     for (int i=slices_count-1; i>=0; --i)
     {
         if (slices[i]->pFree != NULL)
-            return slices[i]->alloc_chunk16();
+            return slices[i]->alloc_chunk32();
     }
     // alloc new slice
     if (slices_count >= MAX_SLICE_COUNT)
         crFatalError();
     lstring_chunk_slice_t * new_slice = new lstring_chunk_slice_t( FIRST_SLICE_SIZE << (slices_count+1) );
     slices[slices_count++] = new_slice;
-    return slices[slices_count-1]->alloc_chunk16();
+    return slices[slices_count-1]->alloc_chunk32();
 }
 
-void lstring16_chunk_t::free( lstring16_chunk_t * pChunk )
+void lstring32_chunk_t::free( lstring32_chunk_t * pChunk )
 {
     for (int i=slices_count-1; i>=0; --i)
     {
-        if (slices[i]->free_chunk16(pChunk))
+        if (slices[i]->free_chunk32(pChunk))
             return;
     }
     crFatalError(); // wrong pointer!!!
@@ -304,7 +304,7 @@ void lstring16_chunk_t::free( lstring16_chunk_t * pChunk )
 // Utility functions
 ////////////////////////////////////////////////////////////////////////////
 
-inline int _lStr_len(const lChar16 * str)
+inline int _lStr_len(const lChar32 * str)
 {
     int len;
     for (len=0; *str; str++)
@@ -320,7 +320,7 @@ inline int _lStr_len(const lChar8 * str)
     return len;
 }
 
-inline int _lStr_nlen(const lChar16 * str, int maxcount)
+inline int _lStr_nlen(const lChar32 * str, int maxcount)
 {
     int len;
     for (len=0; len<maxcount && *str; str++)
@@ -336,7 +336,7 @@ inline int _lStr_nlen(const lChar8 * str, int maxcount)
     return len;
 }
 
-inline int _lStr_cpy(lChar16 * dst, const lChar16 * src)
+inline int _lStr_cpy(lChar32 * dst, const lChar32 * src)
 {
     int count;
     for ( count=0; (*dst++ = *src++); count++ )
@@ -352,7 +352,7 @@ inline int _lStr_cpy(lChar8 * dst, const lChar8 * src)
     return count;
 }
 
-inline int _lStr_cpy(lChar16 * dst, const lChar8 * src)
+inline int _lStr_cpy(lChar32 * dst, const lChar8 * src)
 {
     int count;
     for ( count=0; (*dst++ = *src++); count++ )
@@ -360,7 +360,7 @@ inline int _lStr_cpy(lChar16 * dst, const lChar8 * src)
     return count;
 }
 
-inline int _lStr_cpy(lChar8 * dst, const lChar16 * src)
+inline int _lStr_cpy(lChar8 * dst, const lChar32 * src)
 {
     int count;
     for ( count=0; (*dst++ = (lChar8)*src++); count++ )
@@ -368,7 +368,7 @@ inline int _lStr_cpy(lChar8 * dst, const lChar16 * src)
     return count;
 }
 
-inline int _lStr_ncpy(lChar16 * dst, const lChar16 * src, int maxcount)
+inline int _lStr_ncpy(lChar32 * dst, const lChar32 * src, int maxcount)
 {
     int count = 0;
     do
@@ -382,7 +382,7 @@ inline int _lStr_ncpy(lChar16 * dst, const lChar16 * src, int maxcount)
     return count;
 }
 
-inline int _lStr_ncpy(lChar16 * dst, const lChar8 * src, int maxcount)
+inline int _lStr_ncpy(lChar32 * dst, const lChar8 * src, int maxcount)
 {
     int count = 0;
     do
@@ -410,7 +410,7 @@ inline int _lStr_ncpy(lChar8 * dst, const lChar8 * src, int maxcount)
     return count;
 }
 
-inline void _lStr_memcpy(lChar16 * dst, const lChar16 * src, int count)
+inline void _lStr_memcpy(lChar32 * dst, const lChar32 * src, int count)
 {
     while ( count-- > 0)
         (*dst++ = *src++);
@@ -421,7 +421,7 @@ inline void _lStr_memcpy(lChar8 * dst, const lChar8 * src, int count)
     memcpy(dst, (const lChar8 *) src, count);
 }
 
-inline void _lStr_memset(lChar16 * dst, lChar16 value, int count)
+inline void _lStr_memset(lChar32 * dst, lChar32 value, int count)
 {
     while ( count-- > 0)
         *dst++ = value;
@@ -432,7 +432,7 @@ inline void _lStr_memset(lChar8 * dst, lChar8 value, int count)
     memset(dst, (lChar8) value, count);
 }
 
-int lStr_len(const lChar16 * str)
+int lStr_len(const lChar32 * str)
 {
     return _lStr_len(str);
 }
@@ -442,7 +442,7 @@ int lStr_len(const lChar8 * str)
     return _lStr_len(str);
 }
 
-int lStr_nlen(const lChar16 * str, int maxcount)
+int lStr_nlen(const lChar32 * str, int maxcount)
 {
     return _lStr_nlen(str, maxcount);
 }
@@ -452,7 +452,7 @@ int lStr_nlen(const lChar8 * str, int maxcount)
     return _lStr_nlen(str, maxcount);
 }
 
-int lStr_cpy(lChar16 * dst, const lChar16 * src)
+int lStr_cpy(lChar32 * dst, const lChar32 * src)
 {
     return _lStr_cpy(dst, src);
 }
@@ -462,12 +462,12 @@ int lStr_cpy(lChar8 * dst, const lChar8 * src)
     return _lStr_cpy(dst, src);
 }
 
-int lStr_cpy(lChar16 * dst, const lChar8 * src)
+int lStr_cpy(lChar32 * dst, const lChar8 * src)
 {
     return _lStr_cpy(dst, src);
 }
 
-int lStr_ncpy(lChar16 * dst, const lChar16 * src, int maxcount)
+int lStr_ncpy(lChar32 * dst, const lChar32 * src, int maxcount)
 {
     return _lStr_ncpy(dst, src, maxcount);
 }
@@ -477,7 +477,7 @@ int lStr_ncpy(lChar8 * dst, const lChar8 * src, int maxcount)
     return _lStr_ncpy(dst, src, maxcount);
 }
 
-void lStr_memcpy(lChar16 * dst, const lChar16 * src, int count)
+void lStr_memcpy(lChar32 * dst, const lChar32 * src, int count)
 {
     _lStr_memcpy(dst, src, count);
 }
@@ -487,7 +487,7 @@ void lStr_memcpy(lChar8 * dst, const lChar8 * src, int count)
     _lStr_memcpy(dst, src, count);
 }
 
-void lStr_memset(lChar16 * dst, lChar16 value, int count)
+void lStr_memset(lChar32 * dst, lChar32 value, int count)
 {
     _lStr_memset(dst, value, count);
 }
@@ -497,7 +497,7 @@ void lStr_memset(lChar8 * dst, lChar8 value, int count)
     _lStr_memset(dst, value, count);
 }
 
-int lStr_cmp(const lChar16 * dst, const lChar16 * src)
+int lStr_cmp(const lChar32 * dst, const lChar32 * src)
 {
     while ( *dst == *src)
     {
@@ -527,50 +527,50 @@ int lStr_cmp(const lChar8 * dst, const lChar8 * src)
         return -1;
 }
 
-int lStr_cmp(const lChar16 * dst, const lChar8 * src)
+int lStr_cmp(const lChar32 * dst, const lChar8 * src)
 {
-    while ( *dst == (lChar16)*src)
+    while ( *dst == (lChar32)*src)
     {
         if (! *dst )
             return 0;
         ++dst;
         ++src;
     }
-    if ( *dst > (lChar16)*src )
+    if ( *dst > (lChar32)*src )
         return 1;
     else
         return -1;
 }
 
-int lStr_cmp(const lChar8 * dst, const lChar16 * src)
+int lStr_cmp(const lChar8 * dst, const lChar32 * src)
 {
-    while ( (lChar16)*dst == *src)
+    while ( (lChar32)*dst == *src)
     {
         if (! *dst )
             return 0;
         ++dst;
         ++src;
     }
-    if ( (lChar16)*dst > *src )
+    if ( (lChar32)*dst > *src )
         return 1;
     else
         return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////
-// lString16
+// lString32
 ////////////////////////////////////////////////////////////////////////////
 
-void lString16::free()
+void lString32::free()
 {
-    if ( pchunk==EMPTY_STR_16 )
+    if ( pchunk==EMPTY_STR_32 )
         return;
-    //assert(pchunk->buf16[pchunk->len]==0);
-    ::free(pchunk->buf16);
+    //assert(pchunk->buf32[pchunk->len]==0);
+    ::free(pchunk->buf32);
 #if (LDOM_USE_OWN_MEM_MAN == 1)
     for (int i=slices_count-1; i>=0; --i)
     {
-        if (slices[i]->free_chunk16(pchunk))
+        if (slices[i]->free_chunk32(pchunk))
             return;
     }
     crFatalError(); // wrong pointer!!!
@@ -579,94 +579,94 @@ void lString16::free()
 #endif
 }
 
-void lString16::alloc(int sz)
+void lString32::alloc(int sz)
 {
 #if (LDOM_USE_OWN_MEM_MAN == 1)
     pchunk = lstring_chunk_t::alloc();
 #else
     pchunk = (lstring_chunk_t*)::malloc(sizeof(lstring_chunk_t));
 #endif
-    pchunk->buf16 = (lChar16*) ::malloc( sizeof(lChar16) * (sz+1) );
-    assert( pchunk->buf16!=NULL );
+    pchunk->buf32 = (lChar32*) ::malloc( sizeof(lChar32) * (sz+1) );
+    assert( pchunk->buf32!=NULL );
     pchunk->size = sz;
     pchunk->nref = 1;
 }
 
-lString16::lString16(const lChar16 * str)
+lString32::lString32(const lChar32 * str)
 {
     if (!str || !(*str))
     {
-        pchunk = EMPTY_STR_16;
+        pchunk = EMPTY_STR_32;
         addref();
         return;
     }
     size_type len = _lStr_len(str);
     alloc( len );
     pchunk->len = len;
-    _lStr_cpy( pchunk->buf16, str );
+    _lStr_cpy( pchunk->buf32, str );
 }
 
-lString16::lString16(const lChar8 * str)
+lString32::lString32(const lChar8 * str)
 {
     if (!str || !(*str))
     {
-        pchunk = EMPTY_STR_16;
+        pchunk = EMPTY_STR_32;
         addref();
         return;
     }
-    pchunk = EMPTY_STR_16;
+    pchunk = EMPTY_STR_32;
     addref();
 	*this = Utf8ToUnicode( str );
 }
 
 /// constructor from utf8 character array fragment
-lString16::lString16(const lChar8 * str, size_type count)
+lString32::lString32(const lChar8 * str, size_type count)
 {
     if (!str || !(*str))
     {
-        pchunk = EMPTY_STR_16;
+        pchunk = EMPTY_STR_32;
         addref();
         return;
     }
-    pchunk = EMPTY_STR_16;
+    pchunk = EMPTY_STR_32;
     addref();
 	*this = Utf8ToUnicode( str, count );
 }
 
 
-lString16::lString16(const value_type * str, size_type count)
+lString32::lString32(const value_type * str, size_type count)
 {
     if ( !str || !(*str) || count<=0 )
     {
-        pchunk = EMPTY_STR_16; addref();
+        pchunk = EMPTY_STR_32; addref();
     }
     else
     {
         size_type len = _lStr_nlen(str, count);
         alloc(len);
-        _lStr_ncpy( pchunk->buf16, str, len );
+        _lStr_ncpy( pchunk->buf32, str, len );
         pchunk->len = len;
     }
 }
 
-lString16::lString16(const lString16 & str, size_type offset, size_type count)
+lString32::lString32(const lString32 & str, size_type offset, size_type count)
 {
     if ( count > str.length() - offset )
         count = str.length() - offset;
     if (count<=0)
     {
-        pchunk = EMPTY_STR_16; addref();
+        pchunk = EMPTY_STR_32; addref();
     }
     else
     {
         alloc(count);
-        _lStr_memcpy( pchunk->buf16, str.pchunk->buf16+offset, count );
-        pchunk->buf16[count]=0;
+        _lStr_memcpy( pchunk->buf32, str.pchunk->buf32+offset, count );
+        pchunk->buf32[count]=0;
         pchunk->len = count;
     }
 }
 
-lString16 & lString16::assign(const lChar16 * str)
+lString32 & lString32::assign(const lChar32 * str)
 {
     if (!str || !(*str))
     {
@@ -680,7 +680,7 @@ lString16 & lString16::assign(const lChar16 * str)
             if (pchunk->size<=len)
             {
                 // resize is necessary
-                pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(len+1) );
+                pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
                 pchunk->size = len+1;
             }
         }
@@ -689,13 +689,13 @@ lString16 & lString16::assign(const lChar16 * str)
             release();
             alloc(len);
         }
-        _lStr_cpy( pchunk->buf16, str );
+        _lStr_cpy( pchunk->buf32, str );
         pchunk->len = len;
     }
     return *this;
 }
 
-lString16 & lString16::assign(const lChar8 * str)
+lString32 & lString32::assign(const lChar8 * str)
 {
     if (!str || !(*str))
     {
@@ -709,7 +709,7 @@ lString16 & lString16::assign(const lChar8 * str)
             if (pchunk->size<=len)
             {
                 // resize is necessary
-                pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(len+1) );
+                pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
                 pchunk->size = len+1;
             }
         }
@@ -718,13 +718,13 @@ lString16 & lString16::assign(const lChar8 * str)
             release();
             alloc(len);
         }
-        _lStr_cpy( pchunk->buf16, str );
+        _lStr_cpy( pchunk->buf32, str );
         pchunk->len = len;
     }
     return *this;
 }
 
-lString16 & lString16::assign(const lChar16 * str, size_type count)
+lString32 & lString32::assign(const lChar32 * str, size_type count)
 {
     if ( !str || !(*str) || count<=0 )
     {
@@ -738,7 +738,7 @@ lString16 & lString16::assign(const lChar16 * str, size_type count)
             if (pchunk->size<=len)
             {
                 // resize is necessary
-                pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(len+1) );
+                pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
                 pchunk->size = len+1;
             }
         }
@@ -747,13 +747,13 @@ lString16 & lString16::assign(const lChar16 * str, size_type count)
             release();
             alloc(len);
         }
-        _lStr_ncpy( pchunk->buf16, str, count );
+        _lStr_ncpy( pchunk->buf32, str, count );
         pchunk->len = len;
     }
     return *this;
 }
 
-lString16 & lString16::assign(const lChar8 * str, size_type count)
+lString32 & lString32::assign(const lChar8 * str, size_type count)
 {
     if ( !str || !(*str) || count<=0 )
     {
@@ -767,7 +767,7 @@ lString16 & lString16::assign(const lChar8 * str, size_type count)
             if (pchunk->size<=len)
             {
                 // resize is necessary
-                pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(len+1) );
+                pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
                 pchunk->size = len+1;
             }
         }
@@ -776,13 +776,13 @@ lString16 & lString16::assign(const lChar8 * str, size_type count)
             release();
             alloc(len);
         }
-        _lStr_ncpy( pchunk->buf16, str, count );
+        _lStr_ncpy( pchunk->buf32, str, count );
         pchunk->len = len;
     }
     return *this;
 }
 
-lString16 & lString16::assign(const lString16 & str, size_type offset, size_type count)
+lString32 & lString32::assign(const lString32 & str, size_type offset, size_type count)
 {
     if ( count > str.length() - offset )
         count = str.length() - offset;
@@ -801,9 +801,9 @@ lString16 & lString16::assign(const lString16 & str, size_type offset, size_type
             }
             if (offset>0)
             {
-                _lStr_memcpy( pchunk->buf16, str.pchunk->buf16+offset, count );
+                _lStr_memcpy( pchunk->buf32, str.pchunk->buf32+offset, count );
             }
-            pchunk->buf16[count]=0;
+            pchunk->buf32[count]=0;
         }
         else
         {
@@ -812,7 +812,7 @@ lString16 & lString16::assign(const lString16 & str, size_type offset, size_type
                 if (pchunk->size<=count)
                 {
                     // resize is necessary
-                    pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(count+1) );
+                    pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(count+1) );
                     pchunk->size = count+1;
                 }
             }
@@ -821,15 +821,15 @@ lString16 & lString16::assign(const lString16 & str, size_type offset, size_type
                 release();
                 alloc(count);
             }
-            _lStr_memcpy( pchunk->buf16, str.pchunk->buf16+offset, count );
-            pchunk->buf16[count]=0;
+            _lStr_memcpy( pchunk->buf32, str.pchunk->buf32+offset, count );
+            pchunk->buf32[count]=0;
         }
         pchunk->len = count;
     }
     return *this;
 }
 
-lString16 & lString16::erase(size_type offset, size_type count)
+lString32 & lString32::erase(size_type offset, size_type count)
 {
     if ( count > length() - offset )
         count = length() - offset;
@@ -842,29 +842,29 @@ lString16 & lString16::erase(size_type offset, size_type count)
         size_type newlen = length()-count;
         if (pchunk->nref==1)
         {
-            _lStr_memcpy( pchunk->buf16+offset, pchunk->buf16+offset+count, newlen-offset+1 );
+            _lStr_memcpy( pchunk->buf32+offset, pchunk->buf32+offset+count, newlen-offset+1 );
         }
         else
         {
             lstring_chunk_t * poldchunk = pchunk;
             release();
             alloc( newlen );
-            _lStr_memcpy( pchunk->buf16, poldchunk->buf16, offset );
-            _lStr_memcpy( pchunk->buf16+offset, poldchunk->buf16+offset+count, newlen-offset+1 );
+            _lStr_memcpy( pchunk->buf32, poldchunk->buf32, offset );
+            _lStr_memcpy( pchunk->buf32+offset, poldchunk->buf32+offset+count, newlen-offset+1 );
         }
         pchunk->len = newlen;
-        pchunk->buf16[newlen]=0;
+        pchunk->buf32[newlen]=0;
     }
     return *this;
 }
 
-void lString16::reserve(size_type n)
+void lString32::reserve(size_type n)
 {
     if (pchunk->nref==1)
     {
         if (pchunk->size < n)
         {
-            pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(n+1) );
+            pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(n+1) );
             pchunk->size = n;
         }
     }
@@ -873,12 +873,12 @@ void lString16::reserve(size_type n)
         lstring_chunk_t * poldchunk = pchunk;
         release();
         alloc( n );
-        _lStr_memcpy( pchunk->buf16, poldchunk->buf16, poldchunk->len+1 );
+        _lStr_memcpy( pchunk->buf32, poldchunk->buf32, poldchunk->len+1 );
         pchunk->len = poldchunk->len;
     }
 }
 
-void lString16::lock( size_type newsize )
+void lString32::lock( size_type newsize )
 {
     if (pchunk->nref>1)
     {
@@ -888,141 +888,141 @@ void lString16::lock( size_type newsize )
         size_type len = newsize;
         if (len>poldchunk->len)
             len = poldchunk->len;
-        _lStr_memcpy( pchunk->buf16, poldchunk->buf16, len );
-        pchunk->buf16[len]=0;
+        _lStr_memcpy( pchunk->buf32, poldchunk->buf32, len );
+        pchunk->buf32[len]=0;
         pchunk->len = len;
     }
 }
 
 // lock string, allocate buffer and reset length to 0
-void lString16::reset( size_type size )
+void lString32::reset( size_type size )
 {
     if (pchunk->nref>1 || pchunk->size<size)
     {
         release();
         alloc( size );
     }
-    pchunk->buf16[0] = 0;
+    pchunk->buf32[0] = 0;
     pchunk->len = 0;
 }
 
-void lString16::resize(size_type n, lChar16 e)
+void lString32::resize(size_type n, lChar32 e)
 {
     lock( n );
     if (n>=pchunk->size)
     {
-        pchunk->buf16 = (lChar16*) ::realloc( pchunk->buf16, sizeof(lChar16)*(n+1) );
+        pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(n+1) );
         pchunk->size = n;
     }
     // fill with data if expanded
     for (size_type i=pchunk->len; i<n; i++)
-        pchunk->buf16[i] = e;
-    pchunk->buf16[pchunk->len] = 0;
+        pchunk->buf32[i] = e;
+    pchunk->buf32[pchunk->len] = 0;
 }
 
-lString16 & lString16::append(const lChar16 * str)
+lString32 & lString32::append(const lChar32 * str)
 {
     size_type len = _lStr_len(str);
     reserve( pchunk->len+len );
-    _lStr_memcpy(pchunk->buf16+pchunk->len, str, len+1);
+    _lStr_memcpy(pchunk->buf32+pchunk->len, str, len+1);
     pchunk->len += len;
     return *this;
 }
 
-lString16 & lString16::append(const lChar16 * str, size_type count)
+lString32 & lString32::append(const lChar32 * str, size_type count)
 {
     reserve(pchunk->len + count);
-    _lStr_ncpy(pchunk->buf16 + pchunk->len, str, count);
+    _lStr_ncpy(pchunk->buf32 + pchunk->len, str, count);
     pchunk->len += count;
     return *this;
 }
 
-lString16 & lString16::append(const lChar8 * str)
+lString32 & lString32::append(const lChar8 * str)
 {
     size_type len = _lStr_len(str);
     reserve( pchunk->len+len );
-    _lStr_ncpy(pchunk->buf16+pchunk->len, str, len+1);
+    _lStr_ncpy(pchunk->buf32+pchunk->len, str, len+1);
     pchunk->len += len;
     return *this;
 }
 
-lString16 & lString16::append(const lChar8 * str, size_type count)
+lString32 & lString32::append(const lChar8 * str, size_type count)
 {
     reserve(pchunk->len + count);
-    _lStr_ncpy(pchunk->buf16+pchunk->len, str, count);
+    _lStr_ncpy(pchunk->buf32+pchunk->len, str, count);
     pchunk->len += count;
     return *this;
 }
 
-lString16 & lString16::append(const lString16 & str)
+lString32 & lString32::append(const lString32 & str)
 {
     size_type len2 = pchunk->len + str.pchunk->len;
     reserve( len2 );
-    _lStr_memcpy( pchunk->buf16+pchunk->len, str.pchunk->buf16, str.pchunk->len+1 );
+    _lStr_memcpy( pchunk->buf32+pchunk->len, str.pchunk->buf32, str.pchunk->len+1 );
     pchunk->len = len2;
     return *this;
 }
 
-lString16 & lString16::append(const lString16 & str, size_type offset, size_type count)
+lString32 & lString32::append(const lString32 & str, size_type offset, size_type count)
 {
     if ( str.pchunk->len>offset )
     {
         if ( offset + count > str.pchunk->len )
             count = str.pchunk->len - offset;
         reserve( pchunk->len+count );
-        _lStr_ncpy(pchunk->buf16 + pchunk->len, str.pchunk->buf16 + offset, count);
+        _lStr_ncpy(pchunk->buf32 + pchunk->len, str.pchunk->buf32 + offset, count);
         pchunk->len += count;
-        pchunk->buf16[pchunk->len] = 0;
+        pchunk->buf32[pchunk->len] = 0;
     }
     return *this;
 }
 
-lString16 & lString16::append(size_type count, lChar16 ch)
+lString32 & lString32::append(size_type count, lChar32 ch)
 {
     reserve( pchunk->len+count );
-    _lStr_memset(pchunk->buf16+pchunk->len, ch, count);
+    _lStr_memset(pchunk->buf32+pchunk->len, ch, count);
     pchunk->len += count;
-    pchunk->buf16[pchunk->len] = 0;
+    pchunk->buf32[pchunk->len] = 0;
     return *this;
 }
 
-lString16 & lString16::insert(size_type p0, size_type count, lChar16 ch)
+lString32 & lString32::insert(size_type p0, size_type count, lChar32 ch)
 {
     if (p0>pchunk->len)
         p0 = pchunk->len;
     reserve( pchunk->len+count );
     for (size_type i=pchunk->len+count; i>p0; i--)
-        pchunk->buf16[i] = pchunk->buf16[i-1];
-    _lStr_memset(pchunk->buf16+p0, ch, count);
+        pchunk->buf32[i] = pchunk->buf32[i-1];
+    _lStr_memset(pchunk->buf32+p0, ch, count);
     pchunk->len += count;
-    pchunk->buf16[pchunk->len] = 0;
+    pchunk->buf32[pchunk->len] = 0;
     return *this;
 }
 
-lString16 & lString16::insert(size_type p0, const lString16 & str)
+lString32 & lString32::insert(size_type p0, const lString32 & str)
 {
     if (p0>pchunk->len)
         p0 = pchunk->len;
     int count = str.length();
     reserve( pchunk->len+count );
     for (size_type i=pchunk->len+count; i>p0; i--)
-        pchunk->buf16[i] = pchunk->buf16[i-1];
-    _lStr_memcpy(pchunk->buf16 + p0, str.c_str(), count);
+        pchunk->buf32[i] = pchunk->buf32[i-1];
+    _lStr_memcpy(pchunk->buf32 + p0, str.c_str(), count);
     pchunk->len += count;
-    pchunk->buf16[pchunk->len] = 0;
+    pchunk->buf32[pchunk->len] = 0;
     return *this;
 }
 
-lString16 lString16::substr(size_type pos, size_type n) const
+lString32 lString32::substr(size_type pos, size_type n) const
 {
     if (pos>=length())
-        return lString16::empty_str;
+        return lString32::empty_str;
     if (pos+n>length())
         n = length() - pos;
-    return lString16( pchunk->buf16+pos, n );
+    return lString32( pchunk->buf32+pos, n );
 }
 
-lString16 & lString16::pack()
+lString32 & lString32::pack()
 {
     if (pchunk->len + 4 < pchunk->size )
     {
@@ -1032,24 +1032,24 @@ lString16 & lString16::pack()
         }
         else
         {
-            pchunk->buf16 = cr_realloc( pchunk->buf16, pchunk->len+1 );
+            pchunk->buf32 = cr_realloc( pchunk->buf32, pchunk->len+1 );
             pchunk->size = pchunk->len;
         }
     }
     return *this;
 }
 
-bool isAlNum(lChar16 ch) {
-    lUInt16 props = lGetCharProps(ch);
+bool isAlNum(lChar32 ch) {
+    lUInt32 props = lGetCharProps(ch);
     return (props & (CH_PROP_ALPHA | CH_PROP_DIGIT)) != 0;
 }
 
 /// trims non alpha at beginning and end of string
-lString16 & lString16::trimNonAlpha()
+lString32 & lString32::trimNonAlpha()
 {
     int firstns;
     for (firstns = 0; firstns<pchunk->len &&
-        !isAlNum(pchunk->buf16[firstns]); ++firstns)
+        !isAlNum(pchunk->buf32[firstns]); ++firstns)
         ;
     if (firstns >= pchunk->len)
     {
@@ -1058,7 +1058,7 @@ lString16 & lString16::trimNonAlpha()
     }
     int lastns;
     for (lastns = pchunk->len-1; lastns>0 &&
-        !isAlNum(pchunk->buf16[lastns]); --lastns)
+        !isAlNum(pchunk->buf32[lastns]); --lastns)
         ;
     int newlen = lastns-firstns+1;
     if (newlen == pchunk->len)
@@ -1066,8 +1066,8 @@ lString16 & lString16::trimNonAlpha()
     if (pchunk->nref == 1)
     {
         if (firstns>0)
-            lStr_memcpy( pchunk->buf16, pchunk->buf16+firstns, newlen );
-        pchunk->buf16[newlen] = 0;
+            lStr_memcpy( pchunk->buf32, pchunk->buf32+firstns, newlen );
+        pchunk->buf32[newlen] = 0;
         pchunk->len = newlen;
     }
     else
@@ -1075,19 +1075,19 @@ lString16 & lString16::trimNonAlpha()
         lstring_chunk_t * poldchunk = pchunk;
         release();
         alloc( newlen );
-        _lStr_memcpy( pchunk->buf16, poldchunk->buf16+firstns, newlen );
-        pchunk->buf16[newlen] = 0;
+        _lStr_memcpy( pchunk->buf32, poldchunk->buf32+firstns, newlen );
+        pchunk->buf32[newlen] = 0;
         pchunk->len = newlen;
     }
     return *this;
 }
 
-lString16 & lString16::trim()
+lString32 & lString32::trim()
 {
     //
     int firstns;
     for (firstns = 0; firstns<pchunk->len &&
-        (pchunk->buf16[firstns]==' ' || pchunk->buf16[firstns]=='\t'); ++firstns)
+        (pchunk->buf32[firstns]==' ' || pchunk->buf32[firstns]=='\t'); ++firstns)
         ;
     if (firstns >= pchunk->len)
     {
@@ -1096,7 +1096,7 @@ lString16 & lString16::trim()
     }
     int lastns;
     for (lastns = pchunk->len-1; lastns>0 &&
-        (pchunk->buf16[lastns]==' ' || pchunk->buf16[lastns]=='\t'); --lastns)
+        (pchunk->buf32[lastns]==' ' || pchunk->buf32[lastns]=='\t'); --lastns)
         ;
     int newlen = lastns-firstns+1;
     if (newlen == pchunk->len)
@@ -1104,8 +1104,8 @@ lString16 & lString16::trim()
     if (pchunk->nref == 1)
     {
         if (firstns>0)
-            lStr_memcpy( pchunk->buf16, pchunk->buf16+firstns, newlen );
-        pchunk->buf16[newlen] = 0;
+            lStr_memcpy( pchunk->buf32, pchunk->buf32+firstns, newlen );
+        pchunk->buf32[newlen] = 0;
         pchunk->len = newlen;
     }
     else
@@ -1113,14 +1113,14 @@ lString16 & lString16::trim()
         lstring_chunk_t * poldchunk = pchunk;
         release();
         alloc( newlen );
-        _lStr_memcpy( pchunk->buf16, poldchunk->buf16+firstns, newlen );
-        pchunk->buf16[newlen] = 0;
+        _lStr_memcpy( pchunk->buf32, poldchunk->buf32+firstns, newlen );
+        pchunk->buf32[newlen] = 0;
         pchunk->len = newlen;
     }
     return *this;
 }
 
-int lString16::atoi() const
+int lString32::atoi() const
 {
     int n = 0;
     atoi(n);
@@ -1147,7 +1147,7 @@ int hexDigit( int c )
 }
 
 // decode LEN hex digits, return decoded number, -1 if invalid
-int decodeHex( const lChar16 * str, int len ) {
+int decodeHex( const lChar32 * str, int len ) {
     int n = 0;
     for ( int i=0; i<len; i++ ) {
         if ( !str[i] )
@@ -1161,7 +1161,7 @@ int decodeHex( const lChar16 * str, int len ) {
 }
 
 // decode LEN decimal digits, return decoded number, -1 if invalid
-int decodeDecimal( const lChar16 * str, int len ) {
+int decodeDecimal( const lChar32 * str, int len ) {
     int n = 0;
     for ( int i=0; i<len; i++ ) {
         if ( !str[i] )
@@ -1174,11 +1174,11 @@ int decodeDecimal( const lChar16 * str, int len ) {
     return n;
 }
 
-bool lString16::atoi( int &n ) const
+bool lString32::atoi( int &n ) const
 {
 	n = 0;
     int sgn = 1;
-    const lChar16 * s = c_str();
+    const lChar32 * s = c_str();
     while (*s == ' ' || *s == '\t')
         s++;
     if ( s[0]=='0' && s[1]=='x') {
@@ -1210,10 +1210,10 @@ bool lString16::atoi( int &n ) const
     return *s=='\0' || *s==' ' || *s=='\t';
 }
 
-bool lString16::atoi( lInt64 &n ) const
+bool lString32::atoi( lInt64 &n ) const
 {
     int sgn = 1;
-    const lChar16 * s = c_str();
+    const lChar32 * s = c_str();
     while (*s == ' ' || *s == '\t')
         s++;
     if (*s == '-')
@@ -1237,17 +1237,17 @@ bool lString16::atoi( lInt64 &n ) const
 }
 
 #define STRING_HASH_MULT 31
-lUInt32 lString16::getHash() const
+lUInt32 lString32::getHash() const
 {
     lUInt32 res = 0;
     for (lInt32 i=0; i<pchunk->len; i++)
-        res = res * STRING_HASH_MULT + pchunk->buf16[i];
+        res = res * STRING_HASH_MULT + pchunk->buf32[i];
     return res;
 }
 
 
 
-void lString16Collection::reserve(int space)
+void lString32Collection::reserve(int space)
 {
     if ( count + space > size )
     {
@@ -1256,40 +1256,40 @@ void lString16Collection::reserve(int space)
     }
 }
 
-static int (str16_comparator)(const void * n1, const void * n2)
+static int (str32_comparator)(const void * n1, const void * n2)
 {
-    lstring16_chunk_t ** s1 = (lstring16_chunk_t **)n1;
-    lstring16_chunk_t ** s2 = (lstring16_chunk_t **)n2;
-    return lStr_cmp( (*s1)->data16(), (*s2)->data16() );
+    lstring32_chunk_t ** s1 = (lstring32_chunk_t **)n1;
+    lstring32_chunk_t ** s2 = (lstring32_chunk_t **)n2;
+    return lStr_cmp( (*s1)->data32(), (*s2)->data32() );
 }
 
-static int(*custom_lstr16_comparator_ptr)(lString16 & s1, lString16 & s2);
-static int (str16_custom_comparator)(const void * n1, const void * n2)
+static int(*custom_lstr32_comparator_ptr)(lString32 & s1, lString32 & s2);
+static int (str32_custom_comparator)(const void * n1, const void * n2)
 {
-    lString16 s1(*((lstring16_chunk_t **)n1));
-    lString16 s2(*((lstring16_chunk_t **)n2));
-    return custom_lstr16_comparator_ptr(s1, s2);
+    lString32 s1(*((lstring32_chunk_t **)n1));
+    lString32 s2(*((lstring32_chunk_t **)n2));
+    return custom_lstr32_comparator_ptr(s1, s2);
 }
 
-void lString16Collection::sort(int(comparator)(lString16 & s1, lString16 & s2))
+void lString32Collection::sort(int(comparator)(lString32 & s1, lString32 & s2))
 {
-    custom_lstr16_comparator_ptr = comparator;
-    qsort(chunks,count,sizeof(lstring16_chunk_t*), str16_custom_comparator);
+    custom_lstr32_comparator_ptr = comparator;
+    qsort(chunks,count,sizeof(lstring32_chunk_t*), str32_custom_comparator);
 }
 
-void lString16Collection::sort()
+void lString32Collection::sort()
 {
-    qsort(chunks,count,sizeof(lstring16_chunk_t*), str16_comparator);
+    qsort(chunks,count,sizeof(lstring32_chunk_t*), str32_comparator);
 }
 
-int lString16Collection::add( const lString16 & str )
+int lString32Collection::add( const lString32 & str )
 {
     reserve( 1 );
     chunks[count] = str.pchunk;
     str.addref();
     return count++;
 }
-int lString16Collection::insert( int pos, const lString16 & str )
+int lString32Collection::insert( int pos, const lString32 & str )
 {
     if (pos<0 || pos>=count)
         return add(str);
@@ -1300,12 +1300,12 @@ int lString16Collection::insert( int pos, const lString16 & str )
     str.addref();
     return count++;
 }
-void lString16Collection::clear()
+void lString32Collection::clear()
 {
     if (chunks) {
         for (int i=0; i<count; i++)
         {
-            ((lString16 *)chunks)[i].release();
+            ((lString32 *)chunks)[i].release();
         }
         free(chunks);
         chunks = NULL;
@@ -1314,7 +1314,7 @@ void lString16Collection::clear()
     size = 0;
 }
 
-void lString16Collection::erase(int offset, int cnt)
+void lString32Collection::erase(int offset, int cnt)
 {
     if (count<=0)
         return;
@@ -1323,7 +1323,7 @@ void lString16Collection::erase(int offset, int cnt)
     int i;
     for (i = offset; i < offset + cnt; i++)
     {
-        ((lString16 *)chunks)[i].release();
+        ((lString32 *)chunks)[i].release();
     }
     for (i = offset + cnt; i < count; i++)
     {
@@ -1347,7 +1347,7 @@ void lString8Collection::split( const lString8 & str, const lString8 & delimiter
     }
 }
 
-void lString16Collection::split( const lString16 & str, const lString16 & delimiter )
+void lString32Collection::split( const lString32 & str, const lString32 & delimiter )
 {
     if (str.empty())
         return;
@@ -1409,7 +1409,7 @@ void lString8Collection::clear()
     size = 0;
 }
 
-lUInt32 calcStringHash( const lChar16 * s )
+lUInt32 calcStringHash( const lChar32 * s )
 {
     lUInt32 a = 2166136261u;
     while (*s)
@@ -1422,7 +1422,7 @@ lUInt32 calcStringHash( const lChar16 * s )
 static const char * str_hash_magic="STRS";
 
 /// serialize to byte array (pointer will be incremented by number of bytes written)
-void lString16HashedCollection::serialize( SerialBuf & buf )
+void lString32HashedCollection::serialize( SerialBuf & buf )
 {
     if ( buf.error() )
         return;
@@ -1493,7 +1493,7 @@ bool SerialBuf::checkCRC( int size )
 }
 
 /// deserialize from byte array (pointer will be incremented by number of bytes read)
-bool lString16HashedCollection::deserialize( SerialBuf & buf )
+bool lString32HashedCollection::deserialize( SerialBuf & buf )
 {
     if ( buf.error() )
         return false;
@@ -1503,7 +1503,7 @@ bool lString16HashedCollection::deserialize( SerialBuf & buf )
     lInt32 count = 0;
     buf >> count;
     for ( int i=0; i<count; i++ ) {
-        lString16 s;
+        lString32 s;
         buf >> s;
         if ( buf.error() )
             break;
@@ -1513,8 +1513,8 @@ bool lString16HashedCollection::deserialize( SerialBuf & buf )
     return !buf.error();
 }
 
-lString16HashedCollection::lString16HashedCollection( lString16HashedCollection & v )
-: lString16Collection( v )
+lString32HashedCollection::lString32HashedCollection( lString32HashedCollection & v )
+: lString32Collection( v )
 , hashSize( v.hashSize )
 , hash( NULL )
 {
@@ -1530,7 +1530,7 @@ lString16HashedCollection::lString16HashedCollection( lString16HashedCollection 
     }
 }
 
-void lString16HashedCollection::addHashItem( int hashIndex, int storageIndex )
+void lString32HashedCollection::addHashItem( int hashIndex, int storageIndex )
 {
     if ( hash[ hashIndex ].index == -1 ) {
         hash[hashIndex].index = storageIndex;
@@ -1542,7 +1542,7 @@ void lString16HashedCollection::addHashItem( int hashIndex, int storageIndex )
     }
 }
 
-void lString16HashedCollection::clearHash()
+void lString32HashedCollection::clearHash()
 {
     if ( hash ) {
         for ( int i=0; i<hashSize; i++) {
@@ -1558,7 +1558,7 @@ void lString16HashedCollection::clearHash()
     hash = NULL;
 }
 
-lString16HashedCollection::lString16HashedCollection( lUInt32 hash_size )
+lString32HashedCollection::lString32HashedCollection( lUInt32 hash_size )
 : hashSize(hash_size), hash(NULL)
 {
 
@@ -1567,12 +1567,12 @@ lString16HashedCollection::lString16HashedCollection( lUInt32 hash_size )
         hash[i].clear();
 }
 
-lString16HashedCollection::~lString16HashedCollection()
+lString32HashedCollection::~lString32HashedCollection()
 {
     clearHash();
 }
 
-int lString16HashedCollection::find( const lChar16 * s )
+int lString32HashedCollection::find( const lChar32 * s )
 {
     if ( !hash || !length() )
         return -1;
@@ -1580,12 +1580,12 @@ int lString16HashedCollection::find( const lChar16 * s )
     lUInt32 n = h % hashSize;
     if ( hash[n].index!=-1 )
     {
-        const lString16 & str = at( hash[n].index );
+        const lString32 & str = at( hash[n].index );
         if ( str == s )
             return hash[n].index;
         HashPair * p = hash[n].next;
         for ( ;p ;p = p->next ) {
-            const lString16 & str = at( p->index );
+            const lString32 & str = at( p->index );
             if ( str==s )
                 return p->index;
         }
@@ -1593,7 +1593,7 @@ int lString16HashedCollection::find( const lChar16 * s )
     return -1;
 }
 
-void lString16HashedCollection::reHash( int newSize )
+void lString32HashedCollection::reHash( int newSize )
 {
     if (hashSize == newSize)
         return;
@@ -1611,7 +1611,7 @@ void lString16HashedCollection::reHash( int newSize )
     }
 }
 
-int lString16HashedCollection::add( const lChar16 * s )
+int lString32HashedCollection::add( const lChar32 * s )
 {
     if ( !hash || hashSize < length()*2 ) {
         int sz = 16;
@@ -1624,22 +1624,22 @@ int lString16HashedCollection::add( const lChar16 * s )
     lUInt32 n = h % hashSize;
     if ( hash[n].index!=-1 )
     {
-        const lString16 & str = at( hash[n].index );
+        const lString32 & str = at( hash[n].index );
         if ( str == s )
             return hash[n].index;
         HashPair * p = hash[n].next;
         for ( ;p ;p = p->next ) {
-            const lString16 & str = at( p->index );
+            const lString32 & str = at( p->index );
             if ( str==s )
                 return p->index;
         }
     }
-    lUInt32 i = lString16Collection::add( lString16(s) );
+    lUInt32 i = lString32Collection::add( lString32(s) );
     addHashItem( n, i );
     return i;
 }
 
-const lString16 lString16::empty_str;
+const lString32 lString32::empty_str;
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -1690,7 +1690,7 @@ lString8::lString8(const lChar8 * str)
     _lStr_cpy( pchunk->buf8, str );
 }
 
-lString8::lString8(const lChar16 * str)
+lString8::lString8(const lChar32 * str)
 {
     if (!str || !(*str))
     {
@@ -1982,9 +1982,9 @@ lString8 & lString8::appendHex(lUInt64 n)
     return *this;
 }
 
-lString16 & lString16::appendDecimal(lInt64 n)
+lString32 & lString32::appendDecimal(lInt64 n)
 {
-    lChar16 buf[24];
+    lChar32 buf[24];
     int i=0;
     int negative = 0;
     if (n==0)
@@ -2006,7 +2006,7 @@ lString16 & lString16::appendDecimal(lInt64 n)
     return *this;
 }
 
-lString16 & lString16::appendHex(lUInt64 n)
+lString32 & lString32::appendHex(lUInt64 n)
 {
     if (n == 0)
         return append(1, '0');
@@ -2177,7 +2177,7 @@ int lString8::pos(const lString8 & subStr, int startPos) const
     return -1;
 }
 
-int lString16::pos(const lString16 & subStr, int startPos) const
+int lString32::pos(const lString32 & subStr, int startPos) const
 {
     if (subStr.length() > length() - startPos)
         return -1;
@@ -2186,7 +2186,7 @@ int lString16::pos(const lString16 & subStr, int startPos) const
     for (int i = startPos; i <= dl; i++) {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j]!=subStr.pchunk->buf16[j])
+            if (pchunk->buf32[i+j]!=subStr.pchunk->buf32[j])
             {
                 flg = 0;
                 break;
@@ -2221,7 +2221,7 @@ int lString8::pos(const char * subStr, int startPos) const
 }
 
 /// find position of substring inside string, -1 if not found
-int lString16::pos(const lChar16 * subStr, int startPos) const
+int lString32::pos(const lChar32 * subStr, int startPos) const
 {
     if (!subStr || !subStr[0])
         return -1;
@@ -2232,7 +2232,7 @@ int lString16::pos(const lChar16 * subStr, int startPos) const
     for (int i = startPos; i <= dl; i++) {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != subStr[j])
             {
                 flg = 0;
                 break;
@@ -2244,7 +2244,7 @@ int lString16::pos(const lChar16 * subStr, int startPos) const
 }
 
 /// find position of substring inside string, right to left, return -1 if not found
-int lString16::rpos(lString16 subStr) const
+int lString32::rpos(lString32 subStr) const
 {
     if (subStr.length()>length())
         return -1;
@@ -2254,7 +2254,7 @@ int lString16::rpos(lString16 subStr) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j]!=subStr.pchunk->buf16[j])
+            if (pchunk->buf32[i+j]!=subStr.pchunk->buf32[j])
             {
                 flg = 0;
                 break;
@@ -2266,7 +2266,7 @@ int lString16::rpos(lString16 subStr) const
 }
 
 /// find position of substring inside string, -1 if not found
-int lString16::pos(const lChar16 * subStr) const
+int lString32::pos(const lChar32 * subStr) const
 {
     if (!subStr)
         return -1;
@@ -2278,7 +2278,7 @@ int lString16::pos(const lChar16 * subStr) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != subStr[j])
             {
                 flg = 0;
                 break;
@@ -2290,7 +2290,7 @@ int lString16::pos(const lChar16 * subStr) const
 }
 
 /// find position of substring inside string, -1 if not found
-int lString16::pos(const lChar8 * subStr) const
+int lString32::pos(const lChar8 * subStr) const
 {
     if (!subStr)
         return -1;
@@ -2302,7 +2302,7 @@ int lString16::pos(const lChar8 * subStr) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != subStr[j])
             {
                 flg = 0;
                 break;
@@ -2314,7 +2314,7 @@ int lString16::pos(const lChar8 * subStr) const
 }
 
 /// find position of substring inside string, -1 if not found
-int lString16::pos(const lChar8 * subStr, int start) const
+int lString32::pos(const lChar8 * subStr, int start) const
 {
     if (!subStr)
         return -1;
@@ -2326,7 +2326,7 @@ int lString16::pos(const lChar8 * subStr, int start) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != subStr[j])
             {
                 flg = 0;
                 break;
@@ -2337,7 +2337,7 @@ int lString16::pos(const lChar8 * subStr, int start) const
     return -1;
 }
 
-int lString16::pos(lString16 subStr) const
+int lString32::pos(lString32 subStr) const
 {
     if (subStr.length()>length())
         return -1;
@@ -2347,7 +2347,7 @@ int lString16::pos(lString16 subStr) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf16[i+j]!=subStr.pchunk->buf16[j])
+            if (pchunk->buf32[i+j]!=subStr.pchunk->buf32[j])
             {
                 flg = 0;
                 break;
@@ -2536,19 +2536,19 @@ lString8 lString8::itoa( lInt64 n )
 }
 
 // constructs string representation of integer
-lString16 lString16::itoa( int n )
+lString32 lString32::itoa( int n )
 {
     return itoa( (lInt64)n );
 }
 
 // constructs string representation of integer
-lString16 lString16::itoa( lInt64 n )
+lString32 lString32::itoa( lInt64 n )
 {
-    lChar16 buf[32];
+    lChar32 buf[32];
     int i=0;
     int negative = 0;
     if (n==0)
-        return cs16("0");
+        return cs32("0");
     else if (n<0)
     {
         negative = 1;
@@ -2556,18 +2556,18 @@ lString16 lString16::itoa( lInt64 n )
     }
     for ( ; n && i<30; n/=10 )
     {
-        buf[i++] = (lChar16)('0' + (n%10));
+        buf[i++] = (lChar32)('0' + (n%10));
     }
-    lString16 res;
+    lString32 res;
     res.reserve(i+negative);
     if (negative)
-        res.append(1, L'-');
+        res.append(1, U'-');
     for (int j=i-1; j>=0; j--)
         res.append(1, buf[j]);
     return res;
 }
 
-bool lvUnicodeIsAlpha( lChar16 ch )
+bool lvUnicodeIsAlpha( lChar32 ch )
 {
     if ( ch<128 ) {
         if ( (ch>='a' && ch<='z') || (ch>='A' && ch<='Z') )
@@ -2579,34 +2579,34 @@ bool lvUnicodeIsAlpha( lChar16 ch )
 }
 
 
-lString16 & lString16::uppercase()
+lString32 & lString32::uppercase()
 {
     lStr_uppercase( modify(), length() );
     return *this;
 }
 
-lString16 & lString16::lowercase()
+lString32 & lString32::lowercase()
 {
     lStr_lowercase( modify(), length() );
     return *this;
 }
 
-lString16 & lString16::capitalize()
+lString32 & lString32::capitalize()
 {
     lStr_capitalize( modify(), length() );
     return *this;
 }
 
-lString16 & lString16::fullWidthChars()
+lString32 & lString32::fullWidthChars()
 {
     lStr_fullWidthChars( modify(), length() );
     return *this;
 }
 
-void lStr_uppercase( lChar16 * str, int len )
+void lStr_uppercase( lChar32 * str, int len )
 {
     for ( int i=0; i<len; i++ ) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
 #if (USE_UTF8PROC==1)
         str[i] = utf8proc_toupper(ch);
 #else
@@ -2619,7 +2619,7 @@ void lStr_uppercase( lChar16 * str, int len )
         } else if ( ch>=0x3b0 && ch<=0x3cF ) {
             str[i] = ch - 0x20;
         } else if ( (ch >> 8)==0x1F ) { // greek
-            lChar16 n = ch & 255;
+            lChar32 n = ch & 255;
             if (n<0x70) {
                 str[i] = ch | 8;
             } else if (n<0x80) {
@@ -2632,10 +2632,10 @@ void lStr_uppercase( lChar16 * str, int len )
     }
 }
 
-void lStr_lowercase( lChar16 * str, int len )
+void lStr_lowercase( lChar32 * str, int len )
 {
     for ( int i=0; i<len; i++ ) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
 #if (USE_UTF8PROC==1)
         str[i] = utf8proc_tolower(ch);
 #else
@@ -2648,7 +2648,7 @@ void lStr_lowercase( lChar16 * str, int len )
         } else if ( ch>=0x390 && ch<=0x3aF ) {
             str[i] = ch + 0x20;
         } else if ( (ch >> 8)==0x1F ) { // greek
-            lChar16 n = ch & 255;
+            lChar32 n = ch & 255;
             if (n<0x70) {
                 str[i] = ch & (~8);
             } else if (n<0x80) {
@@ -2661,10 +2661,10 @@ void lStr_lowercase( lChar16 * str, int len )
     }
 }
 
-void lStr_fullWidthChars( lChar16 * str, int len )
+void lStr_fullWidthChars( lChar32 * str, int len )
 {
     for ( int i=0; i<len; i++ ) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         if ( ch>=0x21 && ch<=0x7E ) {
             // full-width versions of ascii chars 0x21-0x7E are at 0xFF01-0Xff5E
             str[i] = ch + UNICODE_ASCII_FULL_WIDTH_OFFSET;
@@ -2674,11 +2674,11 @@ void lStr_fullWidthChars( lChar16 * str, int len )
     }
 }
 
-void lStr_capitalize( lChar16 * str, int len )
+void lStr_capitalize( lChar32 * str, int len )
 {
     bool prev_is_word_sep = true; // first char of string will be capitalized
     for ( int i=0; i<len; i++ ) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         if (prev_is_word_sep) {
             // as done as in lStr_uppercase()
 #if (USE_UTF8PROC==1)
@@ -2693,7 +2693,7 @@ void lStr_capitalize( lChar16 * str, int len )
             } else if ( ch>=0x3b0 && ch<=0x3cF ) {
                 str[i] = ch - 0x20;
             } else if ( (ch >> 8)==0x1F ) { // greek
-                lChar16 n = ch & 255;
+                lChar32 n = ch & 255;
                 if (n<0x70) {
                     str[i] = ch | 8;
                 } else if (n<0x80) {
@@ -2709,12 +2709,12 @@ void lStr_capitalize( lChar16 * str, int len )
     }
 }
 
-void lString16Collection::parse( lString16 string, lChar16 delimiter, bool flgTrim )
+void lString32Collection::parse( lString32 string, lChar32 delimiter, bool flgTrim )
 {
     int wstart=0;
     for ( int i=0; i<=string.length(); i++ ) {
         if ( i==string.length() || string[i]==delimiter ) {
-            lString16 s( string.substr( wstart, i-wstart) );
+            lString32 s( string.substr( wstart, i-wstart) );
             if ( flgTrim )
                 s.trimDoubleSpaces(false, false, false);
             if ( !flgTrim || !s.empty() )
@@ -2724,10 +2724,10 @@ void lString16Collection::parse( lString16 string, lChar16 delimiter, bool flgTr
     }
 }
 
-void lString16Collection::parse( lString16 string, lString16 delimiter, bool flgTrim )
+void lString32Collection::parse( lString32 string, lString32 delimiter, bool flgTrim )
 {
     if ( delimiter.empty() || string.pos(delimiter)<0 ) {
-        lString16 s( string );
+        lString32 s( string );
         if ( flgTrim )
             s.trimDoubleSpaces(false, false, false);
         add(s);
@@ -2743,7 +2743,7 @@ void lString16Collection::parse( lString16 string, lString16 delimiter, bool flg
             }
         }
         if ( matched ) {
-            lString16 s( string.substr( wstart, i-wstart) );
+            lString32 s( string.substr( wstart, i-wstart) );
             if ( flgTrim )
                 s.trimDoubleSpaces(false, false, false);
             if ( !flgTrim || !s.empty() )
@@ -2754,13 +2754,13 @@ void lString16Collection::parse( lString16 string, lString16 delimiter, bool flg
     }
 }
 
-int TrimDoubleSpaces(lChar16 * buf, int len,  bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens)
+int TrimDoubleSpaces(lChar32 * buf, int len,  bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens)
 {
-    lChar16 * psrc = buf;
-    lChar16 * pdst = buf;
+    lChar32 * psrc = buf;
+    lChar32 * pdst = buf;
     int state = 0; // 0=beginning, 1=after space, 2=after non-space
     while ((len--) > 0) {
-        lChar16 ch = *psrc++;
+        lChar32 ch = *psrc++;
         if (ch == ' ' || ch == '\t') {
             if ( state==2 ) {
                 if ( *psrc || allowEndSpace ) // if not last
@@ -2787,11 +2787,11 @@ int TrimDoubleSpaces(lChar16 * buf, int len,  bool allowStartSpace, bool allowEn
     return (int)(pdst - buf);
 }
 
-lString16 & lString16::trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens )
+lString32 & lString32::trimDoubleSpaces( bool allowStartSpace, bool allowEndSpace, bool removeEolHyphens )
 {
     if ( empty() )
         return *this;
-    lChar16 * buf = modify();
+    lChar32 * buf = modify();
     int len = length();
     int nlen = TrimDoubleSpaces(buf, len,  allowStartSpace, allowEndSpace, removeEolHyphens);
     if (nlen < len)
@@ -2800,23 +2800,23 @@ lString16 & lString16::trimDoubleSpaces( bool allowStartSpace, bool allowEndSpac
 }
 
 // constructs string representation of integer
-lString16 lString16::itoa( unsigned int n )
+lString32 lString32::itoa( unsigned int n )
 {
     return itoa( (lUInt64) n );
 }
 
 // constructs string representation of integer
-lString16 lString16::itoa( lUInt64 n )
+lString32 lString32::itoa( lUInt64 n )
 {
-    lChar16 buf[24];
+    lChar32 buf[24];
     int i=0;
     if (n==0)
-        return cs16("0");
+        return cs32("0");
     for ( ; n; n/=10 )
     {
-        buf[i++] = (lChar16)('0' + (n%10));
+        buf[i++] = (lChar32)('0' + (n%10));
     }
-    lString16 res;
+    lString32 res;
     res.reserve(i);
     for (int j=i-1; j>=0; j--)
         res.append(1, buf[j]);
@@ -2905,7 +2905,7 @@ inline int charUtf8ByteCount(int ch) {
     return 1;
 }
 
-int Utf8ByteCount(const lChar16 * str)
+int Utf8ByteCount(const lChar32 * str)
 {
     int count = 0;
     lUInt32 ch;
@@ -2915,7 +2915,7 @@ int Utf8ByteCount(const lChar16 * str)
     return count;
 }
 
-int Utf8ByteCount(const lChar16 * str, int len)
+int Utf8ByteCount(const lChar32 * str, int len)
 {
     int count = 0;
     lUInt32 ch;
@@ -2926,16 +2926,16 @@ int Utf8ByteCount(const lChar16 * str, int len)
     return count;
 }
 
-lString16 Utf8ToUnicode( const lString8 & str )
+lString32 Utf8ToUnicode( const lString8 & str )
 {
 	return Utf8ToUnicode( str.c_str() );
 }
 
-#define CONT_BYTE(index,shift) (((lChar16)(s[index]) & 0x3F) << shift)
+#define CONT_BYTE(index,shift) (((lChar32)(s[index]) & 0x3F) << shift)
 
-static void DecodeUtf8(const char * s,  lChar16 * p, int len)
+static void DecodeUtf8(const char * s,  lChar32 * p, int len)
 {
-    lChar16 * endp = p + len;
+    lChar32 * endp = p + len;
     lUInt32 ch;
     while (p < endp) {
         ch = *s++;
@@ -2967,12 +2967,12 @@ static void DecodeUtf8(const char * s,  lChar16 * p, int len)
 // Top two bits are 10, i.e. original & 11000000(2) == 10000000(2)
 #define IS_FOLLOWING(index) ((s[index] & 0xC0) == 0x80)
 
-void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen)
+void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar32 * dst, int &dstlen)
 {
     const lUInt8 * s = src;
     const lUInt8 * ends = s + srclen;
-    lChar16 * p = dst;
-    lChar16 * endp = p + dstlen;
+    lChar32 * p = dst;
+    lChar32 * endp = p + dstlen;
     lUInt32 ch;
     bool matched;
     while (p < endp && s < ends) {
@@ -3015,8 +3015,6 @@ void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen)
                 //   trailing, or low, surrogates are from DC00 to DFFF. They
                 //   are called surrogates, since they do not represent
                 //   characters directly, but only as a pair.
-                // (Note that lChar16 (wchar_t) is 4-bytes, and can store
-                // unicode codepoint > 0xFFFF like 0x10123)
                 if (*(p-1) >= 0xD800 && *(p-1) <= 0xDBFF && s+2 < ends) { // what we wrote is a high surrogate,
                     lUInt32 next = *s;                            // and there's room next for a low surrogate
                     if ( (next & 0xF0) == 0xE0 && IS_FOLLOWING(1) && IS_FOLLOWING(2)) { // is a valid 3-bytes sequence
@@ -3058,34 +3056,34 @@ void Utf8ToUnicode(const lUInt8 * src,  int &srclen, lChar16 * dst, int &dstlen)
     dstlen = (int)(p - dst);
 }
 
-lString16 Utf8ToUnicode( const char * s ) {
+lString32 Utf8ToUnicode( const char * s ) {
     if (!s || !s[0])
-      return lString16::empty_str;
+      return lString32::empty_str;
     int len = Utf8CharCount( s );
     if (!len)
-      return lString16::empty_str;
-    lString16 dst;
-    dst.append(len, (lChar16)0);
-    lChar16 * p = dst.modify();
+      return lString32::empty_str;
+    lString32 dst;
+    dst.append(len, (lChar32)0);
+    lChar32 * p = dst.modify();
     DecodeUtf8(s, p, len);
     return dst;
 }
 
-lString16 Utf8ToUnicode( const char * s, int sz ) {
+lString32 Utf8ToUnicode( const char * s, int sz ) {
     if (!s || !s[0] || sz <= 0)
-      return lString16::empty_str;
+      return lString32::empty_str;
     int len = Utf8CharCount( s, sz );
     if (!len)
-      return lString16::empty_str;
-    lString16 dst;
+      return lString32::empty_str;
+    lString32 dst;
     dst.append(len, 0);
-    lChar16 * p = dst.modify();
+    lChar32 * p = dst.modify();
     DecodeUtf8(s, p, len);
     return dst;
 }
 
 
-lString8 UnicodeToUtf8(const lChar16 * s, int count)
+lString8 UnicodeToUtf8(const lChar32 * s, int count)
 {
     if (count <= 0)
       return lString8::empty_str;
@@ -3123,17 +3121,17 @@ lString8 UnicodeToUtf8(const lChar16 * s, int count)
     return dst;
 }
 
-lString8 UnicodeToUtf8( const lString16 & str )
+lString8 UnicodeToUtf8( const lString32 & str )
 {
     return UnicodeToUtf8(str.c_str(), str.length());
 }
 
-lString8 UnicodeTo8Bit( const lString16 & str, const lChar8 * * table )
+lString8 UnicodeTo8Bit( const lString32 & str, const lChar8 * * table )
 {
     lString8 buf;
     buf.reserve( str.length() );
     for (int i=0; i < str.length(); i++) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         const lChar8 * p = table[ (ch>>8) & 255 ];
         if ( p ) {
             buf += p[ ch&255 ];
@@ -3144,14 +3142,14 @@ lString8 UnicodeTo8Bit( const lString16 & str, const lChar8 * * table )
     return buf;
 }
 
-lString16 ByteToUnicode( const lString8 & str, const lChar16 * table )
+lString32 ByteToUnicode( const lString8 & str, const lChar32 * table )
 {
-    lString16 buf;
+    lString32 buf;
     buf.reserve( str.length() );
     for (int i=0; i < str.length(); i++) {
-        lChar16 ch = (unsigned char)str[i];
-        lChar16 ch16 = ((ch & 0x80) && table) ? table[ (ch&0x7F) ] : ch;
-        buf += ch16;
+        lChar32 ch = (unsigned char)str[i];
+        lChar32 ch32 = ((ch & 0x80) && table) ? table[ (ch&0x7F) ] : ch;
+        buf += ch32;
     }
     return buf;
 }
@@ -3159,7 +3157,7 @@ lString16 ByteToUnicode( const lString8 & str, const lChar16 * table )
 
 #if !defined(__SYMBIAN32__) && defined(_WIN32)
 
-lString8 UnicodeToLocal( const lString16 & str )
+lString8 UnicodeToLocal( const lString32 & str )
 {
    lString8 dst;
    if (str.empty())
@@ -3195,9 +3193,9 @@ lString8 UnicodeToLocal( const lString16 & str )
    return dst;
 }
 
-lString16 LocalToUnicode( const lString8 & str )
+lString32 LocalToUnicode( const lString8 & str )
 {
-   lString16 dst;
+   lString32 dst;
    if (str.empty())
       return dst;
    int len = MultiByteToWideChar(
@@ -3225,12 +3223,12 @@ lString16 LocalToUnicode( const lString8 & str )
 
 #else
 
-lString8 UnicodeToLocal( const lString16 & str )
+lString8 UnicodeToLocal( const lString32 & str )
 {
     return UnicodeToUtf8( str );
 }
 
-lString16 LocalToUnicode( const lString8 & str )
+lString32 LocalToUnicode( const lString8 & str )
 {
     return Utf8ToUnicode( str );
 }
@@ -3317,7 +3315,7 @@ static const char * latin_1[64] =
 "y", // U+00FF	LATIN SMALL LETTER Y WITH DIAERESIS
 };
 
-static const char * getCharTranscript( lChar16 ch )
+static const char * getCharTranscript( lChar32 ch )
 {
     if ( ch>=0x410 && ch<0x430 )
         return russian_capital[ch-0x410];
@@ -3333,14 +3331,14 @@ static const char * getCharTranscript( lChar16 ch )
 }
 
 
-lString8  UnicodeToTranslit( const lString16 & str )
+lString8  UnicodeToTranslit( const lString32 & str )
 {
     lString8 buf;
 	if ( str.empty() )
 		return buf;
     buf.reserve( str.length()*5/4 );
     for ( int i=0; i<str.length(); i++ ) {
-		lChar16 ch = str[i];
+		lChar32 ch = str[i];
         if ( ch>=32 && ch<=127 ) {
             buf.append( 1, (lChar8)ch );
         } else {
@@ -4234,8 +4232,8 @@ CH_PROP_UPPER | CH_PROP_VOWEL, // GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
 0, 0, 0
 };
 
-inline lUInt16 getCharProp(lChar16 ch) {
-    static const lChar16 maxchar = sizeof(char_props) / sizeof( lUInt16 );
+inline lUInt16 getCharProp(lChar32 ch) {
+    static const lChar32 maxchar = sizeof(char_props) / sizeof( lUInt16 );
     if (ch<maxchar)
         return char_props[ch];
     else if ((ch>>8) == 0x1F)
@@ -4256,15 +4254,15 @@ inline lUInt16 getCharProp(lChar16 ch) {
     return 0;
 }
 
-void lStr_getCharProps( const lChar16 * str, int sz, lUInt16 * props )
+void lStr_getCharProps( const lChar32 * str, int sz, lUInt16 * props )
 {
     for ( int i=0; i<sz; i++ ) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         props[i] = getCharProp(ch);
     }
 }
 
-bool lStr_isWordSeparator( lChar16 ch )
+bool lStr_isWordSeparator( lChar32 ch )
 {
     // ASCII letters and digits are NOT word separators
     if (ch >= 0x61 && ch <= 0x7A) return false; // lowercase ascii letters
@@ -4298,7 +4296,7 @@ bool lStr_isWordSeparator( lChar16 ch )
 }
 
 /// find alpha sequence bounds
-void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int & end )
+void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end )
 {
     int hwStart, hwEnd;
 
@@ -4313,7 +4311,7 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
 //    // skip spaces
 //    for (hwStart=pos-1; hwStart>0; hwStart--)
 //    {
-//        lChar16 ch = str[hwStart];
+//        lChar32 ch = str[hwStart];
 //        if ( ch<(int)maxchar ) {
 //            lUInt16 props = char_props[ch];
 //            if ( !(props & CH_PROP_SPACE) )
@@ -4323,7 +4321,7 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
 //    // skip punctuation signs and digits
 //    for (; hwStart>0; hwStart--)
 //    {
-//        lChar16 ch = str[hwStart];
+//        lChar32 ch = str[hwStart];
 //        if ( ch<(int)maxchar ) {
 //            lUInt16 props = char_props[ch];
 //            if ( !(props & (CH_PROP_PUNCT|CH_PROP_DIGIT)) )
@@ -4333,7 +4331,7 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
     // skip until first alpha
     for (hwStart = pos-1; hwStart > 0; hwStart--)
     {
-        lChar16 ch = str[hwStart];
+        lChar32 ch = str[hwStart];
         lUInt16 props = getCharProp(ch);
         if ( props & CH_PROP_ALPHA || props & CH_PROP_HYPHEN )
             break;
@@ -4347,7 +4345,7 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
     // skipping while alpha
     for (; hwStart>0; hwStart--)
     {
-        lChar16 ch = str[hwStart];
+        lChar32 ch = str[hwStart];
         //int lastAlpha = -1;
         if ( getCharProp(ch) & CH_PROP_ALPHA || getCharProp(ch) & CH_PROP_HYPHEN ) {
             //lastAlpha = hwStart;
@@ -4363,7 +4361,7 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
 //    }
     for (hwEnd=hwStart+1; hwEnd<sz; hwEnd++) // 20080404
     {
-        lChar16 ch = str[hwEnd];
+        lChar32 ch = str[hwEnd];
         if (!(getCharProp(ch) & CH_PROP_ALPHA) && !(getCharProp(ch) & CH_PROP_HYPHEN))
             break;
         ch = str[hwEnd-1];
@@ -4372,19 +4370,19 @@ void lStr_findWordBounds( const lChar16 * str, int sz, int pos, int & start, int
     }
     start = hwStart;
     end = hwEnd;
-    //CRLog::debug("Word bounds: '%s'", LCSTR(lString16(str+start, end-start)));
+    //CRLog::debug("Word bounds: '%s'", LCSTR(lString32(str+start, end-start)));
 }
 
-void  lString16::limit( size_type sz )
+void  lString32::limit( size_type sz )
 {
     if ( length() > sz ) {
         modify();
         pchunk->len = sz;
-        pchunk->buf16[sz] = 0;
+        pchunk->buf32[sz] = 0;
     }
 }
 
-lUInt16 lGetCharProps( lChar16 ch )
+lUInt16 lGetCharProps( lChar32 ch )
 {
     return getCharProp(ch);
 }
@@ -4582,10 +4580,10 @@ void CRLog::setStderrLogger()
 }
 
 /// returns true if string starts with specified substring, case insensitive
-bool lString16::startsWithNoCase ( const lString16 & substring ) const
+bool lString32::startsWithNoCase ( const lString32 & substring ) const
 {
-    lString16 a = *this;
-    lString16 b = substring;
+    lString32 a = *this;
+    lString32 b = substring;
     a.uppercase();
     b.uppercase();
     return a.startsWith( b );
@@ -4637,54 +4635,54 @@ bool lString8::endsWith( const lChar8 * substring ) const
 }
 
 /// returns true if string ends with specified substring
-bool lString16::endsWith( const lChar16 * substring ) const
+bool lString32::endsWith( const lChar32 * substring ) const
 {
 	if ( !substring || !*substring )
 		return true;
     int len = lStr_len(substring);
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str() + (length()-len);
-    const lChar16 * s2 = substring;
+    const lChar32 * s1 = c_str() + (length()-len);
+    const lChar32 * s2 = substring;
 	return lStr_cmp( s1, s2 )==0;
 }
 
 /// returns true if string ends with specified substring
-bool lString16::endsWith( const lChar8 * substring ) const
+bool lString32::endsWith( const lChar8 * substring ) const
 {
     if ( !substring || !*substring )
         return true;
     int len = lStr_len(substring);
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str() + (length()-len);
+    const lChar32 * s1 = c_str() + (length()-len);
     const lChar8 * s2 = substring;
     return lStr_cmp( s1, s2 )==0;
 }
 
 /// returns true if string ends with specified substring
-bool lString16::endsWith ( const lString16 & substring ) const
+bool lString32::endsWith ( const lString32 & substring ) const
 {
     if ( substring.empty() )
         return true;
     int len = substring.length();
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str() + (length()-len);
-    const lChar16 * s2 = substring.c_str();
+    const lChar32 * s1 = c_str() + (length()-len);
+    const lChar32 * s2 = substring.c_str();
 	return lStr_cmp( s1, s2 )==0;
 }
 
 /// returns true if string starts with specified substring
-bool lString16::startsWith( const lString16 & substring ) const
+bool lString32::startsWith( const lString32 & substring ) const
 {
     if ( substring.empty() )
         return true;
     int len = substring.length();
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str();
-    const lChar16 * s2 = substring.c_str();
+    const lChar32 * s1 = c_str();
+    const lChar32 * s2 = substring.c_str();
     for ( int i=0; i<len; i++ )
         if ( s1[i]!=s2[i] )
             return false;
@@ -4692,15 +4690,15 @@ bool lString16::startsWith( const lString16 & substring ) const
 }
 
 /// returns true if string starts with specified substring
-bool lString16::startsWith(const lChar16 * substring) const
+bool lString32::startsWith(const lChar32 * substring) const
 {
     if (!substring || !substring[0])
         return true;
     int len = _lStr_len(substring);
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str();
-    const lChar16 * s2 = substring;
+    const lChar32 * s1 = c_str();
+    const lChar32 * s2 = substring;
     for ( int i=0; i<len; i++ )
         if ( s1[i] != s2[i] )
             return false;
@@ -4708,14 +4706,14 @@ bool lString16::startsWith(const lChar16 * substring) const
 }
 
 /// returns true if string starts with specified substring
-bool lString16::startsWith(const lChar8 * substring) const
+bool lString32::startsWith(const lChar8 * substring) const
 {
     if (!substring || !substring[0])
         return true;
     int len = _lStr_len(substring);
     if ( length() < len )
         return false;
-    const lChar16 * s1 = c_str();
+    const lChar32 * s1 = c_str();
     const lChar8 * s2 = substring;
     for ( int i=0; i<len; i++ )
         if (s1[i] != s2[i])
@@ -4870,7 +4868,7 @@ SerialBuf & SerialBuf::operator << ( lInt32 n )
 	_buf[_pos++] = (lUInt8)((n>>24) & 255);
 	return *this;
 }
-SerialBuf & SerialBuf::operator << ( const lString16 & s )
+SerialBuf & SerialBuf::operator << ( const lString32 & s )
 {
 	if ( check(2) )
 		return *this;
@@ -4980,7 +4978,7 @@ SerialBuf & SerialBuf::operator >> ( lString8 & s8 )
 	return *this;
 }
 
-SerialBuf & SerialBuf::operator >> ( lString16 & s )
+SerialBuf & SerialBuf::operator >> ( lString32 & s )
 {
 	lString8 s8;
 	(*this) >> s8;
@@ -5004,7 +5002,7 @@ bool SerialBuf::checkMagic( const char * s )
 	return true;
 }
 
-bool lString16::split2( const lString16 & delim, lString16 & value1, lString16 & value2 )
+bool lString32::split2( const lString32 & delim, lString32 & value1, lString32 & value2 )
 {
     if ( empty() )
         return false;
@@ -5016,7 +5014,7 @@ bool lString16::split2( const lString16 & delim, lString16 & value1, lString16 &
     return true;
 }
 
-bool lString16::split2( const lChar16 * delim, lString16 & value1, lString16 & value2 )
+bool lString32::split2( const lChar32 * delim, lString32 & value1, lString32 & value2 )
 {
     if (empty())
         return false;
@@ -5029,7 +5027,7 @@ bool lString16::split2( const lChar16 * delim, lString16 & value1, lString16 & v
     return true;
 }
 
-bool lString16::split2( const lChar8 * delim, lString16 & value1, lString16 & value2 )
+bool lString32::split2( const lChar8 * delim, lString32 & value1, lString32 & value2 )
 {
     if (empty())
         return false;
@@ -5042,11 +5040,11 @@ bool lString16::split2( const lChar8 * delim, lString16 & value1, lString16 & va
     return true;
 }
 
-bool splitIntegerList( lString16 s, lString16 delim, int &value1, int &value2 )
+bool splitIntegerList( lString32 s, lString32 delim, int &value1, int &value2 )
 {
     if ( s.empty() )
         return false;
-    lString16 s1, s2;
+    lString32 s1, s2;
     if ( !s.split2( delim, s1, s2 ) )
         return false;
     int n1, n2;
@@ -5066,16 +5064,16 @@ lString8 & lString8::replace(size_type p0, size_type n0, const lString8 & str) {
     return *this;
 }
 
-lString16 & lString16::replace(size_type p0, size_type n0, const lString16 & str)
+lString32 & lString32::replace(size_type p0, size_type n0, const lString32 & str)
 {
-    lString16 s1 = substr( 0, p0 );
-    lString16 s2 = length() - p0 - n0 > 0 ? substr( p0+n0, length()-p0-n0 ) : lString16::empty_str;
+    lString32 s1 = substr( 0, p0 );
+    lString32 s2 = length() - p0 - n0 > 0 ? substr( p0+n0, length()-p0-n0 ) : lString32::empty_str;
     *this = s1 + str + s2;
     return *this;
 }
 
 /// replaces part of string, if pattern is found
-bool lString16::replace(const lString16 & findStr, const lString16 & replaceStr)
+bool lString32::replace(const lString32 & findStr, const lString32 & replaceStr)
 {
     int p = pos(findStr);
     if ( p<0 )
@@ -5084,18 +5082,18 @@ bool lString16::replace(const lString16 & findStr, const lString16 & replaceStr)
     return true;
 }
 
-bool lString16::replaceParam(int index, const lString16 & replaceStr)
+bool lString32::replaceParam(int index, const lString32 & replaceStr)
 {
-    return replace( cs16("$") + fmt::decimal(index), replaceStr );
+    return replace( cs32("$") + fmt::decimal(index), replaceStr );
 }
 
 /// replaces first found occurence of "$N" pattern with itoa of integer, where N=index
-bool lString16::replaceIntParam(int index, int replaceNumber)
+bool lString32::replaceIntParam(int index, int replaceNumber)
 {
-    return replaceParam( index, lString16::itoa(replaceNumber));
+    return replaceParam( index, lString32::itoa(replaceNumber));
 }
 
-static int decodeHex( lChar16 ch )
+static int decodeHex( lChar32 ch )
 {
     if ( ch>='0' && ch<='9' )
         return ch-'0';
@@ -5106,7 +5104,7 @@ static int decodeHex( lChar16 ch )
     return -1;
 }
 
-static lChar8 decodeHTMLChar( const lChar16 * s )
+static lChar8 decodeHTMLChar( const lChar32 * s )
 {
     if (s[0] == '%') {
         int d1 = decodeHex( s[1] );
@@ -5121,9 +5119,9 @@ static lChar8 decodeHTMLChar( const lChar16 * s )
 }
 
 /// decodes path like "file%20name%C3%A7" to "file nameç"
-lString16 DecodeHTMLUrlString( lString16 s )
+lString32 DecodeHTMLUrlString( lString32 s )
 {
-    const lChar16 * str = s.c_str();
+    const lChar32 * str = s.c_str();
     for ( int i=0; str[i]; i++ ) {
         if ( str[i]=='%'  ) {
             lChar8 ch = decodeHTMLChar( str + i );
@@ -5157,7 +5155,7 @@ lString16 DecodeHTMLUrlString( lString16 s )
     return s;
 }
 
-void limitStringSize(lString16 & str, int maxSize) {
+void limitStringSize(lString32 & str, int maxSize) {
     if (str.length() < maxSize)
 		return;
 	int lastSpace = -1;
@@ -5174,9 +5172,9 @@ void limitStringSize(lString16 & str, int maxSize) {
 }
 
 /// remove soft-hyphens from string
-lString16 removeSoftHyphens( lString16 s )
+lString32 removeSoftHyphens( lString32 s )
 {
-    lChar16 hyphen = lChar16(UNICODE_SOFT_HYPHEN_CODE);
+    lChar32 hyphen = lChar32(UNICODE_SOFT_HYPHEN_CODE);
     int start = 0;
     while (true) {
         int p = -1;
@@ -5190,8 +5188,8 @@ lString16 removeSoftHyphens( lString16 s )
         if (p == -1)
             break;
         start = p;
-        lString16 s1 = s.substr( 0, p );
-        lString16 s2 = p < len-1 ? s.substr( p+1, len-p-1 ) : lString16::empty_str;
+        lString32 s1 = s.substr( 0, p );
+        lString32 s2 = p < len-1 ? s.substr( p+1, len-p-1 ) : lString32::empty_str;
         s = s1 + s2;
     }
     return s;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -603,22 +603,22 @@ static bool parse_number_value( const char * & str, css_length_t & value,
     return true;
 }
 
-static lString16 parse_nth_value( const lString16 value )
+static lString32 parse_nth_value( const lString32 value )
 {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child
     // Parse "even", "odd", "5", "5n", "5n+2", "-n"...
-    // Pack 3 numbers, enough to check if match, into another lString16
+    // Pack 3 numbers, enough to check if match, into another lString32
     // for quicker checking:
-    // - a tuple of 3 lChar16: (negative, n-step, offset)
+    // - a tuple of 3 lChar32: (negative, n-step, offset)
     // - or the empty string when invalid or if it would never match
     // (Note that we get the input already trimmed and lowercased.)
-    lString16 ret = lString16(); // empty string = never match
+    lString32 ret = lString32(); // empty string = never match
     if ( value == "even" ) { //  = "2n"
-        ret << lChar16(0) <<lChar16(2) << lChar16(0);
+        ret << lChar32(0) <<lChar32(2) << lChar32(0);
         return ret;
     }
     if ( value == "odd" ) {  // = "2n+1"
-        ret << lChar16(0) <<lChar16(2) << lChar16(1);
+        ret << lChar32(0) <<lChar32(2) << lChar32(1);
         return ret;
     }
     int len = value.length();
@@ -628,7 +628,7 @@ static lString16 parse_nth_value( const lString16 value )
     int first = 0;
     int second = 0;
     int i = 0;
-    lChar16 c;
+    lChar32 c;
     c = value[i];
     if ( c == '-' ) {
         negative = true;
@@ -650,7 +650,7 @@ static lString16 parse_nth_value( const lString16 value )
             if ( i==len ) { // single number seen: this parsed number is actually the offset
                 if ( negative ) // "-4"
                     return ret; // never match
-                ret << lChar16(0) << lChar16(0) << lChar16(first);
+                ret << lChar32(0) << lChar32(0) << lChar32(first);
                 return ret;
             }
             c = value[i];
@@ -664,7 +664,7 @@ static lString16 parse_nth_value( const lString16 value )
     if ( i==len ) { // ends with that 'n'
         if ( negative || first == 0) // valid, but would never match anything
             return ret; // never match
-        ret << lChar16(0) << lChar16(first) << lChar16(0);
+        ret << lChar32(0) << lChar32(first) << lChar32(0);
         return ret;
     }
     c = value[i];
@@ -687,11 +687,11 @@ static lString16 parse_nth_value( const lString16 value )
             return ret; // invalid
     }
     // Valid, and we parsed everything
-    ret << lChar16(negative) << lChar16(first) << lChar16(second);
+    ret << lChar32(negative) << lChar32(first) << lChar32(second);
     return ret;
 }
 
-static bool match_nth_value( const lString16 value, int n)
+static bool match_nth_value( const lString32 value, int n)
 {
     // Apply packed parsed value (parsed by above function) to n
     if ( value.empty() ) // invalid, or never match
@@ -1060,7 +1060,7 @@ bool parse_color_value( const char * & str, css_length_t & value )
 }
 
 // Parse a CSS "content:" property into an intermediate format single string.
-bool parse_content_property( const char * & str, lString16 & parsed_content)
+bool parse_content_property( const char * & str, lString32 & parsed_content)
 {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/content
     // The property may have multiple tokens:
@@ -1076,8 +1076,8 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
     // data: its length (+1 to avoid NULLs in strings) and that data.
     // parsed_content may contain multiple values, in the format
     //   'X' for 'none' (or 'normal', = none with pseudo elements)
-    //   's' + <len> + string16 (string content) for ""
-    //   'a' + <len> + string16 (attribute name) for attr()
+    //   's' + <len> + string32 (string content) for ""
+    //   'a' + <len> + string32 (attribute name) for attr()
     //   'Q' for 'open-quote'
     //   'q' for 'close-quote'
     //   'N' for 'no-open-quote'
@@ -1106,22 +1106,22 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
             continue; // continue parsing
         }
         else if ( substr_icompare("open-quote", str) ) {
-            parsed_content << L'Q';
+            parsed_content << U'Q';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("close-quote", str) ) {
-            parsed_content << L'q';
+            parsed_content << U'q';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("no-open-quote", str) ) {
-            parsed_content << L'N';
+            parsed_content << U'N';
             needs_processing_when_applying = true;
             continue;
         }
         else if ( substr_icompare("no-close-quote", str) ) {
-            parsed_content << L'n';
+            parsed_content << U'n';
             needs_processing_when_applying = true;
             continue;
         }
@@ -1136,10 +1136,10 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
                 }
                 if ( *str == ')' ) {
                     str++;
-                    lString16 attr = Utf8ToUnicode(attr8);
+                    lString32 attr = Utf8ToUnicode(attr8);
                     attr.trim();
-                    parsed_content << L'a';
-                    parsed_content << lChar16(attr.length() + 1); // (+1 to avoid storing \x00)
+                    parsed_content << U'a';
+                    parsed_content << lChar32(attr.length() + 1); // (+1 to avoid storing \x00)
                     parsed_content << attr;
                     continue;
                 }
@@ -1158,7 +1158,7 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
                 }
                 if ( *str == ')' ) {
                     str++;
-                    parsed_content << L'u';
+                    parsed_content << U'u';
                     continue;
                 }
                 // No closing ')': invalid
@@ -1196,8 +1196,8 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
                             codepoint = 0xFFFD; // replacement character
                         }
                         // Serialize it as UTF-8
-                        lString16 c;
-                        c << (lChar16)codepoint;
+                        lString32 c;
+                        c << (lChar32)codepoint;
                         str8 << UnicodeToLocal(c);
                     }
                     else if ( *str == '\r' && *(str+1) == '\n' ) {
@@ -1226,27 +1226,27 @@ bool parse_content_property( const char * & str, lString16 & parsed_content)
                 // (declaration or rule) in which the string was found."
             }
             if ( *str == quote_ch ) {
-                lString16 str16 = Utf8ToUnicode(str8);
-                parsed_content << L's';
-                parsed_content << lChar16(str16.length() + 1); // (+1 to avoid storing \x00)
-                parsed_content << str16;
+                lString32 str32 = Utf8ToUnicode(str8);
+                parsed_content << U's';
+                parsed_content << lChar32(str32.length() + 1); // (+1 to avoid storing \x00)
+                parsed_content << str32;
                 str++;
                 continue;
             }
         }
         else {
             // Not supported
-            parsed_content << L'z';
+            parsed_content << U'z';
             next_token(str);
         }
     }
     if ( has_none ) {
         // Forget all other tokens parsed
         parsed_content.clear();
-        parsed_content << L'X';
+        parsed_content << U'X';
     }
     else if ( needs_processing_when_applying ) {
-        parsed_content.insert(0, 1, L'$');
+        parsed_content.insert(0, 1, U'$');
     }
     if (*str) // something (;, } or !important) follows
         return true;
@@ -1268,7 +1268,7 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
     // But we need to resolve quotes, according to their nesting level,
     // and transform them into a litteral string 's'.
 
-    if ( style->content.empty() || style->content[0] != L'$' ) {
+    if ( style->content.empty() || style->content[0] != U'$' ) {
         // No update needed
         return;
     }
@@ -1309,31 +1309,31 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
     // Might be that HarfBuzz first substitute it with arabic quotes (which
     // happen to look inverted), and then mirror that?
 
-    lString16 res;
-    lString16 parsed_content = style->content;
-    lString16 quote;
+    lString32 res;
+    lString32 parsed_content = style->content;
+    lString32 quote;
     int i = 1; // skip initial '$'
     int parsed_content_len = parsed_content.length();
     while ( i < parsed_content_len ) {
-        lChar16 ctype = parsed_content[i];
+        lChar32 ctype = parsed_content[i];
         if ( ctype == 's' ) { // literal string: copy as-is
-            lChar16 len = parsed_content[i] - 1; // (remove added +1)
+            lChar32 len = parsed_content[i] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }
         else if ( ctype == 'a' ) { // attribute value: copy as-is
-            lChar16 len = parsed_content[i] - 1; // (remove added +1)
+            lChar32 len = parsed_content[i] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }
         else if ( ctype == 'Q' ) { // open-quote
             quote = lang_cfg->getOpeningQuote(visible);
-            res << L's' << quote.length() << quote;
+            res << U's' << quote.length() << quote;
             i += 1;
         }
         else if ( ctype == 'q' ) { // close-quote
             quote = lang_cfg->getClosingQuote(visible);
-            res << L's' << quote.length() << quote;
+            res << U's' << quote.length() << quote;
             i += 1;
         }
         else if ( ctype == 'N' ) { // no-open-quote
@@ -1357,24 +1357,24 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
 }
 
 /// Returns the computed value for a node from its parsed CSS "content:" value
-lString16 get_applied_content_property( ldomNode * node ) {
-    lString16 res;
+lString32 get_applied_content_property( ldomNode * node ) {
+    lString32 res;
     css_style_ref_t style = node->getStyle();
-    lString16 parsed_content = style->content;
+    lString32 parsed_content = style->content;
     if ( parsed_content.empty() )
         return res;
     int i = 0;
     int parsed_content_len = parsed_content.length();
     while ( i < parsed_content_len ) {
-        lChar16 ctype = parsed_content[i++];
+        lChar32 ctype = parsed_content[i++];
         if ( ctype == 's' ) { // literal string
-            lChar16 len = parsed_content[i++] - 1; // (remove added +1)
+            lChar32 len = parsed_content[i++] - 1; // (remove added +1)
             res << parsed_content.substr(i, len);
             i += len;
         }
         else if ( ctype == 'a' ) { // attribute value
-            lChar16 len = parsed_content[i++] - 1; // (remove added +1)
-            lString16 attr_name = parsed_content.substr(i, len);
+            lChar32 len = parsed_content[i++] - 1; // (remove added +1)
+            lString32 attr_name = parsed_content.substr(i, len);
             i += len;
             ldomNode * attrNode = node;
             if ( node->getNodeId() == el_pseudoElem ) {
@@ -1425,22 +1425,22 @@ lString16 get_applied_content_property( ldomNode * node ) {
     return res;
 }
 
-static void resolve_url_path( lString8 & str, lString16 codeBase ) {
+static void resolve_url_path( lString8 & str, lString32 codeBase ) {
     // A URL (path to local or container's file) must be resolved
     // at parsing time, as it is related to this stylesheet file
     // path (and not to the HTML files that are linking to this
     // stylesheet) - it wouldn't be possible to resolve it later.
-    lString16 path = Utf8ToUnicode(str);
+    lString32 path = Utf8ToUnicode(str);
     path.trim();
-    if (path.startsWithNoCase(lString16("url"))) path = path.substr(3);
+    if (path.startsWithNoCase(lString32("url"))) path = path.substr(3);
     path.trim();
-    if (path.startsWith(L"(")) path = path.substr(1);
-    if (path.endsWith(L")")) path = path.substr(0, path.length() - 1);
+    if (path.startsWith(U"(")) path = path.substr(1);
+    if (path.endsWith(U")")) path = path.substr(0, path.length() - 1);
     path.trim();
-    if (path.startsWith(L"\"") || path.startsWith(L"'")) path = path.substr(1);
-    if (path.endsWith(L"\"") || path.endsWith(L"'")) path = path.substr(0, path.length() - 1);
+    if (path.startsWith(U"\"") || path.startsWith(U"'")) path = path.substr(1);
+    if (path.endsWith(U"\"") || path.endsWith(U"'")) path = path.substr(0, path.length() - 1);
     path.trim();
-    if (path.startsWith(lString16("data:image"))) {
+    if (path.startsWith(lString32("data:image"))) {
         // base64 encoded image: leave as-is
     }
     else {
@@ -1821,7 +1821,7 @@ enum cr_only_if_t {
     cr_only_if_fb2_document, // fb2 or fb3
 };
 
-bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, bool higher_importance, lxmlDocBase * doc, lString16 codeBase )
+bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, bool higher_importance, lxmlDocBase * doc, lString32 codeBase )
 {
     if ( !decl )
         return false;
@@ -2869,7 +2869,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 break;
             case cssd_content:
                 {
-                    lString16 parsed_content;
+                    lString32 parsed_content;
                     if ( parse_content_property( decl, parsed_content) ) {
                         buf<<(lUInt32) (cssd_content | importance | parsed_important | parse_important(decl));
                         buf<<(lUInt32) parsed_content.length();
@@ -3186,11 +3186,11 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
         case cssd_content:
             {
                 int l = *p++;
-                lString16 content;
+                lString32 content;
                 if ( l > 0 ) {
                     content.reserve(l);
                     for (int i=0; i<l; i++)
-                        content << (lChar16)(*p++);
+                        content << (lChar32)(*p++);
                 }
                 style->Apply( content, &style->content, imp_bit_content, is_important );
             }
@@ -3403,7 +3403,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         {
             if ( !node->hasAttribute(_attrid) )
                 return false;
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             if (_type == cssrt_attreq_i)
                 val.lowercase();
             return val == _value;
@@ -3415,10 +3415,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         {
             if ( !node->hasAttribute(_attrid) )
                 return false;
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             if (_type == cssrt_attrhas_i)
                 val.lowercase();
-            int p = val.pos( lString16(_value.c_str()) );            
+            int p = val.pos( lString32(_value.c_str()) );            
             if (p<0)
                 return false;
             if ( (p>0 && val[p-1]!=' ') 
@@ -3434,7 +3434,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
                 return false;
             // value can be exactly value or can begin with value
             // immediately followed by a hyphen
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             int val_len = val.length();
             int value_len = _value.length();
             if (value_len > val_len)
@@ -3455,7 +3455,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         {
             if ( !node->hasAttribute(_attrid) )
                 return false;
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             int val_len = val.length();
             int value_len = _value.length();
             if (value_len > val_len)
@@ -3471,7 +3471,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         {
             if ( !node->hasAttribute(_attrid) )
                 return false;
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             int val_len = val.length();
             int value_len = _value.length();
             if (value_len > val_len)
@@ -3487,7 +3487,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         {
             if ( !node->hasAttribute(_attrid) )
                 return false;
-            lString16 val = node->getAttributeValue(_attrid);
+            lString32 val = node->getAttributeValue(_attrid);
             if (_value.length()>val.length())
                 return false;
             if (_type == cssrt_attrcontains_i)
@@ -3497,10 +3497,10 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         break;
     case cssrt_id:            // E#id
         {
-            lString16 val = node->getAttributeValue(attr_id);
+            lString32 val = node->getAttributeValue(attr_id);
             if ( val.empty() )
                 return false;
-            /*lString16 ldomDocumentFragmentWriter::convertId( lString16 id ) adds codeBasePrefix to
+            /*lString32 ldomDocumentFragmentWriter::convertId( lString32 id ) adds codeBasePrefix to
              *original id name, I can not get codeBasePrefix from here so I add a space to identify the
              *real id name.*/
             int pos = val.pos(" ");
@@ -3514,7 +3514,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         break;
     case cssrt_class:         // E.class
         {
-            lString16 val = node->getAttributeValue(attr_class);
+            lString32 val = node->getAttributeValue(attr_class);
             if ( val.empty() )
                 return false;
             // val.lowercase(); // className should be case sensitive
@@ -3524,14 +3524,14 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
             /*As I have eliminated leading and ending spaces in the attribute value, any space in
              *val means there are more than one classes */
             if (val.pos(" ") != -1) {
-                lString16 value_w_space_after = _value + " ";
+                lString32 value_w_space_after = _value + " ";
                 if (val.pos(value_w_space_after) == 0)
                     return true; // at start
-                lString16 value_w_space_before = " " + _value;
+                lString32 value_w_space_before = " " + _value;
                 int pos = val.pos(value_w_space_before);
                 if (pos != -1 && pos + value_w_space_before.length() == val.length())
                     return true; // at end
-                lString16 value_w_spaces_before_after = " " + _value + " ";
+                lString32 value_w_spaces_before_after = " " + _value + " ";
                 if (val.pos(value_w_spaces_before_after) != -1)
                     return true; // in between
                 return false;
@@ -3586,7 +3586,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
                             elem = elem->getParentNode();
                             continue;
                         }
-                        lString16 dir = elem->getAttributeValue( attr_dir );
+                        lString32 dir = elem->getAttributeValue( attr_dir );
                         dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
                         if ( dir.compare(_value) == 0 )
                             return true;
@@ -3858,7 +3858,7 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         if (!parse_ident( str, attrvalue ))
             return NULL;
         LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_class);
-        lString16 s( attrvalue );
+        lString32 s( attrvalue );
         // s.lowercase(); // className should be case sensitive
         rule->setAttr(attr_class, s);
         return rule;
@@ -3868,7 +3868,7 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         if (!parse_ident( str, attrvalue ))
             return NULL;
         LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_id);
-        lString16 s( attrvalue );
+        lString32 s( attrvalue );
         rule->setAttr(attr_id, s);
         return rule;
     } else if ( *str==':' ) {
@@ -3896,11 +3896,11 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
             // values, so trim() and lowercase() below to avoid doing it on each check.
         }
         LVCssSelectorRule * rule = new LVCssSelectorRule(cssrt_pseudoclass);
-        lString16 s( attrvalue );
+        lString32 s( attrvalue );
         s.trim().lowercase();
         if ( n == csspc_nth_child || n == csspc_nth_of_type || n == csspc_nth_last_child || n == csspc_nth_last_of_type ) {
             // Parse "even", "odd", "5", "5n", "5n+2", "-n" into a few
-            // numbers packed into a lString16, for quicker checking.
+            // numbers packed into a lString32, for quicker checking.
             s = parse_nth_value(s);
         }
         rule->setAttr(n, s);
@@ -4002,11 +4002,11 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         return NULL;
     }
     LVCssSelectorRule * rule = new LVCssSelectorRule(st);
-    lString16 s( attrvalue );
+    lString32 s( attrvalue );
     if (parse_trailing_i) { // cssrt_attr*_i met
         s.lowercase();
     }
-    lUInt16 id = doc->getAttrNameIndex( lString16(attrname).c_str() );
+    lUInt16 id = doc->getAttrNameIndex( lString32(attrname).c_str() );
     rule->setAttr(id, s);
     return rule;
 }
@@ -4073,7 +4073,7 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
             // All element names have been lowercased by HTMLParser (except
             // a few ones that are added explicitely by crengine): we need
             // to lowercase them here too to expect a match.
-            lString16 element(ident);
+            lString32 element(ident);
             if ( element.length() < 7 ) {
                 // Avoid following string comparisons if element name string
                 // is shorter than the shortest of them (rubyBox)
@@ -4389,7 +4389,7 @@ lUInt32 LVStyleSheet::getHash()
     return hash;
 }
 
-bool LVStyleSheet::parse( const char * str, bool higher_importance, lString16 codeBase )
+bool LVStyleSheet::parse( const char * str, bool higher_importance, lString32 codeBase )
 {
     if ( !_doc ) {
         // We can't parse anything if no _doc to get element name ids from
@@ -4548,7 +4548,7 @@ bool LVProcessStyleSheetImport( const char * &str, lString8 & import_file )
 }
 
 /// load stylesheet from file, with processing of import
-bool LVLoadStylesheetFile( lString16 pathName, lString8 & css )
+bool LVLoadStylesheetFile( lString32 pathName, lString8 & css )
 {
     LVStreamRef file = LVOpenFileStream( pathName.c_str(), LVOM_READ );
     if ( file.isNull() )
@@ -4558,7 +4558,7 @@ bool LVLoadStylesheetFile( lString16 pathName, lString8 & css )
     const char * s = txt.c_str();
     lString8 import_file;
     if ( LVProcessStyleSheetImport( s, import_file ) ) {
-        lString16 importFilename = LVMakeRelativeFilename( pathName, Utf8ToUnicode(import_file) );
+        lString32 importFilename = LVMakeRelativeFilename( pathName, Utf8ToUnicode(import_file) );
         //lString8 ifn = UnicodeToLocal(importFilename);
         //const char * ifns = ifn.c_str();
         if ( !importFilename.empty() ) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4294,6 +4294,7 @@ LVStyleSheet::LVStyleSheet( LVStyleSheet & sheet )
 {
     set( sheet._selectors );
     _selector_count = sheet._selector_count;
+    _charset = sheet._charset;
 }
 
 void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style )
@@ -4407,6 +4408,9 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString32 co
         bool err = false;
         for (;*str;)
         {
+            // parse charset, and... ignored it
+            // just to avoid generating a parse error
+            parseCharsetRule(str);
             // parse selector(s)
             // Have selector count number make the initial value
             // of _specificity, so order of selectors is preserved
@@ -4489,6 +4493,34 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString32 co
         }
     }
     return _selectors.length() > 0;
+}
+
+bool LVStyleSheet::parseCharsetRule( const char * &str )
+{
+    // Parse rule '@charset' according https://developer.mozilla.org/en-US/docs/Web/CSS/@charset
+    if (!str || !*str)
+        return false;
+    skip_spaces( str );
+    if ( *str == '@' ) {
+        str++;
+        char word[64];
+        if ( parse_ident( str, word ) ) {
+            lString8 keyword(word);
+            if (keyword == "charset") {
+                // skip required space(s)
+                if (*str == ' ' || *str == '\t') {
+                    skip_spaces(str);
+                    if (parse_attr_value(str, word, ';')) {
+                        if (_charset.empty()) {
+                            _charset = word;
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return false;
 }
 
 /// extract @import filename from beginning of CSS

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2716,6 +2716,9 @@ public:
         #endif
         // Ignorables
         bool isToIgnore = false;
+        // Used when LTEXT_FIT_GLYPHS and preceeding or following word is an image or inline box
+        int prev_word_overflow = 0;
+        bool prev_word_is_object = false;
         for ( int i=start; i<=end; i++ ) { // loop thru each char
             src_text_fragment_t * newSrc = i<end ? m_srcs[i] : NULL;
             if ( i<end ) {
@@ -2911,6 +2914,16 @@ public:
 
                 if ( srcline->flags & LTEXT_SRC_IS_OBJECT ) {
                     // object: image or inline-block box (floats have been skipped above)
+
+                    // This is set or used only when LTEXT_FIT_GLYPHS
+                    if ( prev_word_overflow ) {
+                        frmline->width += prev_word_overflow;
+                        frmline->words[frmline->word_count-2].width += prev_word_overflow;
+                        frmline->words[frmline->word_count-2].min_width += prev_word_overflow;
+                        prev_word_overflow = 0;
+                    }
+                    prev_word_is_object = true; // to be used when processing next word
+
                     word->distinct_glyphs = 0;
                     word->x = frmline->width;
                     word->width = srcline->o.width;
@@ -3165,6 +3178,16 @@ public:
                     // on neighbour text nodes), we might need to tweak words x and width
                     bool fit_glyphs = srcline->flags & LTEXT_FIT_GLYPHS;
 
+                    if ( fit_glyphs && !firstWord && prev_word_is_object ) {
+                        int lsb = font->getLeftSideBearing(m_text[wstart]);
+                        if ( lsb < 0 ) {
+                            // Prev word was an image or inline box: avoid first glyph
+                            // from overflowing in it by shifting this new word start
+                            // on the right
+                            frmline->width += -lsb;
+                        }
+                    }
+
                     if ( firstWord && (align == LTEXT_ALIGN_LEFT || align == LTEXT_ALIGN_WIDTH) ) {
                         // Adjust line start x if needed
                         // No need to do it when line is centered or right aligned (doing so
@@ -3394,6 +3417,18 @@ public:
                                 shift_w = usable_right_overflow + rsb;
                             }
                             word->width -= shift_w;
+                        }
+                    }
+
+                    // This is set or used only when LTEXT_FIT_GLYPHS
+                    prev_word_is_object = false;
+                    prev_word_overflow = 0;
+                    if ( fit_glyphs && !lastWord ) {
+                        int rsb = font->getRightSideBearing(m_text[i-1]);
+                        if ( rsb < 0 ) {
+                            // This may be added to shit word width if next
+                            // word is an image or an inline box
+                            prev_word_overflow = -rsb;
                         }
                     }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1324,8 +1324,10 @@ public:
                         last_non_space_pos = pos;
                         last_non_collapsed_space_pos = -1;
                         is_locked_spacing = false;
-                        if ( !is_space ) {
-                            has_non_space = true;
+                        if ( !has_non_space ) {
+                            if ( !is_space && c != UNICODE_NO_BREAK_SPACE ) {
+                                has_non_space = true;
+                            }
                         }
                     }
                     prev_was_space = is_space || (c == '\n');

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -205,7 +205,7 @@ void lvtextFreeFormatter( formatted_text_fragment_t * pbuffer )
 void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
    lvfont_handle   font,     /* handle of font to draw string */
    TextLangCfg *   lang_cfg,
-   const lChar16 * text,     /* pointer to unicode text string */
+   const lChar32 * text,     /* pointer to unicode text string */
    lUInt32         len,      /* number of chars in text, 0 for auto(strlen) */
    lUInt32         color,    /* color */
    lUInt32         bgcolor,  /* bgcolor */
@@ -245,8 +245,8 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
         // allocation size of 0 bytes" without having to add checks for NULL pointer
         // (in lvrend.cpp, we're normalling not adding empty text with LTEXT_FLAG_OWNTEXT)
         lUInt32 alloc_len = len > 0 ? len : 1;
-        pline->t.text = (lChar16*)malloc( alloc_len * sizeof(lChar16) );
-        memcpy((void*)pline->t.text, text, len * sizeof(lChar16));
+        pline->t.text = (lChar32*)malloc( alloc_len * sizeof(lChar32) );
+        memcpy((void*)pline->t.text, text, len * sizeof(lChar32));
     }
     else
     {
@@ -402,7 +402,7 @@ public:
     #if (USE_LIBUNIBREAK==1)
     static bool      m_libunibreak_init_done;
     #endif
-    lChar16 * m_text;
+    lChar32 * m_text;
     lUInt16 * m_flags;
     src_text_fragment_t * * m_srcs;
     lUInt16 * m_charindex;
@@ -628,9 +628,9 @@ public:
             // Gather footnotes links accumulated by alt_context
             // (We only need to gather links in the rendering phase, for
             // page splitting, so no worry if we don't when already_rendered)
-            lString16Collection * link_ids = alt_context.getLinkIds();
+            lString32Collection * link_ids = alt_context.getLinkIds();
             if (link_ids->length() > 0) {
-                flt->links = new lString16Collection();
+                flt->links = new lString32Collection();
                 for ( int n=0; n<link_ids->length(); n++ ) {
                     flt->links->add( link_ids->at(n) );
                 }
@@ -974,7 +974,7 @@ public:
             m_staticBufs = false;
         } else {
             // static buffer space
-            static lChar16 m_static_text[STATIC_BUFS_SIZE];
+            static lChar32 m_static_text[STATIC_BUFS_SIZE];
             static lUInt16 m_static_flags[STATIC_BUFS_SIZE];
             static src_text_fragment_t * m_static_srcs[STATIC_BUFS_SIZE];
             static lUInt16 m_static_charindex[STATIC_BUFS_SIZE];
@@ -1271,7 +1271,7 @@ public:
 
                 bool preformatted = (src->flags & LTEXT_FLAG_PREFORMATTED);
                 for ( int k=0; k<len; k++ ) {
-                    lChar16 c = m_text[pos];
+                    lChar32 c = m_text[pos];
 
                     // If not on a 'pre' text node, we should strip trailing
                     // spaces and collapse consecutive spaces (other spaces
@@ -1287,7 +1287,7 @@ public:
                             // Note: with a mix of normal spaces and non-break-spaces,
                             // we seem to behave just as Firefox.
                             // Note: for the empty lines or indentation we might add
-                            // with 'txform->AddSourceLine(L" "...)', we need to
+                            // with 'txform->AddSourceLine(U" "...)', we need to
                             // provide LTEXT_FLAG_PREFORMATTED if we don't want them
                             // to be collapsed.
                             m_flags[pos] = LCHAR_IS_COLLAPSED_SPACE | LCHAR_ALLOW_WRAP_AFTER;
@@ -1411,7 +1411,7 @@ public:
                             m_flags[pos] |= LCHAR_DEPRECATED_WRAP_AFTER;
                         }
                     }
-                    lChar16 ch = m_text[pos];
+                    lChar32 ch = m_text[pos];
                     if ( src->lang_cfg->hasLBCharSubFunc() ) {
                         // Lang specific function may want to substitute char (for
                         // libunibreak only) to tweak line breaking around it
@@ -1520,7 +1520,7 @@ public:
                 // m_text[k] = '='; // uncomment when debugging
             }
         }
-        TR("%s", LCSTR(lString16(m_text, m_length)));
+        TR("%s", LCSTR(lString32(m_text, m_length)));
 
         // Whether any "-cr-hint: strut-confined" should be applied: only when
         // we have non-space-only text in the paragraph - standalone images
@@ -1671,7 +1671,7 @@ public:
     {
         src_text_fragment_t * srcline = &m_pbuffer->srctext[word->src_text_index];
         LVFont * srcfont= (LVFont *) srcline->t.font;
-        const lChar16 * str = srcline->t.text + word->t.start;
+        const lChar32 * str = srcline->t.text + word->t.start;
         // Avoid malloc by using static buffers. Returns false if word too long.
         #define MAX_MEASURED_WORD_SIZE 127
         static lUInt16 widths[MAX_MEASURED_WORD_SIZE+1];
@@ -2041,14 +2041,14 @@ public:
                             // we have them here too early, and we would need to associate
                             // the links to this "char" index, so needing in LVFormatter
                             // something like:
-                            //   LVHashTable<lUInt32, lString16Collection> m_inlinebox_links
+                            //   LVHashTable<lUInt32, lString32Collection> m_inlinebox_links
                             // When adding this inlineBox to a frmline, we could then get back
                             // the links, and associate them to the frmline (so, needing a
-                            // new field holding a lString16Collection, which would hold
+                            // new field holding a lString32Collection, which would hold
                             // all the links in all the inlineBoxs part of that line).
                             // Finally, in renderBlockElementEnhanced, when adding
                             // links for words, we'd also need to add the one found
-                            // in the frmline's lString16Collection.
+                            // in the frmline's lString32Collection.
                             // A bit complicated, for a probably very rare case, so
                             // let's just forget it and not have footnotes from inlineBox
                             // among our in-page footnotes...
@@ -2139,9 +2139,9 @@ public:
             }
         }
 //        // debug dump
-//        lString16 buf;
+//        lString32 buf;
 //        for ( int i=0; i<m_length; i++ ) {
-//            buf << L" " << lChar16(m_text[i]) << L" " << lString16::itoa(m_widths[i]);
+//            buf << U" " << lChar32(m_text[i]) << U" " << lString32::itoa(m_widths[i]);
 //        }
 //        TR("%s", LCSTR(buf));
     }
@@ -2484,7 +2484,7 @@ public:
                 printf("CRE WARNING: bidi processing line overflow (%d > %d)\n", end-start, MAX_LINE_SIZE);
                 end = start + MAX_LINE_SIZE;
             }
-            static lChar16 bidi_tmp_text[MAX_LINE_SIZE];
+            static lChar32 bidi_tmp_text[MAX_LINE_SIZE];
             static lUInt16 bidi_tmp_flags[MAX_LINE_SIZE];
             static src_text_fragment_t * bidi_tmp_srcs[MAX_LINE_SIZE];
             static lUInt16 bidi_tmp_charindex[MAX_LINE_SIZE];
@@ -2867,7 +2867,7 @@ public:
                                 // This is a bit hacky, but no other solution: just
                                 // replace that ignorable char with a space in the
                                 // src text
-                                *((lChar16 *) (m_srcs[wstart]->t.text + m_charindex[wstart])) = L' ';
+                                *((lChar32 *) (m_srcs[wstart]->t.text + m_charindex[wstart])) = U' ';
                             }
                         }
                         else { // Last or single para with no word
@@ -3066,7 +3066,7 @@ public:
                         word->y = srcline->valign_dy;
                     }
                     // printf("baseline_to_bottom=%d top_to_baseline=%d word->y=%d txt=|%s|\n", baseline_to_bottom,
-                    //   top_to_baseline, word->y, UnicodeToLocal(lString16(srcline->t.text, srcline->t.len)).c_str());
+                    //   top_to_baseline, word->y, UnicodeToLocal(lString32(srcline->t.text, srcline->t.len)).c_str());
 
                     // Set word start and end (start+len-1) indices in the source text node
                     if ( !m_has_bidi ) {
@@ -3089,11 +3089,11 @@ public:
                         // do that if Harfbuzz is used, as it does that by itself, and
                         // would mirror back our mirrored chars!)
                         if ( font->getKerningMode() != KERNING_MODE_HARFBUZZ) {
-                            lChar16 * str = (lChar16*)(srcline->t.text + word->t.start);
+                            lChar32 * str = (lChar32*)(srcline->t.text + word->t.start);
                             FriBidiChar mirror;
                             for (int i=0; i < word->t.len; i++) {
                                 if ( fribidi_get_mirror_char( (FriBidiChar)(str[i]), &mirror) )
-                                    str[i] = (lChar16)mirror;
+                                    str[i] = (lChar32)mirror;
                             }
                         }
                         #endif
@@ -3243,7 +3243,7 @@ public:
                     // Set and adjust word natural width (and min_width which might be used in alignLine())
                     word->width = m_widths[i>0 ? i-1 : 0] - (wstart>0 ? m_widths[wstart-1] : 0);
                     word->min_width = word->width;
-                    TR("addLine - word(%d, %d) x=%d (%d..%d)[%d] |%s|", wstart, i, frmline->width, wstart>0 ? m_widths[wstart-1] : 0, m_widths[i-1], word->width, LCSTR(lString16(m_text+wstart, i-wstart)));
+                    TR("addLine - word(%d, %d) x=%d (%d..%d)[%d] |%s|", wstart, i, frmline->width, wstart>0 ? m_widths[wstart-1] : 0, m_widths[i-1], word->width, LCSTR(lString32(m_text+wstart, i-wstart)));
                     if ( m_flags[wstart] & LCHAR_IS_CLUSTER_TAIL ) {
                         // The start of this word is part of a ligature that started
                         // in a previous word: some hyphenation wrap happened on
@@ -3497,7 +3497,7 @@ public:
 
                     // printf("addLine - word(%d, %d) x=%d (%d..%d)[%d>%d %x] |%s|\n", wstart, i,
                     //      frmline->width, wstart>0 ? m_widths[wstart-1] : 0, m_widths[i-1], word->width,
-                    //      word->min_width, word->flags, LCSTR(lString16(m_text+wstart, i-wstart)));
+                    //      word->min_width, word->flags, LCSTR(lString32(m_text+wstart, i-wstart)));
                 }
 
                 // Word added: adjust frmline height and baseline to account for this word
@@ -3653,7 +3653,7 @@ public:
         return 0;
     }
 
-    bool isCJKIdeograph(lChar16 c) {
+    bool isCJKIdeograph(lChar32 c) {
         return c >= UNICODE_CJK_IDEOGRAPHS_BEGIN &&
                c <= UNICODE_CJK_IDEOGRAPHS_END   &&
                ( c <= UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_BEGIN ||
@@ -3661,7 +3661,7 @@ public:
     }
 
     #if (USE_LIBUNIBREAK!=1)
-    bool isCJKPunctuation(lChar16 c) {
+    bool isCJKPunctuation(lChar32 c) {
         return ( c >= UNICODE_CJK_PUNCTUATION_BEGIN && c <= UNICODE_CJK_PUNCTUATION_END ) ||
                ( c >= UNICODE_GENERAL_PUNCTUATION_BEGIN && c <= UNICODE_GENERAL_PUNCTUATION_END &&
                     c!=0x2018 && c!=0x201a && c!=0x201b &&    // ‘ ‚ ‛  left quotation marks
@@ -3673,14 +3673,14 @@ public:
                ( c == 0x00b7 ); // · middle dot
     }
 
-    bool isCJKLeftPunctuation(lChar16 c) {
+    bool isCJKLeftPunctuation(lChar32 c) {
         return c==0x2018 || c==0x201c || // ‘ “ left single and double quotation marks
                c==0x3008 || c==0x300a || c==0x300c || c==0x300e || c==0x3010 || // 〈 《 「 『 【 CJK left brackets
                c==0xff08; // （ fullwidth left parenthesis
     }
     #endif
 
-    bool isLeftPunctuation(lChar16 c) {
+    bool isLeftPunctuation(lChar32 c) {
         // Opening quotation marks and dashes that we don't want a followup space to
         // have its width changed
         return ( c >= 0x2010 && c <= 0x2027 ) || // Hyphens, dashes, quotation marks, bullets...
@@ -3998,7 +3998,7 @@ public:
                         debug_loop_num++;
                         if (debug_loop_num > 1)
                             printf("hyph loop #%d checking: %s\n", debug_loop_num,
-                                LCSTR(lString16(m_text+wordpos_min, i-wordpos_min+1)));
+                                LCSTR(lString32(m_text+wordpos_min, i-wordpos_min+1)));
                     #endif
                     if ( !(m_srcs[wordpos]->flags & LTEXT_HYPHENATE) || (m_srcs[wordpos]->flags & LTEXT_FLAG_NOWRAP) ) {
                         // The word at worpos can't be hyphenated, but it might be
@@ -4035,11 +4035,11 @@ public:
                     }
                     #ifdef DEBUG_HYPH_EXTRA_LOOPS
                         if (debug_loop_num > 1)
-                            printf("  hyphenating: %s\n", LCSTR(lString16(m_text+wstart, len)));
+                            printf("  hyphenating: %s\n", LCSTR(lString32(m_text+wstart, len)));
                     #endif
                     #if TRACE_LINE_SPLITTING==1
                         TR("wordBounds(%s) unusedSpace=%d wordWidth=%d",
-                                LCSTR(lString16(m_text+wstart, len)), unusedSpace, m_widths[wend]-m_widths[wstart]);
+                                LCSTR(lString32(m_text+wstart, len)), unusedSpace, m_widths[wend]-m_widths[wstart]);
                     #endif
                     // We have a valid word to look for hyphenation
                     if ( len > MAX_WORD_SIZE ) // hyphenate() stops/truncates at 64 chars
@@ -4138,13 +4138,13 @@ public:
             int upSkipCount = 0;
             if (endp > 1 && isCJKLeftPunctuation(*(m_text + endp))) {
                 // Next char will be fine at the start of next line.
-                //CRLog::trace("skip skip punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
+                //CRLog::trace("skip skip punctuation %s, at index %d", LCSTR(lString32(m_text+endp, 1)), endp);
             } else if (endp > 1 && endp < m_length - 1 && isCJKLeftPunctuation(*(m_text + endp - 1))) {
                 // Most right char is left punctuation: go back 1 char so this one
                 // goes onto next line.
                 upSkipPos = endp;
                 endp--; wrapPos--;
-                //CRLog::trace("up skip left punctuation %s, at index %d", LCSTR(lString16(m_text+endp, 1)), endp);
+                //CRLog::trace("up skip left punctuation %s, at index %d", LCSTR(lString32(m_text+endp, 1)), endp);
             } else if (endp > 1 && isCJKPunctuation(*(m_text + endp))) {
                 // Next char (start of next line) is some right punctuation that
                 // is not allowed at start of line.
@@ -4153,11 +4153,11 @@ public:
                 // which to use.
                 for (int epos = endp; epos<m_length; epos++, downSkipCount++) {
                    if ( !isCJKPunctuation(*(m_text + epos)) ) break;
-                   //CRLog::trace("down skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
+                   //CRLog::trace("down skip punctuation %s, at index %d", LCSTR(lString32(m_text + epos, 1)), epos);
                 }
                 for (int epos = endp; epos>=start; epos--, upSkipCount++) {
                    if ( !isCJKPunctuation(*(m_text + epos)) ) break;
-                   //CRLog::trace("up skip punctuation %s, at index %d", LCSTR(lString16(m_text + epos, 1)), epos);
+                   //CRLog::trace("up skip punctuation %s, at index %d", LCSTR(lString32(m_text + epos, 1)), epos);
                 }
                 if (downSkipCount <= upSkipCount && downSkipCount <= 2 && false ) {
                             // last check was "&& m_hanging_punctuation", but we
@@ -4666,7 +4666,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
     LVFont * font;
     lvRect clip;
     buf->GetClipRect( &clip );
-    const lChar16 * str;
+    const lChar32 * str;
     int line_y = y;
 
     // We might need to translate "marks" (native highlights) from relative
@@ -4907,8 +4907,8 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         text_decoration_back_gap);
                     /* To display the added letter spacing % at end of line
                     if (j == frmline->word_count-1 && word->added_letter_spacing ) {
-                        // lString16 val = lString16::itoa(word->added_letter_spacing);
-                        lString16 val = lString16::itoa(100*word->added_letter_spacing / font->getSize());
+                        // lString32 val = lString32::itoa(word->added_letter_spacing);
+                        lString32 val = lString32::itoa(100*word->added_letter_spacing / font->getSize());
                         font->DrawTextString( buf, x + frmline->x + word->x + word->width + 10,
                             line_y + (frmline->baseline - font->getBaseline()) + word->y,
                             val.c_str(), val.length(), '?', NULL, false);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -88,7 +88,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.53k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0025
+#define FORMATTING_VERSION_ID 0x0026
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4222,7 +4222,9 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                 *stream << " ";
                 if ( nsName.length() > 0 )
                     *stream << nsName << ":";
-                *stream << attrName << "=\"" << attrValue << "\"";
+                *stream << attrName;
+                if ( !attrValue.empty() ) // don't show ="" if empty
+                    *stream << "=\"" << attrValue << "\"";
                 if ( attrName == "StyleSheet" ) { // gather linked css files
                     lString32 cssFile = node->getDocument()->getAttrValue(attr->index);
                     if (!cssFiles.contains(cssFile))

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -309,7 +309,7 @@ public:
         return _text;
     }
 
-    lString16 getText16()
+    lString32 getText32()
     {
         return Utf8ToUnicode(_text);
     }
@@ -319,7 +319,7 @@ public:
         _text = s;
     }
 
-    void setText( const lString16 & s )
+    void setText( const lString32 & s )
     {
         _text = UnicodeToUtf8(s);
     }
@@ -414,9 +414,9 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     return hash;
 }
 
-static void dumpRendMethods( ldomNode * node, lString16 prefix )
+static void dumpRendMethods( ldomNode * node, lString32 prefix )
 {
-    lString16 name = prefix;
+    lString32 name = prefix;
     if ( node->isText() )
         name << node->getText();
     else
@@ -535,7 +535,7 @@ class CacheFile
     bool _indexChanged;
     bool _dirty;
     lUInt32 _domVersion;
-    lString16 _cachePath;
+    lString32 _cachePath;
     LVStreamRef _stream; // file stream
     LVPtrVector<CacheFileItem, true> _index; // full file block index
     LVPtrVector<CacheFileItem, false> _freeIndex; // free file block index
@@ -562,11 +562,11 @@ public:
     // free resources
     ~CacheFile();
     // try open existing cache file
-    bool open( lString16 filename );
+    bool open( lString32 filename );
     // try open existing cache file from stream
     bool open( LVStreamRef stream );
     // create new cache file
-    bool create( lString16 filename );
+    bool create( lString32 filename );
     // create new cache file in stream
     bool create( LVStreamRef stream );
     /// writes block to file
@@ -605,10 +605,10 @@ public:
     void setAutoSyncSize(int sz) {
         _stream->setAutoSyncSize(sz);
     }
-    void setCachePath(const lString16 cachePath) {
+    void setCachePath(const lString32 cachePath) {
         _cachePath = cachePath;
     }
-    const lString16 getCachePath() {
+    const lString32 getCachePath() {
         return _cachePath;
     }
 };
@@ -616,7 +616,7 @@ public:
 
 // create uninitialized cache file, call open or create to initialize
 CacheFile::CacheFile(lUInt32 domVersion)
-: _sectorSize( CACHE_FILE_SECTOR_SIZE ), _size(0), _indexChanged(false), _dirty(true), _domVersion(domVersion), _map(1024), _cachePath(lString16::empty_str)
+: _sectorSize( CACHE_FILE_SECTOR_SIZE ), _size(0), _indexChanged(false), _dirty(true), _domVersion(domVersion), _map(1024), _cachePath(lString32::empty_str)
 {
 }
 
@@ -1157,7 +1157,7 @@ bool CacheFile::read( lUInt16 type, lUInt16 index, SerialBuf & buf )
 }
 
 // try open existing cache file
-bool CacheFile::open( lString16 filename )
+bool CacheFile::open( lString32 filename )
 {
     LVStreamRef stream = LVOpenFileStream( filename.c_str(), LVOM_APPEND );
     if ( !stream ) {
@@ -1187,7 +1187,7 @@ bool CacheFile::open( LVStreamRef stream )
     return true;
 }
 
-bool CacheFile::create( lString16 filename )
+bool CacheFile::create( lString32 filename )
 {
     LVStreamRef stream = LVOpenFileStream( filename.c_str(), LVOM_APPEND );
     if ( _stream.isNull() ) {
@@ -1227,11 +1227,11 @@ bool CacheFile::create( LVStreamRef stream )
 
 class ldomBlobItem {
     int _storageIndex;
-    lString16 _name;
+    lString32 _name;
     int _size;
     lUInt8 * _data;
 public:
-    ldomBlobItem( lString16 name ) : _storageIndex(-1), _name(name), _size(0), _data(NULL) {
+    ldomBlobItem( lString32 name ) : _storageIndex(-1), _name(name), _size(0), _data(NULL) {
 
     }
     ~ldomBlobItem() {
@@ -1241,7 +1241,7 @@ public:
     int getSize() { return _size; }
     int getIndex() { return _storageIndex; }
     lUInt8 * getData() { return _data; }
-    lString16 getName() { return _name; }
+    lString32 getName() { return _name; }
     void setIndex(int index, int size) {
         if ( _data )
             delete[] _data;
@@ -1284,7 +1284,7 @@ bool ldomBlobCache::loadIndex()
     lUInt32 len;
     buf >> len;
     for ( lUInt32 i = 0; i<len; i++ ) {
-        lString16 name;
+        lString32 name;
         buf >> name;
         lUInt32 size;
         buf >> size;
@@ -1345,7 +1345,7 @@ void ldomBlobCache::setCacheFile( CacheFile * cacheFile )
         saveToCache(infinite);
 }
 
-bool ldomBlobCache::addBlob( const lUInt8 * data, int size, lString16 name )
+bool ldomBlobCache::addBlob( const lUInt8 * data, int size, lString32 name )
 {
     CRLog::debug("ldomBlobCache::addBlob( %s, size=%d, [%02x,%02x,%02x,%02x] )", LCSTR(name), size, data[0], data[1], data[2], data[3]);
     int index = _list.length();
@@ -1361,7 +1361,7 @@ bool ldomBlobCache::addBlob( const lUInt8 * data, int size, lString16 name )
     return true;
 }
 
-LVStreamRef ldomBlobCache::getBlob( lString16 name )
+LVStreamRef ldomBlobCache::getBlob( lString32 name )
 {
     ldomBlobItem * item = NULL;
     lUInt16 index = 0;
@@ -1955,7 +1955,7 @@ struct TextDataStorageItem : public DataStorageItemHeader {
     /// utf8 text, w/o zero
     lChar8 text[2]; // utf8 text follows here, w/o zero byte at end
     /// return text
-    inline lString16 getText() { return Utf8ToUnicode( text, length ); }
+    inline lString32 getText() { return Utf8ToUnicode( text, length ); }
     inline lString8 getText8() { return lString8( text, length ); }
 };
 
@@ -2138,9 +2138,9 @@ bool tinyNodeCollection::openCacheFile()
     if ( _cacheFile )
         return true;
     CacheFile * f = new CacheFile(_DOMVersionRequested);
-    //lString16 cacheFileName("/tmp/cr3swap.tmp");
+    //lString32 cacheFileName("/tmp/cr3swap.tmp");
 
-    lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
+    lString32 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
     //lUInt32 sz = (lUInt32)getProps()->getInt64Def(DOC_PROP_FILE_SIZE, 0);
     lUInt32 crc = (lUInt32)getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
 
@@ -2152,7 +2152,7 @@ bool tinyNodeCollection::openCacheFile()
 
     CRLog::info("ldomDocument::openCacheFile() - looking for cache file %s", UnicodeToUtf8(fname).c_str() );
 
-    lString16 cache_path;
+    lString32 cache_path;
     LVStreamRef map = ldomDocCache::openExisting( fname, crc, getPersistenceFlags(), cache_path );
     if ( map.isNull() ) {
         delete f;
@@ -2188,9 +2188,9 @@ bool tinyNodeCollection::createCacheFile()
     if ( _cacheFile )
         return true;
     CacheFile * f = new CacheFile(_DOMVersionRequested);
-    //lString16 cacheFileName("/tmp/cr3swap.tmp");
+    //lString32 cacheFileName("/tmp/cr3swap.tmp");
 
-    lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
+    lString32 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "noname" );
     lUInt32 sz = (lUInt32)getProps()->getInt64Def(DOC_PROP_FILE_SIZE, 0);
     lUInt32 crc = (lUInt32)getProps()->getIntDef(DOC_PROP_FILE_CRC32, 0);
 
@@ -2202,7 +2202,7 @@ bool tinyNodeCollection::createCacheFile()
 
     CRLog::info("ldomDocument::createCacheFile() - initialized swapping of document %s to cache file", UnicodeToUtf8(fname).c_str() );
 
-    lString16 cache_path;
+    lString32 cache_path;
     LVStreamRef map = ldomDocCache::createNew( fname, crc, getPersistenceFlags(), sz, cache_path );
     if ( map.isNull() ) {
         delete f;
@@ -2225,8 +2225,8 @@ bool tinyNodeCollection::createCacheFile()
     return true;
 }
 
-lString16 tinyNodeCollection::getCacheFilePath() {
-    return _cacheFile != NULL ? _cacheFile->getCachePath() : lString16::empty_str;
+lString32 tinyNodeCollection::getCacheFilePath() {
+    return _cacheFile != NULL ? _cacheFile->getCachePath() : lString32::empty_str;
 }
 
 void tinyNodeCollection::clearNodeStyle( lUInt32 dataIndex )
@@ -3470,7 +3470,7 @@ public:
     ~simpleLogFile() { if (f) fclose(f); }
     simpleLogFile & operator << ( const char * str ) { fprintf( f, "%s", str ); fflush( f ); return *this; }
     simpleLogFile & operator << ( int d ) { fprintf( f, "%d(0x%X) ", d, d ); fflush( f ); return *this; }
-    simpleLogFile & operator << ( const wchar_t * str )
+    simpleLogFile & operator << ( const lChar32 * str )
     {
         if (str)
         {
@@ -3532,18 +3532,18 @@ void lxmlDocBase::onAttributeSet( lUInt16 attrId, lUInt32 valueId, ldomNode * no
     if (attrId == _idAttrId) {
         _idNodeMap.set( valueId, node->getDataIndex() );
     } else if ( attrId==_nameAttrId ) {
-        lString16 nodeName = node->getNodeName();
+        lString32 nodeName = node->getNodeName();
         if (nodeName == "a")
             _idNodeMap.set( valueId, node->getDataIndex() );
     }
 }
 
-lUInt16 lxmlDocBase::getNsNameIndex( const lChar16 * name )
+lUInt16 lxmlDocBase::getNsNameIndex( const lChar32 * name )
 {
     const LDOMNameIdMapItem * item = _nsNameTable.findItem( name );
     if (item)
         return item->id;
-    _nsNameTable.AddItem( _nextUnknownNsId, lString16(name), NULL );
+    _nsNameTable.AddItem( _nextUnknownNsId, lString32(name), NULL );
     return _nextUnknownNsId++;
 }
 
@@ -3552,16 +3552,16 @@ lUInt16 lxmlDocBase::getNsNameIndex( const lChar8 * name )
     const LDOMNameIdMapItem * item = _nsNameTable.findItem( name );
     if (item)
         return item->id;
-    _nsNameTable.AddItem( _nextUnknownNsId, lString16(name), NULL );
+    _nsNameTable.AddItem( _nextUnknownNsId, lString32(name), NULL );
     return _nextUnknownNsId++;
 }
 
-lUInt16 lxmlDocBase::getAttrNameIndex( const lChar16 * name )
+lUInt16 lxmlDocBase::getAttrNameIndex( const lChar32 * name )
 {
     const LDOMNameIdMapItem * item = _attrNameTable.findItem( name );
     if (item)
         return item->id;
-    _attrNameTable.AddItem( _nextUnknownAttrId, lString16(name), NULL );
+    _attrNameTable.AddItem( _nextUnknownAttrId, lString32(name), NULL );
     return _nextUnknownAttrId++;
 }
 
@@ -3570,16 +3570,16 @@ lUInt16 lxmlDocBase::getAttrNameIndex( const lChar8 * name )
     const LDOMNameIdMapItem * item = _attrNameTable.findItem( name );
     if (item)
         return item->id;
-    _attrNameTable.AddItem( _nextUnknownAttrId, lString16(name), NULL );
+    _attrNameTable.AddItem( _nextUnknownAttrId, lString32(name), NULL );
     return _nextUnknownAttrId++;
 }
 
-lUInt16 lxmlDocBase::getElementNameIndex( const lChar16 * name )
+lUInt16 lxmlDocBase::getElementNameIndex( const lChar32 * name )
 {
     const LDOMNameIdMapItem * item = _elementNameTable.findItem( name );
     if (item)
         return item->id;
-    _elementNameTable.AddItem( _nextUnknownElementId, lString16(name), NULL );
+    _elementNameTable.AddItem( _nextUnknownElementId, lString32(name), NULL );
     return _nextUnknownElementId++;
 }
 
@@ -3596,7 +3596,7 @@ lUInt16 lxmlDocBase::getElementNameIndex( const lChar8 * name )
     const LDOMNameIdMapItem * item = _elementNameTable.findItem( name );
     if (item)
         return item->id;
-    _elementNameTable.AddItem( _nextUnknownElementId, lString16(name), NULL );
+    _elementNameTable.AddItem( _nextUnknownElementId, lString32(name), NULL );
     return _nextUnknownElementId++;
 }
 
@@ -3735,18 +3735,18 @@ static void writeNode( LVStream * stream, ldomNode * node, bool treeLayout )
                 if ( fmt ) {
                     lvRect rect;
                     elem->getAbsRect( rect );
-                    *stream << L" fmt=\"";
-                    *stream << L"rm:" << lString16::itoa( (int)elem->getRendMethod() ) << L" ";
+                    *stream << U" fmt=\"";
+                    *stream << U"rm:" << lString32::itoa( (int)elem->getRendMethod() ) << U" ";
                     if ( style.isNull() )
-                        *stream << L"style: NULL ";
+                        *stream << U"style: NULL ";
                     else {
-                        *stream << L"disp:" << lString16::itoa( (int)style->display ) << L" ";
+                        *stream << U"disp:" << lString32::itoa( (int)style->display ) << U" ";
                     }
-                    *stream << L"y:" << lString16::itoa( (int)fmt->getY() ) << L" ";
-                    *stream << L"h:" << lString16::itoa( (int)fmt->getHeight() ) << L" ";
-                    *stream << L"ay:" << lString16::itoa( (int)rect.top ) << L" ";
-                    *stream << L"ah:" << lString16::itoa( (int)rect.height() ) << L" ";
-                    *stream << L"\"";
+                    *stream << U"y:" << lString32::itoa( (int)fmt->getY() ) << U" ";
+                    *stream << U"h:" << lString32::itoa( (int)fmt->getHeight() ) << U" ";
+                    *stream << U"ay:" << lString32::itoa( (int)rect.top ) << U" ";
+                    *stream << U"ah:" << lString32::itoa( (int)rect.height() ) << U" ";
+                    *stream << U"\"";
                 }
             }
 #endif
@@ -3806,7 +3806,7 @@ static void writeNode( LVStream * stream, ldomNode * node, bool treeLayout )
 
 #define WNEFLAG(x) ( wflags & WRITENODEEX_##x )
 
-static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection & cssFiles, int wflags=0,
+static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection & cssFiles, int wflags=0,
     ldomXPointerEx startXP=ldomXPointerEx(), ldomXPointerEx endXP=ldomXPointerEx(), int indentBaseLevel=-1)
 {
     bool isStartNode = false;
@@ -3860,8 +3860,8 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
     }
 
     bool isInitialNode = false;
-    lString16 initialDirAttribute = lString16::empty_str;
-    lString16 initialLangAttribute = lString16::empty_str;
+    lString32 initialDirAttribute = lString32::empty_str;
+    lString32 initialLangAttribute = lString32::empty_str;
     if (indentBaseLevel < 0) { // initial call (recursive ones will have it >=0)
         indentBaseLevel = node->getNodeLevel();
         isInitialNode = true;
@@ -3891,7 +3891,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
     if ( node->isText() && isAfterStart && isBeforeEnd ) {
         bool doNewLine =  WNEFLAG(NEWLINE_ALL_NODES);
         bool doIndent = doNewLine && WNEFLAG(INDENT_NEWLINE);
-        lString16 txt = node->getText();
+        lString32 txt = node->getText();
         lString8 prefix = lString8::empty_str;
         lString8 suffix = lString8::empty_str;
 
@@ -3951,10 +3951,10 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             // (see https://en.wikipedia.org/wiki/Specials_(Unicode_block) )
             // for 2-steps '&' replacement (to avoid infinite loop or the
             // need for more complicated code)
-            while ( txt.replace( cs16("&"), cs16(L"\xFFFF") ) ) ;
-            while ( txt.replace( cs16(L"\xFFFF"), cs16("&amp;") ) ) ;
-            while ( txt.replace( cs16("<"), cs16("&lt;") ) ) ;
-            while ( txt.replace( cs16(">"), cs16("&gt;") ) ) ;
+            while ( txt.replace( cs32("&"), cs32(U"\xFFFF") ) ) ;
+            while ( txt.replace( cs32(U"\xFFFF"), cs32("&amp;") ) ) ;
+            while ( txt.replace( cs32("<"), cs32("&lt;") ) ) ;
+            while ( txt.replace( cs32(">"), cs32("&gt;") ) ) ;
         }
         #define HYPH_MIN_WORD_LEN_TO_HYPHENATE 4
         #define HYPH_MAX_WORD_SIZE 64
@@ -3970,7 +3970,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
             // settings) says hyphenation is allowed.
             // We do that here while we output the text to avoid the need
             // for temporary storage of a string with soft-hyphens added.
-            const lChar16 * text16 = txt.c_str();
+            const lChar32 * text32 = txt.c_str();
             int txtlen = txt.length();
             lUInt8 * flags = (lUInt8*)calloc(txtlen, sizeof(*flags));
             lUInt16 widths[HYPH_MAX_WORD_SIZE] = { 0 }; // array needed by hyphenate()
@@ -3982,7 +3982,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 // (or the previous word if wordpos happens to be a space or some
                 // punctuation) by looking only for alpha chars in m_text.
                 int start, end;
-                lStr_findWordBounds( text16, txtlen, wordpos, start, end );
+                lStr_findWordBounds( text32, txtlen, wordpos, start, end );
                 if ( end <= HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
                     // Too short word at start, we're done
                     break;
@@ -4004,7 +4004,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                 // Have hyphenate() set flags inside 'flags'
                 // (Fetching the lang_cfg for each text node is not really cheap, but
                 // it's easier than having to pass it to each writeNodeEx())
-                TextLangMan::getTextLangCfg(node)->getHyphMethod()->hyphenate(text16+start, len, widths, flags+start, 0, 0xFFFF, 1);
+                TextLangMan::getTextLangCfg(node)->getHyphMethod()->hyphenate(text32+start, len, widths, flags+start, 0, 0xFFFF, 1);
                 // Continue with previous word
                 wordpos = start - 1;
             }
@@ -4208,7 +4208,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     if ( node->getNodeId() == el_pseudoElem && (attr->id == attr_Before || attr->id == attr_After) ) {
                         // Show the rendered content as the otherwise empty Before/After attribute value
                         if ( WNEFLAG(TEXT_SHOW_UNICODE_CODEPOINT) ) {
-                            lString16 content = get_applied_content_property(node);
+                            lString32 content = get_applied_content_property(node);
                             attrValue.empty();
                             for ( int i=0; i<content.length(); i++ ) {
                                 attrValue << UnicodeToUtf8(content.substr(i, 1)) << "⟨U+" << lString8().appendHex(content[i]) << "⟩";
@@ -4224,7 +4224,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     *stream << nsName << ":";
                 *stream << attrName << "=\"" << attrValue << "\"";
                 if ( attrName == "StyleSheet" ) { // gather linked css files
-                    lString16 cssFile = node->getDocument()->getAttrValue(attr->index);
+                    lString32 cssFile = node->getDocument()->getAttrValue(attr->index);
                     if (!cssFiles.contains(cssFile))
                         cssFiles.add(cssFile);
                 }
@@ -4281,7 +4281,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     if ( ! LVProcessStyleSheetImport( s, import_file ) ) {
                         break;
                     }
-                    lString16 cssFile = LVCombinePaths( node->getAttributeValue(attr_href), Utf8ToUnicode(import_file) );
+                    lString32 cssFile = LVCombinePaths( node->getAttributeValue(attr_href), Utf8ToUnicode(import_file) );
                     if ( !cssFile.empty() && !cssFiles.contains(cssFile) ) {
                         cssFiles.add(cssFile);
                     }
@@ -4335,7 +4335,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                     // The CSS file in StyleSheet="" attribute was the first one seen by
                     // crengine, so add it first to cssFiles
                     if (pnode->hasAttribute(attr_StyleSheet) ) {
-                        lString16 cssFile = pnode->getAttributeValue(attr_StyleSheet);
+                        lString32 cssFile = pnode->getAttributeValue(attr_StyleSheet);
                         if (!cssFiles.contains(cssFile))
                             cssFiles.add(cssFile);
                     }
@@ -4351,7 +4351,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString16Collection
                                 if ( ! LVProcessStyleSheetImport( s, import_file ) ) {
                                     break;
                                 }
-                                lString16 cssFile = LVCombinePaths( pnode->getAttributeValue(attr_href), Utf8ToUnicode(import_file) );
+                                lString32 cssFile = LVCombinePaths( pnode->getAttributeValue(attr_href), Utf8ToUnicode(import_file) );
                                 if ( !cssFile.empty() && !cssFiles.contains(cssFile) ) {
                                     cssFiles.add(cssFile);
                                 }
@@ -4370,7 +4370,7 @@ bool ldomDocument::saveToStream( LVStreamRef stream, const char *, bool treeLayo
     if (!stream || !getRootNode()->getChildCount())
         return false;
 
-    *stream.get() << UnicodeToLocal(cs16(L"\xFEFF"));
+    *stream.get() << UnicodeToLocal(cs32(U"\xFEFF"));
     writeNode( stream.get(), getRootNode(), treeLayout );
     return true;
 }
@@ -4412,19 +4412,19 @@ public:
         _inProgress.clear();
     }
 
-    bool Parse(lString16 cssFile)
+    bool Parse(lString32 cssFile)
     {
         bool ret = false;
         if ( cssFile.empty() )
             return ret;
 
-        lString16 codeBase = cssFile;
+        lString32 codeBase = cssFile;
         LVExtractLastPathElement(codeBase);
         LVContainerRef container = _document->getContainer();
         if (!container.isNull()) {
             LVStreamRef cssStream = container->OpenStream(cssFile.c_str(), LVOM_READ);
             if (!cssStream.isNull()) {
-                lString16 css;
+                lString32 css;
                 css << LVReadTextFile(cssStream);
                 int offset = _inProgress.add(cssFile);
                 ret = Parse(codeBase, css) || ret;
@@ -4434,7 +4434,7 @@ public:
         return ret;
     }
 
-    bool Parse(lString16 codeBase, lString16 css)
+    bool Parse(lString32 codeBase, lString32 css)
     {
         bool ret = false;
         if ( css.empty() )
@@ -4447,7 +4447,7 @@ public:
             lString8 import_file;
 
             if ( LVProcessStyleSheetImport( s, import_file ) ) {
-                lString16 importFilename = LVCombinePaths( codeBase, Utf8ToUnicode(import_file) );
+                lString32 importFilename = LVCombinePaths( codeBase, Utf8ToUnicode(import_file) );
                 if ( !importFilename.empty() && !_inProgress.contains(importFilename) ) {
                     ret = Parse(importFilename) || ret;
                 }
@@ -4460,7 +4460,7 @@ public:
     }
 private:
     ldomDocument  *_document;
-    lString16Collection _inProgress;
+    lString32Collection _inProgress;
     int _nestingLevel;
 };
 
@@ -4619,9 +4619,9 @@ void ldomDocument::applyDocumentStyleSheet()
                          LCSTR(_docStylesheetFileName));
         }
     } else {
-        ldomXPointer ss = createXPointer(cs16("/FictionBook/stylesheet"));
+        ldomXPointer ss = createXPointer(cs32("/FictionBook/stylesheet"));
         if ( !ss.isNull() ) {
-            lString16 css = ss.getText('\n');
+            lString32 css = ss.getText('\n');
             if ( !css.empty() ) {
                 CRLog::debug("applyDocumentStyleSheet() : Using internal FB2 document stylesheet:\n%s", LCSTR(css));
                 _stylesheet.parse(LCSTR(css));
@@ -4634,13 +4634,13 @@ void ldomDocument::applyDocumentStyleSheet()
     }
 }
 
-bool ldomDocument::parseStyleSheet(lString16 codeBase, lString16 css)
+bool ldomDocument::parseStyleSheet(lString32 codeBase, lString32 css)
 {
     LVImportStylesheetParser parser(this);
     return parser.Parse(codeBase, css);
 }
 
-bool ldomDocument::parseStyleSheet(lString16 cssFile)
+bool ldomDocument::parseStyleSheet(lString32 cssFile)
 {
     LVImportStylesheetParser parser(this);
     return parser.Parse(cssFile);
@@ -4729,7 +4729,7 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
         updateRenderContext();
 
         // DEBUG dump of render methods
-        //dumpRendMethods( getRootNode(), cs16(" - ") );
+        //dumpRendMethods( getRootNode(), cs32(" - ") );
 //        lUInt32 styleHash = calcStyleHash();
 //        styleHash = styleHash * 31 + calcGlobalSettingsHash();
 //        CRLog::debug("Style hash: %x", styleHash);
@@ -4821,7 +4821,7 @@ void lxmlDocBase::setNodeTypes( const elem_def_t * node_scheme )
     {
         _elementNameTable.AddItem(
             node_scheme->id,               // ID
-            lString16(node_scheme->name),  // Name
+            lString32(node_scheme->name),  // Name
             &node_scheme->props );  // ptr
     }
 }
@@ -4835,7 +4835,7 @@ void lxmlDocBase::setAttributeTypes( const attr_def_t * attr_scheme )
     {
         _attrNameTable.AddItem(
             attr_scheme->id,               // ID
-            lString16(attr_scheme->name),  // Name
+            lString32(attr_scheme->name),  // Name
             NULL);
     }
     _idAttrId = _attrNameTable.idByName("id");
@@ -4850,7 +4850,7 @@ void lxmlDocBase::setNameSpaceTypes( const ns_def_t * ns_scheme )
     {
         _nsNameTable.AddItem(
             ns_scheme->id,                 // ID
-            lString16(ns_scheme->name),    // Name
+            lString32(ns_scheme->name),    // Name
             NULL);
     }
 }
@@ -4872,9 +4872,9 @@ void lxmlDocBase::dumpUnknownEntities( const char * fname )
     fclose(f);
 }
 
-lString16Collection lxmlDocBase::getUnknownEntities()
+lString32Collection lxmlDocBase::getUnknownEntities()
 {
-    lString16Collection unknown_entities;
+    lString32Collection unknown_entities;
     unknown_entities.add( _elementNameTable.getUnknownItems(UNKNOWN_ELEMENT_TYPE_ID) );
     unknown_entities.add( _attrNameTable.getUnknownItems(UNKNOWN_ATTRIBUTE_TYPE_ID) );
     unknown_entities.add( _nsNameTable.getUnknownItems(UNKNOWN_NAMESPACE_TYPE_ID) );
@@ -5038,7 +5038,7 @@ bool lxmlDocBase::deserializeMaps( SerialBuf & buf )
 }
 #endif
 
-bool IsEmptySpace( const lChar16 * text, int len )
+bool IsEmptySpace( const lChar32 * text, int len )
 {
    for (int i=0; i<len; i++)
       if ( text[i]!=' ' && text[i]!='\r' && text[i]!='\n' && text[i]!='\t')
@@ -5156,19 +5156,19 @@ static bool isNotBoxingInlineBoxNode( ldomNode * node )
     return !node->isBoxingInlineBox();
 }
 
-static lString16 getSectionHeader( ldomNode * section )
+static lString32 getSectionHeader( ldomNode * section )
 {
-    lString16 header;
+    lString32 header;
     if ( !section || section->getChildCount() == 0 )
         return header;
-    ldomNode * child = section->getChildElementNode(0, L"title");
+    ldomNode * child = section->getChildElementNode(0, U"title");
     if ( !child )
         return header;
-    header = child->getText(L' ', 1024);
+    header = child->getText(U' ', 1024);
     return header;
 }
 
-lString16 ldomElementWriter::getPath()
+lString32 ldomElementWriter::getPath()
 {
     if ( !_path.empty() || _element->isRoot() )
         return _path;
@@ -5183,12 +5183,12 @@ void ldomElementWriter::updateTocItem()
     if ( !_parent )
         return;
     if ( _parent->_tocItem ) { // <section> in the first <body>
-        lString16 title = getSectionHeader( _element );
+        lString32 title = getSectionHeader( _element );
         //CRLog::trace("TOC ITEM: %s", LCSTR(title));
         _tocItem = _parent->_tocItem->addChild(title, ldomXPointer(_element,0), getPath() );
     }
     else if ( getElement()->getNodeId() == el_body ) { // 2nd, 3rd... <body>, in FB2 documents
-        lString16 title = getSectionHeader( _element );
+        lString32 title = getSectionHeader( _element );
         _document->getToc()->addChild(title, ldomXPointer(_element,0), getPath() );
     }
     _isSection = false;
@@ -5300,7 +5300,7 @@ void ldomNode::ensurePseudoElement( bool is_before ) {
         else {
             ldomNode * pseudo = insertChildElement( insertChildIndex, LXML_NS_NONE, el_pseudoElem );
             lUInt16 attribute_id = is_before ? attr_Before : attr_After;
-            pseudo->setAttributeValue(LXML_NS_NONE, attribute_id, L"");
+            pseudo->setAttributeValue(LXML_NS_NONE, attribute_id, U"");
             // We are called by lvrend.cpp setNodeStyle(), after the parent
             // style and font have been fully set up. We could set this pseudo
             // element style with pseudo->initNodeStyle(), as it can inherit
@@ -5362,13 +5362,13 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
     // (Note: did not check how floats inside <PRE> are supposed to work)
     if ( !pre ) {
         while ( firstNonEmpty<=endIndex && getChildNode(firstNonEmpty)->isText() ) {
-            lString16 s = getChildNode(firstNonEmpty)->getText();
+            lString32 s = getChildNode(firstNonEmpty)->getText();
             if ( !IsEmptySpace(s.c_str(), s.length() ) )
                 break;
             firstNonEmpty++;
         }
         while ( lastNonEmpty>=endIndex && getChildNode(lastNonEmpty)->isText() ) {
-            lString16 s = getChildNode(lastNonEmpty)->getText();
+            lString32 s = getChildNode(lastNonEmpty)->getText();
             if ( !IsEmptySpace(s.c_str(), s.length() ) )
                 break;
             lastNonEmpty--;
@@ -5380,7 +5380,7 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
                 hasInline = true;
                 if ( !hasNonEmptyInline ) {
                     if (node->isText()) {
-                        lString16 s = node->getText();
+                        lString32 s = node->getText();
                         if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
                             hasNonEmptyInline = true;
                         }
@@ -5512,7 +5512,7 @@ bool ldomNode::cleanIfOnlyEmptyTextInline( bool handleFloating )
     for ( ; i>=0; i-- ) {
         ldomNode * node = getChildNode(i);
         if ( node->isText() ) {
-            lString16 s = node->getText();
+            lString32 s = node->getText();
             if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
                 return false;
             }
@@ -5551,7 +5551,7 @@ bool ldomNode::hasNonEmptyInlineContent( bool ignoreFloats )
     // padding top/bottom (and height if check ENSURE_STYLE_HEIGHT)
     // if these will introduce some content.
     if ( isText() ) {
-        lString16 s = getText();
+        lString32 s = getText();
         return !IsEmptySpace(s.c_str(), s.length() );
     }
     if (getNodeId() == el_br) {
@@ -5623,13 +5623,13 @@ ldomNode * ldomNode::boxWrapChildren( int startIndex, int endIndex, lUInt16 elem
     int lastNonEmpty = endIndex;
 
     while ( firstNonEmpty<=endIndex && getChildNode(firstNonEmpty)->isText() ) {
-        lString16 s = getChildNode(firstNonEmpty)->getText();
+        lString32 s = getChildNode(firstNonEmpty)->getText();
         if ( !IsEmptySpace(s.c_str(), s.length() ) )
             break;
         firstNonEmpty++;
     }
     while ( lastNonEmpty>=endIndex && getChildNode(lastNonEmpty)->isText() ) {
-        lString16 s = getChildNode(lastNonEmpty)->getText();
+        lString32 s = getChildNode(lastNonEmpty)->getText();
         if ( !IsEmptySpace(s.c_str(), s.length() ) )
             break;
         lastNonEmpty--;
@@ -5871,7 +5871,7 @@ int initTableRendMethods( ldomNode * enode, int state )
                     // be remembered and re-used when styles change, and just
                     // setting the appropriate rendering method is all that is
                     // needed for rendering after this.
-                    // tbox->setAttributeValue(LXML_NS_NONE, enode->getDocument()->getAttrNameIndex(L"style"), L"display: table-row");
+                    // tbox->setAttributeValue(LXML_NS_NONE, enode->getDocument()->getAttrNameIndex(U"style"), U"display: table-row");
                     tbox->initNodeStyle();
                     tbox->setRendMethod( erm_table_row );
                     cellCount += initTableRendMethods( tbox, 3 ); // > row
@@ -5899,7 +5899,7 @@ int initTableRendMethods( ldomNode * enode, int state )
         }
     }
     // if ( state==0 ) {
-    //     dumpRendMethods( enode, cs16("   ") );
+    //     dumpRendMethods( enode, cs32("   ") );
     // }
     return cellCount;
 }
@@ -6094,7 +6094,7 @@ void ldomNode::initNodeRendMethod()
                     // are all empty text.
                     for ( int i=0; i < getChildCount(); i++ ) {
                         if ( getChildNode(i)->isText() ) {
-                            lString16 s = getChildNode(i)->getText();
+                            lString32 s = getChildNode(i)->getText();
                             if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
                                 has_non_empty_text_nodes = true;
                                 break;
@@ -6139,13 +6139,13 @@ void ldomNode::initNodeRendMethod()
                             // Remove any preceeding or following empty text nodes (there can't
                             // be consecutive text nodes) so we don't get spurious empty lines.
                             if ( i < getChildCount()-1 && getChildNode(i+1)->isText() ) {
-                                lString16 s = getChildNode(i+1)->getText();
+                                lString32 s = getChildNode(i+1)->getText();
                                 if ( IsEmptySpace(s.c_str(), s.length() ) ) {
                                     removeChildren(i+1, i+1);
                                 }
                             }
                             if ( i > 0 && getChildNode(i-1)->isText() ) {
-                                lString16 s = getChildNode(i-1)->getText();
+                                lString32 s = getChildNode(i-1)->getText();
                                 if ( IsEmptySpace(s.c_str(), s.length() ) ) {
                                     removeChildren(i-1, i-1);
                                     i--; // update our position
@@ -6154,7 +6154,7 @@ void ldomNode::initNodeRendMethod()
                             ldomNode * ibox = insertChildElement( i, LXML_NS_NONE, el_inlineBox );
                             moveItemsTo( ibox, i+1, i+1 ); // move this child from 'this' into ibox
                             // Mark this inlineBox so we can handle its pecularities
-                            ibox->setAttributeValue(LXML_NS_NONE, attr_T, L"EmbeddedBlock");
+                            ibox->setAttributeValue(LXML_NS_NONE, attr_T, U"EmbeddedBlock");
                             setNodeStyle( ibox, getStyle(), getFont() );
                             ibox->setRendMethod( erm_inline );
                         }
@@ -6393,7 +6393,7 @@ void ldomNode::initNodeRendMethod()
                             int run_in_idx = inBetweenTextNode ? i-2 : i-1;
                             int block_idx = i;
                             if ( inBetweenTextNode ) {
-                                lString16 text = inBetweenTextNode->getText();
+                                lString32 text = inBetweenTextNode->getText();
                                 if ( IsEmptySpace(text.c_str(), text.length() ) ) {
                                     removeChildren(i-1, i-1);
                                     block_idx = i-1;
@@ -6808,7 +6808,7 @@ void ldomNode::initNodeRendMethod()
                         elemId = child->getNodeId();
                     }
                     else {
-                        lString16 s = child->getText();
+                        lString32 s = child->getText();
                         elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
                         // When meeting an empty space (elemId==-2), we'll delay wrapping
                         // decision to when we process the next node.
@@ -6827,7 +6827,7 @@ void ldomNode::initNodeRendMethod()
                         if ( rbox1 && !rbox1->isNull() ) {
                             // Set an attribute for the kind of container we made (Ruby Segment)
                             // so we can style it via CSS.
-                            rbox1->setAttributeValue(LXML_NS_NONE, attr_T, L"rseg");
+                            rbox1->setAttributeValue(LXML_NS_NONE, attr_T, U"rseg");
                             rbox1->initNodeStyle();
                             // Update loop index and end
                             int removed = last_to_wrap - first_to_wrap;
@@ -6888,7 +6888,7 @@ void ldomNode::initNodeRendMethod()
                             elemId = child->getNodeId();
                         }
                         else {
-                            lString16 s = child->getText();
+                            lString32 s = child->getText();
                             elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
                             // When meeting an empty space (elemId==-2), we'll delay wrapping
                             // decision to when we process the next node.
@@ -6909,7 +6909,7 @@ void ldomNode::initNodeRendMethod()
                             if ( rbox2 && !rbox2->isNull() ) {
                                 // Set an attribute for the kind of container we made (<rbc> or <rtc>-like),
                                 // so we can style it like real <rbc> and <rtc> via CSS.
-                                rbox2->setAttributeValue(LXML_NS_NONE, attr_T, ruby_base_wrap_done ? L"rtc" : L"rbc");
+                                rbox2->setAttributeValue(LXML_NS_NONE, attr_T, ruby_base_wrap_done ? U"rtc" : U"rbc");
                                 rbox2->initNodeStyle();
                                 // Update loop index and end
                                 int removed = i1-1 - first_to_wrap;
@@ -6957,7 +6957,7 @@ void ldomNode::initNodeRendMethod()
                     }
                     else {
                         ldomNode * rbox2 = rbox1->insertChildElement( 0, LXML_NS_NONE, el_rubyBox );
-                        rbox2->setAttributeValue(LXML_NS_NONE, attr_T, L"rbc");
+                        rbox2->setAttributeValue(LXML_NS_NONE, attr_T, U"rbc");
                         rbox2->initNodeStyle();
                     }
                 }
@@ -7006,10 +7006,10 @@ void ldomNode::initNodeRendMethod()
                             if ( len2 > 0 ) { // some children to wrap
                                 ldomNode * rbox3 = rbox2->boxWrapChildren(0, len2-1, el_rubyBox);
                                 if ( rbox3 && !rbox3->isNull() ) {
-                                    rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? L"rb" : L"rt");
+                                    rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? U"rb" : U"rt");
                                     if ( elemId == el_rtc ) {
                                         // Firefox makes a <rtc>text</rtc> (without any <rt>) span the whole involved base
-                                        rbox3->setAttributeValue(LXML_NS_NONE, attr_rbspan, L"99"); // (our max supported)
+                                        rbox3->setAttributeValue(LXML_NS_NONE, attr_rbspan, U"99"); // (our max supported)
                                     }
                                     rbox3->initNodeStyle();
                                 }
@@ -7018,11 +7018,11 @@ void ldomNode::initNodeRendMethod()
                                 // We need to insert an empty element to play the role of a <td> for
                                 // the table rendering code to work correctly.
                                 ldomNode * rbox3 = rbox2->insertChildElement( 0, LXML_NS_NONE, el_rubyBox );
-                                rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? L"rb" : L"rt");
+                                rbox3->setAttributeValue(LXML_NS_NONE, attr_T, expected_child_elem_id == el_rb ? U"rb" : U"rt");
                                 rbox3->initNodeStyle();
                                 // We need to add some text for the cell to ensure its height.
                                 // We add a ZERO WIDTH SPACE, which will not collapse into nothing
-                                rbox3->insertChildText(L"\x200B");
+                                rbox3->insertChildText(U"\x200B");
                             }
                         }
                     }
@@ -7364,10 +7364,10 @@ void ldomElementWriter::onBodyExit()
         child->initNodeRendMethod();
     }
 //    if ( _element->getStyle().isNull() ) {
-//        lString16 path;
+//        lString32 path;
 //        ldomNode * p = _element->getParentNode();
 //        while (p) {
-//            path = p->getNodeName() + L"/" + path;
+//            path = p->getNodeName() + U"/" + path;
 //            p = p->getParentNode();
 //        }
 //        //CRLog::error("style not initialized for element 0x%04x %s path %s", _element->getDataIndex(), LCSTR(_element->getNodeName()), LCSTR(path));
@@ -7380,7 +7380,7 @@ void ldomElementWriter::onBodyExit()
 #endif
 }
 
-void ldomElementWriter::onText( const lChar16 * text, int len, lUInt32, bool insert_before_last_child )
+void ldomElementWriter::onText( const lChar32 * text, int len, lUInt32, bool insert_before_last_child )
 {
     //logfile << "{t";
     {
@@ -7455,7 +7455,7 @@ bool ldomNode::applyNodeStylesheet()
 }
 #endif
 
-void ldomElementWriter::addAttribute( lUInt16 nsid, lUInt16 id, const wchar_t * value )
+void ldomElementWriter::addAttribute( lUInt16 nsid, lUInt16 id, const lChar32 * value )
 {
     getElement()->setAttributeValue(nsid, id, value);
 #if BUILD_LITE!=1
@@ -7539,7 +7539,7 @@ void ldomDocumentWriter::OnStart(LVFileFormatParser * parser)
     if ( !_headerOnly )
         _stopTagId = 0xFFFE;
     else {
-        _stopTagId = _document->getElementNameIndex(L"description");
+        _stopTagId = _document->getElementNameIndex(U"description");
         //CRLog::trace( "ldomDocumentWriter() : header only, tag id=%d", _stopTagId );
     }
     LVXMLParserCallback::OnStart( parser );
@@ -7577,14 +7577,14 @@ void ldomDocumentWriter::OnTagBody()
 
         // Make out an aggregated single stylesheet text.
         // @import's need to be first in the final stylesheet text
-        lString16 imports;
+        lString32 imports;
         for (int i = 0; i < _stylesheetLinks.length(); i++) {
-            lString16 import("@import url(\"");
+            lString32 import("@import url(\"");
             import << _stylesheetLinks.at(i);
             import << "\");\n";
             imports << import;
         }
-        lString16 styleText = imports + _headStyleText.c_str();
+        lString32 styleText = imports + _headStyleText.c_str();
         _stylesheetLinks.clear();
         _headStyleText.clear();
 
@@ -7593,7 +7593,7 @@ void ldomDocumentWriter::OnTagBody()
         if ( _document->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) ) {
             _document->getStyleSheet()->push();
             _popStyleOnFinish = true; // superclass ~ldomDocumentWriter() will do the ->pop()
-            _document->parseStyleSheet(lString16(), styleText);
+            _document->parseStyleSheet(lString32(), styleText);
             // printf("applied: %s\n", LCSTR(styleText));
             // apply any FB2 stylesheet too, so it's removed too when pop()
             _document->applyDocumentStyleSheet();
@@ -7606,10 +7606,10 @@ void ldomDocumentWriter::OnTagBody()
         // And only after this we can add the <stylesheet> as a first child
         // element of this BODY node. It will not be displayed thanks to fb2def.h:
         //   XS_TAG1D( stylesheet, true, css_d_none, css_ws_inherit )
-        OnTagOpen(L"", L"stylesheet");
+        OnTagOpen(U"", U"stylesheet");
         OnTagBody();
         OnText(styleText.c_str(), styleText.length(), 0);
-        OnTagClose(L"", L"stylesheet");
+        OnTagClose(U"", U"stylesheet");
         CRLog::trace("added BODY>stylesheet child element with HEAD>STYLE&LINKS content");
     }
     else if ( _currNode ) { // for all other tags (including BODY when no style)
@@ -7618,10 +7618,10 @@ void ldomDocumentWriter::OnTagBody()
     }
 }
 
-ldomNode * ldomDocumentWriter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
+ldomNode * ldomDocumentWriter::OnTagOpen( const lChar32 * nsname, const lChar32 * tagname )
 {
     //logfile << "ldomDocumentWriter::OnTagOpen() [" << nsname << ":" << tagname << "]";
-    //CRLog::trace("OnTagOpen(%s)", UnicodeToUtf8(lString16(tagname)).c_str());
+    //CRLog::trace("OnTagOpen(%s)", UnicodeToUtf8(lString32(tagname)).c_str());
     lUInt16 id = _document->getElementNameIndex(tagname);
     lUInt16 nsid = (nsname && nsname[0]) ? _document->getNsNameIndex(nsname) : 0;
 
@@ -7689,7 +7689,7 @@ ldomDocumentWriter::~ldomDocumentWriter()
 #endif
 }
 
-void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname, bool self_closing_tag )
+void ldomDocumentWriter::OnTagClose( const lChar32 *, const lChar32 * tagname, bool self_closing_tag )
 {
     //logfile << "ldomDocumentWriter::OnTagClose() [" << nsname << ":" << tagname << "]";
     if (!_currNode || !_currNode->getElement())
@@ -7714,10 +7714,10 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname, b
     if ( id == el_link && curNodeId == el_link ) { // link node
         ldomNode * n = _currNode->getElement();
         if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
-                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = n->getAttributeValue("href");
-            lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
+                 lString32(n->getAttributeValue("rel")).lowercase() == U"stylesheet" &&
+                 lString32(n->getAttributeValue("type")).lowercase() == U"text/css" ) {
+            lString32 href = n->getAttributeValue("href");
+            lString32 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
             // _document->setDocStylesheetFileName(stylesheetFile);
@@ -7767,7 +7767,7 @@ void ldomDocumentWriter::OnTagClose( const lChar16 *, const lChar16 * tagname, b
     //logfile << " !c!\n";
 }
 
-void ldomDocumentWriter::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+void ldomDocumentWriter::OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
 {
     //logfile << "ldomDocumentWriter::OnAttribute() [" << nsname << ":" << attrname << "]";
     lUInt16 attr_ns = (nsname && nsname[0]) ? _document->getNsNameIndex( nsname ) : 0;
@@ -7777,13 +7777,13 @@ void ldomDocumentWriter::OnAttribute( const lChar16 * nsname, const lChar16 * at
     //logfile << " !a!\n";
 }
 
-void ldomDocumentWriter::OnText( const lChar16 * text, int len, lUInt32 flags )
+void ldomDocumentWriter::OnText( const lChar32 * text, int len, lUInt32 flags )
 {
     //logfile << "ldomDocumentWriter::OnText() fpos=" << fpos;
 
     // Accumulate <HEAD><STYLE> content
     if (_inHeadStyle) {
-        _headStyleText << lString16(text, len);
+        _headStyleText << lString32(text, len);
         _inHeadStyle = false;
         return;
     }
@@ -7799,7 +7799,7 @@ void ldomDocumentWriter::OnText( const lChar16 * text, int len, lUInt32 flags )
     //logfile << " !t!\n";
 }
 
-void ldomDocumentWriter::OnEncoding( const lChar16 *, const lChar16 *)
+void ldomDocumentWriter::OnEncoding( const lChar32 *, const lChar32 *)
 {
 }
 
@@ -7874,7 +7874,7 @@ class LVBase64NodeStream : public LVNamedStream
 private:
     ldomNode *  m_elem;
     ldomNode *  m_curr_node;
-    lString16   m_curr_text;
+    lString32   m_curr_text;
     int         m_text_pos;
     lvsize_t    m_size;
     lvpos_t     m_pos;
@@ -7898,10 +7898,10 @@ private:
                     return bytesRead;
             }
             int len = m_curr_text.length();
-            const lChar16 * txt = m_curr_text.c_str();
+            const lChar32 * txt = m_curr_text.c_str();
             for ( ; m_text_pos<len && m_bytes_count < BASE64_BUF_SIZE - 3; m_text_pos++ )
             {
-                lChar16 ch = txt[ m_text_pos ];
+                lChar32 ch = txt[ m_text_pos ];
                 if ( ch < 128 )
                 {
                     if ( ch == '=' )
@@ -8175,16 +8175,16 @@ bool img_scaling_options_t::update( CRPropRef props, int fontSize )
     return updated;
 }
 
-xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & index )
+xpath_step_t ParseXPathStep( const lChar32 * &path, lString32 & name, int & index )
 {
     int pos = 0;
-    const lChar16 * s = path;
+    const lChar32 * s = path;
     //int len = path.GetLength();
     name.clear();
     index = -1;
     int flgPrefix = 0;
     if (s && s[pos]) {
-        lChar16 ch = s[pos];
+        lChar32 ch = s[pos];
         // prefix: none, '/' or '.'
         if (ch=='/') {
             flgPrefix = 1;
@@ -8201,7 +8201,7 @@ xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & inde
                 pos++;
             if (s[pos] && s[pos]!='/' && s[pos]!='.')
                 return xpath_step_error;
-            lString16 sindex( path+nstart, pos-nstart );
+            lString32 sindex( path+nstart, pos-nstart );
             index = sindex.atoi();
             if (index<((flgPrefix==2)?0:1))
                 return xpath_step_error;
@@ -8212,7 +8212,7 @@ xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & inde
             pos++;
         if (pos==nstart)
             return xpath_step_error;
-        name = lString16( path+ nstart, pos-nstart );
+        name = lString32( path+ nstart, pos-nstart );
         if (s[pos]=='[') {
             // index
             pos++;
@@ -8222,7 +8222,7 @@ xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & inde
             if (!s[pos] || pos==istart)
                 return xpath_step_error;
 
-            lString16 sindex( path+istart, pos-istart );
+            lString32 sindex( path+istart, pos-istart );
             index = sindex.atoi();
             pos++;
         }
@@ -8237,15 +8237,15 @@ xpath_step_t ParseXPathStep( const lChar16 * &path, lString16 & name, int & inde
 
 
 /// get pointer for relative path
-ldomXPointer ldomXPointer::relative( lString16 relativePath )
+ldomXPointer ldomXPointer::relative( lString32 relativePath )
 {
     return getDocument()->createXPointer( getNode(), relativePath );
 }
 /// create xpointer from pointer string
-ldomXPointer ldomDocument::createXPointer( const lString16 & xPointerStr )
+ldomXPointer ldomDocument::createXPointer( const lString32 & xPointerStr )
 {
     if ( xPointerStr[0]=='#' ) {
-        lString16 id = xPointerStr.substr(1);
+        lString32 id = xPointerStr.substr(1);
         lUInt32 idid = getAttrValueIndex(id.c_str());
         lInt32 nodeIndex;
         if ( _idNodeMap.get(idid, nodeIndex) ) {
@@ -8538,7 +8538,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 lUInt16 width[512];
                 lUInt8 flg[512];
 
-                lString16 str = node->getText();
+                lString32 str = node->getText();
                 // We need to transform the node text as it had been when
                 // rendered (the transform may change chars widths) for the
                 // XPointer offset to be correct
@@ -8721,7 +8721,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
 //                        ldomNode * txt = txt = child->getFirstTextChild( true );
 //                        if ( txt ) {
 //                            node = txt;
-////                            lString16 s = txt->getText();
+////                            lString32 s = txt->getText();
 ////                            CRLog::debug("text: [%d] '%s'", s.length(), LCSTR(s));
 //                            break;
 //                        }
@@ -8883,7 +8883,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                                 LVFont *font = (LVFont *) txtform->GetSrcInfo(srcIndex)->t.font;
                                 lUInt16 w[512];
                                 lUInt8 flg[512];
-                                lString16 str = node->getText();
+                                lString32 str = node->getText();
                                 if (offset == word->t.start && str.empty()) {
                                     rect.left = word->x + rc.left + frmline->x;
                                     rect.top = rc.top + frmline->y;
@@ -9051,10 +9051,10 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                         LVFont *font = (LVFont *) txtform->GetSrcInfo(srcIndex)->t.font;
                         lUInt16 w[512];
                         lUInt8 flg[512];
-                        lString16 str = node->getText();
+                        lString32 str = node->getText();
                         // With "|| (extended && offset < word->t.start)" added to the first if
                         // above, we may now be here with: offset = word->t.start = 0
-                        // and a node->getText() returning THE lString16::empty_str:
+                        // and a node->getText() returning THE lString32::empty_str:
                         // font->measureText() would segfault on it because its just a dummy
                         // pointer. Not really sure why that happens.
                         // It happens when node is the <a> in:
@@ -9246,23 +9246,23 @@ static ldomNode * getNodeByIndex(ldomNode *parent, int index, T predicat, int& c
 }
 
 /// create XPointer from relative pointer non-normalized string made by toStringV1()
-ldomXPointer ldomDocument::createXPointerV1( ldomNode * baseNode, const lString16 & xPointerStr )
+ldomXPointer ldomDocument::createXPointerV1( ldomNode * baseNode, const lString32 & xPointerStr )
 {
     //CRLog::trace( "ldomDocument::createXPointer(%s)", UnicodeToUtf8(xPointerStr).c_str() );
     if ( xPointerStr.empty() || !baseNode )
         return ldomXPointer();
-    const lChar16 * str = xPointerStr.c_str();
+    const lChar32 * str = xPointerStr.c_str();
     int index = -1;
     ldomNode * currNode = baseNode;
-    lString16 name;
+    lString32 name;
     lString8 ptr8 = UnicodeToUtf8(xPointerStr);
     //const char * ptr = ptr8.c_str();
     xpath_step_t step_type;
 
     while ( *str ) {
-        //CRLog::trace( "    %s", UnicodeToUtf8(lString16(str)).c_str() );
+        //CRLog::trace( "    %s", UnicodeToUtf8(lString32(str)).c_str() );
         step_type = ParseXPathStep( str, name, index );
-        //CRLog::trace( "        name=%s index=%d", UnicodeToUtf8(lString16(name)).c_str(), index );
+        //CRLog::trace( "        name=%s index=%d", UnicodeToUtf8(lString32(name)).c_str(), index );
         switch (step_type ) {
         case xpath_step_error:
             // error
@@ -9349,23 +9349,23 @@ ldomXPointer ldomDocument::createXPointerV1( ldomNode * baseNode, const lString1
 }
 
 /// create XPointer from relative pointer normalized string made by toStringV2()
-ldomXPointer ldomDocument::createXPointerV2( ldomNode * baseNode, const lString16 & xPointerStr )
+ldomXPointer ldomDocument::createXPointerV2( ldomNode * baseNode, const lString32 & xPointerStr )
 {
     //CRLog::trace( "ldomDocument::createXPointer(%s)", UnicodeToUtf8(xPointerStr).c_str() );
     if ( xPointerStr.empty() || !baseNode )
         return ldomXPointer();
-    const lChar16 * str = xPointerStr.c_str();
+    const lChar32 * str = xPointerStr.c_str();
     int index = -1;
     int count;
     ldomNode * currNode = baseNode;
     ldomNode * foundNode;
-    lString16 name;
+    lString32 name;
     xpath_step_t step_type;
 
     while ( *str ) {
-        //CRLog::trace( "    %s", UnicodeToUtf8(lString16(str)).c_str() );
+        //CRLog::trace( "    %s", UnicodeToUtf8(lString32(str)).c_str() );
         step_type = ParseXPathStep( str, name, index );
-        //CRLog::trace( "        name=%s index=%d", UnicodeToUtf8(lString16(name)).c_str(), index );
+        //CRLog::trace( "        name=%s index=%d", UnicodeToUtf8(lString32(name)).c_str(), index );
         switch (step_type ) {
         case xpath_step_error:
             // error
@@ -9383,7 +9383,7 @@ ldomXPointer ldomDocument::createXPointerV2( ldomNode * baseNode, const lString1
                 }
                 // found element node
                 currNode = foundNode;
-                lString16 nm = currNode->getNodeName();
+                lString32 nm = currNode->getNodeName();
                 CRLog::trace("%d -> %s", index, LCSTR(nm));
             }
             break;
@@ -9427,10 +9427,10 @@ ldomXPointer ldomDocument::createXPointerV2( ldomNode * baseNode, const lString1
 }
 
 /// returns XPath segment for this element relative to parent element (e.g. "p[10]")
-lString16 ldomNode::getXPathSegment()
+lString32 ldomNode::getXPathSegment()
 {
     if ( isNull() || isRoot() )
-        return lString16::empty_str;
+        return lString32::empty_str;
     ldomNode * parent = getParentNode();
     int cnt = parent->getChildCount();
     int index = 0;
@@ -9448,19 +9448,19 @@ lString16 ldomNode::getXPathSegment()
         for ( int i=0; i<cnt; i++ ) {
             ldomNode * node = parent->getChildNode(i);
             if ( node == this ) {
-                return "text()[" + lString16::itoa(index+1) + "]";
+                return "text()[" + lString32::itoa(index+1) + "]";
             }
             if ( node->isText() )
                 index++;
         }
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 // Using names, old, with boxing elements (non-normalized)
-lString16 ldomXPointer::toStringV1()
+lString32 ldomXPointer::toStringV1()
 {
-    lString16 path;
+    lString32 path;
     if ( isNull() )
         return path;
     ldomNode * node = getNode();
@@ -9474,7 +9474,7 @@ lString16 ldomXPointer::toStringV1()
         ldomNode * parent = p->getParentNode();
         if ( p->isElement() ) {
             // element
-            lString16 name = p->getNodeName();
+            lString32 name = p->getNodeName();
             lUInt16 id = p->getNodeId();
             if ( !parent )
                 return "/" + name + path;
@@ -9489,13 +9489,13 @@ lString16 ldomXPointer::toStringV1()
                 }
             }
             if ( count>1 )
-                path = cs16("/") + name + "[" + fmt::decimal(index) + "]" + path;
+                path = cs32("/") + name + "[" + fmt::decimal(index) + "]" + path;
             else
-                path = cs16("/") + name + path;
+                path = cs32("/") + name + path;
         } else {
             // text
             if ( !parent )
-                return cs16("/text()") + path;
+                return cs32("/text()") + path;
             int index = -1;
             int count = 0;
             for ( int i=0; i<parent->getChildCount(); i++ ) {
@@ -9507,7 +9507,7 @@ lString16 ldomXPointer::toStringV1()
                 }
             }
             if ( count>1 )
-                path = cs16("/text()") + "[" + fmt::decimal(index) + "]" + path;
+                path = cs32("/text()") + "[" + fmt::decimal(index) + "]" + path;
             else
                 path = "/text()" + path;
         }
@@ -9534,9 +9534,9 @@ static int getElementIndex(ldomNode* parent, ldomNode *targetNode, T predicat, i
 }
 
 // Using names, new, without boxing elements, so: normalized
-lString16 ldomXPointer::toStringV2()
+lString32 ldomXPointer::toStringV2()
 {
-    lString16 path;
+    lString32 path;
     if ( isNull() )
         return path;
     ldomNode * node = getNode();
@@ -9560,7 +9560,7 @@ lString16 ldomXPointer::toStringV2()
             parent = parent->getParentNode();
         if ( p->isElement() ) {
             // element
-            lString16 name = p->getNodeName();
+            lString32 name = p->getNodeName();
             if ( !parent )
                 return "/" + name + path;
             int count = 0;
@@ -9579,13 +9579,13 @@ lString16 ldomXPointer::toStringV2()
                 }
             }
             if ( count>1 )
-                path = cs16("/") + name + "[" + fmt::decimal(index) + "]" + path;
+                path = cs32("/") + name + "[" + fmt::decimal(index) + "]" + path;
             else
-                path = cs16("/") + name + path;
+                path = cs32("/") + name + path;
         } else {
             // text
             if ( !parent )
-                return cs16("/text()") + path;
+                return cs32("/text()") + path;
             int count = 0;
             int index = getElementIndex(parent, p, isTextNode, count);
             if ( count == 1 ) {
@@ -9601,7 +9601,7 @@ lString16 ldomXPointer::toStringV2()
                 }
             }
             if ( count>1 )
-                path = cs16("/text()") + "[" + fmt::decimal(index) + "]" + path;
+                path = cs32("/text()") + "[" + fmt::decimal(index) + "]" + path;
             else
                 path = "/text()" + path;
         }
@@ -9611,9 +9611,9 @@ lString16 ldomXPointer::toStringV2()
 }
 
 // Without element names, normalized (not used)
-lString16 ldomXPointer::toStringV2AsIndexes()
+lString32 ldomXPointer::toStringV2AsIndexes()
 {
-    lString16 path;
+    lString32 path;
     if ( isNull() )
         return path;
     int offset = getOffset();
@@ -9625,7 +9625,7 @@ lString16 ldomXPointer::toStringV2AsIndexes()
     while( p && p!=rootNode ) {
         ldomNode * parent = p->getParentNode();
         if ( !parent )
-            return "/" + (p->isElement() ? p->getNodeName() : cs16("/text()")) + path;
+            return "/" + (p->isElement() ? p->getNodeName() : cs32("/text()")) + path;
 
         while( isBoxingNode(parent) )
             parent = parent->getParentNode();
@@ -9634,7 +9634,7 @@ lString16 ldomXPointer::toStringV2AsIndexes()
         int index = getElementIndex(parent, p, notNull, count);
 
         if( index>0 ) {
-            path = cs16("/") + fmt::decimal(index) + path;
+            path = cs32("/") + fmt::decimal(index) + path;
         } else {
             CRLog::error("!!! child node not found in a parent");
         }
@@ -9654,26 +9654,26 @@ int ldomDocument::getFullHeight()
 
 
 
-lString16 extractDocAuthors( ldomDocument * doc, lString16 delimiter, bool shortMiddleName )
+lString32 extractDocAuthors( ldomDocument * doc, lString32 delimiter, bool shortMiddleName )
 {
     if ( delimiter.empty() )
         delimiter = ", ";
-    lString16 authors;
+    lString32 authors;
     for ( int i=0; i<16; i++) {
-        lString16 path = cs16("/FictionBook/description/title-info/author[") + fmt::decimal(i+1) + "]";
+        lString32 path = cs32("/FictionBook/description/title-info/author[") + fmt::decimal(i+1) + "]";
         ldomXPointer pauthor = doc->createXPointer(path);
         if ( !pauthor ) {
             //CRLog::trace( "xpath not found: %s", UnicodeToUtf8(path).c_str() );
             break;
         }
-        lString16 firstName = pauthor.relative( L"/first-name" ).getText().trim();
-        lString16 lastName = pauthor.relative( L"/last-name" ).getText().trim();
-        lString16 middleName = pauthor.relative( L"/middle-name" ).getText().trim();
-        lString16 author = firstName;
+        lString32 firstName = pauthor.relative( U"/first-name" ).getText().trim();
+        lString32 lastName = pauthor.relative( U"/last-name" ).getText().trim();
+        lString32 middleName = pauthor.relative( U"/middle-name" ).getText().trim();
+        lString32 author = firstName;
         if ( !author.empty() )
             author += " ";
         if ( !middleName.empty() )
-            author += shortMiddleName ? lString16(middleName, 0, 1) + "." : middleName;
+            author += shortMiddleName ? lString32(middleName, 0, 1) + "." : middleName;
         if ( !lastName.empty() && !author.empty() )
             author += " ";
         author += lastName;
@@ -9684,23 +9684,23 @@ lString16 extractDocAuthors( ldomDocument * doc, lString16 delimiter, bool short
     return authors;
 }
 
-lString16 extractDocTitle( ldomDocument * doc )
+lString32 extractDocTitle( ldomDocument * doc )
 {
-    return doc->createXPointer(L"/FictionBook/description/title-info/book-title").getText().trim();
+    return doc->createXPointer(U"/FictionBook/description/title-info/book-title").getText().trim();
 }
 
-lString16 extractDocLanguage( ldomDocument * doc )
+lString32 extractDocLanguage( ldomDocument * doc )
 {
-    return doc->createXPointer(L"/FictionBook/description/title-info/lang").getText().trim();
+    return doc->createXPointer(U"/FictionBook/description/title-info/lang").getText().trim();
 }
 
-lString16 extractDocSeries( ldomDocument * doc, int * pSeriesNumber )
+lString32 extractDocSeries( ldomDocument * doc, int * pSeriesNumber )
 {
-    lString16 res;
-    ldomNode * series = doc->createXPointer(L"/FictionBook/description/title-info/sequence").getNode();
+    lString32 res;
+    ldomNode * series = doc->createXPointer(U"/FictionBook/description/title-info/sequence").getNode();
     if ( series ) {
-        lString16 sname = lString16(series->getAttributeValue(attr_name)).trim();
-        lString16 snumber = series->getAttributeValue(attr_number);
+        lString32 sname = lString32(series->getAttributeValue(attr_name)).trim();
+        lString32 snumber = series->getAttributeValue(attr_number);
         if ( !sname.empty() ) {
             if ( pSeriesNumber ) {
                 *pSeriesNumber = snumber.atoi();
@@ -9715,14 +9715,14 @@ lString16 extractDocSeries( ldomDocument * doc, int * pSeriesNumber )
     return res;
 }
 
-lString16 extractDocKeywords( ldomDocument * doc )
+lString32 extractDocKeywords( ldomDocument * doc )
 {
-    lString16 res;
+    lString32 res;
     // Year
-    res << doc->createXPointer(L"/FictionBook/description/title-info/date").getText().trim();
+    res << doc->createXPointer(U"/FictionBook/description/title-info/date").getText().trim();
     // Genres
     for ( int i=0; i<16; i++) {
-        lString16 path = cs16("/FictionBook/description/title-info/genre[") + fmt::decimal(i+1) + "]";
+        lString32 path = cs32("/FictionBook/description/title-info/genre[") + fmt::decimal(i+1) + "]";
         ldomXPointer genre = doc->createXPointer(path);
         if ( !genre ) {
             break;
@@ -9734,27 +9734,27 @@ lString16 extractDocKeywords( ldomDocument * doc )
     return res;
 }
 
-lString16 extractDocDescription( ldomDocument * doc )
+lString32 extractDocDescription( ldomDocument * doc )
 {
     // We put all other FB2 meta info in this description
-    lString16 res;
+    lString32 res;
 
     // Annotation (description)
-    res << doc->createXPointer(L"/FictionBook/description/title-info/annotation").getText().trim();
+    res << doc->createXPointer(U"/FictionBook/description/title-info/annotation").getText().trim();
 
     // Translators
-    lString16 translators;
+    lString32 translators;
     int nbTranslators = 0;
     for ( int i=0; i<16; i++) {
-        lString16 path = cs16("/FictionBook/description/title-info/translator[") + fmt::decimal(i+1) + "]";
+        lString32 path = cs32("/FictionBook/description/title-info/translator[") + fmt::decimal(i+1) + "]";
         ldomXPointer ptranslator = doc->createXPointer(path);
         if ( !ptranslator ) {
             break;
         }
-        lString16 firstName = ptranslator.relative( L"/first-name" ).getText().trim();
-        lString16 lastName = ptranslator.relative( L"/last-name" ).getText().trim();
-        lString16 middleName = ptranslator.relative( L"/middle-name" ).getText().trim();
-        lString16 translator = firstName;
+        lString32 firstName = ptranslator.relative( U"/first-name" ).getText().trim();
+        lString32 lastName = ptranslator.relative( U"/last-name" ).getText().trim();
+        lString32 middleName = ptranslator.relative( U"/middle-name" ).getText().trim();
+        lString32 translator = firstName;
         if ( !translator.empty() )
             translator += " ";
         if ( !middleName.empty() )
@@ -9777,14 +9777,14 @@ lString16 extractDocDescription( ldomDocument * doc )
     }
 
     // Publication info & publisher
-    ldomXPointer publishInfo = doc->createXPointer(L"/FictionBook/description/publish-info");
+    ldomXPointer publishInfo = doc->createXPointer(U"/FictionBook/description/publish-info");
     if ( !publishInfo.isNull() ) {
-        lString16 publisher = publishInfo.relative( L"/publisher" ).getText().trim();
-        lString16 pubcity = publishInfo.relative( L"/city" ).getText().trim();
-        lString16 pubyear = publishInfo.relative( L"/year" ).getText().trim();
-        lString16 isbn = publishInfo.relative( L"/isbn" ).getText().trim();
-        lString16 bookName = publishInfo.relative( L"/book-name" ).getText().trim();
-        lString16 publication;
+        lString32 publisher = publishInfo.relative( U"/publisher" ).getText().trim();
+        lString32 pubcity = publishInfo.relative( U"/city" ).getText().trim();
+        lString32 pubyear = publishInfo.relative( U"/year" ).getText().trim();
+        lString32 isbn = publishInfo.relative( U"/isbn" ).getText().trim();
+        lString32 bookName = publishInfo.relative( U"/book-name" ).getText().trim();
+        lString32 publication;
         if ( !publisher.empty() || !pubcity.empty() ) {
             if ( !publisher.empty() ) {
                 publication << publisher;
@@ -9822,21 +9822,21 @@ lString16 extractDocDescription( ldomDocument * doc )
     }
 
     // Document info
-    ldomXPointer pDocInfo = doc->createXPointer(L"/FictionBook/description/document-info");
+    ldomXPointer pDocInfo = doc->createXPointer(U"/FictionBook/description/document-info");
     if ( !pDocInfo.isNull() ) {
-        lString16 docInfo;
-        lString16 docAuthors;
+        lString32 docInfo;
+        lString32 docAuthors;
         int nbAuthors = 0;
         for ( int i=0; i<16; i++) {
-            lString16 path = cs16("/FictionBook/description/document-info/author[") + fmt::decimal(i+1) + "]";
+            lString32 path = cs32("/FictionBook/description/document-info/author[") + fmt::decimal(i+1) + "]";
             ldomXPointer pdocAuthor = doc->createXPointer(path);
             if ( !pdocAuthor ) {
                 break;
             }
-            lString16 firstName = pdocAuthor.relative( L"/first-name" ).getText().trim();
-            lString16 lastName = pdocAuthor.relative( L"/last-name" ).getText().trim();
-            lString16 middleName = pdocAuthor.relative( L"/middle-name" ).getText().trim();
-            lString16 docAuthor = firstName;
+            lString32 firstName = pdocAuthor.relative( U"/first-name" ).getText().trim();
+            lString32 lastName = pdocAuthor.relative( U"/last-name" ).getText().trim();
+            lString32 middleName = pdocAuthor.relative( U"/middle-name" ).getText().trim();
+            lString32 docAuthor = firstName;
             if ( !docAuthor.empty() )
                 docAuthor += " ";
             if ( !middleName.empty() )
@@ -9855,14 +9855,14 @@ lString16 extractDocDescription( ldomDocument * doc )
             else
                 docInfo << "Author: " << docAuthors;
         }
-        lString16 docPublisher = pDocInfo.relative( L"/publisher" ).getText().trim();
-        lString16 docId = pDocInfo.relative( L"/id" ).getText().trim();
-        lString16 docVersion = pDocInfo.relative( L"/version" ).getText().trim();
-        lString16 docDate = pDocInfo.relative( L"/date" ).getText().trim();
-        lString16 docHistory = pDocInfo.relative( L"/history" ).getText().trim();
-        lString16 docSrcUrl = pDocInfo.relative( L"/src-url" ).getText().trim();
-        lString16 docSrcOcr = pDocInfo.relative( L"/src-ocr" ).getText().trim();
-        lString16 docProgramUsed = pDocInfo.relative( L"/program-used" ).getText().trim();
+        lString32 docPublisher = pDocInfo.relative( U"/publisher" ).getText().trim();
+        lString32 docId = pDocInfo.relative( U"/id" ).getText().trim();
+        lString32 docVersion = pDocInfo.relative( U"/version" ).getText().trim();
+        lString32 docDate = pDocInfo.relative( U"/date" ).getText().trim();
+        lString32 docHistory = pDocInfo.relative( U"/history" ).getText().trim();
+        lString32 docSrcUrl = pDocInfo.relative( U"/src-url" ).getText().trim();
+        lString32 docSrcOcr = pDocInfo.relative( U"/src-ocr" ).getText().trim();
+        lString32 docProgramUsed = pDocInfo.relative( U"/program-used" ).getText().trim();
         if ( !docPublisher.empty() ) {
             if ( !docInfo.empty() )
                 docInfo << "\n";
@@ -10308,7 +10308,7 @@ void ldomXRangeList::split( ldomXRange * r )
 
 #if BUILD_LITE!=1
 
-bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY )
+bool ldomDocument::findText( lString32 pattern, bool caseInsensitive, bool reverse, int minY, int maxY, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY )
 {
     if ( minY<0 )
         minY = 0;
@@ -10379,13 +10379,13 @@ bool ldomDocument::findText( lString16 pattern, bool caseInsensitive, bool rever
     return range.findText( pattern, caseInsensitive, reverse, words, maxCount, maxHeight, maxHeightCheckStartY );
 }
 
-static bool findText( const lString16 & str, int & pos, int & endpos, const lString16 & pattern )
+static bool findText( const lString32 & str, int & pos, int & endpos, const lString32 & pattern )
 {
     int len = pattern.length();
     if ( pos < 0 || pos + len > (int)str.length() )
         return false;
-    const lChar16 * s1 = str.c_str() + pos;
-    const lChar16 * s2 = pattern.c_str();
+    const lChar32 * s1 = str.c_str() + pos;
+    const lChar32 * s2 = pattern.c_str();
     int nlen = str.length() - pos - len;
     for ( int j=0; j<=nlen; j++ ) {
         bool matched = true;
@@ -10409,15 +10409,15 @@ static bool findText( const lString16 & str, int & pos, int & endpos, const lStr
     return false;
 }
 
-static bool findTextRev( const lString16 & str, int & pos, int & endpos, const lString16 & pattern )
+static bool findTextRev( const lString32 & str, int & pos, int & endpos, const lString32 & pattern )
 {
     int len = pattern.length();
     if ( pos+len>(int)str.length() )
         pos = str.length()-len;
     if ( pos < 0 )
         return false;
-    const lChar16 * s1 = str.c_str() + pos;
-    const lChar16 * s2 = pattern.c_str();
+    const lChar32 * s1 = str.c_str() + pos;
+    const lChar32 * s2 = pattern.c_str();
     int nlen = pos;
     for ( int j=nlen; j>=0; j-- ) {
         bool matched = true;
@@ -10442,7 +10442,7 @@ static bool findTextRev( const lString16 & str, int & pos, int & endpos, const l
 }
 
 /// searches for specified text inside range
-bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY, bool checkMaxFromStart )
+bool ldomXRange::findText( lString32 pattern, bool caseInsensitive, bool reverse, LVArray<ldomWord> & words, int maxCount, int maxHeight, int maxHeightCheckStartY, bool checkMaxFromStart )
 {
     if ( caseInsensitive )
         pattern.lowercase();
@@ -10453,13 +10453,13 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
         // reverse search
         if ( !_end.isText() ) {
             _end.prevVisibleText();
-            lString16 txt = _end.getNode()->getText();
+            lString32 txt = _end.getNode()->getText();
             _end.setOffset(txt.length());
         }
         int firstFoundTextY = -1;
         while ( !isNull() ) {
 
-            lString16 txt = _end.getNode()->getText();
+            lString32 txt = _end.getNode()->getText();
             int offs = _end.getOffset();
             int endpos;
 
@@ -10511,7 +10511,7 @@ bool ldomXRange::findText( lString16 pattern, bool caseInsensitive, bool reverse
                     return words.length()>0;
             }
 
-            lString16 txt = _start.getNode()->getText();
+            lString32 txt = _start.getNode()->getText();
             if ( caseInsensitive )
                 txt.lowercase();
 
@@ -10596,7 +10596,7 @@ void ldomXRangeList::getRanges( ldomMarkedRangeList &dst )
 /// fill text selection list by splitting text into monotonic flags ranges
 void ldomXRangeList::splitText( ldomMarkedTextList &dst, ldomNode * textNodeToSplit )
 {
-    lString16 text = textNodeToSplit->getText();
+    lString32 text = textNodeToSplit->getText();
     if ( length()==0 ) {
         dst.add( new ldomMarkedText( text, 0, 0 ) );
         return;
@@ -10759,7 +10759,7 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects )
         }
 
         int startOffset = curPos.getOffset();
-        lString16 nodeText = curPos.getText();
+        lString32 nodeText = curPos.getText();
         int textLen = nodeText.length();
 
         if (startOffset == 0) { // new text node
@@ -10866,7 +10866,7 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects )
         for (int i=startOffset+1; i<=textLen-1; i++) {
             // skip spaces (but let soft-hyphens in, so they are part of the
             // highlight when they are shown at end of line)
-            lChar16 c = nodeText[i];
+            lChar32 c = nodeText[i];
             if (c == ' ') // || c == 0x00AD)
                 continue;
             curPos.setOffset(i);
@@ -10912,14 +10912,14 @@ bool ldomXRange::getWordRange( ldomXRange & range, ldomXPointer & p )
     if ( !node->isText() )
         return false;
     int pos = p.getOffset();
-    lString16 txt = node->getText();
+    lString32 txt = node->getText();
     if ( pos<0 )
         pos = 0;
     if ( pos>(int)txt.length() )
         pos = txt.length();
     int endpos = pos;
     for (;;) {
-        lChar16 ch = txt[endpos];
+        lChar32 ch = txt[endpos];
         if ( ch==0 || ch==' ' )
             break;
         endpos++;
@@ -10927,7 +10927,7 @@ bool ldomXRange::getWordRange( ldomXRange & range, ldomXPointer & p )
     /*
     // include trailing space
     for (;;) {
-        lChar16 ch = txt[endpos];
+        lChar32 ch = txt[endpos];
         if ( ch==0 || ch!=' ' )
             break;
         endpos++;
@@ -11042,8 +11042,8 @@ ldomNode * ldomXRange::getNearestCommonParent()
 }
 
 /// returns HTML (serialized from the DOM, may be different from the source HTML)
-/// puts the paths of the linked css files met into the provided lString16Collection cssFiles
-lString8 ldomXPointer::getHtml(lString16Collection & cssFiles, int wflags)
+/// puts the paths of the linked css files met into the provided lString32Collection cssFiles
+lString8 ldomXPointer::getHtml(lString32Collection & cssFiles, int wflags)
 {
     if ( isNull() )
         return lString8::empty_str;
@@ -11060,8 +11060,8 @@ lString8 ldomXPointer::getHtml(lString16Collection & cssFiles, int wflags)
 }
 
 /// returns HTML (serialized from the DOM, may be different from the source HTML)
-/// puts the paths of the linked css files met into the provided lString16Collection cssFiles
-lString8 ldomXRange::getHtml(lString16Collection & cssFiles, int wflags, bool fromRootNode)
+/// puts the paths of the linked css files met into the provided lString32Collection cssFiles
+lString8 ldomXRange::getHtml(lString32Collection & cssFiles, int wflags, bool fromRootNode)
 {
     if ( isNull() )
         return lString8::empty_str;
@@ -11321,7 +11321,7 @@ bool ldomXPointerEx::prevVisibleChar( bool thisBlockOnly )
         if ( !prevVisibleText(thisBlockOnly) )
             return false;
         ldomNode * node = getNode();
-        lString16 text = node->getText();
+        lString32 text = node->getText();
         int textLen = text.length();
         _data->setOffset( textLen );
     }
@@ -11342,7 +11342,7 @@ bool ldomXPointerEx::nextVisibleChar( bool thisBlockOnly )
         return true;
     }
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     int textLen = text.length();
     if ( _data->getOffset() == textLen ) {
         // move to next text
@@ -11356,7 +11356,7 @@ bool ldomXPointerEx::nextVisibleChar( bool thisBlockOnly )
 }
 
 // TODO: implement better behavior
-inline bool IsUnicodeSpace( lChar16 ch )
+inline bool IsUnicodeSpace( lChar32 ch )
 {
     //return ch==' ';
     switch ((unsigned short)ch) {
@@ -11376,7 +11376,7 @@ inline bool IsUnicodeSpace( lChar16 ch )
 }
 
 // TODO: implement better behavior
-inline bool IsUnicodeSpaceOrNull( lChar16 ch )
+inline bool IsUnicodeSpaceOrNull( lChar32 ch )
 {
     return ch==0 || IsUnicodeSpace(ch);
 }
@@ -11390,22 +11390,22 @@ inline bool IsUnicodeSpaceOrNull( lChar16 ch )
 //  they use (but KOReader does not use these *Sentence* functions).
 
 // For better accuracy than IsUnicodeSpace for detecting words
-inline bool IsWordSeparator( lChar16 ch )
+inline bool IsWordSeparator( lChar32 ch )
 {
     return lStr_isWordSeparator(ch);
 }
 
-inline bool IsWordSeparatorOrNull( lChar16 ch )
+inline bool IsWordSeparatorOrNull( lChar32 ch )
 {
     if (ch==0) return true;
     return IsWordSeparator(ch);
 }
 
-inline bool canWrapWordBefore( lChar16 ch ) {
+inline bool canWrapWordBefore( lChar32 ch ) {
     return ch>=0x2e80 && ch<0x2CEAF;
 }
 
-inline bool canWrapWordAfter( lChar16 ch ) {
+inline bool canWrapWordAfter( lChar32 ch ) {
     return ch>=0x2e80 && ch<0x2CEAF;
 }
 
@@ -11415,7 +11415,7 @@ bool ldomXPointerEx::isVisibleWordChar() {
     if ( !isText() || !isVisible() )
         return false;
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     return !IsWordSeparator(text[_data->getOffset()]);
 }
 
@@ -11425,7 +11425,7 @@ bool ldomXPointerEx::prevVisibleWordStart( bool thisBlockOnly )
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
             // move to previous text
@@ -11461,7 +11461,7 @@ bool ldomXPointerEx::prevVisibleWordEnd( bool thisBlockOnly )
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     bool moved = false;
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
@@ -11509,7 +11509,7 @@ bool ldomXPointerEx::nextVisibleWordStart( bool thisBlockOnly )
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     bool moved = false;
     for ( ;; ) {
@@ -11568,7 +11568,7 @@ bool ldomXPointerEx::thisVisibleWordEnd(bool thisBlockOnly)
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     bool moved = false;
     if ( !isText() || !isVisible() )
@@ -11599,7 +11599,7 @@ bool ldomXPointerEx::nextVisibleWordEnd( bool thisBlockOnly )
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     //bool moved = false;
     for ( ;; ) {
@@ -11661,7 +11661,7 @@ bool ldomXPointerEx::prevVisibleWordStartInSentence()
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
             // move to previous text
@@ -11697,7 +11697,7 @@ bool ldomXPointerEx::nextVisibleWordStartInSentence()
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     bool moved = false;
     for ( ;; ) {
@@ -11755,7 +11755,7 @@ bool ldomXPointerEx::thisVisibleWordEndInSentence()
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     bool moved = false;
     if ( !isText() || !isVisible() )
@@ -11786,7 +11786,7 @@ bool ldomXPointerEx::nextVisibleWordEndInSentence()
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     int textLen = 0;
     //bool moved = false;
     for ( ;; ) {
@@ -11848,7 +11848,7 @@ bool ldomXPointerEx::prevVisibleWordEndInSentence()
     if ( isNull() )
         return false;
     ldomNode * node = NULL;
-    lString16 text;
+    lString32 text;
     bool moved = false;
     for ( ;; ) {
         if ( !isText() || !isVisible() || _data->getOffset()==0 ) {
@@ -11898,14 +11898,14 @@ bool ldomXPointerEx::isVisibleWordStart()
     if ( !isText() || !isVisible() )
         return false;
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
     // We're actually testing the boundary between the char at i-1 and
     // the char at i. So, we return true when [i] is the first letter
     // of a word.
-    lChar16 currCh = i<textLen ? text[i] : 0;
-    lChar16 prevCh = i<=textLen && i>0 ? text[i-1] : 0;
+    lChar32 currCh = i<textLen ? text[i] : 0;
+    lChar32 prevCh = i<=textLen && i>0 ? text[i-1] : 0;
     if (canWrapWordBefore(currCh)) {
         // If [i] is a CJK char (that's what canWrapWordBefore()
         // checks), this is a visible word start.
@@ -11927,14 +11927,14 @@ bool ldomXPointerEx::isVisibleWordEnd()
     if ( !isText() || !isVisible() )
         return false;
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
     // We're actually testing the boundary between the char at i-1 and
     // the char at i. So, we return true when [i-1] is the last letter
     // of a word.
-    lChar16 currCh = i>0 ? text[i-1] : 0;
-    lChar16 nextCh = i<textLen ? text[i] : 0;
+    lChar32 currCh = i>0 ? text[i-1] : 0;
+    lChar32 nextCh = i<textLen ? text[i] : 0;
     if (canWrapWordAfter(currCh)) {
         // If [i-1] is a CJK char (that's what canWrapWordAfter()
         // checks), this is a visible word end.
@@ -12002,14 +12002,14 @@ bool ldomXPointerEx::isSentenceStart()
     if ( !isText() || !isVisible() )
         return false;
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
-    lChar16 currCh = i<textLen ? text[i] : 0;
-    lChar16 prevCh = i>0 ? text[i-1] : 0;
-    lChar16 prevNonSpace = 0;
+    lChar32 currCh = i<textLen ? text[i] : 0;
+    lChar32 prevCh = i>0 ? text[i-1] : 0;
+    lChar32 prevNonSpace = 0;
     for ( ;i>0; i-- ) {
-        lChar16 ch = text[i-1];
+        lChar32 ch = text[i-1];
         if ( !IsUnicodeSpace(ch) ) {
             prevNonSpace = ch;
             break;
@@ -12020,9 +12020,9 @@ bool ldomXPointerEx::isSentenceStart()
     if ( !prevNonSpace ) {
         ldomXPointerEx pos(*this);
         while ( !prevNonSpace && pos.prevVisibleText(true) ) {
-            lString16 prevText = pos.getText();
+            lString32 prevText = pos.getText();
             for ( int j=prevText.length()-1; j>=0; j-- ) {
-                lChar16 ch = prevText[j];
+                lChar32 ch = prevText[j];
                 if ( !IsUnicodeSpace(ch) ) {
                     prevNonSpace = ch;
                     break;
@@ -12038,7 +12038,7 @@ bool ldomXPointerEx::isSentenceStart()
             case '.':
             case '?':
             case '!':
-            case L'\x2026': // horizontal ellypsis
+            case U'\x2026': // horizontal ellypsis
                 return false;
         }
     }
@@ -12049,7 +12049,7 @@ bool ldomXPointerEx::isSentenceStart()
         case '.':
         case '?':
         case '!':
-        case L'\x2026': // horizontal ellypsis
+        case U'\x2026': // horizontal ellypsis
             return true;
         default:
             return false;
@@ -12066,18 +12066,18 @@ bool ldomXPointerEx::isSentenceEnd()
     if ( !isText() || !isVisible() )
         return false;
     ldomNode * node = getNode();
-    lString16 text = node->getText();
+    lString32 text = node->getText();
     int textLen = text.length();
     int i = _data->getOffset();
-    lChar16 currCh = i<textLen ? text[i] : 0;
-    lChar16 prevCh = i>0 ? text[i-1] : 0;
+    lChar32 currCh = i<textLen ? text[i] : 0;
+    lChar32 prevCh = i>0 ? text[i-1] : 0;
     if ( IsUnicodeSpaceOrNull(currCh) ) {
         switch (prevCh) {
         case 0:
         case '.':
         case '?':
         case '!':
-        case L'\x2026': // horizontal ellypsis
+        case U'\x2026': // horizontal ellypsis
             return true;
         default:
             break;
@@ -12229,12 +12229,12 @@ void ldomXRange::forEach( ldomNodeCallback * callback )
     while ( !pos._start.isNull() && pos._start.compare( _end ) < 0 ) {
         // do something
         ldomNode * node = pos._start.getNode();
-        //lString16 path = pos._start.toString();
+        //lString32 path = pos._start.toString();
         //CRLog::trace( "%s", UnicodeToUtf8(path).c_str() );
         if ( node->isElement() ) {
             allowGoRecurse = callback->onElement( &pos.getStart() );
         } else if ( node->isText() ) {
-            lString16 txt = node->getText();
+            lString32 txt = node->getText();
             pos._end = pos._start;
             pos._start.setOffset( 0 );
             pos._end.setOffset( txt.length() );
@@ -12277,7 +12277,7 @@ public:
     virtual void onText( ldomXRange * nodeRange )
     {
         ldomNode * node = nodeRange->getStart().getNode();
-        lString16 text = node->getText();
+        lString32 text = node->getText();
         int len = text.length();
         int end = nodeRange->getEnd().getOffset();
         if ( len>end )
@@ -12406,7 +12406,7 @@ ldomWordEx * ldomWordExList::findWordByPattern()
         ldomWordEx * item = get(i);
         if ( item==selWord )
             selReached = true;
-        lString16 text = item->getText();
+        lString32 text = item->getText();
         text.lowercase();
         bool flg = true;
         for ( int j=0; j<pattern.length(); j++ ) {
@@ -12414,7 +12414,7 @@ ldomWordEx * ldomWordExList::findWordByPattern()
                 flg = false;
                 break;
             }
-            lString16 chars = pattern[j];
+            lString32 chars = pattern[j];
             chars.lowercase();
             bool charFound = false;
             for ( int k=0; k<chars.length(); k++ ) {
@@ -12445,7 +12445,7 @@ ldomWordEx * ldomWordExList::findWordByPattern()
 }
 
 /// try append search pattern and find word
-ldomWordEx * ldomWordExList::appendPattern(lString16 chars)
+ldomWordEx * ldomWordExList::appendPattern(lString32 chars)
 {
     pattern.add(chars);
     ldomWordEx * foundWord = findWordByPattern();
@@ -12578,11 +12578,11 @@ class ldomTextCollector : public ldomNodeCallback
 private:
     bool lastText;
     bool newBlock;
-    lChar16  delimiter;
+    lChar32  delimiter;
     int  maxLen;
-    lString16 text;
+    lString32 text;
 public:
-    ldomTextCollector( lChar16 blockDelimiter, int maxTextLen )
+    ldomTextCollector( lChar32 blockDelimiter, int maxTextLen )
         : lastText(false), newBlock(true), delimiter( blockDelimiter), maxLen( maxTextLen )
     {
     }
@@ -12594,7 +12594,7 @@ public:
         if ( newBlock && !text.empty()) {
             text << delimiter;
         }
-        lString16 txt = nodeRange->getStart().getNode()->getText();
+        lString32 txt = nodeRange->getStart().getNode()->getText();
         int start = nodeRange->getStart().getOffset();
         int end = nodeRange->getEnd().getOffset();
         if ( start < end ) {
@@ -12649,11 +12649,11 @@ public:
 #endif
     }
     /// get collected text
-    lString16 getText() { return text; }
+    lString32 getText() { return text; }
 };
 
 /// returns text between two XPointer positions
-lString16 ldomXRange::getRangeText( lChar16 blockDelimiter, int maxTextLen )
+lString32 ldomXRange::getRangeText( lChar32 blockDelimiter, int maxTextLen )
 {
     ldomTextCollector callback( blockDelimiter, maxTextLen );
     forEach( &callback );
@@ -12661,45 +12661,45 @@ lString16 ldomXRange::getRangeText( lChar16 blockDelimiter, int maxTextLen )
 }
 
 /// returns href attribute of <A> element, plus xpointer of <A> element itself
-lString16 ldomXPointer::getHRef(ldomXPointer & a_xpointer)
+lString32 ldomXPointer::getHRef(ldomXPointer & a_xpointer)
 {
     if ( isNull() )
-        return lString16::empty_str;
+        return lString32::empty_str;
     ldomNode * node = getNode();
     while ( node && !node->isElement() )
         node = node->getParentNode();
     while ( node && node->getNodeId()!=el_a )
         node = node->getParentNode();
     if ( !node )
-        return lString16::empty_str;
+        return lString32::empty_str;
     a_xpointer.setNode(node);
     a_xpointer.setOffset(0);
-    lString16 ref = node->getAttributeValue( LXML_NS_ANY, attr_href );
+    lString32 ref = node->getAttributeValue( LXML_NS_ANY, attr_href );
     if (!ref.empty() && ref[0] != '#')
         ref = DecodeHTMLUrlString(ref);
     return ref;
 }
 
 /// returns href attribute of <A> element, null string if not found
-lString16 ldomXPointer::getHRef()
+lString32 ldomXPointer::getHRef()
 {
     ldomXPointer unused_a_xpointer;
     return getHRef(unused_a_xpointer);
 }
 
 /// returns href attribute of <A> element, plus xpointer of <A> element itself
-lString16 ldomXRange::getHRef(ldomXPointer & a_xpointer)
+lString32 ldomXRange::getHRef(ldomXPointer & a_xpointer)
 {
     if ( isNull() )
-        return lString16::empty_str;
+        return lString32::empty_str;
     return _start.getHRef(a_xpointer);
 }
 
 /// returns href attribute of <A> element, null string if not found
-lString16 ldomXRange::getHRef()
+lString32 ldomXRange::getHRef()
 {
     if ( isNull() )
-        return lString16::empty_str;
+        return lString32::empty_str;
     return _start.getHRef();
 }
 
@@ -12769,10 +12769,10 @@ ldomDocument * LVParseHTMLStream( LVStreamRef stream,
 }
 
 #if 0
-static lString16 escapeDocPath( lString16 path )
+static lString32 escapeDocPath( lString32 path )
 {
     for ( int i=0; i<path.length(); i++ ) {
-        lChar16 ch = path[i];
+        lChar32 ch = path[i];
         if ( ch=='/' || ch=='\\')
             path[i] = '_';
     }
@@ -12785,7 +12785,7 @@ static lString16 escapeDocPath( lString16 path )
 // Used for EPUB with each individual HTML files in the EPUB,
 // drives ldomDocumentWriter to build one single document from them.
 
-lString16 ldomDocumentFragmentWriter::convertId( lString16 id )
+lString32 ldomDocumentFragmentWriter::convertId( lString32 id )
 {
     if ( !codeBasePrefix.empty() ) {
         return codeBasePrefix + "_" + " " + id;//add a space for later
@@ -12793,7 +12793,7 @@ lString16 ldomDocumentFragmentWriter::convertId( lString16 id )
     return id;
 }
 
-lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
+lString32 ldomDocumentFragmentWriter::convertHref( lString32 href )
 {
     if ( href.pos("://")>=0 )
         return href; // fully qualified href: no conversion
@@ -12802,10 +12802,10 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
 
     if (href[0] == '#') {
         // Link to anchor in the same docFragment
-        lString16 replacement = pathSubstitutions.get(filePathName);
+        lString32 replacement = pathSubstitutions.get(filePathName);
         if (replacement.empty())
             return href;
-        lString16 p = cs16("#") + replacement + "_" + " " + href.substr(1);
+        lString32 p = cs32("#") + replacement + "_" + " " + href.substr(1);
         //CRLog::trace("href %s -> %s", LCSTR(href), LCSTR(p));
         return p;
     }
@@ -12819,8 +12819,8 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
     // thru DecodeHTMLUrlString(), and so did 'codeBase').
 
     // resolve relative links
-    lString16 p, id; // path, id
-    if ( !href.split2(cs16("#"), p, id) )
+    lString32 p, id; // path, id
+    if ( !href.split2(cs32("#"), p, id) )
         p = href;
     if ( p.empty() ) {
         //CRLog::trace("codebase = %s -> href = %s", LCSTR(codeBase), LCSTR(href));
@@ -12829,7 +12829,7 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
         p = codeBasePrefix;
     }
     else {
-        lString16 replacement = pathSubstitutions.get(LVCombinePaths(codeBase, p));
+        lString32 replacement = pathSubstitutions.get(LVCombinePaths(codeBase, p));
         //CRLog::trace("href %s -> %s", LCSTR(p), LCSTR(replacement));
         if ( !replacement.empty() )
             p = replacement;
@@ -12849,14 +12849,14 @@ lString16 ldomDocumentFragmentWriter::convertHref( lString16 href )
     if ( !id.empty() )
         p = p + "_" + " " + id;
 
-    p = cs16("#") + p;
+    p = cs32("#") + p;
 
     //CRLog::debug("converted href=%s to %s", LCSTR(href), LCSTR(p) );
 
     return p;
 }
 
-void ldomDocumentFragmentWriter::setCodeBase( lString16 fileName )
+void ldomDocumentFragmentWriter::setCodeBase( lString32 fileName )
 {
     filePathName = fileName;
     codeBasePrefix = pathSubstitutions.get(fileName);
@@ -12869,16 +12869,16 @@ void ldomDocumentFragmentWriter::setCodeBase( lString16 fileName )
 }
 
 /// called on attribute
-void ldomDocumentFragmentWriter::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+void ldomDocumentFragmentWriter::OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
 {
     if ( insideTag ) {
         if ( !lStr_cmp(attrname, "href") || !lStr_cmp(attrname, "src") ) {
-            parent->OnAttribute(nsname, attrname, convertHref(lString16(attrvalue)).c_str() );
+            parent->OnAttribute(nsname, attrname, convertHref(lString32(attrvalue)).c_str() );
         } else if ( !lStr_cmp(attrname, "id") ) {
-            parent->OnAttribute(nsname, attrname, convertId(lString16(attrvalue)).c_str() );
+            parent->OnAttribute(nsname, attrname, convertId(lString32(attrvalue)).c_str() );
         } else if ( !lStr_cmp(attrname, "name") ) {
-            //CRLog::trace("name attribute = %s", LCSTR(lString16(attrvalue)));
-            parent->OnAttribute(nsname, attrname, convertId(lString16(attrvalue)).c_str() );
+            //CRLog::trace("name attribute = %s", LCSTR(lString32(attrvalue)));
+            parent->OnAttribute(nsname, attrname, convertId(lString32(attrvalue)).c_str() );
         } else {
             parent->OnAttribute(nsname, attrname, attrvalue);
         }
@@ -12892,16 +12892,16 @@ void ldomDocumentFragmentWriter::OnAttribute( const lChar16 * nsname, const lCha
                 htmlLang = attrvalue;
         }
         else if ( styleDetectionState ) {
-            if ( !lStr_cmp(attrname, "rel") && lString16(attrvalue).lowercase() == L"stylesheet" )
+            if ( !lStr_cmp(attrname, "rel") && lString32(attrvalue).lowercase() == U"stylesheet" )
                 styleDetectionState |= 2;
             else if ( !lStr_cmp(attrname, "type") ) {
-                if ( lString16(attrvalue).lowercase() == L"text/css")
+                if ( lString32(attrvalue).lowercase() == U"text/css")
                     styleDetectionState |= 4;
                 else
                     styleDetectionState = 0;  // text/css type supported only
             } else if ( !lStr_cmp(attrname, "href") ) {
                 styleDetectionState |= 8;
-                lString16 href = attrvalue;
+                lString32 href = attrvalue;
                 if ( stylesheetFile.empty() )
                     tmpStylesheetFile = LVCombinePaths( codeBase, href );
                 else
@@ -12920,7 +12920,7 @@ void ldomDocumentFragmentWriter::OnAttribute( const lChar16 * nsname, const lCha
 }
 
 /// called on opening tag
-ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
+ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const lChar32 * tagname )
 {
     if ( insideTag ) {
         return parent->OnTagOpen(nsname, tagname);
@@ -12959,34 +12959,34 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
     if ( !insideTag && baseTag==tagname ) { // with EPUBs: baseTag="body"
         insideTag = true;
         if ( !baseTagReplacement.empty() ) { // with EPUBs: baseTagReplacement="DocFragment"
-            baseElement = parent->OnTagOpen(L"", baseTagReplacement.c_str()); // start <DocFragment
+            baseElement = parent->OnTagOpen(U"", baseTagReplacement.c_str()); // start <DocFragment
             lastBaseElement = baseElement;
             if ( !stylesheetFile.empty() ) {
                 // add attribute <DocFragment StyleSheet="path_to_css_1st_file"
-                parent->OnAttribute(L"", L"StyleSheet", stylesheetFile.c_str() );
+                parent->OnAttribute(U"", U"StyleSheet", stylesheetFile.c_str() );
                 CRLog::debug("Setting StyleSheet attribute to %s for document fragment", LCSTR(stylesheetFile) );
             }
             if ( !codeBasePrefix.empty() ) // add attribute <DocFragment id="..html_file_name"
-                parent->OnAttribute(L"", L"id", codeBasePrefix.c_str() );
+                parent->OnAttribute(U"", U"id", codeBasePrefix.c_str() );
             if ( !htmlDir.empty() ) // add attribute <DocFragment dir="rtl" from <html dir="rtl"> tag
-                parent->OnAttribute(L"", L"dir", htmlDir.c_str() );
+                parent->OnAttribute(U"", U"dir", htmlDir.c_str() );
             if ( !htmlLang.empty() ) // add attribute <DocFragment lang="ar" from <html lang="ar"> tag
-                parent->OnAttribute(L"", L"lang", htmlLang.c_str() );
+                parent->OnAttribute(U"", U"lang", htmlLang.c_str() );
 
             parent->OnTagBody(); // inside <DocFragment>
             if ( !headStyleText.empty() || stylesheetLinks.length() > 0 ) {
                 // add stylesheet element as child of <DocFragment>: <stylesheet href="...">
-                parent->OnTagOpen(L"", L"stylesheet");
-                parent->OnAttribute(L"", L"href", codeBase.c_str() );
-                lString16 imports;
+                parent->OnTagOpen(U"", U"stylesheet");
+                parent->OnAttribute(U"", U"href", codeBase.c_str() );
+                lString32 imports;
                 for (int i = 0; i < stylesheetLinks.length(); i++) {
-                    lString16 import("@import url(\"");
+                    lString32 import("@import url(\"");
                     import << stylesheetLinks.at(i);
                     import << "\");\n";
                     imports << import;
                 }
                 stylesheetLinks.clear();
-                lString16 styleText = imports + headStyleText.c_str();
+                lString32 styleText = imports + headStyleText.c_str();
                 // Add it to <DocFragment><stylesheet>, so it becomes:
                 //   <stylesheet href="...">
                 //     @import url(path_to_css_2nd_file)
@@ -12995,7 +12995,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
                 //   </stylesheet>
                 parent->OnTagBody();
                 parent->OnText(styleText.c_str(), styleText.length(), 0);
-                parent->OnTagClose(L"", L"stylesheet");
+                parent->OnTagClose(U"", U"stylesheet");
                 // done with <DocFragment><stylesheet>...</stylesheet>
             }
             // Finally, create <body> and go on.
@@ -13005,7 +13005,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
             // the previous stylesheet state, that will be pop()'ed when the
             // ldomElementWriter for DocFragment is left/destroyed (by onBodyExit(),
             // because this OnTagOpen has set to it _stylesheetIsSet).
-            parent->OnTagOpen(L"", baseTag.c_str());
+            parent->OnTagOpen(U"", baseTag.c_str());
             parent->OnTagBody();
             return baseElement;
         }
@@ -13014,14 +13014,14 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar16 * nsname, const 
 }
 
 /// called on closing tag
-void ldomDocumentFragmentWriter::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
+void ldomDocumentFragmentWriter::OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag )
 {
     styleDetectionState = headStyleState = 0;
     if ( insideTag && baseTag==tagname ) {
         insideTag = false;
         if ( !baseTagReplacement.empty() ) {
-            parent->OnTagClose(L"", baseTag.c_str());
-            parent->OnTagClose(L"", baseTagReplacement.c_str());
+            parent->OnTagClose(U"", baseTag.c_str());
+            parent->OnTagClose(U"", baseTagReplacement.c_str());
         }
         baseElement = NULL;
         return;
@@ -13069,29 +13069,29 @@ void ldomDocumentFragmentWriter::OnTagBody()
     Autoclose HTML tags.
 */
 
-void ldomDocumentWriterFilter::setClass( const lChar16 * className, bool overrideExisting )
+void ldomDocumentWriterFilter::setClass( const lChar32 * className, bool overrideExisting )
 {
     ldomNode * node = _currNode->_element;
     if ( _classAttrId==0 ) {
-        _classAttrId = _document->getAttrNameIndex(L"class");
+        _classAttrId = _document->getAttrNameIndex(U"class");
     }
     if ( overrideExisting || !node->hasAttribute(_classAttrId) ) {
         node->setAttributeValue(LXML_NS_NONE, _classAttrId, className);
     }
 }
 
-void ldomDocumentWriterFilter::appendStyle( const lChar16 * style )
+void ldomDocumentWriterFilter::appendStyle( const lChar32 * style )
 {
     ldomNode * node = _currNode->_element;
     if ( _styleAttrId==0 ) {
-        _styleAttrId = _document->getAttrNameIndex(L"style");
+        _styleAttrId = _document->getAttrNameIndex(U"style");
     }
     // Append to the style attribute even if embedded styles are disabled
     // at loading time, otherwise it won't be there if we enable them later
     // if (!_document->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES))
     //     return; // disabled
 
-    lString16 oldStyle = node->getAttributeValue(_styleAttrId);
+    lString32 oldStyle = node->getAttributeValue(_styleAttrId);
     if ( !oldStyle.empty() && oldStyle.at(oldStyle.length()-1)!=';' )
         oldStyle << "; ";
     oldStyle << style;
@@ -13393,14 +13393,14 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             if ( !_htmlTagSeen ) {
                 _htmlTagSeen = true;
                 if ( tag_id != el_html ) {
-                    OnTagOpen(L"", L"html");
+                    OnTagOpen(U"", U"html");
                     OnTagBody();
                 }
             }
             if ( (tag_id >= EL_IN_HEAD_START && tag_id <= EL_IN_HEAD_END) || tag_id == el_noscript ) {
                 _headTagSeen = true;
                 if ( tag_id != el_head ) {
-                    OnTagOpen(L"", L"head");
+                    OnTagOpen(U"", U"head");
                     OnTagBody();
                 }
             }
@@ -13411,12 +13411,12 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // (text while being in <HTML><HEAD><TITLE> should not trigger this):
             // end of <head> and start of <body>
             if ( _headTagSeen )
-                OnTagClose(L"", L"head");
+                OnTagClose(U"", U"head");
             else
                 _headTagSeen = true; // We won't open any <head> anymore
             _bodyTagSeen = true;
             if ( tag_id != el_body ) {
-                OnTagOpen(L"", L"body");
+                OnTagOpen(U"", U"body");
                 OnTagBody();
             }
             curNodeId = _currNode ? _currNode->getElement()->getNodeId() : el_NULL;
@@ -13471,7 +13471,7 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // We must be in a TR. If we're not, have missing elements created
             if ( curNodeId != el_tr ) {
                 // This will create all the other missing elements if needed
-                OnTagOpen(L"", L"tr");
+                OnTagOpen(U"", U"tr");
                 OnTagBody();
             }
         }
@@ -13485,7 +13485,7 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // We must be in a THEAD/TBODY/TFOOT. If we're not, have missing elements created
             if ( curNodeId < el_thead || curNodeId > el_tfoot ) {
                 // This will create all the other missing elements if needed
-                OnTagOpen(L"", L"tbody");
+                OnTagOpen(U"", U"tbody");
                 OnTagBody();
             }
         }
@@ -13498,7 +13498,7 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // We must be in a COLGROUP. If we're not, have missing elements created
             if ( curNodeId != el_colgroup ) {
                 // This will create all the other missing elements if needed
-                OnTagOpen(L"", L"colgroup");
+                OnTagOpen(U"", U"colgroup");
                 OnTagBody();
             }
         }
@@ -13589,9 +13589,9 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
             // a standalone closing </BR> (so, not self closing)
             // Specs say we should insert a new/another one
             if ( tag_id == el_br && step == PARSER_STEP_TAG_CLOSING ) {
-                OnTagOpen(L"", L"br");
+                OnTagOpen(U"", U"br");
                 OnTagBody();
-                OnTagClose(L"", L"br", true);
+                OnTagClose(U"", U"br", true);
                 return true;
             }
             return false; // ignored
@@ -13604,7 +13604,7 @@ bool ldomDocumentWriterFilter::AutoOpenClosePop( int step, lUInt16 tag_id )
         if ( tag_id == el_p && !_lastP ) {
             // </P> without any previous <P> should emit <P></P>
             // Insert new one and pop it
-            OnTagOpen(L"", L"p");
+            OnTagOpen(U"", U"p");
             OnTagBody();
             popUpTo(_currNode);
             return true;
@@ -13695,12 +13695,12 @@ bool ldomDocumentWriterFilter::CheckAndEnsureFosterParenting(lUInt16 tag_id)
     return false;
 }
 
-ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname )
+ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar32 * nsname, const lChar32 * tagname )
 {
     // We expect from the parser to always have OnTagBody called
     // after OnTagOpen before any other OnTagOpen
     if ( !_tagBodyCalled ) {
-        CRLog::error("OnTagOpen w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));
+        CRLog::error("OnTagOpen w/o parent's OnTagBody : %s", LCSTR(lString32(tagname)));
         crFatalError();
     }
     // _tagBodyCalled = false;
@@ -13730,7 +13730,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
         // At this point _currNode is still the parent of the FORM that is opening
         if ( _currNode && _currNode->_element->getNodeId() == el_div ) {
             ldomNode * node = _currNode->_element;
-            lString16 style = node->getAttributeValue(attr_style);
+            lString32 style = node->getAttributeValue(attr_style);
             // align=right would have been translated to style="text-align: right"
             if ( !style.empty() && style.pos("text-align: right", 0) >= 0 ) {
                 _libRuDocumentDetected = true;
@@ -13781,7 +13781,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
                 _currNode = pop( _currNode, el_pre);
             }
             else if ( n && n->getNodeId() == el_div && n->hasAttribute( attr_ParserHint ) &&
-                        n->getAttributeValue( attr_ParserHint ) == L"ParseAsPre" ) {
+                        n->getAttributeValue( attr_ParserHint ) == U"ParseAsPre" ) {
                 // Also close any previous PRE we already masqueraded
                 // as <DIV ParserHint="ParseAsPre">
                 _currNode = pop( _currNode, el_div);
@@ -13868,7 +13868,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     // Some libRu tweaks:
     if ( setParseAsPre ) {
         // Set an attribute on the DIV we just added
-        _currNode->getElement()->setAttributeValue(LXML_NS_NONE, attr_ParserHint, L"ParseAsPre");
+        _currNode->getElement()->setAttributeValue(LXML_NS_NONE, attr_ParserHint, U"ParseAsPre");
         // And set this global flag as we'll need to re-enable PRE (as it
         // will be reset by ldomDocumentWriter::OnTagBody() as we won't have
         // proper CSS white-space:pre inheritance) and XMLParser flags.
@@ -13877,7 +13877,7 @@ ldomNode * ldomDocumentWriterFilter::OnTagOpen( const lChar16 * nsname, const lC
     if ( setDisplayNone ) {
         // Hide the FORM that was used to detect libRu,
         // now that currNode is the FORM element
-        appendStyle( L"display: none" );
+        appendStyle( U"display: none" );
     }
 
     //logfile << " !o!\n";
@@ -13926,14 +13926,14 @@ void ldomDocumentWriterFilter::OnTagBody()
     }
 }
 
-void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+void ldomDocumentWriterFilter::OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
 {
     //logfile << "ldomDocumentWriter::OnAttribute() [" << nsname << ":" << attrname << "]";
     //if ( nsname && nsname[0] )
-    //    lStr_lowercase( const_cast<lChar16 *>(nsname), lStr_len(nsname) );
-    //lStr_lowercase( const_cast<lChar16 *>(attrname), lStr_len(attrname) );
+    //    lStr_lowercase( const_cast<lChar32 *>(nsname), lStr_len(nsname) );
+    //lStr_lowercase( const_cast<lChar32 *>(attrname), lStr_len(attrname) );
 
-    //CRLog::trace("OnAttribute(%s, %s)", LCSTR(lString16(attrname)), LCSTR(lString16(attrvalue)));
+    //CRLog::trace("OnAttribute(%s, %s)", LCSTR(lString32(attrname)), LCSTR(lString32(attrvalue)));
 
     if ( _curTagIsIgnored ) { // Ignore attributes if tag was ignored
         return;
@@ -13956,15 +13956,15 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     // translate to float:left/right, which is ensured by epub.css)
     // Should this be restricted to some specific elements?
     if ( !lStr_cmp(attrname, "align") && (id != el_img) && (id != el_table) ) {
-        lString16 align = lString16(attrvalue).lowercase();
-        if ( align == L"justify")
-            appendStyle( L"text-align: justify" );
-        else if ( align == L"left")
-            appendStyle( L"text-align: left" );
-        else if ( align == L"right")
-            appendStyle( L"text-align: right" );
-        else if ( align == L"center")
-            appendStyle( L"text-align: center" );
+        lString32 align = lString32(attrvalue).lowercase();
+        if ( align == U"justify")
+            appendStyle( U"text-align: justify" );
+        else if ( align == U"left")
+            appendStyle( U"text-align: left" );
+        else if ( align == U"right")
+            appendStyle( U"text-align: right" );
+        else if ( align == U"center")
+            appendStyle( U"text-align: center" );
        return;
     }
 
@@ -13976,13 +13976,13 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     if (id == el_th || id == el_td) {
         // Default rendering for cells is valign=baseline
         if ( !lStr_cmp(attrname, "valign") ) {
-            lString16 valign = lString16(attrvalue).lowercase();
-            if ( valign == L"top" )
-                appendStyle( L"vertical-align: top" );
-            else if ( valign == L"middle" )
-                appendStyle( L"vertical-align: middle" );
-            else if ( valign == L"bottom")
-                appendStyle( L"vertical-align: bottom" );
+            lString32 valign = lString32(attrvalue).lowercase();
+            if ( valign == U"top" )
+                appendStyle( U"vertical-align: top" );
+            else if ( valign == U"middle" )
+                appendStyle( U"vertical-align: middle" );
+            else if ( valign == U"bottom")
+                appendStyle( U"vertical-align: bottom" );
            return;
         }
     }
@@ -13992,8 +13992,8 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
     // style, and not attributes: <img width=100 height=50> would not be used.
     if (id == el_th || id == el_td || id == el_col) {
         if ( !lStr_cmp(attrname, "width") ) {
-            lString16 val = lString16(attrvalue);
-            const wchar_t * s = val.c_str();
+            lString32 val = lString32(attrvalue);
+            const lChar32 * s = val.c_str();
             bool is_pct = false;
             int n=0;
             if (s && s[0]) {
@@ -14006,7 +14006,7 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
                     }
                 }
                 if (n > 0) {
-                    val = lString16("width: ");
+                    val = lString32("width: ");
                     val.appendDecimal(n);
                     val += is_pct ? "%" : "px"; // CSS pixels
                     appendStyle(val.c_str());
@@ -14026,10 +14026,10 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar16 * nsname, const lChar1
 }
 
 /// called on closing tag
-void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lChar16 * tagname, bool self_closing_tag )
+void ldomDocumentWriterFilter::OnTagClose( const lChar32 * /*nsname*/, const lChar32 * tagname, bool self_closing_tag )
 {
     if ( !_tagBodyCalled ) {
-        CRLog::error("OnTagClose w/o parent's OnTagBody : %s", LCSTR(lString16(tagname)));
+        CRLog::error("OnTagClose w/o parent's OnTagBody : %s", LCSTR(lString32(tagname)));
         crFatalError();
     }
     if ( !_currNode || !_currNode->getElement() ) {
@@ -14058,7 +14058,7 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
         // the end by another PRE where it doesn't matter if we keep that flag.)
         ldomNode * n = _currNode->getElement();
         if ( n->getNodeId() == el_div && n->hasAttribute( attr_ParserHint ) &&
-                    n->getAttributeValue( attr_ParserHint ) == L"ParseAsPre" ) {
+                    n->getAttributeValue( attr_ParserHint ) == U"ParseAsPre" ) {
             _libRuParseAsPre = false;
         }
     }
@@ -14069,10 +14069,10 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
     if ( id == el_link && curNodeId == el_link ) { // link node
         ldomNode * n = _currNode->getElement();
         if ( n->getParentNode() && n->getParentNode()->getNodeId() == el_head &&
-                 lString16(n->getAttributeValue("rel")).lowercase() == L"stylesheet" &&
-                 lString16(n->getAttributeValue("type")).lowercase() == L"text/css" ) {
-            lString16 href = n->getAttributeValue("href");
-            lString16 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
+                 lString32(n->getAttributeValue("rel")).lowercase() == U"stylesheet" &&
+                 lString32(n->getAttributeValue("type")).lowercase() == U"text/css" ) {
+            lString32 href = n->getAttributeValue("href");
+            lString32 stylesheetFile = LVCombinePaths( _document->getCodeBase(), href );
             CRLog::debug("Internal stylesheet file: %s", LCSTR(stylesheetFile));
             // We no more apply it immediately: it will be when <BODY> is met
             // _document->setDocStylesheetFileName(stylesheetFile);
@@ -14084,7 +14084,7 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
     // HTML title detection
     if ( id == el_title && curNodeId == el_title && _currNode->_element->getParentNode() &&
                            _currNode->_element->getParentNode()->getNodeId() == el_head ) {
-        lString16 s = _currNode->_element->getText();
+        lString32 s = _currNode->_element->getText();
         s.trim();
         if ( !s.empty() ) {
             // TODO: split authors, title & series
@@ -14129,11 +14129,11 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar16 * /*nsname*/, const lCh
 }
 
 /// called on text
-void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 flags )
+void ldomDocumentWriterFilter::OnText( const lChar32 * text, int len, lUInt32 flags )
 {
     // Accumulate <HEAD><STYLE> content
     if (_inHeadStyle) {
-        _headStyleText << lString16(text, len);
+        _headStyleText << lString32(text, len);
         _inHeadStyle = false;
         return;
     }
@@ -14205,7 +14205,7 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
             // by XMLParser with TXTFLG_PRE | TXTFLG_PRE_PARA_SPLITTING | TXTFLG_TRIM
             bool autoPara = flags & TXTFLG_PRE;
             int leftSpace = 0;
-            const lChar16 * paraTag = NULL;
+            const lChar32 * paraTag = NULL;
             bool isHr = false;
             if ( autoPara ) {
                 while ( (*text==' ' || *text=='\t' || *text==160) && len > 0 ) {
@@ -14213,8 +14213,8 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
                     len--;
                     leftSpace += (*text == '\t') ? 8 : 1;
                 }
-                paraTag = leftSpace > 8 ? L"h2" : L"p";
-                lChar16 ch = 0;
+                paraTag = leftSpace > 8 ? U"h2" : U"p";
+                lChar32 ch = 0;
                 bool sameCh = true;
                 for ( int i=0; i<len; i++ ) {
                     if ( !ch )
@@ -14239,9 +14239,9 @@ void ldomDocumentWriterFilter::OnText( const lChar16 * text, int len, lUInt32 fl
                     isHr = true;
             }
             if ( isHr ) {
-                OnTagOpen( NULL, L"hr" );
+                OnTagOpen( NULL, U"hr" );
                 OnTagBody();
-                OnTagClose( NULL, L"hr" );
+                OnTagClose( NULL, U"hr" );
             } else if ( len > 0 ) {
                 if ( autoPara ) {
                     OnTagOpen( NULL, paraTag );
@@ -14294,7 +14294,7 @@ ldomDocumentWriterFilter::ldomDocumentWriterFilter(ldomDocument * document, bool
         lUInt16 j;
         for ( j=0; rule[j] && j<MAX_ELEMENT_TYPE_ID; j++ ) {
             const char * s = rule[j];
-            items[j] = _document->getElementNameIndex( lString16(s).c_str() );
+            items[j] = _document->getElementNameIndex( lString32(s).c_str() );
         }
         if ( j>=1 ) {
             lUInt16 id = items[0];
@@ -15233,18 +15233,18 @@ static const char * doccache_magic = "CoolReader3 Document Cache Directory Index
 /// document cache
 class ldomDocCacheImpl : public ldomDocCache
 {
-    lString16 _cacheDir;
+    lString32 _cacheDir;
     lvsize_t _maxSize;
     lUInt32 _oldStreamSize;
     lUInt32 _oldStreamCRC;
 
     struct FileItem {
-        lString16 filename;
+        lString32 filename;
         lUInt32 size;
     };
     LVPtrVector<FileItem> _files;
 public:
-    ldomDocCacheImpl( lString16 cacheDir, lvsize_t maxSize )
+    ldomDocCacheImpl( lString32 cacheDir, lvsize_t maxSize )
         : _cacheDir( cacheDir ), _maxSize( maxSize ), _oldStreamSize(0), _oldStreamCRC(0)
     {
         LVAppendPathDelimiter( _cacheDir );
@@ -15253,7 +15253,7 @@ public:
 
     bool writeIndex()
     {
-        lString16 filename = _cacheDir + "cr3cache.inx";
+        lString32 filename = _cacheDir + "cr3cache.inx";
         if (_oldStreamSize == 0)
         {
             LVStreamRef oldStream = LVOpenFileStream(filename.c_str(), LVOM_READ);
@@ -15298,7 +15298,7 @@ public:
 
     bool readIndex(  )
     {
-        lString16 filename = _cacheDir + "cr3cache.inx";
+        lString32 filename = _cacheDir + "cr3cache.inx";
         // read index
         lUInt32 totalSize = 0;
         LVStreamRef instream = LVOpenFileStream( filename.c_str(), LVOM_READ );
@@ -15343,13 +15343,13 @@ public:
     bool removeExtraFiles( )
     {
         LVContainerRef container;
-        container = LVOpenDirectory( _cacheDir.c_str(), L"*.cr3" );
+        container = LVOpenDirectory( _cacheDir.c_str(), U"*.cr3" );
         if ( container.isNull() ) {
             if ( !LVCreateDirectory( _cacheDir ) ) {
                 CRLog::error("Cannot create directory %s", UnicodeToUtf8(_cacheDir).c_str() );
                 return false;
             }
-            container = LVOpenDirectory( _cacheDir.c_str(), L"*.cr3" );
+            container = LVOpenDirectory( _cacheDir.c_str(), U"*.cr3" );
             if ( container.isNull() ) {
                 CRLog::error("Cannot open directory %s", UnicodeToUtf8(_cacheDir).c_str() );
                 return false;
@@ -15358,7 +15358,7 @@ public:
         for ( int i=0; i<container->GetObjectCount(); i++ ) {
             const LVContainerItemInfo * item = container->GetObjectInfo( i );
             if ( !item->IsContainer() ) {
-                lString16 fn = item->GetName();
+                lString32 fn = item->GetName();
                 if ( !fn.endsWith(".cr3") )
                     continue;
                 if ( findFileIndex(fn)<0 ) {
@@ -15402,7 +15402,7 @@ public:
         return res;
     }
 
-    int findFileIndex( lString16 filename )
+    int findFileIndex( lString32 filename )
     {
         for ( int i=0; i<_files.length(); i++ ) {
             if ( _files[i]->filename == filename )
@@ -15411,7 +15411,7 @@ public:
         return -1;
     }
 
-    bool moveFileToTop( lString16 filename, lUInt32 size )
+    bool moveFileToTop( lString32 filename, lUInt32 size )
     {
         int index = findFileIndex( filename );
         if ( index<0 ) {
@@ -15458,15 +15458,15 @@ public:
     }
 
     // dir/filename.{crc32}.cr3
-    lString16 makeFileName( lString16 filename, lUInt32 crc, lUInt32 docFlags )
+    lString32 makeFileName( lString32 filename, lUInt32 crc, lUInt32 docFlags )
     {
-        lString16 fn;
+        lString32 fn;
         lString8 filename8 = UnicodeToTranslit(filename);
         bool lastUnderscore = false;
         int goodCount = 0;
         int badCount = 0;
         for (int i = 0; i < filename8.length(); i++) {
-            lChar16 ch = filename8[i];
+            lChar32 ch = filename8[i];
 
             if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '.' || ch == '-') {
                 fn << ch;
@@ -15474,7 +15474,7 @@ public:
                 goodCount++;
             } else {
                 if (!lastUnderscore) {
-                    fn << L"_";
+                    fn << U"_";
                     lastUnderscore = true;
                 }
                 badCount++;
@@ -15486,19 +15486,19 @@ public:
             fn = fn.substr(0, 12) + "-" + fn.substr(fn.length()-12, 12);
         char s[16];
         sprintf(s, ".%08x.%d.cr3", (unsigned)crc, (int)docFlags);
-        return fn + lString16( s ); //_cacheDir +
+        return fn + lString32( s ); //_cacheDir +
     }
 
     /// open existing cache file stream
-    LVStreamRef openExisting( lString16 filename, lUInt32 crc, lUInt32 docFlags, lString16 &cachePath )
+    LVStreamRef openExisting( lString32 filename, lUInt32 crc, lUInt32 docFlags, lString32 &cachePath )
     {
-        lString16 fn = makeFileName( filename, crc, docFlags );
+        lString32 fn = makeFileName( filename, crc, docFlags );
         CRLog::debug("ldomDocCache::openExisting(%s)", LCSTR(fn));
         // Try filename with ".keep" extension (that a user can manually add
         // to a .cr3 cache file, for it to no more be maintained by crengine
         // in its index, thus not subject to _maxSize enforcement, so sure
         // to not be deleted by crengine)
-        lString16 fn_keep = _cacheDir + fn + ".keep";
+        lString32 fn_keep = _cacheDir + fn + ".keep";
         if ( LVFileExists(fn_keep) ) {
             LVStreamRef stream = LVOpenFileStream( fn_keep.c_str(), LVOM_APPEND|LVOM_FLAG_SYNC );
             if ( !stream.isNull() ) {
@@ -15515,7 +15515,7 @@ public:
             CRLog::error( "ldomDocCache::openExisting - File %s is not found in cache index", UnicodeToUtf8(fn).c_str() );
             return res;
         }
-        lString16 pathname = _cacheDir + fn;
+        lString32 pathname = _cacheDir + fn;
         res = LVOpenFileStream( pathname.c_str(), LVOM_APPEND|LVOM_FLAG_SYNC );
         if ( !res ) {
             CRLog::error( "ldomDocCache::openExisting - File %s is listed in cache index, but cannot be opened", UnicodeToUtf8(fn).c_str() );
@@ -15542,17 +15542,17 @@ public:
     }
 
     /// create new cache file
-    LVStreamRef createNew( lString16 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString16 &cachePath )
+    LVStreamRef createNew( lString32 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString32 &cachePath )
     {
-        lString16 fn = makeFileName( filename, crc, docFlags );
+        lString32 fn = makeFileName( filename, crc, docFlags );
         LVStreamRef res;
-        lString16 pathname = _cacheDir + fn;
+        lString32 pathname = _cacheDir + fn;
         // If this cache filename exists with a ".keep" extension (manually
         // added by the user), and we were going to create a new one (because
         // this .keep is invalid, or cache file format version has changed),
         // remove it and create the new one with this same .keep extension,
         // so it stays (as wished by the user) not maintained by crengine.
-        lString16 fn_keep = pathname + ".keep";
+        lString32 fn_keep = pathname + ".keep";
         if ( LVFileExists( fn_keep ) ) {
             LVDeleteFile( pathname ); // delete .cr3 if any
             LVDeleteFile( fn_keep ); // delete invalid .cr3.keep
@@ -15580,7 +15580,7 @@ public:
 #if ENABLED_BLOCK_WRITE_CACHE
         res = LVCreateBlockWriteStream( res, WRITE_CACHE_BLOCK_SIZE, WRITE_CACHE_BLOCK_COUNT );
 #if TEST_BLOCK_STREAM
-        LVStreamRef stream2 = LVOpenFileStream( (pathname+L"_c").c_str(), LVOM_APPEND );
+        LVStreamRef stream2 = LVOpenFileStream( (pathname+U"_c").c_str(), LVOM_APPEND );
         if ( !stream2 ) {
             CRLog::error( "ldomDocCache::createNew - file %s is cannot be created", UnicodeToUtf8(fn).c_str() );
             return stream2;
@@ -15599,7 +15599,7 @@ public:
 
 static ldomDocCacheImpl * _cacheInstance = NULL;
 
-bool ldomDocCache::init( lString16 cacheDir, lvsize_t maxSize )
+bool ldomDocCache::init( lString32 cacheDir, lvsize_t maxSize )
 {
     if ( _cacheInstance )
         delete _cacheInstance;
@@ -15623,7 +15623,7 @@ bool ldomDocCache::close()
 }
 
 /// open existing cache file stream
-LVStreamRef ldomDocCache::openExisting( lString16 filename, lUInt32 crc, lUInt32 docFlags, lString16 &cachePath )
+LVStreamRef ldomDocCache::openExisting( lString32 filename, lUInt32 crc, lUInt32 docFlags, lString32 &cachePath )
 {
     if ( !_cacheInstance )
         return LVStreamRef();
@@ -15631,7 +15631,7 @@ LVStreamRef ldomDocCache::openExisting( lString16 filename, lUInt32 crc, lUInt32
 }
 
 /// create new cache file
-LVStreamRef ldomDocCache::createNew( lString16 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString16 &cachePath )
+LVStreamRef ldomDocCache::createNew( lString32 filename, lUInt32 crc, lUInt32 docFlags, lUInt32 fileSize, lString32 &cachePath )
 {
     if ( !_cacheInstance )
         return LVStreamRef();
@@ -16181,7 +16181,7 @@ bool ldomNode::isChildNodeText( lUInt32 index ) const
 }
 
 /// returns child node by index, NULL if node with this index is not element or nodeTag!=0 and element node name!=nodeTag
-ldomNode * ldomNode::getChildElementNode( lUInt32 index, const lChar16 * nodeTag ) const
+ldomNode * ldomNode::getChildElementNode( lUInt32 index, const lChar32 * nodeTag ) const
 {
     lUInt16 nodeId = getDocument()->getElementNameIndex(nodeTag);
     return getChildElementNode( index, nodeId );
@@ -16286,11 +16286,11 @@ int ldomNode::getAttrCount() const
 }
 
 /// returns attribute value by attribute name id and namespace id
-const lString16 & ldomNode::getAttributeValue( lUInt16 nsid, lUInt16 id ) const
+const lString32 & ldomNode::getAttributeValue( lUInt16 nsid, lUInt16 id ) const
 {
     ASSERT_NODE_NOT_NULL;
     if ( !isElement() )
-        return lString16::empty_str;
+        return lString32::empty_str;
 #if BUILD_LITE!=1
     if ( !isPersistent() ) {
 #endif
@@ -16298,7 +16298,7 @@ const lString16 & ldomNode::getAttributeValue( lUInt16 nsid, lUInt16 id ) const
         tinyElement * me = NPELEM;
         lUInt32 valueId = me->_attrs.get( nsid, id );
         if ( valueId==LXML_ATTR_VALUE_NONE )
-            return lString16::empty_str;
+            return lString32::empty_str;
         return getDocument()->getAttrValue(valueId);
 #if BUILD_LITE!=1
     } else {
@@ -16306,14 +16306,14 @@ const lString16 & ldomNode::getAttributeValue( lUInt16 nsid, lUInt16 id ) const
         ElementDataStorageItem * me = getDocument()->_elemStorage.getElem( _data._pelem_addr );
         lUInt32 valueId = me->getAttrValueId( nsid, id );
         if ( valueId==LXML_ATTR_VALUE_NONE )
-            return lString16::empty_str;
+            return lString32::empty_str;
         return getDocument()->getAttrValue(valueId);
     }
 #endif
 }
 
 /// returns attribute value by attribute name and namespace
-const lString16 & ldomNode::getAttributeValue( const lChar16 * nsName, const lChar16 * attrName ) const
+const lString32 & ldomNode::getAttributeValue( const lChar32 * nsName, const lChar32 * attrName ) const
 {
     ASSERT_NODE_NOT_NULL;
     lUInt16 nsId = (nsName && nsName[0]) ? getDocument()->getNsNameIndex( nsName ) : LXML_NS_ANY;
@@ -16322,7 +16322,7 @@ const lString16 & ldomNode::getAttributeValue( const lChar16 * nsName, const lCh
 }
 
 /// returns attribute value by attribute name and namespace
-const lString16 & ldomNode::getAttributeValue( const lChar8 * nsName, const lChar8 * attrName ) const
+const lString32 & ldomNode::getAttributeValue( const lChar8 * nsName, const lChar8 * attrName ) const
 {
     ASSERT_NODE_NOT_NULL;
     lUInt16 nsId = (nsName && nsName[0]) ? getDocument()->getNsNameIndex( nsName ) : LXML_NS_ANY;
@@ -16374,17 +16374,17 @@ bool ldomNode::hasAttribute( lUInt16 nsid, lUInt16 id ) const
 }
 
 /// returns attribute name by index
-const lString16 & ldomNode::getAttributeName( lUInt32 index ) const
+const lString32 & ldomNode::getAttributeName( lUInt32 index ) const
 {
     ASSERT_NODE_NOT_NULL;
     const lxmlAttribute * attr = getAttribute( index );
     if ( attr )
         return getDocument()->getAttrName( attr->id );
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 /// sets attribute value
-void ldomNode::setAttributeValue( lUInt16 nsid, lUInt16 id, const lChar16 * value )
+void ldomNode::setAttributeValue( lUInt16 nsid, lUInt16 id, const lChar32 * value )
 {
     ASSERT_NODE_NOT_NULL;
     if ( !isElement() )
@@ -16412,7 +16412,7 @@ void ldomNode::setAttributeValue( lUInt16 nsid, lUInt16 id, const lChar16 * valu
 }
 
 /// returns attribute value by attribute name id, looking at children if needed
-const lString16 & ldomNode::getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const
+const lString32 & ldomNode::getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const
 {
     ASSERT_NODE_NOT_NULL;
     if (hasAttribute(nsid, id))
@@ -16444,7 +16444,7 @@ const lString16 & ldomNode::getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 i
                 break;
         }
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 /// returns element type structure pointer if it was set in document for this element name
@@ -16537,11 +16537,11 @@ void ldomNode::setNodeId( lUInt16 id )
 }
 
 /// returns element name
-const lString16 & ldomNode::getNodeName() const
+const lString32 & ldomNode::getNodeName() const
 {
     ASSERT_NODE_NOT_NULL;
     if ( !isElement() )
-        return lString16::empty_str;
+        return lString32::empty_str;
 #if BUILD_LITE!=1
     if ( !isPersistent() ) {
         // element
@@ -16580,11 +16580,11 @@ bool ldomNode::isNodeName(const char * s) const
 }
 
 /// returns element namespace name
-const lString16 & ldomNode::getNodeNsName() const
+const lString32 & ldomNode::getNodeNsName() const
 {
     ASSERT_NODE_NOT_NULL;
     if ( !isElement() )
-        return lString16::empty_str;
+        return lString32::empty_str;
 #if BUILD_LITE!=1
     if ( !isPersistent() ) {
 #endif
@@ -16602,7 +16602,7 @@ const lString16 & ldomNode::getNodeNsName() const
 
 
 /// returns text node text as wide string
-lString16 ldomNode::getText( lChar16 blockDelimiter, int maxSize ) const
+lString32 ldomNode::getText( lChar32 blockDelimiter, int maxSize ) const
 {
     ASSERT_NODE_NOT_NULL;
     switch ( TNTYPE ) {
@@ -16611,7 +16611,7 @@ lString16 ldomNode::getText( lChar16 blockDelimiter, int maxSize ) const
 #endif
     case NT_ELEMENT:
         {
-            lString16 txt;
+            lString32 txt;
             unsigned cc = getChildCount();
             for ( unsigned i=0; i<cc; i++ ) {
                 ldomNode * child = getChildNode(i);
@@ -16635,9 +16635,9 @@ lString16 ldomNode::getText( lChar16 blockDelimiter, int maxSize ) const
         return Utf8ToUnicode(getDocument()->_textStorage.getText( _data._ptext_addr ));
 #endif
     case NT_TEXT:
-        return _data._text_ptr->getText16();
+        return _data._text_ptr->getText32();
     }
-    return lString16::empty_str;
+    return lString32::empty_str;
 }
 
 /// returns text node text as utf8 string
@@ -16676,7 +16676,7 @@ lString8 ldomNode::getText8( lChar8 blockDelimiter, int maxSize ) const
 }
 
 /// sets text node text as wide string
-void ldomNode::setText( lString16 str )
+void ldomNode::setText( lString32 str )
 {
     ASSERT_NODE_NOT_NULL;
     switch ( TNTYPE ) {
@@ -16982,10 +16982,10 @@ ldomNode * ldomNode::getFirstTextChild(bool skipEmpty)
     if ( isText() ) {
         if ( !skipEmpty )
             return this;
-        lString16 txt = getText();
+        lString32 txt = getText();
         bool nonSpaceFound = false;
         for ( int i=0; i<txt.length(); i++ ) {
-            lChar16 ch = txt[i];
+            lChar32 ch = txt[i];
             if ( ch!=' ' && ch!='\t' && ch!='\r' && ch!='\n' ) {
                 nonSpaceFound = true;
                 break;
@@ -17598,7 +17598,7 @@ ldomNode * ldomNode::getUnboxedPrevSibling( bool skip_text_nodes ) const
 }
 
 /// for display:list-item node, get marker
-bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & markerWidth )
+bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & markerWidth )
 {
 #if BUILD_LITE!=1
     css_style_ref_t s = getStyle();
@@ -17611,18 +17611,18 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
     default:
         // treat default as disc
     case css_lst_disc:
-        marker = L"\x2022"; //L"\x25CF"; // 25e6
+        marker = U"\x2022"; //U"\x25CF"; // 25e6
         break;
     case css_lst_circle:
-        marker = L"\x2022"; //L"\x25CB";
+        marker = U"\x2022"; //U"\x25CB";
         break;
     case css_lst_square:
-        marker = L"\x25A0";
+        marker = U"\x25A0";
         break;
     case css_lst_none:
         // When css_lsp_inside, no space is used by the invisible marker
         if ( s->list_style_position != css_lsp_inside ) {
-            marker = L"\x0020";
+            marker = U"\x0020";
         }
         break;
     case css_lst_decimal:
@@ -17638,7 +17638,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
             // See if parent has a 'start' attribute that overrides this 0
             // https://www.w3.org/TR/html5/grouping-content.html#the-ol-element
             // "The start attribute, if present, must be a valid integer giving the ordinal value of the first list item."
-            lString16 value = parent->getAttributeValue(attr_start);
+            lString32 value = parent->getAttributeValue(attr_start);
             if ( !value.empty() ) {
                 int ivalue;
                 if (value.atoi(ivalue))
@@ -17676,7 +17676,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
                 // See if it has a 'value' attribute that overrides the incremented value
                 // https://www.w3.org/TR/html5/grouping-content.html#the-li-element
                 // "The value attribute, if present, must be a valid integer giving the ordinal value of the list item."
-                lString16 value = sibling->getAttributeValue(attr_value);
+                lString32 value = sibling->getAttributeValue(attr_value);
                 if ( !value.empty() ) {
                     int ivalue;
                     if ( value.atoi(ivalue) )
@@ -17696,32 +17696,32 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
         if (counterValue > 0 || st == css_lst_decimal) {
             switch (st) {
             case css_lst_decimal:
-                marker = lString16::itoa(counterValue);
+                marker = lString32::itoa(counterValue);
                 break;
             case css_lst_lower_roman:
                 if (counterValue - 1 < (int)(sizeof(lower_roman) / sizeof(lower_roman[0])))
-                    marker = lString16(lower_roman[counterValue-1]);
+                    marker = lString32(lower_roman[counterValue-1]);
                 else
-                    marker = lString16::itoa(counterValue); // fallback to simple counter
+                    marker = lString32::itoa(counterValue); // fallback to simple counter
                 break;
             case css_lst_upper_roman:
                 if (counterValue - 1 < (int)(sizeof(lower_roman) / sizeof(lower_roman[0])))
-                    marker = lString16(lower_roman[counterValue-1]);
+                    marker = lString32(lower_roman[counterValue-1]);
                 else
-                    marker = lString16::itoa(counterValue); // fallback to simple digital counter
+                    marker = lString32::itoa(counterValue); // fallback to simple digital counter
                 marker.uppercase();
                 break;
             case css_lst_lower_alpha:
                 if ( counterValue<=26 )
-                    marker.append(1, (lChar16)('a' + counterValue - 1));
+                    marker.append(1, (lChar32)('a' + counterValue - 1));
                 else
-                    marker = lString16::itoa(counterValue); // fallback to simple digital counter
+                    marker = lString32::itoa(counterValue); // fallback to simple digital counter
                 break;
             case css_lst_upper_alpha:
                 if ( counterValue<=26 )
-                    marker.append(1, (lChar16)('A' + counterValue - 1));
+                    marker.append(1, (lChar32)('A' + counterValue - 1));
                 else
-                    marker = lString16::itoa(counterValue); // fallback to simple digital counter
+                    marker = lString32::itoa(counterValue); // fallback to simple digital counter
                 break;
             case css_lst_disc:
             case css_lst_circle:
@@ -17747,7 +17747,7 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString16 & marker, int & 
     }
     return res;
 #else
-    marker = cs16("*");
+    marker = cs32("*");
     return true;
 #endif
 }
@@ -17934,7 +17934,7 @@ ldomNode * ldomNode::insertChildElement( lUInt16 id )
 }
 
 /// inserts child text
-ldomNode * ldomNode::insertChildText( lUInt32 index, const lString16 & value )
+ldomNode * ldomNode::insertChildText( lUInt32 index, const lString32 & value )
 {
     ASSERT_NODE_NOT_NULL;
     if  ( isElement() ) {
@@ -17961,7 +17961,7 @@ ldomNode * ldomNode::insertChildText( lUInt32 index, const lString16 & value )
 }
 
 /// inserts child text
-ldomNode * ldomNode::insertChildText( const lString16 & value )
+ldomNode * ldomNode::insertChildText( const lString32 & value )
 {
     ASSERT_NODE_NOT_NULL;
     if  ( isElement() ) {
@@ -18032,9 +18032,9 @@ LVStreamRef ldomNode::createBase64Stream()
         return LVStreamRef();
 #define DEBUG_BASE64_IMAGE 0
 #if DEBUG_BASE64_IMAGE==1
-    lString16 fname = getAttributeValue( attr_id );
+    lString32 fname = getAttributeValue( attr_id );
     lString8 fname8 = UnicodeToUtf8( fname );
-    LVStreamRef ostream = LVOpenFileStream( fname.empty() ? L"image.png" : fname.c_str(), LVOM_WRITE );
+    LVStreamRef ostream = LVOpenFileStream( fname.empty() ? U"image.png" : fname.c_str(), LVOM_WRITE );
     printf("createBase64Stream(%s)\n", fname8.c_str());
 #endif
     LVStream * stream = new LVBase64NodeStream( this );
@@ -18061,11 +18061,11 @@ LVStreamRef ldomNode::createBase64Stream()
 class NodeImageProxy : public LVImageSource
 {
     ldomNode * _node;
-    lString16 _refName;
+    lString32 _refName;
     int _dx;
     int _dy;
 public:
-    NodeImageProxy( ldomNode * node, lString16 refName, int dx, int dy )
+    NodeImageProxy( ldomNode * node, lString32 refName, int dx, int dy )
         : _node(node), _refName(refName), _dx(dx), _dy(dy)
     {
 
@@ -18097,18 +18097,18 @@ public:
 };
 
 /// returns object image ref name
-lString16 ldomNode::getObjectImageRefName(bool percentDecode)
+lString32 ldomNode::getObjectImageRefName(bool percentDecode)
 {
     if (!isElement())
-        return lString16::empty_str;
+        return lString32::empty_str;
     //printf("ldomElement::getObjectImageSource() ... ");
     const css_elem_def_props_t * et = getDocument()->getElementTypePtr(getNodeId());
     if (!et || !et->is_object)
-        return lString16::empty_str;
+        return lString32::empty_str;
     lUInt16 hrefId = getDocument()->getAttrNameIndex("href");
     lUInt16 srcId = getDocument()->getAttrNameIndex("src");
     lUInt16 recIndexId = getDocument()->getAttrNameIndex("recindex");
-    lString16 refName = getAttributeValue( getDocument()->getNsNameIndex("xlink"),
+    lString32 refName = getAttributeValue( getDocument()->getNsNameIndex("xlink"),
         hrefId );
 
     if ( refName.empty() )
@@ -18118,11 +18118,11 @@ lString16 ldomNode::getObjectImageRefName(bool percentDecode)
     if ( refName.empty() )
         refName = getAttributeValue( LXML_NS_ANY, srcId ); //LXML_NS_NONE
     if (refName.empty()) {
-        lString16 recindex = getAttributeValue( LXML_NS_ANY, recIndexId );
+        lString32 recindex = getAttributeValue( LXML_NS_ANY, recIndexId );
         if (!recindex.empty()) {
             int n;
             if (recindex.atoi(n)) {
-                refName = lString16(MOBI_IMAGE_NAME_PREFIX) + fmt::decimal(n);
+                refName = lString32(MOBI_IMAGE_NAME_PREFIX) + fmt::decimal(n);
                 //CRLog::debug("get mobi image %s", LCSTR(refName));
             }
         }
@@ -18133,7 +18133,7 @@ lString16 ldomNode::getObjectImageRefName(bool percentDecode)
 //        }
     }
     if ( refName.length()<2 )
-        return lString16::empty_str;
+        return lString32::empty_str;
     if (percentDecode)
         refName = DecodeHTMLUrlString(refName);
     return refName;
@@ -18143,7 +18143,7 @@ lString16 ldomNode::getObjectImageRefName(bool percentDecode)
 /// returns object image stream
 LVStreamRef ldomNode::getObjectImageStream()
 {
-    lString16 refName = getObjectImageRefName();
+    lString32 refName = getObjectImageRefName();
     if ( refName.empty() )
         return LVStreamRef();
     return getDocument()->getObjectImageStream( refName );
@@ -18153,7 +18153,7 @@ LVStreamRef ldomNode::getObjectImageStream()
 /// returns object image source
 LVImageSourceRef ldomNode::getObjectImageSource()
 {
-    lString16 refName = getObjectImageRefName(true);
+    lString32 refName = getObjectImageRefName(true);
     LVImageSourceRef ref;
     if ( refName.empty() )
         return ref;
@@ -18184,12 +18184,12 @@ void ldomDocument::registerEmbeddedFonts()
         return;
     int list = _fontList.length();
     lString8 x=lString8("");
-    lString16Collection flist;
+    lString32Collection flist;
     fontMan->getFaceList(flist);
     int cnt = flist.length();
     for (int i = 0; i < list; i++) {
         LVEmbeddedFontDef *item = _fontList.get(i);
-        lString16 url = item->getUrl();
+        lString32 url = item->getUrl();
         lString8 face = item->getFace();
         if (face.empty()) {
             for (int a=i+1;a<list;a++){
@@ -18200,7 +18200,7 @@ void ldomDocument::registerEmbeddedFonts()
         if ((!x.empty() && x.pos(face)!=-1) || url.empty()) {
             continue;
         }
-        if (url.startsWithNoCase(lString16("res://")) || url.startsWithNoCase(lString16("file://"))) {
+        if (url.startsWithNoCase(lString32("res://")) || url.startsWithNoCase(lString32("file://"))) {
             if (!fontMan->RegisterExternalFont(item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register external font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
             }
@@ -18209,13 +18209,13 @@ void ldomDocument::registerEmbeddedFonts()
         else {
             if (!fontMan->RegisterDocumentFont(getDocIndex(), _container, item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register document font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
-                lString16 fontface = lString16("");
+                lString32 fontface = lString32("");
                 for (int j = 0; j < cnt; j = j + 1) {
                 fontface = flist[j];
-                do { (fontface.replace(lString16(" "), lString16("\0"))); }
-                while (fontface.pos(lString16(" ")) != -1);
-                do { (url.replace(lString16(" "), lString16("\0"))); }
-                while (url.pos(lString16(" ")) != -1);
+                do { (fontface.replace(lString32(" "), lString32("\0"))); }
+                while (fontface.pos(lString32(" ")) != -1);
+                do { (url.replace(lString32(" "), lString32("\0"))); }
+                while (url.pos(lString32(" ")) != -1);
                  if (fontface.lowercase().pos(url.lowercase()) != -1) {
                     if(fontMan->SetAlias(face, UnicodeToLocal(flist[j]), getDocIndex(),item->getBold(),item->getItalic())){
                     x.append(face).append(lString8(","));
@@ -18234,16 +18234,16 @@ void ldomDocument::unregisterEmbeddedFonts()
 }
 
 /// returns object image stream
-LVStreamRef ldomDocument::getObjectImageStream( lString16 refName )
+LVStreamRef ldomDocument::getObjectImageStream( lString32 refName )
 {
     LVStreamRef ref;
-    if ( refName.startsWith(lString16(BLOB_NAME_PREFIX)) ) {
+    if ( refName.startsWith(lString32(BLOB_NAME_PREFIX)) ) {
         return _blobCache.getBlob(refName);
     }
-    if ( refName.length() > 10 && refName[4] == ':' && refName.startsWith(lString16("data:image/")) ) {
+    if ( refName.length() > 10 && refName[4] == ':' && refName.startsWith(lString32("data:image/")) ) {
         // <img src="data:image/png;base64,iVBORw0KG...>
-        lString16 data = refName.substr(0, 50);
-        int pos = data.pos(L";base64,");
+        lString32 data = refName.substr(0, 50);
+        int pos = data.pos(U";base64,");
         if ( pos > 0 ) {
             lString8 b64data = UnicodeToLocal(refName.substr(pos+8));
             ref = LVStreamRef(new LVBase64Stream(b64data));
@@ -18252,19 +18252,19 @@ LVStreamRef ldomDocument::getObjectImageStream( lString16 refName )
     }
     if ( refName[0]!='#' ) {
         if ( !getContainer().isNull() ) {
-            lString16 name = refName;
+            lString32 name = refName;
             if ( !getCodeBase().empty() )
                 name = getCodeBase() + refName;
             ref = getContainer()->OpenStream(name.c_str(), LVOM_READ);
             if ( ref.isNull() ) {
-                lString16 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "" );
+                lString32 fname = getProps()->getStringDef( DOC_PROP_FILE_NAME, "" );
                 fname = LVExtractFilenameWithoutExtension(fname);
                 if ( !fname.empty() ) {
-                    lString16 fn = fname + "_img";
+                    lString32 fn = fname + "_img";
 //                    if ( getContainer()->GetObjectInfo(fn) ) {
 
 //                    }
-                    lString16 name = fn + "/" + refName;
+                    lString32 name = fn + "/" + refName;
                     if ( !getCodeBase().empty() )
                         name = getCodeBase() + name;
                     ref = getContainer()->OpenStream(name.c_str(), LVOM_READ);
@@ -18287,7 +18287,7 @@ LVStreamRef ldomDocument::getObjectImageStream( lString16 refName )
 }
 
 /// returns object image source
-LVImageSourceRef ldomDocument::getObjectImageSource( lString16 refName )
+LVImageSourceRef ldomDocument::getObjectImageSource( lString32 refName )
 {
     LVStreamRef stream = getObjectImageStream( refName );
     if (stream.isNull())
@@ -18568,9 +18568,9 @@ void tinyNodeCollection::dumpStatistics()
                 _itemCount, _itemCount*16/1024,
                 _tinyElementCount, _tinyElementCount*(sizeof(tinyElement)+8*4)/1024 );
 }
-lString16 tinyNodeCollection::getStatistics()
+lString32 tinyNodeCollection::getStatistics()
 {
-    lString16 s;
+    lString32 s;
     s << "Elements: " << fmt::decimal(_elemCount) << ", " << fmt::decimal(_elemStorage.getUncompressedSize()/1024) << " KB\n";
     s << "Text nodes: " << fmt::decimal(_textCount) << ", " << fmt::decimal(_textStorage.getUncompressedSize()/1024) << " KB\n";
     s << "Styles: " << fmt::decimal(_styles.length()) << ", " << fmt::decimal(_styleStorage.getUncompressedSize()/1024) << " KB\n";
@@ -18601,7 +18601,7 @@ ldomXPointer LVTocItem::getXPointer()
 }
 
 /// returns position path
-lString16 LVTocItem::getPath()
+lString32 LVTocItem::getPath()
 {
     if ( _path.empty() && !_position.isNull())
         _path = _position.toString();
@@ -18626,7 +18626,7 @@ bool LVTocItem::serialize( SerialBuf & buf )
 //    int             _index;
 //    int             _page;
 //    int             _percent;
-//    lString16       _name;
+//    lString32       _name;
 //    ldomXPointer    _position;
 //    LVPtrVector<LVTocItem> _children;
 
@@ -18709,7 +18709,7 @@ static inline void makeTocFromCrHintsOrHeadings( ldomNode * node, bool ensure_cr
         else
             return;
     }
-    lString16 title = removeSoftHyphens( node->getText(' ') );
+    lString32 title = removeSoftHyphens( node->getText(' ') );
     ldomXPointer xp = ldomXPointer(node, 0);
     LVTocItem * root = node->getDocument()->getToc();
     LVTocItem * parent = root;
@@ -18724,11 +18724,11 @@ static inline void makeTocFromCrHintsOrHeadings( ldomNode * node, bool ensure_cr
             // If we'd like to stick it to the last parent found, even if
             // of wrong level, just do: break;
             // But it is cleaner to create intermediate(s)
-            parent = parent->addChild(L"", xp, lString16::empty_str);
+            parent = parent->addChild(U"", xp, lString32::empty_str);
         }
         plevel++;
     }
-    parent->addChild(title, xp, lString16::empty_str);
+    parent->addChild(title, xp, lString32::empty_str);
 }
 
 static void makeTocFromHeadings( ldomNode * node )
@@ -18748,7 +18748,7 @@ static void makeTocFromDocFragments( ldomNode * node )
     // No title, and only level 1 with DocFragments
     ldomXPointer xp = ldomXPointer(node, 0);
     LVTocItem * root = node->getDocument()->getToc();
-    root->addChild(L"", xp, lString16::empty_str);
+    root->addChild(U"", xp, lString32::empty_str);
 }
 
 void ldomDocument::buildTocFromHeadings()
@@ -18791,7 +18791,7 @@ ldomXPointer LVPageMapItem::getXPointer()
 }
 
 /// returns position path
-lString16 LVPageMapItem::getPath()
+lString32 LVPageMapItem::getPath()
 {
     if ( _path.empty() && !_position.isNull())
         _path = _position.toString();
@@ -18899,7 +18899,7 @@ void testCacheFile()
     lUInt8 * buf2;
     int sz1;
     int sz2;
-    lString16 fn(TEST_FILE_NAME);
+    lString32 fn(TEST_FILE_NAME);
 
     {
         lUInt8 data1[] = {'T', 'e', 's', 't', 'D', 'a', 't', 'a', '1'};
@@ -18927,7 +18927,7 @@ void testCacheFile()
     // write
     {
         CacheFile f;
-        MYASSERT(f.open(cs16("/tmp/blabla-not-exits-file-name"))==false, "Wrong failed open result");
+        MYASSERT(f.open(cs32("/tmp/blabla-not-exits-file-name"))==false, "Wrong failed open result");
         MYASSERT(f.create( fn )==true, "new file created");
         MYASSERT(f.write(CBT_TEXT_DATA, 1, data1, sizeof(data1), true)==true, "write 1");
         MYASSERT(f.write(CBT_ELEM_DATA, 3, data2, sizeof(data2), false)==true, "write 2");
@@ -18967,7 +18967,7 @@ void runFileCacheTest()
     CRLog::info("====Cache test started =====");
 
     // init and clear cache
-    ldomDocCache::init(cs16("/tmp/cr3cache"), 100);
+    ldomDocCache::init(cs32("/tmp/cr3cache"), 100);
     MYASSERT(ldomDocCache::enabled(), "clear cache");
 
     {
@@ -19003,12 +19003,12 @@ void runBasicTinyDomUnitTests()
     ldomNode * root = doc->getRootNode();//doc->allocTinyElement( NULL, 0, 0 );
     MYASSERT(root!=NULL,"root != NULL");
 
-    int el_p = doc->getElementNameIndex(L"p");
-    int el_title = doc->getElementNameIndex(L"title");
-    int el_strong = doc->getElementNameIndex(L"strong");
-    int el_emphasis = doc->getElementNameIndex(L"emphasis");
-    int attr_id = doc->getAttrNameIndex(L"id");
-    int attr_name = doc->getAttrNameIndex(L"name");
+    int el_p = doc->getElementNameIndex(U"p");
+    int el_title = doc->getElementNameIndex(U"title");
+    int el_strong = doc->getElementNameIndex(U"strong");
+    int el_emphasis = doc->getElementNameIndex(U"emphasis");
+    int attr_id = doc->getAttrNameIndex(U"id");
+    int attr_name = doc->getAttrNameIndex(U"name");
     static lUInt16 path1[] = {el_title, el_p, 0};
     static lUInt16 path2[] = {el_title, el_p, el_strong, 0};
 
@@ -19028,9 +19028,9 @@ void runBasicTinyDomUnitTests()
     MYASSERT(root->getChildCount()==2,"root child count 2");
     MYASSERT(el2->getNodeId()==el_title, "node id");
     MYASSERT(el2->getNodeNsId()==LXML_NS_NONE, "node nsid");
-    lString16 nodename = el2->getNodeName();
+    lString32 nodename = el2->getNodeName();
     //CRLog::debug("node name: %s", LCSTR(nodename));
-    MYASSERT(nodename==L"title","node name");
+    MYASSERT(nodename==U"title","node name");
     ldomNode * el21 = el2->insertChildElement(el_p);
     MYASSERT(root->getNodeLevel()==1,"node level 1");
     MYASSERT(el2->getNodeLevel()==2,"node level 2");
@@ -19072,9 +19072,9 @@ void runBasicTinyDomUnitTests()
     }
 
     CRLog::info("* simple DOM operations, mutable text");
-    lString16 sampleText("Some sample text.");
-    lString16 sampleText2("Some sample text 2.");
-    lString16 sampleText3("Some sample text 3.");
+    lString32 sampleText("Some sample text.");
+    lString32 sampleText2("Some sample text 2.");
+    lString32 sampleText3("Some sample text 3.");
     ldomNode * text1 = el1->insertChildText(sampleText);
     MYASSERT(text1->getText()==sampleText, "sample text 1 match unicode");
     MYASSERT(text1->getNodeLevel()==3,"text node level");
@@ -19227,16 +19227,16 @@ void runBasicTinyDomUnitTests()
 
     CRLog::info("* persistance test");
 
-    el2->setAttributeValue(LXML_NS_NONE, attr_id, L"id1");
-    el2->setAttributeValue(LXML_NS_NONE, attr_name, L"name1");
+    el2->setAttributeValue(LXML_NS_NONE, attr_id, U"id1");
+    el2->setAttributeValue(LXML_NS_NONE, attr_name, U"name1");
     MYASSERT(el2->getNodeId()==el_title, "mutable node id");
     MYASSERT(el2->getNodeNsId()==LXML_NS_NONE, "mutable node nsid");
-    MYASSERT(el2->getAttributeValue(attr_id)==L"id1", "attr id1 mutable");
-    MYASSERT(el2->getAttributeValue(attr_name)==L"name1", "attr name1 mutable");
+    MYASSERT(el2->getAttributeValue(attr_id)==U"id1", "attr id1 mutable");
+    MYASSERT(el2->getAttributeValue(attr_name)==U"name1", "attr name1 mutable");
     MYASSERT(el2->getAttrCount()==2, "attr count mutable");
     el2->persist();
-    MYASSERT(el2->getAttributeValue(attr_id)==L"id1", "attr id1 pers");
-    MYASSERT(el2->getAttributeValue(attr_name)==L"name1", "attr name1 pers");
+    MYASSERT(el2->getAttributeValue(attr_id)==U"id1", "attr id1 pers");
+    MYASSERT(el2->getAttributeValue(attr_name)==U"name1", "attr name1 pers");
     MYASSERT(el2->getNodeId()==el_title, "persistent node id");
     MYASSERT(el2->getNodeNsId()==LXML_NS_NONE, "persistent node nsid");
     MYASSERT(el2->getAttrCount()==2, "attr count persist");
@@ -19250,8 +19250,8 @@ void runBasicTinyDomUnitTests()
     el2->modify();
     MYASSERT(el2->getNodeId()==el_title, "mutable 2 node id");
     MYASSERT(el2->getNodeNsId()==LXML_NS_NONE, "mutable 2 node nsid");
-    MYASSERT(el2->getAttributeValue(attr_id)==L"id1", "attr id1 mutable 2");
-    MYASSERT(el2->getAttributeValue(attr_name)==L"name1", "attr name1 mutable 2");
+    MYASSERT(el2->getAttributeValue(attr_id)==U"id1", "attr id1 mutable 2");
+    MYASSERT(el2->getAttributeValue(attr_name)==U"name1", "attr name1 mutable 2");
     MYASSERT(el2->getAttrCount()==2, "attr count mutable 2");
 
     {
@@ -19271,8 +19271,8 @@ void runBasicTinyDomUnitTests()
     MYASSERT(!el21->isPersistent(), "mutable after insertChildElement");
     el211->persist();
     MYASSERT(el211->isPersistent(), "persistent before insertChildText");
-    el211->insertChildText(cs16(L"bla bla bla"));
-    el211->insertChildText(cs16(L"bla bla blaw"));
+    el211->insertChildText(cs32(U"bla bla bla"));
+    el211->insertChildText(cs32(U"bla bla blaw"));
     MYASSERT(!el211->isPersistent(), "modifable after insertChildText");
     //el21->insertChildElement(el_strong);
     MYASSERT(el211->getChildCount()==2, "child count, in mutable");
@@ -19314,7 +19314,7 @@ void runCHMUnitTest()
     LVContainerRef dir = LVOpenCHMContainer( stream );
     MYASSERT ( !dir.isNull(), "container opened" );
     CRLog::trace("runCHMUnitTest() -- container opened ok");
-    LVStreamRef s = dir->OpenStream(L"/index.html", LVOM_READ);
+    LVStreamRef s = dir->OpenStream(U"/index.html", LVOM_READ);
     MYASSERT ( !s.isNull(), "item opened" );
     CRLog::trace("runCHMUnitTest() -- index.html opened ok: size=%d", (int)s->GetSize());
     lvsize_t bytesRead = 0;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4532,12 +4532,12 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
         _def_font = def_font;
         changed = true;
     }
-    if ( _page_height != dy ) {
+    if ( _page_height != dy && dy > 0 ) {
         CRLog::trace("ldomDocument::setRenderProps() - page height is changed");
         _page_height = dy;
         changed = true;
     }
-    if ( _page_width != width ) {
+    if ( _page_width != width && width > 0 ) {
         CRLog::trace("ldomDocument::setRenderProps() - page width is changed");
         _page_width = width;
         changed = true;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4390,11 +4390,11 @@ void ldomDocument::printWarning(const char * msg, int warning_id) {
 
 ldomDocument::~ldomDocument()
 {
-    ldomNode::unregisterDocument(this);
-    fontMan->UnregisterDocumentFonts(_docIndex);
 #if BUILD_LITE!=1
     updateMap(); // NOLINT: Call to virtual function during destruction
 #endif
+    fontMan->UnregisterDocumentFonts(_docIndex);
+    ldomNode::unregisterDocument(this);
 }
 
 #if BUILD_LITE!=1

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -45,9 +45,9 @@ typedef unsigned int ucs4_t;
 
 
 
-int CalcTabCount(const lChar16 * str, int nlen);
-void ExpandTabs(lString16 & s);
-void ExpandTabs(lString16 & buf, const lChar16 * str, int len);
+int CalcTabCount(const lChar32 * str, int nlen);
+void ExpandTabs(lString32 & s);
+void ExpandTabs(lString32 & buf, const lChar32 * str, int len);
 
 /// virtual destructor
 LVFileFormatParser::~LVFileFormatParser()
@@ -130,11 +130,11 @@ int LVFileParserBase::getProgressPercent()
     return (int)((lInt64)100 * (m_buf_pos + m_buf_fpos) / m_stream_size);
 }
 
-lString16 LVFileParserBase::getFileName()
+lString32 LVFileParserBase::getFileName()
 {
     if ( m_stream.isNull() )
-        return lString16::empty_str;
-    lString16 name( m_stream->GetName() );
+        return lString32::empty_str;
+    lString32 name( m_stream->GetName() );
     int lastPathDelim = -1;
     for ( int i=0; i<name.length(); i++ ) {
         if ( name[i]=='\\' || name[i]=='/' ) {
@@ -189,10 +189,10 @@ static int charToHex( lUInt8 ch )
 
 
 /// reads one character from buffer in RTF format
-lChar16 LVTextFileBase::ReadRtfChar( int, const lChar16 * conv_table )
+lChar32 LVTextFileBase::ReadRtfChar( int, const lChar32 * conv_table )
 {
-    lChar16 ch = m_buf[m_buf_pos++];
-    lChar16 ch2 = m_buf[m_buf_pos];
+    lChar32 ch = m_buf[m_buf_pos++];
+    lChar32 ch2 = m_buf[m_buf_pos];
     if ( ch=='\\' && ch2!='\'' ) {
     } else if (ch=='\\' ) {
         m_buf_pos++;
@@ -228,7 +228,7 @@ void LVTextFileBase::checkEof()
 
 #if GBK_ENCODING_SUPPORT == 1
 // based on code from libiconv
-static lChar16 cr3_gb2312_mbtowc(const unsigned char *s)
+static lChar32 cr3_gb2312_mbtowc(const unsigned char *s)
 {
     unsigned char c1 = s[0];
     if ((c1 >= 0x21 && c1 <= 0x29) || (c1 >= 0x30 && c1 <= 0x77)) {
@@ -248,7 +248,7 @@ static lChar16 cr3_gb2312_mbtowc(const unsigned char *s)
 }
 
 // based on code from libiconv
-static lChar16 cr3_cp936ext_mbtowc (const unsigned char *s)
+static lChar32 cr3_cp936ext_mbtowc (const unsigned char *s)
 {
     unsigned char c1 = s[0];
     if ((c1 == 0xa6) || (c1 == 0xa8)) {
@@ -268,7 +268,7 @@ static lChar16 cr3_cp936ext_mbtowc (const unsigned char *s)
 }
 
 // based on code from libiconv
-static lChar16 cr3_gbkext1_mbtowc (lChar16 c1, lChar16 c2)
+static lChar32 cr3_gbkext1_mbtowc (lChar32 c1, lChar32 c2)
 {
     if ((c1 >= 0x81 && c1 <= 0xa0)) {
         if ((c2 >= 0x40 && c2 < 0x7f) || (c2 >= 0x80 && c2 < 0xff)) {
@@ -281,7 +281,7 @@ static lChar16 cr3_gbkext1_mbtowc (lChar16 c1, lChar16 c2)
 }
 
 // based on code from libiconv
-static lChar16 cr3_gbkext2_mbtowc(lChar16 c1, lChar16 c2)
+static lChar32 cr3_gbkext2_mbtowc(lChar32 c1, lChar32 c2)
 {
     if ((c1 >= 0xa8 && c1 <= 0xfe)) {
         if ((c2 >= 0x40 && c2 < 0x7f) || (c2 >= 0x80 && c2 < 0xa1)) {
@@ -296,9 +296,9 @@ static lChar16 cr3_gbkext2_mbtowc(lChar16 c1, lChar16 c2)
 
 #if JIS_ENCODING_SUPPORT == 1
 // based on code from libiconv
-static lChar16 cr3_jisx0213_to_ucs4(unsigned int row, unsigned int col)
+static lChar32 cr3_jisx0213_to_ucs4(unsigned int row, unsigned int col)
 {
-    lChar16 val;
+    lChar32 val;
 
     if (row >= 0x121 && row <= 0x17e)
         row -= 289;
@@ -320,8 +320,8 @@ static lChar16 cr3_jisx0213_to_ucs4(unsigned int row, unsigned int col)
     else
         return 0x0000;
 
-    val = (lChar16)jisx0213_to_ucs_main[row * 94 + col];
-    val = (lChar16)jisx0213_to_ucs_pagestart[val >> 8] + (val & 0xff);
+    val = (lChar32)jisx0213_to_ucs_main[row * 94 + col];
+    val = (lChar32)jisx0213_to_ucs_pagestart[val >> 8] + (val & 0xff);
     if (val == 0xfffd)
         val = 0x0000;
     return val;
@@ -330,7 +330,7 @@ static lChar16 cr3_jisx0213_to_ucs4(unsigned int row, unsigned int col)
 
 #if BIG5_ENCODING_SUPPORT == 1
 // based on code from libiconv
-static lUInt16 cr3_big5_mbtowc(lChar16 c1, lChar16 c2)
+static lUInt16 cr3_big5_mbtowc(lChar32 c1, lChar32 c2)
 {
     if ((c1 >= 0xa1 && c1 <= 0xc7) || (c1 >= 0xc9 && c1 <= 0xf9)) {
         if ((c2 >= 0x40 && c2 < 0x7f) || (c2 >= 0xa1 && c2 < 0xff)) {
@@ -355,7 +355,7 @@ static lUInt16 cr3_big5_mbtowc(lChar16 c1, lChar16 c2)
 
 #if EUC_KR_ENCODING_SUPPORT == 1
 // based on code from libiconv
-static lChar16 cr3_ksc5601_mbtowc(lChar16 c1, lChar16 c2)
+static lChar32 cr3_ksc5601_mbtowc(lChar32 c1, lChar32 c2)
 {
     if ((c1 >= 0x21 && c1 <= 0x2c) || (c1 >= 0x30 && c1 <= 0x48) || (c1 >= 0x4a && c1 <= 0x7d)) {
         if (c2 >= 0x21 && c2 < 0x7f) {
@@ -382,7 +382,7 @@ static lChar16 cr3_ksc5601_mbtowc(lChar16 c1, lChar16 c2)
 
 
 /// reads several characters from buffer
-int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
+int LVTextFileBase::ReadChars( lChar32 * buf, int maxsize )
 {
     if (m_buf_pos >= m_buf_len)
         return 0;
@@ -504,7 +504,7 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                     lUInt16 ch2 = 0;
                     ch2 = m_buf[m_buf_pos++];
                     if ((ch2 >= 0x40 && ch2 <= 0x7e) || (ch2 >= 0x80 && ch2 <= 0xfc)) {
-                        lChar16 ch1;
+                        lChar32 ch1;
                         /* Convert to row and column. */
                         if (ch < 0xe0)
                             ch -= 0x81;
@@ -528,12 +528,12 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                             else
                                 ch1 += 162;
                         }
-                        lChar16 wc = cr3_jisx0213_to_ucs4(0x121+ch1, ch2);
+                        lChar32 wc = cr3_jisx0213_to_ucs4(0x121+ch1, ch2);
                         if (wc) {
                             if (wc < 0x80) {
                                 /* It's a combining character. */
-                                lChar16 wc1 = jisx0213_to_ucs_combining[wc - 1][0];
-                                lChar16 wc2 = jisx0213_to_ucs_combining[wc - 1][1];
+                                lChar32 wc1 = jisx0213_to_ucs_combining[wc - 1][0];
+                                lChar32 wc2 = jisx0213_to_ucs_combining[wc - 1][1];
                                 buf[count++] = wc1;
                                 res = wc2;
                             } else
@@ -579,7 +579,7 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                               res = ch2 + 0xfec0;
                             }
                         } else {
-                            lChar16 wc;
+                            lChar32 wc;
                             if (ch == 0x8f) {
                                 /* JISX 0213 plane 2. */
                                 lUInt16 ch3 = m_buf[m_buf_pos++];
@@ -595,10 +595,10 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                                     ucs4_t wc2 = jisx0213_to_ucs_combining[wc - 1][1];
                                     /* We cannot output two Unicode characters at once. So,
                                        output the first character and buffer the second one. */
-                                    buf[count++] = (lChar16)wc1;
-                                    res = (lChar16)wc2;
+                                    buf[count++] = (lChar32)wc1;
+                                    res = (lChar32)wc2;
                                 } else
-                                    res = (lChar16)wc;
+                                    res = (lChar32)wc;
                             }
                         }
                     }
@@ -638,7 +638,7 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                         if (ch >= 0xa1) {
                             if (ch < 0xa3) {
                                 unsigned int i = 157 * (ch - 0xa1) + (ch2 - (ch2 >= 0xa1 ? 0x62 : 0x40));
-                                lChar16 wc = big5_2003_2uni_pagea1[i];
+                                lChar32 wc = big5_2003_2uni_pagea1[i];
                                 if (wc != 0xfffd) {
                                     res = wc;
                                 }
@@ -668,16 +668,16 @@ int LVTextFileBase::ReadChars( lChar16 * buf, int maxsize )
                                 unsigned int i = 157 * (ch - 0xc6) + (ch2 - (ch2 >= 0xa1 ? 0x62 : 0x40));
                                 if (i < 133) {
                                     /* 63 <= i < 133. */
-                                    lChar16 wc = big5_2003_2uni_pagec6[i-63];
+                                    lChar32 wc = big5_2003_2uni_pagec6[i-63];
                                     if (wc != 0xfffd) {
                                         res = wc;
                                     }
                                 } else if (i < 216) {
                                     /* 133 <= i < 216. Hiragana. */
-                                    res = (lChar16)(0x3041 - 133 + i);
+                                    res = (lChar32)(0x3041 - 133 + i);
                                 } else if (i < 302) {
                                     /* 216 <= i < 302. Katakana. */
-                                    res = (lChar16)(0x30a1 - 216 + i);
+                                    res = (lChar32)(0x30a1 - 216 + i);
                                 }
                             }
                         } else {
@@ -812,8 +812,8 @@ bool LVTextFileBase::AutodetectEncoding( bool utfOnly )
     m_stream->SetPos( oldpos );
     if ( res) {
         //CRLog::debug("Code page decoding results: encoding=%s, lang=%s", enc_name, lang_name);
-        m_lang_name = lString16( lang_name );
-        SetCharset( lString16( enc_name ).c_str() );
+        m_lang_name = lString32( lang_name );
+        SetCharset( lString32( enc_name ).c_str() );
     }
 
     // restore state
@@ -855,7 +855,7 @@ bool LVFileParserBase::Seek( lvpos_t pos, int bytesToPrefetch )
 }
 
 /// reads specified number of bytes, converts to characters and saves to buffer
-int LVTextFileBase::ReadTextBytes( lvpos_t pos, int bytesToRead, lChar16 * buf, int buf_size, int flags)
+int LVTextFileBase::ReadTextBytes( lvpos_t pos, int bytesToRead, lChar32 * buf, int buf_size, int flags)
 {
     if ( !Seek( pos, bytesToRead ) ) {
         CRLog::error("LVTextFileBase::ReadTextBytes seek error! cannot set pos to %d to read %d bytes", (int)pos, (int)bytesToRead);
@@ -867,12 +867,12 @@ int LVTextFileBase::ReadTextBytes( lvpos_t pos, int bytesToRead, lChar16 * buf, 
         max_pos = m_buf_len;
     if ( (flags & TXTFLG_RTF)!=0 ) {
         char_encoding_type enc_type = ce_utf8;
-        lChar16 * conv_table = NULL;
+        lChar32 * conv_table = NULL;
         if ( flags & TXTFLG_ENCODING_MASK ) {
         // set new encoding
             int enc_id = (flags & TXTFLG_ENCODING_MASK) >> TXTFLG_ENCODING_SHIFT;
             if ( enc_id >= ce_8bit_cp ) {
-                conv_table = (lChar16 *)GetCharsetByte2UnicodeTableById( enc_id );
+                conv_table = (lChar32 *)GetCharsetByte2UnicodeTableById( enc_id );
                 if (conv_table)
                     enc_type = ce_8bit_cp;
                 else
@@ -955,9 +955,9 @@ void LVTextFileBase::Reset()
         ReadCharFromBuffer();
 }
 
-void LVTextFileBase::SetCharset( const lChar16 * name )
+void LVTextFileBase::SetCharset( const lChar32 * name )
 {
-    m_encoding_name = lString16( name );
+    m_encoding_name = lString32( name );
     if ( m_encoding_name == "utf-8" ) {
         m_enc_type = ce_utf8;
         SetCharsetTable( NULL );
@@ -1004,14 +1004,14 @@ void LVTextFileBase::SetCharset( const lChar16 * name )
         SetCharsetTable( NULL );
     } else {
         m_enc_type = ce_8bit_cp;
-        //CRLog::trace("charset: %s", LCSTR(lString16(name)));
-        const lChar16 * table = GetCharsetByte2UnicodeTable( name );
+        //CRLog::trace("charset: %s", LCSTR(lString32(name)));
+        const lChar32 * table = GetCharsetByte2UnicodeTable( name );
         if ( table )
             SetCharsetTable( table );
     }
 }
 
-void LVTextFileBase::SetCharsetTable( const lChar16 * table )
+void LVTextFileBase::SetCharsetTable( const lChar32 * table )
 {
     if (!table)
     {
@@ -1024,37 +1024,37 @@ void LVTextFileBase::SetCharsetTable( const lChar16 * table )
     }
     m_enc_type = ce_8bit_cp;
     if (!m_conv_table)
-        m_conv_table = new lChar16[128];
+        m_conv_table = new lChar32[128];
     lStr_memcpy( m_conv_table, table, 128 );
 }
 
 
-static const lChar16 * heading_volume[] = {
-    L"volume",
-    L"vol",
-    L"\x0442\x043e\x043c", // tom
+static const lChar32 * heading_volume[] = {
+    U"volume",
+    U"vol",
+    U"\x0442\x043e\x043c", // tom
     NULL
 };
 
-static const lChar16 * heading_part[] = {
-    L"part",
-    L"\x0447\x0430\x0441\x0442\x044c", // chast'
+static const lChar32 * heading_part[] = {
+    U"part",
+    U"\x0447\x0430\x0441\x0442\x044c", // chast'
     NULL
 };
 
-static const lChar16 * heading_chapter[] = {
-    L"chapter",
-    L"\x0433\x043B\x0430\x0432\x0430", // glava
+static const lChar32 * heading_chapter[] = {
+    U"chapter",
+    U"\x0433\x043B\x0430\x0432\x0430", // glava
     NULL
 };
 
-static bool startsWithOneOf( const lString16 & s, const lChar16 * list[] )
+static bool startsWithOneOf( const lString32 & s, const lChar32 * list[] )
 {
-    lString16 str = s;
+    lString32 str = s;
     str.lowercase();
-    const lChar16 * p = str.c_str();
+    const lChar32 * p = str.c_str();
     for ( int i=0; list[i]; i++ ) {
-        const lChar16 * q = list[i];
+        const lChar32 * q = list[i];
         int j=0;
         for ( ; q[j]; j++ ) {
             if ( !p[j] ) {
@@ -1069,7 +1069,7 @@ static bool startsWithOneOf( const lString16 & s, const lChar16 * list[] )
     return false;
 }
 
-int DetectHeadingLevelByText( const lString16 & str )
+int DetectHeadingLevelByText( const lString32 & str )
 {
     if ( str.empty() )
         return 0;
@@ -1079,7 +1079,7 @@ int DetectHeadingLevelByText( const lString16 & str )
         return 2;
     if ( startsWithOneOf( str, heading_chapter ) )
         return 3;
-    lChar16 ch = str[0];
+    lChar32 ch = str[0];
     if ( ch>='0' && ch<='9' ) {
         int i;
         int point_count = 0;
@@ -1126,7 +1126,7 @@ public:
     //lvpos_t fpos;   // position of line in file
     //lvsize_t fsize;  // size of data in file
     lUInt32 flags;  // flags. 1=eoln
-    lString16 text; // line text
+    lString32 text; // line text
     lUInt16 lpos;   // left non-space char position
     lUInt16 rpos;   // right non-space char posision + 1
     lineAlign_t align;
@@ -1138,7 +1138,7 @@ public:
         text = file->ReadLine( maxsize, flags );
         //CRLog::debug("  line read: %s", UnicodeToUtf8(text).c_str() );
         if ( !text.empty() ) {
-            const lChar16 * s = text.c_str();
+            const lChar32 * s = text.c_str();
             for ( int p=0; *s; s++ ) {
                 if ( *s == '\t' ) {
                     p = (p + 8)%8;
@@ -1158,10 +1158,10 @@ public:
 };
 
 // returns char like '*' in "* * *"
-lChar16 getSingleLineChar( const lString16 & s) {
-    lChar16 nonSpace = 0;
-    for ( const lChar16 * p = s.c_str(); *p; p++ ) {
-        lChar16 ch = *p;
+lChar32 getSingleLineChar( const lString32 & s) {
+    lChar32 nonSpace = 0;
+    for ( const lChar32 * p = s.c_str(); *p; p++ ) {
+        lChar32 ch = *p;
         if ( ch!=' ' && ch!='\t' && ch!='\r' && ch!='\n' ) {
             if ( nonSpace==0 )
                 nonSpace = ch;
@@ -1183,10 +1183,10 @@ private:
     LVTextFileBase * file;
     int first_line_index;
     int maxLineSize;
-    lString16 bookTitle;
-    lString16 bookAuthors;
-    lString16 seriesName;
-    lString16 seriesNumber;
+    lString32 bookTitle;
+    lString32 bookAuthors;
+    lString32 seriesName;
+    lString32 seriesNumber;
     int formatFlags;
     int min_left;
     int max_right;
@@ -1348,8 +1348,8 @@ public:
                 avg_left += line->lpos;
                 avg_right += line->rpos;
                 for (int j=line->lpos; j<line->rpos-1; j++ ) {
-                    lChar16 ch = line->text[j];
-                    lChar16 ch2 = line->text[j+1];
+                    lChar32 ch = line->text[j];
+                    lChar32 ch2 = line->text[j+1];
                     if ( ch=='\\' ) {
                         switch ( ch2 ) {
                         case 'p':
@@ -1494,8 +1494,8 @@ public:
             return false;
         bookTitle.clear();
         bookAuthors.clear();
-        lString16 firstLine = get(i)->text;
-        lString16 pgPrefix("The Project Gutenberg Etext of ");
+        lString32 firstLine = get(i)->text;
+        lString32 pgPrefix("The Project Gutenberg Etext of ");
         if ( firstLine.length() < pgPrefix.length() )
             return false;
         if ( firstLine.substr(0, pgPrefix.length()) != pgPrefix )
@@ -1526,7 +1526,7 @@ public:
             return false;
         bookTitle.clear();
         bookAuthors.clear();
-        lString16 firstLine = get(i)->text;
+        lString32 firstLine = get(i)->text;
         firstLine.trim();
         int dotPos = firstLine.pos(". ");
         if ( dotPos<=0 )
@@ -1548,12 +1548,12 @@ public:
 /*
 
             int necount = 0;
-            lString16 s[3];
+            lString32 s[3];
             unsigned i;
             for ( i=0; i<(unsigned)length() && necount<2; i++ ) {
                 LVTextFileLine * item = get(i);
                 if ( item->rpos>item->lpos ) {
-                    lString16 str = item->text;
+                    lString32 str = item->text;
                     str.trimDoubleSpaces(false, false, true);
                     if ( !str.empty() ) {
                         s[necount] = str;
@@ -1571,51 +1571,51 @@ public:
 */
         }
 
-        lString16Collection author_list;
+        lString32Collection author_list;
         if ( !bookAuthors.empty() )
             author_list.parse( bookAuthors, ',', true );
 
         int i;
         for ( i=0; i<author_list.length(); i++ ) {
-            lString16Collection name_list;
+            lString32Collection name_list;
             name_list.parse( author_list[i], ' ', true );
             if ( name_list.length()>0 ) {
-                lString16 firstName = name_list[0];
-                lString16 lastName;
-                lString16 middleName;
+                lString32 firstName = name_list[0];
+                lString32 lastName;
+                lString32 middleName;
                 if ( name_list.length() == 2 ) {
                     lastName = name_list[1];
                 } else if ( name_list.length()>2 ) {
                     middleName = name_list[1];
                     lastName = name_list[2];
                 }
-                callback->OnTagOpenNoAttr( NULL, L"author" );
-                  callback->OnTagOpenNoAttr( NULL, L"first-name" );
+                callback->OnTagOpenNoAttr( NULL, U"author" );
+                  callback->OnTagOpenNoAttr( NULL, U"first-name" );
                     if ( !firstName.empty() )
                         callback->OnText( firstName.c_str(), firstName.length(), TXTFLG_TRIM|TXTFLG_TRIM_REMOVE_EOL_HYPHENS );
-                  callback->OnTagClose( NULL, L"first-name" );
-                  callback->OnTagOpenNoAttr( NULL, L"middle-name" );
+                  callback->OnTagClose( NULL, U"first-name" );
+                  callback->OnTagOpenNoAttr( NULL, U"middle-name" );
                     if ( !middleName.empty() )
                         callback->OnText( middleName.c_str(), middleName.length(), TXTFLG_TRIM|TXTFLG_TRIM_REMOVE_EOL_HYPHENS );
-                  callback->OnTagClose( NULL, L"middle-name" );
-                  callback->OnTagOpenNoAttr( NULL, L"last-name" );
+                  callback->OnTagClose( NULL, U"middle-name" );
+                  callback->OnTagOpenNoAttr( NULL, U"last-name" );
                     if ( !lastName.empty() )
                         callback->OnText( lastName.c_str(), lastName.length(), TXTFLG_TRIM|TXTFLG_TRIM_REMOVE_EOL_HYPHENS );
-                  callback->OnTagClose( NULL, L"last-name" );
-                callback->OnTagClose( NULL, L"author" );
+                  callback->OnTagClose( NULL, U"last-name" );
+                callback->OnTagClose( NULL, U"author" );
             }
         }
-        callback->OnTagOpenNoAttr( NULL, L"book-title" );
+        callback->OnTagOpenNoAttr( NULL, U"book-title" );
             if ( !bookTitle.empty() )
                 callback->OnText( bookTitle.c_str(), bookTitle.length(), 0 );
-        callback->OnTagClose( NULL, L"book-title" );
+        callback->OnTagClose( NULL, U"book-title" );
         if ( !seriesName.empty() || !seriesNumber.empty() ) {
-            callback->OnTagOpenNoAttr( NULL, L"sequence" );
+            callback->OnTagOpenNoAttr( NULL, U"sequence" );
             if ( !seriesName.empty() )
-                callback->OnAttribute( NULL, L"name", seriesName.c_str() );
+                callback->OnAttribute( NULL, U"name", seriesName.c_str() );
             if ( !seriesNumber.empty() )
-                callback->OnAttribute( NULL, L"number", seriesNumber.c_str() );
-            callback->OnTagClose( NULL, L"sequence" );
+                callback->OnAttribute( NULL, U"number", seriesNumber.c_str() );
+            callback->OnTagClose( NULL, U"sequence" );
         }
 
         // remove description lines
@@ -1626,13 +1626,13 @@ public:
     /// add one paragraph
     void AddEmptyLine( LVXMLParserCallback * callback )
     {
-        callback->OnTagOpenAndClose( NULL, L"empty-line" );
+        callback->OnTagOpenAndClose( NULL, U"empty-line" );
     }
     /// add one paragraph
     void AddPara( int startline, int endline, LVXMLParserCallback * callback )
     {
         // TODO: remove pos, sz tracking
-        lString16 str;
+        lString32 str;
         //lvpos_t pos = 0;
         //lvsize_t sz = 0;
         for ( int i=startline; i<=endline; i++ ) {
@@ -1653,7 +1653,7 @@ public:
                 }
         }
         str.trimDoubleSpaces(false, false, true);
-        lChar16 singleChar = getSingleLineChar( str );
+        lChar32 singleChar = getSingleLineChar( str );
         if ( singleChar!=0 && singleChar>='A' )
             singleChar = 0;
         bool isHeader = singleChar!=0;
@@ -1682,16 +1682,16 @@ public:
         if ( str.length() > MAX_HEADING_CHARS )
             isHeader = false;
         if ( !str.empty() ) {
-            const lChar16 * title_tag = L"title";
+            const lChar32 * title_tag = U"title";
             if ( isHeader ) {
-                if ( singleChar ) { //str.compare(L"* * *")==0 ) {
-                    title_tag = L"subtitle";
+                if ( singleChar ) { //str.compare(U"* * *")==0 ) {
+                    title_tag = U"subtitle";
                     lastParaWasTitle = false;
                 } else {
                     if ( !lastParaWasTitle ) {
                         if ( inSubSection )
-                            callback->OnTagClose( NULL, L"section" );
-                        callback->OnTagOpenNoAttr( NULL, L"section" );
+                            callback->OnTagClose( NULL, U"section" );
+                        callback->OnTagOpenNoAttr( NULL, U"section" );
                         inSubSection = true;
                     }
                     lastParaWasTitle = true;
@@ -1699,9 +1699,9 @@ public:
                 callback->OnTagOpenNoAttr( NULL, title_tag );
             } else
                     lastParaWasTitle = false;
-            callback->OnTagOpenNoAttr( NULL, L"p" );
+            callback->OnTagOpenNoAttr( NULL, U"p" );
                callback->OnText( str.c_str(), str.length(), TXTFLG_TRIM | TXTFLG_TRIM_REMOVE_EOL_HYPHENS );
-            callback->OnTagClose( NULL, L"p" );
+            callback->OnTagClose( NULL, U"p" );
             if ( isHeader ) {
                 callback->OnTagClose( NULL, title_tag );
             } else {
@@ -1709,7 +1709,7 @@ public:
             paraCount++;
         } else {
             if ( !(formatFlags & tftEmptyLineDelimPara) || !isHeader ) {
-                callback->OnTagOpenAndClose( NULL, L"empty-line" );
+                callback->OnTagOpenAndClose( NULL, U"empty-line" );
             }
         }
     }
@@ -1717,18 +1717,18 @@ public:
     class PMLTextImport {
         LVXMLParserCallback * callback;
         bool insideInvisibleText;
-        const lChar16 * cp1252;
+        const lChar32 * cp1252;
         int align; // 0, 'c' or 'r'
-        lString16 line;
+        lString32 line;
         int chapterIndent;
         bool insideChapterTitle;
-        lString16 chapterTitle;
+        lString32 chapterTitle;
         int sectionId;
         bool inSection;
         bool inParagraph;
         bool indented;
         bool inLink;
-        lString16 styleTags;
+        lString32 styleTags;
     public:
         PMLTextImport( LVXMLParserCallback * cb )
         : callback(cb), insideInvisibleText(false), align(0)
@@ -1740,39 +1740,39 @@ public:
         , indented(false)
         , inLink(false)
         {
-            cp1252 = GetCharsetByte2UnicodeTable(L"windows-1252");
+            cp1252 = GetCharsetByte2UnicodeTable(U"windows-1252");
         }
-        void addChar( lChar16 ch ) {
+        void addChar( lChar32 ch ) {
             if ( !insideInvisibleText )
                 line << ch;
         }
 
-        const lChar16 * getStyleTagName( lChar16 ch ) {
+        const lChar32 * getStyleTagName( lChar32 ch ) {
             switch ( ch ) {
             case 'b':
             case 'B':
-                return L"b";
+                return U"b";
             case 'i':
-                return L"i";
+                return U"i";
             case 'u':
-                return L"u";
+                return U"u";
             case 's':
-                return L"strikethrough";
+                return U"strikethrough";
             case 'a':
-                return L"a";
+                return U"a";
             default:
                 return NULL;
             }
         }
 
-        int styleTagPos(lChar16 ch) {
+        int styleTagPos(lChar32 ch) {
             for ( int i=0; i<styleTags.length(); i++ )
                 if ( styleTags[i]==ch )
                     return i;
             return -1;
         }
 
-        void closeStyleTag( lChar16 ch, bool updateStack ) {
+        void closeStyleTag( lChar32 ch, bool updateStack ) {
             int pos = ch ? styleTagPos( ch ) : 0;
             if ( updateStack && pos<0 )
                 return;
@@ -1780,25 +1780,25 @@ public:
             //if ( !line.empty() )
                 postText();
             for ( int i=styleTags.length()-1; i>=pos; i-- ) {
-                const lChar16 * tag = getStyleTagName(styleTags[i]);
+                const lChar32 * tag = getStyleTagName(styleTags[i]);
                 if ( updateStack )
                     styleTags.erase(styleTags.length()-1, 1);
                 if ( tag ) {
-                    callback->OnTagClose(L"", tag);
+                    callback->OnTagClose(U"", tag);
                 }
             }
         }
 
-        void openStyleTag( lChar16 ch, bool updateStack ) {
+        void openStyleTag( lChar32 ch, bool updateStack ) {
             int pos = styleTagPos( ch );
             if ( updateStack && pos>=0 )
                 return;
             if ( updateStack )
             //if ( !line.empty() )
                 postText();
-            const lChar16 * tag = getStyleTagName(ch);
+            const lChar32 * tag = getStyleTagName(ch);
             if ( tag ) {
-                callback->OnTagOpenNoAttr(L"", tag);
+                callback->OnTagOpenNoAttr(U"", tag);
                 if ( updateStack )
                     styleTags.append( 1,  ch );
             }
@@ -1814,7 +1814,7 @@ public:
                 closeStyleTag(styleTags[i], false);
         }
 
-        void onStyleTag(lChar16 ch ) {
+        void onStyleTag(lChar32 ch ) {
             int pos = ch!=0 ? styleTagPos( ch ) : 0;
             if ( pos<0 ) {
                 openStyleTag(ch, true);
@@ -1824,30 +1824,30 @@ public:
 
         }
 
-        void onImage( lString16 url ) {
-            //url = cs16("book_img/") + url;
-            callback->OnTagOpen(L"", L"img");
-            callback->OnAttribute(L"", L"src", url.c_str());
+        void onImage( lString32 url ) {
+            //url = cs32("book_img/") + url;
+            callback->OnTagOpen(U"", U"img");
+            callback->OnAttribute(U"", U"src", url.c_str());
             callback->OnTagBody();
-            callback->OnTagClose(L"", L"img", true);
+            callback->OnTagClose(U"", U"img", true);
         }
 
         void startParagraph() {
             if ( !inParagraph ) {
-                callback->OnTagOpen(L"", L"p");
-                lString16 style;
+                callback->OnTagOpen(U"", U"p");
+                lString32 style;
                 if ( indented )
-                    style<< L"left-margin: 15%; ";
+                    style<< U"left-margin: 15%; ";
                 if ( align ) {
                     if ( align=='c' ) {
-                        style << L"text-align: center; ";
+                        style << U"text-align: center; ";
                         if ( !indented )
-                            style << L"text-indent: 0px; ";
+                            style << U"text-indent: 0px; ";
                     } else if ( align=='r' )
-                        style << L"text-align: right; ";
+                        style << U"text-align: right; ";
                 }
                 if ( !style.empty() )
-                    callback->OnAttribute(L"", L"style", style.c_str() );
+                    callback->OnAttribute(U"", U"style", style.c_str() );
                 callback->OnTagBody();
                 openStyleTags();
                 inParagraph = true;
@@ -1868,8 +1868,8 @@ public:
             if ( inSection )
                 return;
             sectionId++;
-            callback->OnTagOpen(NULL, L"section");
-            callback->OnAttribute(NULL, L"id", (cs16("_section") + fmt::decimal(sectionId)).c_str() );
+            callback->OnTagOpen(NULL, U"section");
+            callback->OnAttribute(NULL, U"id", (cs32("_section") + fmt::decimal(sectionId)).c_str() );
             callback->OnTagBody();
             inSection = true;
             endOfParagraph();
@@ -1879,7 +1879,7 @@ public:
                 return;
             indented = false;
             endOfParagraph();
-            callback->OnTagClose(NULL, L"section");
+            callback->OnTagClose(NULL, U"section");
             inSection = false;
         }
         void newPage() {
@@ -1899,14 +1899,14 @@ public:
             if ( inParagraph ) {
                 //closeStyleTag(0);
                 closeStyleTags();
-                callback->OnTagClose(L"", L"p");
+                callback->OnTagClose(U"", U"p");
                 inParagraph = false;
             }
         }
 
         void addSeparator( int /*width*/ ) {
             endOfParagraph();
-            callback->OnTagOpenAndClose(L"", L"hr");
+            callback->OnTagOpenAndClose(U"", U"hr");
         }
 
         void startOfChapterTitle( bool startNewPage, int level ) {
@@ -1916,10 +1916,10 @@ public:
             chapterTitle.clear();
             insideChapterTitle = true;
             chapterIndent = level;
-            callback->OnTagOpenNoAttr(NULL, L"title");
+            callback->OnTagOpenNoAttr(NULL, U"title");
         }
 
-        void addChapterTitle( int /*level*/, lString16 title ) {
+        void addChapterTitle( int /*level*/, lString32 title ) {
             // add title, invisible, for TOC only
         }
 
@@ -1929,22 +1929,22 @@ public:
                 return;
             endOfParagraph();
             insideChapterTitle = false;
-            callback->OnTagClose(NULL, L"title");
+            callback->OnTagClose(NULL, U"title");
         }
 
-        void addAnchor( lString16 ref ) {
+        void addAnchor( lString32 ref ) {
             startParagraph();
-            callback->OnTagOpen(NULL, L"a");
-            callback->OnAttribute(NULL, L"name", ref.c_str());
+            callback->OnTagOpen(NULL, U"a");
+            callback->OnAttribute(NULL, U"name", ref.c_str());
             callback->OnTagBody();
-            callback->OnTagClose(NULL, L"a");
+            callback->OnTagClose(NULL, U"a");
         }
 
-        void startLink( lString16 ref ) {
+        void startLink( lString32 ref ) {
             if ( !inLink ) {
                 postText();
-                callback->OnTagOpen(NULL, L"a");
-                callback->OnAttribute(NULL, L"href", ref.c_str());
+                callback->OnTagOpen(NULL, U"a");
+                callback->OnAttribute(NULL, U"href", ref.c_str());
                 callback->OnTagBody();
                 styleTags << "a";
                 inLink = true;
@@ -1955,12 +1955,12 @@ public:
             if ( inLink ) {
                 inLink = false;
                 closeStyleTag('a', true);
-                //callback->OnTagClose(NULL, L"a");
+                //callback->OnTagClose(NULL, U"a");
             }
         }
 
-        lString16 readParam( const lChar16 * str, int & j ) {
-            lString16 res;
+        lString32 readParam( const lChar32 * str, int & j ) {
+            lString32 res;
             if ( str[j]!='=' || str[j+1]!='\"' )
                 return res;
             for ( j=j+2; str[j] && str[j]!='\"'; j++ )
@@ -1968,13 +1968,13 @@ public:
             return res;
         }
 
-        void processLine( lString16 text ) {
+        void processLine( lString32 text ) {
             int len = text.length();
-            const lChar16 * str = text.c_str();
+            const lChar32 * str = text.c_str();
             for ( int j=0; j<len; j++ ) {
                 //bool isStartOfLine = (j==0);
-                lChar16 ch = str[j];
-                lChar16 ch2 = str[j+1];
+                lChar32 ch = str[j];
+                lChar32 ch2 = str[j+1];
                 if ( ch=='\\' ) {
                     if ( ch2=='a' ) {
                         // \aXXX	Insert non-ASCII character whose Windows 1252 code is decimal XXX.
@@ -1985,7 +1985,7 @@ public:
                             j+=4;
                             continue;
                         } else if ( n>=1 && n<=255 ) {
-                            addChar((lChar16)n);
+                            addChar((lChar32)n);
                             j+=4;
                             continue;
                         }
@@ -1993,7 +1993,7 @@ public:
                         // \UXXXX	Insert non-ASCII character whose Unicode code is hexidecimal XXXX.
                         int n = decodeHex( str + j + 2, 4 );
                         if ( n>0 ) {
-                            addChar((lChar16)n);
+                            addChar((lChar32)n);
                             j+=5;
                             continue;
                         }
@@ -2011,19 +2011,19 @@ public:
                         // Indents the specified percentage of the screen width, 50% in this case.
                         // If the current drawing position is already past the specified screen location, this tag is ignored.
                         j+=2;
-                        lString16 w = readParam( str, j );
+                        lString32 w = readParam( str, j );
                         // IGNORE
                         continue;
                     } else if ( ch2=='m' ) {
                         // Insert the named image.
                         j+=2;
-                        lString16 image = readParam( str, j );
+                        lString32 image = readParam( str, j );
                         onImage( image );
                         continue;
                     } else if ( ch2=='Q' ) {
                         // \Q="linkanchor" - Specify a link anchor in the document.
                         j+=2;
-                        lString16 anchor = readParam( str, j );
+                        lString32 anchor = readParam( str, j );
                         addAnchor(anchor);
                         continue;
                     } else if ( ch2=='q' ) {
@@ -2032,7 +2032,7 @@ public:
                         // or otherwise shown to be a link when viewing the document.
                         if ( !inLink ) {
                             j+=2;
-                            lString16 ref = readParam( str, j );
+                            lString32 ref = readParam( str, j );
                             startLink(ref);
                         } else {
                             j+=1;
@@ -2043,7 +2043,7 @@ public:
                         // Embed a horizontal rule of a given percentage width of the screen, in this case 50%.
                         // This tag causes a line break before and after it. The rule is centered. The percent sign is mandatory.
                         j+=2;
-                        lString16 w = readParam( str, j );
+                        lString32 w = readParam( str, j );
                         addSeparator( 50 );
                         continue;
                     } else if ( ch2=='C' ) {
@@ -2056,7 +2056,7 @@ public:
                             if ( level<0 || level>4 )
                                 level = 0;
                             j+=5; // skip \Cn="
-                            lString16 title;
+                            lString32 title;
                             for ( ;str[j] && str[j]!='\"'; j++ )
                                 title << str[j];
                             addChapterTitle( level, title );
@@ -2171,7 +2171,7 @@ public:
         CRLog::debug("DoPMLImport()");
         RemoveLines( length() );
         file->Reset();
-        file->SetCharset(L"windows-1252");
+        file->SetCharset(U"windows-1252");
         ReadLines( 100 );
         int remainingLines = 0;
         PMLTextImport importer(callback);
@@ -2211,7 +2211,7 @@ public:
             remainingLines = 3;
         } while ( ReadLines( 100 ) );
         if ( inSubSection )
-            callback->OnTagClose( NULL, L"section" );
+            callback->OnTagClose( NULL, U"section" );
         return true;
     }
 
@@ -2254,7 +2254,7 @@ public:
             pos = i;
         }
         if ( inSubSection )
-            callback->OnTagClose( NULL, L"section" );
+            callback->OnTagClose( NULL, U"section" );
         return true;
     }
     /// delimited by empty lines
@@ -2313,7 +2313,7 @@ public:
             pos = i+1;
         }
         if ( inSubSection )
-            callback->OnTagClose( NULL, L"section" );
+            callback->OnTagClose( NULL, U"section" );
         return true;
     }
     /// delimited by empty lines
@@ -2325,20 +2325,20 @@ public:
             for ( int i=remainingLines; i<length(); i++ ) {
                 LVTextFileLine * item = get(i);
                 if ( item->rpos > item->lpos ) {
-                    callback->OnTagOpenNoAttr( NULL, L"pre" );
+                    callback->OnTagOpenNoAttr( NULL, U"pre" );
                        callback->OnText( item->text.c_str(), item->text.length(), item->flags );
                        file->updateProgress();
 
-                    callback->OnTagClose( NULL, L"pre" );
+                    callback->OnTagClose( NULL, U"pre" );
                 } else {
-                    callback->OnTagOpenAndClose( NULL, L"empty-line" );
+                    callback->OnTagOpenAndClose( NULL, U"empty-line" );
                 }
            }
             RemoveLines( length()-3 );
             remainingLines = 3;
         } while ( ReadLines( 100 ) );
         if ( inSubSection )
-            callback->OnTagClose( NULL, L"section" );
+            callback->OnTagClose( NULL, U"section" );
         return true;
     }
     /// import document body
@@ -2358,16 +2358,16 @@ public:
 };
 
 /// reads next text line, tells file position and size of line, sets EOL flag
-lString16 LVTextFileBase::ReadLine( int maxLineSize, lUInt32 & flags )
+lString32 LVTextFileBase::ReadLine( int maxLineSize, lUInt32 & flags )
 {
     //fsize = 0;
     flags = 0;
 
-    lString16 res;
+    lString32 res;
     res.reserve( 80 );
     //FillBuffer( maxLineSize*3 );
 
-    lChar16 ch = 0;
+    lChar32 ch = 0;
     for (;;) {
         if ( m_eof ) {
             // EOF: treat as EOLN
@@ -2386,7 +2386,7 @@ lString16 LVTextFileBase::ReadLine( int maxLineSize, lUInt32 & flags )
         } else {
             // eoln
             if ( !m_eof ) {
-                lChar16 ch2 = PeekCharFromBuffer();
+                lChar32 ch2 = PeekCharFromBuffer();
                 if ( ch2!=ch && (ch2=='\r' || ch2=='\n') ) {
                     ReadCharFromBuffer();
                 }
@@ -2398,7 +2398,7 @@ lString16 LVTextFileBase::ReadLine( int maxLineSize, lUInt32 & flags )
 
     if ( !res.empty() ) {
         int firstNs = 0;
-        lChar16 ch = 0;
+        lChar32 ch = 0;
         for ( ;; firstNs++ ) {
             ch = res[firstNs];
             if ( !ch )
@@ -2416,7 +2416,7 @@ lString16 LVTextFileBase::ReadLine( int maxLineSize, lUInt32 & flags )
         } else if ( ch=='-' || ch=='*' || ch=='=' ) {
             bool sameChars = true;
             for ( int i=firstNs; i<res.length(); i++ ) {
-                lChar16 ch2 = res[i];
+                lChar32 ch2 = res[i];
                 if ( ch2!=' ' && ch2!='\t' && ch2!=ch ) {
                     sameChars = false;
                     break;
@@ -2453,16 +2453,16 @@ bool LVTextBookmarkParser::CheckFormat()
 {
     Reset();
     // encoding test
-    m_lang_name = cs16("en");
-    SetCharset( L"utf8" );
+    m_lang_name = cs32("en");
+    SetCharset( U"utf8" );
 
     #define TEXT_PARSER_DETECT_SIZE 16384
     Reset();
-    lChar16 * chbuf = new lChar16[TEXT_PARSER_DETECT_SIZE];
+    lChar32 * chbuf = new lChar32[TEXT_PARSER_DETECT_SIZE];
     FillBuffer( TEXT_PARSER_DETECT_SIZE );
     int charsDecoded = ReadTextBytes( 0, m_buf_len, chbuf, TEXT_PARSER_DETECT_SIZE-1, 0 );
     bool res = false;
-    lString16 pattern("# Cool Reader 3 - exported bookmarks\r\n# file name: ");
+    lString32 pattern("# Cool Reader 3 - exported bookmarks\r\n# file name: ");
     if ( charsDecoded > (int)pattern.length() && chbuf[0]==0xFEFF) { // BOM
         res = true;
         for ( int i=0; i<(int)pattern.length(); i++ )
@@ -2474,9 +2474,9 @@ bool LVTextBookmarkParser::CheckFormat()
     return res;
 }
 
-static bool extractItem( lString16 & dst, const lString16 & src, const char * prefix )
+static bool extractItem( lString32 & dst, const lString32 & src, const char * prefix )
 {
-    lString16 pref( prefix );
+    lString32 pref( prefix );
     if ( src.startsWith( pref ) ) {
         dst = src.substr( pref.length() );
         return true;
@@ -2484,37 +2484,37 @@ static bool extractItem( lString16 & dst, const lString16 & src, const char * pr
     return false;
 }
 
-static void postParagraph(LVXMLParserCallback * callback, const char * prefix, lString16 text, bool allowEmptyLine)
+static void postParagraph(LVXMLParserCallback * callback, const char * prefix, lString32 text, bool allowEmptyLine)
 {
-    lString16 title( prefix );
+    lString32 title( prefix );
     if ( text.empty() ) {
         if (allowEmptyLine) {
-            callback->OnTagOpen( NULL, L"p" );
-            callback->OnTagClose( NULL, L"p" );
+            callback->OnTagOpen( NULL, U"p" );
+            callback->OnTagClose( NULL, U"p" );
         }
         return;
     }
-    callback->OnTagOpen( NULL, L"p" );
-    callback->OnAttribute(NULL, L"style", L"text-indent: 0em");
+    callback->OnTagOpen( NULL, U"p" );
+    callback->OnAttribute(NULL, U"style", U"text-indent: 0em");
     callback->OnTagBody();
     if ( !title.empty() ) {
-        callback->OnTagOpenNoAttr( NULL, L"strong" );
+        callback->OnTagOpenNoAttr( NULL, U"strong" );
         callback->OnText( title.c_str(), title.length(), 0 );
-        callback->OnTagClose( NULL, L"strong" );
+        callback->OnTagClose( NULL, U"strong" );
     }
     callback->OnText( text.c_str(), text.length(), 0 );
-    callback->OnTagClose( NULL, L"p" );
+    callback->OnTagClose( NULL, U"p" );
 }
 
 /// parses input stream
 bool LVTextBookmarkParser::Parse()
 {
-    lString16 line;
+    lString32 line;
     lUInt32 flags = 0;
-    lString16 fname("Unknown");
-    lString16 path;
-    lString16 title("No Title");
-    lString16 author;
+    lString32 fname("Unknown");
+    lString32 path;
+    lString32 title("No Title");
+    lString32 author;
     for ( ;; ) {
         line = ReadLine( 20000, flags );
         if ( line.empty() || m_eof )
@@ -2523,9 +2523,9 @@ bool LVTextBookmarkParser::Parse()
         extractItem( path,  line, "# file path: " );
         extractItem( title, line, "# book title: " );
         extractItem( author, line, "# author: " );
-        //if ( line.startsWith( lString16() )
+        //if ( line.startsWith( lString32() )
     }
-    lString16 desc;
+    lString32 desc;
     desc << "Bookmarks: ";
     if ( !author.empty() )
         desc << author << "  ";
@@ -2535,42 +2535,42 @@ bool LVTextBookmarkParser::Parse()
         desc << fname << "  ";
     //queue.
     // make fb2 document structure
-    m_callback->OnTagOpen( NULL, L"?xml" );
-    m_callback->OnAttribute( NULL, L"version", L"1.0" );
-    m_callback->OnAttribute( NULL, L"encoding", GetEncodingName().c_str() );
+    m_callback->OnTagOpen( NULL, U"?xml" );
+    m_callback->OnAttribute( NULL, U"version", U"1.0" );
+    m_callback->OnAttribute( NULL, U"encoding", GetEncodingName().c_str() );
     m_callback->OnEncoding( GetEncodingName().c_str(), GetCharsetTable( ) );
     m_callback->OnTagBody();
-    m_callback->OnTagClose( NULL, L"?xml" );
-    m_callback->OnTagOpenNoAttr( NULL, L"FictionBook" );
+    m_callback->OnTagClose( NULL, U"?xml" );
+    m_callback->OnTagOpenNoAttr( NULL, U"FictionBook" );
       // DESCRIPTION
-      m_callback->OnTagOpenNoAttr( NULL, L"description" );
-        m_callback->OnTagOpenNoAttr( NULL, L"title-info" );
-          m_callback->OnTagOpenNoAttr( NULL, L"book-title" );
+      m_callback->OnTagOpenNoAttr( NULL, U"description" );
+        m_callback->OnTagOpenNoAttr( NULL, U"title-info" );
+          m_callback->OnTagOpenNoAttr( NULL, U"book-title" );
             m_callback->OnText( desc.c_str(), desc.length(), 0 );
-          m_callback->OnTagClose( NULL, L"book-title" );
-        m_callback->OnTagClose( NULL, L"title-info" );
-      m_callback->OnTagClose( NULL, L"description" );
+          m_callback->OnTagClose( NULL, U"book-title" );
+        m_callback->OnTagClose( NULL, U"title-info" );
+      m_callback->OnTagClose( NULL, U"description" );
       // BODY
-      m_callback->OnTagOpenNoAttr( NULL, L"body" );
-          m_callback->OnTagOpenNoAttr( NULL, L"title" );
-              postParagraph( m_callback, "", cs16("CoolReader Bookmarks file"), false );
-          m_callback->OnTagClose( NULL, L"title" );
+      m_callback->OnTagOpenNoAttr( NULL, U"body" );
+          m_callback->OnTagOpenNoAttr( NULL, U"title" );
+              postParagraph( m_callback, "", cs32("CoolReader Bookmarks file"), false );
+          m_callback->OnTagClose( NULL, U"title" );
           postParagraph( m_callback, "file: ", fname, false );
           postParagraph( m_callback, "path: ", path, false );
           postParagraph( m_callback, "title: ", title, false );
           postParagraph( m_callback, "author: ", author, false );
-          m_callback->OnTagOpenAndClose( NULL, L"empty-line" );
-          m_callback->OnTagOpenNoAttr( NULL, L"section" );
+          m_callback->OnTagOpenAndClose( NULL, U"empty-line" );
+          m_callback->OnTagOpenNoAttr( NULL, U"section" );
           // process text
             for ( ;; ) {
                 line = ReadLine( 20000, flags );
                 if ( m_eof )
                     break;
                 if ( line.empty() ) {
-                  m_callback->OnTagOpenAndClose( NULL, L"empty-line" );
+                  m_callback->OnTagOpenAndClose( NULL, U"empty-line" );
                 } else {
-                    lString16 prefix;
-                    lString16 txt = line;
+                    lString32 prefix;
+                    lString32 txt = line;
                     if ( txt.length()>3 && txt[1]==txt[0] && txt[2]==' ' ) {
                         if ( txt[0] < 'A' ) {
                             prefix = txt.substr(0, 3);
@@ -2584,9 +2584,9 @@ bool LVTextBookmarkParser::Parse()
                     postParagraph( m_callback, UnicodeToUtf8(prefix).c_str(), txt, false );
                 }
             }
-        m_callback->OnTagClose( NULL, L"section" );
-      m_callback->OnTagClose( NULL, L"body" );
-    m_callback->OnTagClose( NULL, L"FictionBook" );
+        m_callback->OnTagClose( NULL, U"section" );
+      m_callback->OnTagClose( NULL, U"body" );
+    m_callback->OnTagClose( NULL, U"FictionBook" );
     return true;
 }
 
@@ -2618,7 +2618,7 @@ bool LVTextParser::CheckFormat()
         return false;
     #define TEXT_PARSER_DETECT_SIZE 16384
     Reset();
-    lChar16 * chbuf = new lChar16[TEXT_PARSER_DETECT_SIZE];
+    lChar32 * chbuf = new lChar32[TEXT_PARSER_DETECT_SIZE];
     FillBuffer( TEXT_PARSER_DETECT_SIZE );
     int charsDecoded = ReadTextBytes( 0, m_buf_len, chbuf, TEXT_PARSER_DETECT_SIZE-1, 0 );
     bool res = false;
@@ -2668,27 +2668,27 @@ bool LVTextParser::Parse()
     if ( !m_isPreFormatted )
         queue.detectFormatFlags();
     // make fb2 document structure
-    m_callback->OnTagOpen( NULL, L"?xml" );
-    m_callback->OnAttribute( NULL, L"version", L"1.0" );
-    m_callback->OnAttribute( NULL, L"encoding", GetEncodingName().c_str() );
+    m_callback->OnTagOpen( NULL, U"?xml" );
+    m_callback->OnAttribute( NULL, U"version", U"1.0" );
+    m_callback->OnAttribute( NULL, U"encoding", GetEncodingName().c_str() );
     m_callback->OnEncoding( GetEncodingName().c_str(), GetCharsetTable( ) );
     m_callback->OnTagBody();
-    m_callback->OnTagClose( NULL, L"?xml" );
-    m_callback->OnTagOpenNoAttr( NULL, L"FictionBook" );
+    m_callback->OnTagClose( NULL, U"?xml" );
+    m_callback->OnTagOpenNoAttr( NULL, U"FictionBook" );
       // DESCRIPTION
-      m_callback->OnTagOpenNoAttr( NULL, L"description" );
-        m_callback->OnTagOpenNoAttr( NULL, L"title-info" );
+      m_callback->OnTagOpenNoAttr( NULL, U"description" );
+        m_callback->OnTagOpenNoAttr( NULL, U"title-info" );
           queue.DetectBookDescription( m_callback );
-        m_callback->OnTagClose( NULL, L"title-info" );
-      m_callback->OnTagClose( NULL, L"description" );
+        m_callback->OnTagClose( NULL, U"title-info" );
+      m_callback->OnTagClose( NULL, U"description" );
       // BODY
-      m_callback->OnTagOpenNoAttr( NULL, L"body" );
-        //m_callback->OnTagOpen( NULL, L"section" );
+      m_callback->OnTagOpenNoAttr( NULL, U"body" );
+        //m_callback->OnTagOpen( NULL, U"section" );
           // process text
           queue.DoTextImport( m_callback );
-        //m_callback->OnTagClose( NULL, L"section" );
-      m_callback->OnTagClose( NULL, L"body" );
-    m_callback->OnTagClose( NULL, L"FictionBook" );
+        //m_callback->OnTagClose( NULL, U"section" );
+      m_callback->OnTagClose( NULL, U"body" );
+    m_callback->OnTagClose( NULL, U"FictionBook" );
     return true;
 }
 
@@ -2710,8 +2710,8 @@ LVTextRobustParser::~LVTextRobustParser()
 /// returns true if format is recognized by parser
 bool LVTextRobustParser::CheckFormat()
 {
-    m_lang_name = lString16( "en" );
-    SetCharset( lString16( "utf-8" ).c_str() );
+    m_lang_name = lString32( "en" );
+    SetCharset( lString32( "utf-8" ).c_str() );
     return true;
 }
 
@@ -2741,7 +2741,7 @@ LVXMLTextCache::~LVXMLTextCache()
     }
 }
 
-void LVXMLTextCache::addItem( lString16 & str )
+void LVXMLTextCache::addItem( lString32 & str )
 {
     cleanOldItems( str.length() );
     cache_item * ptr = new cache_item( str );
@@ -2775,7 +2775,7 @@ void LVXMLTextCache::cleanOldItems( lUInt32 newItemChars )
     }
 }
 
-lString16 LVXMLTextCache::getText( lUInt32 pos, lUInt32 size, lUInt32 flags )
+lString32 LVXMLTextCache::getText( lUInt32 pos, lUInt32 size, lUInt32 flags )
 {
     // TRY TO SEARCH IN CACHE
     cache_item * ptr = m_head, * prevptr = NULL;
@@ -2795,10 +2795,10 @@ lString16 LVXMLTextCache::getText( lUInt32 pos, lUInt32 size, lUInt32 flags )
     }
     // NO CACHE RECORD FOUND
     // read new pme
-    lString16 text;
+    lString32 text;
     text.reserve(size);
     text.append(size, ' ');
-    lChar16 * buf = text.modify();
+    lChar32 * buf = text.modify();
     unsigned chcount = (unsigned)ReadTextBytes( pos, size, buf, size, flags );
     //CRLog::debug("ReadTextBytes(%d,%d) done - %d chars read", (int)pos, (int)size, (int)chcount);
     text.limit( chcount );
@@ -2831,7 +2831,7 @@ enum parser_state_t {
 };
 
 
-void LVXMLParser::SetCharset( const lChar16 * name )
+void LVXMLParser::SetCharset( const lChar32 * name )
 {
     LVTextFileBase::SetCharset( name );
     m_callback->OnEncoding( name, m_conv_table );
@@ -2861,7 +2861,7 @@ LVXMLParser::~LVXMLParser()
 {
 }
 
-inline bool IsSpaceChar( lChar16 ch )
+inline bool IsSpaceChar( lChar32 ch )
 {
     return (ch == ' ')
         || (ch == '\t')
@@ -2877,19 +2877,19 @@ bool LVXMLParser::CheckFormat()
     Reset();
     AutodetectEncoding();
     Reset();
-    lChar16 * chbuf = new lChar16[XML_PARSER_DETECT_SIZE];
+    lChar32 * chbuf = new lChar32[XML_PARSER_DETECT_SIZE];
     FillBuffer( XML_PARSER_DETECT_SIZE );
     int charsDecoded = ReadTextBytes( 0, m_buf_len, chbuf, XML_PARSER_DETECT_SIZE-1, 0 );
     chbuf[charsDecoded] = 0;
     bool res = false;
     if ( charsDecoded > 30 ) {
-        lString16 s( chbuf, charsDecoded );
+        lString32 s( chbuf, charsDecoded );
         res = s.pos("<FictionBook") >= 0;
         if ( s.pos("<?xml") >= 0 && s.pos("version=") >= 6 ) {
             res = res || !m_fb2Only;
             int encpos;
             if ( res && (encpos=s.pos("encoding=\"")) >= 0 ) {
-                lString16 encname = s.substr( encpos+10, 20 );
+                lString32 encname = s.substr( encpos+10, 20 );
                 int endpos = s.pos("\"");
                 if ( endpos>0 ) {
                     encname.erase( endpos, encname.length() - endpos );
@@ -2928,11 +2928,11 @@ bool LVXMLParser::Parse()
     bool closeFlag = false;
     bool qFlag = false;
     bool bodyStarted = false;
-    lString16 tagname;
-    lString16 tagns;
-    lString16 attrname;
-    lString16 attrns;
-    lString16 attrvalue;
+    lString32 tagname;
+    lString32 tagns;
+    lString32 attrname;
+    lString32 attrns;
+    lString32 attrvalue;
     bool errorFlag = false;
     int flags = m_callback->getFlags();
     for (;!m_eof && !errorFlag;)
@@ -2940,7 +2940,7 @@ bool LVXMLParser::Parse()
         if ( m_stopped )
              break;
         // load next portion of data if necessary
-        lChar16 ch = PeekCharFromBuffer();
+        lChar32 ch = PeekCharFromBuffer();
         switch (m_state)
         {
         case ps_bof:
@@ -3012,9 +3012,9 @@ bool LVXMLParser::Parse()
                 }
                 if (closeFlag)
                 {
-//                    if ( tagname==L"body" ) {
+//                    if ( tagname==U"body" ) {
 //                        dumpActive = true;
-//                    } else if ( tagname==L"section" ) {
+//                    } else if ( tagname==U"section" ) {
 //                        dumpActive = false;
 //                    }
                         m_callback->OnTagClose(tagns.c_str(), tagname.c_str());
@@ -3048,7 +3048,7 @@ bool LVXMLParser::Parse()
                 if (!SkipSpaces())
                     break;
                 ch = PeekCharFromBuffer();
-                lChar16 nch = PeekCharFromBuffer(1);
+                lChar32 nch = PeekCharFromBuffer(1);
                 if ( ch=='>' || (nch=='>' && (ch=='/' || ch=='?')) )
                 {
                     m_callback->OnTagBody();
@@ -3080,7 +3080,7 @@ bool LVXMLParser::Parse()
                     //PeekNextCharFromBuffer();
                     ReadCharFromBuffer(); // skip '='
                     SkipSpaces();
-                    lChar16 qChar = 0;
+                    lChar32 qChar = 0;
                     ch = PeekCharFromBuffer();
                     if (ch=='\"' || ch=='\'')
                     {
@@ -3130,7 +3130,7 @@ bool LVXMLParser::Parse()
         case ps_text:
             {
 //                if ( dumpActive ) {
-//                    lString16 s;
+//                    lString32 s;
 //                    s << PeekCharFromBuffer(0) << PeekCharFromBuffer(1) << PeekCharFromBuffer(2) << PeekCharFromBuffer(3)
 //                      << PeekCharFromBuffer(4) << PeekCharFromBuffer(5) << PeekCharFromBuffer(6) << PeekCharFromBuffer(7);
 //                    CRLog::trace("text: %s...", LCSTR(s) );
@@ -3162,2140 +3162,2140 @@ bool LVXMLParser::Parse()
 #define TEXT_SPLIT_SIZE 8192
 
 typedef struct  {
-    const wchar_t * name;
-    wchar_t code;
-    wchar_t code2;
+    const lChar32 * name;
+    lChar32 code;
+    lChar32 code2;
 } ent_def_t;
 
 // From https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references
 // Also see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
 // Note that some entities translate to 2 codepoints, so code2=0 for those that do not.
 static const ent_def_t def_entity_table[] = {
-{L"AElig", 198, 0},
-{L"AMP", 38, 0},
-{L"Aacute", 193, 0},
-{L"Abreve", 258, 0},
-{L"Acirc", 194, 0},
-{L"Acy", 1040, 0},
-{L"Afr", 120068, 0},
-{L"Agrave", 192, 0},
-{L"Alpha", 913, 0},
-{L"Amacr", 256, 0},
-{L"And", 10835, 0},
-{L"Aogon", 260, 0},
-{L"Aopf", 120120, 0},
-{L"ApplyFunction", 8289, 0},
-{L"Aring", 197, 0},
-{L"Ascr", 119964, 0},
-{L"Assign", 8788, 0},
-{L"Atilde", 195, 0},
-{L"Auml", 196, 0},
-{L"Backslash", 8726, 0},
-{L"Barv", 10983, 0},
-{L"Barwed", 8966, 0},
-{L"Bcy", 1041, 0},
-{L"Because", 8757, 0},
-{L"Bernoullis", 8492, 0},
-{L"Beta", 914, 0},
-{L"Bfr", 120069, 0},
-{L"Bopf", 120121, 0},
-{L"Breve", 728, 0},
-{L"Bscr", 8492, 0},
-{L"Bumpeq", 8782, 0},
-{L"CHcy", 1063, 0},
-{L"COPY", 169, 0},
-{L"Cacute", 262, 0},
-{L"Cap", 8914, 0},
-{L"CapitalDifferentialD", 8517, 0},
-{L"Cayleys", 8493, 0},
-{L"Ccaron", 268, 0},
-{L"Ccedil", 199, 0},
-{L"Ccirc", 264, 0},
-{L"Cconint", 8752, 0},
-{L"Cdot", 266, 0},
-{L"Cedilla", 184, 0},
-{L"CenterDot", 183, 0},
-{L"Cfr", 8493, 0},
-{L"Chi", 935, 0},
-{L"CircleDot", 8857, 0},
-{L"CircleMinus", 8854, 0},
-{L"CirclePlus", 8853, 0},
-{L"CircleTimes", 8855, 0},
-{L"ClockwiseContourIntegral", 8754, 0},
-{L"CloseCurlyDoubleQuote", 8221, 0},
-{L"CloseCurlyQuote", 8217, 0},
-{L"Colon", 8759, 0},
-{L"Colone", 10868, 0},
-{L"Congruent", 8801, 0},
-{L"Conint", 8751, 0},
-{L"ContourIntegral", 8750, 0},
-{L"Copf", 8450, 0},
-{L"Coproduct", 8720, 0},
-{L"CounterClockwiseContourIntegral", 8755, 0},
-{L"Cross", 10799, 0},
-{L"Cscr", 119966, 0},
-{L"Cup", 8915, 0},
-{L"CupCap", 8781, 0},
-{L"DD", 8517, 0},
-{L"DDotrahd", 10513, 0},
-{L"DJcy", 1026, 0},
-{L"DScy", 1029, 0},
-{L"DZcy", 1039, 0},
-{L"Dagger", 8225, 0},
-{L"Darr", 8609, 0},
-{L"Dashv", 10980, 0},
-{L"Dcaron", 270, 0},
-{L"Dcy", 1044, 0},
-{L"Del", 8711, 0},
-{L"Delta", 916, 0},
-{L"Dfr", 120071, 0},
-{L"DiacriticalAcute", 180, 0},
-{L"DiacriticalDot", 729, 0},
-{L"DiacriticalDoubleAcute", 733, 0},
-{L"DiacriticalGrave", 96, 0},
-{L"DiacriticalTilde", 732, 0},
-{L"Diamond", 8900, 0},
-{L"DifferentialD", 8518, 0},
-{L"Dopf", 120123, 0},
-{L"Dot", 168, 0},
-{L"DotDot", 8412, 0},
-{L"DotEqual", 8784, 0},
-{L"DoubleContourIntegral", 8751, 0},
-{L"DoubleDot", 168, 0},
-{L"DoubleDownArrow", 8659, 0},
-{L"DoubleLeftArrow", 8656, 0},
-{L"DoubleLeftRightArrow", 8660, 0},
-{L"DoubleLeftTee", 10980, 0},
-{L"DoubleLongLeftArrow", 10232, 0},
-{L"DoubleLongLeftRightArrow", 10234, 0},
-{L"DoubleLongRightArrow", 10233, 0},
-{L"DoubleRightArrow", 8658, 0},
-{L"DoubleRightTee", 8872, 0},
-{L"DoubleUpArrow", 8657, 0},
-{L"DoubleUpDownArrow", 8661, 0},
-{L"DoubleVerticalBar", 8741, 0},
-{L"DownArrow", 8595, 0},
-{L"DownArrowBar", 10515, 0},
-{L"DownArrowUpArrow", 8693, 0},
-{L"DownBreve", 785, 0},
-{L"DownLeftRightVector", 10576, 0},
-{L"DownLeftTeeVector", 10590, 0},
-{L"DownLeftVector", 8637, 0},
-{L"DownLeftVectorBar", 10582, 0},
-{L"DownRightTeeVector", 10591, 0},
-{L"DownRightVector", 8641, 0},
-{L"DownRightVectorBar", 10583, 0},
-{L"DownTee", 8868, 0},
-{L"DownTeeArrow", 8615, 0},
-{L"Downarrow", 8659, 0},
-{L"Dscr", 119967, 0},
-{L"Dstrok", 272, 0},
-{L"ENG", 330, 0},
-{L"ETH", 208, 0},
-{L"Eacute", 201, 0},
-{L"Ecaron", 282, 0},
-{L"Ecirc", 202, 0},
-{L"Ecy", 1069, 0},
-{L"Edot", 278, 0},
-{L"Efr", 120072, 0},
-{L"Egrave", 200, 0},
-{L"Element", 8712, 0},
-{L"Emacr", 274, 0},
-{L"EmptySmallSquare", 9723, 0},
-{L"EmptyVerySmallSquare", 9643, 0},
-{L"Eogon", 280, 0},
-{L"Eopf", 120124, 0},
-{L"Epsilon", 917, 0},
-{L"Equal", 10869, 0},
-{L"EqualTilde", 8770, 0},
-{L"Equilibrium", 8652, 0},
-{L"Escr", 8496, 0},
-{L"Esim", 10867, 0},
-{L"Eta", 919, 0},
-{L"Euml", 203, 0},
-{L"Exists", 8707, 0},
-{L"ExponentialE", 8519, 0},
-{L"Fcy", 1060, 0},
-{L"Ffr", 120073, 0},
-{L"FilledSmallSquare", 9724, 0},
-{L"FilledVerySmallSquare", 9642, 0},
-{L"Fopf", 120125, 0},
-{L"ForAll", 8704, 0},
-{L"Fouriertrf", 8497, 0},
-{L"Fscr", 8497, 0},
-{L"GJcy", 1027, 0},
-{L"GT", 62, 0},
-{L"Gamma", 915, 0},
-{L"Gammad", 988, 0},
-{L"Gbreve", 286, 0},
-{L"Gcedil", 290, 0},
-{L"Gcirc", 284, 0},
-{L"Gcy", 1043, 0},
-{L"Gdot", 288, 0},
-{L"Gfr", 120074, 0},
-{L"Gg", 8921, 0},
-{L"Gopf", 120126, 0},
-{L"GreaterEqual", 8805, 0},
-{L"GreaterEqualLess", 8923, 0},
-{L"GreaterFullEqual", 8807, 0},
-{L"GreaterGreater", 10914, 0},
-{L"GreaterLess", 8823, 0},
-{L"GreaterSlantEqual", 10878, 0},
-{L"GreaterTilde", 8819, 0},
-{L"Gscr", 119970, 0},
-{L"Gt", 8811, 0},
-{L"HARDcy", 1066, 0},
-{L"Hacek", 711, 0},
-{L"Hat", 94, 0},
-{L"Hcirc", 292, 0},
-{L"Hfr", 8460, 0},
-{L"HilbertSpace", 8459, 0},
-{L"Hopf", 8461, 0},
-{L"HorizontalLine", 9472, 0},
-{L"Hscr", 8459, 0},
-{L"Hstrok", 294, 0},
-{L"HumpDownHump", 8782, 0},
-{L"HumpEqual", 8783, 0},
-{L"IEcy", 1045, 0},
-{L"IJlig", 306, 0},
-{L"IOcy", 1025, 0},
-{L"Iacute", 205, 0},
-{L"Icirc", 206, 0},
-{L"Icy", 1048, 0},
-{L"Idot", 304, 0},
-{L"Ifr", 8465, 0},
-{L"Igrave", 204, 0},
-{L"Im", 8465, 0},
-{L"Imacr", 298, 0},
-{L"ImaginaryI", 8520, 0},
-{L"Implies", 8658, 0},
-{L"Int", 8748, 0},
-{L"Integral", 8747, 0},
-{L"Intersection", 8898, 0},
-{L"InvisibleComma", 8291, 0},
-{L"InvisibleTimes", 8290, 0},
-{L"Iogon", 302, 0},
-{L"Iopf", 120128, 0},
-{L"Iota", 921, 0},
-{L"Iscr", 8464, 0},
-{L"Itilde", 296, 0},
-{L"Iukcy", 1030, 0},
-{L"Iuml", 207, 0},
-{L"Jcirc", 308, 0},
-{L"Jcy", 1049, 0},
-{L"Jfr", 120077, 0},
-{L"Jopf", 120129, 0},
-{L"Jscr", 119973, 0},
-{L"Jsercy", 1032, 0},
-{L"Jukcy", 1028, 0},
-{L"KHcy", 1061, 0},
-{L"KJcy", 1036, 0},
-{L"Kappa", 922, 0},
-{L"Kcedil", 310, 0},
-{L"Kcy", 1050, 0},
-{L"Kfr", 120078, 0},
-{L"Kopf", 120130, 0},
-{L"Kscr", 119974, 0},
-{L"LJcy", 1033, 0},
-{L"LT", 60, 0},
-{L"Lacute", 313, 0},
-{L"Lambda", 923, 0},
-{L"Lang", 10218, 0},
-{L"Laplacetrf", 8466, 0},
-{L"Larr", 8606, 0},
-{L"Lcaron", 317, 0},
-{L"Lcedil", 315, 0},
-{L"Lcy", 1051, 0},
-{L"LeftAngleBracket", 10216, 0},
-{L"LeftArrow", 8592, 0},
-{L"LeftArrowBar", 8676, 0},
-{L"LeftArrowRightArrow", 8646, 0},
-{L"LeftCeiling", 8968, 0},
-{L"LeftDoubleBracket", 10214, 0},
-{L"LeftDownTeeVector", 10593, 0},
-{L"LeftDownVector", 8643, 0},
-{L"LeftDownVectorBar", 10585, 0},
-{L"LeftFloor", 8970, 0},
-{L"LeftRightArrow", 8596, 0},
-{L"LeftRightVector", 10574, 0},
-{L"LeftTee", 8867, 0},
-{L"LeftTeeArrow", 8612, 0},
-{L"LeftTeeVector", 10586, 0},
-{L"LeftTriangle", 8882, 0},
-{L"LeftTriangleBar", 10703, 0},
-{L"LeftTriangleEqual", 8884, 0},
-{L"LeftUpDownVector", 10577, 0},
-{L"LeftUpTeeVector", 10592, 0},
-{L"LeftUpVector", 8639, 0},
-{L"LeftUpVectorBar", 10584, 0},
-{L"LeftVector", 8636, 0},
-{L"LeftVectorBar", 10578, 0},
-{L"Leftarrow", 8656, 0},
-{L"Leftrightarrow", 8660, 0},
-{L"LessEqualGreater", 8922, 0},
-{L"LessFullEqual", 8806, 0},
-{L"LessGreater", 8822, 0},
-{L"LessLess", 10913, 0},
-{L"LessSlantEqual", 10877, 0},
-{L"LessTilde", 8818, 0},
-{L"Lfr", 120079, 0},
-{L"Ll", 8920, 0},
-{L"Lleftarrow", 8666, 0},
-{L"Lmidot", 319, 0},
-{L"LongLeftArrow", 10229, 0},
-{L"LongLeftRightArrow", 10231, 0},
-{L"LongRightArrow", 10230, 0},
-{L"Longleftarrow", 10232, 0},
-{L"Longleftrightarrow", 10234, 0},
-{L"Longrightarrow", 10233, 0},
-{L"Lopf", 120131, 0},
-{L"LowerLeftArrow", 8601, 0},
-{L"LowerRightArrow", 8600, 0},
-{L"Lscr", 8466, 0},
-{L"Lsh", 8624, 0},
-{L"Lstrok", 321, 0},
-{L"Lt", 8810, 0},
-{L"Map", 10501, 0},
-{L"Mcy", 1052, 0},
-{L"MediumSpace", 8287, 0},
-{L"Mellintrf", 8499, 0},
-{L"Mfr", 120080, 0},
-{L"MinusPlus", 8723, 0},
-{L"Mopf", 120132, 0},
-{L"Mscr", 8499, 0},
-{L"Mu", 924, 0},
-{L"NJcy", 1034, 0},
-{L"Nacute", 323, 0},
-{L"Ncaron", 327, 0},
-{L"Ncedil", 325, 0},
-{L"Ncy", 1053, 0},
-{L"NegativeMediumSpace", 8203, 0},
-{L"NegativeThickSpace", 8203, 0},
-{L"NegativeThinSpace", 8203, 0},
-{L"NegativeVeryThinSpace", 8203, 0},
-{L"NestedGreaterGreater", 8811, 0},
-{L"NestedLessLess", 8810, 0},
-{L"NewLine", 10, 0},
-{L"Nfr", 120081, 0},
-{L"NoBreak", 8288, 0},
-{L"NonBreakingSpace", 160, 0},
-{L"Nopf", 8469, 0},
-{L"Not", 10988, 0},
-{L"NotCongruent", 8802, 0},
-{L"NotCupCap", 8813, 0},
-{L"NotDoubleVerticalBar", 8742, 0},
-{L"NotElement", 8713, 0},
-{L"NotEqual", 8800, 0},
-{L"NotEqualTilde", 8770, 824},
-{L"NotExists", 8708, 0},
-{L"NotGreater", 8815, 0},
-{L"NotGreaterEqual", 8817, 0},
-{L"NotGreaterFullEqual", 8807, 824},
-{L"NotGreaterGreater", 8811, 824},
-{L"NotGreaterLess", 8825, 0},
-{L"NotGreaterSlantEqual", 10878, 824},
-{L"NotGreaterTilde", 8821, 0},
-{L"NotHumpDownHump", 8782, 824},
-{L"NotHumpEqual", 8783, 824},
-{L"NotLeftTriangle", 8938, 0},
-{L"NotLeftTriangleBar", 10703, 824},
-{L"NotLeftTriangleEqual", 8940, 0},
-{L"NotLess", 8814, 0},
-{L"NotLessEqual", 8816, 0},
-{L"NotLessGreater", 8824, 0},
-{L"NotLessLess", 8810, 824},
-{L"NotLessSlantEqual", 10877, 824},
-{L"NotLessTilde", 8820, 0},
-{L"NotNestedGreaterGreater", 10914, 824},
-{L"NotNestedLessLess", 10913, 824},
-{L"NotPrecedes", 8832, 0},
-{L"NotPrecedesEqual", 10927, 824},
-{L"NotPrecedesSlantEqual", 8928, 0},
-{L"NotReverseElement", 8716, 0},
-{L"NotRightTriangle", 8939, 0},
-{L"NotRightTriangleBar", 10704, 824},
-{L"NotRightTriangleEqual", 8941, 0},
-{L"NotSquareSubset", 8847, 824},
-{L"NotSquareSubsetEqual", 8930, 0},
-{L"NotSquareSuperset", 8848, 824},
-{L"NotSquareSupersetEqual", 8931, 0},
-{L"NotSubset", 8834, 8402},
-{L"NotSubsetEqual", 8840, 0},
-{L"NotSucceeds", 8833, 0},
-{L"NotSucceedsEqual", 10928, 824},
-{L"NotSucceedsSlantEqual", 8929, 0},
-{L"NotSucceedsTilde", 8831, 824},
-{L"NotSuperset", 8835, 8402},
-{L"NotSupersetEqual", 8841, 0},
-{L"NotTilde", 8769, 0},
-{L"NotTildeEqual", 8772, 0},
-{L"NotTildeFullEqual", 8775, 0},
-{L"NotTildeTilde", 8777, 0},
-{L"NotVerticalBar", 8740, 0},
-{L"Nscr", 119977, 0},
-{L"Ntilde", 209, 0},
-{L"Nu", 925, 0},
-{L"OElig", 338, 0},
-{L"Oacute", 211, 0},
-{L"Ocirc", 212, 0},
-{L"Ocy", 1054, 0},
-{L"Odblac", 336, 0},
-{L"Ofr", 120082, 0},
-{L"Ograve", 210, 0},
-{L"Omacr", 332, 0},
-{L"Omega", 937, 0},
-{L"Omicron", 927, 0},
-{L"Oopf", 120134, 0},
-{L"OpenCurlyDoubleQuote", 8220, 0},
-{L"OpenCurlyQuote", 8216, 0},
-{L"Or", 10836, 0},
-{L"Oscr", 119978, 0},
-{L"Oslash", 216, 0},
-{L"Otilde", 213, 0},
-{L"Otimes", 10807, 0},
-{L"Ouml", 214, 0},
-{L"OverBar", 8254, 0},
-{L"OverBrace", 9182, 0},
-{L"OverBracket", 9140, 0},
-{L"OverParenthesis", 9180, 0},
-{L"PartialD", 8706, 0},
-{L"Pcy", 1055, 0},
-{L"Pfr", 120083, 0},
-{L"Phi", 934, 0},
-{L"Pi", 928, 0},
-{L"PlusMinus", 177, 0},
-{L"Poincareplane", 8460, 0},
-{L"Popf", 8473, 0},
-{L"Pr", 10939, 0},
-{L"Precedes", 8826, 0},
-{L"PrecedesEqual", 10927, 0},
-{L"PrecedesSlantEqual", 8828, 0},
-{L"PrecedesTilde", 8830, 0},
-{L"Prime", 8243, 0},
-{L"Product", 8719, 0},
-{L"Proportion", 8759, 0},
-{L"Proportional", 8733, 0},
-{L"Pscr", 119979, 0},
-{L"Psi", 936, 0},
-{L"QUOT", 34, 0},
-{L"Qfr", 120084, 0},
-{L"Qopf", 8474, 0},
-{L"Qscr", 119980, 0},
-{L"RBarr", 10512, 0},
-{L"REG", 174, 0},
-{L"Racute", 340, 0},
-{L"Rang", 10219, 0},
-{L"Rarr", 8608, 0},
-{L"Rarrtl", 10518, 0},
-{L"Rcaron", 344, 0},
-{L"Rcedil", 342, 0},
-{L"Rcy", 1056, 0},
-{L"Re", 8476, 0},
-{L"ReverseElement", 8715, 0},
-{L"ReverseEquilibrium", 8651, 0},
-{L"ReverseUpEquilibrium", 10607, 0},
-{L"Rfr", 8476, 0},
-{L"Rho", 929, 0},
-{L"RightAngleBracket", 10217, 0},
-{L"RightArrow", 8594, 0},
-{L"RightArrowBar", 8677, 0},
-{L"RightArrowLeftArrow", 8644, 0},
-{L"RightCeiling", 8969, 0},
-{L"RightDoubleBracket", 10215, 0},
-{L"RightDownTeeVector", 10589, 0},
-{L"RightDownVector", 8642, 0},
-{L"RightDownVectorBar", 10581, 0},
-{L"RightFloor", 8971, 0},
-{L"RightTee", 8866, 0},
-{L"RightTeeArrow", 8614, 0},
-{L"RightTeeVector", 10587, 0},
-{L"RightTriangle", 8883, 0},
-{L"RightTriangleBar", 10704, 0},
-{L"RightTriangleEqual", 8885, 0},
-{L"RightUpDownVector", 10575, 0},
-{L"RightUpTeeVector", 10588, 0},
-{L"RightUpVector", 8638, 0},
-{L"RightUpVectorBar", 10580, 0},
-{L"RightVector", 8640, 0},
-{L"RightVectorBar", 10579, 0},
-{L"Rightarrow", 8658, 0},
-{L"Ropf", 8477, 0},
-{L"RoundImplies", 10608, 0},
-{L"Rrightarrow", 8667, 0},
-{L"Rscr", 8475, 0},
-{L"Rsh", 8625, 0},
-{L"RuleDelayed", 10740, 0},
-{L"SHCHcy", 1065, 0},
-{L"SHcy", 1064, 0},
-{L"SOFTcy", 1068, 0},
-{L"Sacute", 346, 0},
-{L"Sc", 10940, 0},
-{L"Scaron", 352, 0},
-{L"Scedil", 350, 0},
-{L"Scirc", 348, 0},
-{L"Scy", 1057, 0},
-{L"Sfr", 120086, 0},
-{L"ShortDownArrow", 8595, 0},
-{L"ShortLeftArrow", 8592, 0},
-{L"ShortRightArrow", 8594, 0},
-{L"ShortUpArrow", 8593, 0},
-{L"Sigma", 931, 0},
-{L"SmallCircle", 8728, 0},
-{L"Sopf", 120138, 0},
-{L"Sqrt", 8730, 0},
-{L"Square", 9633, 0},
-{L"SquareIntersection", 8851, 0},
-{L"SquareSubset", 8847, 0},
-{L"SquareSubsetEqual", 8849, 0},
-{L"SquareSuperset", 8848, 0},
-{L"SquareSupersetEqual", 8850, 0},
-{L"SquareUnion", 8852, 0},
-{L"Sscr", 119982, 0},
-{L"Star", 8902, 0},
-{L"Sub", 8912, 0},
-{L"Subset", 8912, 0},
-{L"SubsetEqual", 8838, 0},
-{L"Succeeds", 8827, 0},
-{L"SucceedsEqual", 10928, 0},
-{L"SucceedsSlantEqual", 8829, 0},
-{L"SucceedsTilde", 8831, 0},
-{L"SuchThat", 8715, 0},
-{L"Sum", 8721, 0},
-{L"Sup", 8913, 0},
-{L"Superset", 8835, 0},
-{L"SupersetEqual", 8839, 0},
-{L"Supset", 8913, 0},
-{L"THORN", 222, 0},
-{L"TRADE", 8482, 0},
-{L"TSHcy", 1035, 0},
-{L"TScy", 1062, 0},
-{L"Tab", 9, 0},
-{L"Tau", 932, 0},
-{L"Tcaron", 356, 0},
-{L"Tcedil", 354, 0},
-{L"Tcy", 1058, 0},
-{L"Tfr", 120087, 0},
-{L"Therefore", 8756, 0},
-{L"Theta", 920, 0},
-{L"ThickSpace", 8287, 8202},
-{L"ThinSpace", 8201, 0},
-{L"Tilde", 8764, 0},
-{L"TildeEqual", 8771, 0},
-{L"TildeFullEqual", 8773, 0},
-{L"TildeTilde", 8776, 0},
-{L"Topf", 120139, 0},
-{L"TripleDot", 8411, 0},
-{L"Tscr", 119983, 0},
-{L"Tstrok", 358, 0},
-{L"Uacute", 218, 0},
-{L"Uarr", 8607, 0},
-{L"Uarrocir", 10569, 0},
-{L"Ubrcy", 1038, 0},
-{L"Ubreve", 364, 0},
-{L"Ucirc", 219, 0},
-{L"Ucy", 1059, 0},
-{L"Udblac", 368, 0},
-{L"Ufr", 120088, 0},
-{L"Ugrave", 217, 0},
-{L"Umacr", 362, 0},
-{L"UnderBar", 95, 0},
-{L"UnderBrace", 9183, 0},
-{L"UnderBracket", 9141, 0},
-{L"UnderParenthesis", 9181, 0},
-{L"Union", 8899, 0},
-{L"UnionPlus", 8846, 0},
-{L"Uogon", 370, 0},
-{L"Uopf", 120140, 0},
-{L"UpArrow", 8593, 0},
-{L"UpArrowBar", 10514, 0},
-{L"UpArrowDownArrow", 8645, 0},
-{L"UpDownArrow", 8597, 0},
-{L"UpEquilibrium", 10606, 0},
-{L"UpTee", 8869, 0},
-{L"UpTeeArrow", 8613, 0},
-{L"Uparrow", 8657, 0},
-{L"Updownarrow", 8661, 0},
-{L"UpperLeftArrow", 8598, 0},
-{L"UpperRightArrow", 8599, 0},
-{L"Upsi", 978, 0},
-{L"Upsilon", 933, 0},
-{L"Uring", 366, 0},
-{L"Uscr", 119984, 0},
-{L"Utilde", 360, 0},
-{L"Uuml", 220, 0},
-{L"VDash", 8875, 0},
-{L"Vbar", 10987, 0},
-{L"Vcy", 1042, 0},
-{L"Vdash", 8873, 0},
-{L"Vdashl", 10982, 0},
-{L"Vee", 8897, 0},
-{L"Verbar", 8214, 0},
-{L"Vert", 8214, 0},
-{L"VerticalBar", 8739, 0},
-{L"VerticalLine", 124, 0},
-{L"VerticalSeparator", 10072, 0},
-{L"VerticalTilde", 8768, 0},
-{L"VeryThinSpace", 8202, 0},
-{L"Vfr", 120089, 0},
-{L"Vopf", 120141, 0},
-{L"Vscr", 119985, 0},
-{L"Vvdash", 8874, 0},
-{L"Wcirc", 372, 0},
-{L"Wedge", 8896, 0},
-{L"Wfr", 120090, 0},
-{L"Wopf", 120142, 0},
-{L"Wscr", 119986, 0},
-{L"Xfr", 120091, 0},
-{L"Xi", 926, 0},
-{L"Xopf", 120143, 0},
-{L"Xscr", 119987, 0},
-{L"YAcy", 1071, 0},
-{L"YIcy", 1031, 0},
-{L"YUcy", 1070, 0},
-{L"Yacute", 221, 0},
-{L"Ycirc", 374, 0},
-{L"Ycy", 1067, 0},
-{L"Yfr", 120092, 0},
-{L"Yopf", 120144, 0},
-{L"Yscr", 119988, 0},
-{L"Yuml", 376, 0},
-{L"ZHcy", 1046, 0},
-{L"Zacute", 377, 0},
-{L"Zcaron", 381, 0},
-{L"Zcy", 1047, 0},
-{L"Zdot", 379, 0},
-{L"ZeroWidthSpace", 8203, 0},
-{L"Zeta", 918, 0},
-{L"Zfr", 8488, 0},
-{L"Zopf", 8484, 0},
-{L"Zscr", 119989, 0},
-{L"aacute", 225, 0},
-{L"abreve", 259, 0},
-{L"ac", 8766, 0},
-{L"acE", 8766, 819},
-{L"acd", 8767, 0},
-{L"acirc", 226, 0},
-{L"acute", 180, 0},
-{L"acy", 1072, 0},
-{L"aelig", 230, 0},
-{L"af", 8289, 0},
-{L"afr", 120094, 0},
-{L"agrave", 224, 0},
-{L"alefsym", 8501, 0},
-{L"aleph", 8501, 0},
-{L"alpha", 945, 0},
-{L"amacr", 257, 0},
-{L"amalg", 10815, 0},
-{L"amp", 38, 0},
-{L"and", 8743, 0},
-{L"andand", 10837, 0},
-{L"andd", 10844, 0},
-{L"andslope", 10840, 0},
-{L"andv", 10842, 0},
-{L"ang", 8736, 0},
-{L"ange", 10660, 0},
-{L"angle", 8736, 0},
-{L"angmsd", 8737, 0},
-{L"angmsdaa", 10664, 0},
-{L"angmsdab", 10665, 0},
-{L"angmsdac", 10666, 0},
-{L"angmsdad", 10667, 0},
-{L"angmsdae", 10668, 0},
-{L"angmsdaf", 10669, 0},
-{L"angmsdag", 10670, 0},
-{L"angmsdah", 10671, 0},
-{L"angrt", 8735, 0},
-{L"angrtvb", 8894, 0},
-{L"angrtvbd", 10653, 0},
-{L"angsph", 8738, 0},
-{L"angst", 197, 0},
-{L"angzarr", 9084, 0},
-{L"aogon", 261, 0},
-{L"aopf", 120146, 0},
-{L"ap", 8776, 0},
-{L"apE", 10864, 0},
-{L"apacir", 10863, 0},
-{L"ape", 8778, 0},
-{L"apid", 8779, 0},
-{L"apos", 39, 0},
-{L"approx", 8776, 0},
-{L"approxeq", 8778, 0},
-{L"aring", 229, 0},
-{L"ascr", 119990, 0},
-{L"ast", 42, 0},
-{L"asymp", 8776, 0},
-{L"asympeq", 8781, 0},
-{L"atilde", 227, 0},
-{L"auml", 228, 0},
-{L"awconint", 8755, 0},
-{L"awint", 10769, 0},
-{L"bNot", 10989, 0},
-{L"backcong", 8780, 0},
-{L"backepsilon", 1014, 0},
-{L"backprime", 8245, 0},
-{L"backsim", 8765, 0},
-{L"backsimeq", 8909, 0},
-{L"barvee", 8893, 0},
-{L"barwed", 8965, 0},
-{L"barwedge", 8965, 0},
-{L"bbrk", 9141, 0},
-{L"bbrktbrk", 9142, 0},
-{L"bcong", 8780, 0},
-{L"bcy", 1073, 0},
-{L"bdquo", 8222, 0},
-{L"becaus", 8757, 0},
-{L"because", 8757, 0},
-{L"bemptyv", 10672, 0},
-{L"bepsi", 1014, 0},
-{L"bernou", 8492, 0},
-{L"beta", 946, 0},
-{L"beth", 8502, 0},
-{L"between", 8812, 0},
-{L"bfr", 120095, 0},
-{L"bigcap", 8898, 0},
-{L"bigcirc", 9711, 0},
-{L"bigcup", 8899, 0},
-{L"bigodot", 10752, 0},
-{L"bigoplus", 10753, 0},
-{L"bigotimes", 10754, 0},
-{L"bigsqcup", 10758, 0},
-{L"bigstar", 9733, 0},
-{L"bigtriangledown", 9661, 0},
-{L"bigtriangleup", 9651, 0},
-{L"biguplus", 10756, 0},
-{L"bigvee", 8897, 0},
-{L"bigwedge", 8896, 0},
-{L"bkarow", 10509, 0},
-{L"blacklozenge", 10731, 0},
-{L"blacksquare", 9642, 0},
-{L"blacktriangle", 9652, 0},
-{L"blacktriangledown", 9662, 0},
-{L"blacktriangleleft", 9666, 0},
-{L"blacktriangleright", 9656, 0},
-{L"blank", 9251, 0},
-{L"blk12", 9618, 0},
-{L"blk14", 9617, 0},
-{L"blk34", 9619, 0},
-{L"block", 9608, 0},
-{L"bne", 61, 8421},
-{L"bnequiv", 8801, 8421},
-{L"bnot", 8976, 0},
-{L"bopf", 120147, 0},
-{L"bot", 8869, 0},
-{L"bottom", 8869, 0},
-{L"bowtie", 8904, 0},
-{L"boxDL", 9559, 0},
-{L"boxDR", 9556, 0},
-{L"boxDl", 9558, 0},
-{L"boxDr", 9555, 0},
-{L"boxH", 9552, 0},
-{L"boxHD", 9574, 0},
-{L"boxHU", 9577, 0},
-{L"boxHd", 9572, 0},
-{L"boxHu", 9575, 0},
-{L"boxUL", 9565, 0},
-{L"boxUR", 9562, 0},
-{L"boxUl", 9564, 0},
-{L"boxUr", 9561, 0},
-{L"boxV", 9553, 0},
-{L"boxVH", 9580, 0},
-{L"boxVL", 9571, 0},
-{L"boxVR", 9568, 0},
-{L"boxVh", 9579, 0},
-{L"boxVl", 9570, 0},
-{L"boxVr", 9567, 0},
-{L"boxbox", 10697, 0},
-{L"boxdL", 9557, 0},
-{L"boxdR", 9554, 0},
-{L"boxdl", 9488, 0},
-{L"boxdr", 9484, 0},
-{L"boxh", 9472, 0},
-{L"boxhD", 9573, 0},
-{L"boxhU", 9576, 0},
-{L"boxhd", 9516, 0},
-{L"boxhu", 9524, 0},
-{L"boxminus", 8863, 0},
-{L"boxplus", 8862, 0},
-{L"boxtimes", 8864, 0},
-{L"boxuL", 9563, 0},
-{L"boxuR", 9560, 0},
-{L"boxul", 9496, 0},
-{L"boxur", 9492, 0},
-{L"boxv", 9474, 0},
-{L"boxvH", 9578, 0},
-{L"boxvL", 9569, 0},
-{L"boxvR", 9566, 0},
-{L"boxvh", 9532, 0},
-{L"boxvl", 9508, 0},
-{L"boxvr", 9500, 0},
-{L"bprime", 8245, 0},
-{L"breve", 728, 0},
-{L"brvbar", 166, 0},
-{L"bscr", 119991, 0},
-{L"bsemi", 8271, 0},
-{L"bsim", 8765, 0},
-{L"bsime", 8909, 0},
-{L"bsol", 92, 0},
-{L"bsolb", 10693, 0},
-{L"bsolhsub", 10184, 0},
-{L"bull", 8226, 0},
-{L"bullet", 8226, 0},
-{L"bump", 8782, 0},
-{L"bumpE", 10926, 0},
-{L"bumpe", 8783, 0},
-{L"bumpeq", 8783, 0},
-{L"cacute", 263, 0},
-{L"cap", 8745, 0},
-{L"capand", 10820, 0},
-{L"capbrcup", 10825, 0},
-{L"capcap", 10827, 0},
-{L"capcup", 10823, 0},
-{L"capdot", 10816, 0},
-{L"caps", 8745, 65024},
-{L"caret", 8257, 0},
-{L"caron", 711, 0},
-{L"ccaps", 10829, 0},
-{L"ccaron", 269, 0},
-{L"ccedil", 231, 0},
-{L"ccirc", 265, 0},
-{L"ccups", 10828, 0},
-{L"ccupssm", 10832, 0},
-{L"cdot", 267, 0},
-{L"cedil", 184, 0},
-{L"cemptyv", 10674, 0},
-{L"cent", 162, 0},
-{L"centerdot", 183, 0},
-{L"cfr", 120096, 0},
-{L"chcy", 1095, 0},
-{L"check", 10003, 0},
-{L"checkmark", 10003, 0},
-{L"chi", 967, 0},
-{L"cir", 9675, 0},
-{L"cirE", 10691, 0},
-{L"circ", 710, 0},
-{L"circeq", 8791, 0},
-{L"circlearrowleft", 8634, 0},
-{L"circlearrowright", 8635, 0},
-{L"circledR", 174, 0},
-{L"circledS", 9416, 0},
-{L"circledast", 8859, 0},
-{L"circledcirc", 8858, 0},
-{L"circleddash", 8861, 0},
-{L"cire", 8791, 0},
-{L"cirfnint", 10768, 0},
-{L"cirmid", 10991, 0},
-{L"cirscir", 10690, 0},
-{L"clubs", 9827, 0},
-{L"clubsuit", 9827, 0},
-{L"colon", 58, 0},
-{L"colone", 8788, 0},
-{L"coloneq", 8788, 0},
-{L"comma", 44, 0},
-{L"commat", 64, 0},
-{L"comp", 8705, 0},
-{L"compfn", 8728, 0},
-{L"complement", 8705, 0},
-{L"complexes", 8450, 0},
-{L"cong", 8773, 0},
-{L"congdot", 10861, 0},
-{L"conint", 8750, 0},
-{L"copf", 120148, 0},
-{L"coprod", 8720, 0},
-{L"copy", 169, 0},
-{L"copysr", 8471, 0},
-{L"crarr", 8629, 0},
-{L"cross", 10007, 0},
-{L"cscr", 119992, 0},
-{L"csub", 10959, 0},
-{L"csube", 10961, 0},
-{L"csup", 10960, 0},
-{L"csupe", 10962, 0},
-{L"ctdot", 8943, 0},
-{L"cudarrl", 10552, 0},
-{L"cudarrr", 10549, 0},
-{L"cuepr", 8926, 0},
-{L"cuesc", 8927, 0},
-{L"cularr", 8630, 0},
-{L"cularrp", 10557, 0},
-{L"cup", 8746, 0},
-{L"cupbrcap", 10824, 0},
-{L"cupcap", 10822, 0},
-{L"cupcup", 10826, 0},
-{L"cupdot", 8845, 0},
-{L"cupor", 10821, 0},
-{L"cups", 8746, 65024},
-{L"curarr", 8631, 0},
-{L"curarrm", 10556, 0},
-{L"curlyeqprec", 8926, 0},
-{L"curlyeqsucc", 8927, 0},
-{L"curlyvee", 8910, 0},
-{L"curlywedge", 8911, 0},
-{L"curren", 164, 0},
-{L"curvearrowleft", 8630, 0},
-{L"curvearrowright", 8631, 0},
-{L"cuvee", 8910, 0},
-{L"cuwed", 8911, 0},
-{L"cwconint", 8754, 0},
-{L"cwint", 8753, 0},
-{L"cylcty", 9005, 0},
-{L"dArr", 8659, 0},
-{L"dHar", 10597, 0},
-{L"dagger", 8224, 0},
-{L"daleth", 8504, 0},
-{L"darr", 8595, 0},
-{L"dash", 8208, 0},
-{L"dashv", 8867, 0},
-{L"dbkarow", 10511, 0},
-{L"dblac", 733, 0},
-{L"dcaron", 271, 0},
-{L"dcy", 1076, 0},
-{L"dd", 8518, 0},
-{L"ddagger", 8225, 0},
-{L"ddarr", 8650, 0},
-{L"ddotseq", 10871, 0},
-{L"deg", 176, 0},
-{L"delta", 948, 0},
-{L"demptyv", 10673, 0},
-{L"dfisht", 10623, 0},
-{L"dfr", 120097, 0},
-{L"dharl", 8643, 0},
-{L"dharr", 8642, 0},
-{L"diam", 8900, 0},
-{L"diamond", 8900, 0},
-{L"diamondsuit", 9830, 0},
-{L"diams", 9830, 0},
-{L"die", 168, 0},
-{L"digamma", 989, 0},
-{L"disin", 8946, 0},
-{L"div", 247, 0},
-{L"divide", 247, 0},
-{L"divideontimes", 8903, 0},
-{L"divonx", 8903, 0},
-{L"djcy", 1106, 0},
-{L"dlcorn", 8990, 0},
-{L"dlcrop", 8973, 0},
-{L"dollar", 36, 0},
-{L"dopf", 120149, 0},
-{L"dot", 729, 0},
-{L"doteq", 8784, 0},
-{L"doteqdot", 8785, 0},
-{L"dotminus", 8760, 0},
-{L"dotplus", 8724, 0},
-{L"dotsquare", 8865, 0},
-{L"doublebarwedge", 8966, 0},
-{L"downarrow", 8595, 0},
-{L"downdownarrows", 8650, 0},
-{L"downharpoonleft", 8643, 0},
-{L"downharpoonright", 8642, 0},
-{L"drbkarow", 10512, 0},
-{L"drcorn", 8991, 0},
-{L"drcrop", 8972, 0},
-{L"dscr", 119993, 0},
-{L"dscy", 1109, 0},
-{L"dsol", 10742, 0},
-{L"dstrok", 273, 0},
-{L"dtdot", 8945, 0},
-{L"dtri", 9663, 0},
-{L"dtrif", 9662, 0},
-{L"duarr", 8693, 0},
-{L"duhar", 10607, 0},
-{L"dwangle", 10662, 0},
-{L"dzcy", 1119, 0},
-{L"dzigrarr", 10239, 0},
-{L"eDDot", 10871, 0},
-{L"eDot", 8785, 0},
-{L"eacute", 233, 0},
-{L"easter", 10862, 0},
-{L"ecaron", 283, 0},
-{L"ecir", 8790, 0},
-{L"ecirc", 234, 0},
-{L"ecolon", 8789, 0},
-{L"ecy", 1101, 0},
-{L"edot", 279, 0},
-{L"ee", 8519, 0},
-{L"efDot", 8786, 0},
-{L"efr", 120098, 0},
-{L"eg", 10906, 0},
-{L"egrave", 232, 0},
-{L"egs", 10902, 0},
-{L"egsdot", 10904, 0},
-{L"el", 10905, 0},
-{L"elinters", 9191, 0},
-{L"ell", 8467, 0},
-{L"els", 10901, 0},
-{L"elsdot", 10903, 0},
-{L"emacr", 275, 0},
-{L"empty", 8709, 0},
-{L"emptyset", 8709, 0},
-{L"emptyv", 8709, 0},
-{L"emsp", 8195, 0},
-{L"emsp13", 8196, 0},
-{L"emsp14", 8197, 0},
-{L"eng", 331, 0},
-{L"ensp", 8194, 0},
-{L"eogon", 281, 0},
-{L"eopf", 120150, 0},
-{L"epar", 8917, 0},
-{L"eparsl", 10723, 0},
-{L"eplus", 10865, 0},
-{L"epsi", 949, 0},
-{L"epsilon", 949, 0},
-{L"epsiv", 1013, 0},
-{L"eqcirc", 8790, 0},
-{L"eqcolon", 8789, 0},
-{L"eqsim", 8770, 0},
-{L"eqslantgtr", 10902, 0},
-{L"eqslantless", 10901, 0},
-{L"equals", 61, 0},
-{L"equest", 8799, 0},
-{L"equiv", 8801, 0},
-{L"equivDD", 10872, 0},
-{L"eqvparsl", 10725, 0},
-{L"erDot", 8787, 0},
-{L"erarr", 10609, 0},
-{L"escr", 8495, 0},
-{L"esdot", 8784, 0},
-{L"esim", 8770, 0},
-{L"eta", 951, 0},
-{L"eth", 240, 0},
-{L"euml", 235, 0},
-{L"euro", 8364, 0},
-{L"excl", 33, 0},
-{L"exist", 8707, 0},
-{L"expectation", 8496, 0},
-{L"exponentiale", 8519, 0},
-{L"fallingdotseq", 8786, 0},
-{L"fcy", 1092, 0},
-{L"female", 9792, 0},
-{L"ffilig", 64259, 0},
-{L"fflig", 64256, 0},
-{L"ffllig", 64260, 0},
-{L"ffr", 120099, 0},
-{L"filig", 64257, 0},
-{L"fjlig", 102, 106},
-{L"flat", 9837, 0},
-{L"fllig", 64258, 0},
-{L"fltns", 9649, 0},
-{L"fnof", 402, 0},
-{L"fopf", 120151, 0},
-{L"forall", 8704, 0},
-{L"fork", 8916, 0},
-{L"forkv", 10969, 0},
-{L"fpartint", 10765, 0},
-{L"frac12", 189, 0},
-{L"frac13", 8531, 0},
-{L"frac14", 188, 0},
-{L"frac15", 8533, 0},
-{L"frac16", 8537, 0},
-{L"frac18", 8539, 0},
-{L"frac23", 8532, 0},
-{L"frac25", 8534, 0},
-{L"frac34", 190, 0},
-{L"frac35", 8535, 0},
-{L"frac38", 8540, 0},
-{L"frac45", 8536, 0},
-{L"frac56", 8538, 0},
-{L"frac58", 8541, 0},
-{L"frac78", 8542, 0},
-{L"frasl", 8260, 0},
-{L"frown", 8994, 0},
-{L"fscr", 119995, 0},
-{L"gE", 8807, 0},
-{L"gEl", 10892, 0},
-{L"gacute", 501, 0},
-{L"gamma", 947, 0},
-{L"gammad", 989, 0},
-{L"gap", 10886, 0},
-{L"gbreve", 287, 0},
-{L"gcirc", 285, 0},
-{L"gcy", 1075, 0},
-{L"gdot", 289, 0},
-{L"ge", 8805, 0},
-{L"gel", 8923, 0},
-{L"geq", 8805, 0},
-{L"geqq", 8807, 0},
-{L"geqslant", 10878, 0},
-{L"ges", 10878, 0},
-{L"gescc", 10921, 0},
-{L"gesdot", 10880, 0},
-{L"gesdoto", 10882, 0},
-{L"gesdotol", 10884, 0},
-{L"gesl", 8923, 65024},
-{L"gesles", 10900, 0},
-{L"gfr", 120100, 0},
-{L"gg", 8811, 0},
-{L"ggg", 8921, 0},
-{L"gimel", 8503, 0},
-{L"gjcy", 1107, 0},
-{L"gl", 8823, 0},
-{L"glE", 10898, 0},
-{L"gla", 10917, 0},
-{L"glj", 10916, 0},
-{L"gnE", 8809, 0},
-{L"gnap", 10890, 0},
-{L"gnapprox", 10890, 0},
-{L"gne", 10888, 0},
-{L"gneq", 10888, 0},
-{L"gneqq", 8809, 0},
-{L"gnsim", 8935, 0},
-{L"gopf", 120152, 0},
-{L"grave", 96, 0},
-{L"gscr", 8458, 0},
-{L"gsim", 8819, 0},
-{L"gsime", 10894, 0},
-{L"gsiml", 10896, 0},
-{L"gt", 62, 0},
-{L"gtcc", 10919, 0},
-{L"gtcir", 10874, 0},
-{L"gtdot", 8919, 0},
-{L"gtlPar", 10645, 0},
-{L"gtquest", 10876, 0},
-{L"gtrapprox", 10886, 0},
-{L"gtrarr", 10616, 0},
-{L"gtrdot", 8919, 0},
-{L"gtreqless", 8923, 0},
-{L"gtreqqless", 10892, 0},
-{L"gtrless", 8823, 0},
-{L"gtrsim", 8819, 0},
-{L"gvertneqq", 8809, 65024},
-{L"gvnE", 8809, 65024},
-{L"hArr", 8660, 0},
-{L"hairsp", 8202, 0},
-{L"half", 189, 0},
-{L"hamilt", 8459, 0},
-{L"hardcy", 1098, 0},
-{L"harr", 8596, 0},
-{L"harrcir", 10568, 0},
-{L"harrw", 8621, 0},
-{L"hbar", 8463, 0},
-{L"hcirc", 293, 0},
-{L"hearts", 9829, 0},
-{L"heartsuit", 9829, 0},
-{L"hellip", 8230, 0},
-{L"hercon", 8889, 0},
-{L"hfr", 120101, 0},
-{L"hksearow", 10533, 0},
-{L"hkswarow", 10534, 0},
-{L"hoarr", 8703, 0},
-{L"homtht", 8763, 0},
-{L"hookleftarrow", 8617, 0},
-{L"hookrightarrow", 8618, 0},
-{L"hopf", 120153, 0},
-{L"horbar", 8213, 0},
-{L"hscr", 119997, 0},
-{L"hslash", 8463, 0},
-{L"hstrok", 295, 0},
-{L"hybull", 8259, 0},
-{L"hyphen", 8208, 0},
-{L"iacute", 237, 0},
-{L"ic", 8291, 0},
-{L"icirc", 238, 0},
-{L"icy", 1080, 0},
-{L"iecy", 1077, 0},
-{L"iexcl", 161, 0},
-{L"iff", 8660, 0},
-{L"ifr", 120102, 0},
-{L"igrave", 236, 0},
-{L"ii", 8520, 0},
-{L"iiiint", 10764, 0},
-{L"iiint", 8749, 0},
-{L"iinfin", 10716, 0},
-{L"iiota", 8489, 0},
-{L"ijlig", 307, 0},
-{L"imacr", 299, 0},
-{L"image", 8465, 0},
-{L"imagline", 8464, 0},
-{L"imagpart", 8465, 0},
-{L"imath", 305, 0},
-{L"imof", 8887, 0},
-{L"imped", 437, 0},
-{L"in", 8712, 0},
-{L"incare", 8453, 0},
-{L"infin", 8734, 0},
-{L"infintie", 10717, 0},
-{L"inodot", 305, 0},
-{L"int", 8747, 0},
-{L"intcal", 8890, 0},
-{L"integers", 8484, 0},
-{L"intercal", 8890, 0},
-{L"intlarhk", 10775, 0},
-{L"intprod", 10812, 0},
-{L"iocy", 1105, 0},
-{L"iogon", 303, 0},
-{L"iopf", 120154, 0},
-{L"iota", 953, 0},
-{L"iprod", 10812, 0},
-{L"iquest", 191, 0},
-{L"iscr", 119998, 0},
-{L"isin", 8712, 0},
-{L"isinE", 8953, 0},
-{L"isindot", 8949, 0},
-{L"isins", 8948, 0},
-{L"isinsv", 8947, 0},
-{L"isinv", 8712, 0},
-{L"it", 8290, 0},
-{L"itilde", 297, 0},
-{L"iukcy", 1110, 0},
-{L"iuml", 239, 0},
-{L"jcirc", 309, 0},
-{L"jcy", 1081, 0},
-{L"jfr", 120103, 0},
-{L"jmath", 567, 0},
-{L"jopf", 120155, 0},
-{L"jscr", 119999, 0},
-{L"jsercy", 1112, 0},
-{L"jukcy", 1108, 0},
-{L"kappa", 954, 0},
-{L"kappav", 1008, 0},
-{L"kcedil", 311, 0},
-{L"kcy", 1082, 0},
-{L"kfr", 120104, 0},
-{L"kgreen", 312, 0},
-{L"khcy", 1093, 0},
-{L"kjcy", 1116, 0},
-{L"kopf", 120156, 0},
-{L"kscr", 120000, 0},
-{L"lAarr", 8666, 0},
-{L"lArr", 8656, 0},
-{L"lAtail", 10523, 0},
-{L"lBarr", 10510, 0},
-{L"lE", 8806, 0},
-{L"lEg", 10891, 0},
-{L"lHar", 10594, 0},
-{L"lacute", 314, 0},
-{L"laemptyv", 10676, 0},
-{L"lagran", 8466, 0},
-{L"lambda", 955, 0},
-{L"lang", 10216, 0},
-{L"langd", 10641, 0},
-{L"langle", 10216, 0},
-{L"lap", 10885, 0},
-{L"laquo", 171, 0},
-{L"larr", 8592, 0},
-{L"larrb", 8676, 0},
-{L"larrbfs", 10527, 0},
-{L"larrfs", 10525, 0},
-{L"larrhk", 8617, 0},
-{L"larrlp", 8619, 0},
-{L"larrpl", 10553, 0},
-{L"larrsim", 10611, 0},
-{L"larrtl", 8610, 0},
-{L"lat", 10923, 0},
-{L"latail", 10521, 0},
-{L"late", 10925, 0},
-{L"lates", 10925, 65024},
-{L"lbarr", 10508, 0},
-{L"lbbrk", 10098, 0},
-{L"lbrace", 123, 0},
-{L"lbrack", 91, 0},
-{L"lbrke", 10635, 0},
-{L"lbrksld", 10639, 0},
-{L"lbrkslu", 10637, 0},
-{L"lcaron", 318, 0},
-{L"lcedil", 316, 0},
-{L"lceil", 8968, 0},
-{L"lcub", 123, 0},
-{L"lcy", 1083, 0},
-{L"ldca", 10550, 0},
-{L"ldquo", 8220, 0},
-{L"ldquor", 8222, 0},
-{L"ldrdhar", 10599, 0},
-{L"ldrushar", 10571, 0},
-{L"ldsh", 8626, 0},
-{L"le", 8804, 0},
-{L"leftarrow", 8592, 0},
-{L"leftarrowtail", 8610, 0},
-{L"leftharpoondown", 8637, 0},
-{L"leftharpoonup", 8636, 0},
-{L"leftleftarrows", 8647, 0},
-{L"leftrightarrow", 8596, 0},
-{L"leftrightarrows", 8646, 0},
-{L"leftrightharpoons", 8651, 0},
-{L"leftrightsquigarrow", 8621, 0},
-{L"leftthreetimes", 8907, 0},
-{L"leg", 8922, 0},
-{L"leq", 8804, 0},
-{L"leqq", 8806, 0},
-{L"leqslant", 10877, 0},
-{L"les", 10877, 0},
-{L"lescc", 10920, 0},
-{L"lesdot", 10879, 0},
-{L"lesdoto", 10881, 0},
-{L"lesdotor", 10883, 0},
-{L"lesg", 8922, 65024},
-{L"lesges", 10899, 0},
-{L"lessapprox", 10885, 0},
-{L"lessdot", 8918, 0},
-{L"lesseqgtr", 8922, 0},
-{L"lesseqqgtr", 10891, 0},
-{L"lessgtr", 8822, 0},
-{L"lesssim", 8818, 0},
-{L"lfisht", 10620, 0},
-{L"lfloor", 8970, 0},
-{L"lfr", 120105, 0},
-{L"lg", 8822, 0},
-{L"lgE", 10897, 0},
-{L"lhard", 8637, 0},
-{L"lharu", 8636, 0},
-{L"lharul", 10602, 0},
-{L"lhblk", 9604, 0},
-{L"ljcy", 1113, 0},
-{L"ll", 8810, 0},
-{L"llarr", 8647, 0},
-{L"llcorner", 8990, 0},
-{L"llhard", 10603, 0},
-{L"lltri", 9722, 0},
-{L"lmidot", 320, 0},
-{L"lmoust", 9136, 0},
-{L"lmoustache", 9136, 0},
-{L"lnE", 8808, 0},
-{L"lnap", 10889, 0},
-{L"lnapprox", 10889, 0},
-{L"lne", 10887, 0},
-{L"lneq", 10887, 0},
-{L"lneqq", 8808, 0},
-{L"lnsim", 8934, 0},
-{L"loang", 10220, 0},
-{L"loarr", 8701, 0},
-{L"lobrk", 10214, 0},
-{L"longleftarrow", 10229, 0},
-{L"longleftrightarrow", 10231, 0},
-{L"longmapsto", 10236, 0},
-{L"longrightarrow", 10230, 0},
-{L"looparrowleft", 8619, 0},
-{L"looparrowright", 8620, 0},
-{L"lopar", 10629, 0},
-{L"lopf", 120157, 0},
-{L"loplus", 10797, 0},
-{L"lotimes", 10804, 0},
-{L"lowast", 8727, 0},
-{L"lowbar", 95, 0},
-{L"loz", 9674, 0},
-{L"lozenge", 9674, 0},
-{L"lozf", 10731, 0},
-{L"lpar", 40, 0},
-{L"lparlt", 10643, 0},
-{L"lrarr", 8646, 0},
-{L"lrcorner", 8991, 0},
-{L"lrhar", 8651, 0},
-{L"lrhard", 10605, 0},
-{L"lrm", 8206, 0},
-{L"lrtri", 8895, 0},
-{L"lsaquo", 8249, 0},
-{L"lscr", 120001, 0},
-{L"lsh", 8624, 0},
-{L"lsim", 8818, 0},
-{L"lsime", 10893, 0},
-{L"lsimg", 10895, 0},
-{L"lsqb", 91, 0},
-{L"lsquo", 8216, 0},
-{L"lsquor", 8218, 0},
-{L"lstrok", 322, 0},
-{L"lt", 60, 0},
-{L"ltcc", 10918, 0},
-{L"ltcir", 10873, 0},
-{L"ltdot", 8918, 0},
-{L"lthree", 8907, 0},
-{L"ltimes", 8905, 0},
-{L"ltlarr", 10614, 0},
-{L"ltquest", 10875, 0},
-{L"ltrPar", 10646, 0},
-{L"ltri", 9667, 0},
-{L"ltrie", 8884, 0},
-{L"ltrif", 9666, 0},
-{L"lurdshar", 10570, 0},
-{L"luruhar", 10598, 0},
-{L"lvertneqq", 8808, 65024},
-{L"lvnE", 8808, 65024},
-{L"mDDot", 8762, 0},
-{L"macr", 175, 0},
-{L"male", 9794, 0},
-{L"malt", 10016, 0},
-{L"maltese", 10016, 0},
-{L"map", 8614, 0},
-{L"mapsto", 8614, 0},
-{L"mapstodown", 8615, 0},
-{L"mapstoleft", 8612, 0},
-{L"mapstoup", 8613, 0},
-{L"marker", 9646, 0},
-{L"mcomma", 10793, 0},
-{L"mcy", 1084, 0},
-{L"mdash", 8212, 0},
-{L"measuredangle", 8737, 0},
-{L"mfr", 120106, 0},
-{L"mho", 8487, 0},
-{L"micro", 181, 0},
-{L"mid", 8739, 0},
-{L"midast", 42, 0},
-{L"midcir", 10992, 0},
-{L"middot", 183, 0},
-{L"minus", 8722, 0},
-{L"minusb", 8863, 0},
-{L"minusd", 8760, 0},
-{L"minusdu", 10794, 0},
-{L"mlcp", 10971, 0},
-{L"mldr", 8230, 0},
-{L"mnplus", 8723, 0},
-{L"models", 8871, 0},
-{L"mopf", 120158, 0},
-{L"mp", 8723, 0},
-{L"mscr", 120002, 0},
-{L"mstpos", 8766, 0},
-{L"mu", 956, 0},
-{L"multimap", 8888, 0},
-{L"mumap", 8888, 0},
-{L"nGg", 8921, 824},
-{L"nGt", 8811, 8402},
-{L"nGtv", 8811, 824},
-{L"nLeftarrow", 8653, 0},
-{L"nLeftrightarrow", 8654, 0},
-{L"nLl", 8920, 824},
-{L"nLt", 8810, 8402},
-{L"nLtv", 8810, 824},
-{L"nRightarrow", 8655, 0},
-{L"nVDash", 8879, 0},
-{L"nVdash", 8878, 0},
-{L"nabla", 8711, 0},
-{L"nacute", 324, 0},
-{L"nang", 8736, 8402},
-{L"nap", 8777, 0},
-{L"napE", 10864, 824},
-{L"napid", 8779, 824},
-{L"napos", 329, 0},
-{L"napprox", 8777, 0},
-{L"natur", 9838, 0},
-{L"natural", 9838, 0},
-{L"naturals", 8469, 0},
-{L"nbsp", 160, 0},
-{L"nbump", 8782, 824},
-{L"nbumpe", 8783, 824},
-{L"ncap", 10819, 0},
-{L"ncaron", 328, 0},
-{L"ncedil", 326, 0},
-{L"ncong", 8775, 0},
-{L"ncongdot", 10861, 824},
-{L"ncup", 10818, 0},
-{L"ncy", 1085, 0},
-{L"ndash", 8211, 0},
-{L"ne", 8800, 0},
-{L"neArr", 8663, 0},
-{L"nearhk", 10532, 0},
-{L"nearr", 8599, 0},
-{L"nearrow", 8599, 0},
-{L"nedot", 8784, 824},
-{L"nequiv", 8802, 0},
-{L"nesear", 10536, 0},
-{L"nesim", 8770, 824},
-{L"nexist", 8708, 0},
-{L"nexists", 8708, 0},
-{L"nfr", 120107, 0},
-{L"ngE", 8807, 824},
-{L"nge", 8817, 0},
-{L"ngeq", 8817, 0},
-{L"ngeqq", 8807, 824},
-{L"ngeqslant", 10878, 824},
-{L"nges", 10878, 824},
-{L"ngsim", 8821, 0},
-{L"ngt", 8815, 0},
-{L"ngtr", 8815, 0},
-{L"nhArr", 8654, 0},
-{L"nharr", 8622, 0},
-{L"nhpar", 10994, 0},
-{L"ni", 8715, 0},
-{L"nis", 8956, 0},
-{L"nisd", 8954, 0},
-{L"niv", 8715, 0},
-{L"njcy", 1114, 0},
-{L"nlArr", 8653, 0},
-{L"nlE", 8806, 824},
-{L"nlarr", 8602, 0},
-{L"nldr", 8229, 0},
-{L"nle", 8816, 0},
-{L"nleftarrow", 8602, 0},
-{L"nleftrightarrow", 8622, 0},
-{L"nleq", 8816, 0},
-{L"nleqq", 8806, 824},
-{L"nleqslant", 10877, 824},
-{L"nles", 10877, 824},
-{L"nless", 8814, 0},
-{L"nlsim", 8820, 0},
-{L"nlt", 8814, 0},
-{L"nltri", 8938, 0},
-{L"nltrie", 8940, 0},
-{L"nmid", 8740, 0},
-{L"nopf", 120159, 0},
-{L"not", 172, 0},
-{L"notin", 8713, 0},
-{L"notinE", 8953, 824},
-{L"notindot", 8949, 824},
-{L"notinva", 8713, 0},
-{L"notinvb", 8951, 0},
-{L"notinvc", 8950, 0},
-{L"notni", 8716, 0},
-{L"notniva", 8716, 0},
-{L"notnivb", 8958, 0},
-{L"notnivc", 8957, 0},
-{L"npar", 8742, 0},
-{L"nparallel", 8742, 0},
-{L"nparsl", 11005, 8421},
-{L"npart", 8706, 824},
-{L"npolint", 10772, 0},
-{L"npr", 8832, 0},
-{L"nprcue", 8928, 0},
-{L"npre", 10927, 824},
-{L"nprec", 8832, 0},
-{L"npreceq", 10927, 824},
-{L"nrArr", 8655, 0},
-{L"nrarr", 8603, 0},
-{L"nrarrc", 10547, 824},
-{L"nrarrw", 8605, 824},
-{L"nrightarrow", 8603, 0},
-{L"nrtri", 8939, 0},
-{L"nrtrie", 8941, 0},
-{L"nsc", 8833, 0},
-{L"nsccue", 8929, 0},
-{L"nsce", 10928, 824},
-{L"nscr", 120003, 0},
-{L"nshortmid", 8740, 0},
-{L"nshortparallel", 8742, 0},
-{L"nsim", 8769, 0},
-{L"nsime", 8772, 0},
-{L"nsimeq", 8772, 0},
-{L"nsmid", 8740, 0},
-{L"nspar", 8742, 0},
-{L"nsqsube", 8930, 0},
-{L"nsqsupe", 8931, 0},
-{L"nsub", 8836, 0},
-{L"nsubE", 10949, 824},
-{L"nsube", 8840, 0},
-{L"nsubset", 8834, 8402},
-{L"nsubseteq", 8840, 0},
-{L"nsubseteqq", 10949, 824},
-{L"nsucc", 8833, 0},
-{L"nsucceq", 10928, 824},
-{L"nsup", 8837, 0},
-{L"nsupE", 10950, 824},
-{L"nsupe", 8841, 0},
-{L"nsupset", 8835, 8402},
-{L"nsupseteq", 8841, 0},
-{L"nsupseteqq", 10950, 824},
-{L"ntgl", 8825, 0},
-{L"ntilde", 241, 0},
-{L"ntlg", 8824, 0},
-{L"ntriangleleft", 8938, 0},
-{L"ntrianglelefteq", 8940, 0},
-{L"ntriangleright", 8939, 0},
-{L"ntrianglerighteq", 8941, 0},
-{L"nu", 957, 0},
-{L"num", 35, 0},
-{L"numero", 8470, 0},
-{L"numsp", 8199, 0},
-{L"nvDash", 8877, 0},
-{L"nvHarr", 10500, 0},
-{L"nvap", 8781, 8402},
-{L"nvdash", 8876, 0},
-{L"nvge", 8805, 8402},
-{L"nvgt", 62, 8402},
-{L"nvinfin", 10718, 0},
-{L"nvlArr", 10498, 0},
-{L"nvle", 8804, 8402},
-{L"nvlt", 60, 8402},
-{L"nvltrie", 8884, 8402},
-{L"nvrArr", 10499, 0},
-{L"nvrtrie", 8885, 8402},
-{L"nvsim", 8764, 8402},
-{L"nwArr", 8662, 0},
-{L"nwarhk", 10531, 0},
-{L"nwarr", 8598, 0},
-{L"nwarrow", 8598, 0},
-{L"nwnear", 10535, 0},
-{L"oS", 9416, 0},
-{L"oacute", 243, 0},
-{L"oast", 8859, 0},
-{L"ocir", 8858, 0},
-{L"ocirc", 244, 0},
-{L"ocy", 1086, 0},
-{L"odash", 8861, 0},
-{L"odblac", 337, 0},
-{L"odiv", 10808, 0},
-{L"odot", 8857, 0},
-{L"odsold", 10684, 0},
-{L"oelig", 339, 0},
-{L"ofcir", 10687, 0},
-{L"ofr", 120108, 0},
-{L"ogon", 731, 0},
-{L"ograve", 242, 0},
-{L"ogt", 10689, 0},
-{L"ohbar", 10677, 0},
-{L"ohm", 937, 0},
-{L"oint", 8750, 0},
-{L"olarr", 8634, 0},
-{L"olcir", 10686, 0},
-{L"olcross", 10683, 0},
-{L"oline", 8254, 0},
-{L"olt", 10688, 0},
-{L"omacr", 333, 0},
-{L"omega", 969, 0},
-{L"omicron", 959, 0},
-{L"omid", 10678, 0},
-{L"ominus", 8854, 0},
-{L"oopf", 120160, 0},
-{L"opar", 10679, 0},
-{L"operp", 10681, 0},
-{L"oplus", 8853, 0},
-{L"or", 8744, 0},
-{L"orarr", 8635, 0},
-{L"ord", 10845, 0},
-{L"order", 8500, 0},
-{L"orderof", 8500, 0},
-{L"ordf", 170, 0},
-{L"ordm", 186, 0},
-{L"origof", 8886, 0},
-{L"oror", 10838, 0},
-{L"orslope", 10839, 0},
-{L"orv", 10843, 0},
-{L"oscr", 8500, 0},
-{L"oslash", 248, 0},
-{L"osol", 8856, 0},
-{L"otilde", 245, 0},
-{L"otimes", 8855, 0},
-{L"otimesas", 10806, 0},
-{L"ouml", 246, 0},
-{L"ovbar", 9021, 0},
-{L"par", 8741, 0},
-{L"para", 182, 0},
-{L"parallel", 8741, 0},
-{L"parsim", 10995, 0},
-{L"parsl", 11005, 0},
-{L"part", 8706, 0},
-{L"pcy", 1087, 0},
-{L"percnt", 37, 0},
-{L"period", 46, 0},
-{L"permil", 8240, 0},
-{L"perp", 8869, 0},
-{L"pertenk", 8241, 0},
-{L"pfr", 120109, 0},
-{L"phi", 966, 0},
-{L"phiv", 981, 0},
-{L"phmmat", 8499, 0},
-{L"phone", 9742, 0},
-{L"pi", 960, 0},
-{L"pitchfork", 8916, 0},
-{L"piv", 982, 0},
-{L"planck", 8463, 0},
-{L"planckh", 8462, 0},
-{L"plankv", 8463, 0},
-{L"plus", 43, 0},
-{L"plusacir", 10787, 0},
-{L"plusb", 8862, 0},
-{L"pluscir", 10786, 0},
-{L"plusdo", 8724, 0},
-{L"plusdu", 10789, 0},
-{L"pluse", 10866, 0},
-{L"plusmn", 177, 0},
-{L"plussim", 10790, 0},
-{L"plustwo", 10791, 0},
-{L"pm", 177, 0},
-{L"pointint", 10773, 0},
-{L"popf", 120161, 0},
-{L"pound", 163, 0},
-{L"pr", 8826, 0},
-{L"prE", 10931, 0},
-{L"prap", 10935, 0},
-{L"prcue", 8828, 0},
-{L"pre", 10927, 0},
-{L"prec", 8826, 0},
-{L"precapprox", 10935, 0},
-{L"preccurlyeq", 8828, 0},
-{L"preceq", 10927, 0},
-{L"precnapprox", 10937, 0},
-{L"precneqq", 10933, 0},
-{L"precnsim", 8936, 0},
-{L"precsim", 8830, 0},
-{L"prime", 8242, 0},
-{L"primes", 8473, 0},
-{L"prnE", 10933, 0},
-{L"prnap", 10937, 0},
-{L"prnsim", 8936, 0},
-{L"prod", 8719, 0},
-{L"profalar", 9006, 0},
-{L"profline", 8978, 0},
-{L"profsurf", 8979, 0},
-{L"prop", 8733, 0},
-{L"propto", 8733, 0},
-{L"prsim", 8830, 0},
-{L"prurel", 8880, 0},
-{L"pscr", 120005, 0},
-{L"psi", 968, 0},
-{L"puncsp", 8200, 0},
-{L"qfr", 120110, 0},
-{L"qint", 10764, 0},
-{L"qopf", 120162, 0},
-{L"qprime", 8279, 0},
-{L"qscr", 120006, 0},
-{L"quaternions", 8461, 0},
-{L"quatint", 10774, 0},
-{L"quest", 63, 0},
-{L"questeq", 8799, 0},
-{L"quot", 34, 0},
-{L"rAarr", 8667, 0},
-{L"rArr", 8658, 0},
-{L"rAtail", 10524, 0},
-{L"rBarr", 10511, 0},
-{L"rHar", 10596, 0},
-{L"race", 8765, 817},
-{L"racute", 341, 0},
-{L"radic", 8730, 0},
-{L"raemptyv", 10675, 0},
-{L"rang", 10217, 0},
-{L"rangd", 10642, 0},
-{L"range", 10661, 0},
-{L"rangle", 10217, 0},
-{L"raquo", 187, 0},
-{L"rarr", 8594, 0},
-{L"rarrap", 10613, 0},
-{L"rarrb", 8677, 0},
-{L"rarrbfs", 10528, 0},
-{L"rarrc", 10547, 0},
-{L"rarrfs", 10526, 0},
-{L"rarrhk", 8618, 0},
-{L"rarrlp", 8620, 0},
-{L"rarrpl", 10565, 0},
-{L"rarrsim", 10612, 0},
-{L"rarrtl", 8611, 0},
-{L"rarrw", 8605, 0},
-{L"ratail", 10522, 0},
-{L"ratio", 8758, 0},
-{L"rationals", 8474, 0},
-{L"rbarr", 10509, 0},
-{L"rbbrk", 10099, 0},
-{L"rbrace", 125, 0},
-{L"rbrack", 93, 0},
-{L"rbrke", 10636, 0},
-{L"rbrksld", 10638, 0},
-{L"rbrkslu", 10640, 0},
-{L"rcaron", 345, 0},
-{L"rcedil", 343, 0},
-{L"rceil", 8969, 0},
-{L"rcub", 125, 0},
-{L"rcy", 1088, 0},
-{L"rdca", 10551, 0},
-{L"rdldhar", 10601, 0},
-{L"rdquo", 8221, 0},
-{L"rdquor", 8221, 0},
-{L"rdsh", 8627, 0},
-{L"real", 8476, 0},
-{L"realine", 8475, 0},
-{L"realpart", 8476, 0},
-{L"reals", 8477, 0},
-{L"rect", 9645, 0},
-{L"reg", 174, 0},
-{L"rfisht", 10621, 0},
-{L"rfloor", 8971, 0},
-{L"rfr", 120111, 0},
-{L"rhard", 8641, 0},
-{L"rharu", 8640, 0},
-{L"rharul", 10604, 0},
-{L"rho", 961, 0},
-{L"rhov", 1009, 0},
-{L"rightarrow", 8594, 0},
-{L"rightarrowtail", 8611, 0},
-{L"rightharpoondown", 8641, 0},
-{L"rightharpoonup", 8640, 0},
-{L"rightleftarrows", 8644, 0},
-{L"rightleftharpoons", 8652, 0},
-{L"rightrightarrows", 8649, 0},
-{L"rightsquigarrow", 8605, 0},
-{L"rightthreetimes", 8908, 0},
-{L"ring", 730, 0},
-{L"risingdotseq", 8787, 0},
-{L"rlarr", 8644, 0},
-{L"rlhar", 8652, 0},
-{L"rlm", 8207, 0},
-{L"rmoust", 9137, 0},
-{L"rmoustache", 9137, 0},
-{L"rnmid", 10990, 0},
-{L"roang", 10221, 0},
-{L"roarr", 8702, 0},
-{L"robrk", 10215, 0},
-{L"ropar", 10630, 0},
-{L"ropf", 120163, 0},
-{L"roplus", 10798, 0},
-{L"rotimes", 10805, 0},
-{L"rpar", 41, 0},
-{L"rpargt", 10644, 0},
-{L"rppolint", 10770, 0},
-{L"rrarr", 8649, 0},
-{L"rsaquo", 8250, 0},
-{L"rscr", 120007, 0},
-{L"rsh", 8625, 0},
-{L"rsqb", 93, 0},
-{L"rsquo", 8217, 0},
-{L"rsquor", 8217, 0},
-{L"rthree", 8908, 0},
-{L"rtimes", 8906, 0},
-{L"rtri", 9657, 0},
-{L"rtrie", 8885, 0},
-{L"rtrif", 9656, 0},
-{L"rtriltri", 10702, 0},
-{L"ruluhar", 10600, 0},
-{L"rx", 8478, 0},
-{L"sacute", 347, 0},
-{L"sbquo", 8218, 0},
-{L"sc", 8827, 0},
-{L"scE", 10932, 0},
-{L"scap", 10936, 0},
-{L"scaron", 353, 0},
-{L"sccue", 8829, 0},
-{L"sce", 10928, 0},
-{L"scedil", 351, 0},
-{L"scirc", 349, 0},
-{L"scnE", 10934, 0},
-{L"scnap", 10938, 0},
-{L"scnsim", 8937, 0},
-{L"scpolint", 10771, 0},
-{L"scsim", 8831, 0},
-{L"scy", 1089, 0},
-{L"sdot", 8901, 0},
-{L"sdotb", 8865, 0},
-{L"sdote", 10854, 0},
-{L"seArr", 8664, 0},
-{L"searhk", 10533, 0},
-{L"searr", 8600, 0},
-{L"searrow", 8600, 0},
-{L"sect", 167, 0},
-{L"semi", 59, 0},
-{L"seswar", 10537, 0},
-{L"setminus", 8726, 0},
-{L"setmn", 8726, 0},
-{L"sext", 10038, 0},
-{L"sfr", 120112, 0},
-{L"sfrown", 8994, 0},
-{L"sharp", 9839, 0},
-{L"shchcy", 1097, 0},
-{L"shcy", 1096, 0},
-{L"shortmid", 8739, 0},
-{L"shortparallel", 8741, 0},
-{L"shy", 173, 0},
-{L"sigma", 963, 0},
-{L"sigmaf", 962, 0},
-{L"sigmav", 962, 0},
-{L"sim", 8764, 0},
-{L"simdot", 10858, 0},
-{L"sime", 8771, 0},
-{L"simeq", 8771, 0},
-{L"simg", 10910, 0},
-{L"simgE", 10912, 0},
-{L"siml", 10909, 0},
-{L"simlE", 10911, 0},
-{L"simne", 8774, 0},
-{L"simplus", 10788, 0},
-{L"simrarr", 10610, 0},
-{L"slarr", 8592, 0},
-{L"smallsetminus", 8726, 0},
-{L"smashp", 10803, 0},
-{L"smeparsl", 10724, 0},
-{L"smid", 8739, 0},
-{L"smile", 8995, 0},
-{L"smt", 10922, 0},
-{L"smte", 10924, 0},
-{L"smtes", 10924, 65024},
-{L"softcy", 1100, 0},
-{L"sol", 47, 0},
-{L"solb", 10692, 0},
-{L"solbar", 9023, 0},
-{L"sopf", 120164, 0},
-{L"spades", 9824, 0},
-{L"spadesuit", 9824, 0},
-{L"spar", 8741, 0},
-{L"sqcap", 8851, 0},
-{L"sqcaps", 8851, 65024},
-{L"sqcup", 8852, 0},
-{L"sqcups", 8852, 65024},
-{L"sqsub", 8847, 0},
-{L"sqsube", 8849, 0},
-{L"sqsubset", 8847, 0},
-{L"sqsubseteq", 8849, 0},
-{L"sqsup", 8848, 0},
-{L"sqsupe", 8850, 0},
-{L"sqsupset", 8848, 0},
-{L"sqsupseteq", 8850, 0},
-{L"squ", 9633, 0},
-{L"square", 9633, 0},
-{L"squarf", 9642, 0},
-{L"squf", 9642, 0},
-{L"srarr", 8594, 0},
-{L"sscr", 120008, 0},
-{L"ssetmn", 8726, 0},
-{L"ssmile", 8995, 0},
-{L"sstarf", 8902, 0},
-{L"star", 9734, 0},
-{L"starf", 9733, 0},
-{L"straightepsilon", 1013, 0},
-{L"straightphi", 981, 0},
-{L"strns", 175, 0},
-{L"sub", 8834, 0},
-{L"subE", 10949, 0},
-{L"subdot", 10941, 0},
-{L"sube", 8838, 0},
-{L"subedot", 10947, 0},
-{L"submult", 10945, 0},
-{L"subnE", 10955, 0},
-{L"subne", 8842, 0},
-{L"subplus", 10943, 0},
-{L"subrarr", 10617, 0},
-{L"subset", 8834, 0},
-{L"subseteq", 8838, 0},
-{L"subseteqq", 10949, 0},
-{L"subsetneq", 8842, 0},
-{L"subsetneqq", 10955, 0},
-{L"subsim", 10951, 0},
-{L"subsub", 10965, 0},
-{L"subsup", 10963, 0},
-{L"succ", 8827, 0},
-{L"succapprox", 10936, 0},
-{L"succcurlyeq", 8829, 0},
-{L"succeq", 10928, 0},
-{L"succnapprox", 10938, 0},
-{L"succneqq", 10934, 0},
-{L"succnsim", 8937, 0},
-{L"succsim", 8831, 0},
-{L"sum", 8721, 0},
-{L"sung", 9834, 0},
-{L"sup", 8835, 0},
-{L"sup1", 185, 0},
-{L"sup2", 178, 0},
-{L"sup3", 179, 0},
-{L"supE", 10950, 0},
-{L"supdot", 10942, 0},
-{L"supdsub", 10968, 0},
-{L"supe", 8839, 0},
-{L"supedot", 10948, 0},
-{L"suphsol", 10185, 0},
-{L"suphsub", 10967, 0},
-{L"suplarr", 10619, 0},
-{L"supmult", 10946, 0},
-{L"supnE", 10956, 0},
-{L"supne", 8843, 0},
-{L"supplus", 10944, 0},
-{L"supset", 8835, 0},
-{L"supseteq", 8839, 0},
-{L"supseteqq", 10950, 0},
-{L"supsetneq", 8843, 0},
-{L"supsetneqq", 10956, 0},
-{L"supsim", 10952, 0},
-{L"supsub", 10964, 0},
-{L"supsup", 10966, 0},
-{L"swArr", 8665, 0},
-{L"swarhk", 10534, 0},
-{L"swarr", 8601, 0},
-{L"swarrow", 8601, 0},
-{L"swnwar", 10538, 0},
-{L"szlig", 223, 0},
-{L"target", 8982, 0},
-{L"tau", 964, 0},
-{L"tbrk", 9140, 0},
-{L"tcaron", 357, 0},
-{L"tcedil", 355, 0},
-{L"tcy", 1090, 0},
-{L"tdot", 8411, 0},
-{L"telrec", 8981, 0},
-{L"tfr", 120113, 0},
-{L"there4", 8756, 0},
-{L"therefore", 8756, 0},
-{L"theta", 952, 0},
-{L"thetasym", 977, 0},
-{L"thetav", 977, 0},
-{L"thickapprox", 8776, 0},
-{L"thicksim", 8764, 0},
-{L"thinsp", 8201, 0},
-{L"thkap", 8776, 0},
-{L"thksim", 8764, 0},
-{L"thorn", 254, 0},
-{L"tilde", 732, 0},
-{L"times", 215, 0},
-{L"timesb", 8864, 0},
-{L"timesbar", 10801, 0},
-{L"timesd", 10800, 0},
-{L"tint", 8749, 0},
-{L"toea", 10536, 0},
-{L"top", 8868, 0},
-{L"topbot", 9014, 0},
-{L"topcir", 10993, 0},
-{L"topf", 120165, 0},
-{L"topfork", 10970, 0},
-{L"tosa", 10537, 0},
-{L"tprime", 8244, 0},
-{L"trade", 8482, 0},
-{L"triangle", 9653, 0},
-{L"triangledown", 9663, 0},
-{L"triangleleft", 9667, 0},
-{L"trianglelefteq", 8884, 0},
-{L"triangleq", 8796, 0},
-{L"triangleright", 9657, 0},
-{L"trianglerighteq", 8885, 0},
-{L"tridot", 9708, 0},
-{L"trie", 8796, 0},
-{L"triminus", 10810, 0},
-{L"triplus", 10809, 0},
-{L"trisb", 10701, 0},
-{L"tritime", 10811, 0},
-{L"trpezium", 9186, 0},
-{L"tscr", 120009, 0},
-{L"tscy", 1094, 0},
-{L"tshcy", 1115, 0},
-{L"tstrok", 359, 0},
-{L"twixt", 8812, 0},
-{L"twoheadleftarrow", 8606, 0},
-{L"twoheadrightarrow", 8608, 0},
-{L"uArr", 8657, 0},
-{L"uHar", 10595, 0},
-{L"uacute", 250, 0},
-{L"uarr", 8593, 0},
-{L"ubrcy", 1118, 0},
-{L"ubreve", 365, 0},
-{L"ucirc", 251, 0},
-{L"ucy", 1091, 0},
-{L"udarr", 8645, 0},
-{L"udblac", 369, 0},
-{L"udhar", 10606, 0},
-{L"ufisht", 10622, 0},
-{L"ufr", 120114, 0},
-{L"ugrave", 249, 0},
-{L"uharl", 8639, 0},
-{L"uharr", 8638, 0},
-{L"uhblk", 9600, 0},
-{L"ulcorn", 8988, 0},
-{L"ulcorner", 8988, 0},
-{L"ulcrop", 8975, 0},
-{L"ultri", 9720, 0},
-{L"umacr", 363, 0},
-{L"uml", 168, 0},
-{L"uogon", 371, 0},
-{L"uopf", 120166, 0},
-{L"uparrow", 8593, 0},
-{L"updownarrow", 8597, 0},
-{L"upharpoonleft", 8639, 0},
-{L"upharpoonright", 8638, 0},
-{L"uplus", 8846, 0},
-{L"upsi", 965, 0},
-{L"upsih", 978, 0},
-{L"upsilon", 965, 0},
-{L"upuparrows", 8648, 0},
-{L"urcorn", 8989, 0},
-{L"urcorner", 8989, 0},
-{L"urcrop", 8974, 0},
-{L"uring", 367, 0},
-{L"urtri", 9721, 0},
-{L"uscr", 120010, 0},
-{L"utdot", 8944, 0},
-{L"utilde", 361, 0},
-{L"utri", 9653, 0},
-{L"utrif", 9652, 0},
-{L"uuarr", 8648, 0},
-{L"uuml", 252, 0},
-{L"uwangle", 10663, 0},
-{L"vArr", 8661, 0},
-{L"vBar", 10984, 0},
-{L"vBarv", 10985, 0},
-{L"vDash", 8872, 0},
-{L"vangrt", 10652, 0},
-{L"varepsilon", 1013, 0},
-{L"varkappa", 1008, 0},
-{L"varnothing", 8709, 0},
-{L"varphi", 981, 0},
-{L"varpi", 982, 0},
-{L"varpropto", 8733, 0},
-{L"varr", 8597, 0},
-{L"varrho", 1009, 0},
-{L"varsigma", 962, 0},
-{L"varsubsetneq", 8842, 65024},
-{L"varsubsetneqq", 10955, 65024},
-{L"varsupsetneq", 8843, 65024},
-{L"varsupsetneqq", 10956, 65024},
-{L"vartheta", 977, 0},
-{L"vartriangleleft", 8882, 0},
-{L"vartriangleright", 8883, 0},
-{L"vcy", 1074, 0},
-{L"vdash", 8866, 0},
-{L"vee", 8744, 0},
-{L"veebar", 8891, 0},
-{L"veeeq", 8794, 0},
-{L"vellip", 8942, 0},
-{L"verbar", 124, 0},
-{L"vert", 124, 0},
-{L"vfr", 120115, 0},
-{L"vltri", 8882, 0},
-{L"vnsub", 8834, 8402},
-{L"vnsup", 8835, 8402},
-{L"vopf", 120167, 0},
-{L"vprop", 8733, 0},
-{L"vrtri", 8883, 0},
-{L"vscr", 120011, 0},
-{L"vsubnE", 10955, 65024},
-{L"vsubne", 8842, 65024},
-{L"vsupnE", 10956, 65024},
-{L"vsupne", 8843, 65024},
-{L"vzigzag", 10650, 0},
-{L"wcirc", 373, 0},
-{L"wedbar", 10847, 0},
-{L"wedge", 8743, 0},
-{L"wedgeq", 8793, 0},
-{L"weierp", 8472, 0},
-{L"wfr", 120116, 0},
-{L"wopf", 120168, 0},
-{L"wp", 8472, 0},
-{L"wr", 8768, 0},
-{L"wreath", 8768, 0},
-{L"wscr", 120012, 0},
-{L"xcap", 8898, 0},
-{L"xcirc", 9711, 0},
-{L"xcup", 8899, 0},
-{L"xdtri", 9661, 0},
-{L"xfr", 120117, 0},
-{L"xhArr", 10234, 0},
-{L"xharr", 10231, 0},
-{L"xi", 958, 0},
-{L"xlArr", 10232, 0},
-{L"xlarr", 10229, 0},
-{L"xmap", 10236, 0},
-{L"xnis", 8955, 0},
-{L"xodot", 10752, 0},
-{L"xopf", 120169, 0},
-{L"xoplus", 10753, 0},
-{L"xotime", 10754, 0},
-{L"xrArr", 10233, 0},
-{L"xrarr", 10230, 0},
-{L"xscr", 120013, 0},
-{L"xsqcup", 10758, 0},
-{L"xuplus", 10756, 0},
-{L"xutri", 9651, 0},
-{L"xvee", 8897, 0},
-{L"xwedge", 8896, 0},
-{L"yacute", 253, 0},
-{L"yacy", 1103, 0},
-{L"ycirc", 375, 0},
-{L"ycy", 1099, 0},
-{L"yen", 165, 0},
-{L"yfr", 120118, 0},
-{L"yicy", 1111, 0},
-{L"yopf", 120170, 0},
-{L"yscr", 120014, 0},
-{L"yucy", 1102, 0},
-{L"yuml", 255, 0},
-{L"zacute", 378, 0},
-{L"zcaron", 382, 0},
-{L"zcy", 1079, 0},
-{L"zdot", 380, 0},
-{L"zeetrf", 8488, 0},
-{L"zeta", 950, 0},
-{L"zfr", 120119, 0},
-{L"zhcy", 1078, 0},
-{L"zigrarr", 8669, 0},
-{L"zopf", 120171, 0},
-{L"zscr", 120015, 0},
-{L"zwj", 8205, 0},
-{L"zwnj", 8204, 0},
+{U"AElig", 198, 0},
+{U"AMP", 38, 0},
+{U"Aacute", 193, 0},
+{U"Abreve", 258, 0},
+{U"Acirc", 194, 0},
+{U"Acy", 1040, 0},
+{U"Afr", 120068, 0},
+{U"Agrave", 192, 0},
+{U"Alpha", 913, 0},
+{U"Amacr", 256, 0},
+{U"And", 10835, 0},
+{U"Aogon", 260, 0},
+{U"Aopf", 120120, 0},
+{U"ApplyFunction", 8289, 0},
+{U"Aring", 197, 0},
+{U"Ascr", 119964, 0},
+{U"Assign", 8788, 0},
+{U"Atilde", 195, 0},
+{U"Auml", 196, 0},
+{U"Backslash", 8726, 0},
+{U"Barv", 10983, 0},
+{U"Barwed", 8966, 0},
+{U"Bcy", 1041, 0},
+{U"Because", 8757, 0},
+{U"Bernoullis", 8492, 0},
+{U"Beta", 914, 0},
+{U"Bfr", 120069, 0},
+{U"Bopf", 120121, 0},
+{U"Breve", 728, 0},
+{U"Bscr", 8492, 0},
+{U"Bumpeq", 8782, 0},
+{U"CHcy", 1063, 0},
+{U"COPY", 169, 0},
+{U"Cacute", 262, 0},
+{U"Cap", 8914, 0},
+{U"CapitalDifferentialD", 8517, 0},
+{U"Cayleys", 8493, 0},
+{U"Ccaron", 268, 0},
+{U"Ccedil", 199, 0},
+{U"Ccirc", 264, 0},
+{U"Cconint", 8752, 0},
+{U"Cdot", 266, 0},
+{U"Cedilla", 184, 0},
+{U"CenterDot", 183, 0},
+{U"Cfr", 8493, 0},
+{U"Chi", 935, 0},
+{U"CircleDot", 8857, 0},
+{U"CircleMinus", 8854, 0},
+{U"CirclePlus", 8853, 0},
+{U"CircleTimes", 8855, 0},
+{U"ClockwiseContourIntegral", 8754, 0},
+{U"CloseCurlyDoubleQuote", 8221, 0},
+{U"CloseCurlyQuote", 8217, 0},
+{U"Colon", 8759, 0},
+{U"Colone", 10868, 0},
+{U"Congruent", 8801, 0},
+{U"Conint", 8751, 0},
+{U"ContourIntegral", 8750, 0},
+{U"Copf", 8450, 0},
+{U"Coproduct", 8720, 0},
+{U"CounterClockwiseContourIntegral", 8755, 0},
+{U"Cross", 10799, 0},
+{U"Cscr", 119966, 0},
+{U"Cup", 8915, 0},
+{U"CupCap", 8781, 0},
+{U"DD", 8517, 0},
+{U"DDotrahd", 10513, 0},
+{U"DJcy", 1026, 0},
+{U"DScy", 1029, 0},
+{U"DZcy", 1039, 0},
+{U"Dagger", 8225, 0},
+{U"Darr", 8609, 0},
+{U"Dashv", 10980, 0},
+{U"Dcaron", 270, 0},
+{U"Dcy", 1044, 0},
+{U"Del", 8711, 0},
+{U"Delta", 916, 0},
+{U"Dfr", 120071, 0},
+{U"DiacriticalAcute", 180, 0},
+{U"DiacriticalDot", 729, 0},
+{U"DiacriticalDoubleAcute", 733, 0},
+{U"DiacriticalGrave", 96, 0},
+{U"DiacriticalTilde", 732, 0},
+{U"Diamond", 8900, 0},
+{U"DifferentialD", 8518, 0},
+{U"Dopf", 120123, 0},
+{U"Dot", 168, 0},
+{U"DotDot", 8412, 0},
+{U"DotEqual", 8784, 0},
+{U"DoubleContourIntegral", 8751, 0},
+{U"DoubleDot", 168, 0},
+{U"DoubleDownArrow", 8659, 0},
+{U"DoubleLeftArrow", 8656, 0},
+{U"DoubleLeftRightArrow", 8660, 0},
+{U"DoubleLeftTee", 10980, 0},
+{U"DoubleLongLeftArrow", 10232, 0},
+{U"DoubleLongLeftRightArrow", 10234, 0},
+{U"DoubleLongRightArrow", 10233, 0},
+{U"DoubleRightArrow", 8658, 0},
+{U"DoubleRightTee", 8872, 0},
+{U"DoubleUpArrow", 8657, 0},
+{U"DoubleUpDownArrow", 8661, 0},
+{U"DoubleVerticalBar", 8741, 0},
+{U"DownArrow", 8595, 0},
+{U"DownArrowBar", 10515, 0},
+{U"DownArrowUpArrow", 8693, 0},
+{U"DownBreve", 785, 0},
+{U"DownLeftRightVector", 10576, 0},
+{U"DownLeftTeeVector", 10590, 0},
+{U"DownLeftVector", 8637, 0},
+{U"DownLeftVectorBar", 10582, 0},
+{U"DownRightTeeVector", 10591, 0},
+{U"DownRightVector", 8641, 0},
+{U"DownRightVectorBar", 10583, 0},
+{U"DownTee", 8868, 0},
+{U"DownTeeArrow", 8615, 0},
+{U"Downarrow", 8659, 0},
+{U"Dscr", 119967, 0},
+{U"Dstrok", 272, 0},
+{U"ENG", 330, 0},
+{U"ETH", 208, 0},
+{U"Eacute", 201, 0},
+{U"Ecaron", 282, 0},
+{U"Ecirc", 202, 0},
+{U"Ecy", 1069, 0},
+{U"Edot", 278, 0},
+{U"Efr", 120072, 0},
+{U"Egrave", 200, 0},
+{U"Element", 8712, 0},
+{U"Emacr", 274, 0},
+{U"EmptySmallSquare", 9723, 0},
+{U"EmptyVerySmallSquare", 9643, 0},
+{U"Eogon", 280, 0},
+{U"Eopf", 120124, 0},
+{U"Epsilon", 917, 0},
+{U"Equal", 10869, 0},
+{U"EqualTilde", 8770, 0},
+{U"Equilibrium", 8652, 0},
+{U"Escr", 8496, 0},
+{U"Esim", 10867, 0},
+{U"Eta", 919, 0},
+{U"Euml", 203, 0},
+{U"Exists", 8707, 0},
+{U"ExponentialE", 8519, 0},
+{U"Fcy", 1060, 0},
+{U"Ffr", 120073, 0},
+{U"FilledSmallSquare", 9724, 0},
+{U"FilledVerySmallSquare", 9642, 0},
+{U"Fopf", 120125, 0},
+{U"ForAll", 8704, 0},
+{U"Fouriertrf", 8497, 0},
+{U"Fscr", 8497, 0},
+{U"GJcy", 1027, 0},
+{U"GT", 62, 0},
+{U"Gamma", 915, 0},
+{U"Gammad", 988, 0},
+{U"Gbreve", 286, 0},
+{U"Gcedil", 290, 0},
+{U"Gcirc", 284, 0},
+{U"Gcy", 1043, 0},
+{U"Gdot", 288, 0},
+{U"Gfr", 120074, 0},
+{U"Gg", 8921, 0},
+{U"Gopf", 120126, 0},
+{U"GreaterEqual", 8805, 0},
+{U"GreaterEqualLess", 8923, 0},
+{U"GreaterFullEqual", 8807, 0},
+{U"GreaterGreater", 10914, 0},
+{U"GreaterLess", 8823, 0},
+{U"GreaterSlantEqual", 10878, 0},
+{U"GreaterTilde", 8819, 0},
+{U"Gscr", 119970, 0},
+{U"Gt", 8811, 0},
+{U"HARDcy", 1066, 0},
+{U"Hacek", 711, 0},
+{U"Hat", 94, 0},
+{U"Hcirc", 292, 0},
+{U"Hfr", 8460, 0},
+{U"HilbertSpace", 8459, 0},
+{U"Hopf", 8461, 0},
+{U"HorizontalLine", 9472, 0},
+{U"Hscr", 8459, 0},
+{U"Hstrok", 294, 0},
+{U"HumpDownHump", 8782, 0},
+{U"HumpEqual", 8783, 0},
+{U"IEcy", 1045, 0},
+{U"IJlig", 306, 0},
+{U"IOcy", 1025, 0},
+{U"Iacute", 205, 0},
+{U"Icirc", 206, 0},
+{U"Icy", 1048, 0},
+{U"Idot", 304, 0},
+{U"Ifr", 8465, 0},
+{U"Igrave", 204, 0},
+{U"Im", 8465, 0},
+{U"Imacr", 298, 0},
+{U"ImaginaryI", 8520, 0},
+{U"Implies", 8658, 0},
+{U"Int", 8748, 0},
+{U"Integral", 8747, 0},
+{U"Intersection", 8898, 0},
+{U"InvisibleComma", 8291, 0},
+{U"InvisibleTimes", 8290, 0},
+{U"Iogon", 302, 0},
+{U"Iopf", 120128, 0},
+{U"Iota", 921, 0},
+{U"Iscr", 8464, 0},
+{U"Itilde", 296, 0},
+{U"Iukcy", 1030, 0},
+{U"Iuml", 207, 0},
+{U"Jcirc", 308, 0},
+{U"Jcy", 1049, 0},
+{U"Jfr", 120077, 0},
+{U"Jopf", 120129, 0},
+{U"Jscr", 119973, 0},
+{U"Jsercy", 1032, 0},
+{U"Jukcy", 1028, 0},
+{U"KHcy", 1061, 0},
+{U"KJcy", 1036, 0},
+{U"Kappa", 922, 0},
+{U"Kcedil", 310, 0},
+{U"Kcy", 1050, 0},
+{U"Kfr", 120078, 0},
+{U"Kopf", 120130, 0},
+{U"Kscr", 119974, 0},
+{U"LJcy", 1033, 0},
+{U"LT", 60, 0},
+{U"Lacute", 313, 0},
+{U"Lambda", 923, 0},
+{U"Lang", 10218, 0},
+{U"Laplacetrf", 8466, 0},
+{U"Larr", 8606, 0},
+{U"Lcaron", 317, 0},
+{U"Lcedil", 315, 0},
+{U"Lcy", 1051, 0},
+{U"LeftAngleBracket", 10216, 0},
+{U"LeftArrow", 8592, 0},
+{U"LeftArrowBar", 8676, 0},
+{U"LeftArrowRightArrow", 8646, 0},
+{U"LeftCeiling", 8968, 0},
+{U"LeftDoubleBracket", 10214, 0},
+{U"LeftDownTeeVector", 10593, 0},
+{U"LeftDownVector", 8643, 0},
+{U"LeftDownVectorBar", 10585, 0},
+{U"LeftFloor", 8970, 0},
+{U"LeftRightArrow", 8596, 0},
+{U"LeftRightVector", 10574, 0},
+{U"LeftTee", 8867, 0},
+{U"LeftTeeArrow", 8612, 0},
+{U"LeftTeeVector", 10586, 0},
+{U"LeftTriangle", 8882, 0},
+{U"LeftTriangleBar", 10703, 0},
+{U"LeftTriangleEqual", 8884, 0},
+{U"LeftUpDownVector", 10577, 0},
+{U"LeftUpTeeVector", 10592, 0},
+{U"LeftUpVector", 8639, 0},
+{U"LeftUpVectorBar", 10584, 0},
+{U"LeftVector", 8636, 0},
+{U"LeftVectorBar", 10578, 0},
+{U"Leftarrow", 8656, 0},
+{U"Leftrightarrow", 8660, 0},
+{U"LessEqualGreater", 8922, 0},
+{U"LessFullEqual", 8806, 0},
+{U"LessGreater", 8822, 0},
+{U"LessLess", 10913, 0},
+{U"LessSlantEqual", 10877, 0},
+{U"LessTilde", 8818, 0},
+{U"Lfr", 120079, 0},
+{U"Ll", 8920, 0},
+{U"Lleftarrow", 8666, 0},
+{U"Lmidot", 319, 0},
+{U"LongLeftArrow", 10229, 0},
+{U"LongLeftRightArrow", 10231, 0},
+{U"LongRightArrow", 10230, 0},
+{U"Longleftarrow", 10232, 0},
+{U"Longleftrightarrow", 10234, 0},
+{U"Longrightarrow", 10233, 0},
+{U"Lopf", 120131, 0},
+{U"LowerLeftArrow", 8601, 0},
+{U"LowerRightArrow", 8600, 0},
+{U"Lscr", 8466, 0},
+{U"Lsh", 8624, 0},
+{U"Lstrok", 321, 0},
+{U"Lt", 8810, 0},
+{U"Map", 10501, 0},
+{U"Mcy", 1052, 0},
+{U"MediumSpace", 8287, 0},
+{U"Mellintrf", 8499, 0},
+{U"Mfr", 120080, 0},
+{U"MinusPlus", 8723, 0},
+{U"Mopf", 120132, 0},
+{U"Mscr", 8499, 0},
+{U"Mu", 924, 0},
+{U"NJcy", 1034, 0},
+{U"Nacute", 323, 0},
+{U"Ncaron", 327, 0},
+{U"Ncedil", 325, 0},
+{U"Ncy", 1053, 0},
+{U"NegativeMediumSpace", 8203, 0},
+{U"NegativeThickSpace", 8203, 0},
+{U"NegativeThinSpace", 8203, 0},
+{U"NegativeVeryThinSpace", 8203, 0},
+{U"NestedGreaterGreater", 8811, 0},
+{U"NestedLessLess", 8810, 0},
+{U"NewLine", 10, 0},
+{U"Nfr", 120081, 0},
+{U"NoBreak", 8288, 0},
+{U"NonBreakingSpace", 160, 0},
+{U"Nopf", 8469, 0},
+{U"Not", 10988, 0},
+{U"NotCongruent", 8802, 0},
+{U"NotCupCap", 8813, 0},
+{U"NotDoubleVerticalBar", 8742, 0},
+{U"NotElement", 8713, 0},
+{U"NotEqual", 8800, 0},
+{U"NotEqualTilde", 8770, 824},
+{U"NotExists", 8708, 0},
+{U"NotGreater", 8815, 0},
+{U"NotGreaterEqual", 8817, 0},
+{U"NotGreaterFullEqual", 8807, 824},
+{U"NotGreaterGreater", 8811, 824},
+{U"NotGreaterLess", 8825, 0},
+{U"NotGreaterSlantEqual", 10878, 824},
+{U"NotGreaterTilde", 8821, 0},
+{U"NotHumpDownHump", 8782, 824},
+{U"NotHumpEqual", 8783, 824},
+{U"NotLeftTriangle", 8938, 0},
+{U"NotLeftTriangleBar", 10703, 824},
+{U"NotLeftTriangleEqual", 8940, 0},
+{U"NotLess", 8814, 0},
+{U"NotLessEqual", 8816, 0},
+{U"NotLessGreater", 8824, 0},
+{U"NotLessLess", 8810, 824},
+{U"NotLessSlantEqual", 10877, 824},
+{U"NotLessTilde", 8820, 0},
+{U"NotNestedGreaterGreater", 10914, 824},
+{U"NotNestedLessLess", 10913, 824},
+{U"NotPrecedes", 8832, 0},
+{U"NotPrecedesEqual", 10927, 824},
+{U"NotPrecedesSlantEqual", 8928, 0},
+{U"NotReverseElement", 8716, 0},
+{U"NotRightTriangle", 8939, 0},
+{U"NotRightTriangleBar", 10704, 824},
+{U"NotRightTriangleEqual", 8941, 0},
+{U"NotSquareSubset", 8847, 824},
+{U"NotSquareSubsetEqual", 8930, 0},
+{U"NotSquareSuperset", 8848, 824},
+{U"NotSquareSupersetEqual", 8931, 0},
+{U"NotSubset", 8834, 8402},
+{U"NotSubsetEqual", 8840, 0},
+{U"NotSucceeds", 8833, 0},
+{U"NotSucceedsEqual", 10928, 824},
+{U"NotSucceedsSlantEqual", 8929, 0},
+{U"NotSucceedsTilde", 8831, 824},
+{U"NotSuperset", 8835, 8402},
+{U"NotSupersetEqual", 8841, 0},
+{U"NotTilde", 8769, 0},
+{U"NotTildeEqual", 8772, 0},
+{U"NotTildeFullEqual", 8775, 0},
+{U"NotTildeTilde", 8777, 0},
+{U"NotVerticalBar", 8740, 0},
+{U"Nscr", 119977, 0},
+{U"Ntilde", 209, 0},
+{U"Nu", 925, 0},
+{U"OElig", 338, 0},
+{U"Oacute", 211, 0},
+{U"Ocirc", 212, 0},
+{U"Ocy", 1054, 0},
+{U"Odblac", 336, 0},
+{U"Ofr", 120082, 0},
+{U"Ograve", 210, 0},
+{U"Omacr", 332, 0},
+{U"Omega", 937, 0},
+{U"Omicron", 927, 0},
+{U"Oopf", 120134, 0},
+{U"OpenCurlyDoubleQuote", 8220, 0},
+{U"OpenCurlyQuote", 8216, 0},
+{U"Or", 10836, 0},
+{U"Oscr", 119978, 0},
+{U"Oslash", 216, 0},
+{U"Otilde", 213, 0},
+{U"Otimes", 10807, 0},
+{U"Ouml", 214, 0},
+{U"OverBar", 8254, 0},
+{U"OverBrace", 9182, 0},
+{U"OverBracket", 9140, 0},
+{U"OverParenthesis", 9180, 0},
+{U"PartialD", 8706, 0},
+{U"Pcy", 1055, 0},
+{U"Pfr", 120083, 0},
+{U"Phi", 934, 0},
+{U"Pi", 928, 0},
+{U"PlusMinus", 177, 0},
+{U"Poincareplane", 8460, 0},
+{U"Popf", 8473, 0},
+{U"Pr", 10939, 0},
+{U"Precedes", 8826, 0},
+{U"PrecedesEqual", 10927, 0},
+{U"PrecedesSlantEqual", 8828, 0},
+{U"PrecedesTilde", 8830, 0},
+{U"Prime", 8243, 0},
+{U"Product", 8719, 0},
+{U"Proportion", 8759, 0},
+{U"Proportional", 8733, 0},
+{U"Pscr", 119979, 0},
+{U"Psi", 936, 0},
+{U"QUOT", 34, 0},
+{U"Qfr", 120084, 0},
+{U"Qopf", 8474, 0},
+{U"Qscr", 119980, 0},
+{U"RBarr", 10512, 0},
+{U"REG", 174, 0},
+{U"Racute", 340, 0},
+{U"Rang", 10219, 0},
+{U"Rarr", 8608, 0},
+{U"Rarrtl", 10518, 0},
+{U"Rcaron", 344, 0},
+{U"Rcedil", 342, 0},
+{U"Rcy", 1056, 0},
+{U"Re", 8476, 0},
+{U"ReverseElement", 8715, 0},
+{U"ReverseEquilibrium", 8651, 0},
+{U"ReverseUpEquilibrium", 10607, 0},
+{U"Rfr", 8476, 0},
+{U"Rho", 929, 0},
+{U"RightAngleBracket", 10217, 0},
+{U"RightArrow", 8594, 0},
+{U"RightArrowBar", 8677, 0},
+{U"RightArrowLeftArrow", 8644, 0},
+{U"RightCeiling", 8969, 0},
+{U"RightDoubleBracket", 10215, 0},
+{U"RightDownTeeVector", 10589, 0},
+{U"RightDownVector", 8642, 0},
+{U"RightDownVectorBar", 10581, 0},
+{U"RightFloor", 8971, 0},
+{U"RightTee", 8866, 0},
+{U"RightTeeArrow", 8614, 0},
+{U"RightTeeVector", 10587, 0},
+{U"RightTriangle", 8883, 0},
+{U"RightTriangleBar", 10704, 0},
+{U"RightTriangleEqual", 8885, 0},
+{U"RightUpDownVector", 10575, 0},
+{U"RightUpTeeVector", 10588, 0},
+{U"RightUpVector", 8638, 0},
+{U"RightUpVectorBar", 10580, 0},
+{U"RightVector", 8640, 0},
+{U"RightVectorBar", 10579, 0},
+{U"Rightarrow", 8658, 0},
+{U"Ropf", 8477, 0},
+{U"RoundImplies", 10608, 0},
+{U"Rrightarrow", 8667, 0},
+{U"Rscr", 8475, 0},
+{U"Rsh", 8625, 0},
+{U"RuleDelayed", 10740, 0},
+{U"SHCHcy", 1065, 0},
+{U"SHcy", 1064, 0},
+{U"SOFTcy", 1068, 0},
+{U"Sacute", 346, 0},
+{U"Sc", 10940, 0},
+{U"Scaron", 352, 0},
+{U"Scedil", 350, 0},
+{U"Scirc", 348, 0},
+{U"Scy", 1057, 0},
+{U"Sfr", 120086, 0},
+{U"ShortDownArrow", 8595, 0},
+{U"ShortLeftArrow", 8592, 0},
+{U"ShortRightArrow", 8594, 0},
+{U"ShortUpArrow", 8593, 0},
+{U"Sigma", 931, 0},
+{U"SmallCircle", 8728, 0},
+{U"Sopf", 120138, 0},
+{U"Sqrt", 8730, 0},
+{U"Square", 9633, 0},
+{U"SquareIntersection", 8851, 0},
+{U"SquareSubset", 8847, 0},
+{U"SquareSubsetEqual", 8849, 0},
+{U"SquareSuperset", 8848, 0},
+{U"SquareSupersetEqual", 8850, 0},
+{U"SquareUnion", 8852, 0},
+{U"Sscr", 119982, 0},
+{U"Star", 8902, 0},
+{U"Sub", 8912, 0},
+{U"Subset", 8912, 0},
+{U"SubsetEqual", 8838, 0},
+{U"Succeeds", 8827, 0},
+{U"SucceedsEqual", 10928, 0},
+{U"SucceedsSlantEqual", 8829, 0},
+{U"SucceedsTilde", 8831, 0},
+{U"SuchThat", 8715, 0},
+{U"Sum", 8721, 0},
+{U"Sup", 8913, 0},
+{U"Superset", 8835, 0},
+{U"SupersetEqual", 8839, 0},
+{U"Supset", 8913, 0},
+{U"THORN", 222, 0},
+{U"TRADE", 8482, 0},
+{U"TSHcy", 1035, 0},
+{U"TScy", 1062, 0},
+{U"Tab", 9, 0},
+{U"Tau", 932, 0},
+{U"Tcaron", 356, 0},
+{U"Tcedil", 354, 0},
+{U"Tcy", 1058, 0},
+{U"Tfr", 120087, 0},
+{U"Therefore", 8756, 0},
+{U"Theta", 920, 0},
+{U"ThickSpace", 8287, 8202},
+{U"ThinSpace", 8201, 0},
+{U"Tilde", 8764, 0},
+{U"TildeEqual", 8771, 0},
+{U"TildeFullEqual", 8773, 0},
+{U"TildeTilde", 8776, 0},
+{U"Topf", 120139, 0},
+{U"TripleDot", 8411, 0},
+{U"Tscr", 119983, 0},
+{U"Tstrok", 358, 0},
+{U"Uacute", 218, 0},
+{U"Uarr", 8607, 0},
+{U"Uarrocir", 10569, 0},
+{U"Ubrcy", 1038, 0},
+{U"Ubreve", 364, 0},
+{U"Ucirc", 219, 0},
+{U"Ucy", 1059, 0},
+{U"Udblac", 368, 0},
+{U"Ufr", 120088, 0},
+{U"Ugrave", 217, 0},
+{U"Umacr", 362, 0},
+{U"UnderBar", 95, 0},
+{U"UnderBrace", 9183, 0},
+{U"UnderBracket", 9141, 0},
+{U"UnderParenthesis", 9181, 0},
+{U"Union", 8899, 0},
+{U"UnionPlus", 8846, 0},
+{U"Uogon", 370, 0},
+{U"Uopf", 120140, 0},
+{U"UpArrow", 8593, 0},
+{U"UpArrowBar", 10514, 0},
+{U"UpArrowDownArrow", 8645, 0},
+{U"UpDownArrow", 8597, 0},
+{U"UpEquilibrium", 10606, 0},
+{U"UpTee", 8869, 0},
+{U"UpTeeArrow", 8613, 0},
+{U"Uparrow", 8657, 0},
+{U"Updownarrow", 8661, 0},
+{U"UpperLeftArrow", 8598, 0},
+{U"UpperRightArrow", 8599, 0},
+{U"Upsi", 978, 0},
+{U"Upsilon", 933, 0},
+{U"Uring", 366, 0},
+{U"Uscr", 119984, 0},
+{U"Utilde", 360, 0},
+{U"Uuml", 220, 0},
+{U"VDash", 8875, 0},
+{U"Vbar", 10987, 0},
+{U"Vcy", 1042, 0},
+{U"Vdash", 8873, 0},
+{U"Vdashl", 10982, 0},
+{U"Vee", 8897, 0},
+{U"Verbar", 8214, 0},
+{U"Vert", 8214, 0},
+{U"VerticalBar", 8739, 0},
+{U"VerticalLine", 124, 0},
+{U"VerticalSeparator", 10072, 0},
+{U"VerticalTilde", 8768, 0},
+{U"VeryThinSpace", 8202, 0},
+{U"Vfr", 120089, 0},
+{U"Vopf", 120141, 0},
+{U"Vscr", 119985, 0},
+{U"Vvdash", 8874, 0},
+{U"Wcirc", 372, 0},
+{U"Wedge", 8896, 0},
+{U"Wfr", 120090, 0},
+{U"Wopf", 120142, 0},
+{U"Wscr", 119986, 0},
+{U"Xfr", 120091, 0},
+{U"Xi", 926, 0},
+{U"Xopf", 120143, 0},
+{U"Xscr", 119987, 0},
+{U"YAcy", 1071, 0},
+{U"YIcy", 1031, 0},
+{U"YUcy", 1070, 0},
+{U"Yacute", 221, 0},
+{U"Ycirc", 374, 0},
+{U"Ycy", 1067, 0},
+{U"Yfr", 120092, 0},
+{U"Yopf", 120144, 0},
+{U"Yscr", 119988, 0},
+{U"Yuml", 376, 0},
+{U"ZHcy", 1046, 0},
+{U"Zacute", 377, 0},
+{U"Zcaron", 381, 0},
+{U"Zcy", 1047, 0},
+{U"Zdot", 379, 0},
+{U"ZeroWidthSpace", 8203, 0},
+{U"Zeta", 918, 0},
+{U"Zfr", 8488, 0},
+{U"Zopf", 8484, 0},
+{U"Zscr", 119989, 0},
+{U"aacute", 225, 0},
+{U"abreve", 259, 0},
+{U"ac", 8766, 0},
+{U"acE", 8766, 819},
+{U"acd", 8767, 0},
+{U"acirc", 226, 0},
+{U"acute", 180, 0},
+{U"acy", 1072, 0},
+{U"aelig", 230, 0},
+{U"af", 8289, 0},
+{U"afr", 120094, 0},
+{U"agrave", 224, 0},
+{U"alefsym", 8501, 0},
+{U"aleph", 8501, 0},
+{U"alpha", 945, 0},
+{U"amacr", 257, 0},
+{U"amalg", 10815, 0},
+{U"amp", 38, 0},
+{U"and", 8743, 0},
+{U"andand", 10837, 0},
+{U"andd", 10844, 0},
+{U"andslope", 10840, 0},
+{U"andv", 10842, 0},
+{U"ang", 8736, 0},
+{U"ange", 10660, 0},
+{U"angle", 8736, 0},
+{U"angmsd", 8737, 0},
+{U"angmsdaa", 10664, 0},
+{U"angmsdab", 10665, 0},
+{U"angmsdac", 10666, 0},
+{U"angmsdad", 10667, 0},
+{U"angmsdae", 10668, 0},
+{U"angmsdaf", 10669, 0},
+{U"angmsdag", 10670, 0},
+{U"angmsdah", 10671, 0},
+{U"angrt", 8735, 0},
+{U"angrtvb", 8894, 0},
+{U"angrtvbd", 10653, 0},
+{U"angsph", 8738, 0},
+{U"angst", 197, 0},
+{U"angzarr", 9084, 0},
+{U"aogon", 261, 0},
+{U"aopf", 120146, 0},
+{U"ap", 8776, 0},
+{U"apE", 10864, 0},
+{U"apacir", 10863, 0},
+{U"ape", 8778, 0},
+{U"apid", 8779, 0},
+{U"apos", 39, 0},
+{U"approx", 8776, 0},
+{U"approxeq", 8778, 0},
+{U"aring", 229, 0},
+{U"ascr", 119990, 0},
+{U"ast", 42, 0},
+{U"asymp", 8776, 0},
+{U"asympeq", 8781, 0},
+{U"atilde", 227, 0},
+{U"auml", 228, 0},
+{U"awconint", 8755, 0},
+{U"awint", 10769, 0},
+{U"bNot", 10989, 0},
+{U"backcong", 8780, 0},
+{U"backepsilon", 1014, 0},
+{U"backprime", 8245, 0},
+{U"backsim", 8765, 0},
+{U"backsimeq", 8909, 0},
+{U"barvee", 8893, 0},
+{U"barwed", 8965, 0},
+{U"barwedge", 8965, 0},
+{U"bbrk", 9141, 0},
+{U"bbrktbrk", 9142, 0},
+{U"bcong", 8780, 0},
+{U"bcy", 1073, 0},
+{U"bdquo", 8222, 0},
+{U"becaus", 8757, 0},
+{U"because", 8757, 0},
+{U"bemptyv", 10672, 0},
+{U"bepsi", 1014, 0},
+{U"bernou", 8492, 0},
+{U"beta", 946, 0},
+{U"beth", 8502, 0},
+{U"between", 8812, 0},
+{U"bfr", 120095, 0},
+{U"bigcap", 8898, 0},
+{U"bigcirc", 9711, 0},
+{U"bigcup", 8899, 0},
+{U"bigodot", 10752, 0},
+{U"bigoplus", 10753, 0},
+{U"bigotimes", 10754, 0},
+{U"bigsqcup", 10758, 0},
+{U"bigstar", 9733, 0},
+{U"bigtriangledown", 9661, 0},
+{U"bigtriangleup", 9651, 0},
+{U"biguplus", 10756, 0},
+{U"bigvee", 8897, 0},
+{U"bigwedge", 8896, 0},
+{U"bkarow", 10509, 0},
+{U"blacklozenge", 10731, 0},
+{U"blacksquare", 9642, 0},
+{U"blacktriangle", 9652, 0},
+{U"blacktriangledown", 9662, 0},
+{U"blacktriangleleft", 9666, 0},
+{U"blacktriangleright", 9656, 0},
+{U"blank", 9251, 0},
+{U"blk12", 9618, 0},
+{U"blk14", 9617, 0},
+{U"blk34", 9619, 0},
+{U"block", 9608, 0},
+{U"bne", 61, 8421},
+{U"bnequiv", 8801, 8421},
+{U"bnot", 8976, 0},
+{U"bopf", 120147, 0},
+{U"bot", 8869, 0},
+{U"bottom", 8869, 0},
+{U"bowtie", 8904, 0},
+{U"boxDL", 9559, 0},
+{U"boxDR", 9556, 0},
+{U"boxDl", 9558, 0},
+{U"boxDr", 9555, 0},
+{U"boxH", 9552, 0},
+{U"boxHD", 9574, 0},
+{U"boxHU", 9577, 0},
+{U"boxHd", 9572, 0},
+{U"boxHu", 9575, 0},
+{U"boxUL", 9565, 0},
+{U"boxUR", 9562, 0},
+{U"boxUl", 9564, 0},
+{U"boxUr", 9561, 0},
+{U"boxV", 9553, 0},
+{U"boxVH", 9580, 0},
+{U"boxVL", 9571, 0},
+{U"boxVR", 9568, 0},
+{U"boxVh", 9579, 0},
+{U"boxVl", 9570, 0},
+{U"boxVr", 9567, 0},
+{U"boxbox", 10697, 0},
+{U"boxdL", 9557, 0},
+{U"boxdR", 9554, 0},
+{U"boxdl", 9488, 0},
+{U"boxdr", 9484, 0},
+{U"boxh", 9472, 0},
+{U"boxhD", 9573, 0},
+{U"boxhU", 9576, 0},
+{U"boxhd", 9516, 0},
+{U"boxhu", 9524, 0},
+{U"boxminus", 8863, 0},
+{U"boxplus", 8862, 0},
+{U"boxtimes", 8864, 0},
+{U"boxuL", 9563, 0},
+{U"boxuR", 9560, 0},
+{U"boxul", 9496, 0},
+{U"boxur", 9492, 0},
+{U"boxv", 9474, 0},
+{U"boxvH", 9578, 0},
+{U"boxvL", 9569, 0},
+{U"boxvR", 9566, 0},
+{U"boxvh", 9532, 0},
+{U"boxvl", 9508, 0},
+{U"boxvr", 9500, 0},
+{U"bprime", 8245, 0},
+{U"breve", 728, 0},
+{U"brvbar", 166, 0},
+{U"bscr", 119991, 0},
+{U"bsemi", 8271, 0},
+{U"bsim", 8765, 0},
+{U"bsime", 8909, 0},
+{U"bsol", 92, 0},
+{U"bsolb", 10693, 0},
+{U"bsolhsub", 10184, 0},
+{U"bull", 8226, 0},
+{U"bullet", 8226, 0},
+{U"bump", 8782, 0},
+{U"bumpE", 10926, 0},
+{U"bumpe", 8783, 0},
+{U"bumpeq", 8783, 0},
+{U"cacute", 263, 0},
+{U"cap", 8745, 0},
+{U"capand", 10820, 0},
+{U"capbrcup", 10825, 0},
+{U"capcap", 10827, 0},
+{U"capcup", 10823, 0},
+{U"capdot", 10816, 0},
+{U"caps", 8745, 65024},
+{U"caret", 8257, 0},
+{U"caron", 711, 0},
+{U"ccaps", 10829, 0},
+{U"ccaron", 269, 0},
+{U"ccedil", 231, 0},
+{U"ccirc", 265, 0},
+{U"ccups", 10828, 0},
+{U"ccupssm", 10832, 0},
+{U"cdot", 267, 0},
+{U"cedil", 184, 0},
+{U"cemptyv", 10674, 0},
+{U"cent", 162, 0},
+{U"centerdot", 183, 0},
+{U"cfr", 120096, 0},
+{U"chcy", 1095, 0},
+{U"check", 10003, 0},
+{U"checkmark", 10003, 0},
+{U"chi", 967, 0},
+{U"cir", 9675, 0},
+{U"cirE", 10691, 0},
+{U"circ", 710, 0},
+{U"circeq", 8791, 0},
+{U"circlearrowleft", 8634, 0},
+{U"circlearrowright", 8635, 0},
+{U"circledR", 174, 0},
+{U"circledS", 9416, 0},
+{U"circledast", 8859, 0},
+{U"circledcirc", 8858, 0},
+{U"circleddash", 8861, 0},
+{U"cire", 8791, 0},
+{U"cirfnint", 10768, 0},
+{U"cirmid", 10991, 0},
+{U"cirscir", 10690, 0},
+{U"clubs", 9827, 0},
+{U"clubsuit", 9827, 0},
+{U"colon", 58, 0},
+{U"colone", 8788, 0},
+{U"coloneq", 8788, 0},
+{U"comma", 44, 0},
+{U"commat", 64, 0},
+{U"comp", 8705, 0},
+{U"compfn", 8728, 0},
+{U"complement", 8705, 0},
+{U"complexes", 8450, 0},
+{U"cong", 8773, 0},
+{U"congdot", 10861, 0},
+{U"conint", 8750, 0},
+{U"copf", 120148, 0},
+{U"coprod", 8720, 0},
+{U"copy", 169, 0},
+{U"copysr", 8471, 0},
+{U"crarr", 8629, 0},
+{U"cross", 10007, 0},
+{U"cscr", 119992, 0},
+{U"csub", 10959, 0},
+{U"csube", 10961, 0},
+{U"csup", 10960, 0},
+{U"csupe", 10962, 0},
+{U"ctdot", 8943, 0},
+{U"cudarrl", 10552, 0},
+{U"cudarrr", 10549, 0},
+{U"cuepr", 8926, 0},
+{U"cuesc", 8927, 0},
+{U"cularr", 8630, 0},
+{U"cularrp", 10557, 0},
+{U"cup", 8746, 0},
+{U"cupbrcap", 10824, 0},
+{U"cupcap", 10822, 0},
+{U"cupcup", 10826, 0},
+{U"cupdot", 8845, 0},
+{U"cupor", 10821, 0},
+{U"cups", 8746, 65024},
+{U"curarr", 8631, 0},
+{U"curarrm", 10556, 0},
+{U"curlyeqprec", 8926, 0},
+{U"curlyeqsucc", 8927, 0},
+{U"curlyvee", 8910, 0},
+{U"curlywedge", 8911, 0},
+{U"curren", 164, 0},
+{U"curvearrowleft", 8630, 0},
+{U"curvearrowright", 8631, 0},
+{U"cuvee", 8910, 0},
+{U"cuwed", 8911, 0},
+{U"cwconint", 8754, 0},
+{U"cwint", 8753, 0},
+{U"cylcty", 9005, 0},
+{U"dArr", 8659, 0},
+{U"dHar", 10597, 0},
+{U"dagger", 8224, 0},
+{U"daleth", 8504, 0},
+{U"darr", 8595, 0},
+{U"dash", 8208, 0},
+{U"dashv", 8867, 0},
+{U"dbkarow", 10511, 0},
+{U"dblac", 733, 0},
+{U"dcaron", 271, 0},
+{U"dcy", 1076, 0},
+{U"dd", 8518, 0},
+{U"ddagger", 8225, 0},
+{U"ddarr", 8650, 0},
+{U"ddotseq", 10871, 0},
+{U"deg", 176, 0},
+{U"delta", 948, 0},
+{U"demptyv", 10673, 0},
+{U"dfisht", 10623, 0},
+{U"dfr", 120097, 0},
+{U"dharl", 8643, 0},
+{U"dharr", 8642, 0},
+{U"diam", 8900, 0},
+{U"diamond", 8900, 0},
+{U"diamondsuit", 9830, 0},
+{U"diams", 9830, 0},
+{U"die", 168, 0},
+{U"digamma", 989, 0},
+{U"disin", 8946, 0},
+{U"div", 247, 0},
+{U"divide", 247, 0},
+{U"divideontimes", 8903, 0},
+{U"divonx", 8903, 0},
+{U"djcy", 1106, 0},
+{U"dlcorn", 8990, 0},
+{U"dlcrop", 8973, 0},
+{U"dollar", 36, 0},
+{U"dopf", 120149, 0},
+{U"dot", 729, 0},
+{U"doteq", 8784, 0},
+{U"doteqdot", 8785, 0},
+{U"dotminus", 8760, 0},
+{U"dotplus", 8724, 0},
+{U"dotsquare", 8865, 0},
+{U"doublebarwedge", 8966, 0},
+{U"downarrow", 8595, 0},
+{U"downdownarrows", 8650, 0},
+{U"downharpoonleft", 8643, 0},
+{U"downharpoonright", 8642, 0},
+{U"drbkarow", 10512, 0},
+{U"drcorn", 8991, 0},
+{U"drcrop", 8972, 0},
+{U"dscr", 119993, 0},
+{U"dscy", 1109, 0},
+{U"dsol", 10742, 0},
+{U"dstrok", 273, 0},
+{U"dtdot", 8945, 0},
+{U"dtri", 9663, 0},
+{U"dtrif", 9662, 0},
+{U"duarr", 8693, 0},
+{U"duhar", 10607, 0},
+{U"dwangle", 10662, 0},
+{U"dzcy", 1119, 0},
+{U"dzigrarr", 10239, 0},
+{U"eDDot", 10871, 0},
+{U"eDot", 8785, 0},
+{U"eacute", 233, 0},
+{U"easter", 10862, 0},
+{U"ecaron", 283, 0},
+{U"ecir", 8790, 0},
+{U"ecirc", 234, 0},
+{U"ecolon", 8789, 0},
+{U"ecy", 1101, 0},
+{U"edot", 279, 0},
+{U"ee", 8519, 0},
+{U"efDot", 8786, 0},
+{U"efr", 120098, 0},
+{U"eg", 10906, 0},
+{U"egrave", 232, 0},
+{U"egs", 10902, 0},
+{U"egsdot", 10904, 0},
+{U"el", 10905, 0},
+{U"elinters", 9191, 0},
+{U"ell", 8467, 0},
+{U"els", 10901, 0},
+{U"elsdot", 10903, 0},
+{U"emacr", 275, 0},
+{U"empty", 8709, 0},
+{U"emptyset", 8709, 0},
+{U"emptyv", 8709, 0},
+{U"emsp", 8195, 0},
+{U"emsp13", 8196, 0},
+{U"emsp14", 8197, 0},
+{U"eng", 331, 0},
+{U"ensp", 8194, 0},
+{U"eogon", 281, 0},
+{U"eopf", 120150, 0},
+{U"epar", 8917, 0},
+{U"eparsl", 10723, 0},
+{U"eplus", 10865, 0},
+{U"epsi", 949, 0},
+{U"epsilon", 949, 0},
+{U"epsiv", 1013, 0},
+{U"eqcirc", 8790, 0},
+{U"eqcolon", 8789, 0},
+{U"eqsim", 8770, 0},
+{U"eqslantgtr", 10902, 0},
+{U"eqslantless", 10901, 0},
+{U"equals", 61, 0},
+{U"equest", 8799, 0},
+{U"equiv", 8801, 0},
+{U"equivDD", 10872, 0},
+{U"eqvparsl", 10725, 0},
+{U"erDot", 8787, 0},
+{U"erarr", 10609, 0},
+{U"escr", 8495, 0},
+{U"esdot", 8784, 0},
+{U"esim", 8770, 0},
+{U"eta", 951, 0},
+{U"eth", 240, 0},
+{U"euml", 235, 0},
+{U"euro", 8364, 0},
+{U"excl", 33, 0},
+{U"exist", 8707, 0},
+{U"expectation", 8496, 0},
+{U"exponentiale", 8519, 0},
+{U"fallingdotseq", 8786, 0},
+{U"fcy", 1092, 0},
+{U"female", 9792, 0},
+{U"ffilig", 64259, 0},
+{U"fflig", 64256, 0},
+{U"ffllig", 64260, 0},
+{U"ffr", 120099, 0},
+{U"filig", 64257, 0},
+{U"fjlig", 102, 106},
+{U"flat", 9837, 0},
+{U"fllig", 64258, 0},
+{U"fltns", 9649, 0},
+{U"fnof", 402, 0},
+{U"fopf", 120151, 0},
+{U"forall", 8704, 0},
+{U"fork", 8916, 0},
+{U"forkv", 10969, 0},
+{U"fpartint", 10765, 0},
+{U"frac12", 189, 0},
+{U"frac13", 8531, 0},
+{U"frac14", 188, 0},
+{U"frac15", 8533, 0},
+{U"frac16", 8537, 0},
+{U"frac18", 8539, 0},
+{U"frac23", 8532, 0},
+{U"frac25", 8534, 0},
+{U"frac34", 190, 0},
+{U"frac35", 8535, 0},
+{U"frac38", 8540, 0},
+{U"frac45", 8536, 0},
+{U"frac56", 8538, 0},
+{U"frac58", 8541, 0},
+{U"frac78", 8542, 0},
+{U"frasl", 8260, 0},
+{U"frown", 8994, 0},
+{U"fscr", 119995, 0},
+{U"gE", 8807, 0},
+{U"gEl", 10892, 0},
+{U"gacute", 501, 0},
+{U"gamma", 947, 0},
+{U"gammad", 989, 0},
+{U"gap", 10886, 0},
+{U"gbreve", 287, 0},
+{U"gcirc", 285, 0},
+{U"gcy", 1075, 0},
+{U"gdot", 289, 0},
+{U"ge", 8805, 0},
+{U"gel", 8923, 0},
+{U"geq", 8805, 0},
+{U"geqq", 8807, 0},
+{U"geqslant", 10878, 0},
+{U"ges", 10878, 0},
+{U"gescc", 10921, 0},
+{U"gesdot", 10880, 0},
+{U"gesdoto", 10882, 0},
+{U"gesdotol", 10884, 0},
+{U"gesl", 8923, 65024},
+{U"gesles", 10900, 0},
+{U"gfr", 120100, 0},
+{U"gg", 8811, 0},
+{U"ggg", 8921, 0},
+{U"gimel", 8503, 0},
+{U"gjcy", 1107, 0},
+{U"gl", 8823, 0},
+{U"glE", 10898, 0},
+{U"gla", 10917, 0},
+{U"glj", 10916, 0},
+{U"gnE", 8809, 0},
+{U"gnap", 10890, 0},
+{U"gnapprox", 10890, 0},
+{U"gne", 10888, 0},
+{U"gneq", 10888, 0},
+{U"gneqq", 8809, 0},
+{U"gnsim", 8935, 0},
+{U"gopf", 120152, 0},
+{U"grave", 96, 0},
+{U"gscr", 8458, 0},
+{U"gsim", 8819, 0},
+{U"gsime", 10894, 0},
+{U"gsiml", 10896, 0},
+{U"gt", 62, 0},
+{U"gtcc", 10919, 0},
+{U"gtcir", 10874, 0},
+{U"gtdot", 8919, 0},
+{U"gtlPar", 10645, 0},
+{U"gtquest", 10876, 0},
+{U"gtrapprox", 10886, 0},
+{U"gtrarr", 10616, 0},
+{U"gtrdot", 8919, 0},
+{U"gtreqless", 8923, 0},
+{U"gtreqqless", 10892, 0},
+{U"gtrless", 8823, 0},
+{U"gtrsim", 8819, 0},
+{U"gvertneqq", 8809, 65024},
+{U"gvnE", 8809, 65024},
+{U"hArr", 8660, 0},
+{U"hairsp", 8202, 0},
+{U"half", 189, 0},
+{U"hamilt", 8459, 0},
+{U"hardcy", 1098, 0},
+{U"harr", 8596, 0},
+{U"harrcir", 10568, 0},
+{U"harrw", 8621, 0},
+{U"hbar", 8463, 0},
+{U"hcirc", 293, 0},
+{U"hearts", 9829, 0},
+{U"heartsuit", 9829, 0},
+{U"hellip", 8230, 0},
+{U"hercon", 8889, 0},
+{U"hfr", 120101, 0},
+{U"hksearow", 10533, 0},
+{U"hkswarow", 10534, 0},
+{U"hoarr", 8703, 0},
+{U"homtht", 8763, 0},
+{U"hookleftarrow", 8617, 0},
+{U"hookrightarrow", 8618, 0},
+{U"hopf", 120153, 0},
+{U"horbar", 8213, 0},
+{U"hscr", 119997, 0},
+{U"hslash", 8463, 0},
+{U"hstrok", 295, 0},
+{U"hybull", 8259, 0},
+{U"hyphen", 8208, 0},
+{U"iacute", 237, 0},
+{U"ic", 8291, 0},
+{U"icirc", 238, 0},
+{U"icy", 1080, 0},
+{U"iecy", 1077, 0},
+{U"iexcl", 161, 0},
+{U"iff", 8660, 0},
+{U"ifr", 120102, 0},
+{U"igrave", 236, 0},
+{U"ii", 8520, 0},
+{U"iiiint", 10764, 0},
+{U"iiint", 8749, 0},
+{U"iinfin", 10716, 0},
+{U"iiota", 8489, 0},
+{U"ijlig", 307, 0},
+{U"imacr", 299, 0},
+{U"image", 8465, 0},
+{U"imagline", 8464, 0},
+{U"imagpart", 8465, 0},
+{U"imath", 305, 0},
+{U"imof", 8887, 0},
+{U"imped", 437, 0},
+{U"in", 8712, 0},
+{U"incare", 8453, 0},
+{U"infin", 8734, 0},
+{U"infintie", 10717, 0},
+{U"inodot", 305, 0},
+{U"int", 8747, 0},
+{U"intcal", 8890, 0},
+{U"integers", 8484, 0},
+{U"intercal", 8890, 0},
+{U"intlarhk", 10775, 0},
+{U"intprod", 10812, 0},
+{U"iocy", 1105, 0},
+{U"iogon", 303, 0},
+{U"iopf", 120154, 0},
+{U"iota", 953, 0},
+{U"iprod", 10812, 0},
+{U"iquest", 191, 0},
+{U"iscr", 119998, 0},
+{U"isin", 8712, 0},
+{U"isinE", 8953, 0},
+{U"isindot", 8949, 0},
+{U"isins", 8948, 0},
+{U"isinsv", 8947, 0},
+{U"isinv", 8712, 0},
+{U"it", 8290, 0},
+{U"itilde", 297, 0},
+{U"iukcy", 1110, 0},
+{U"iuml", 239, 0},
+{U"jcirc", 309, 0},
+{U"jcy", 1081, 0},
+{U"jfr", 120103, 0},
+{U"jmath", 567, 0},
+{U"jopf", 120155, 0},
+{U"jscr", 119999, 0},
+{U"jsercy", 1112, 0},
+{U"jukcy", 1108, 0},
+{U"kappa", 954, 0},
+{U"kappav", 1008, 0},
+{U"kcedil", 311, 0},
+{U"kcy", 1082, 0},
+{U"kfr", 120104, 0},
+{U"kgreen", 312, 0},
+{U"khcy", 1093, 0},
+{U"kjcy", 1116, 0},
+{U"kopf", 120156, 0},
+{U"kscr", 120000, 0},
+{U"lAarr", 8666, 0},
+{U"lArr", 8656, 0},
+{U"lAtail", 10523, 0},
+{U"lBarr", 10510, 0},
+{U"lE", 8806, 0},
+{U"lEg", 10891, 0},
+{U"lHar", 10594, 0},
+{U"lacute", 314, 0},
+{U"laemptyv", 10676, 0},
+{U"lagran", 8466, 0},
+{U"lambda", 955, 0},
+{U"lang", 10216, 0},
+{U"langd", 10641, 0},
+{U"langle", 10216, 0},
+{U"lap", 10885, 0},
+{U"laquo", 171, 0},
+{U"larr", 8592, 0},
+{U"larrb", 8676, 0},
+{U"larrbfs", 10527, 0},
+{U"larrfs", 10525, 0},
+{U"larrhk", 8617, 0},
+{U"larrlp", 8619, 0},
+{U"larrpl", 10553, 0},
+{U"larrsim", 10611, 0},
+{U"larrtl", 8610, 0},
+{U"lat", 10923, 0},
+{U"latail", 10521, 0},
+{U"late", 10925, 0},
+{U"lates", 10925, 65024},
+{U"lbarr", 10508, 0},
+{U"lbbrk", 10098, 0},
+{U"lbrace", 123, 0},
+{U"lbrack", 91, 0},
+{U"lbrke", 10635, 0},
+{U"lbrksld", 10639, 0},
+{U"lbrkslu", 10637, 0},
+{U"lcaron", 318, 0},
+{U"lcedil", 316, 0},
+{U"lceil", 8968, 0},
+{U"lcub", 123, 0},
+{U"lcy", 1083, 0},
+{U"ldca", 10550, 0},
+{U"ldquo", 8220, 0},
+{U"ldquor", 8222, 0},
+{U"ldrdhar", 10599, 0},
+{U"ldrushar", 10571, 0},
+{U"ldsh", 8626, 0},
+{U"le", 8804, 0},
+{U"leftarrow", 8592, 0},
+{U"leftarrowtail", 8610, 0},
+{U"leftharpoondown", 8637, 0},
+{U"leftharpoonup", 8636, 0},
+{U"leftleftarrows", 8647, 0},
+{U"leftrightarrow", 8596, 0},
+{U"leftrightarrows", 8646, 0},
+{U"leftrightharpoons", 8651, 0},
+{U"leftrightsquigarrow", 8621, 0},
+{U"leftthreetimes", 8907, 0},
+{U"leg", 8922, 0},
+{U"leq", 8804, 0},
+{U"leqq", 8806, 0},
+{U"leqslant", 10877, 0},
+{U"les", 10877, 0},
+{U"lescc", 10920, 0},
+{U"lesdot", 10879, 0},
+{U"lesdoto", 10881, 0},
+{U"lesdotor", 10883, 0},
+{U"lesg", 8922, 65024},
+{U"lesges", 10899, 0},
+{U"lessapprox", 10885, 0},
+{U"lessdot", 8918, 0},
+{U"lesseqgtr", 8922, 0},
+{U"lesseqqgtr", 10891, 0},
+{U"lessgtr", 8822, 0},
+{U"lesssim", 8818, 0},
+{U"lfisht", 10620, 0},
+{U"lfloor", 8970, 0},
+{U"lfr", 120105, 0},
+{U"lg", 8822, 0},
+{U"lgE", 10897, 0},
+{U"lhard", 8637, 0},
+{U"lharu", 8636, 0},
+{U"lharul", 10602, 0},
+{U"lhblk", 9604, 0},
+{U"ljcy", 1113, 0},
+{U"ll", 8810, 0},
+{U"llarr", 8647, 0},
+{U"llcorner", 8990, 0},
+{U"llhard", 10603, 0},
+{U"lltri", 9722, 0},
+{U"lmidot", 320, 0},
+{U"lmoust", 9136, 0},
+{U"lmoustache", 9136, 0},
+{U"lnE", 8808, 0},
+{U"lnap", 10889, 0},
+{U"lnapprox", 10889, 0},
+{U"lne", 10887, 0},
+{U"lneq", 10887, 0},
+{U"lneqq", 8808, 0},
+{U"lnsim", 8934, 0},
+{U"loang", 10220, 0},
+{U"loarr", 8701, 0},
+{U"lobrk", 10214, 0},
+{U"longleftarrow", 10229, 0},
+{U"longleftrightarrow", 10231, 0},
+{U"longmapsto", 10236, 0},
+{U"longrightarrow", 10230, 0},
+{U"looparrowleft", 8619, 0},
+{U"looparrowright", 8620, 0},
+{U"lopar", 10629, 0},
+{U"lopf", 120157, 0},
+{U"loplus", 10797, 0},
+{U"lotimes", 10804, 0},
+{U"lowast", 8727, 0},
+{U"lowbar", 95, 0},
+{U"loz", 9674, 0},
+{U"lozenge", 9674, 0},
+{U"lozf", 10731, 0},
+{U"lpar", 40, 0},
+{U"lparlt", 10643, 0},
+{U"lrarr", 8646, 0},
+{U"lrcorner", 8991, 0},
+{U"lrhar", 8651, 0},
+{U"lrhard", 10605, 0},
+{U"lrm", 8206, 0},
+{U"lrtri", 8895, 0},
+{U"lsaquo", 8249, 0},
+{U"lscr", 120001, 0},
+{U"lsh", 8624, 0},
+{U"lsim", 8818, 0},
+{U"lsime", 10893, 0},
+{U"lsimg", 10895, 0},
+{U"lsqb", 91, 0},
+{U"lsquo", 8216, 0},
+{U"lsquor", 8218, 0},
+{U"lstrok", 322, 0},
+{U"lt", 60, 0},
+{U"ltcc", 10918, 0},
+{U"ltcir", 10873, 0},
+{U"ltdot", 8918, 0},
+{U"lthree", 8907, 0},
+{U"ltimes", 8905, 0},
+{U"ltlarr", 10614, 0},
+{U"ltquest", 10875, 0},
+{U"ltrPar", 10646, 0},
+{U"ltri", 9667, 0},
+{U"ltrie", 8884, 0},
+{U"ltrif", 9666, 0},
+{U"lurdshar", 10570, 0},
+{U"luruhar", 10598, 0},
+{U"lvertneqq", 8808, 65024},
+{U"lvnE", 8808, 65024},
+{U"mDDot", 8762, 0},
+{U"macr", 175, 0},
+{U"male", 9794, 0},
+{U"malt", 10016, 0},
+{U"maltese", 10016, 0},
+{U"map", 8614, 0},
+{U"mapsto", 8614, 0},
+{U"mapstodown", 8615, 0},
+{U"mapstoleft", 8612, 0},
+{U"mapstoup", 8613, 0},
+{U"marker", 9646, 0},
+{U"mcomma", 10793, 0},
+{U"mcy", 1084, 0},
+{U"mdash", 8212, 0},
+{U"measuredangle", 8737, 0},
+{U"mfr", 120106, 0},
+{U"mho", 8487, 0},
+{U"micro", 181, 0},
+{U"mid", 8739, 0},
+{U"midast", 42, 0},
+{U"midcir", 10992, 0},
+{U"middot", 183, 0},
+{U"minus", 8722, 0},
+{U"minusb", 8863, 0},
+{U"minusd", 8760, 0},
+{U"minusdu", 10794, 0},
+{U"mlcp", 10971, 0},
+{U"mldr", 8230, 0},
+{U"mnplus", 8723, 0},
+{U"models", 8871, 0},
+{U"mopf", 120158, 0},
+{U"mp", 8723, 0},
+{U"mscr", 120002, 0},
+{U"mstpos", 8766, 0},
+{U"mu", 956, 0},
+{U"multimap", 8888, 0},
+{U"mumap", 8888, 0},
+{U"nGg", 8921, 824},
+{U"nGt", 8811, 8402},
+{U"nGtv", 8811, 824},
+{U"nLeftarrow", 8653, 0},
+{U"nLeftrightarrow", 8654, 0},
+{U"nLl", 8920, 824},
+{U"nLt", 8810, 8402},
+{U"nLtv", 8810, 824},
+{U"nRightarrow", 8655, 0},
+{U"nVDash", 8879, 0},
+{U"nVdash", 8878, 0},
+{U"nabla", 8711, 0},
+{U"nacute", 324, 0},
+{U"nang", 8736, 8402},
+{U"nap", 8777, 0},
+{U"napE", 10864, 824},
+{U"napid", 8779, 824},
+{U"napos", 329, 0},
+{U"napprox", 8777, 0},
+{U"natur", 9838, 0},
+{U"natural", 9838, 0},
+{U"naturals", 8469, 0},
+{U"nbsp", 160, 0},
+{U"nbump", 8782, 824},
+{U"nbumpe", 8783, 824},
+{U"ncap", 10819, 0},
+{U"ncaron", 328, 0},
+{U"ncedil", 326, 0},
+{U"ncong", 8775, 0},
+{U"ncongdot", 10861, 824},
+{U"ncup", 10818, 0},
+{U"ncy", 1085, 0},
+{U"ndash", 8211, 0},
+{U"ne", 8800, 0},
+{U"neArr", 8663, 0},
+{U"nearhk", 10532, 0},
+{U"nearr", 8599, 0},
+{U"nearrow", 8599, 0},
+{U"nedot", 8784, 824},
+{U"nequiv", 8802, 0},
+{U"nesear", 10536, 0},
+{U"nesim", 8770, 824},
+{U"nexist", 8708, 0},
+{U"nexists", 8708, 0},
+{U"nfr", 120107, 0},
+{U"ngE", 8807, 824},
+{U"nge", 8817, 0},
+{U"ngeq", 8817, 0},
+{U"ngeqq", 8807, 824},
+{U"ngeqslant", 10878, 824},
+{U"nges", 10878, 824},
+{U"ngsim", 8821, 0},
+{U"ngt", 8815, 0},
+{U"ngtr", 8815, 0},
+{U"nhArr", 8654, 0},
+{U"nharr", 8622, 0},
+{U"nhpar", 10994, 0},
+{U"ni", 8715, 0},
+{U"nis", 8956, 0},
+{U"nisd", 8954, 0},
+{U"niv", 8715, 0},
+{U"njcy", 1114, 0},
+{U"nlArr", 8653, 0},
+{U"nlE", 8806, 824},
+{U"nlarr", 8602, 0},
+{U"nldr", 8229, 0},
+{U"nle", 8816, 0},
+{U"nleftarrow", 8602, 0},
+{U"nleftrightarrow", 8622, 0},
+{U"nleq", 8816, 0},
+{U"nleqq", 8806, 824},
+{U"nleqslant", 10877, 824},
+{U"nles", 10877, 824},
+{U"nless", 8814, 0},
+{U"nlsim", 8820, 0},
+{U"nlt", 8814, 0},
+{U"nltri", 8938, 0},
+{U"nltrie", 8940, 0},
+{U"nmid", 8740, 0},
+{U"nopf", 120159, 0},
+{U"not", 172, 0},
+{U"notin", 8713, 0},
+{U"notinE", 8953, 824},
+{U"notindot", 8949, 824},
+{U"notinva", 8713, 0},
+{U"notinvb", 8951, 0},
+{U"notinvc", 8950, 0},
+{U"notni", 8716, 0},
+{U"notniva", 8716, 0},
+{U"notnivb", 8958, 0},
+{U"notnivc", 8957, 0},
+{U"npar", 8742, 0},
+{U"nparallel", 8742, 0},
+{U"nparsl", 11005, 8421},
+{U"npart", 8706, 824},
+{U"npolint", 10772, 0},
+{U"npr", 8832, 0},
+{U"nprcue", 8928, 0},
+{U"npre", 10927, 824},
+{U"nprec", 8832, 0},
+{U"npreceq", 10927, 824},
+{U"nrArr", 8655, 0},
+{U"nrarr", 8603, 0},
+{U"nrarrc", 10547, 824},
+{U"nrarrw", 8605, 824},
+{U"nrightarrow", 8603, 0},
+{U"nrtri", 8939, 0},
+{U"nrtrie", 8941, 0},
+{U"nsc", 8833, 0},
+{U"nsccue", 8929, 0},
+{U"nsce", 10928, 824},
+{U"nscr", 120003, 0},
+{U"nshortmid", 8740, 0},
+{U"nshortparallel", 8742, 0},
+{U"nsim", 8769, 0},
+{U"nsime", 8772, 0},
+{U"nsimeq", 8772, 0},
+{U"nsmid", 8740, 0},
+{U"nspar", 8742, 0},
+{U"nsqsube", 8930, 0},
+{U"nsqsupe", 8931, 0},
+{U"nsub", 8836, 0},
+{U"nsubE", 10949, 824},
+{U"nsube", 8840, 0},
+{U"nsubset", 8834, 8402},
+{U"nsubseteq", 8840, 0},
+{U"nsubseteqq", 10949, 824},
+{U"nsucc", 8833, 0},
+{U"nsucceq", 10928, 824},
+{U"nsup", 8837, 0},
+{U"nsupE", 10950, 824},
+{U"nsupe", 8841, 0},
+{U"nsupset", 8835, 8402},
+{U"nsupseteq", 8841, 0},
+{U"nsupseteqq", 10950, 824},
+{U"ntgl", 8825, 0},
+{U"ntilde", 241, 0},
+{U"ntlg", 8824, 0},
+{U"ntriangleleft", 8938, 0},
+{U"ntrianglelefteq", 8940, 0},
+{U"ntriangleright", 8939, 0},
+{U"ntrianglerighteq", 8941, 0},
+{U"nu", 957, 0},
+{U"num", 35, 0},
+{U"numero", 8470, 0},
+{U"numsp", 8199, 0},
+{U"nvDash", 8877, 0},
+{U"nvHarr", 10500, 0},
+{U"nvap", 8781, 8402},
+{U"nvdash", 8876, 0},
+{U"nvge", 8805, 8402},
+{U"nvgt", 62, 8402},
+{U"nvinfin", 10718, 0},
+{U"nvlArr", 10498, 0},
+{U"nvle", 8804, 8402},
+{U"nvlt", 60, 8402},
+{U"nvltrie", 8884, 8402},
+{U"nvrArr", 10499, 0},
+{U"nvrtrie", 8885, 8402},
+{U"nvsim", 8764, 8402},
+{U"nwArr", 8662, 0},
+{U"nwarhk", 10531, 0},
+{U"nwarr", 8598, 0},
+{U"nwarrow", 8598, 0},
+{U"nwnear", 10535, 0},
+{U"oS", 9416, 0},
+{U"oacute", 243, 0},
+{U"oast", 8859, 0},
+{U"ocir", 8858, 0},
+{U"ocirc", 244, 0},
+{U"ocy", 1086, 0},
+{U"odash", 8861, 0},
+{U"odblac", 337, 0},
+{U"odiv", 10808, 0},
+{U"odot", 8857, 0},
+{U"odsold", 10684, 0},
+{U"oelig", 339, 0},
+{U"ofcir", 10687, 0},
+{U"ofr", 120108, 0},
+{U"ogon", 731, 0},
+{U"ograve", 242, 0},
+{U"ogt", 10689, 0},
+{U"ohbar", 10677, 0},
+{U"ohm", 937, 0},
+{U"oint", 8750, 0},
+{U"olarr", 8634, 0},
+{U"olcir", 10686, 0},
+{U"olcross", 10683, 0},
+{U"oline", 8254, 0},
+{U"olt", 10688, 0},
+{U"omacr", 333, 0},
+{U"omega", 969, 0},
+{U"omicron", 959, 0},
+{U"omid", 10678, 0},
+{U"ominus", 8854, 0},
+{U"oopf", 120160, 0},
+{U"opar", 10679, 0},
+{U"operp", 10681, 0},
+{U"oplus", 8853, 0},
+{U"or", 8744, 0},
+{U"orarr", 8635, 0},
+{U"ord", 10845, 0},
+{U"order", 8500, 0},
+{U"orderof", 8500, 0},
+{U"ordf", 170, 0},
+{U"ordm", 186, 0},
+{U"origof", 8886, 0},
+{U"oror", 10838, 0},
+{U"orslope", 10839, 0},
+{U"orv", 10843, 0},
+{U"oscr", 8500, 0},
+{U"oslash", 248, 0},
+{U"osol", 8856, 0},
+{U"otilde", 245, 0},
+{U"otimes", 8855, 0},
+{U"otimesas", 10806, 0},
+{U"ouml", 246, 0},
+{U"ovbar", 9021, 0},
+{U"par", 8741, 0},
+{U"para", 182, 0},
+{U"parallel", 8741, 0},
+{U"parsim", 10995, 0},
+{U"parsl", 11005, 0},
+{U"part", 8706, 0},
+{U"pcy", 1087, 0},
+{U"percnt", 37, 0},
+{U"period", 46, 0},
+{U"permil", 8240, 0},
+{U"perp", 8869, 0},
+{U"pertenk", 8241, 0},
+{U"pfr", 120109, 0},
+{U"phi", 966, 0},
+{U"phiv", 981, 0},
+{U"phmmat", 8499, 0},
+{U"phone", 9742, 0},
+{U"pi", 960, 0},
+{U"pitchfork", 8916, 0},
+{U"piv", 982, 0},
+{U"planck", 8463, 0},
+{U"planckh", 8462, 0},
+{U"plankv", 8463, 0},
+{U"plus", 43, 0},
+{U"plusacir", 10787, 0},
+{U"plusb", 8862, 0},
+{U"pluscir", 10786, 0},
+{U"plusdo", 8724, 0},
+{U"plusdu", 10789, 0},
+{U"pluse", 10866, 0},
+{U"plusmn", 177, 0},
+{U"plussim", 10790, 0},
+{U"plustwo", 10791, 0},
+{U"pm", 177, 0},
+{U"pointint", 10773, 0},
+{U"popf", 120161, 0},
+{U"pound", 163, 0},
+{U"pr", 8826, 0},
+{U"prE", 10931, 0},
+{U"prap", 10935, 0},
+{U"prcue", 8828, 0},
+{U"pre", 10927, 0},
+{U"prec", 8826, 0},
+{U"precapprox", 10935, 0},
+{U"preccurlyeq", 8828, 0},
+{U"preceq", 10927, 0},
+{U"precnapprox", 10937, 0},
+{U"precneqq", 10933, 0},
+{U"precnsim", 8936, 0},
+{U"precsim", 8830, 0},
+{U"prime", 8242, 0},
+{U"primes", 8473, 0},
+{U"prnE", 10933, 0},
+{U"prnap", 10937, 0},
+{U"prnsim", 8936, 0},
+{U"prod", 8719, 0},
+{U"profalar", 9006, 0},
+{U"profline", 8978, 0},
+{U"profsurf", 8979, 0},
+{U"prop", 8733, 0},
+{U"propto", 8733, 0},
+{U"prsim", 8830, 0},
+{U"prurel", 8880, 0},
+{U"pscr", 120005, 0},
+{U"psi", 968, 0},
+{U"puncsp", 8200, 0},
+{U"qfr", 120110, 0},
+{U"qint", 10764, 0},
+{U"qopf", 120162, 0},
+{U"qprime", 8279, 0},
+{U"qscr", 120006, 0},
+{U"quaternions", 8461, 0},
+{U"quatint", 10774, 0},
+{U"quest", 63, 0},
+{U"questeq", 8799, 0},
+{U"quot", 34, 0},
+{U"rAarr", 8667, 0},
+{U"rArr", 8658, 0},
+{U"rAtail", 10524, 0},
+{U"rBarr", 10511, 0},
+{U"rHar", 10596, 0},
+{U"race", 8765, 817},
+{U"racute", 341, 0},
+{U"radic", 8730, 0},
+{U"raemptyv", 10675, 0},
+{U"rang", 10217, 0},
+{U"rangd", 10642, 0},
+{U"range", 10661, 0},
+{U"rangle", 10217, 0},
+{U"raquo", 187, 0},
+{U"rarr", 8594, 0},
+{U"rarrap", 10613, 0},
+{U"rarrb", 8677, 0},
+{U"rarrbfs", 10528, 0},
+{U"rarrc", 10547, 0},
+{U"rarrfs", 10526, 0},
+{U"rarrhk", 8618, 0},
+{U"rarrlp", 8620, 0},
+{U"rarrpl", 10565, 0},
+{U"rarrsim", 10612, 0},
+{U"rarrtl", 8611, 0},
+{U"rarrw", 8605, 0},
+{U"ratail", 10522, 0},
+{U"ratio", 8758, 0},
+{U"rationals", 8474, 0},
+{U"rbarr", 10509, 0},
+{U"rbbrk", 10099, 0},
+{U"rbrace", 125, 0},
+{U"rbrack", 93, 0},
+{U"rbrke", 10636, 0},
+{U"rbrksld", 10638, 0},
+{U"rbrkslu", 10640, 0},
+{U"rcaron", 345, 0},
+{U"rcedil", 343, 0},
+{U"rceil", 8969, 0},
+{U"rcub", 125, 0},
+{U"rcy", 1088, 0},
+{U"rdca", 10551, 0},
+{U"rdldhar", 10601, 0},
+{U"rdquo", 8221, 0},
+{U"rdquor", 8221, 0},
+{U"rdsh", 8627, 0},
+{U"real", 8476, 0},
+{U"realine", 8475, 0},
+{U"realpart", 8476, 0},
+{U"reals", 8477, 0},
+{U"rect", 9645, 0},
+{U"reg", 174, 0},
+{U"rfisht", 10621, 0},
+{U"rfloor", 8971, 0},
+{U"rfr", 120111, 0},
+{U"rhard", 8641, 0},
+{U"rharu", 8640, 0},
+{U"rharul", 10604, 0},
+{U"rho", 961, 0},
+{U"rhov", 1009, 0},
+{U"rightarrow", 8594, 0},
+{U"rightarrowtail", 8611, 0},
+{U"rightharpoondown", 8641, 0},
+{U"rightharpoonup", 8640, 0},
+{U"rightleftarrows", 8644, 0},
+{U"rightleftharpoons", 8652, 0},
+{U"rightrightarrows", 8649, 0},
+{U"rightsquigarrow", 8605, 0},
+{U"rightthreetimes", 8908, 0},
+{U"ring", 730, 0},
+{U"risingdotseq", 8787, 0},
+{U"rlarr", 8644, 0},
+{U"rlhar", 8652, 0},
+{U"rlm", 8207, 0},
+{U"rmoust", 9137, 0},
+{U"rmoustache", 9137, 0},
+{U"rnmid", 10990, 0},
+{U"roang", 10221, 0},
+{U"roarr", 8702, 0},
+{U"robrk", 10215, 0},
+{U"ropar", 10630, 0},
+{U"ropf", 120163, 0},
+{U"roplus", 10798, 0},
+{U"rotimes", 10805, 0},
+{U"rpar", 41, 0},
+{U"rpargt", 10644, 0},
+{U"rppolint", 10770, 0},
+{U"rrarr", 8649, 0},
+{U"rsaquo", 8250, 0},
+{U"rscr", 120007, 0},
+{U"rsh", 8625, 0},
+{U"rsqb", 93, 0},
+{U"rsquo", 8217, 0},
+{U"rsquor", 8217, 0},
+{U"rthree", 8908, 0},
+{U"rtimes", 8906, 0},
+{U"rtri", 9657, 0},
+{U"rtrie", 8885, 0},
+{U"rtrif", 9656, 0},
+{U"rtriltri", 10702, 0},
+{U"ruluhar", 10600, 0},
+{U"rx", 8478, 0},
+{U"sacute", 347, 0},
+{U"sbquo", 8218, 0},
+{U"sc", 8827, 0},
+{U"scE", 10932, 0},
+{U"scap", 10936, 0},
+{U"scaron", 353, 0},
+{U"sccue", 8829, 0},
+{U"sce", 10928, 0},
+{U"scedil", 351, 0},
+{U"scirc", 349, 0},
+{U"scnE", 10934, 0},
+{U"scnap", 10938, 0},
+{U"scnsim", 8937, 0},
+{U"scpolint", 10771, 0},
+{U"scsim", 8831, 0},
+{U"scy", 1089, 0},
+{U"sdot", 8901, 0},
+{U"sdotb", 8865, 0},
+{U"sdote", 10854, 0},
+{U"seArr", 8664, 0},
+{U"searhk", 10533, 0},
+{U"searr", 8600, 0},
+{U"searrow", 8600, 0},
+{U"sect", 167, 0},
+{U"semi", 59, 0},
+{U"seswar", 10537, 0},
+{U"setminus", 8726, 0},
+{U"setmn", 8726, 0},
+{U"sext", 10038, 0},
+{U"sfr", 120112, 0},
+{U"sfrown", 8994, 0},
+{U"sharp", 9839, 0},
+{U"shchcy", 1097, 0},
+{U"shcy", 1096, 0},
+{U"shortmid", 8739, 0},
+{U"shortparallel", 8741, 0},
+{U"shy", 173, 0},
+{U"sigma", 963, 0},
+{U"sigmaf", 962, 0},
+{U"sigmav", 962, 0},
+{U"sim", 8764, 0},
+{U"simdot", 10858, 0},
+{U"sime", 8771, 0},
+{U"simeq", 8771, 0},
+{U"simg", 10910, 0},
+{U"simgE", 10912, 0},
+{U"siml", 10909, 0},
+{U"simlE", 10911, 0},
+{U"simne", 8774, 0},
+{U"simplus", 10788, 0},
+{U"simrarr", 10610, 0},
+{U"slarr", 8592, 0},
+{U"smallsetminus", 8726, 0},
+{U"smashp", 10803, 0},
+{U"smeparsl", 10724, 0},
+{U"smid", 8739, 0},
+{U"smile", 8995, 0},
+{U"smt", 10922, 0},
+{U"smte", 10924, 0},
+{U"smtes", 10924, 65024},
+{U"softcy", 1100, 0},
+{U"sol", 47, 0},
+{U"solb", 10692, 0},
+{U"solbar", 9023, 0},
+{U"sopf", 120164, 0},
+{U"spades", 9824, 0},
+{U"spadesuit", 9824, 0},
+{U"spar", 8741, 0},
+{U"sqcap", 8851, 0},
+{U"sqcaps", 8851, 65024},
+{U"sqcup", 8852, 0},
+{U"sqcups", 8852, 65024},
+{U"sqsub", 8847, 0},
+{U"sqsube", 8849, 0},
+{U"sqsubset", 8847, 0},
+{U"sqsubseteq", 8849, 0},
+{U"sqsup", 8848, 0},
+{U"sqsupe", 8850, 0},
+{U"sqsupset", 8848, 0},
+{U"sqsupseteq", 8850, 0},
+{U"squ", 9633, 0},
+{U"square", 9633, 0},
+{U"squarf", 9642, 0},
+{U"squf", 9642, 0},
+{U"srarr", 8594, 0},
+{U"sscr", 120008, 0},
+{U"ssetmn", 8726, 0},
+{U"ssmile", 8995, 0},
+{U"sstarf", 8902, 0},
+{U"star", 9734, 0},
+{U"starf", 9733, 0},
+{U"straightepsilon", 1013, 0},
+{U"straightphi", 981, 0},
+{U"strns", 175, 0},
+{U"sub", 8834, 0},
+{U"subE", 10949, 0},
+{U"subdot", 10941, 0},
+{U"sube", 8838, 0},
+{U"subedot", 10947, 0},
+{U"submult", 10945, 0},
+{U"subnE", 10955, 0},
+{U"subne", 8842, 0},
+{U"subplus", 10943, 0},
+{U"subrarr", 10617, 0},
+{U"subset", 8834, 0},
+{U"subseteq", 8838, 0},
+{U"subseteqq", 10949, 0},
+{U"subsetneq", 8842, 0},
+{U"subsetneqq", 10955, 0},
+{U"subsim", 10951, 0},
+{U"subsub", 10965, 0},
+{U"subsup", 10963, 0},
+{U"succ", 8827, 0},
+{U"succapprox", 10936, 0},
+{U"succcurlyeq", 8829, 0},
+{U"succeq", 10928, 0},
+{U"succnapprox", 10938, 0},
+{U"succneqq", 10934, 0},
+{U"succnsim", 8937, 0},
+{U"succsim", 8831, 0},
+{U"sum", 8721, 0},
+{U"sung", 9834, 0},
+{U"sup", 8835, 0},
+{U"sup1", 185, 0},
+{U"sup2", 178, 0},
+{U"sup3", 179, 0},
+{U"supE", 10950, 0},
+{U"supdot", 10942, 0},
+{U"supdsub", 10968, 0},
+{U"supe", 8839, 0},
+{U"supedot", 10948, 0},
+{U"suphsol", 10185, 0},
+{U"suphsub", 10967, 0},
+{U"suplarr", 10619, 0},
+{U"supmult", 10946, 0},
+{U"supnE", 10956, 0},
+{U"supne", 8843, 0},
+{U"supplus", 10944, 0},
+{U"supset", 8835, 0},
+{U"supseteq", 8839, 0},
+{U"supseteqq", 10950, 0},
+{U"supsetneq", 8843, 0},
+{U"supsetneqq", 10956, 0},
+{U"supsim", 10952, 0},
+{U"supsub", 10964, 0},
+{U"supsup", 10966, 0},
+{U"swArr", 8665, 0},
+{U"swarhk", 10534, 0},
+{U"swarr", 8601, 0},
+{U"swarrow", 8601, 0},
+{U"swnwar", 10538, 0},
+{U"szlig", 223, 0},
+{U"target", 8982, 0},
+{U"tau", 964, 0},
+{U"tbrk", 9140, 0},
+{U"tcaron", 357, 0},
+{U"tcedil", 355, 0},
+{U"tcy", 1090, 0},
+{U"tdot", 8411, 0},
+{U"telrec", 8981, 0},
+{U"tfr", 120113, 0},
+{U"there4", 8756, 0},
+{U"therefore", 8756, 0},
+{U"theta", 952, 0},
+{U"thetasym", 977, 0},
+{U"thetav", 977, 0},
+{U"thickapprox", 8776, 0},
+{U"thicksim", 8764, 0},
+{U"thinsp", 8201, 0},
+{U"thkap", 8776, 0},
+{U"thksim", 8764, 0},
+{U"thorn", 254, 0},
+{U"tilde", 732, 0},
+{U"times", 215, 0},
+{U"timesb", 8864, 0},
+{U"timesbar", 10801, 0},
+{U"timesd", 10800, 0},
+{U"tint", 8749, 0},
+{U"toea", 10536, 0},
+{U"top", 8868, 0},
+{U"topbot", 9014, 0},
+{U"topcir", 10993, 0},
+{U"topf", 120165, 0},
+{U"topfork", 10970, 0},
+{U"tosa", 10537, 0},
+{U"tprime", 8244, 0},
+{U"trade", 8482, 0},
+{U"triangle", 9653, 0},
+{U"triangledown", 9663, 0},
+{U"triangleleft", 9667, 0},
+{U"trianglelefteq", 8884, 0},
+{U"triangleq", 8796, 0},
+{U"triangleright", 9657, 0},
+{U"trianglerighteq", 8885, 0},
+{U"tridot", 9708, 0},
+{U"trie", 8796, 0},
+{U"triminus", 10810, 0},
+{U"triplus", 10809, 0},
+{U"trisb", 10701, 0},
+{U"tritime", 10811, 0},
+{U"trpezium", 9186, 0},
+{U"tscr", 120009, 0},
+{U"tscy", 1094, 0},
+{U"tshcy", 1115, 0},
+{U"tstrok", 359, 0},
+{U"twixt", 8812, 0},
+{U"twoheadleftarrow", 8606, 0},
+{U"twoheadrightarrow", 8608, 0},
+{U"uArr", 8657, 0},
+{U"uHar", 10595, 0},
+{U"uacute", 250, 0},
+{U"uarr", 8593, 0},
+{U"ubrcy", 1118, 0},
+{U"ubreve", 365, 0},
+{U"ucirc", 251, 0},
+{U"ucy", 1091, 0},
+{U"udarr", 8645, 0},
+{U"udblac", 369, 0},
+{U"udhar", 10606, 0},
+{U"ufisht", 10622, 0},
+{U"ufr", 120114, 0},
+{U"ugrave", 249, 0},
+{U"uharl", 8639, 0},
+{U"uharr", 8638, 0},
+{U"uhblk", 9600, 0},
+{U"ulcorn", 8988, 0},
+{U"ulcorner", 8988, 0},
+{U"ulcrop", 8975, 0},
+{U"ultri", 9720, 0},
+{U"umacr", 363, 0},
+{U"uml", 168, 0},
+{U"uogon", 371, 0},
+{U"uopf", 120166, 0},
+{U"uparrow", 8593, 0},
+{U"updownarrow", 8597, 0},
+{U"upharpoonleft", 8639, 0},
+{U"upharpoonright", 8638, 0},
+{U"uplus", 8846, 0},
+{U"upsi", 965, 0},
+{U"upsih", 978, 0},
+{U"upsilon", 965, 0},
+{U"upuparrows", 8648, 0},
+{U"urcorn", 8989, 0},
+{U"urcorner", 8989, 0},
+{U"urcrop", 8974, 0},
+{U"uring", 367, 0},
+{U"urtri", 9721, 0},
+{U"uscr", 120010, 0},
+{U"utdot", 8944, 0},
+{U"utilde", 361, 0},
+{U"utri", 9653, 0},
+{U"utrif", 9652, 0},
+{U"uuarr", 8648, 0},
+{U"uuml", 252, 0},
+{U"uwangle", 10663, 0},
+{U"vArr", 8661, 0},
+{U"vBar", 10984, 0},
+{U"vBarv", 10985, 0},
+{U"vDash", 8872, 0},
+{U"vangrt", 10652, 0},
+{U"varepsilon", 1013, 0},
+{U"varkappa", 1008, 0},
+{U"varnothing", 8709, 0},
+{U"varphi", 981, 0},
+{U"varpi", 982, 0},
+{U"varpropto", 8733, 0},
+{U"varr", 8597, 0},
+{U"varrho", 1009, 0},
+{U"varsigma", 962, 0},
+{U"varsubsetneq", 8842, 65024},
+{U"varsubsetneqq", 10955, 65024},
+{U"varsupsetneq", 8843, 65024},
+{U"varsupsetneqq", 10956, 65024},
+{U"vartheta", 977, 0},
+{U"vartriangleleft", 8882, 0},
+{U"vartriangleright", 8883, 0},
+{U"vcy", 1074, 0},
+{U"vdash", 8866, 0},
+{U"vee", 8744, 0},
+{U"veebar", 8891, 0},
+{U"veeeq", 8794, 0},
+{U"vellip", 8942, 0},
+{U"verbar", 124, 0},
+{U"vert", 124, 0},
+{U"vfr", 120115, 0},
+{U"vltri", 8882, 0},
+{U"vnsub", 8834, 8402},
+{U"vnsup", 8835, 8402},
+{U"vopf", 120167, 0},
+{U"vprop", 8733, 0},
+{U"vrtri", 8883, 0},
+{U"vscr", 120011, 0},
+{U"vsubnE", 10955, 65024},
+{U"vsubne", 8842, 65024},
+{U"vsupnE", 10956, 65024},
+{U"vsupne", 8843, 65024},
+{U"vzigzag", 10650, 0},
+{U"wcirc", 373, 0},
+{U"wedbar", 10847, 0},
+{U"wedge", 8743, 0},
+{U"wedgeq", 8793, 0},
+{U"weierp", 8472, 0},
+{U"wfr", 120116, 0},
+{U"wopf", 120168, 0},
+{U"wp", 8472, 0},
+{U"wr", 8768, 0},
+{U"wreath", 8768, 0},
+{U"wscr", 120012, 0},
+{U"xcap", 8898, 0},
+{U"xcirc", 9711, 0},
+{U"xcup", 8899, 0},
+{U"xdtri", 9661, 0},
+{U"xfr", 120117, 0},
+{U"xhArr", 10234, 0},
+{U"xharr", 10231, 0},
+{U"xi", 958, 0},
+{U"xlArr", 10232, 0},
+{U"xlarr", 10229, 0},
+{U"xmap", 10236, 0},
+{U"xnis", 8955, 0},
+{U"xodot", 10752, 0},
+{U"xopf", 120169, 0},
+{U"xoplus", 10753, 0},
+{U"xotime", 10754, 0},
+{U"xrArr", 10233, 0},
+{U"xrarr", 10230, 0},
+{U"xscr", 120013, 0},
+{U"xsqcup", 10758, 0},
+{U"xuplus", 10756, 0},
+{U"xutri", 9651, 0},
+{U"xvee", 8897, 0},
+{U"xwedge", 8896, 0},
+{U"yacute", 253, 0},
+{U"yacy", 1103, 0},
+{U"ycirc", 375, 0},
+{U"ycy", 1099, 0},
+{U"yen", 165, 0},
+{U"yfr", 120118, 0},
+{U"yicy", 1111, 0},
+{U"yopf", 120170, 0},
+{U"yscr", 120014, 0},
+{U"yucy", 1102, 0},
+{U"yuml", 255, 0},
+{U"zacute", 378, 0},
+{U"zcaron", 382, 0},
+{U"zcy", 1079, 0},
+{U"zdot", 380, 0},
+{U"zeetrf", 8488, 0},
+{U"zeta", 950, 0},
+{U"zfr", 120119, 0},
+{U"zhcy", 1078, 0},
+{U"zigrarr", 8669, 0},
+{U"zopf", 120171, 0},
+{U"zscr", 120015, 0},
+{U"zwj", 8205, 0},
+{U"zwnj", 8204, 0},
 {NULL, 0},
 };
 
@@ -5337,12 +5337,12 @@ int codeconvert(int code)
 }
 
 /// in-place XML string decoding, don't expand tabs, returns new length (may be less than initial len)
-int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * enc_table)
+int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * enc_table)
 {
     int state = 0;
-    lChar16 nch = 0;
-    lChar16 lch = 0;
-    lChar16 nsp = 0;
+    lChar32 nch = 0;
+    lChar32 lch = 0;
+    lChar32 nsp = 0;
     bool pre = (flags & TXTFLG_PRE) != 0;
     bool pre_para_splitting = (flags & TXTFLG_PRE_PARA_SPLITTING)!=0;
     if ( pre_para_splitting )
@@ -5353,7 +5353,7 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
     for (int i=0; i<len; ++i ) {
         if (j >= len)
             break;
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         if (pre) {
             if (ch == '\r') {
                 if ((i==0 || lch!='\n') && (i==len-1 || str[i+1]!='\n')) {
@@ -5386,14 +5386,14 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
             if (state == 2 && ch=='x')
                 state = 22;
             else if (state == 22 && hexDigit(ch)>=0)
-                nch = (lChar16)((nch << 4) | hexDigit(ch));
+                nch = (lChar32)((nch << 4) | hexDigit(ch));
             else if (state == 2 && ch>='0' && ch<='9')
-                nch = (lChar16)(nch * 10 + (ch - '0'));
+                nch = (lChar32)(nch * 10 + (ch - '0'));
             else if (ch=='#' && state==1)
                 state = 2;
             else if (state==1 && ((ch>='a' && ch<='z') || (ch>='A' && ch<='Z')) ) {
                 int k;
-                lChar16 entname[16];
+                lChar32 entname[16];
                 for ( k = 0; k < 16; k++ ) {
                     entname[k] = str[k + i];
                     if (!entname[k] || entname[k]==';' || entname[k]==' ')
@@ -5403,17 +5403,17 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
                     k--;
                 entname[k] = 0;
                 int n;
-                lChar16 code = 0;
-                lChar16 code2 = 0;
+                lChar32 code = 0;
+                lChar32 code2 = 0;
                 if ( str[i+k]==';' || str[i+k]==' ' ) {
                     // Nb of iterations for some classic named entities:
                     //   nbsp: 5 - amp: 7 - lt: 8 - quot: 9
                     //   apos gt shy eacute   10
                     // Let's have some early straight comparisons for the ones we
                     // have a chance to find in huge quantities in some documents.
-                    if ( !lStr_cmp( entname, L"nbsp" ) )
+                    if ( !lStr_cmp( entname, U"nbsp" ) )
                         code = 160;
-                    else if ( !lStr_cmp( entname, L"shy" ) )
+                    else if ( !lStr_cmp( entname, U"shy" ) )
                         code = 173;
                     else {
                         // Binary search (usually takes 5 to 12 iterations)
@@ -5475,7 +5475,7 @@ int PreProcessXmlString(lChar16 * str, int len, lUInt32 flags, const lChar16 * e
     return j;
 }
 
-int CalcTabCount(const lChar16 * str, int nlen) {
+int CalcTabCount(const lChar32 * str, int nlen) {
     int tabCount = 0;
     for (int i=0; i<nlen; i++) {
         if (str[i] == '\t')
@@ -5484,19 +5484,19 @@ int CalcTabCount(const lChar16 * str, int nlen) {
     return tabCount;
 }
 
-void ExpandTabs(lString16 & buf, const lChar16 * str, int len)
+void ExpandTabs(lString32 & buf, const lChar32 * str, int len)
 {
     // check for tabs
     int x = 0;
     for (int i = 0; i < len; i++) {
-        lChar16 ch = str[i];
+        lChar32 ch = str[i];
         if ( ch=='\r' || ch=='\n' )
             x = 0;
         if ( ch=='\t' ) {
             int delta = 8 - (x & 7);
             x += delta;
             while ( delta-- )
-                buf << L' ';
+                buf << U' ';
         } else {
             buf << ch;
             x++;
@@ -5504,14 +5504,14 @@ void ExpandTabs(lString16 & buf, const lChar16 * str, int len)
     }
 }
 
-void ExpandTabs(lString16 & s)
+void ExpandTabs(lString32 & s)
 {
     // check for tabs
     int nlen = s.length();
     int tabCount = CalcTabCount(s.c_str(), nlen);
     if ( tabCount > 0 ) {
         // expand tabs
-        lString16 buf;
+        lString32 buf;
         buf.reserve(nlen + tabCount * 8);
         ExpandTabs(buf, s.c_str(), s.length());
         s = buf;
@@ -5519,9 +5519,9 @@ void ExpandTabs(lString16 & s)
 }
 
 // returns new length
-void PreProcessXmlString( lString16 & s, lUInt32 flags, const lChar16 * enc_table )
+void PreProcessXmlString( lString32 & s, lUInt32 flags, const lChar32 * enc_table )
 {
-    lChar16 * str = s.modify();
+    lChar32 * str = s.modify();
     int len = s.length();
     int nlen = PreProcessXmlString(str, len, flags, enc_table);
     // remove extra characters from end of line
@@ -5546,16 +5546,16 @@ int LVTextFileBase::fillCharBuffer()
     if ( m_buf_len - m_buf_pos < MIN_BUF_DATA_SIZE )
         FillBuffer( MIN_BUF_DATA_SIZE*2 );
     if ( m_read_buffer_len > (XML_CHAR_BUFFER_SIZE - (XML_CHAR_BUFFER_SIZE>>3)) ) {
-        memcpy( m_read_buffer, m_read_buffer+m_read_buffer_pos, available * sizeof(lChar16) );
+        memcpy( m_read_buffer, m_read_buffer+m_read_buffer_pos, available * sizeof(lChar32) );
         m_read_buffer_pos = 0;
         m_read_buffer_len = available;
     }
     int charsRead = ReadChars( m_read_buffer + m_read_buffer_len, XML_CHAR_BUFFER_SIZE - m_read_buffer_len );
     m_read_buffer_len += charsRead;
 //#ifdef _DEBUG
-//    CRLog::trace("buf: %s\n", UnicodeToUtf8(lString16(m_read_buffer, m_read_buffer_len)).c_str() );
+//    CRLog::trace("buf: %s\n", UnicodeToUtf8(lString32(m_read_buffer, m_read_buffer_len)).c_str() );
 //#endif
-    //CRLog::trace("Buf:'%s'", LCSTR(lString16(m_read_buffer, m_read_buffer_len)) );
+    //CRLog::trace("Buf:'%s'", LCSTR(lString32(m_read_buffer, m_read_buffer_len)) );
     return m_read_buffer_len - m_read_buffer_pos;
 }
 
@@ -5586,7 +5586,7 @@ bool LVXMLParser::ReadText()
                     // But ignore it if empty space
                     done = true;
                     for (int i=0; i<m_txt_buf.length(); i++) {
-                        lChar16 ch = m_txt_buf[i];
+                        lChar32 ch = m_txt_buf[i];
                         if ( ch!=' ' && ch!='\r' && ch!='\n' && ch!='\t') {
                             done = false;
                             flgBreak = true;
@@ -5600,8 +5600,8 @@ bool LVXMLParser::ReadText()
         }
       if ( !m_eof ) { // just skip the following if m_eof but still some text in buffer to handle
         for ( ; m_read_buffer_pos+i<m_read_buffer_len; i++ ) {
-            lChar16 ch = m_read_buffer[m_read_buffer_pos + i];
-            lChar16 nextch = m_read_buffer_pos + i + 1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 1] : 0;
+            lChar32 ch = m_read_buffer[m_read_buffer_pos + i];
+            lChar32 nextch = m_read_buffer_pos + i + 1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 1] : 0;
             flgBreak = ch=='<' || m_eof;
             if ( flgBreak && !tlen ) {
                 m_read_buffer_pos++;
@@ -5636,9 +5636,9 @@ bool LVXMLParser::ReadText()
         if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas)
         {
             //=====================================================
-            lChar16 * buf = m_txt_buf.modify();
+            lChar32 * buf = m_txt_buf.modify();
 
-            const lChar16 * enc_table = NULL;
+            const lChar32 * enc_table = NULL;
             if ( flags & TXTFLG_CONVERT_8BIT_ENTITY_ENCODING )
                 enc_table = this->m_conv_table;
 
@@ -5655,7 +5655,7 @@ bool LVXMLParser::ReadText()
                 int tabCount = CalcTabCount(buf, nlen);
                 if ( tabCount > 0 ) {
                     // expand tabs
-                    lString16 tmp;
+                    lString32 tmp;
                     tmp.reserve(nlen + tabCount * 8);
                     ExpandTabs(tmp, buf, nlen);
                     m_callback->OnText(tmp.c_str(), tmp.length(), flags);
@@ -5700,7 +5700,7 @@ bool LVXMLParser::SkipSpaces()
     return (!m_eof);
 }
 
-bool LVXMLParser::SkipTillChar( lChar16 charToFind )
+bool LVXMLParser::SkipTillChar( lChar32 charToFind )
 {
     for ( lUInt16 ch = PeekCharFromBuffer(); !m_eof; ch = PeekNextCharFromBuffer() ) {
         if ( ch == charToFind )
@@ -5709,7 +5709,7 @@ bool LVXMLParser::SkipTillChar( lChar16 charToFind )
     return false; // EOF
 }
 
-inline bool isValidIdentChar( lChar16 ch )
+inline bool isValidIdentChar( lChar32 ch )
 {
     return ( (ch>='a' && ch<='z')
           || (ch>='A' && ch<='Z')
@@ -5720,7 +5720,7 @@ inline bool isValidIdentChar( lChar16 ch )
           || (ch==':') );
 }
 
-inline bool isValidFirstIdentChar( lChar16 ch )
+inline bool isValidFirstIdentChar( lChar32 ch )
 {
     return ( (ch>='a' && ch<='z')
           || (ch>='A' && ch<='Z')
@@ -5728,13 +5728,13 @@ inline bool isValidFirstIdentChar( lChar16 ch )
 }
 
 // read identifier from stream
-bool LVXMLParser::ReadIdent( lString16 & ns, lString16 & name )
+bool LVXMLParser::ReadIdent( lString32 & ns, lString32 & name )
 {
     // clear string buffer
     ns.reset(16);
     name.reset(16);
     // check first char
-    lChar16 ch0 = PeekCharFromBuffer();
+    lChar32 ch0 = PeekCharFromBuffer();
     if ( !isValidFirstIdentChar(ch0) )
         return false;
 
@@ -5755,7 +5755,7 @@ bool LVXMLParser::ReadIdent( lString16 & ns, lString16 & name )
             name += ch;
         }
     }
-    lChar16 ch = PeekCharFromBuffer();
+    lChar32 ch = PeekCharFromBuffer();
     return (!name.empty()) && (ch==' ' || ch=='/' || ch=='>' || ch=='?' || ch=='=' || ch==0 || ch == '\r' || ch == '\n');
 }
 
@@ -5764,13 +5764,13 @@ void LVXMLParser::SetSpaceMode( bool flgTrimSpaces )
     m_trimspaces = flgTrimSpaces;
 }
 
-lString16 htmlCharset( lString16 htmlHeader )
+lString32 htmlCharset( lString32 htmlHeader )
 {
     // Parse meta http-equiv or
     // meta charset
     // https://www.w3.org/TR/2011/WD-html5-author-20110809/the-meta-element.html
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
-    lString16 enc;
+    lString32 enc;
     int metapos = htmlHeader.pos("<meta");
     if (metapos >= 0) {
         // 1. attribute 'http-equiv'
@@ -5790,7 +5790,7 @@ lString16 htmlCharset( lString16 htmlHeader )
                                 if (pos > 0) {
                                     pos += 1;       // skip "="
                                     // skip spaces
-                                    lChar16 ch;
+                                    lChar32 ch;
                                     for ( int i=0; i + pos < (int)htmlHeader.length(); i++ ) {
                                         ch = htmlHeader[i + pos];
                                         if ( !IsSpaceChar(ch) )
@@ -5818,7 +5818,7 @@ lString16 htmlCharset( lString16 htmlHeader )
                 if (pos > 0) {
                     pos += 1;           // skip "="
                     // skip spaces
-                    lChar16 ch;
+                    lChar32 ch;
                     for ( int i=0; i + pos < (int)htmlHeader.length(); i++ ) {
                         ch = htmlHeader[i + pos];
                         if ( !IsSpaceChar(ch) )
@@ -5840,7 +5840,7 @@ lString16 htmlCharset( lString16 htmlHeader )
         }
     }
     if (enc == "utf-16")
-        return lString16::empty_str;
+        return lString32::empty_str;
     return enc;
 }
 
@@ -5852,13 +5852,13 @@ bool LVHTMLParser::CheckFormat()
     // encoding test
     if ( !AutodetectEncoding(!this->m_encoding_name.empty()) )
         return false;
-    lChar16 * chbuf = new lChar16[XML_PARSER_DETECT_SIZE];
+    lChar32 * chbuf = new lChar32[XML_PARSER_DETECT_SIZE];
     FillBuffer( XML_PARSER_DETECT_SIZE );
     int charsDecoded = ReadTextBytes( 0, m_buf_len, chbuf, XML_PARSER_DETECT_SIZE-1, 0 );
     chbuf[charsDecoded] = 0;
     bool res = false;
     if ( charsDecoded > 30 ) {
-        lString16 s( chbuf, charsDecoded );
+        lString32 s( chbuf, charsDecoded );
         s.lowercase();
         if ( s.pos("<html") >=0 && ( s.pos("<head") >= 0 || s.pos("<body") >=0 ) ) {
             res = true;
@@ -5872,13 +5872,13 @@ bool LVHTMLParser::CheckFormat()
             }
         }
         if ( !res ) { // check filename extension and present of common HTML tags
-            lString16 name=m_stream->GetName();
+            lString32 name=m_stream->GetName();
             name.lowercase();
             bool html_ext = name.endsWith(".htm") || name.endsWith(".html") || name.endsWith(".hhc") || name.endsWith(".xhtml");
             if ( html_ext && (s.pos("<!--")>=0 || s.pos("ul")>=0 || s.pos("<p>")>=0) )
                 res = true;
         }
-        lString16 enc = htmlCharset( s );
+        lString32 enc = htmlCharset( s );
         if ( !enc.empty() )
             SetCharset( enc.c_str() );
         //else if ( s.pos("<html xmlns=\"http://www.w3.org/1999/xhtml\"") >= 0 )
@@ -5911,25 +5911,25 @@ bool LVHTMLParser::Parse()
 
 
 /// read file contents to string
-lString16 LVReadTextFile( lString16 filename )
+lString32 LVReadTextFile( lString32 filename )
 {
 	LVStreamRef stream = LVOpenFileStream( filename.c_str(), LVOM_READ );
 	return LVReadTextFile( stream );
 }
 
-lString16 LVReadTextFile( LVStreamRef stream )
+lString32 LVReadTextFile( LVStreamRef stream )
 {
 	if ( stream.isNull() )
-        return lString16::empty_str;
-    lString16 buf;
+        return lString32::empty_str;
+    lString32 buf;
     LVTextParser reader( stream, NULL, true );
     if ( !reader.AutodetectEncoding() )
         return buf;
     lUInt32 flags;
     while ( !reader.Eof() ) {
-        lString16 line = reader.ReadLine( 4096, flags );
+        lString32 line = reader.ReadLine( 4096, flags );
         if ( !buf.empty() )
-            buf << L'\n';
+            buf << U'\n';
         if ( !line.empty() ) {
             buf << line;
         }
@@ -6063,7 +6063,7 @@ int LVBase64Stream::readNextBytes()
         const lChar8 * txt = m_curr_text.c_str();
         for ( ; m_text_pos<len && m_bytes_count < BASE64_BUF_SIZE - 3; m_text_pos++ )
         {
-            lChar16 ch = txt[ m_text_pos ];
+            lChar32 ch = txt[ m_text_pos ];
             if ( ch < 128 )
             {
                 if ( ch == '=' )
@@ -6249,7 +6249,7 @@ protected:
     bool insideBinary;
     bool insideCoverBinary;
     int tagCounter;
-    lString16 binaryId;
+    lString32 binaryId;
     lString8 data;
 public:
     ///
@@ -6280,9 +6280,9 @@ public:
     {
     }
     /// add named BLOB data to document
-    virtual bool OnBlob(lString16 /*name*/, const lUInt8 * /*data*/, int /*size*/) { return true; }
+    virtual bool OnBlob(lString32 /*name*/, const lUInt8 * /*data*/, int /*size*/) { return true; }
     /// called on opening tag
-    virtual ldomNode * OnTagOpen( const lChar16 * /*nsname*/, const lChar16 * tagname)
+    virtual ldomNode * OnTagOpen( const lChar32 * /*nsname*/, const lChar32 * tagname)
     {
         tagCounter++;
         if (!insideFictionBook && tagCounter > 5) {
@@ -6311,7 +6311,7 @@ public:
         return NULL;
     }
     /// called on closing
-    virtual void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false )
+    virtual void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false )
     {
         if ( lStr_cmp(nsname, "FictionBook")==0) {
             insideFictionBook = false;
@@ -6329,16 +6329,16 @@ public:
         }
     }
     /// called on element attribute
-    virtual void OnAttribute( const lChar16 * /*nsname*/, const lChar16 * attrname, const lChar16 * attrvalue )
+    virtual void OnAttribute( const lChar32 * /*nsname*/, const lChar32 * attrname, const lChar32 * attrvalue )
     {
         if (lStr_cmp(attrname, "href")==0 && insideImage) {
-            lString16 s(attrvalue);
+            lString32 s(attrvalue);
             if (s.startsWith("#")) {
                 binaryId = s.substr(1);
                 //CRLog::trace("found FB2 cover ID");
             }
         } else if (lStr_cmp(attrname, "id")==0 && insideBinary) {
-            lString16 id(attrvalue);
+            lString32 id(attrvalue);
             if (!id.empty() && id == binaryId) {
                 insideCoverBinary = true;
                 //CRLog::trace("found FB2 cover data");
@@ -6347,11 +6347,11 @@ public:
         }
     }
     /// called on text
-    virtual void OnText( const lChar16 * text, int len, lUInt32 /*flags*/ )
+    virtual void OnText( const lChar32 * text, int len, lUInt32 /*flags*/ )
     {
         if (!insideCoverBinary)
             return;
-        lString16 txt( text, len );
+        lString32 txt( text, len );
         data.append(UnicodeToUtf8(txt));
     }
     /// destructor

--- a/crengine/src/odtfmt.cpp
+++ b/crengine/src/odtfmt.cpp
@@ -51,7 +51,7 @@
 #define ODT_TAG_NAME(itm) odt_el_##itm##_name
 #define ODT_TAG_ID(itm) odt_el_##itm
 #define ODT_TAG_CHILD(itm) { ODT_TAG_ID(itm), ODT_TAG_NAME(itm) }
-#define ODT_TAG_CHILD2(itm, name) { ODT_TAG_ID(itm), L ## name }
+#define ODT_TAG_CHILD2(itm, name) { ODT_TAG_ID(itm), U ## name }
 #define ODT_LAST_ITEM { -1, NULL }
 
 enum {
@@ -64,8 +64,8 @@ enum {
 
 #undef ODT_TAG
 #undef ODT_TAG2
-#define ODT_TAG(itm) static const lChar16 * const ODT_TAG_NAME(itm) = L ## #itm;
-#define ODT_TAG2(itm, name) static const lChar16 * const ODT_TAG_NAME(itm) = L ## name;
+#define ODT_TAG(itm) static const lChar32 * const ODT_TAG_NAME(itm) = U ## #itm;
+#define ODT_TAG2(itm, name) static const lChar32 * const ODT_TAG_NAME(itm) = U ## name;
     ODT_TAGS
 
 #undef ODT_TAG
@@ -75,44 +75,44 @@ enum {
 
 const struct item_def_t odt_elements_mapping[] = {
     { odt_el_NULL, NULL },
-    { odt_el_a, L"a" },
+    { odt_el_a, U"a" },
     { odt_el_automaticStyles, NULL },
-    { odt_el_body, L"body" },
-    { odt_el_bookmark, L"a" },
-    { odt_el_bookmarkRef, L"a" },
-    { odt_el_bookmarkStart, L"a" },
+    { odt_el_body, U"body" },
+    { odt_el_bookmark, U"a" },
+    { odt_el_bookmarkRef, U"a" },
+    { odt_el_bookmarkStart, U"a" },
     { odt_el_defaultStyle, NULL },
     { odt_el_documentContent, NULL },
     { odt_el_documentStyles, NULL },
     { odt_el_frame, NULL },
     { odt_el_h, NULL /*Special processing*/},
-    { odt_el_image, L"img" },
+    { odt_el_image, U"img" },
     { odt_el_indexBody, NULL },
-    { odt_el_lineBreak, L"br" },
-    { odt_el_list, L"ol" },
+    { odt_el_lineBreak, U"br" },
+    { odt_el_list, U"ol" },
     { odt_el_listStyle, NULL },
     { odt_el_listLevelStyleBullet, NULL },
     { odt_el_listLevelStyleNumber, NULL },
-    { odt_el_listItem, L"li" },
+    { odt_el_listItem, U"li" },
     { odt_el_note, NULL },
     { odt_el_noteBody, NULL /*Special Processing */ },
     { odt_el_noteCitation, NULL /*Special Processing */ },
-    { odt_el_noteRef, L"a" },
-    { odt_el_p, L"p" },
+    { odt_el_noteRef, U"a" },
+    { odt_el_p, U"p" },
     { odt_el_paragraphProperties, NULL },
-    { odt_el_referenceMark, L"a" },
-    { odt_el_referenceMarkStart, L"a" },
-    { odt_el_referenceRef, L"a" },
+    { odt_el_referenceMark, U"a" },
+    { odt_el_referenceMarkStart, U"a" },
+    { odt_el_referenceRef, U"a" },
     { odt_el_s, NULL },
     { odt_el_span, NULL },
     { odt_el_style, NULL },
     { odt_el_styles, NULL },
     { odt_el_tab, NULL },
-    { odt_el_table, L"table" },
-    { odt_el_tableHeaderRows, L"thead" },
+    { odt_el_table, U"table" },
+    { odt_el_tableHeaderRows, U"thead" },
     { odt_el_tableOfContent, NULL },
-    { odt_el_tableRow, L"tr" },
-    { odt_el_tableCell, L"td" },
+    { odt_el_tableRow, U"tr" },
+    { odt_el_tableCell, U"td" },
     { odt_el_text, NULL },
     { odt_el_textBox, NULL },
     { odt_el_textProperties, NULL }
@@ -169,34 +169,34 @@ const struct item_def_t odt_style_elements[] = {
 };
 
 static const struct item_def_t styleFamily_attr_values[] = {
-    { odx_paragraph_style, L"paragraph" },
-    { odx_character_style, L"text"},
+    { odx_paragraph_style, U"paragraph" },
+    { odx_character_style, U"text"},
     ODT_LAST_ITEM
 };
 
 const struct item_def_t odt_fontWeigth_attr_values[] = {
-    { 400, L"normal" },
-    { 600, L"bold" },
-    { 100, L"100" },
-    { 200, L"200" },
-    { 300, L"300" },
-    { 400, L"400" },
-    { 500, L"500" },
-    { 600, L"600" },
-    { 700, L"700" },
-    { 800, L"800" },
-    { 900, L"900" },
+    { 400, U"normal" },
+    { 600, U"bold" },
+    { 100, U"100" },
+    { 200, U"200" },
+    { 300, U"300" },
+    { 400, U"400" },
+    { 500, U"500" },
+    { 600, U"600" },
+    { 700, U"700" },
+    { 800, U"800" },
+    { 900, U"900" },
     ODT_LAST_ITEM
 };
 
 static const struct item_def_t odt_textAlign_attr_values[] =
 {
-    { css_ta_left, L"left" },
-    { css_ta_right, L"right" },
-    { css_ta_center, L"center" },
-    { css_ta_justify, L"justify" },
-    { css_ta_start, L"start" },
-    { css_ta_end, L"end" },
+    { css_ta_left, U"left" },
+    { css_ta_right, U"right" },
+    { css_ta_center, U"center" },
+    { css_ta_justify, U"justify" },
+    { css_ta_start, U"start" },
+    { css_ta_end, U"end" },
     ODT_LAST_ITEM
 };
 
@@ -205,9 +205,9 @@ bool DetectOpenDocumentFormat( LVStreamRef stream )
     LVContainerRef arc = LVOpenArchieve( stream );
     if ( arc.isNull() )
         return false; // not a ZIP archive
-    lString16 mimeType;
+    lString32 mimeType;
     {
-        LVStreamRef mtStream = arc->OpenStream(L"mimetype", LVOM_READ );
+        LVStreamRef mtStream = arc->OpenStream(U"mimetype", LVOM_READ );
         if ( !mtStream.isNull() ) {
             lvsize_t size = mtStream->GetSize();
             if ( size>4 && size<100 ) {
@@ -223,7 +223,7 @@ bool DetectOpenDocumentFormat( LVStreamRef stream )
             }
         }
     }
-    return ( mimeType == L"application/vnd.oasis.opendocument.text" );
+    return ( mimeType == U"application/vnd.oasis.opendocument.text" );
 }
 
 class odt_ListLevelStyle : public LVRefCounter
@@ -241,7 +241,7 @@ public:
         m_lvlStart.value = value;
     }
     inline int getLevel() { return m_level; }
-    inline void setLevel( const lChar16* value) { m_level = lString16(value).atoi(); }
+    inline void setLevel( const lChar32* value) { m_level = lString32(value).atoi(); }
     inline css_list_style_type_t getLevelType() { return m_levelType; }
     inline void setLevelType(css_list_style_type_t levelType) { m_levelType = levelType; }
     void reset() {}
@@ -253,15 +253,15 @@ class odt_ListStyle : public LVRefCounter
 {
     LVHashTable<lUInt32, odt_ListLevelStyleRef> m_levels;
     bool m_consecutiveNumbering;
-    lString16 m_Id;
+    lString32 m_Id;
 public:
     odt_ListStyle() : m_levels(10), m_consecutiveNumbering(false) {}
     virtual ~odt_ListStyle() {}
     odt_ListLevelStyle* getLevel(int level) {
         return m_levels.get(level).get();
     }
-    inline lString16 getId() const { return m_Id; }
-    inline void setId(const lChar16 * value) { m_Id = value; }
+    inline lString32 getId() const { return m_Id; }
+    inline void setId(const lChar32 * value) { m_Id = value; }
     bool getConsecutiveNumbering() { return m_consecutiveNumbering; }
     void setConsecutiveNumbering(bool value) {
         m_consecutiveNumbering = value;
@@ -274,16 +274,16 @@ typedef LVFastRef< odt_ListStyle > odt_ListStyleRef;
 
 class odtImportContext : public odx_ImportContext
 {
-    LVHashTable<lString16, odt_ListStyleRef> m_ListStyles;
+    LVHashTable<lString32, odt_ListStyleRef> m_ListStyles;
 public:
     explicit odtImportContext(ldomDocument* doc) : odx_ImportContext(doc), m_ListStyles(64) { }
     void addListStyle(odt_ListStyleRef listStyle);
-    odt_ListStyle* getListStyle(lString16 id) {
+    odt_ListStyle* getListStyle(lString32 id) {
         if( !id.empty() )
             return m_ListStyles.get(id).get();
         return NULL;
     }
-    LVStreamRef openFile(const lChar16 * const fileName);
+    LVStreamRef openFile(const lChar32 * const fileName);
 };
 
 class odt_stylesHandler : public xml_ElementHandler
@@ -308,8 +308,8 @@ public:
     {
     }
     ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue);
-    void handleTagClose( const lChar16 * nsname, const lChar16 * tagname );
+    void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue);
+    void handleTagClose( const lChar32 * nsname, const lChar32 * tagname );
 };
 
 class odt_documentHandler : public xml_ElementHandler, odx_styleTagsHandler
@@ -324,22 +324,22 @@ class odt_documentHandler : public xml_ElementHandler, odx_styleTagsHandler
     ldomNode *m_footNotes;
     ldomNode *m_endNotes;
     ldomNode *m_body;
-    lString16 m_noteId;
-    lString16 m_noteRefText;
-    lString16 m_StyleName;
-    lString16 m_spanStyleName;
+    lString32 m_noteId;
+    lString32 m_noteRefText;
+    lString32 m_StyleName;
+    lString32 m_spanStyleName;
     bool m_isEndNote;
     bool m_paragraphStarted;
     odt_stylesHandler m_stylesHandler;
 private:
-    ldomNode* startNotes(const lChar16 * notesKind) {
+    ldomNode* startNotes(const lChar32 * notesKind) {
         m_writer->OnStart(NULL);
 #ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
-        ldomNode* notes = m_writer->OnTagOpen(L"", L"body");
-        m_writer->OnAttribute(L"", L"name", notesKind);
+        ldomNode* notes = m_writer->OnTagOpen(U"", U"body");
+        m_writer->OnAttribute(U"", U"name", notesKind);
 #else
-        ldomNode* notes = m_writer->OnTagOpen(L"", L"div");
-        m_writer->OnAttribute(L"", L"style", L"page-break-before: always");
+        ldomNode* notes = m_writer->OnTagOpen(U"", U"div");
+        m_writer->OnAttribute(U"", U"style", U"page-break-before: always");
 #endif
         m_writer->OnTagBody();
         return notes;
@@ -348,9 +348,9 @@ private:
         ldomNode* parent = notes->getParentNode();
         int index = notes->getNodeIndex();
 #ifdef ODX_CRENGINE_IN_PAGE_FOOTNOTES
-        writer.OnTagClose(L"", L"body");
+        writer.OnTagClose(U"", U"body");
 #else
-        writer.OnTagClose(L"", L"div");
+        writer.OnTagClose(U"", U"div");
 #endif
         writer.OnStop();
         parent->moveItemsTo(m_body->getParentNode(), index, index);
@@ -381,16 +381,16 @@ public:
     }
     inline bool isInList() { return m_ListLevels.length() != 0; }
     ldomNode *handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 *attrname, const lChar16 *attrValue);
+    void handleAttribute(const lChar32 *attrname, const lChar32 *attrValue);
     void handleTagBody();
-    void handleTagClose(const lChar16 *nsname, const lChar16 *tagname);
-    void handleText(const lChar16 *text, int len, lUInt32 flags);
+    void handleTagClose(const lChar32 *nsname, const lChar32 *tagname);
+    void handleText(const lChar32 *text, int len, lUInt32 flags);
     void reset();
 };
 
 static bool parseStyles(odtImportContext *context)
 {
-    LVStreamRef stream = context->openFile(L"styles.xml");
+    LVStreamRef stream = context->openFile(U"styles.xml");
     if ( stream.isNull() )
         return false;
 
@@ -414,16 +414,16 @@ bool ImportOpenDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     doc->setContainer(arc);
 
     //Read document metadata
-    LVStreamRef meta_stream = arc->OpenStream(L"meta.xml", LVOM_READ);
+    LVStreamRef meta_stream = arc->OpenStream(U"meta.xml", LVOM_READ);
     if ( meta_stream.isNull() )
         return false;
     ldomDocument * metaDoc = LVParseXMLStream( meta_stream );
     if ( metaDoc ) {
         CRPropRef doc_props = doc->getProps();
 
-        lString16 author = metaDoc->textFromXPath( cs16("document-meta/meta/creator") );
-        lString16 title = metaDoc->textFromXPath( cs16("document-meta/meta/title") );
-        lString16 description = metaDoc->textFromXPath( cs16("document-meta/meta/description") );
+        lString32 author = metaDoc->textFromXPath( cs32("document-meta/meta/creator") );
+        lString32 title = metaDoc->textFromXPath( cs32("document-meta/meta/title") );
+        lString32 description = metaDoc->textFromXPath( cs32("document-meta/meta/description") );
         doc_props->setString(DOC_PROP_TITLE, title);
         doc_props->setString(DOC_PROP_AUTHORS, author );
         doc_props->setString(DOC_PROP_DESCRIPTION, description );
@@ -448,7 +448,7 @@ bool ImportOpenDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
     if( !parseStyles(&importContext) )
         return false;
 
-    LVStreamRef m_stream = arc->OpenStream(L"content.xml", LVOM_READ);
+    LVStreamRef m_stream = arc->OpenStream(U"content.xml", LVOM_READ);
     if ( m_stream.isNull() )
         return false;
 
@@ -493,26 +493,26 @@ void odt_documentHandler::startParagraph()
 {
     if(m_inListItem) {
         m_listItemHadContent = true;
-        m_writer->OnTagOpenNoAttr(L"", L"li");
+        m_writer->OnTagOpenNoAttr(U"", U"li");
     }
-    m_writer->OnTagOpen(L"", L"p");
+    m_writer->OnTagOpen(U"", U"p");
     odx_Style* style = m_context->getStyle(m_StyleName);
     if( style ) {
         odx_pPr pPr;
 
         pPr.combineWith(style->get_pPr(m_context));
         pPr.combineWith(m_context->get_pPrDefault());
-        lString16 css = pPr.getCss();
+        lString32 css = pPr.getCss();
         if( !css.empty() )
-            m_writer->OnAttribute(L"", L"style", css.c_str());
+            m_writer->OnAttribute(U"", U"style", css.c_str());
     }
     m_writer->OnTagBody();
 #ifndef DOCX_FB2_DOM_STRUCTURE
     if(m_state == odt_el_noteBody) {
-        m_writer->OnTagOpen(L"", L"sup");
+        m_writer->OnTagOpen(U"", U"sup");
         m_writer->OnTagBody();
         m_writer->OnText(m_noteRefText.c_str(), m_noteRefText.length(), 0);
-        m_writer->OnTagClose(L"", L"sup");
+        m_writer->OnTagClose(U"", U"sup");
     }
 #endif
     m_paragraphStarted = true;
@@ -528,7 +528,7 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
         break;
     case odt_el_note:
         m_isEndNote = false;
-        m_writer->OnTagOpen(L"", L"a");
+        m_writer->OnTagOpen(U"", U"a");
         break;
     case odt_el_body:
         m_body = m_titleHandler->onBodyStart();
@@ -559,7 +559,7 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
         if( odt_el_p == m_state)
             checkParagraphStart();
         m_StyleName.clear();
-        m_writer->OnTagOpen(L"", L"ol");
+        m_writer->OnTagOpen(U"", U"ol");
         if (isInList())
             m_listItems.add(m_listItemHadContent);
         break;
@@ -571,29 +571,29 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
     case odt_el_s:
         if( odt_el_p == m_state)
             checkParagraphStart();
-        m_writer->OnText(L" ", 1, TXTFLG_PRE);
+        m_writer->OnText(U" ", 1, TXTFLG_PRE);
         break;
     case odt_el_noteBody:
         m_saveWriter = m_writer;
         if(m_isEndNote) {
             m_writer = &m_endNotesWriter;
             if(!m_endNotes)
-                m_endNotes = startNotes(L"comments");
+                m_endNotes = startNotes(U"comments");
         } else {
             m_writer = &m_footNotesWriter;
             if(!m_footNotes)
-                m_footNotes = startNotes(L"notes");;
+                m_footNotes = startNotes(U"notes");;
         }
-        m_writer->OnTagOpen(L"", L"section");
-        m_writer->OnAttribute(L"", L"id", m_noteId.c_str());
-        m_writer->OnAttribute(L"", L"role", m_isEndNote ? L"doc-rearnote" : L"doc-footnote");
+        m_writer->OnTagOpen(U"", U"section");
+        m_writer->OnAttribute(U"", U"id", m_noteId.c_str());
+        m_writer->OnAttribute(U"", U"role", m_isEndNote ? U"doc-rearnote" : U"doc-footnote");
         m_writer->OnTagBody();
 #ifdef DOCX_FB2_DOM_STRUCTURE
-        m_writer->OnTagOpenNoAttr(L"", L"title");
-        m_writer->OnTagOpenNoAttr(L"", L"p");
+        m_writer->OnTagOpenNoAttr(U"", U"title");
+        m_writer->OnTagOpenNoAttr(U"", U"p");
         m_writer->OnText(m_noteRefText.c_str(), m_noteRefText.length(), 0);
-        m_writer->OnTagClose(L"", L"p");
-        m_writer->OnTagClose(L"", L"title");
+        m_writer->OnTagClose(U"", U"p");
+        m_writer->OnTagClose(U"", U"title");
 #else
         m_paragraphStarted = false;
 #endif
@@ -604,7 +604,7 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
         if( odt_elements_mapping[tagId].name ) {
             if( odt_el_p == m_state)
                 checkParagraphStart();
-            m_writer->OnTagOpen(L"", odt_elements_mapping[tagId].name);
+            m_writer->OnTagOpen(U"", odt_elements_mapping[tagId].name);
         }
         break;
     }
@@ -615,7 +615,7 @@ ldomNode *odt_documentHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void odt_documentHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrValue)
+void odt_documentHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrValue)
 {
     switch (m_state) {
     case odt_el_bookmark:
@@ -623,20 +623,20 @@ void odt_documentHandler::handleAttribute(const lChar16 *attrname, const lChar16
     case odt_el_referenceMark:
     case odt_el_referenceMarkStart:
         if(!lStr_cmp(attrname, "name") ) {
-            m_writer->OnAttribute(L"", L"id", attrValue);
+            m_writer->OnAttribute(U"", U"id", attrValue);
         }
         break;
     case odt_el_bookmarkRef:
     case odt_el_noteRef:
     case odt_el_referenceRef:
         if(!lStr_cmp(attrname, "ref-name") ) {
-            lString16 target = cs16("#") + lString16(attrValue);
-            m_writer->OnAttribute(L"", L"href", target.c_str());
+            lString32 target = cs32("#") + lString32(attrValue);
+            m_writer->OnAttribute(U"", U"href", target.c_str());
         }
         break;
     case odt_el_h:
         if(!lStr_cmp(attrname, "outline-level") ) {
-            lString16 value = attrValue;
+            lString32 value = attrValue;
             int tmp;
 
             if(value.atoi(tmp))
@@ -650,28 +650,28 @@ void odt_documentHandler::handleAttribute(const lChar16 *attrname, const lChar16
     case odt_el_note:
         if(!lStr_cmp(attrname, "note-class")) {
             if(!lStr_cmp(attrValue, "endnote")) {
-                m_writer->OnAttribute(L"", L"type", L"comment");
+                m_writer->OnAttribute(U"", U"type", U"comment");
                 m_isEndNote = true;
             } else if(!lStr_cmp(attrValue, "footnote")) {
-                m_writer->OnAttribute(L"", L"type", L"note");
+                m_writer->OnAttribute(U"", U"type", U"note");
             }
-            m_writer->OnAttribute(L"", L"role", L"doc-noteref");
+            m_writer->OnAttribute(U"", U"role", U"doc-noteref");
         } else if(!lStr_cmp(attrname, "id")) {
-            m_noteId = lString16(attrValue);
-            lString16 target = cs16("#") + m_noteId;
-            m_writer->OnAttribute(L"", L"href", target.c_str());
+            m_noteId = lString32(attrValue);
+            lString32 target = cs32("#") + m_noteId;
+            m_writer->OnAttribute(U"", U"href", target.c_str());
         }
         break;
     case odt_el_tableCell:
         if(!lStr_cmp(attrname, "number-columns-spanned"))
-            m_writer->OnAttribute(L"", L"colspan", attrValue);
+            m_writer->OnAttribute(U"", U"colspan", attrValue);
         else if(!lStr_cmp(attrname, "number-rows-spanned"))
-            m_writer->OnAttribute(L"", L"rowspan", attrValue);
+            m_writer->OnAttribute(U"", U"rowspan", attrValue);
         break;
     case odt_el_a:
     case odt_el_image:
         if( !lStr_cmp(attrname, "href") )
-            m_writer->OnAttribute(L"", attrname, attrValue);
+            m_writer->OnAttribute(U"", attrname, attrValue);
         break;
     case odt_el_p:
     case odt_el_list:
@@ -710,16 +710,16 @@ void odt_documentHandler::handleTagBody()
                     levelStart = levelStyle->getLevelStart();
                 }
             }
-            m_writer->OnAttribute(L"", L"style", m_context->getListStyleCss(listType).c_str());
+            m_writer->OnAttribute(U"", U"style", m_context->getListStyleCss(listType).c_str());
             if(levelStart.type != css_val_unspecified)
-                m_writer->OnAttribute(L"", L"start", lString16::itoa(levelStart.value).c_str());
+                m_writer->OnAttribute(U"", U"start", lString32::itoa(levelStart.value).c_str());
             m_writer->OnTagBody();
         }
         break;
     case odt_el_h:
         if(m_inListItem) {
             m_listItemHadContent = true;
-            m_writer->OnTagOpenNoAttr(L"", L"li");
+            m_writer->OnTagOpenNoAttr(U"", U"li");
         }
         m_titleHandler->onTitleStart(m_outlineLevel + 1, m_inTable || m_inListItem);
         m_writer->OnTagBody();
@@ -731,7 +731,7 @@ void odt_documentHandler::handleTagBody()
     }
 }
 
-void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void odt_documentHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     switch(m_state) {
     case odt_el_body:
@@ -749,12 +749,12 @@ void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *t
     case odt_el_p:
         if( !m_paragraphStarted ) {
             if( m_inListItem) {
-                m_writer->OnTagOpen(L"", L"li");
-                m_writer->OnAttribute(L"", L"style", L"display:none");
+                m_writer->OnTagOpen(U"", U"li");
+                m_writer->OnAttribute(U"", U"style", U"display:none");
                 m_writer->OnTagBody();
-                m_writer->OnTagClose(L"", L"li");
+                m_writer->OnTagClose(U"", U"li");
             } else
-                m_writer->OnTagOpenNoAttr(L"", L"p");
+                m_writer->OnTagOpenNoAttr(U"", U"p");
             m_paragraphStarted = true;
         } else
             closeStyleTags(m_writer);
@@ -762,11 +762,11 @@ void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *t
         break;
     case odt_el_list:
         m_ListLevels.remove(m_ListLevels.length() - 1);
-        m_writer->OnTagClose(L"", L"ol");
+        m_writer->OnTagClose(U"", U"ol");
         break;
     case odt_el_listItem:
         if(m_listItemHadContent)
-            m_writer->OnTagClose(L"", L"li");
+            m_writer->OnTagClose(U"", U"li");
         if(!m_listItems.empty()) {
             m_listItemHadContent = m_listItems[m_listItems.length() - 1];
             m_listItems.erase(m_listItems.length() - 1, 1);
@@ -774,17 +774,17 @@ void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *t
         m_inListItem = false;
         break;
     case odt_el_noteBody:
-        m_writer->OnTagClose(L"", L"section");
+        m_writer->OnTagClose(U"", U"section");
         m_writer = m_saveWriter;
         break;
     case odt_el_noteCitation:
-        m_writer->OnTagClose(L"", L"a");
+        m_writer->OnTagClose(U"", U"a");
         break;
     case odt_el_table:
         m_inTable = false;
     default:
         if( odt_elements_mapping[m_state].name )
-            m_writer->OnTagClose(L"", odt_elements_mapping[m_state].name);
+            m_writer->OnTagClose(U"", odt_elements_mapping[m_state].name);
         break;
     }
     m_levels.erase(m_levels.length() - 1, 1);
@@ -794,7 +794,7 @@ void odt_documentHandler::handleTagClose(const lChar16 *nsname, const lChar16 *t
         m_state = odt_el_NULL;
 }
 
-void odt_documentHandler::handleText(const lChar16 *text, int len, lUInt32 flags)
+void odt_documentHandler::handleText(const lChar32 *text, int len, lUInt32 flags)
 {
     odx_Style* style;
 
@@ -850,7 +850,7 @@ void odtImportContext::addListStyle(odt_ListStyleRef listStyle)
         m_ListStyles.set(listStyle->getId(), listStyle);
 }
 
-LVStreamRef odtImportContext::openFile(const lChar16 * const fileName)
+LVStreamRef odtImportContext::openFile(const lChar32 * const fileName)
 {
     LVContainerRef container = m_doc->getContainer();
     if( !container.isNull() )
@@ -890,7 +890,7 @@ ldomNode *odt_stylesHandler::handleTagOpen(int tagId)
     return NULL;
 }
 
-void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *attrvalue)
+void odt_stylesHandler::handleAttribute(const lChar32 *attrname, const lChar32 *attrvalue)
 {
     switch(m_state) {
     case odt_el_style:
@@ -912,7 +912,7 @@ void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *
         break;
     case odt_el_listLevelStyleNumber:
         if( !lStr_cmp(attrname, "num-format") ) {
-            lString16 format(attrvalue);
+            lString32 format(attrvalue);
 
             if( format.length() == 1) {
                 switch(attrvalue[0]) {
@@ -942,7 +942,7 @@ void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *
         if( !lStr_cmp(attrname, "start-value") ) {
             int startValue;
 
-            if( lString16(attrvalue).atoi( startValue) )
+            if( lString32(attrvalue).atoi( startValue) )
                 m_ListLevelStyle->setLevelStart( startValue );
             break;
         }
@@ -975,11 +975,11 @@ void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *
         } else if( !lStr_cmp(attrname, "text-line-through-type") ) {
             m_rPr->setStrikeThrough( lStr_cmp( attrvalue, "none") !=0 );
         } else if( !lStr_cmp(attrname, "text-position") ) {
-            lString16 val = attrvalue;
+            lString32 val = attrvalue;
 
-            if( val.startsWith(L"super") ) {
+            if( val.startsWith(U"super") ) {
                 m_rPr->setVertAlign(css_va_super);
-            } else if( val.startsWith(L"sub") ) {
+            } else if( val.startsWith(U"sub") ) {
                 m_rPr->setVertAlign(css_va_sub);
             }
         }
@@ -989,7 +989,7 @@ void odt_stylesHandler::handleAttribute(const lChar16 *attrname, const lChar16 *
     }
 }
 
-void odt_stylesHandler::handleTagClose(const lChar16 *nsname, const lChar16 *tagname)
+void odt_stylesHandler::handleTagClose(const lChar32 *nsname, const lChar32 *tagname)
 {
     CR_UNUSED2(nsname, tagname);
 

--- a/crengine/src/odxutil.cpp
+++ b/crengine/src/odxutil.cpp
@@ -1,7 +1,7 @@
 #include "../include/fb2def.h"
 #include "odxutil.h"
 
-ldomNode * docXMLreader::OnTagOpen( const lChar16 * nsname, const lChar16 * tagname)
+ldomNode * docXMLreader::OnTagOpen( const lChar32 * nsname, const lChar32 * tagname)
 {
     if ( m_state == xml_doc_in_start && !lStr_cmp(tagname, "?xml") )
         m_state = xml_doc_in_xml_declaration;
@@ -26,7 +26,7 @@ void docXMLreader::OnTagBody()
         m_handler->handleTagBody();
 }
 
-void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag )
+void docXMLreader::OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag )
 {
     CR_UNUSED(nsname);
 
@@ -38,7 +38,7 @@ void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, 
         if( isSkipping() )
             skipped();
         else if ( m_handler )
-            m_handler->handleTagClose(L"", tagname);
+            m_handler->handleTagClose(U"", tagname);
         break;
     default:
         CRLog::error("Unexpected state");
@@ -46,7 +46,7 @@ void docXMLreader::OnTagClose( const lChar16 * nsname, const lChar16 * tagname, 
     }
 }
 
-void docXMLreader::OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue )
+void docXMLreader::OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue )
 {
     switch(m_state) {
     case xml_doc_in_xml_declaration:
@@ -62,13 +62,13 @@ void docXMLreader::OnAttribute( const lChar16 * nsname, const lChar16 * attrname
     }
 }
 
-void docXMLreader::OnText( const lChar16 * text, int len, lUInt32 flags )
+void docXMLreader::OnText( const lChar32 * text, int len, lUInt32 flags )
 {
     if( !isSkipping() && m_handler )
         m_handler->handleText(text, len, flags);
 }
 
-bool docXMLreader::OnBlob(lString16 name, const lUInt8 * data, int size)
+bool docXMLreader::OnBlob(lString32 name, const lUInt8 * data, int size)
 {
     if ( !isSkipping() && m_writer )
         return m_writer->OnBlob(name, data, size);
@@ -80,7 +80,7 @@ void xml_ElementHandler::setChildrenInfo(const struct item_def_t *tags)
     m_children = tags;
 }
 
-int xml_ElementHandler::parse_name(const struct item_def_t *tags, const lChar16 * nameValue)
+int xml_ElementHandler::parse_name(const struct item_def_t *tags, const lChar32 * nameValue)
 {
     for (int i=0; tags[i].name; i++) {
         if ( !lStr_cmp( tags[i].name, nameValue )) {
@@ -91,16 +91,16 @@ int xml_ElementHandler::parse_name(const struct item_def_t *tags, const lChar16 
     return -1;
 }
 
-void xml_ElementHandler::parse_int(const lChar16 * attrValue, css_length_t & result)
+void xml_ElementHandler::parse_int(const lChar32 * attrValue, css_length_t & result)
 {
-    lString16 value = attrValue;
+    lString32 value = attrValue;
 
     result.type = css_val_unspecified;
     if ( value.atoi(result.value) )
         result.type = css_val_pt; //just to distinguish with unspecified value
 }
 
-ldomNode *xml_ElementHandler::handleTagOpen(const lChar16 *nsname, const lChar16 *tagname)
+ldomNode *xml_ElementHandler::handleTagOpen(const lChar32 *nsname, const lChar32 *tagname)
 {
     int tag = parseTagName(tagname);
 
@@ -138,7 +138,7 @@ void xml_ElementHandler::reset()
 
 ldomNode *odx_titleHandler::onBodyStart()
 {
-    return m_writer->OnTagOpen(L"", L"body");
+    return m_writer->OnTagOpen(U"", U"body");
 }
 
 void odx_titleHandler::onTitleStart(int level, bool noSection)
@@ -146,26 +146,26 @@ void odx_titleHandler::onTitleStart(int level, bool noSection)
     CR_UNUSED(noSection);
 
     m_titleLevel = level;
-    lString16 name = cs16("h") +  lString16::itoa(m_titleLevel);
+    lString32 name = cs32("h") +  lString32::itoa(m_titleLevel);
     if( m_useClassName ) {
-        m_writer->OnTagOpen(L"", L"p");
-        m_writer->OnAttribute(L"", L"class", name.c_str());
+        m_writer->OnTagOpen(U"", U"p");
+        m_writer->OnAttribute(U"", U"class", name.c_str());
     } else
-        m_writer->OnTagOpen(L"", name.c_str());
+        m_writer->OnTagOpen(U"", name.c_str());
 }
 
 void odx_titleHandler::onTitleEnd()
 {
     if( !m_useClassName ) {
-        lString16 tagName = cs16("h") +  lString16::itoa(m_titleLevel);
-        m_writer->OnTagClose(L"", tagName.c_str());
+        lString32 tagName = cs32("h") +  lString32::itoa(m_titleLevel);
+        m_writer->OnTagClose(U"", tagName.c_str());
     } else
-        m_writer->OnTagClose(L"", L"p");
+        m_writer->OnTagClose(U"", U"p");
 }
 
 ldomNode* odx_fb2TitleHandler::onBodyStart()
 {
-    m_section = m_writer->OnTagOpen(L"", L"body");
+    m_section = m_writer->OnTagOpen(U"", U"body");
     return m_section;
 }
 
@@ -182,15 +182,15 @@ void odx_fb2TitleHandler::onTitleStart(int level, bool noSection)
         } else
             closeSection(m_titleLevel - level + 1);
         openSection(level);
-        m_writer->OnTagOpen(L"", L"title");
-        lString16 headingName = cs16("h") +  lString16::itoa(level);
+        m_writer->OnTagOpen(U"", U"title");
+        lString32 headingName = cs32("h") +  lString32::itoa(level);
         if( m_useClassName ) {
             m_writer->OnTagBody();
-            m_writer->OnTagOpen(L"", L"p");
-            m_writer->OnAttribute(L"", L"class", headingName.c_str());
+            m_writer->OnTagOpen(U"", U"p");
+            m_writer->OnAttribute(U"", U"class", headingName.c_str());
         } else {
             m_writer->OnTagBody();
-            m_writer->OnTagOpen(L"", headingName.c_str());
+            m_writer->OnTagOpen(U"", headingName.c_str());
         }
     }
 }
@@ -198,12 +198,12 @@ void odx_fb2TitleHandler::onTitleStart(int level, bool noSection)
 void odx_fb2TitleHandler::onTitleEnd()
 {
     if( !m_useClassName ) {
-        lString16 headingName = cs16("h") +  lString16::itoa(m_titleLevel);
-        m_writer->OnTagClose(L"", headingName.c_str());
+        lString32 headingName = cs32("h") +  lString32::itoa(m_titleLevel);
+        m_writer->OnTagClose(U"", headingName.c_str());
     } else
-        m_writer->OnTagClose(L"", L"p");
+        m_writer->OnTagClose(U"", U"p");
 
-    m_writer->OnTagClose(L"", L"title");
+    m_writer->OnTagClose(U"", U"title");
     m_hasTitle = true;
 }
 
@@ -219,7 +219,7 @@ void odx_fb2TitleHandler::makeSection(int startIndex)
 void odx_fb2TitleHandler::openSection(int level)
 {
     for(int i = m_titleLevel; i < level; i++) {
-        m_section = m_writer->OnTagOpen(L"", L"section");
+        m_section = m_writer->OnTagOpen(U"", U"section");
         m_writer->OnTagBody();
     }
     m_titleLevel = level;
@@ -229,7 +229,7 @@ void odx_fb2TitleHandler::openSection(int level)
 void odx_fb2TitleHandler::closeSection(int level)
 {
     for(int i = 0; i < level; i++) {
-        m_writer->OnTagClose(L"", L"section");
+        m_writer->OnTagClose(U"", U"section");
         m_titleLevel--;
     }
     m_hasTitle = false;
@@ -239,9 +239,9 @@ odx_rPr::odx_rPr() : odx_StylePropertiesContainer(odx_character_style)
 {
 }
 
-lString16 odx_rPr::getCss()
+lString32 odx_rPr::getCss()
 {
-    lString16 style;
+    lString32 style;
 
     if( isBold() )
         style << " font-weight: bold;";
@@ -258,9 +258,9 @@ odx_pPr::odx_pPr() : odx_StylePropertiesContainer(odx_paragraph_style)
 {
 }
 
-lString16 odx_pPr::getCss()
+lString32 odx_pPr::getCss()
 {
-    lString16 style;
+    lString32 style;
 
     css_text_align_t align = getTextAlign();
     if(align != css_ta_inherit)
@@ -310,7 +310,7 @@ bool odx_Style::isValid() const
 
 odx_Style *odx_Style::getBaseStyle(odx_ImportContext *context)
 {
-    lString16 basedOn = getBasedOn();
+    lString32 basedOn = getBasedOn();
     if ( !basedOn.empty() ) {
         odx_Style *pStyle = context->getStyle(basedOn);
         if( pStyle && pStyle->getStyleType() == getStyleType() )
@@ -365,60 +365,60 @@ void odx_ImportContext::addStyle(odx_StyleRef style)
     }
 }
 
-void odx_ImportContext::setLanguage(const lChar16 *lang)
+void odx_ImportContext::setLanguage(const lChar32 *lang)
 {
-    lString16 language(lang);
+    lString32 language(lang);
 
-    int p = language.pos(cs16("-"));
+    int p = language.pos(cs32("-"));
     if ( p > 0  ) {
         language = language.substr(0, p);
     }
     m_doc->getProps()->setString(DOC_PROP_LANGUAGE, language);
 }
 
-lString16 odx_ImportContext::getListStyleCss(css_list_style_type_t listType)
+lString32 odx_ImportContext::getListStyleCss(css_list_style_type_t listType)
 {
     switch(listType) {
     case css_lst_disc:
-        return cs16("list-style-type: disc;");
+        return cs32("list-style-type: disc;");
     case css_lst_circle:
-        return cs16("list-style-type: circle;");
+        return cs32("list-style-type: circle;");
     case css_lst_square:
-        return cs16("list-style-type: square;");
+        return cs32("list-style-type: square;");
     case css_lst_decimal:
-        return cs16("list-style-type: decimal;");
+        return cs32("list-style-type: decimal;");
     case css_lst_lower_roman:
-        return cs16("list-style-type: lower-roman;");
+        return cs32("list-style-type: lower-roman;");
     case css_lst_upper_roman:
-        return cs16("list-style-type: upper-roman;");
+        return cs32("list-style-type: upper-roman;");
     case css_lst_lower_alpha:
-        return cs16("list-style-type: lower-alpha;");
+        return cs32("list-style-type: lower-alpha;");
     case css_lst_upper_alpha:
-        return cs16("list-style-type: upper-alpha;");
+        return cs32("list-style-type: upper-alpha;");
     default:
         break;
     }
-    return cs16("list-style-type: none;");
+    return cs32("list-style-type: none;");
 }
 
 void odx_ImportContext::startDocument(ldomDocumentWriter &writer)
 {
 #ifdef DOCX_FB2_DOM_STRUCTURE
     writer.OnStart(NULL);
-    writer.OnTagOpen(NULL, L"?xml");
-    writer.OnAttribute(NULL, L"version", L"1.0");
-    writer.OnAttribute(NULL, L"encoding", L"utf-8");
-    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagOpen(NULL, U"?xml");
+    writer.OnAttribute(NULL, U"version", U"1.0");
+    writer.OnAttribute(NULL, U"encoding", U"utf-8");
+    writer.OnEncoding(U"utf-8", NULL);
     writer.OnTagBody();
-    writer.OnTagClose(NULL, L"?xml");
-    writer.OnTagOpenNoAttr(NULL, L"FictionBook");
+    writer.OnTagClose(NULL, U"?xml");
+    writer.OnTagOpenNoAttr(NULL, U"FictionBook");
     // DESCRIPTION
-    writer.OnTagOpenNoAttr(NULL, L"description");
-    writer.OnTagOpenNoAttr(NULL, L"title-info");
-    writer.OnTagOpenNoAttr(NULL, L"book-title");
-    writer.OnTagClose(NULL, L"book-title");
-    writer.OnTagClose(NULL, L"title-info");
-    writer.OnTagClose(NULL, L"description");
+    writer.OnTagOpenNoAttr(NULL, U"description");
+    writer.OnTagOpenNoAttr(NULL, U"title-info");
+    writer.OnTagOpenNoAttr(NULL, U"book-title");
+    writer.OnTagClose(NULL, U"book-title");
+    writer.OnTagClose(NULL, U"title-info");
+    writer.OnTagClose(NULL, U"description");
 #else
     writer.OnStart(NULL);
     // Note: the following is not needed:
@@ -426,27 +426,27 @@ void odx_ImportContext::startDocument(ldomDocumentWriter &writer)
     // document.xml '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
     // to the <FictionBook> or <html> tags.
     /*
-    writer.OnTagOpen(NULL, L"?xml");
-    writer.OnAttribute(NULL, L"version", L"1.0");
-    writer.OnAttribute(NULL, L"encoding", L"utf-8");
-    writer.OnEncoding(L"utf-8", NULL);
+    writer.OnTagOpen(NULL, U"?xml");
+    writer.OnAttribute(NULL, U"version", U"1.0");
+    writer.OnAttribute(NULL, U"encoding", U"utf-8");
+    writer.OnEncoding(U"utf-8", NULL);
     writer.OnTagBody();
-    writer.OnTagClose(NULL, L"?xml");
+    writer.OnTagClose(NULL, U"?xml");
     */
-    writer.OnTagOpenNoAttr(NULL, L"html");
+    writer.OnTagOpenNoAttr(NULL, U"html");
 #endif
 }
 
 void odx_ImportContext::endDocument(ldomDocumentWriter &writer)
 {
 #ifdef DOCX_FB2_DOM_STRUCTURE
-    writer.OnTagClose(NULL, L"FictionBook");
+    writer.OnTagClose(NULL, U"FictionBook");
 #else
-    writer.OnTagClose(NULL, L"html");
+    writer.OnTagClose(NULL, U"html");
 #endif
 }
 
-int odx_styleTagsHandler::styleTagPos(lChar16 ch)
+int odx_styleTagsHandler::styleTagPos(lChar32 ch)
 {
     for (int i=0; i < m_styleTags.length(); i++)
         if (m_styleTags[i] == ch)
@@ -454,47 +454,47 @@ int odx_styleTagsHandler::styleTagPos(lChar16 ch)
     return -1;
 }
 
-const lChar16 *odx_styleTagsHandler::getStyleTagName(lChar16 ch)
+const lChar32 *odx_styleTagsHandler::getStyleTagName(lChar32 ch)
 {
     switch ( ch ) {
     case 'b':
-        return L"strong";
+        return U"strong";
     case 'i':
-        return L"em";
+        return U"em";
     case 'u':
-        return L"u";
+        return U"u";
     case 's':
-        return L"s";
+        return U"s";
     case 't':
-        return L"sup";
+        return U"sup";
     case 'd':
-        return L"sub";
+        return U"sub";
     default:
         return NULL;
     }
 }
 
-void odx_styleTagsHandler::closeStyleTag(lChar16 ch, ldomDocumentWriter *writer)
+void odx_styleTagsHandler::closeStyleTag(lChar32 ch, ldomDocumentWriter *writer)
 {
     int pos = styleTagPos( ch );
     if (pos >= 0) {
         for (int i = m_styleTags.length() - 1; i >= pos; i--) {
-            const lChar16 * tag = getStyleTagName(m_styleTags[i]);
+            const lChar32 * tag = getStyleTagName(m_styleTags[i]);
             m_styleTags.erase(m_styleTags.length() - 1, 1);
             if ( tag ) {
-                writer->OnTagClose(L"", tag);
+                writer->OnTagClose(U"", tag);
             }
         }
     }
 }
 
-void odx_styleTagsHandler::openStyleTag(lChar16 ch, ldomDocumentWriter *writer)
+void odx_styleTagsHandler::openStyleTag(lChar32 ch, ldomDocumentWriter *writer)
 {
     int pos = styleTagPos( ch );
     if (pos < 0) {
-        const lChar16 * tag = getStyleTagName(ch);
+        const lChar32 * tag = getStyleTagName(ch);
         if ( tag ) {
-            writer->OnTagOpenNoAttr(L"", tag);
+            writer->OnTagOpenNoAttr(U"", tag);
             m_styleTags.append( 1,  ch );
         }
     }

--- a/crengine/src/odxutil.h
+++ b/crengine/src/odxutil.h
@@ -44,7 +44,7 @@ template <int N>
 class odx_StylePropertiesContainer : public odx_StylePropertiesGetter
 {
     odx_style_type m_styleType;
-    lString16 m_styleId;
+    lString32 m_styleId;
 public:
     static const int PROP_COUNT = N;
 
@@ -104,7 +104,7 @@ public:
                 set(i, baseValue);
         }
     }
-    void setStyleId(odx_ImportContext* context, const lChar16* styleId);
+    void setStyleId(odx_ImportContext* context, const lChar32* styleId);
     odx_Style* getStyle(odx_ImportContext* context);
 protected:
     css_length_t m_properties[N];
@@ -156,7 +156,7 @@ public:
         return getValue(odx_run_valign_prop, css_va_inherit);
     }
     inline void setVertAlign(css_vertical_align_t value) { set(odx_run_valign_prop,value); }
-    lString16 getCss();
+    lString32 getCss();
 };
 
 enum odx_p_properties {
@@ -214,12 +214,12 @@ public:
     inline int getNumberingId() { return getValue(odx_p_num_id_prop, 0); }
     css_length_t getOutlineLvl() { return get(odx_p_outline_level_prop); }
     inline int getNumberingLevel() { return get(odx_p_ilvl_prop).value; }
-    lString16 getCss();
+    lString32 getCss();
 };
 
 class odx_ImportContext
 {
-    LVHashTable<lString16, odx_StyleRef> m_styles;
+    LVHashTable<lString32, odx_StyleRef> m_styles;
     odx_rPr m_rPrDefault;
     odx_pPr m_pPrDefault;
 protected:
@@ -228,22 +228,22 @@ public:
     odx_ImportContext(ldomDocument* doc) : m_styles(64), m_doc(doc) { }
     virtual ~odx_ImportContext() {}
     void addStyle( odx_StyleRef style );
-    odx_Style * getStyle( lString16 id ) {
+    odx_Style * getStyle( lString32 id ) {
         return m_styles.get(id).get();
     }
     inline odx_rPr * get_rPrDefault() { return &m_rPrDefault; }
     inline odx_pPr * get_pPrDefault() { return &m_pPrDefault; }
-    void setLanguage(const lChar16 *lang);
-    lString16 getListStyleCss(css_list_style_type_t listType);
+    void setLanguage(const lChar32 *lang);
+    lString32 getListStyleCss(css_list_style_type_t listType);
     void startDocument(ldomDocumentWriter& writer);
     void endDocument(ldomDocumentWriter& writer);
 };
 
 class odx_Style : public LVRefCounter
 {
-    lString16 m_Name;
-    lString16 m_Id;
-    lString16 m_basedOn;
+    lString32 m_Name;
+    lString32 m_Id;
+    lString32 m_basedOn;
     odx_style_type m_type;
     odx_pPr m_pPr;
     odx_rPr m_rPr;
@@ -252,14 +252,14 @@ class odx_Style : public LVRefCounter
 public:
     odx_Style();
 
-    inline lString16 getName() const { return m_Name; }
-    inline void setName(const lChar16 * value) { m_Name = value; }
+    inline lString32 getName() const { return m_Name; }
+    inline void setName(const lChar32 * value) { m_Name = value; }
 
-    inline lString16 getId() const { return m_Id; }
-    inline void setId(const lChar16 * value) { m_Id = value; }
+    inline lString32 getId() const { return m_Id; }
+    inline void setId(const lChar32 * value) { m_Id = value; }
 
-    inline lString16 getBasedOn() const { return m_basedOn; }
-    inline void setBasedOn(const lChar16 * value) { m_basedOn = value; }
+    inline lString32 getBasedOn() const { return m_basedOn; }
+    inline void setBasedOn(const lChar32 * value) { m_basedOn = value; }
     bool isValid() const;
 
     inline odx_style_type getStyleType() const { return m_type; }
@@ -274,7 +274,7 @@ public:
 };
 
 template<int N>
-void odx_StylePropertiesContainer<N>::setStyleId(odx_ImportContext *context, const lChar16 *styleId) {
+void odx_StylePropertiesContainer<N>::setStyleId(odx_ImportContext *context, const lChar32 *styleId) {
     m_styleId = styleId;
     if ( !m_styleId.empty() ) {
         odx_Style *style = context->getStyle(m_styleId);
@@ -297,7 +297,7 @@ odx_Style *odx_StylePropertiesContainer<N>::getStyle(odx_ImportContext *context)
 /// known docx items name and identifier
 struct item_def_t {
     int      id;
-    const lChar16 * name;
+    const lChar32 * name;
 };
 
 class xml_ElementHandler;
@@ -347,22 +347,22 @@ public:
     }
 
     /// called on opening tag <
-    ldomNode * OnTagOpen( const lChar16 * nsname, const lChar16 * tagname);
+    ldomNode * OnTagOpen( const lChar32 * nsname, const lChar32 * tagname);
 
     /// called after > of opening tag (when entering tag body)
     void OnTagBody();
 
     /// called on tag close
-    void OnTagClose( const lChar16 * nsname, const lChar16 * tagname, bool self_closing_tag=false );
+    void OnTagClose( const lChar32 * nsname, const lChar32 * tagname, bool self_closing_tag=false );
 
     /// called on element attribute
-    void OnAttribute( const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue );
+    void OnAttribute( const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue );
 
     /// called on text
-    void OnText( const lChar16 * text, int len, lUInt32 flags );
+    void OnText( const lChar32 * text, int len, lUInt32 flags );
 
     /// add named BLOB data to document
-    bool OnBlob(lString16 name, const lUInt8 * data, int size);
+    bool OnBlob(lString32 name, const lUInt8 * data, int size);
 
     xml_ElementHandler * getHandler()
     {
@@ -397,31 +397,31 @@ protected:
     {
     }
     virtual ~xml_ElementHandler() {}
-    virtual int parseTagName(const lChar16 *tagname) {
+    virtual int parseTagName(const lChar32 *tagname) {
         if(m_children)
             return parse_name(m_children, tagname);
         return -1;
     }
 public:
-    static int parse_name(const struct item_def_t *tags, const lChar16 * nameValue);
-    static void parse_int(const lChar16 * attrValue, css_length_t & result);
+    static int parse_name(const struct item_def_t *tags, const lChar32 * nameValue);
+    static void parse_int(const lChar32 * attrValue, css_length_t & result);
     void setChildrenInfo(const struct item_def_t *tags);
-    ldomNode * handleTagOpen(const lChar16 * nsname, const lChar16 * tagname);
+    ldomNode * handleTagOpen(const lChar32 * nsname, const lChar32 * tagname);
     virtual ldomNode * handleTagOpen(int tagId);
-    void handleAttribute(const lChar16 * nsname, const lChar16 * attrname, const lChar16 * attrvalue)
+    void handleAttribute(const lChar32 * nsname, const lChar32 * attrname, const lChar32 * attrvalue)
     {
         CR_UNUSED(nsname);
 
         handleAttribute(attrname, attrvalue);
     }
-    virtual void handleAttribute(const lChar16 * attrname, const lChar16 * attrvalue) {
+    virtual void handleAttribute(const lChar32 * attrname, const lChar32 * attrvalue) {
         CR_UNUSED2(attrname, attrvalue);
     }
     virtual void handleTagBody() {}
-    virtual void handleText( const lChar16 * text, int len, lUInt32 flags ) {
+    virtual void handleText( const lChar32 * text, int len, lUInt32 flags ) {
         CR_UNUSED3(text,len,flags);
     }
-    virtual void handleTagClose( const lChar16 * nsname, const lChar16 * tagname )
+    virtual void handleTagClose( const lChar32 * nsname, const lChar32 * tagname )
     {
         CR_UNUSED2(nsname, tagname);
 
@@ -448,12 +448,12 @@ public:
 
 class odx_styleTagsHandler
 {
-    lString16 m_styleTags;
-    int styleTagPos(lChar16 ch);
+    lString32 m_styleTags;
+    int styleTagPos(lChar32 ch);
 protected:
-    const lChar16 * getStyleTagName( lChar16 ch );
-    void closeStyleTag( lChar16 ch, ldomDocumentWriter *writer);
-    void openStyleTag(lChar16 ch, ldomDocumentWriter *writer);
+    const lChar32 * getStyleTagName( lChar32 ch );
+    void closeStyleTag( lChar32 ch, ldomDocumentWriter *writer);
+    void openStyleTag(lChar32 ch, ldomDocumentWriter *writer);
 public:
     odx_styleTagsHandler() {}
     void openStyleTags(odx_rPr* runProps, ldomDocumentWriter *writer);

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -296,7 +296,7 @@ protected:
     PDBFile * _file;
     int _startBlock;
     int _size;
-    lString16 _name;
+    lString32 _name;
 public:
     /// returns object size (file size or directory entry count)
     virtual lverror_t GetSize( lvsize_t * pSize ) {
@@ -304,14 +304,14 @@ public:
 		return LVERR_OK;
     }
     virtual lvsize_t        GetSize() const { return _size; }
-    virtual const lChar16 * GetName() const { return _name.c_str(); }
+    virtual const lChar32 * GetName() const { return _name.c_str(); }
     virtual lUInt32         GetFlags() const { return 0; }
     virtual bool            IsContainer() const { return false; }
     virtual LVStreamRef openStream() {
         // TODO: implement stream creation
         return LVStreamRef();
     }
-    LVPDBContainerItem( LVStreamRef stream, PDBFile * file, lString16 name, int startBlockIndex, int size )
+    LVPDBContainerItem( LVStreamRef stream, PDBFile * file, lString32 name, int startBlockIndex, int size )
         : _stream(stream), _file(file), _startBlock(startBlockIndex), _size(size), _name(name) {
     }
 };
@@ -324,7 +324,7 @@ public:
         // return region of base stream
         return LVStreamRef( new LVStreamFragment( _stream, _startBlock, _size ) );
     }
-    LVPDBRegionContainerItem( LVStreamRef stream, PDBFile * file, lString16 name, int startOffset, int size )
+    LVPDBRegionContainerItem( LVStreamRef stream, PDBFile * file, lString32 name, int startOffset, int size )
         : LVPDBContainerItem(stream, file, name, startOffset, size) {
     }
 };
@@ -340,7 +340,7 @@ public:
         _list.add(item);
     }
 
-    //virtual const LVContainerItemInfo * GetObjectInfo(const wchar_t * pname);
+    //virtual const LVContainerItemInfo * GetObjectInfo(const lChar32 * pname);
     virtual const LVContainerItemInfo * GetObjectInfo(int index) {
         if ( index>=0 && index<_list.length() )
             return _list[index];
@@ -353,11 +353,11 @@ public:
 		return LVERR_OK;
     }
 
-    virtual LVStreamRef OpenStream( const lChar16 * fname, lvopen_mode_t mode ) {
+    virtual LVStreamRef OpenStream( const lChar32 * fname, lvopen_mode_t mode ) {
         if ( mode!=LVOM_READ )
             return LVStreamRef();
         for ( int i=0; i<_list.length(); i++ ) {
-            //CRLog::trace("OpenStream(%s) : %s", LCSTR(lString16(fname)), LCSTR(lString16(_list[i]->GetName())) );
+            //CRLog::trace("OpenStream(%s) : %s", LCSTR(lString32(fname)), LCSTR(lString32(_list[i]->GetName())) );
             if ( !lStr_cmp(_list[i]->GetName(), fname) )
                 return _list[i]->openStream();
         }
@@ -634,11 +634,11 @@ public:
             if ( bytesRead>0 ) {
                 int pmlCount = 0;
                 int htmlCount = 0;
-                lString16 pmlChars("pXxCcriuovtnsblaUBSmqQI");
+                lString32 pmlChars("pXxCcriuovtnsblaUBSmqQI");
                 for ( int i=0; i<bytesRead-10; i++ ) {
                     const lUInt8 * p = buf.get() + i;
                     if ( p[0]=='\\' ) {
-                        if ( pmlChars.pos(lString16((const lChar8 *)p+1, 1)) >=0 )
+                        if ( pmlChars.pos(lString32((const lChar8 *)p+1, 1)) >=0 )
                             pmlCount++;
                     } else if (p[0]=='<') {
                         if ( pattern_cmp(p+1, "html") )
@@ -739,7 +739,7 @@ public:
                             lvsize_t bytesRead = 0;
                             stream->Read(name, 32, &bytesRead);
                             if ( name[0] ) {
-                                lString16 fname = lString16(name);
+                                lString32 fname = lString32(name);
                                 container->addItem( new LVPDBRegionContainerItem( stream, this, fname, start, size ) );
                             }
                         }
@@ -835,7 +835,7 @@ public:
                     if (buf[0]=='G' && buf[1]=='I' && buf[2]=='F')
                         fmt = "gif";
                     if (fmt) {
-                        lString16 name = lString16(MOBI_IMAGE_NAME_PREFIX) + fmt::decimal((int) (index - preamble.firstImageIndex + 1));
+                        lString32 name = lString32(MOBI_IMAGE_NAME_PREFIX) + fmt::decimal((int) (index - preamble.firstImageIndex + 1));
                         //CRLog::debug("Adding image %s [%d] %s", LCSTR(name), _records[index].size, fmt);
                         container->addItem( new LVPDBRegionContainerItem( stream, this, name, _records[index].offset, _records[index].size ) );
                         if ((unsigned)index == preamble.firstImageIndex + coverOffset) {
@@ -1162,7 +1162,7 @@ LVStreamRef GetPDBCoverpage(LVStreamRef stream)
     LVContainerRef cnt(container);
     container->setStream(stream);
     LVStreamRef coverStream;
-    lString16 coverName = pdb->getDocProps()->getStringDef(DOC_PROP_COVER_FILE);
+    lString32 coverName = pdb->getDocProps()->getStringDef(DOC_PROP_COVER_FILE);
     if (!coverName.empty()) {
         coverStream = cnt->OpenStream(coverName.c_str(), LVOM_READ);
     }
@@ -1211,7 +1211,7 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
                 return false;
             } else {
                 if (pdb->getFormat()==PDBFile::MOBI && isCorrectUtf8Text(stream))
-                    parser.SetCharset(L"utf-8");
+                    parser.SetCharset(U"utf-8");
                 if (!parser.Parse()) {
                     return false;
                 }
@@ -1256,10 +1256,10 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
         const LVContainerItemInfo * item = container->GetObjectInfo(i);
         if (item->IsContainer())
             continue;
-        lString16 fn = item->GetName();
+        lString32 fn = item->GetName();
         if (fn.empty())
-            fn = cs16("pdb_item_") + lString16::itoa(i);
-        fn = cs16("/tmp/") + fn;
+            fn = cs32("pdb_item_") + lString32::itoa(i);
+        fn = cs32("/tmp/") + fn;
         LVStreamRef in = container->OpenStream(item->GetName(), LVOM_READ);
         if (in.isNull())
             continue;

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -21,9 +21,9 @@ class CRPropItem
 {
 private:
     lString8 _name;
-    lString16 _value;
+    lString32 _value;
 public:
-    CRPropItem( const char * name, const lString16 value )
+    CRPropItem( const char * name, const lString32 value )
     : _name(name), _value(value)
     { }
     CRPropItem( const CRPropItem& v )
@@ -37,8 +37,8 @@ public:
       return *this;
     }
     const char * getName() const { return _name.c_str(); }
-    const lString16 & getValue() const { return _value; }
-    void setValue(const lString16 &v) { _value = v; }
+    const lString32 & getValue() const { return _value; }
+    void setValue(const lString32 &v) { _value = v; }
 };
 
 /// set contents from specified properties
@@ -159,8 +159,8 @@ CRPropRef operator ^ ( CRPropRef props1, CRPropRef props2 )
             if ( res<0 ) {
                 p1++;
             } else if ( res==0 ) {
-                lString16 v1 = props1->getValue( p1 );
-                lString16 v2 = props2->getValue( p2 );
+                lString32 v1 = props1->getValue( p1 );
+                lString32 v2 = props2->getValue( p2 );
                 if ( v1!=v2 )
                     v->setString( props2->getName( p2 ), v2 );
                 p1++;
@@ -209,13 +209,13 @@ public:
     /// returns property name by index
     virtual const char * getName( int index ) const;
     /// returns property value by index
-    virtual const lString16 & getValue( int index ) const;
+    virtual const lString32 & getValue( int index ) const;
     /// sets property value by index
-    virtual void setValue( int index, const lString16 &value );
+    virtual void setValue( int index, const lString32 &value );
     /// get string property by name, returns false if not found
-    virtual bool getString( const char * propName, lString16 &result ) const;
+    virtual bool getString( const char * propName, lString32 &result ) const;
     /// set string property by name
-    virtual void setString( const char * propName, const lString16 &value );
+    virtual void setString( const char * propName, const lString32 &value );
     /// get subpath container
     virtual CRPropRef getSubProps( const char * path );
     /// constructor
@@ -240,11 +240,11 @@ void CRPropAccessor::setIntDef( const char * propName, int value )
 
 void CRPropAccessor::limitValueList( const char * propName, const char * values[] )
 {
-    lString16 defValue = Utf8ToUnicode( lString8( values[0] ) );
-    lString16 value;
+    lString32 defValue = Utf8ToUnicode( lString8( values[0] ) );
+    lString32 value;
     if ( getString( propName, value ) ) {
         for ( int i=0; values[i]; i++ ) {
-            lString16 v = Utf8ToUnicode( lString8( values[i] ) );
+            lString32 v = Utf8ToUnicode( lString8( values[i] ) );
             if ( v==value )
                 return;
         }
@@ -254,11 +254,11 @@ void CRPropAccessor::limitValueList( const char * propName, const char * values[
 
 void CRPropAccessor::limitValueList( const char * propName, int values[], int value_count )
 {
-    lString16 defValue = lString16::itoa( values[0] );
-    lString16 value;
+    lString32 defValue = lString32::itoa( values[0] );
+    lString32 value;
     if ( getString( propName, value ) ) {
         for ( int i=0; i < value_count; i++ ) {
-            lString16 v = lString16::itoa( values[i] );
+            lString32 v = lString32::itoa( values[i] );
             if ( v==value )
                 return;
         }
@@ -270,18 +270,18 @@ void CRPropAccessor::limitValueList( const char * propName, int values[], int va
 // CRPropAccessor methods
 //============================================================================
 
-lString16 CRPropAccessor::getStringDef( const char * propName, const char * defValue ) const
+lString32 CRPropAccessor::getStringDef( const char * propName, const char * defValue ) const
 {
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) )
-        return lString16( defValue );
+        return lString32( defValue );
     else
         return value;
 }
 
 bool CRPropAccessor::getInt( const char * propName, int &result ) const
 {
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) )
         return false;
     return value.atoi(result);
@@ -306,16 +306,16 @@ void CRPropAccessor::setHex( const char * propName, lUInt32 value )
 
 void CRPropAccessor::setInt( const char * propName, int value )
 {
-    setString( propName, lString16::itoa( value ) );
+    setString( propName, lString32::itoa( value ) );
 }
 
-bool CRPropAccessor::parseColor(lString16 value, lUInt32 & result) {
+bool CRPropAccessor::parseColor(lString32 value, lUInt32 & result) {
     int n = 0;
     if ( value.empty() || (value[0]!='#' && (value[0]!='0' || value[1]!='x')) ) {
         return false;
     }
     for ( int i=value[0]=='#' ? 1 : 2; i<value.length(); i++ ) {
-        lChar16 ch = value[i];
+        lChar32 ch = value[i];
         if ( ch>='0' && ch<='9' )
             n = (n << 4) | (ch - '0');
         else if ( ch>='a' && ch<='f' )
@@ -333,7 +333,7 @@ bool CRPropAccessor::parseColor(lString16 value, lUInt32 & result) {
 bool CRPropAccessor::getColor( const char * propName, lUInt32 &result ) const
 {
     //int n = 0;
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) ) {
         //CRLog::debug("%s is not found", propName);
         return false;
@@ -358,7 +358,7 @@ void CRPropAccessor::setColor( const char * propName, lUInt32 value )
 {
     char s[12];
     sprintf( s, "#%06x", (int)value );
-    setString( propName, lString16( s ) );
+    setString( propName, lString32( s ) );
 }
 
 /// set argb color (#xxxxxx) property by name, if not set
@@ -371,7 +371,7 @@ void CRPropAccessor::setColorDef( const char * propName, lUInt32 defValue ) {
 /// get rect property by name, returns false if not found
 bool CRPropAccessor::getRect( const char * propName, lvRect &result ) const
 {
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) )
         return false;
     lString8 s8 = UnicodeToUtf8( value );
@@ -400,13 +400,13 @@ void CRPropAccessor::setRect( const char * propName, const lvRect & value )
 {
     char s[64];
     sprintf( s, "{%d,%d,%d,%d}", value.left, value.top, value.right, value.bottom );
-    setString( propName, lString16( s ) );
+    setString( propName, lString32( s ) );
 }
 
 /// get point property by name, returns false if not found
 bool CRPropAccessor::getPoint( const char * propName, lvPoint &result ) const
 {
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) )
         return false;
     lString8 s8 = UnicodeToUtf8( value );
@@ -433,12 +433,12 @@ void CRPropAccessor::setPoint( const char * propName, const lvPoint & value )
 {
     char s[64];
     sprintf( s, "{%d,%d}", value.x, value.y );
-    setString( propName, lString16( s ) );
+    setString( propName, lString32( s ) );
 }
 
 bool CRPropAccessor::getBool( const char * propName, bool &result ) const
 {
-    lString16 value;
+    lString32 value;
     if (!getString(propName, value))
         return false;
     if (value == "true" || value == "TRUE" || value == "yes" || value == "YES" || value == "1") {
@@ -463,12 +463,12 @@ bool CRPropAccessor::getBoolDef( const char * propName, bool defValue ) const
 
 void CRPropAccessor::setBool( const char * propName, bool value )
 {
-    setString( propName, lString16( value ? "1" : "0" ) );
+    setString( propName, lString32( value ? "1" : "0" ) );
 }
 
 bool CRPropAccessor::getInt64( const char * propName, lInt64 &result ) const
 {
-    lString16 value;
+    lString32 value;
     if ( !getString( propName, value ) )
         return false;
     return value.atoi(result);
@@ -485,7 +485,7 @@ lInt64 CRPropAccessor::getInt64Def( const char * propName, lInt64 defValue ) con
 
 void CRPropAccessor::setInt64( const char * propName, lInt64 value )
 {
-    setString( propName, lString16::itoa( value ) );
+    setString( propName, lString32::itoa( value ) );
 }
 
 CRPropAccessor::~CRPropAccessor()
@@ -655,13 +655,13 @@ const char * CRPropContainer::getName( int index ) const
 }
 
 /// returns property value by index
-const lString16 & CRPropContainer::getValue( int index ) const
+const lString32 & CRPropContainer::getValue( int index ) const
 {
     return _list[index]->getValue();
 }
 
 /// sets property value by index
-void CRPropContainer::setValue( int index, const lString16 &value )
+void CRPropContainer::setValue( int index, const lString32 &value )
 {
     _list[index]->setValue( value );
 }
@@ -694,7 +694,7 @@ bool CRPropContainer::findItem( const char * name, int & pos ) const
 }
 
 /// get string property by name, returns false if not found
-bool CRPropContainer::getString( const char * propName, lString16 &result ) const
+bool CRPropContainer::getString( const char * propName, lString32 &result ) const
 {
     int pos = 0;
     if ( !findItem( propName, pos ) )
@@ -711,7 +711,7 @@ void CRPropContainer::clear()
 }
 
 /// set string property by name
-void CRPropContainer::setString( const char * propName, const lString16 &value )
+void CRPropContainer::setString( const char * propName, const lString32 &value )
 {
     int pos = 0;
     if ( _list.empty() || !findItem( propName, pos ) ) {
@@ -770,7 +770,7 @@ public:
     /// returns true if specified property exists
     virtual bool hasProperty( const char * propName ) const
     {
-        lString16 str;
+        lString32 str;
         return getString( propName, str );
     }
     CRPropSubContainer(CRPropContainer * root, lString8 path)
@@ -802,19 +802,19 @@ public:
         return _root->getName( index + _start ) + _path.length();
     }
     /// returns property value by index
-    virtual const lString16 & getValue( int index ) const
+    virtual const lString32 & getValue( int index ) const
     {
         sync();
         return _root->getValue( index + _start );
     }
     /// sets property value by index
-    virtual void setValue( int index, const lString16 &value )
+    virtual void setValue( int index, const lString32 &value )
     {
         sync();
         _root->setValue( index + _start, value );
     }
     /// get string property by name, returns false if not found
-    virtual bool getString( const char * propName, lString16 &result ) const
+    virtual bool getString( const char * propName, lString32 &result ) const
     {
         sync();
         int pos = 0;
@@ -824,7 +824,7 @@ public:
         return true;
     }
     /// set string property by name
-    virtual void setString( const char * propName, const lString16 &value )
+    virtual void setString( const char * propName, const lString32 &value )
     {
         sync();
         int pos = 0;
@@ -893,7 +893,7 @@ bool CRPropAccessor::deserialize( SerialBuf & buf )
     buf >> sz;
     for ( int i=0; i<sz; i++ ) {
         lString8 nm;
-        lString16 val;
+        lString32 val;
         if ( !buf.checkMagic( props_name_magic ) )
             return false;
         buf >> nm;

--- a/crengine/src/rtfimp.cpp
+++ b/crengine/src/rtfimp.cpp
@@ -72,7 +72,7 @@ static const rtf_control_word * findControlWord( const char * name )
     }
 }
 
-void LVRtfDestination::SetCharsetTable(const lChar16 * table) {
+void LVRtfDestination::SetCharsetTable(const lChar32 * table) {
     m_parser.SetCharsetTable(table);
 }
 
@@ -105,11 +105,11 @@ public:
     // set table state, open/close tags if necessary
     void SetTableState( rtfTblState state )
     {
-        static const lChar16 * tags[5] = {
+        static const lChar32 * tags[5] = {
             NULL,// tbls_none=0,
-            L"table", // tbls_intable,
-            L"tr", // tbls_inrow,
-            L"td", // tbls_incell,
+            U"table", // tbls_intable,
+            U"tr", // tbls_inrow,
+            U"td", // tbls_incell,
             NULL
         };
         if ( tblState < state ) {
@@ -161,15 +161,15 @@ public:
             break;
         }
     }
-    virtual void OnText( const lChar16 * text, int len, lUInt32 flags )
+    virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
-        lString16 s = text;
+        lString32 s = text;
         s.trimDoubleSpaces(!last_space, true, false);
         text = s.c_str();
         len = s.length();
         if ( !len ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"empty-line");
-            m_callback->OnTagClose(NULL, L"empty-line", true);
+            m_callback->OnTagOpenNoAttr(NULL, U"empty-line");
+            m_callback->OnTagClose(NULL, U"empty-line", true);
             return;
         }
         bool intbl = m_stack.getInt( pi_intbl )>0;
@@ -181,16 +181,16 @@ public:
             OnAction(RA_SECTION);
         }
         if ( !in_section ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"section");
+            m_callback->OnTagOpenNoAttr(NULL, U"section");
             in_section = true;
         }
         if ( !intbl ) {
             if ( !in_title && titleFlag ) {
                 if ( asteriskFlag ) {
-                    m_callback->OnTagOpenNoAttr(NULL, L"subtitle");
+                    m_callback->OnTagOpenNoAttr(NULL, U"subtitle");
                     in_subtitle = true;
                 } else {
-                    m_callback->OnTagOpenNoAttr(NULL, L"title");
+                    m_callback->OnTagOpenNoAttr(NULL, U"title");
                     in_subtitle = false;
                 }
                 in_title = true;
@@ -202,20 +202,20 @@ public:
         if ( !in_para ) {
             if ( !in_title )
                 last_notitle = true;
-            m_callback->OnTagOpenNoAttr(NULL, L"p");
+            m_callback->OnTagOpenNoAttr(NULL, U"p");
             last_space = false;
             in_para = true;
         }
         if ( m_stack.getInt(pi_ch_bold) ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"strong");
+            m_callback->OnTagOpenNoAttr(NULL, U"strong");
         }
         if ( m_stack.getInt(pi_ch_italic) ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"emphasis");
+            m_callback->OnTagOpenNoAttr(NULL, U"emphasis");
         }
         if ( m_stack.getInt(pi_ch_sub) ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"sub");
+            m_callback->OnTagOpenNoAttr(NULL, U"sub");
         } else if ( m_stack.getInt(pi_ch_super) ) {
-            m_callback->OnTagOpenNoAttr(NULL, L"sup");
+            m_callback->OnTagOpenNoAttr(NULL, U"sup");
         }
 
         m_callback->OnText( text, len, flags );
@@ -223,15 +223,15 @@ public:
 
 
         if ( m_stack.getInt(pi_ch_super) && !m_stack.getInt(pi_ch_sub) ) {
-            m_callback->OnTagClose(NULL, L"sup");
+            m_callback->OnTagClose(NULL, U"sup");
         } else if ( m_stack.getInt(pi_ch_sub) ) {
-            m_callback->OnTagClose(NULL, L"sub");
+            m_callback->OnTagClose(NULL, U"sub");
         }
         if ( m_stack.getInt(pi_ch_italic) ) {
-            m_callback->OnTagClose(NULL, L"emphasis");
+            m_callback->OnTagClose(NULL, U"emphasis");
         }
         if ( m_stack.getInt(pi_ch_bold) ) {
-            m_callback->OnTagClose(NULL, L"strong");
+            m_callback->OnTagClose(NULL, U"strong");
         }
     }
     virtual void OnBlob(const lUInt8*, int)
@@ -241,22 +241,22 @@ public:
     {
         if ( action==RA_PARA || action==RA_SECTION ) {
             if ( in_para ) {
-                m_callback->OnTagClose(NULL, L"p");
+                m_callback->OnTagClose(NULL, U"p");
                 m_parser.updateProgress();
                 in_para = false;
             }
             if ( in_title ) {
                 if ( in_subtitle )
-                    m_callback->OnTagClose(NULL, L"subtitle");
+                    m_callback->OnTagClose(NULL, U"subtitle");
                 else
-                    m_callback->OnTagClose(NULL, L"title");
+                    m_callback->OnTagClose(NULL, U"title");
                 in_title = false;
             }
         }
         if ( action==RA_SECTION ) {
             SetTableState( tbls_none );
             if ( in_section ) {
-                m_callback->OnTagClose(NULL, L"section");
+                m_callback->OnTagClose(NULL, U"section");
                 in_section = false;
             }
         }
@@ -285,7 +285,7 @@ public:
     virtual void OnControlWord( const char *, int )
     {
     }
-    virtual void OnText( const lChar16 *, int, lUInt32 )
+    virtual void OnText( const lChar32 *, int, lUInt32 )
     {
     }
     virtual void OnBlob(const lUInt8*, int)
@@ -319,7 +319,7 @@ public:
     virtual void OnControlWord( const char *, int )
     {
     }
-    virtual void OnText( const lChar16 * text, int len, lUInt32)
+    virtual void OnText( const lChar32 * text, int len, lUInt32)
     {
         int fmt = m_stack.getInt(pi_imgfmt);
         if (!fmt)
@@ -357,20 +357,20 @@ public:
         if (!_fmt || _buf.empty())
             return;
         // add Image BLOB
-        lString16 name(BLOB_NAME_PREFIX); // L"@blob#"
+        lString32 name(BLOB_NAME_PREFIX); // U"@blob#"
         name << "image";
         name << fmt::decimal(m_parser.nextImageIndex());
         name << (_fmt==rtf_img_jpeg ? ".jpg" : ".png");
         m_callback->OnBlob(name, _buf.get(), _buf.length());
 #if 0
         {
-            LVStreamRef stream = LVOpenFileStream((cs16("/tmp/") + name).c_str(), LVOM_WRITE);
+            LVStreamRef stream = LVOpenFileStream((cs32("/tmp/") + name).c_str(), LVOM_WRITE);
             stream->Write(_buf.get(), _buf.length(), NULL);
         }
 #endif
-        m_callback->OnTagOpen(LXML_NS_NONE, L"img");
-        m_callback->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-        m_callback->OnTagClose(LXML_NS_NONE, L"img", true);
+        m_callback->OnTagOpen(LXML_NS_NONE, U"img");
+        m_callback->OnAttribute(LXML_NS_NONE, U"src", name.c_str());
+        m_callback->OnTagClose(LXML_NS_NONE, U"img", true);
     }
 };
 
@@ -417,7 +417,7 @@ void LVRtfParser::CommitText()
     txtbuf[txtpos] = 0;
 #ifdef LOG_RTF_PARSING
     if ( CRLog::isLogLevelEnabled(CRLog::LL_TRACE ) ) {
-        lString16 s = txtbuf;
+        lString32 s = txtbuf;
         lString8 s8 = UnicodeToUtf8( s );
         CRLog::trace( "Text(%s)", s8.c_str() );
     }
@@ -430,13 +430,13 @@ void LVRtfParser::CommitText()
 
 void LVRtfParser::AddChar8( lUInt8 ch )
 {
-    lChar16 ch16 = m_stack.byteToUnicode(ch);
-    if ( ch16 )
-        AddChar( ch16 );
+    lChar32 ch32 = m_stack.byteToUnicode(ch);
+    if ( ch32 )
+        AddChar( ch32 );
 }
 
 // m_buf_pos points to first byte of char
-void LVRtfParser::AddChar( lChar16 ch )
+void LVRtfParser::AddChar( lChar32 ch )
 {
     if ( txtpos >= MAX_TXT_SIZE || ch==13 ) {
         CommitText();
@@ -463,38 +463,38 @@ static int charToHex( lUInt8 ch )
 /// parses input stream
 bool LVRtfParser::Parse()
 {
-    //m_conv_table = GetCharsetByte2UnicodeTable( L"cp1251" );
+    //m_conv_table = GetCharsetByte2UnicodeTable( U"cp1251" );
 
     bool errorFlag = false;
     m_callback->OnStart(this);
 
     // make fb2 document structure
-    m_callback->OnTagOpen( NULL, L"?xml" );
-    m_callback->OnAttribute( NULL, L"version", L"1.0" );
-    m_callback->OnAttribute( NULL, L"encoding", L"utf-8" );
+    m_callback->OnTagOpen( NULL, U"?xml" );
+    m_callback->OnAttribute( NULL, U"version", U"1.0" );
+    m_callback->OnAttribute( NULL, U"encoding", U"utf-8" );
     //m_callback->OnEncoding( GetEncodingName().c_str(), GetCharsetTable( ) );
     m_callback->OnTagBody();
-    m_callback->OnTagClose( NULL, L"?xml" );
-    m_callback->OnTagOpenNoAttr( NULL, L"FictionBook" );
+    m_callback->OnTagClose( NULL, U"?xml" );
+    m_callback->OnTagOpenNoAttr( NULL, U"FictionBook" );
       // DESCRIPTION
-      m_callback->OnTagOpenNoAttr( NULL, L"description" );
-        m_callback->OnTagOpenNoAttr( NULL, L"title-info" );
+      m_callback->OnTagOpenNoAttr( NULL, U"description" );
+        m_callback->OnTagOpenNoAttr( NULL, U"title-info" );
           //
-            lString16 bookTitle = LVExtractFilenameWithoutExtension( getFileName() ); //m_stream->GetName();
-            m_callback->OnTagOpenNoAttr( NULL, L"book-title" );
+            lString32 bookTitle = LVExtractFilenameWithoutExtension( getFileName() ); //m_stream->GetName();
+            m_callback->OnTagOpenNoAttr( NULL, U"book-title" );
                 if ( !bookTitle.empty() )
                     m_callback->OnText( bookTitle.c_str(), bookTitle.length(), 0 );
           //queue.DetectBookDescription( m_callback );
-        m_callback->OnTagOpenNoAttr( NULL, L"title-info" );
-      m_callback->OnTagClose( NULL, L"description" );
+        m_callback->OnTagOpenNoAttr( NULL, U"title-info" );
+      m_callback->OnTagClose( NULL, U"description" );
       // BODY
-      m_callback->OnTagOpenNoAttr( NULL, L"body" );
-        //m_callback->OnTagOpen( NULL, L"section" );
+      m_callback->OnTagOpenNoAttr( NULL, U"body" );
+        //m_callback->OnTagOpen( NULL, U"section" );
           // process text
           //queue.DoTextImport( m_callback );
-        //m_callback->OnTagClose( NULL, L"section" );
+        //m_callback->OnTagClose( NULL, U"section" );
 
-    txtbuf = new lChar16[ MAX_TXT_SIZE+1 ];
+    txtbuf = new lChar32[ MAX_TXT_SIZE+1 ];
     txtpos = 0;
     txtfstart = 0;
     char cwname[33];
@@ -564,7 +564,7 @@ bool LVRtfParser::Parse()
                 }
                 // \uN -- unicode character
                 if ( cwi==1 && cwname[0]=='u' ) {
-                    AddChar( (lChar16) (param & 0xFFFF) );
+                    AddChar( (lChar32) (param & 0xFFFF) );
                     m_stack.set( pi_skip_ch_count, m_stack.getInt(pi_uc_count) );
                 } else {
                     // usual control word
@@ -590,7 +590,7 @@ bool LVRtfParser::Parse()
                 m_buf_pos += binLength;
             }
         } else {
-            //lChar16 txtch = 0;
+            //lChar32 txtch = 0;
             if ( ch=='\\' ) {
                 p++;
                 int digit1 = charToHex( p[0] );
@@ -625,8 +625,8 @@ bool LVRtfParser::Parse()
     CommitText();
     m_stack.getDestination()->OnAction(LVRtfDestination::RA_SECTION);
 
-      m_callback->OnTagClose( NULL, L"body" );
-    m_callback->OnTagClose( NULL, L"FictionBook" );
+      m_callback->OnTagClose( NULL, U"body" );
+    m_callback->OnTagClose( NULL, U"FictionBook" );
 
     return !errorFlag;
 }
@@ -638,19 +638,19 @@ void LVRtfParser::Reset()
 }
 
 /// sets charset by name
-void LVRtfParser::SetCharset( const lChar16 * )
+void LVRtfParser::SetCharset( const lChar32 * )
 {
     //TODO
 }
 
 /// sets 8-bit charset conversion table (128 items, for codes 128..255)
-void LVRtfParser::SetCharsetTable( const lChar16 * )
+void LVRtfParser::SetCharsetTable( const lChar32 * )
 {
     //TODO
 }
 
 /// returns 8-bit charset conversion table (128 items, for codes 128..255)
-lChar16 * LVRtfParser::GetCharsetTable( )
+lChar32 * LVRtfParser::GetCharsetTable( )
 {
     return NULL;
 }
@@ -674,7 +674,7 @@ void LVRtfParser::OnControlWord( const char * control, int param, bool asterisk 
         switch ( cw->type ) {
         case CWT_CHAR:
             {
-                lChar16 ch = (lChar16)cw->index;
+                lChar32 ch = (lChar32)cw->index;
                 if ( ch==13 ) {
                     // TODO: end of paragraph
                     CommitText();

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -89,7 +89,7 @@ static struct {
 };
 
 // Init global TextLangMan members
-lString16 TextLangMan::_main_lang = TEXTLANG_DEFAULT_MAIN_LANG_16;
+lString32 TextLangMan::_main_lang = TEXTLANG_DEFAULT_MAIN_LANG_32;
 bool TextLangMan::_embedded_langs_enabled = TEXTLANG_DEFAULT_EMBEDDED_LANGS_ENABLED;
 LVPtrVector<TextLangCfg> TextLangMan::_lang_cfg_list;
 
@@ -128,7 +128,7 @@ void TextLangMan::uninit() {
 }
 
 // For HyphMan legacy methods
-void TextLangMan::setMainLangFromHyphDict( lString16 id ) {
+void TextLangMan::setMainLangFromHyphDict( lString32 id ) {
     // When setting up TextlangMan thru HyphMan legacy methods,
     // disable embedded langs, for a consistent hyphenation.
     TextLangMan::setEmbeddedLangsEnabled( false );
@@ -139,7 +139,7 @@ void TextLangMan::setMainLangFromHyphDict( lString16 id ) {
 
     for (int i=0; _hyph_dict_table[i].lang_tag!=NULL; i++) {
         if ( id.startsWith( _hyph_dict_table[i].hyph_filename_prefix ) ) {
-            TextLangMan::setMainLang( lString16(_hyph_dict_table[i].lang_tag) );
+            TextLangMan::setMainLang( lString32(_hyph_dict_table[i].lang_tag) );
             #ifdef DEBUG_LANG_USAGE
             printf("TextLangMan::setMainLangFromHyphDict %s => %s\n",
                 UnicodeToLocal(id).c_str(), UnicodeToLocal(TextLangMan::getMainLang()).c_str());
@@ -151,21 +151,21 @@ void TextLangMan::setMainLangFromHyphDict( lString16 id ) {
 }
 
 // Used only by TextLangCfg
-HyphMethod * TextLangMan::getHyphMethodForLang( lString16 lang_tag ) {
+HyphMethod * TextLangMan::getHyphMethodForLang( lString32 lang_tag ) {
     // Look for full lang_tag
     for (int i=0; _hyph_dict_table[i].lang_tag!=NULL; i++) {
-        if ( lang_tag == lString16(_hyph_dict_table[i].lang_tag).lowercase() ) {
-            return HyphMan::getHyphMethodForDictionary( lString16(_hyph_dict_table[i].hyph_filename),
+        if ( lang_tag == lString32(_hyph_dict_table[i].lang_tag).lowercase() ) {
+            return HyphMan::getHyphMethodForDictionary( lString32(_hyph_dict_table[i].hyph_filename),
                         _hyph_dict_table[i].left_hyphen_min, _hyph_dict_table[i].right_hyphen_min);
         }
     }
     // Look for lang_tag initial subpart
     int m_pos = lang_tag.pos("-");
     if ( m_pos > 0 ) {
-        lString16 lang_tag2 = lang_tag.substr(0, m_pos);
+        lString32 lang_tag2 = lang_tag.substr(0, m_pos);
         for (int i=0; _hyph_dict_table[i].lang_tag!=NULL; i++) {
-            if ( lang_tag2 == lString16(_hyph_dict_table[i].lang_tag).lowercase() ) {
-                return HyphMan::getHyphMethodForDictionary( lString16(_hyph_dict_table[i].hyph_filename),
+            if ( lang_tag2 == lString32(_hyph_dict_table[i].lang_tag).lowercase() ) {
+                return HyphMan::getHyphMethodForDictionary( lString32(_hyph_dict_table[i].hyph_filename),
                             _hyph_dict_table[i].left_hyphen_min, _hyph_dict_table[i].right_hyphen_min);
             }
         }
@@ -177,7 +177,7 @@ HyphMethod * TextLangMan::getHyphMethodForLang( lString16 lang_tag ) {
 }
 
 // Return the (single and cached) TextLangCfg for the provided lang_tag
-TextLangCfg * TextLangMan::getTextLangCfg( lString16 lang_tag ) {
+TextLangCfg * TextLangMan::getTextLangCfg( lString32 lang_tag ) {
     if ( !_embedded_langs_enabled ) {
         // Drop provided lang_tag: always return main lang TextLangCfg
         lang_tag = _main_lang;
@@ -220,7 +220,7 @@ TextLangCfg * TextLangMan::getTextLangCfg( ldomNode * node ) {
     // any node: so, look at this node parents for that lang= attribute.
     for ( ; !node->isRoot(); node = node->getParentNode() ) {
         if ( node->hasAttribute( attr_lang ) ) {
-            lString16 lang_tag = node->getAttributeValue( attr_lang );
+            lString32 lang_tag = node->getAttributeValue( attr_lang );
             if ( !lang_tag.empty() )
                 return TextLangMan::getTextLangCfg( lang_tag );
         }
@@ -262,10 +262,10 @@ void TextLangMan::resetCounters() {
 // For CSS "content: open-quote / close-quote"
 typedef struct quotes_spec {
     const char * lang_tag;
-    const lChar16 *  open_quote_level_1;
-    const lChar16 * close_quote_level_1;
-    const lChar16 *  open_quote_level_2;
-    const lChar16 * close_quote_level_2;
+    const lChar32 *  open_quote_level_1;
+    const lChar32 * close_quote_level_1;
+    const lChar32 *  open_quote_level_2;
+    const lChar32 * close_quote_level_2;
 } quotes_spec;
 
 // List built 20200601 from https://html.spec.whatwg.org/multipage/rendering.html#quotes
@@ -274,194 +274,194 @@ typedef struct quotes_spec {
 // Small issue: 3-letters lang tag not specified here might match
 // a 2-letter lang tag specified here ("ito" will get those from "it").
 static quotes_spec _quotes_spec_table[] = {
-    { "af",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "agq",      L"\x201e", L"\x201d", L"\x201a", L"\x2019" }, /* „ ” ‚ ’ */
-    { "ak",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "am",       L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "ar",       L"\x201d", L"\x201c", L"\x2019", L"\x2018" }, /* ” “ ’ ‘ */
-    { "asa",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ast",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "az-cyrl",  L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "az",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "bas",      L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "bem",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "bez",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "be",       L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "bg",       L"\x201e", L"\x201c", L"\x2018", L"\x2019" }, /* „ “ ‘ ’ */
-    { "bm",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "bn",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "brx",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "br",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "bs-cyrl",  L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "bs",       L"\x201e", L"\x201d", L"\x2018", L"\x2019" }, /* „ ” ‘ ’ */
-    { "ca",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "cgg",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "chr",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "cs",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "cy",       L"\x2018", L"\x2019", L"\x201c", L"\x201d" }, /* ‘ ’ “ ” */
-    { "dav",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "da",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "de",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "dje",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "dsb",      L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "dua",      L"\x00ab", L"\x00bb", L"\x2018", L"\x2019" }, /* « » ‘ ’ */
-    { "dyo",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "dz",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ebu",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ee",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "el",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "en",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "eo",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "es",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "et",       L"\x201e", L"\x201c", L"\x00ab", L"\x00bb" }, /* „ “ « » */
-    { "eu",       L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "ewo",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "fa",       L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "ff",       L"\x201e", L"\x201d", L"\x201a", L"\x2019" }, /* „ ” ‚ ’ */
-    { "fil",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "fi",       L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "fo",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "fr-ch",    L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    // { "fr",    L"\x00ab", L"\x00bb", L"\x00ab", L"\x00bb" }, /* « » « » */  /* Same pair for both level, bit sad... */
-    { "fr",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */  /* Better to have "fr" just as "it" */
-    { "fur",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */  /* Defaulting to "it", needs verification */
-    { "ga",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "gd",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "gl",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "gsw",      L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "guz",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "gu",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ha",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "he",       L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "hi",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "hr",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "hsb",      L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "hu",       L"\x201e", L"\x201d", L"\x00bb", L"\x00ab" }, /* „ ” » « */
-    { "hy",       L"\x00ab", L"\x00bb", L"\x00ab", L"\x00bb" }, /* « » « » */
-    { "id",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ig",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "is",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "it",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "ja",       L"\x300c", L"\x300d", L"\x300e", L"\x300f" }, /* 「 」 『 』 */
-    { "jgo",      L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "jmc",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "kab",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "kam",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ka",       L"\x201e", L"\x201c", L"\x2018", L"\x2019" }, /* „ “ “ ” */
-    { "kde",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "kea",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "khq",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ki",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "kkj",      L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "kk",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "kln",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "km",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "kn",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ko",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ksb",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ksf",      L"\x00ab", L"\x00bb", L"\x2018", L"\x2019" }, /* « » ‘ ’ */
-    { "ky",       L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "lag",      L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "lb",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "lg",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ln",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "lo",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "lrc",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "lt",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "luo",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "luy",      L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "lu",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "lv",       L"\x201c", L"\x201d", L"\x201e", L"\x201d" }, /* “ ” „ ” */
-    { "mas",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mer",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mfe",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mgo",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mg",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "mk",       L"\x201e", L"\x201c", L"\x2019", L"\x2018" }, /* „ “ ’ ‘ */
-    { "ml",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mn",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mr",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ms",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mt",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mua",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "my",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "mzn",      L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "naq",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "nb",       L"\x00ab", L"\x00bb", L"\x2018", L"\x2019" }, /* « » ‘ ’ */
-    { "nd",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ne",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "nl",       L"\x2018", L"\x2019", L"\x201c", L"\x201d" }, /* ‘ ’ “ ” */
-    { "nmg",      L"\x201e", L"\x201d", L"\x00ab", L"\x00bb" }, /* „ ” « » */
-    { "nnh",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "nn",       L"\x00ab", L"\x00bb", L"\x2018", L"\x2019" }, /* « » ‘ ’ */
-    { "nus",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "nyn",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "oc",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "pa",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "pl",       L"\x201e", L"\x201d", L"\x00ab", L"\x00bb" }, /* „ ” « » */
-    { "pms",      L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */  /* Defaulting to "it", needs verification */
-    { "pt-br",    L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "pt-pt",    L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "pt",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "rm",       L"\x00ab", L"\x00bb", L"\x2039", L"\x203a" }, /* « » ‹ › */
-    { "rn",       L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "rof",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ro",       L"\x201e", L"\x201d", L"\x00ab", L"\x00bb" }, /* „ ” « » */
-    { "ru",       L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "rwk",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "rw",       L"\x00ab", L"\x00bb", L"\x2018", L"\x2019" }, /* « » ‘ ’ */
-    { "sah",      L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "saq",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "sbp",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "seh",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ses",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "sg",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "shi-latn", L"\x00ab", L"\x00bb", L"\x201e", L"\x201d" }, /* « » „ ” */
-    { "shi",      L"\x00ab", L"\x00bb", L"\x201e", L"\x201d" }, /* « » „ ” */
-    { "si",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "sk",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "sl",       L"\x201e", L"\x201c", L"\x201a", L"\x2018" }, /* „ “ ‚ ‘ */
-    { "sn",       L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "so",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "sq",       L"\x00ab", L"\x00bb", L"\x201c", L"\x201d" }, /* « » “ ” */
-    { "sr-latn",  L"\x201e", L"\x201c", L"\x2018", L"\x2018" }, /* „ “ ‘ ‘ */
-    { "sr",       L"\x201e", L"\x201d", L"\x2019", L"\x2019" }, /* „ ” ’ ’ */
-    { "sv",       L"\x201d", L"\x201d", L"\x2019", L"\x2019" }, /* ” ” ’ ’ */
-    { "sw",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ta",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "teo",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "te",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "th",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "ti-er",    L"\x2018", L"\x2019", L"\x201c", L"\x201d" }, /* ‘ ’ “ ” */
-    { "tk",       L"\x201c", L"\x201d", L"\x201c", L"\x201d" }, /* “ ” “ ” */
-    { "to",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "tr",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "twq",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "tzm",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "uk",       L"\x00ab", L"\x00bb", L"\x201e", L"\x201c" }, /* « » „ “ */
-    { "ur",       L"\x201d", L"\x201c", L"\x2019", L"\x2018" }, /* ” “ ’ ‘ */
-    { "uz-cyrl",  L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "uz",       L"\x201c", L"\x201d", L"\x2019", L"\x2018" }, /* “ ” ’ ‘ */
-    { "vai-latn", L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "vai",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "vi",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "vun",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "xog",      L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "yav",      L"\x00ab", L"\x00bb", L"\x00ab", L"\x00bb" }, /* « » « » */
-    { "yo",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "yue-hans", L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "yue",      L"\x300c", L"\x300d", L"\x300e", L"\x300f" }, /* 「 」 『 』 */
-    { "zgh",      L"\x00ab", L"\x00bb", L"\x201e", L"\x201d" }, /* « » „ ” */
-    { "zh-hant",  L"\x300c", L"\x300d", L"\x300e", L"\x300f" }, /* 「 」 『 』 */
-    { "zh",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
-    { "zu",       L"\x201c", L"\x201d", L"\x2018", L"\x2019" }, /* “ ” ‘ ’ */
+    { "af",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "agq",      U"\x201e", U"\x201d", U"\x201a", U"\x2019" }, /* „ ” ‚ ’ */
+    { "ak",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "am",       U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "ar",       U"\x201d", U"\x201c", U"\x2019", U"\x2018" }, /* ” “ ’ ‘ */
+    { "asa",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ast",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "az-cyrl",  U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "az",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "bas",      U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "bem",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "bez",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "be",       U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "bg",       U"\x201e", U"\x201c", U"\x2018", U"\x2019" }, /* „ “ ‘ ’ */
+    { "bm",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "bn",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "brx",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "br",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "bs-cyrl",  U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "bs",       U"\x201e", U"\x201d", U"\x2018", U"\x2019" }, /* „ ” ‘ ’ */
+    { "ca",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "cgg",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "chr",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "cs",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "cy",       U"\x2018", U"\x2019", U"\x201c", U"\x201d" }, /* ‘ ’ “ ” */
+    { "dav",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "da",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "de",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "dje",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "dsb",      U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "dua",      U"\x00ab", U"\x00bb", U"\x2018", U"\x2019" }, /* « » ‘ ’ */
+    { "dyo",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "dz",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ebu",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ee",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "el",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "en",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "eo",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "es",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "et",       U"\x201e", U"\x201c", U"\x00ab", U"\x00bb" }, /* „ “ « » */
+    { "eu",       U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "ewo",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "fa",       U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "ff",       U"\x201e", U"\x201d", U"\x201a", U"\x2019" }, /* „ ” ‚ ’ */
+    { "fil",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "fi",       U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "fo",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "fr-ch",    U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    // { "fr",    U"\x00ab", U"\x00bb", U"\x00ab", U"\x00bb" }, /* « » « » */  /* Same pair for both level, bit sad... */
+    { "fr",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */  /* Better to have "fr" just as "it" */
+    { "fur",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */  /* Defaulting to "it", needs verification */
+    { "ga",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "gd",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "gl",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "gsw",      U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "guz",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "gu",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ha",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "he",       U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "hi",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "hr",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "hsb",      U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "hu",       U"\x201e", U"\x201d", U"\x00bb", U"\x00ab" }, /* „ ” » « */
+    { "hy",       U"\x00ab", U"\x00bb", U"\x00ab", U"\x00bb" }, /* « » « » */
+    { "id",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ig",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "is",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "it",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "ja",       U"\x300c", U"\x300d", U"\x300e", U"\x300f" }, /* 「 」 『 』 */
+    { "jgo",      U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "jmc",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "kab",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "kam",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ka",       U"\x201e", U"\x201c", U"\x2018", U"\x2019" }, /* „ “ “ ” */
+    { "kde",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "kea",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "khq",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ki",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "kkj",      U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "kk",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "kln",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "km",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "kn",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ko",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ksb",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ksf",      U"\x00ab", U"\x00bb", U"\x2018", U"\x2019" }, /* « » ‘ ’ */
+    { "ky",       U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "lag",      U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "lb",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "lg",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ln",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "lo",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "lrc",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "lt",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "luo",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "luy",      U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "lu",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "lv",       U"\x201c", U"\x201d", U"\x201e", U"\x201d" }, /* “ ” „ ” */
+    { "mas",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mer",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mfe",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mgo",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mg",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "mk",       U"\x201e", U"\x201c", U"\x2019", U"\x2018" }, /* „ “ ’ ‘ */
+    { "ml",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mn",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mr",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ms",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mt",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mua",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "my",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "mzn",      U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "naq",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "nb",       U"\x00ab", U"\x00bb", U"\x2018", U"\x2019" }, /* « » ‘ ’ */
+    { "nd",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ne",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "nl",       U"\x2018", U"\x2019", U"\x201c", U"\x201d" }, /* ‘ ’ “ ” */
+    { "nmg",      U"\x201e", U"\x201d", U"\x00ab", U"\x00bb" }, /* „ ” « » */
+    { "nnh",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "nn",       U"\x00ab", U"\x00bb", U"\x2018", U"\x2019" }, /* « » ‘ ’ */
+    { "nus",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "nyn",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "oc",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "pa",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "pl",       U"\x201e", U"\x201d", U"\x00ab", U"\x00bb" }, /* „ ” « » */
+    { "pms",      U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */  /* Defaulting to "it", needs verification */
+    { "pt-br",    U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "pt-pt",    U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "pt",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "rm",       U"\x00ab", U"\x00bb", U"\x2039", U"\x203a" }, /* « » ‹ › */
+    { "rn",       U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "rof",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ro",       U"\x201e", U"\x201d", U"\x00ab", U"\x00bb" }, /* „ ” « » */
+    { "ru",       U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "rwk",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "rw",       U"\x00ab", U"\x00bb", U"\x2018", U"\x2019" }, /* « » ‘ ’ */
+    { "sah",      U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "saq",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "sbp",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "seh",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ses",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "sg",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "shi-latn", U"\x00ab", U"\x00bb", U"\x201e", U"\x201d" }, /* « » „ ” */
+    { "shi",      U"\x00ab", U"\x00bb", U"\x201e", U"\x201d" }, /* « » „ ” */
+    { "si",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "sk",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "sl",       U"\x201e", U"\x201c", U"\x201a", U"\x2018" }, /* „ “ ‚ ‘ */
+    { "sn",       U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "so",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "sq",       U"\x00ab", U"\x00bb", U"\x201c", U"\x201d" }, /* « » “ ” */
+    { "sr-latn",  U"\x201e", U"\x201c", U"\x2018", U"\x2018" }, /* „ “ ‘ ‘ */
+    { "sr",       U"\x201e", U"\x201d", U"\x2019", U"\x2019" }, /* „ ” ’ ’ */
+    { "sv",       U"\x201d", U"\x201d", U"\x2019", U"\x2019" }, /* ” ” ’ ’ */
+    { "sw",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ta",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "teo",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "te",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "th",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "ti-er",    U"\x2018", U"\x2019", U"\x201c", U"\x201d" }, /* ‘ ’ “ ” */
+    { "tk",       U"\x201c", U"\x201d", U"\x201c", U"\x201d" }, /* “ ” “ ” */
+    { "to",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "tr",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "twq",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "tzm",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "uk",       U"\x00ab", U"\x00bb", U"\x201e", U"\x201c" }, /* « » „ “ */
+    { "ur",       U"\x201d", U"\x201c", U"\x2019", U"\x2018" }, /* ” “ ’ ‘ */
+    { "uz-cyrl",  U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "uz",       U"\x201c", U"\x201d", U"\x2019", U"\x2018" }, /* “ ” ’ ‘ */
+    { "vai-latn", U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "vai",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "vi",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "vun",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "xog",      U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "yav",      U"\x00ab", U"\x00bb", U"\x00ab", U"\x00bb" }, /* « » « » */
+    { "yo",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "yue-hans", U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "yue",      U"\x300c", U"\x300d", U"\x300e", U"\x300f" }, /* 「 」 『 』 */
+    { "zgh",      U"\x00ab", U"\x00bb", U"\x201e", U"\x201d" }, /* « » „ ” */
+    { "zh-hant",  U"\x300c", U"\x300d", U"\x300e", U"\x300f" }, /* 「 」 『 』 */
+    { "zh",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
+    { "zu",       U"\x201c", U"\x201d", U"\x2018", U"\x2019" }, /* “ ” ‘ ’ */
     { NULL, NULL, NULL, NULL, NULL }
 };
 // Default to quotes for English
-static quotes_spec _quotes_spec_default = { "", L"\x201c", L"\x201d", L"\x2018", L"\x2019" };
+static quotes_spec _quotes_spec_default = { "", U"\x201c", U"\x201d", U"\x2018", U"\x2019" };
 
 #if USE_LIBUNIBREAK==1
-lChar16 lb_char_sub_func_english(struct LineBreakContext *lbpCtx, const lChar16 * text, int pos, int next_usable) {
+lChar32 lb_char_sub_func_english(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
     // https://github.com/koreader/crengine/issues/364
     // Normally, line breaks are allowed at both sides of an em-dash.
     // When an em-dash is at the "end of a word" (or beginning), we want to avoid separating it from its word,
@@ -486,7 +486,7 @@ lChar16 lb_char_sub_func_english(struct LineBreakContext *lbpCtx, const lChar16 
                 // It will be '{' if no-break on right,
                 //            '}' if no-break on left,
                 //            '"' if no-break on both.
-                lChar16 replacement = text[pos];
+                lChar32 replacement = text[pos];
                 int new_pos;
                 enum LineBreakClass new_lbc;
                 // 1. Detect no-break on right (scan left of dash)
@@ -545,7 +545,7 @@ lChar16 lb_char_sub_func_english(struct LineBreakContext *lbpCtx, const lChar16 
     return text[pos];
 }
 
-lChar16 lb_char_sub_func_polish(struct LineBreakContext *lbpCtx, const lChar16 * text, int pos, int next_usable) {
+lChar32 lb_char_sub_func_polish(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
     // https://github.com/koreader/koreader/issues/5645#issuecomment-559193057
     // Letters aiouwzAIOUWS are prepositions that should not be left at the
     // end of a line.
@@ -575,7 +575,7 @@ lChar16 lb_char_sub_func_polish(struct LineBreakContext *lbpCtx, const lChar16 *
     return text[pos];
 }
 
-lChar16 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lChar16 * text, int pos, int next_usable) {
+lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
     // Same for Czech and Slovak : AIiVvOoUuSsZzKk
     // https://tex.stackexchange.com/questions/27780/one-letter-word-at-the-end-of-line
     // https://github.com/michal-h21/luavlna
@@ -607,7 +607,7 @@ lChar16 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
 #endif
 
 // Instantiate a new TextLangCfg with properties adequate to the provided lang_tag
-TextLangCfg::TextLangCfg( lString16 lang_tag ) {
+TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     if ( TextLangMan::_no_hyph_method == NULL ) {
         // We need to init static TextLangMan::_no_hyph_method and friends after
         // HyphMan is set up. Do that here, even if unrelated, as TextLangCfg
@@ -621,7 +621,7 @@ TextLangCfg::TextLangCfg( lString16 lang_tag ) {
     _lang_tag = lang_tag;
     // Harfbuzz may know more than us about exotic/complex lang tags,
     // so let it deal the the provided one as-is.
-    lString16 hb_lang_tag = lang_tag;
+    lString32 hb_lang_tag = lang_tag;
     // Lowercase it for our tests
     lang_tag.lowercase(); // (used by LANG_STARTS_WITH() macros)
 
@@ -803,7 +803,7 @@ TextLangCfg::TextLangCfg( lString16 lang_tag ) {
         }
     }
     // Avoid a wrap after/before an opening/close quote.
-    const lChar16 * quote_joiner = L"\x2060";
+    const lChar32 * quote_joiner = U"\x2060";
         // (Zero width, equivalent to deprecated ZERO WIDTH NO-BREAK SPACE)
         // We might want with some languages to use a non-breaking thin space instead.
 
@@ -822,14 +822,14 @@ void TextLangCfg::resetCounters() {
     _quote_nesting_level = 0;
 }
 
-lString16 & TextLangCfg::getOpeningQuote( bool update_level ) {
+lString32 & TextLangCfg::getOpeningQuote( bool update_level ) {
     if ( !update_level )
         return _open_quote1;
     _quote_nesting_level++;
     return (_quote_nesting_level % 2) ? _open_quote1 : _open_quote2;
 }
 
-lString16 & TextLangCfg::getClosingQuote( bool update_level ) {
+lString32 & TextLangCfg::getClosingQuote( bool update_level ) {
     if ( !update_level )
         return _close_quote1;
     _quote_nesting_level--;
@@ -840,7 +840,7 @@ int TextLangCfg::getHyphenHangingPercent() {
     return 70; // 70%
 }
 
-int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const lChar16 * text, int pos, int next_usable ) {
+int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const lChar32 * text, int pos, int next_usable ) {
     // We get provided with the BiDi re-ordered m_text (so, visually
     // ordered) and the index of char: if needed, we can look at
     // previous or next chars for context to decide how much to hang
@@ -863,7 +863,7 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
     // Or we could round any value to 0 or 100%  (and/or tweak any
     // glyph in lvtextfm.cpp so it looks like it is full-width).
 
-    lChar16 ch = text[pos];
+    lChar32 ch = text[pos];
     int ratio = 0;
 
     // In French, there's usually a space before and after guillemets,
@@ -877,7 +877,7 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
     bool space_alongside = false;
     if ( right_hanging ) {
         if ( pos > 0 ) {
-            lChar16 prev_ch = text[pos-1];
+            lChar32 prev_ch = text[pos-1];
             if ( prev_ch == 0x0020 || prev_ch == 0x00A0 || (prev_ch >= 0x2000 && prev_ch <= 0x200A ) ) {
                 // Normal space, no-break space, and other unicode spaces (except zero-width ones)
                 space_alongside = true;
@@ -886,7 +886,7 @@ int TextLangCfg::getHangingPercent( bool right_hanging, bool & check_font, const
     }
     else {
         if ( next_usable > 0 ) {
-            lChar16 next_ch = text[pos+1];
+            lChar32 next_ch = text[pos+1];
             if ( next_ch == 0x0020 || next_ch == 0x00A0 || (next_ch >= 0x2000 && next_ch <= 0x200A ) ) {
                 // Normal space, no-break space, and other unicode spaces (except zero-width ones)
                 space_alongside = true;

--- a/crengine/src/wordfmt.cpp
+++ b/crengine/src/wordfmt.cpp
@@ -66,37 +66,37 @@ static encoding_type	eEncoding = encoding_neutral;
     if ((x)) crFatalError(1111, "assertion failed: " #x)
 
 
-static lString16 picasToPercent( const lChar16 * prop, int p, int minvalue, int maxvalue ) {
+static lString32 picasToPercent( const lChar32 * prop, int p, int minvalue, int maxvalue ) {
     int identPercent = 100 * p / 5000;
     if ( identPercent>maxvalue )
         identPercent = maxvalue;
     if ( identPercent<minvalue )
         identPercent = minvalue;
 	//if ( identPercent!=0 )
-    return lString16(prop) << fmt::decimal(identPercent) << "%; ";
-	//return lString16::empty_str;
+    return lString32(prop) << fmt::decimal(identPercent) << "%; ";
+	//return lString32::empty_str;
 }
 
-static lString16 picasToPx( const lChar16 * prop, int p, int minvalue, int maxvalue ) {
+static lString32 picasToPx( const lChar32 * prop, int p, int minvalue, int maxvalue ) {
     int v = 600 * p / 5000;
     if ( v>maxvalue )
         v = maxvalue;
     if ( v<minvalue )
         v = minvalue;
 	if ( v!=0 )
-        return lString16(prop) << fmt::decimal(v) << "px; ";
-	return lString16::empty_str;
+        return lString32(prop) << fmt::decimal(v) << "px; ";
+	return lString32::empty_str;
 }
 
-static lString16 fontSizeToPercent( const lChar16 * prop, int p, int minvalue, int maxvalue ) {
+static lString32 fontSizeToPercent( const lChar32 * prop, int p, int minvalue, int maxvalue ) {
     int v = 100 * p / 20;
     if ( v>maxvalue )
         v = maxvalue;
     if ( v<minvalue )
         v = minvalue;
 	if ( v!=0 )
-        return lString16(prop) << fmt::decimal(v) << "%; ";
-	return lString16::empty_str;
+        return lString32(prop) << fmt::decimal(v) << "%; ";
+	return lString32::empty_str;
 }
 
 static void setOptions() {
@@ -136,24 +136,24 @@ vPrologue1(diagram_type *pDiag, const char *szTask, const char *szFilename)
     TRACE("antiword::vPrologue1()");
     //vPrologueXML(pDiag, &tOptions);
 
-    lString16 title("Word document");
-    writer->OnTagOpen(NULL, L"?xml");
-    writer->OnAttribute(NULL, L"version", L"1.0");
-    writer->OnAttribute(NULL, L"encoding", L"utf-8");
-    writer->OnEncoding(L"utf-8", NULL);
+    lString32 title("Word document");
+    writer->OnTagOpen(NULL, U"?xml");
+    writer->OnAttribute(NULL, U"version", U"1.0");
+    writer->OnAttribute(NULL, U"encoding", U"utf-8");
+    writer->OnEncoding(U"utf-8", NULL);
     writer->OnTagBody();
-    writer->OnTagClose(NULL, L"?xml");
-    writer->OnTagOpenNoAttr(NULL, L"FictionBook");
+    writer->OnTagClose(NULL, U"?xml");
+    writer->OnTagOpenNoAttr(NULL, U"FictionBook");
     // DESCRIPTION
-    writer->OnTagOpenNoAttr(NULL, L"description");
-    writer->OnTagOpenNoAttr(NULL, L"title-info");
-    writer->OnTagOpenNoAttr(NULL, L"book-title");
+    writer->OnTagOpenNoAttr(NULL, U"description");
+    writer->OnTagOpenNoAttr(NULL, U"title-info");
+    writer->OnTagOpenNoAttr(NULL, U"book-title");
     writer->OnText(title.c_str(), title.length(), 0);
-    writer->OnTagClose(NULL, L"book-title");
-    writer->OnTagOpenNoAttr(NULL, L"title-info");
-    writer->OnTagClose(NULL, L"description");
+    writer->OnTagClose(NULL, U"book-title");
+    writer->OnTagOpenNoAttr(NULL, U"title-info");
+    writer->OnTagClose(NULL, U"description");
     // BODY
-    writer->OnTagOpenNoAttr(NULL, L"body");
+    writer->OnTagOpenNoAttr(NULL, U"body");
 } /* end of vPrologue1 */
 
 
@@ -167,8 +167,8 @@ vEpilogue(diagram_type *pDiag)
     //vEpilogueTXT(pDiag->pOutFile);
     //vEpilogueXML(pDiag);
     if ( inside_p )
-        writer->OnTagClose(NULL, L"p");
-    writer->OnTagClose(NULL, L"body");
+        writer->OnTagClose(NULL, U"p");
+    writer->OnTagClose(NULL, U"body");
 } /* end of vEpilogue */
 
 /*
@@ -272,8 +272,8 @@ vMove2NextLine(diagram_type *pDiag, drawfile_fontref tFontRef,
     LFAIL(usFontSize < MIN_FONT_SIZE || usFontSize > MAX_FONT_SIZE);
 
     if ( (inside_p || inside_li) && !last_space_char )
-        writer->OnText(L" ", 1, 0);
-    //writer->OnTagOpenAndClose(NULL, L"br");
+        writer->OnText(U" ", 1, 0);
+    //writer->OnTagOpenAndClose(NULL, U"br");
     //vMove2NextLineXML(pDiag);
 } /* end of vMove2NextLine */
 
@@ -286,7 +286,7 @@ vSubstring2Diagram(diagram_type *pDiag,
     UCHAR ucFontColor, USHORT usFontstyle, drawfile_fontref tFontRef,
     USHORT usFontSize, USHORT usMaxFontSize)
 {
-    lString16 s( szString, (int)tStringLength);
+    lString32 s( szString, (int)tStringLength);
 #ifdef _LINUX
     TRACE("antiword::vSubstring2Diagram(%s)", LCSTR(s));
 #else
@@ -297,31 +297,31 @@ vSubstring2Diagram(diagram_type *pDiag,
 //    vSubstringXML(pDiag, szString, tStringLength, lStringWidth,
 //            usFontstyle);
     if ( !inside_p && !inside_li ) {
-        writer->OnTagOpenNoAttr(NULL, L"p");
+        writer->OnTagOpenNoAttr(NULL, U"p");
         inside_p = true;
     }
     bool styleBold = bIsBold(usFontstyle);
     bool styleItalic = bIsItalic(usFontstyle);
-    lString16 style;
-	style << fontSizeToPercent( L"font-size: ", usFontSize, 30, 300 );
+    lString32 style;
+	style << fontSizeToPercent( U"font-size: ", usFontSize, 30, 300 );
     if ( !style.empty() ) {
-        writer->OnTagOpen(NULL, L"span");
-        writer->OnAttribute(NULL, L"style", style.c_str());
+        writer->OnTagOpen(NULL, U"span");
+        writer->OnAttribute(NULL, U"style", style.c_str());
         writer->OnTagBody();
     }
     if ( styleBold )
-        writer->OnTagOpenNoAttr(NULL, L"b");
+        writer->OnTagOpenNoAttr(NULL, U"b");
     if ( styleItalic )
-        writer->OnTagOpenNoAttr(NULL, L"i");
+        writer->OnTagOpenNoAttr(NULL, U"i");
     //=================
     writer->OnText(s.c_str(), s.length(), 0);
     //=================
     if ( styleItalic )
-        writer->OnTagClose(NULL, L"i");
+        writer->OnTagClose(NULL, U"i");
     if ( styleBold )
-        writer->OnTagClose(NULL, L"b");
+        writer->OnTagClose(NULL, U"b");
     if ( !style.empty() )
-        writer->OnTagClose(NULL, L"span");
+        writer->OnTagClose(NULL, U"span");
 
     pDiag->lXleft += lStringWidth;
 } /* end of vSubstring2Diagram */
@@ -378,9 +378,9 @@ vStartOfParagraph2(diagram_type *pDiag)
     TRACE("antiword::vStartOfParagraph2()");
     LFAIL(pDiag == NULL);
 
-    lString16 style;
+    lString32 style;
     if ( !inside_p && !inside_list && !inside_li ) {
-        writer->OnTagOpen(NULL, L"p");
+        writer->OnTagOpen(NULL, U"p");
         if ( alignment==ALIGNMENT_CENTER )
             style << "text-align: center; ";
         else if ( alignment==ALIGNMENT_RIGHT )
@@ -390,17 +390,17 @@ vStartOfParagraph2(diagram_type *pDiag)
         else
             style << "text-align: left; ";
         //if ( sLeftIndent1!=0 )
-        //style << picasToPercent(L"text-indent: ", sLeftIndent1, 0, 20);
+        //style << picasToPercent(U"text-indent: ", sLeftIndent1, 0, 20);
         if ( sLeftIndent!=0 )
-            style << picasToPercent(L"margin-left: ", sLeftIndent, 0, 40);
+            style << picasToPercent(U"margin-left: ", sLeftIndent, 0, 40);
         if ( sRightIndent!=0 )
-            style << picasToPercent(L"margin-right: ", sRightIndent, 0, 30);
+            style << picasToPercent(U"margin-right: ", sRightIndent, 0, 30);
         if ( usBeforeIndent!=0 )
-            style << picasToPx(L"margin-top: ", usBeforeIndent, 0, 20);
+            style << picasToPx(U"margin-top: ", usBeforeIndent, 0, 20);
         if ( usAfterIndent!=0 )
-            style << picasToPx(L"margin-bottom: ", usAfterIndent, 0, 20);
+            style << picasToPx(U"margin-bottom: ", usAfterIndent, 0, 20);
         if ( !style.empty() )
-            writer->OnAttribute(NULL, L"style", style.c_str());
+            writer->OnAttribute(NULL, U"style", style.c_str());
         writer->OnTagBody();
         inside_p = true;
     }
@@ -421,7 +421,7 @@ vEndOfParagraph(diagram_type *pDiag,
     LFAIL(lAfterIndentation < 0);
     //vEndOfParagraphXML(pDiag, 1);
     if ( inside_p ) {
-        writer->OnTagClose(NULL, L"p");
+        writer->OnTagClose(NULL, U"p");
         inside_p = false;
     }
 } /* end of vEndOfParagraph */
@@ -461,11 +461,11 @@ vStartOfList(diagram_type *pDiag, UCHAR ucNFC, BOOL bIsEndOfTable)
         switch( ucNFC ) {
         case LIST_BULLETS:
             inside_list = 1;
-            writer->OnTagOpenNoAttr(NULL, L"ul");
+            writer->OnTagOpenNoAttr(NULL, U"ul");
             break;
         default:
             inside_list = 2;
-            writer->OnTagOpenNoAttr(NULL, L"ol");
+            writer->OnTagOpenNoAttr(NULL, U"ol");
             break;
         }
     }
@@ -483,13 +483,13 @@ vEndOfList(diagram_type *pDiag)
     TRACE("antiword::vEndOfList()");
 
     if ( inside_li ) {
-        writer->OnTagClose(NULL, L"li");
+        writer->OnTagClose(NULL, U"li");
         inside_li = false;
     }
     if ( inside_list==1 )
-        writer->OnTagClose(NULL, L"ul");
+        writer->OnTagClose(NULL, U"ul");
     else if ( inside_list==2 )
-        writer->OnTagClose(NULL, L"ol");
+        writer->OnTagClose(NULL, U"ol");
 
     //vEndOfListXML(pDiag);
 } /* end of vEndOfList */
@@ -502,10 +502,10 @@ vStartOfListItem(diagram_type *pDiag, BOOL bNoMarks)
 {
     TRACE("antiword::vStartOfListItem()");
     if ( inside_li ) {
-        writer->OnTagClose(NULL, L"li");
+        writer->OnTagClose(NULL, U"li");
     }
     inside_li = true;
-    writer->OnTagOpenNoAttr(NULL, L"li");
+    writer->OnTagOpenNoAttr(NULL, U"li");
     //vStartOfListItemXML(pDiag, bNoMarks);
 } /* end of vStartOfListItem */
 
@@ -517,7 +517,7 @@ vEndOfTable(diagram_type *pDiag)
 {
     TRACE("antiword::vEndOfTable()");
     if ( inside_table ) {
-        writer->OnTagClose(NULL, L"table");
+        writer->OnTagClose(NULL, U"table");
         inside_table = false;
 		table_col_count = 0;
     }
@@ -538,8 +538,8 @@ bAddTableRow(diagram_type *pDiag, char **aszColTxt,
 //                ucBorderInfo);
 	if ( table_col_count!=iNbrOfColumns ) {
 		if (inside_table)
-			writer->OnTagClose(NULL, L"table");
-		writer->OnTagOpenNoAttr(NULL, L"table");
+			writer->OnTagClose(NULL, U"table");
+		writer->OnTagOpenNoAttr(NULL, U"table");
         inside_table = true;
 		int totalWidth = 0;
 		int i;
@@ -548,27 +548,27 @@ bAddTableRow(diagram_type *pDiag, char **aszColTxt,
 		if ( totalWidth>0 ) {
 			for ( i=0; i<iNbrOfColumns; i++ ) {
 				int cw = asColumnWidth[i] * 100 / totalWidth;
-		        writer->OnTagOpen(NULL, L"col");
+		        writer->OnTagOpen(NULL, U"col");
 				if ( cw>=0 )
-                    writer->OnAttribute(NULL, L"width", (lString16::itoa(cw) + "%").c_str());
+                    writer->OnAttribute(NULL, U"width", (lString32::itoa(cw) + "%").c_str());
 		        writer->OnTagBody();
-		        writer->OnTagClose(NULL, L"col");
+		        writer->OnTagClose(NULL, U"col");
 			}
 		}
 		table_col_count = iNbrOfColumns;
 	}
     if (!inside_table) {
-        writer->OnTagOpenNoAttr(NULL, L"table");
+        writer->OnTagOpenNoAttr(NULL, U"table");
         inside_table = true;
     }
-    writer->OnTagOpenNoAttr(NULL, L"tr");
+    writer->OnTagOpenNoAttr(NULL, U"tr");
     for ( int i=0; i<iNbrOfColumns; i++ ) {
-        writer->OnTagOpenNoAttr(NULL, L"td");
-        lString16 text = lString16(aszColTxt[i]);
+        writer->OnTagOpenNoAttr(NULL, U"td");
+        lString32 text = lString32(aszColTxt[i]);
         writer->OnText(text.c_str(), text.length(), 0);
-        writer->OnTagClose(NULL, L"td");
+        writer->OnTagClose(NULL, U"td");
     }
-    writer->OnTagClose(NULL, L"tr");
+    writer->OnTagClose(NULL, U"tr");
     return TRUE;
     //return FALSE;
 } /* end of bAddTableRow */
@@ -704,14 +704,14 @@ bTranslateImage(diagram_type *pDiag, FILE *pFile, BOOL bMinimalInformation,
             }
 
             // add Image BLOB
-            lString16 name(BLOB_NAME_PREFIX); // L"@blob#"
+            lString32 name(BLOB_NAME_PREFIX); // U"@blob#"
             name << "image";
             name << fmt::decimal(image_index++);
             name << (pImg->eImageType==imagetype_is_jpeg ? ".jpg" : ".png");
             writer->OnBlob(name, pucJpeg, len);
-            writer->OnTagOpen(LXML_NS_NONE, L"img");
-            writer->OnAttribute(LXML_NS_NONE, L"src", name.c_str());
-            writer->OnTagClose(LXML_NS_NONE, L"img", true);
+            writer->OnTagOpen(LXML_NS_NONE, U"img");
+            writer->OnAttribute(LXML_NS_NONE, U"src", name.c_str());
+            writer->OnTagClose(LXML_NS_NONE, U"img", true);
 
             free(pucJpeg);
             return TRUE;


### PR DESCRIPTION
`(Upstream) Rename lChar16/lString16 to lChar32/lString32`
See #389. Closes #389.
This is the first commit of https://github.com/buggins/coolreader/pull/183 (not cherry-picked, but renames redone manually on our sources). Second commit (resurrecting lChar16 and lString16 can be ignored, as we don't target Windows).
Needs the same kind of replacements in base/cre.cpp.

`(Upstream) Ignore provided document w/h if negative`
From https://github.com/buggins/coolreader/pull/184.

`(Upstream) Parse and skip '@charset' in CSS`
From https://github.com/buggins/coolreader/pull/185

`(Upstream) Fix possible segfault in ~ldomDocument()`
From https://github.com/buggins/coolreader/pull/188

`lvDefFatalErrorHandler(): add comment on how to get a real crash`
The upstream trick (removed in #354) wasn't working anyway as it was masked to gdb by LuaJIT.
Just added a comment I can quick uncomment when needing to see a stacktrace with gdb.

`writeNodeEx: dont show ="" on empty attributes`
`List item markers: draw even when they overflow`
`Strut confining: avoid it too when only no break spaces`
`Text: ensure LTEXT_FIT_GLYPHS around images/inline boxes`
`Font: fix synthetized italic metrics`
`Font: fix synthetized bold italic drawing`
Various small rendering fixes.

`In-page footnotes: always push vertical margin before`
See #388. Closes #388. Looks sane, but 10 months ago when trying it, I noticed some issues - but I don't remember which... So, we'll see.
It should remove the ugly margin we might often see with the first footnote of a book or chapter:
<kbd>![image](https://user-images.githubusercontent.com/24273478/97339239-a05a0000-1882-11eb-9e0e-8bfca41f95c3.png)</kbd> coming from <kbd>![image](https://user-images.githubusercontent.com/24273478/97339362-c7183680-1882-11eb-8fad-8058ff8c9675.png)</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/390)
<!-- Reviewable:end -->
