### PR TITLE
XML parsing: correctly parse CDATA

### DIFF
--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -79,8 +79,8 @@ public:
 
 /// don't treat CR/LF and TAB characters as space nor remove duplicate spaces
 #define TXTFLG_PRE        1
-/// last character of previous text was space
-#define TXTFLG_LASTSPACE  2
+/// text is to be interpreted literally, as textual data, not as marked up or entity references
+#define TXTFLG_CDATA      2
 
 #define TXTFLG_TRIM                         4
 #define TXTFLG_TRIM_ALLOW_START_SPACE       8
@@ -391,8 +391,9 @@ class LVXMLParser : public LVTextFileBase
 {
 private:
     LVXMLParserCallback * m_callback;
-    bool m_trimspaces;
     int  m_state;
+    bool m_in_cdata;
+    bool m_trimspaces;
     bool SkipSpaces();
     bool SkipTillChar( lChar32 ch );
     bool ReadIdent( lString32 & ns, lString32 & str );

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -2842,6 +2842,7 @@ void LVXMLParser::Reset()
     //CRLog::trace("LVXMLParser::Reset()");
     LVTextFileBase::Reset();
     m_state = ps_bof;
+    m_in_cdata = false;
 }
 
 LVXMLParser::LVXMLParser( LVStreamRef stream, LVXMLParserCallback * callback, bool allowHtml, bool fb2Only )
@@ -2849,6 +2850,7 @@ LVXMLParser::LVXMLParser( LVStreamRef stream, LVXMLParserCallback * callback, bo
     , m_callback(callback)
     , m_trimspaces(true)
     , m_state(0)
+    , m_in_cdata(false)
     , m_citags(false)
     , m_allowHtml(allowHtml)
     , m_fb2Only(fb2Only)
@@ -2989,10 +2991,17 @@ bool LVXMLParser::Parse()
                         m_state = ps_text;
                         break;
                     }
-                    //bypass <![CDATA] in <style type="text/css">
-                    if (PeekCharFromBuffer(1)=='['&&tagname.compare("style")==0&&attrvalue.compare("text/css")==0){
+                    // <![CDATA[ ... ]]>:
+                    if ( PeekCharFromBuffer(1)=='[' && PeekCharFromBuffer(2)=='C' &&
+                                                       PeekCharFromBuffer(3)=='D' &&
+                                                       PeekCharFromBuffer(4)=='A' &&
+                                                       PeekCharFromBuffer(5)=='T' &&
+                                                       PeekCharFromBuffer(6)=='A' && PeekCharFromBuffer(7)=='[' ) {
                         PeekNextCharFromBuffer(7);
-                        m_state =ps_text;
+                        // Handled as text, but don't decode HTML entities (&blah; &#123;),
+                        // and stop after ']]>' instead of before '<'
+                        m_state = ps_text;
+                        m_in_cdata = true;
                         break;
                     }
                 }
@@ -3146,6 +3155,13 @@ bool LVXMLParser::Parse()
                 if ( bodyStarted )
                     updateProgress();
                 m_state = ps_lt;
+                if (m_in_cdata) {
+                    m_in_cdata = false;
+                    // Get back in ps_text state: there may be some
+                    // regular text after ']]>' until the next '<tag>'
+                    m_state = ps_text;
+                }
+
             }
             break;
         default:
@@ -5343,6 +5359,7 @@ int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * e
     lChar32 nch = 0;
     lChar32 lch = 0;
     lChar32 nsp = 0;
+    bool cdata = (flags & TXTFLG_CDATA) != 0;
     bool pre = (flags & TXTFLG_PRE) != 0;
     bool pre_para_splitting = (flags & TXTFLG_PRE_PARA_SPLITTING)!=0;
     if ( pre_para_splitting )
@@ -5370,7 +5387,7 @@ int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * e
             if (ch=='\r' || ch=='\n' || ch=='\t')
                 ch = ' ';
         }
-        if (ch == '&') {
+        if (ch == '&' && !cdata) {
             state = 1;
             nch = 0;
         } else if (state == 0) {
@@ -5602,9 +5619,23 @@ bool LVXMLParser::ReadText()
         for ( ; m_read_buffer_pos+i<m_read_buffer_len; i++ ) {
             lChar32 ch = m_read_buffer[m_read_buffer_pos + i];
             lChar32 nextch = m_read_buffer_pos + i + 1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 1] : 0;
-            flgBreak = ch=='<' || m_eof;
+            flgBreak = m_eof;
+            if ( m_in_cdata ) { // we're done only when we meet ']]>'
+                if ( ch==']' && nextch==']') {
+                    lChar32 nextnextch = m_read_buffer_pos + i + 2 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 2] : 0;
+                    if ( nextnextch=='>' ) {
+                        flgBreak = true;
+                    }
+                }
+            }
+            else if ( ch=='<' ) {
+                flgBreak = true;
+            }
             if ( flgBreak && !tlen ) {
                 m_read_buffer_pos++;
+                if ( m_in_cdata ) {
+                    m_read_buffer_pos+=2;
+                }
                 return false;
             }
             splitParas = false;
@@ -5642,7 +5673,10 @@ bool LVXMLParser::ReadText()
             if ( flags & TXTFLG_CONVERT_8BIT_ENTITY_ENCODING )
                 enc_table = this->m_conv_table;
 
+            if ( m_in_cdata )
+                flags |= TXTFLG_CDATA;
             int nlen = PreProcessXmlString(buf, last_split_txtlen, flags, enc_table);
+
             if ( (flags & TXTFLG_TRIM) && (!(flags & TXTFLG_PRE) || (flags & TXTFLG_PRE_PARA_SPLITTING)) ) {
                 nlen = TrimDoubleSpaces(buf, nlen,
                     ((flags & TXTFLG_TRIM_ALLOW_START_SPACE) || pre_para_splitting)?true:false,
@@ -5676,6 +5710,8 @@ bool LVXMLParser::ReadText()
                 // TODO:LVE???
                 if ( PeekCharFromBuffer()=='<' )
                     m_read_buffer_pos++;
+                else if ( m_in_cdata && PeekCharFromBuffer()==']' )
+                    m_read_buffer_pos += 3; // skip ']]>'
                 //if ( m_read_buffer_pos < m_read_buffer_len )
                 //    m_read_buffer_pos++;
                 break;

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -2989,8 +2989,10 @@ bool LVXMLParser::Parse()
                         m_state = ps_text;
                         break;
                     }
-                    //bypass <![CDATA] in <style type="text/css">
-                    if (PeekCharFromBuffer(1)=='['&&tagname.compare("style")==0&&attrvalue.compare("text/css")==0){
+                    // bypass <![CDATA] in <style type="text/css"> (and more generally in any <style>)
+                    // (We let the trailing ]]> in, our style parser will just ignore it)
+                    // todo: ignoring CDATA should be handled more generally and properly
+                    if ( PeekCharFromBuffer(1)=='[' && tagname.compare("style")==0 ) { // && attrvalue.compare("text/css")==0){
                         PeekNextCharFromBuffer(7);
                         m_state =ps_text;
                         break;

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -2989,10 +2989,8 @@ bool LVXMLParser::Parse()
                         m_state = ps_text;
                         break;
                     }
-                    // bypass <![CDATA] in <style type="text/css"> (and more generally in any <style>)
-                    // (We let the trailing ]]> in, our style parser will just ignore it)
-                    // todo: ignoring CDATA should be handled more generally and properly
-                    if ( PeekCharFromBuffer(1)=='[' && tagname.compare("style")==0 ) { // && attrvalue.compare("text/css")==0){
+                    //bypass <![CDATA] in <style type="text/css">
+                    if (PeekCharFromBuffer(1)=='['&&tagname.compare("style")==0&&attrvalue.compare("text/css")==0){
                         PeekNextCharFromBuffer(7);
                         m_state =ps_text;
                         break;


### PR DESCRIPTION
~~Was added in #17, requiring the presence of `type="text/css"`. Just stop requirint it.~~
Closes #396.
~~More correct handling of CDATA should probably be implemented, but well/xml/hell...~~ gentle hell actually, so done:

`<div>abc <![CDATA[d<e&>f]]> ghi</div>` will now add intothe DOM 3 text nodes: `abc  `, `d<e&>f` and ` ghi`, as it's supposed to happen in XML/XHTML.
(In HTML, browsers would not do any specific parsing, with possibly strange results. We do it too in plain HTML.)
More details and discussion at https://github.com/koreader/crengine/issues/396#issuecomment-739245637 and follow up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/397)
<!-- Reviewable:end -->
