### PR TITLE
Fix for multi-page footnotes in non-linear pages

### DIFF
--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -182,6 +182,7 @@ public:
     int nb_lines_rtl;
     int nb_footnotes_lines;
     int nb_footnotes_lines_rtl;
+    int current_flow;
 
     PageSplitState(LVRendPageList * pl, int pageHeight)
         : page_h(pageHeight)
@@ -200,6 +201,7 @@ public:
         , nb_lines_rtl(0)
         , nb_footnotes_lines(0)
         , nb_footnotes_lines_rtl(0)
+        , current_flow(0)
     {
     }
 
@@ -312,8 +314,6 @@ public:
             printf(" [rtl l:%d/%d fl:%d/%d]\n", nb_lines_rtl, nb_lines, nb_footnotes_lines_rtl, nb_footnotes_lines);
         #endif
         LVRendPageInfo * page = new LVRendPageInfo(start, h, page_list->length());
-        if (pagestart)
-            page->flow = pagestart->flow;
         lastpageend = start + h;
         if ( footnotes.length()>0 ) {
             page->footnotes.add( footnotes );
@@ -331,6 +331,9 @@ public:
             page_footnotes.add(footnote);
         }
         page->flags |= getLineTypeFlags();
+        if (pagestart)
+            current_flow = pagestart->flow;
+        page->flow = current_flow;
         ResetLineAccount(true);
         page_list->add(page);
     }


### PR DESCRIPTION
With in-page long footnotes, there may be pages made exclusively of footnotes, those have no `pagestart` and end up in flow 0. This should fix it by keeping track of the current flow in `PageSplitState`, so footnote pages are added to the flow that was active before that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/392)
<!-- Reviewable:end -->
