### PR TITLE
FB2: mark 2nd++ BODYs as non-linear, fix base64 images in EPUB, sync with upstream

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -26,6 +26,7 @@
 /// Unicode spaces
 #define UNICODE_NO_BREAK_SPACE            0x00A0
 #define UNICODE_ZERO_WIDTH_NO_BREAK_SPACE 0xfeff
+#define UNICODE_WORD_JOINER      0x2060
 // All chars from U+2000 to U+200B allow wrap after, except U+2007
 #define UNICODE_EN_QUAD          0x2000
 #define UNICODE_FIGURE_SPACE     0x2007

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -584,6 +584,10 @@ public:
     /// replaces first found occurence of "$N" pattern with itoa of integer, where N=index
     bool replaceIntParam(int index, int replaceNumber);
 
+    /// find position of char inside string, -1 if not found
+    int pos(lChar32 ch) const;
+    /// find position of char inside string starting from specified position, -1 if not found
+    int pos(lChar32 ch, int start) const;
     /// find position of substring inside string, -1 if not found
     int pos(lString32 subStr) const;
     /// find position of substring inside string starting from specified position, -1 if not found

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -292,7 +292,7 @@ int LVFont::getVisualAligmentWidth() {
     return _visual_alignment_width;
 }
 
-static lChar32 getReplacementChar( lUInt32 code ) {
+static lChar32 getReplacementChar(lUInt32 code, bool * can_be_ignored = NULL) {
     switch (code) {
     case UNICODE_SOFT_HYPHEN_CODE:
         return '-';
@@ -302,7 +302,13 @@ static lChar32 getReplacementChar( lUInt32 code ) {
         return 0x0435; // CYRILLIC SMALL LETTER IE
     case UNICODE_NO_BREAK_SPACE:
         return ' ';
+    case UNICODE_WORD_JOINER:
+        if (can_be_ignored)
+            *can_be_ignored = true;
+        return UNICODE_ZERO_WIDTH_SPACE;
     case UNICODE_ZERO_WIDTH_SPACE:
+        if (can_be_ignored)
+            *can_be_ignored = true;
         // If the font lacks a zero-width breaking space glyph (like
         // some Kindle built-ins) substitute a different zero-width
         // character instead of one with width.
@@ -1727,11 +1733,16 @@ public:
             }
         }
         if ( ch_glyph_index==0 ) {
-            lUInt32 replacement = getReplacementChar( code );
+            bool can_be_ignored = false;
+            lUInt32 replacement = getReplacementChar( code, &can_be_ignored );
             if ( replacement )
                 ch_glyph_index = FT_Get_Char_Index( _face, replacement );
-            if ( ch_glyph_index==0 && def_char )
+            if ( ch_glyph_index==0 && def_char && !can_be_ignored ) {
+                // if neither the index of this character nor the index of the replacement character is found,
+                // and if this character can be safely ignored,
+                // we simply skip it so as not to draw the unnecessary replacement character.
                 ch_glyph_index = FT_Get_Char_Index( _face, def_char );
+            }
         }
         return ch_glyph_index;
     }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -6315,13 +6315,23 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // this is necessary for non-linear fragments if we want the
     // possibility of hiding them from the normal paging flow
     bool force_pb = false;
-    if ( enode->getNodeId() == el_DocFragment) {
+    if ( nodeElementId == el_DocFragment) {
         if ( enode->hasAttribute( attr_NonLinear ) ) {
             flow->newSequence(true);
             force_pb = enode->getDocument()->getDocFlag(DOC_FLAG_NONLINEAR_PAGEBREAK);
         }
         else {
             flow->newSequence(false);
+        }
+    }
+    else if ( nodeElementId == el_body ) {
+        // We also set this attribute on 2nd++ BODYs in FB2 documents
+        // (as this attribute is only set on FB2 documents, and all
+        // 2nd++ BODYs get it, no need to check for the doc format and
+        // no need to reset flow sequence when BODY without met.)
+        if ( enode->hasAttribute( attr_NonLinear ) ) {
+            flow->newSequence(true);
+            force_pb = enode->getDocument()->getDocFlag(DOC_FLAG_NONLINEAR_PAGEBREAK);
         }
     }
 

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -1593,7 +1593,7 @@ public:
 
                 if ( (dwAttrs & FILE_ATTRIBUTE_DIRECTORY) ) {
                     // directory
-                    if (!lStr_cmp(pfn, U"..") || !lStr_cmp(pfn, U".")) {
+                    if (!lStr_cmp(pfn, L"..") || !lStr_cmp(pfn, L".")) {
                         // .. or .
                     } else {
                         // normal directory
@@ -2797,7 +2797,7 @@ class LVRarArc : public LVArcContainerBase
 {
 public:
 
-    virtual LVStreamRef OpenStream( const char32_t * fname, lvopen_mode_t mode )
+    virtual LVStreamRef OpenStream( const lChar32 * fname, lvopen_mode_t mode )
     {
         int found_index = -1;
         for (int i=0; i<m_list.length(); i++) {

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -3162,8 +3162,8 @@ lString8 UnicodeToLocal( const lString32 & str )
    lString8 dst;
    if (str.empty())
       return dst;
-   char def_char[]="?";
-   int usedDefChar = false;
+   CHAR def_char = '?';
+   BOOL usedDefChar = FALSE;
    int len = WideCharToMultiByte(
       CP_ACP,
       WC_COMPOSITECHECK | WC_DISCARDNS
@@ -3172,7 +3172,7 @@ lString8 UnicodeToLocal( const lString32 & str )
       str.length(),
       NULL,
       0,
-      def_char,
+      &def_char,
       &usedDefChar
       );
    if (len)
@@ -3186,7 +3186,7 @@ lString8 UnicodeToLocal( const lString32 & str )
          str.length(),
          dst.modify(),
          len,
-         def_char,
+         &def_char,
          &usedDefChar
          );
    }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -2177,6 +2177,31 @@ int lString8::pos(const lString8 & subStr, int startPos) const
     return -1;
 }
 
+int lString32::pos(lChar32 ch) const {
+    for (int i = 0; i < length(); i++)
+    {
+        if (pchunk->buf32[i] == ch)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int lString32::pos(lChar32 ch, int start) const
+{
+    if (length() - start < 1)
+        return -1;
+    for (int i = start; i < length(); i++)
+    {
+        if (pchunk->buf32[i] == ch)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
 int lString32::pos(const lString32 & subStr, int startPos) const
 {
     if (subStr.length() > length() - startPos)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1198,7 +1198,7 @@ bool parse_content_property( const char * & str, lString32 & parsed_content)
                         // Serialize it as UTF-8
                         lString32 c;
                         c << (lChar32)codepoint;
-                        str8 << UnicodeToLocal(c);
+                        str8 << UnicodeToUtf8(c);
                     }
                     else if ( *str == '\r' && *(str+1) == '\n' ) {
                         // Ignore \ at end of CRLF line

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5103,6 +5103,14 @@ ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUIn
                 // Add FB2 2nd++ BODYs' titles (footnotes and endnotes) in the TOC
                 // (but not their own children that are <section>)
                 _isSection = true; // this is just to have updateTocItem() called
+                // Also add the "NonLinear" attribute so these other BODYs are flagged
+                // as non-linear and can be hidden by frontend code that handles this
+                // (this is actually suggested by the FB2 specs: "... multiple
+                // bodies are used for additional information, like footnotes,
+                // that do not appear in the main book flow. The first body is
+                // presented to the reader by default, and content in the other
+                // bodies should be accessible by hyperlinks.")
+                addAttribute( 0, attr_NonLinear, U"" );
             }
         }
     }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -12810,6 +12810,8 @@ lString32 ldomDocumentFragmentWriter::convertHref( lString32 href )
 {
     if ( href.pos("://")>=0 )
         return href; // fully qualified href: no conversion
+    if ( href.length() > 10 && href[4] == ':' && href.startsWith(lString32("data:image/")) )
+        return href; // base64 encoded image (<img src="data:image/png;base64,iVBORw0KG...>): no conversion
 
     //CRLog::trace("convertHref(%s, codeBase=%s, filePathName=%s)", LCSTR(href), LCSTR(codeBase), LCSTR(filePathName));
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9729,9 +9729,12 @@ lString32 extractDocKeywords( ldomDocument * doc )
         if ( !genre ) {
             break;
         }
-        if ( !res.empty() )
-            res << "\n";
-        res << genre.getText().trim();
+        lString32 text = genre.getText().trim();
+        if (!text.empty()) {
+            if (!res.empty())
+                res << "\n";
+            res << text;
+        }
     }
     return res;
 }


### PR DESCRIPTION
A few little commits:

`(Upstream) Fix errors in lString16 to 32 update`
See https://github.com/koreader/crengine/issues/389#issuecomment-722528703

`(Upstream) Misc Win32 fixes`
From not yet merged https://github.com/buggins/coolreader/pull/202

`(Upstream) lString32: add 2 additional pos() methods` 
From https://github.com/buggins/coolreader/pull/199. Not used, but might be one day.

`(Upstream) Ignore WORD_JOINER when font has no glyph`
From https://github.com/buggins/coolreader/pull/200

`(Upstream) FB2 metadata: discard empty genres`
From https://github.com/buggins/coolreader/pull/195

`FB2: mark 2nd++ BODYs as non-linear`
So that what's been added for EPUB is also available with FB2 books.
See https://github.com/koreader/koreader/pull/6847#issuecomment-727200617 and follow-ups.

`Fix support in EPUB for <img src="data:image/png;base64,...>`
(Never seen that used in EPUBs, except for a little one recently.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/395)
<!-- Reviewable:end -->
