### PR TITLE
XML parsing: slightly better parsing of <script>

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2839,7 +2839,7 @@ public:
     virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
         if (headStyleState == 1) {
-            headStyleText << UnicodeToUtf8(lString32(text).substr(0,len-1));
+            headStyleText << UnicodeToUtf8(lString32(text, len));
             return;
         }
         if ( insideTag )

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -393,6 +393,7 @@ private:
     LVXMLParserCallback * m_callback;
     int  m_state;
     bool m_in_cdata;
+    bool m_in_html_script_tag;
     bool m_trimspaces;
     bool SkipSpaces();
     bool SkipTillChar( lChar32 ch );

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -2843,6 +2843,7 @@ void LVXMLParser::Reset()
     LVTextFileBase::Reset();
     m_state = ps_bof;
     m_in_cdata = false;
+    m_in_html_script_tag = false;
 }
 
 LVXMLParser::LVXMLParser( LVStreamRef stream, LVXMLParserCallback * callback, bool allowHtml, bool fb2Only )
@@ -2851,6 +2852,7 @@ LVXMLParser::LVXMLParser( LVStreamRef stream, LVXMLParserCallback * callback, bo
     , m_trimspaces(true)
     , m_state(0)
     , m_in_cdata(false)
+    , m_in_html_script_tag(false)
     , m_citags(false)
     , m_allowHtml(allowHtml)
     , m_fb2Only(fb2Only)
@@ -3048,6 +3050,17 @@ bool LVXMLParser::Parse()
 //                    CRLog::trace("<%s>", LCSTR(tagname) );
                 if (!bodyStarted && tagname == "body")
                     bodyStarted = true;
+                else if ( tagname.length() == 6 &&
+                        ( tagname[0] == U'S' || tagname[0] == U's') &&
+                        ( tagname[1] == U'C' || tagname[1] == U'c') &&
+                        ( tagname[2] == U'R' || tagname[2] == U'r') &&
+                        ( tagname[3] == U'I' || tagname[3] == U'i') &&
+                        ( tagname[4] == U'P' || tagname[4] == U'p') &&
+                        ( tagname[5] == U'T' || tagname[5] == U't') ) {
+                    // Handle content as text, but don't stop just at any '<',
+                    // only at '</script>', as <script> may contain tags
+                    m_in_html_script_tag = true;
+                }
 
                 m_state = ps_attr;
             }
@@ -3062,8 +3075,11 @@ bool LVXMLParser::Parse()
                 {
                     m_callback->OnTagBody();
                     // end of tag
-                    if ( ch!='>' ) // '/' in '<hr/>' : self closing tag
+                    if ( ch!='>' ) { // '/' in '<hr/>' : self closing tag
                         m_callback->OnTagClose(tagns.c_str(), tagname.c_str(), true);
+                        if ( m_in_html_script_tag )
+                            m_in_html_script_tag = false;
+                    }
                     if ( ch=='>' )
                         PeekNextCharFromBuffer();
                     else
@@ -3155,13 +3171,15 @@ bool LVXMLParser::Parse()
                 if ( bodyStarted )
                     updateProgress();
                 m_state = ps_lt;
-                if (m_in_cdata) {
+                if ( m_in_cdata ) {
                     m_in_cdata = false;
                     // Get back in ps_text state: there may be some
                     // regular text after ']]>' until the next '<tag>'
                     m_state = ps_text;
                 }
-
+                else if ( m_in_html_script_tag ) {
+                    m_in_html_script_tag = false;
+                }
             }
             break;
         default:
@@ -5629,7 +5647,18 @@ bool LVXMLParser::ReadText()
                 }
             }
             else if ( ch=='<' ) {
-                flgBreak = true;
+                if ( m_in_html_script_tag ) { // we're done only when we meet </script>
+                    if ( nextch=='/' && m_read_buffer_pos + i + 7 < m_read_buffer_len ) {
+                        const lChar32 * buf = (const lChar32 *)(m_read_buffer + m_read_buffer_pos + i + 2);
+                        lString32 tag(buf, 6);
+                        if ( tag.lowercase() == U"script" ) {
+                            flgBreak = true;
+                        }
+                    }
+                }
+                else {
+                    flgBreak = true;
+                }
             }
             if ( flgBreak && !tlen ) {
                 m_read_buffer_pos++;


### PR DESCRIPTION
`EPUB: fix truncated HEAD>STYLE stylesheet` Closes #403

`XML parsing: slightly better parsing of <script>` Closes #401
Handle content as text, but don't stop just at any '<', only at '</script>', as <script> may contain tags.
Not doing that might put a lot of javascript as document text content. Note that <script> content is "display: none" by default.
This is not perfect (no script tag case check for balancing), but might work in most cases.
Not tested: <script> + CDATA :/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/405)
<!-- Reviewable:end -->
