### PR TITLE
Two columns status bar

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -603,7 +603,7 @@ public:
     /// returns number of images on current page
     int getCurrentPageImageCount();
     /// calculate page header rectangle
-    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc, bool singleHeader=false );
+    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc );
     /// calculate page header height
     virtual int getPageHeaderHeight( );
     /// set list of icons to display at left side of header

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -870,8 +870,15 @@ public:
     // get page height
     int getPageHeight(int pageIndex);
 
-    /// get rotation mode
+    /// get portrait mode
     bool isPortraitMode();
+    /// get two column mode
+    bool is2ColumnMode();
+    /// get divider for updatePageNumbers
+    int getPageNumberFactor();
+    /// get divider for updatePageNumbers
+    int getPagesPerView();
+
 
     /// get number of current page
     int getCurPage();

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -415,7 +415,7 @@ public:
 
     /// draw current page to specified buffer
     void Draw( LVDrawBuf & drawbuf, bool autoResize = true);
-    
+
     /// close document
     void close();
     /// set buffer format
@@ -603,7 +603,7 @@ public:
     /// returns number of images on current page
     int getCurrentPageImageCount();
     /// calculate page header rectangle
-    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc );
+    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc, bool isPortraitMode=false );
     /// calculate page header height
     virtual int getPageHeaderHeight( );
     /// set list of icons to display at left side of header

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -603,7 +603,7 @@ public:
     /// returns number of images on current page
     int getCurrentPageImageCount();
     /// calculate page header rectangle
-    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc );
+    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc, bool singleHeader=false );
     /// calculate page header height
     virtual int getPageHeaderHeight( );
     /// set list of icons to display at left side of header

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -603,7 +603,7 @@ public:
     /// returns number of images on current page
     int getCurrentPageImageCount();
     /// calculate page header rectangle
-    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc, bool isPortraitMode=false );
+    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc );
     /// calculate page header height
     virtual int getPageHeaderHeight( );
     /// set list of icons to display at left side of header
@@ -869,6 +869,9 @@ public:
     int getPageStartY(int pageIndex);
     // get page height
     int getPageHeight(int pageIndex);
+
+    /// get rotation mode
+    bool isPortraitMode();
 
     /// get number of current page
     int getCurPage();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1837,12 +1837,13 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		}
 		lString32 pageinfo;
 		if (pageCount > 0) {
+            int pageDivider = !isPortraitMode ? 1 : getVisiblePageCount();
 			if (phi & PGHDR_PAGE_NUMBER)
-                pageinfo += fmt::decimal(pageIndex + 1);
+                pageinfo += fmt::decimal( (pageIndex + 1) / pageDivider );
             if (phi & PGHDR_PAGE_COUNT) {
                 if ( !pageinfo.empty() )
                     pageinfo += " / ";
-                pageinfo += fmt::decimal(pageCount);
+                pageinfo += fmt::decimal( (pageCount + pageDivider / 2 ) / pageDivider );
             }
             if (phi & PGHDR_PERCENT) {
                 if ( !pageinfo.empty() )


### PR DESCRIPTION
When in portrait mode and two columns are used the status-bar fills the whole width of the screen and
the number of pages and the actual page numbers are divided by two, to reflect what a user would expect.

With one column or in landscape (one or two pages) there should be no change.

Todo: 
1) With an odd number of pages, the last page shows no full status bar! (This can also happen in landscape mode with two pages.)
2) KOReader: Change the page number in the TOC; Numbers in `skim document` ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/408)
<!-- Reviewable:end -->
