### PR TITLE
Mark non-linear EPUB fragments

### DIFF
--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -354,6 +354,7 @@ XS_ATTR( T )      // to flag subtype of boxing internal elements if needed
 XS_ATTR( Before ) // for pseudoElem internal element
 XS_ATTR( After )  // for pseudoElem internal element
 XS_ATTR( ParserHint )   // HTML parser hints (used for Lib.ru support)
+XS_ATTR( NonLinear )    // for non-linear items in EPUB
 // Other classic attributes present in html5.css
 XS_ATTR2( accept_charset, "accept-charset" )
 XS_ATTR( alt )

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -153,7 +153,7 @@ XS_TAG1D( xmp, true, css_d_block, css_ws_pre ) // similar to "pre"
 XS_TAG1T( details )
 XS_TAG1T( dialog )
 XS_TAG1T( summary )
-// Additional "special" elements mentionned in the HTML standard,
+// Additional "special" elements mentioned in the HTML standard,
 // not supposed to close any P, but let's consider them similarly,
 // and be block elements, so their content is shown.
 XS_TAG1T( frame )

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -875,6 +875,10 @@ public:
     bool goToPage(int page, bool updatePosBookmark = true, bool regulateTwoPages = true);
     /// returns page count
     int getPageCount();
+    /// get the flow the specified page belongs to
+    int getPageFlow(int pageIndex);
+    /// returns whether there are any flows besides the linear flow 0
+    bool hasNonLinearFlows();
 
     /// clear view
     void Clear();

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -33,6 +33,7 @@
 #endif
 #define PROP_EMBEDDED_STYLES         "crengine.doc.embedded.styles.enabled"
 #define PROP_EMBEDDED_FONTS          "crengine.doc.embedded.fonts.enabled"
+#define PROP_NONLINEAR_PAGEBREAK     "crengine.doc.nonlinear.pagebreak.force"
 #define PROP_DISPLAY_INVERSE         "crengine.display.inverse"
 #define PROP_DISPLAY_FULL_UPDATE_INTERVAL "crengine.display.full.update.interval"
 #define PROP_DISPLAY_TURBO_UPDATE_MODE "crengine.display.turbo.update"

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -219,20 +219,25 @@ public:
     lInt16 height; /// height of page, does not include footnotes
     lInt8 flags;   /// RN_PAGE_*
     CompactArray<LVPageFootNoteInfo, 1, 4> footnotes; /// footnote fragment list for page
+    lUInt16 flow;
     LVRendPageInfo(int pageStart, lUInt16 pageHeight, int pageIndex)
-    : start(pageStart), index(pageIndex), height(pageHeight), flags(RN_PAGE_TYPE_NORMAL) {}
+    : start(pageStart), index(pageIndex), height(pageHeight), flags(RN_PAGE_TYPE_NORMAL), flow(0) {}
     LVRendPageInfo(lUInt16 coverHeight)
-    : start(0), index(0), height(coverHeight), flags(RN_PAGE_TYPE_COVER) {}
+    : start(0), index(0), height(coverHeight), flags(RN_PAGE_TYPE_COVER), flow(0) {}
     LVRendPageInfo() 
-    : start(0), index(0), height(0), flags(RN_PAGE_TYPE_NORMAL) { }
+    : start(0), index(0), height(0), flags(RN_PAGE_TYPE_NORMAL), flow(0) {}
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
 };
 
 class LVRendPageList : public LVPtrVector<LVRendPageInfo>
 {
+    bool has_nonlinear_flows;
 public:
+    LVRendPageList() : has_nonlinear_flows(false) {}
     int FindNearestPage( int y, int direction );
+    void setHasNonLinearFlows() { has_nonlinear_flows=true; }
+    bool hasNonLinearFlows() { return has_nonlinear_flows; }
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
 };
@@ -254,6 +259,7 @@ class LVRendLineInfo {
     int height;             // 4 bytes (we may get extra tall lines with tables TR)
 public:
     lUInt16 flags;          // 2 bytes
+    lUInt16 flow;           // 2 bytes (should be enough)
     int getSplitBefore() const { return (flags>>RN_SPLIT_BEFORE)&7; }
     int getSplitAfter() const { return (flags>>RN_SPLIT_AFTER)&7; }
 /*
@@ -282,9 +288,13 @@ public:
     inline int getHeight() const { return height; }
     inline lUInt16 getFlags() const { return flags; }
 
-    LVRendLineInfo() : links(NULL), start(-1), height(0), flags(0) { }
+    LVRendLineInfo() : links(NULL), start(-1), height(0), flags(0), flow(0) { }
     LVRendLineInfo( int line_start, int line_end, lUInt16 line_flags )
-    : links(NULL), start(line_start), height(line_end-line_start), flags(line_flags)
+    : links(NULL), start(line_start), height(line_end-line_start), flags(line_flags), flow(0)
+    {
+    }
+    LVRendLineInfo( int line_start, int line_end, lUInt16 line_flags, int flow )
+    : links(NULL), start(line_start), height(line_end-line_start), flags(line_flags), flow(flow)
     {
     }
     LVFootNoteList * getLinks() { return links; }
@@ -361,6 +371,10 @@ class LVRendPageContext
     bool gather_lines;
     // Links gathered when !gather_lines
     lString32Collection link_ids;
+    // current flow being processed
+    int current_flow;
+    // maximum flow encountered so far
+    int max_flow;
 
     LVHashTable<lString32, LVFootNoteRef> footNotes;
 
@@ -387,6 +401,8 @@ public:
     bool updateRenderProgress( int numFinalBlocksRendered );
 
     bool wantsLines() { return gather_lines; }
+
+    void newFlow( bool nonlinear );
 
     /// Get the number of links in the current line links list, or
     // in link_ids when !gather_lines

--- a/crengine/include/lvrefcache.h
+++ b/crengine/include/lvrefcache.h
@@ -263,7 +263,7 @@ public:
             // This returned boolean seems not used anywhere, so it's not
             // clear whether we should return true or false when the
             // item was not in the cache, and thus created - but the
-            // indexholder (althought not existing) stayed unchanged.
+            // indexholder (although not existing) stayed unchanged.
         }
     }
 

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -215,7 +215,7 @@ typedef struct
    lUInt16               inward_margin; /**< inward margin */
    css_clear_t           clear;       /**< clear: css property value */
    bool                  is_right;    /**< is float: right */
-   bool                  to_position; /**< not yet positionned */
+   bool                  to_position; /**< not yet positioned */
    lString32Collection * links;       /** footnote links found in this float text */
 } embedded_float_t;
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -57,7 +57,7 @@ extern const int gDOMVersionCurrent;
 #define DOC_FLAG_ENABLE_INTERNAL_STYLES 1
 /// docFlag mask, enable paperbook-like footnotes
 #define DOC_FLAG_ENABLE_FOOTNOTES       2
-/// docFlag mask, enable paperbook-like footnotes
+/// docFlag mask, enable preformatted text
 #define DOC_FLAG_PREFORMATTED_TEXT      4
 /// docFlag mask, enable document embedded fonts (EPUB)
 #define DOC_FLAG_ENABLE_DOC_FONTS       8

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -61,6 +61,8 @@ extern const int gDOMVersionCurrent;
 #define DOC_FLAG_PREFORMATTED_TEXT      4
 /// docFlag mask, enable document embedded fonts (EPUB)
 #define DOC_FLAG_ENABLE_DOC_FONTS       8
+/// docFlag mask, force page breaks on non-linear fragments (EPUB)
+#define DOC_FLAG_NONLINEAR_PAGEBREAK   16
 /// default docFlag set
 #define DOC_FLAG_DEFAULTS (DOC_FLAG_ENABLE_INTERNAL_STYLES|DOC_FLAG_ENABLE_FOOTNOTES|DOC_FLAG_ENABLE_DOC_FONTS)
 
@@ -2776,6 +2778,8 @@ private:
     lString32 htmlLang;
     bool insideHtmlTag;
 
+    bool m_nonlinear = false;
+
 public:
 
     /// return content of html/head/style element
@@ -2845,6 +2849,8 @@ public:
     virtual bool OnBlob(lString32 name, const lUInt8 * data, int size) { return parent->OnBlob(name, data, size); }
     /// set document property
     virtual void OnDocProperty(const char * name, lString8 value) { parent->OnDocProperty(name, value); }
+    // set non-linear flag
+    virtual void setNonLinearFlag( bool nonlinear ) { m_nonlinear = nonlinear; }
     /// constructor
     ldomDocumentFragmentWriter( LVXMLParserCallback * parentWriter, lString32 baseTagName, lString32 baseTagReplacementName, lString32 fragmentFilePath )
     : parent(parentWriter), baseTag(baseTagName), baseTagReplacement(baseTagReplacementName),

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -7,6 +7,7 @@ public:
     lString32 mediaType;
     lString32 id;
     lString32 title;
+    bool nonlinear;
     EpubItem()
     { }
     EpubItem( const EpubItem & v )
@@ -1286,6 +1287,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     if ( !item )
                         break;
                     EpubItem * epubItem = epubItems.findById( item->getAttributeValue("idref") );
+                    epubItem->nonlinear = lString32(item->getAttributeValue("linear")).lowercase() == U"no";
                     if ( epubItem ) {
                         // TODO: add to document
                         spineItems.add( epubItem );
@@ -1360,6 +1362,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     //CRLog::trace("base: %s", LCSTR(base));
                     //LVXMLParser
                     LVHTMLParser parser(stream, &appender);
+                    appender.setNonLinearFlag(spineItems[i]->nonlinear);
                     if ( parser.CheckFormat() && parser.Parse() ) {
                         // valid
                         fragmentCount++;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2644,7 +2644,7 @@ LVRef<ldomXRange> LVDocView::getPageDocumentRange(int pageIndex) {
     // Note: this may return a range that may not include some parts
     // of the document that are actually displayed on that page, like
     // floats that were in some HTML fragment of the previous page,
-    // but whose positionning has been shifted/delayed and ended up
+    // but whose positioning has been shifted/delayed and ended up
     // on this page (so, getCurrentPageLinks() may miss links from
     // such floats).
     // With floats, a page may actually show more than one range,

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2102,6 +2102,18 @@ void LVDocView::GetPos(lvRect & rc) {
 	}
 }
 
+int LVDocView::getPageFlow(int pageIndex)
+{
+	if (pageIndex >= 0 && pageIndex < m_pages.length())
+		return m_pages[pageIndex]->flow;
+	return -1;
+}
+
+bool LVDocView::hasNonLinearFlows()
+{
+	return m_pages.hasNonLinearFlows();
+}
+
 int LVDocView::getPageHeight(int pageIndex)
 {
 	if (isPageMode() && pageIndex >= 0 && pageIndex < m_pages.length())
@@ -4508,6 +4520,8 @@ void LVDocView::createEmptyDocument() {
 			PROP_EMBEDDED_STYLES, true));
     m_doc->setDocFlag(DOC_FLAG_ENABLE_DOC_FONTS, m_props->getBoolDef(
             PROP_EMBEDDED_FONTS, true));
+    m_doc->setDocFlag(DOC_FLAG_NONLINEAR_PAGEBREAK, m_props->getBoolDef(
+            PROP_NONLINEAR_PAGEBREAK, false));
     m_doc->setSpaceWidthScalePercent(m_props->getIntDef(PROP_FORMAT_SPACE_WIDTH_SCALE_PERCENT, DEF_SPACE_WIDTH_SCALE_PERCENT));
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
@@ -6540,6 +6554,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             if (m_doc) // not when noDefaultDocument=true
                 getDocument()->setDocFlag(DOC_FLAG_ENABLE_DOC_FONTS, value);
             REQUEST_RENDER("propsApply doc fonts")
+        } else if (name == PROP_NONLINEAR_PAGEBREAK) {
+            bool value = props->getBoolDef(PROP_NONLINEAR_PAGEBREAK, false);
+            if (m_doc) // not when noDefaultDocument=true
+                getDocument()->setDocFlag(DOC_FLAG_NONLINEAR_PAGEBREAK, value);
+            REQUEST_RENDER("propsApply nonlinear")
         } else if (name == PROP_FOOTNOTES) {
             bool value = props->getBoolDef(PROP_FOOTNOTES, true);
             if (m_doc) // not when noDefaultDocument=true

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1363,7 +1363,7 @@ public:
         //   advance metrics are increased by the strength of the emboldening".
         //
         // When using Harfbuzz, which uses itself the font metrics, that we
-        // can't tweak at all from outside, we'll get positionning based on
+        // can't tweak at all from outside, we'll get positioning based on
         // the not-bolded font. We can't increase them as that would totally
         // mess HB work.
         // We can only do as MuPDF does (source/fitz/font.c): keep the HB
@@ -1793,7 +1793,7 @@ public:
             //     Note that this also transforms the `face.glyph.advance' field,
             //     but *not* the values in `face.glyph.metrics'.
             // So, with such fake italic, the values we'll use below are wrong,
-            // and may cause some wrong glyphs positionning or advance.
+            // and may cause some wrong glyphs positioning or advance.
             FT_GlyphSlot_Oblique(_slot); // This uses FT_Outline_Transform(), see freetype2/src/base/ftsynth.c
 
             // QT has some code that seem to fix these metrics in transformBoundingBox() at

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -47,6 +47,7 @@ LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, 
     : callback(NULL), totalFinalBlocks(0)
     , renderedFinalBlocks(0), lastPercent(-1), page_list(pageList), page_h(pageHeight)
     , gather_lines(gatherLines), footNotes(64), curr_note(NULL)
+    , current_flow(0), max_flow(0)
 {
     if ( callback ) {
         callback->OnFormatStart();
@@ -125,6 +126,19 @@ void LVRendPageContext::leaveFootNote()
     curr_note = NULL;
 }
 
+void LVRendPageContext::newFlow( bool nonlinear )
+{
+    /// A new non-linear flow gets the next number
+    /// A new linear flow simply gets appended to flow 0
+    if (nonlinear) {
+       max_flow++;
+       current_flow = max_flow;
+       page_list->setHasNonLinearFlows();
+    } else {
+       current_flow = 0;
+    }
+}
+
 
 void LVRendPageContext::AddLine( int starty, int endy, int flags )
 {
@@ -133,7 +147,7 @@ void LVRendPageContext::AddLine( int starty, int endy, int flags )
     #endif
     if ( curr_note!=NULL )
         flags |= RN_SPLIT_FOOT_NOTE;
-    LVRendLineInfo * line = new LVRendLineInfo(starty, endy, flags);
+    LVRendLineInfo * line = new LVRendLineInfo(starty, endy, flags, current_flow);
     lines.add( line );
     if ( curr_note != NULL ) {
         //CRLog::trace("adding line to note (%d)", line->start);
@@ -298,6 +312,8 @@ public:
             printf(" [rtl l:%d/%d fl:%d/%d]\n", nb_lines_rtl, nb_lines, nb_footnotes_lines_rtl, nb_footnotes_lines);
         #endif
         LVRendPageInfo * page = new LVRendPageInfo(start, h, page_list->length());
+        if (pagestart)
+            page->flow = pagestart->flow;
         lastpageend = start + h;
         if ( footnotes.length()>0 ) {
             page->footnotes.add( footnotes );
@@ -383,11 +399,12 @@ public:
                     page_list->length(), slice_start, slice_start+page_h, page_h);
             #endif
             page->flags |= getLineTypeFlags();
+            page->flow = line->flow;
             ResetLineAccount();
             page_list->add(page);
             slice_start += page_h;
             lastpageend = slice_start;
-            last = new LVRendLineInfo(slice_start, line->getEnd(), line->flags);
+            last = new LVRendLineInfo(slice_start, line->getEnd(), line->flags, line->flow);
             own_lines.add( last ); // so we can have it 'delete'd in Finalize()
             pageend = last;
             did_slice = true;
@@ -820,6 +837,8 @@ bool LVRendPageList::deserialize( SerialBuf & buf )
         item->deserialize( buf );
         item->index = i;
         add( item );
+        if (item->flow > 0)
+            has_nonlinear_flows = true;
     }
     if ( !buf.checkMagic( pagelist_magic ) )
         return false;
@@ -834,6 +853,7 @@ bool LVRendPageInfo::serialize( SerialBuf & buf )
     buf << (lUInt32)start;  /// start of page
     buf << (lUInt16)height; /// height of page, does not include footnotes
     buf << (lUInt8) flags;  /// RN_PAGE_*
+    buf << (lUInt16)flow;   /// flow the page belongs to
     lUInt16 len = footnotes.length();
     buf << len;
     for ( int i=0; i<len; i++ ) {
@@ -848,14 +868,16 @@ bool LVRendPageInfo::deserialize( SerialBuf & buf )
     if ( buf.error() )
         return false;
     lUInt32 n1;
-	lUInt16 n2;
+    lUInt16 n2;
     lUInt8 n3;
+    lUInt16 n4;
 
-    buf >> n1 >> n2 >> n3; /// start of page
+    buf >> n1 >> n2 >> n3 >> n4; /// start of page
 
     start = n1;
     height = n2;
     flags = n3;
+    flow = n4;
 
     lUInt16 len;
     buf >> len;

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -353,7 +353,7 @@ public:
         // this 'line' contains (text, image...), so we can't really
         // find a better 'y' to cut at than the page height. We may
         // then cut in the middle of a text line, and have halves
-        // displayed on different pages (althought it seems crengine
+        // displayed on different pages (although it seems crengine
         // deals with displaying the cut line fully at start of
         // next page).
         // we don't take the current footnotes height into account

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -381,7 +381,7 @@ public:
                         RenderRectAccessor fmt = RenderRectAccessor( item );
                         fmt.setHeight( 15 ); // not squared, so it does not look
                         fmt.setWidth( 10 );  // like a list square bullet
-                        fmt.setX( 0 );       // positionned at top left of its container
+                        fmt.setX( 0 );       // positioned at top left of its container
                         fmt.setY( 0 );       // (which ought to be a proper table element)
                     }
                     break;
@@ -418,7 +418,7 @@ public:
                         }
                         rows.add( row );
                         // What could <tr link="number"> have been in the past ?
-                        // It's not mentionned in any HTML or FB2 spec,
+                        // It's not mentioned in any HTML or FB2 spec,
                         // and row->linkindex is never used.
                         if (row->elem->hasAttribute(LXML_NS_ANY, attr_link)) {
                             lString32 lnk=row->elem->getAttributeValue(attr_link);
@@ -1430,7 +1430,7 @@ public:
         int nb_rows = rows.length();
 
         // We will context.AddLine() for page splitting the elements
-        // (caption, rows) as soon as we meet them and their y-positionnings
+        // (caption, rows) as soon as we meet them and their y-positionings
         // inside the tables are known and won't change.
         // (This would need that rowgroups be dealt with in this flow (and
         // not at the end) if we change the fact that we ignore their
@@ -2098,7 +2098,7 @@ public:
         // relative to its container: RenderRectAccessor X & Y are relative to
         // the parent container top left corner)
         //
-        // As mentionned above, rowgroups' margins and paddings should be
+        // As mentioned above, rowgroups' margins and paddings should be
         // ignored, and their borders are only used with border-collapse,
         // and we collapsed them to the cells when we had to.
         // So, we ignore them here, and DrawDocument() will NOT draw their
@@ -3846,7 +3846,7 @@ int measureBorder(ldomNode *enode,int border) {
         // fmt.setWidth() has not yet been called and fmt.getWidth() would
         // return 0. Later, at drawing time, fmt.getWidth() will return the real
         // width, which could cause rendering of borders over child elements,
-        // as these were positionned with a border=0.)
+        // as these were positioned with a border=0.)
         css_style_ref_t style = enode->getStyle();
         if (border==0){
                 bool hastopBorder = (style->border_style_top >= css_border_solid &&
@@ -3889,7 +3889,7 @@ int measureBorder(ldomNode *enode,int border) {
 }
 
 // Only used by renderBlockElementLegacy()
-//calculate total margin+padding before node,if >0 don't do campulsory page split
+//calculate total margin+padding before node,if >0 don't do compulsory page split
 int pagebreakhelper(ldomNode *enode,int width)
 {
     int flag=css_pb_auto;
@@ -3919,7 +3919,7 @@ int pagebreakhelper(ldomNode *enode,int width)
 //=======================================================================
 // Render block element
 //=======================================================================
-// renderBlockElement() aimed at positionning the node provided: setting
+// renderBlockElement() aimed at positioning the node provided: setting
 // its width and height, and its (x,y) in the coordinates of its parent
 // element's border box (so, including parent's paddings and borders
 // top/left, but not its margins).
@@ -3930,8 +3930,8 @@ int pagebreakhelper(ldomNode *enode,int width)
 // its parent coordinates.
 // So, it just shift coordinates and adjust widths of imbricated block nodes,
 // until it meets a "final" node (a node with text or image content), which
-// will then have been sized and positionned.
-// After the initial rendering, we mostly only care about these positionned
+// will then have been sized and positioned.
+// After the initial rendering, we mostly only care about these positioned
 // final nodes (for text rendering, text selection, text search, links...).
 // We still walk the block nodes when we need absolute coordinates, computed
 // from all the relative shifts of the containing block nodes boxes up to the
@@ -4560,13 +4560,13 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
 // real non-margin content is added.
 // It also forwards lines/spaces to lvpagesplitter's "context", ensuring
 // proper page split flags (and avoiding unwelcome ones).
-// Floats are added to it for positionning along this height
+// Floats are added to it for positioning along this height
 // depending on other floats.
 // It then can provide a "float footprint" to final nodes, so they can
 // lay out their text (and own embedded floats) alongside block floats.
 //
 // Some initial limitations with floats had later found some solutions,
-// which can be enabled by setting some flags. Mentionning them because
+// which can be enabled by setting some flags. Mentioning them because
 // the code might be a bit rooted around these early limitations:
 // - Floats added by a block element are "clear"'ed when leaving
 //   this block: some blank height is added if necessary, so they are
@@ -5148,7 +5148,7 @@ public:
                 vm_target_avoid_pb_inside = avoid_pb_inside;
                 if ( BLOCK_RENDERING(rend_flags, DO_NOT_CLEAR_OWN_FLOATS) && _floats.length()>0 ) {
                     // Reset level of all previous floats as they are
-                    // correctly positionned and should not be moved
+                    // correctly positioned and should not be moved
                     // if this (new) vm_target_node get some margin
                     // and is moved down.
                     resetFloatsLevelToTopLevel();
@@ -5473,14 +5473,14 @@ public:
                     BlockFloat * flt = _floats[i];
                     if ( flt->level > vm_target_level ) {
                         if ( flt->final_pos ) {
-                            // Float already absolutely positionned (block float):
+                            // Float already absolutely positioned (block float):
                             // adjust its relative y to its container's top to
                             // counteract the margin shift
                             RenderRectAccessor fmt( flt->node );
                             fmt.setY( fmt.getY() - margin );
                         }
                         else {
-                            // Float not absolutely positionned (forwarded embedded float):
+                            // Float not absolutely positioned (forwarded embedded float):
                             // update its absolute coordinates as its container will be
                             // moved by this margin, so will its floats.
                             flt->top += margin;
@@ -5745,14 +5745,14 @@ public:
         }
     }
 
-    // Floats positionning helpers. These work in absolute coordinates (relative
+    // Floats positioning helpers. These work in absolute coordinates (relative
     // to flow state initial top)
     // Returns min y for next float
     int getNextFloatMinY(css_clear_t clear) {
         int y = c_y; // current line y
         for (int i=0; i<_floats.length(); i++) {
             BlockFloat * flt = _floats[i];
-            // A later float should never be positionned above an earlier float
+            // A later float should never be positioned above an earlier float
             if ( flt->top > y )
                 y = flt->top;
             if ( clear > css_c_none) {
@@ -5892,9 +5892,9 @@ public:
             in_y_max = fy + height + fmt.getBottomOverflow();
     }
 
-    void addPositionnedFloat( int rel_x, int rel_y, int width, int height, int is_right, ldomNode * node ) {
+    void addPositionedFloat( int rel_x, int rel_y, int width, int height, int is_right, ldomNode * node ) {
         int fx = x_min + rel_x;
-        // Where addPositionnedFloat is used (rendering erm_final), c_y has not
+        // Where addPositionedFloat is used (rendering erm_final), c_y has not
         // yet been updated, so it is still the base for rel_y.
         int fy = c_y + rel_y;
         // These embedded floats are kind of in a sublevel of current level
@@ -5973,7 +5973,7 @@ public:
         int flprint_right_x = right_x;
         int flprint_right_y = top_y;
         // Bottomest top of all our current floats (needed to know the absolute
-        // minimal y at which next left or right float can be positionned)
+        // minimal y at which next left or right float can be positioned)
         int flprint_left_min_y = top_y;
         int flprint_right_min_y = top_y;
         // Extend them to include any part of floats that overlap it.
@@ -6094,7 +6094,7 @@ void BlockFloatFootprint::forwardOverflowingFloat( int x, int y, int w, int h, b
 {
     if ( flow == NULL )
         return;
-    flow->addPositionnedFloat( d_left + x, d_top + y, w, h, r, node );
+    flow->addPositionedFloat( d_left + x, d_top + y, w, h, r, node );
     // Also update used_min_y and used_max_y, so they can be fetched
     // to update erm_final block's top_overflow and bottom_overflow
     // if some floats did overflow
@@ -7119,7 +7119,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // But each child x and y (set by renderBlockElement() below) must
                 // include padding_top and padding_left. So we keep providing these
                 // to renderBlockElement() even if it feels a bit out of place,
-                // notably in the float positionning code. But it works...
+                // notably in the float positioning code. But it works...
 
                 // Update left and right overflows (usable by glyphs) if this node
                 // has some background or borders, to be given below to 'flow'.
@@ -7193,7 +7193,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     // todo: if needed, implement float: and clear: inline-start / inline-end
 
                     if ( child->isFloatingBox() ) {
-                        // Block floats are positionned respecting the current collapsed
+                        // Block floats are positioned respecting the current collapsed
                         // margin, without actually globally pushing it, and without
                         // collapsing with it.
                         int flt_vertical_margin = flow->getCurrentVerticalMargin();
@@ -7211,7 +7211,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // padding-left/right) for the flow to correctly position inner floats
                         // (but we don't provide padding_top, as if non-zero, we already
                         // flow->addContentLine() it above, so the flow is already aware of it):
-                        // flow->addFloat() will additionally shift its positionning by the
+                        // flow->addFloat() will additionally shift its positioning by the
                         // child x/y set by this renderBlockElement().
                         // We provide 0,0 as the usable left/right overflows, so no glyph/hanging
                         // punctuation will leak outside the floatBox - but the floatBox contains

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4810,6 +4810,12 @@ public:
     int getUsableRightOverflow() {
         return usable_overflow_x_max - x_max;
     }
+    // "sequence" is what elsewhere we've called "flow",
+    // just changing the name here to make it clear that
+    // this is not the "flow" of FlowState
+    void newSequence( int nonlinear ) {
+        context.newFlow( nonlinear ) ;
+    }
 
     void setRequestedBaselineType(int baseline_req_type) {
         baseline_req = baseline_req_type;
@@ -6305,6 +6311,20 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     css_style_ref_t style = enode->getStyle();
     lUInt16 nodeElementId = enode->getNodeId();
 
+    // force_pb will force a page break before and after the fragment
+    // this is necessary for non-linear fragments if we want the
+    // possibility of hiding them from the normal paging flow
+    bool force_pb = false;
+    if ( enode->getNodeId() == el_DocFragment) {
+        if ( enode->hasAttribute( attr_NonLinear ) ) {
+            flow->newSequence(true);
+            force_pb = enode->getDocument()->getDocFlag(DOC_FLAG_NONLINEAR_PAGEBREAK);
+        }
+        else {
+            flow->newSequence(false);
+        }
+    }
+
     // See if dir= attribute or CSS specified direction
     int direction = flow->getDirection();
     if ( enode->hasAttribute( attr_dir ) ) {
@@ -6903,6 +6923,12 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     int break_inside = CssPageBreak2Flags( style->page_break_inside );
     // Note: some test suites seem to indicate that an inner "break-inside: auto"
     // can override an outer "break-inside: avoid". We don't ensure that.
+
+    // enforce page breaks if needed
+    if (force_pb) {
+        break_before = RN_SPLIT_ALWAYS;
+        break_after = RN_SPLIT_ALWAYS;
+    }
 
     if ( no_margin_collapse ) {
         // Push any earlier margin so it does not get collapsed with this one

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2145,7 +2145,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 // But font-variant and font-feature-settings, even if they enable the same
                 // OpenType feature tags, should have each a life (inheritance) of their own,
                 // which we won't really ensure by mapping all of them into style->font_features.
-                // Also, font-feature-settings is quite more complicated to parse (optionnal
+                // Also, font-feature-settings is quite more complicated to parse (optional
                 // arguments, 0|1|2|3|on|off...), and we would only support up to the 31 tags
                 // that can be stored in the bitmap, so ignoring all possible others.
                 // As font-feature-settings is quite new, let's not support it (quite

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -481,7 +481,7 @@ public:
     {
     }
 
-    // Embedded floats positionning helpers.
+    // Embedded floats positioning helpers.
     // Returns y of the bottom of the lowest float
     int getFloatsMaxBottomY() {
         int max_b_y = m_y;
@@ -501,9 +501,9 @@ public:
         int y = m_y; // current line y
         for (int i=0; i<m_pbuffer->floatcount; i++) {
             embedded_float_t * flt = m_pbuffer->floats[i];
-            if (flt->to_position) // ignore not yet positionned floats
+            if (flt->to_position) // ignore not yet positioned floats
                 continue;
-            // A later float should never be positionned above an earlier float
+            // A later float should never be positioned above an earlier float
             if ( flt->y > y )
                 y = flt->y;
             if ( clear > css_c_none) {
@@ -532,7 +532,7 @@ public:
         while (y <= start_y + h) {
             for (int i=0; i<m_pbuffer->floatcount; i++) {
                 embedded_float_t * flt = m_pbuffer->floats[i];
-                if (flt->to_position) // ignore not yet positionned floats
+                if (flt->to_position) // ignore not yet positioned floats
                     continue;
                 if (flt->y <= y && flt->y + flt->height > y) { // this float is spanning this y
                     if (flt->is_right) {
@@ -576,7 +576,7 @@ public:
         }
         return y;
     }
-    // The following positionning codes is not the most efficient, as we
+    // The following positioning codes is not the most efficient, as we
     // call the previous functions that do many of the same kind of loops.
     // But it's the clearest to express the decision flow
 
@@ -594,19 +594,19 @@ public:
         // margin, we can set its RenderRectAccessor to be exactly
         // our embedded_float coordinates and sizes.
         //   If the wrapped element has margins, its renderRectAccessor
-        //   will be positionned/sized at the level of borders or padding,
+        //   will be positioned/sized at the level of borders or padding,
         //   as crengine does naturally with:
         //       fmt.setWidth(width - margin_left - margin_right);
         //       fmt.setHeight(height - margin_top - margin_bottom);
         //       fmt.setX(x + margin_left);
         //       fmt.setY(y + margin_top);
         // So, the RenderRectAccessor(floatBox) can act as a cache
-        // of previously rendered and positionned floats!
+        // of previously rendered and positioned floats!
         int width;
         int height;
         // This formatting code is called when rendering, but can also be called when
         // looking for links, highlighting... so it may happen that floats have
-        // already been rendered and positionnned, and we already know their width
+        // already been rendered and positioned, and we already know their width
         // and height.
         bool already_rendered = false;
         { // in its own scope, so this RenderRectAccessor is forgotten when left
@@ -614,7 +614,7 @@ public:
             if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_RENDERED) )
                 already_rendered = true;
             // We could also directly use fmt.getX/Y() if it has already been
-            // positionned, and avoid the positionning code below.
+            // positioned, and avoid the positioning code below.
             // But let's be fully deterministic with that, and redo it.
         }
         if ( !already_rendered ) {
@@ -664,7 +664,7 @@ public:
                 // on current line,
                 // See if it can still fit on this line, accounting for the current
                 // width used by the text before this inline float (getCurrentLineWidth()
-                // accounts for already positionned floats on this line)
+                // accounts for already positioned floats on this line)
                 if ( currentTextWidth + flt->width <= getCurrentLineWidth() ) {
                     // Call getYWithAvailableWidth() just to get x
                     int x;
@@ -749,7 +749,7 @@ public:
             has_ongoing_float = false;
             for (int i=0; i<m_pbuffer->floatcount; i++) {
                 embedded_float_t * flt = m_pbuffer->floats[i];
-                if (flt->to_position) // ignore not yet positionned floats (even if
+                if (flt->to_position) // ignore not yet positioned floats (even if
                     continue;         // there shouldn't be any when this is called)
                 if (flt->y < m_y && flt->y + flt->height > m_y) {
                     has_ongoing_float = true;
@@ -820,7 +820,7 @@ public:
         m_has_ongoing_float = false;
         for (int i=0; i<m_pbuffer->floatcount; i++) {
             embedded_float_t * flt = m_pbuffer->floats[i];
-            if (flt->to_position) // ignore not yet positionned floats, as they
+            if (flt->to_position) // ignore not yet positioned floats, as they
                 continue;         // are not yet running past m_y
             if (flt->y < m_y && flt->y + flt->height > m_y) {
                 m_has_ongoing_float = true;
@@ -858,7 +858,7 @@ public:
             while (y <= end_y) {
                 for (int i=0; i<m_pbuffer->floatcount; i++) {
                     embedded_float_t * flt = m_pbuffer->floats[i];
-                    if (flt->to_position) // ignore not yet positionned floats
+                    if (flt->to_position) // ignore not yet positioned floats
                         continue;
                     if (flt->y <= y && flt->y + flt->height > y) { // this float is spanning this y
                         if (flt->is_right) {
@@ -1029,7 +1029,7 @@ public:
         lb_init_break_context(&lbCtx, 0x200D, NULL); // ZERO WIDTH JOINER
         #endif
 
-        m_has_bidi = false; // will be set if fribidi detects it is bidirectionnal text
+        m_has_bidi = false; // will be set if fribidi detects it is bidirectional text
         m_para_dir_is_rtl = false;
         #if (USE_FRIBIDI==1)
         bool has_rtl = false; // if no RTL char, no need for expensive bidi processing
@@ -1954,7 +1954,7 @@ public:
                     /* If the following was ever needed, it was wrong to do it at this step
                      * of measureText(), as we then get additional fixed spacing that we may
                      * not need in some contexts. So don't do it: browsers do not.
-                     * We'll handle that if LTEXT_FIT_GLYPHS when positionning words
+                     * We'll handle that if LTEXT_FIT_GLYPHS when positioning words
                      * (not implemented for now.)
 
                     // This checks whether we're the last char of a text node, and if
@@ -1982,7 +1982,7 @@ public:
                     }
                     if ( m_charindex[start] == FLOAT_CHAR_INDEX ) {
                         // Embedded floats can have a zero width in this process of
-                        // text measurement. They'll be measured when positionned.
+                        // text measurement. They'll be measured when positioned.
                         m_widths[start] = lastWidth;
                     }
                     else if ( m_charindex[start] == INLINEBOX_CHAR_INDEX ) {
@@ -2036,7 +2036,7 @@ public:
                             RenderRectAccessor fmt( node );
                             fmt.setBaseline(baseline);
                             RENDER_RECT_SET_FLAG(fmt, BOX_IS_RENDERED);
-                            // We'll have alignLine() do the fmt.setX/Y once it is fully positionned
+                            // We'll have alignLine() do the fmt.setX/Y once it is fully positioned
 
                             // We'd like to gather footnote links accumulated by alt_context
                             // (we do that for floats), but it's quite more complicated:
@@ -2365,7 +2365,7 @@ public:
     void addLine( int start, int end, int x, src_text_fragment_t * para, bool first, bool last, bool preFormattedOnly, bool isLastPara, bool hasInlineBoxes )
     {
         // No need to do some x-alignment work if light formatting, when we
-        // are only interested in computing block height and positionning
+        // are only interested in computing block height and positioning
         // floats: 'is_reusable' will be unset, and any attempt at reusing
         // this formatting for drawing will cause a non-light re-formatting.
         // Except when there are inlineBoxes in the text: we need to correctly
@@ -2693,7 +2693,7 @@ public:
             }
         }
 
-        // Some words vertical-align positionning might need to be fixed
+        // Some words vertical-align positioning might need to be fixed
         // only once the whole line has been laid out
         bool delayed_valign_computation = false;
 
@@ -2839,7 +2839,7 @@ public:
                 #endif
 
                 // Remove any collapsed space at start of word: they
-                // may have a zero width and not influence positionning,
+                // may have a zero width and not influence positioning,
                 // but they will be drawn as a space by Draw(). We need
                 // to increment the start index into the src_text_fragment_t
                 // for Draw() to start rendering the text from this position.
@@ -3028,7 +3028,7 @@ public:
                     // i-1 may be a space, or not (when different html tag/text nodes stuck to each other)
                     word->flags = 0;
 
-                    // Handle vertical positionning of this word
+                    // Handle vertical positioning of this word
                     LVFont * font = (LVFont*)srcline->t.font;
                     int vertical_align_flag = srcline->flags & LTEXT_VALIGN_MASK;
                     int line_height = srcline->interval;
@@ -4307,9 +4307,9 @@ public:
                     // gathered by this sub-context via frmlines.
                     // printf("emb line %d>%d\n", frmline->y, frmline->height);
                     m_y += frmline->height;
-                    // We only check for already positionned floats to ensure
-                    // no page break along them. We'll positionned yet-to-be
-                    // positionned floats only when done with this embedded block.
+                    // We only check for already positioned floats to ensure
+                    // no page break along them. We'll positioned yet-to-be
+                    // positioned floats only when done with this embedded block.
                     checkOngoingFloat();
                 }
             }
@@ -4525,7 +4525,7 @@ lUInt32 LFormattedText::Format(lUInt16 width, lUInt16 page_height, int para_dire
         // See FlowState->getFloatFootprint() for details.
         // So, for each of them, just add an embedded_float_t (without
         // a scrtext as they are not ours) to the buffer so our
-        // positionning code can handle them.
+        // positioning code can handle them.
         for (int i=0; i<float_footprint->floats_cnt; i++) {
             embedded_float_t * flt =  lvtextAddEmbeddedFloat( m_pbuffer );
             flt->srctext = NULL; // not our own float
@@ -4686,7 +4686,7 @@ static void getAbsMarksFromMarks(ldomMarkedRangeList * marks, ldomMarkedRangeLis
         newmark->start.x += final_node_rect.left;
         newmark->end.x += final_node_rect.left;
             // (Note: early when developping this, NOT updating x gave the
-            // expected results, althought logically it should be updated...
+            // expected results, although logically it should be updated...
             // But now, it seems to work, and is needed to correctly shift
             // highlight marks in inlineBox by the containing final block's
             // left margin...)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.53k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.54k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0026
 
@@ -12974,6 +12974,8 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const 
                 parent->OnAttribute(U"", U"dir", htmlDir.c_str() );
             if ( !htmlLang.empty() ) // add attribute <DocFragment lang="ar" from <html lang="ar"> tag
                 parent->OnAttribute(U"", U"lang", htmlLang.c_str() );
+            if (this->m_nonlinear)
+                parent->OnAttribute(U"", U"NonLinear", U"" );
 
             parent->OnTagBody(); // inside <DocFragment>
             if ( !headStyleText.empty() || stylesheetLinks.length() > 0 ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6694,7 +6694,7 @@ void ldomNode::initNodeRendMethod()
     if ( d == css_d_ruby && BLOCK_RENDERING(rend_flags, ENHANCED) ) {
         // Ruby input can be quite loose and have various tag strategies (mono/group,
         // interleaved/tabular, double sided). Moreover, the specs have evolved between
-        // 2001 and 2020 (<rbc> tag no more mentionned in 2020; <rtc> being just another
+        // 2001 and 2020 (<rbc> tag no more mentioned in 2020; <rtc> being just another
         // semantic container for Mozilla, and can be preceded by a bunch of <rt> which
         // are pronunciation containers, that don't have to be in an <rtc>...)
         // Moreover, various samples on the following pages don't close tags, and expect
@@ -13056,7 +13056,7 @@ void ldomDocumentFragmentWriter::OnTagBody()
 
 /////////////////////////////////////////////////////////////////
 /// ldomDocumentWriterFilter
-// Used to parse loosy HTML in formats: HTML, CHM, PDB(html)
+// Used to parse lousy HTML in formats: HTML, CHM, PDB(html)
 // For all these document formats, it is fed by HTMLParser that does
 // convert to lowercase the tag names and attributes.
 // ldomDocumentWriterFilter does then deal with auto-closing unbalanced
@@ -15020,7 +15020,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     // _maxAddedLetterSpacingPercent does not need to be accounted, as, working
     // only on a laid out line, it does not need a re-rendering, but just
     // a _renderedBlockCache.clear() to reformat paragraphs and have the
-    // word re-positionned (the paragraphs width & height do not change)
+    // word re-positioned (the paragraphs width & height do not change)
 
     // Hanging punctuation does not need to trigger a re-render, as
     // it's now ensured by alignLine() and won't change paragraphs height.


### PR DESCRIPTION
This contains the backend changes necessary for implementing https://github.com/koreader/koreader/issues/6809:

* Files marked with `linear="no"` in the EPUB spine will be written as `<DocFragment nonlinear="true">`.
* Each page is assigned to the linear flow (0) or to one of possibly many non-linear flows (each source file is a different one). The flow is assigned according to the first line in the page.
* A new method `getPageFlow(page)` is exposed to query the flow to which a given page belongs. Also `hasNonLinearFlows()` to tell whether there are any non-linear flows to care about.
* If the property `crengine.doc.nonlinear.pagebreak.force` is enabled, page breaks will be forced before and after each non-linear flow, to ensure that the non-linear content can be safely skipped by pages.

(This has two commits, the first is only typo fixes with no functional change, in case it helps with reviewing.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/391)
<!-- Reviewable:end -->
