### PR TITLE
CSS: add support for min-width, max-width, min-height, max-height

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -333,7 +333,8 @@ enum css_generic_value_t {
     css_generic_normal = -2,      // (css_val_unspecified, css_generic_normal), for "line-height: normal"
     css_generic_transparent = -3, // (css_val_unspecified, css_generic_transparent), for "color: transparent"
     css_generic_contain = -4,     // (css_val_unspecified, css_generic_contain), for "background-size: contain"
-    css_generic_cover = -5        // (css_val_unspecified, css_generic_cover), for "background-size: cover"
+    css_generic_cover = -5,       // (css_val_unspecified, css_generic_cover), for "background-size: cover"
+    css_generic_none = -6         // (css_val_unspecified, css_generic_none), for "max-width: none"
 };
 
 // -cr-hint is a non standard property for providing hints to crengine via style tweaks

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -135,7 +135,7 @@ int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, in
         int usable_left_overflow, int usable_right_overflow, int direction, int * baseline, lUInt32 rend_flags );
 /// renders table element
 int renderTable( LVRendPageContext & context, ldomNode * element, int x, int y, int width,
-                 bool shrink_to_fit, int & fitted_width, int direction=REND_DIRECTION_UNSET,
+                 bool shrink_to_fit, int min_width, int & fitted_width, int direction=REND_DIRECTION_UNSET,
                  bool pb_inside_avoid=false, bool enhanced_rendering=false, bool is_ruby_table=false );
 /// sets node style
 void setNodeStyle( ldomNode * node, css_style_ref_t parent_style, LVFontRef parent_font );

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -168,6 +168,7 @@ int LVRendGetFontEmbolden();
 int measureBorder(ldomNode *enode,int border);
 int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_em=false );
 int scaleForRenderDPI( int value );
+bool getStyledImageSize( ldomNode * enode, int & img_width, int & img_height, int container_width=-1, int container_height=-1 );
 
 #define BASE_CSS_DPI 96 // at 96 dpi, 1 css px = 1 screen px
 #define DEF_RENDER_DPI 96

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -40,6 +40,10 @@ enum css_style_rec_important_bit {
     imp_bit_line_height,
     imp_bit_width,
     imp_bit_height,
+    imp_bit_min_width,
+    imp_bit_min_height,
+    imp_bit_max_width,
+    imp_bit_max_height,
     imp_bit_margin_left,
     imp_bit_margin_right,
     imp_bit_margin_top,
@@ -85,14 +89,14 @@ enum css_style_rec_important_bit {
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 61 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 65 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[1]
-// So once NB_IMP_SLOTS becomes 3 when IMP_BIT_MAX > 64, add in lvstyles.cpp
-// the needed important[2] and importance[2]. Let us know if we forget that:
-#if (NB_IMP_SLOTS != 2)
-    #error "NB_IMP_SLOTS != 2, some updates in lvstyles.cpp (and then here) are needed"
+// So once NB_IMP_SLOTS becomes 4 when IMP_BIT_MAX > 96, add in lvstyles.cpp
+// the needed important[3] and importance[3]. Let us know if we forget that:
+#if (NB_IMP_SLOTS != 3)
+    #error "NB_IMP_SLOTS != 3, some updates in lvstyles.cpp (and then here) are needed"
 #endif
 
 // Style handling flags
@@ -129,6 +133,10 @@ struct css_style_rec_tag {
     css_length_t         line_height;
     css_length_t         width;
     css_length_t         height;
+    css_length_t         min_width;
+    css_length_t         min_height;
+    css_length_t         max_width;
+    css_length_t         max_height;
     css_length_t         margin[4]; ///< margin-left, -right, -top, -bottom
     css_length_t         padding[4]; ///< padding-left, -right, -top, -bottom
     css_length_t         color;
@@ -186,6 +194,10 @@ struct css_style_rec_tag {
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, 0)
     , height(css_val_unspecified, 0)
+    , min_width(css_val_unspecified, 0)
+    , min_height(css_val_unspecified, 0)
+    , max_width(css_val_unspecified, 0)
+    , max_height(css_val_unspecified, 0)
     , color(css_val_inherited, 0)
     , background_color(css_val_unspecified, 0)
     , letter_spacing(css_val_inherited, 0)

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -114,7 +114,8 @@ void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc
         lString32 href = content->getAttributeValue("src");
         lString32 title = text->getText(' ');
         title.trimDoubleSpaces(false, false, false);
-        if ( href.empty() || title.empty() )
+        // Allow empty title (which is fine, and they may have sub items)
+        if ( href.empty() )
             continue;
         //CRLog::trace("TOC href before convert: %s", LCSTR(href));
         href = DecodeHTMLUrlString(href);
@@ -163,6 +164,7 @@ void ReadEpubNcxPageList( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * pa
         lString32 href = content->getAttributeValue("src");
         lString32 title = text->getText(' ');
         title.trimDoubleSpaces(false, false, false);
+        // Empty titles wouldn't have much sense in page maps, ignore them
         if ( href.empty() || title.empty() )
             continue;
         href = DecodeHTMLUrlString(href);
@@ -288,6 +290,7 @@ void ReadEpubAdobePageMap( ldomDocument * doc, ldomNode * mapRoot, LVPageMap * p
         lString32 href = page->getAttributeValue("href");
         lString32 title = page->getAttributeValue("name");
         title.trimDoubleSpaces(false, false, false);
+        // Empty titles wouldn't have much sense in page maps, ignore them
         if ( href.empty() || title.empty() )
             continue;
         href = DecodeHTMLUrlString(href);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3675,6 +3675,10 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->line_height = source->line_height ;
     dest->width = source->width ;
     dest->height = source->height ;
+    dest->min_width = source->min_width ;
+    dest->min_height = source->min_height ;
+    dest->max_width = source->max_width ;
+    dest->max_height = source->max_height ;
     dest->margin[0] = source->margin[0] ;
     dest->margin[1] = source->margin[1] ;
     dest->margin[2] = source->margin[2] ;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -307,6 +307,7 @@ void collapse_border(css_style_ref_t & target_style, int & current_target_size,
 class CCRTable {
 public:
     int table_width;
+    int table_min_width;
     int digitwidth;
     int direction;
     bool is_rtl;
@@ -1094,21 +1095,22 @@ public:
 
         /////////////////////////// From here until further noticed, we just use and update the cols objects
         // Find width available for cells content (including their borders and paddings)
-        // Start with table full width
-        int assignable_width = table_width;
-        // Remove table outer borders
-        assignable_width -= measureBorder(elem,1) + measureBorder(elem,3); // (border indexes are TRBL)
+        // Get widths used by the table itself
+        int table_outer_borders_width = measureBorder(elem,1) + measureBorder(elem,3); // (border indexes are TRBL)
+        int table_paddings_width = 0;
+        int table_borderspacings_width = 0;
         if ( border_collapse ) {
-            // Table own outer paddings and any border-spacing are
-            // ignored with border-collapse
+            // Table own outer paddings and any border-spacing are ignored with border-collapse
         }
         else { // no collapse
-            // Remove table outer paddings (margin and padding indexes are LRTB)
-            assignable_width -= lengthToPx(table_style->padding[0], table_width, table_em);
-            assignable_width -= lengthToPx(table_style->padding[1], table_width, table_em);
-            // Remove (nb cols + 1) border-spacing
-            assignable_width -= (cols.length() + 1) * borderspacing_h;
+            table_paddings_width = lengthToPx(table_style->padding[0], table_width, table_em)
+                                 + lengthToPx(table_style->padding[1], table_width, table_em);
+                                    // (margin and padding indexes are LRTB)
+            // (nb cols + 1) border-spacing
+            table_borderspacings_width = (cols.length() + 1) * borderspacing_h;
         }
+        // Remove all that from table width to get what can be used by cells
+        int assignable_width = table_width - table_outer_borders_width - table_paddings_width - table_borderspacings_width;
         #ifdef DEBUG_TABLE_RENDERING
             printf("TABLE: table_width=%d assignable_width=%d\n", table_width, assignable_width);
         #endif
@@ -1122,6 +1124,9 @@ public:
         }
 
         // Find best width for each column
+        // Note: support for CSS min-width/max-width on table cells and cols
+        // has not been implemented (not sure where to handle that below in
+        // this already complicated algorithm, feels really tedious)
         int npercent=0;
         int sumpercent=0;
         int nwidth = 0;
@@ -1284,26 +1289,53 @@ public:
                 printf("TABLE WIDTHS step4: cols[%d]: %d%% %dpx (min %dpx)\n",
                     x, cols[x]->percent, cols[x]->width, cols[x]->min_width);
         #endif
-        int restw = assignable_width - sumwidth + rw; // may be negative if we needed to
-                                                      // increase to fulfill min_width
+        int min_needed_width = sumwidth - rw;
+        int restw = assignable_width - min_needed_width; // may be negative if we needed to
+                                                         // increase to fulfill cols min_width
+        bool distribute_restw = true;
         if (shrink_to_fit && restw > 0) {
+            distribute_restw = false;
+            int prev_table_width = table_width;
             // If we're asked to shrink width to fit cells content, don't
             // distribute restw to columns, but shrink table width
-            // Table padding may be in %, and need to be corrected
-            int correction = 0;
-            correction += lengthToPx(table_style->padding[0], table_width, table_em);
-            correction += lengthToPx(table_style->padding[0], table_width, table_em);
+            // Table padding may be in %, and need to be corrected (everything else,
+            // border + border_spacing, don't change when the table width does)
+            int old_table_paddings_width = table_paddings_width;
             table_width -= restw;
-            correction -= lengthToPx(table_style->padding[0], table_width, table_em);
-            correction -= lengthToPx(table_style->padding[0], table_width, table_em);
+            table_paddings_width = 0;
+            if ( !border_collapse ) { // padding were not applied when border-collapse
+                table_paddings_width = lengthToPx(table_style->padding[0], table_width, table_em)
+                                     + lengthToPx(table_style->padding[1], table_width, table_em);
+            }
+            int correction = old_table_paddings_width - table_paddings_width;
             table_width -= correction;
             #ifdef DEBUG_TABLE_RENDERING
                 assignable_width -= restw + correction; // (for debug printf() below)
                 printf("TABLE WIDTHS step5 (fit): reducing table_width %d -%d -%d > %d\n",
                     table_width+restw+correction, restw, correction, table_width);
             #endif
+            if ( table_min_width > table_width && table_min_width <= prev_table_width ) {
+                // The table has a CSS min-width specified that is larger
+                // than the shrinked-to-fit width, and that we can ensure
+                // by distributing a bit of what we just removed
+                table_width = table_min_width;
+                table_paddings_width = 0;
+                if ( !border_collapse ) { // padding were not applied when border-collapse
+                    table_paddings_width += lengthToPx(table_style->padding[0], table_width, table_em);
+                    table_paddings_width += lengthToPx(table_style->padding[0], table_width, table_em);
+                }
+                assignable_width = table_width - table_outer_borders_width - table_paddings_width - table_borderspacings_width;
+                restw = assignable_width - min_needed_width;
+                if ( restw > 0 ) {
+                    distribute_restw = true;
+                    #ifdef DEBUG_TABLE_RENDERING
+                        printf("TABLE WIDTHS step5 (min-width): re-increased table_width to %d, redistributing %d\n",
+                            table_width, restw);
+                    #endif
+                }
+            }
         }
-        else {
+        if ( distribute_restw ) {
             #ifdef DEBUG_TABLE_RENDERING
                 printf("TABLE WIDTHS step5 (dist): %d to distribute to %d cols\n",
                     restw, dist_nb_cols);
@@ -2146,8 +2178,10 @@ public:
         return table_h;
     }
 
-    CCRTable(ldomNode * tbl_elem, int tbl_width, bool tbl_shrink_to_fit, int tbl_direction, bool tbl_avoid_pb_inside,
-                                bool tbl_enhanced_rendering, int dwidth, bool tbl_is_ruby_table) : digitwidth(dwidth) {
+    CCRTable(ldomNode * tbl_elem, int tbl_width, bool tbl_shrink_to_fit, int tbl_min_width, int tbl_direction,
+                bool tbl_avoid_pb_inside, bool tbl_enhanced_rendering, int dwidth, bool tbl_is_ruby_table)
+        : digitwidth(dwidth)
+        {
         currentRowGroup = NULL;
         caption = NULL;
         caption_h = 0;
@@ -2155,6 +2189,7 @@ public:
         elem = tbl_elem;
         table_width = tbl_width;
         shrink_to_fit = tbl_shrink_to_fit;
+        table_min_width = tbl_min_width;
         direction = tbl_direction;
         is_rtl = direction == REND_DIRECTION_RTL;
         avoid_pb_inside = tbl_avoid_pb_inside;
@@ -2185,11 +2220,11 @@ public:
     }
 };
 
-int renderTable( LVRendPageContext & context, ldomNode * node, int x, int y, int width, bool shrink_to_fit,
+int renderTable( LVRendPageContext & context, ldomNode * node, int x, int y, int width, bool shrink_to_fit, int min_width,
                  int & fitted_width, int direction, bool avoid_pb_inside, bool enhanced_rendering, bool is_ruby_table )
 {
     CR_UNUSED2(x, y);
-    CCRTable table( node, width, shrink_to_fit, direction, avoid_pb_inside, enhanced_rendering, 10, is_ruby_table );
+    CCRTable table( node, width, shrink_to_fit, min_width, direction, avoid_pb_inside, enhanced_rendering, 10, is_ruby_table );
     int h = table.renderCells( context );
     if (shrink_to_fit)
         fitted_width = table.table_width;
@@ -3204,19 +3239,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 txform->setStrut(0, 0);
                 line_h = 0;
                 indent = 0;
-                // Also, when such a floating image has a width in %, this width
-                // has been used to set the width of the floating box. We need to
-                // update this % width to be 100%, otherwise the image would be
-                // again set to this % of the floating box width...
-                // This feels a bit hacky, there might be a better place to deal with that...
-                if (style->width.type == css_val_percent && style->width.value != 100*256) {
-                    css_style_ref_t oldstyle = enode->getStyle();
-                    css_style_ref_t newstyle(new css_style_rec_t);
-                    copystyle(oldstyle, newstyle);
-                    newstyle->width.value = 100*256; // 100%
-                    enode->setStyle(newstyle);
-                    style = enode->getStyle().get(); // update to the new style
-                }
+                // Note: floating images with CSS width/height and min/max-width in %
+                // have had them converted to screen_px by renderBlockElementEnhanced()
             }
             // Also, the floating element or inline-block inner element vertical-align drift is dropped
             valign_dy = 0;
@@ -4355,7 +4379,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                             specified_width = width;
                         table_width = specified_width;
                     }
-                    int h = renderTable( context, enode, 0, y, table_width, shrink_to_fit, fitted_width );
+                    int h = renderTable( context, enode, 0, y, table_width, shrink_to_fit, 0, fitted_width );
                     // Should we really apply a specified height ?!
                     int st_h = lengthToPx( style->height, em, em );
                     if ( h < st_h )
@@ -6663,19 +6687,15 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // padding when erm_block or erm_final)
     // Otherwise, this block height will just be its rendered content height.
     int style_h = -1;
-    bool apply_style_height = false;
-    css_length_t style_height;
-    int style_height_base_em;
     if ( is_floating || is_inline_box ) {
         // Nothing special to do: the child style height will be
         // enforced by subcall to renderBlockElement(child)
     }
     else if ( is_hr || is_empty_line_elem || BLOCK_RENDERING(flags, ENSURE_STYLE_HEIGHT) ) {
-        // We always use the style height for <HR>, to actually have
-        // a height to fill with its color
-        style_height = style->height;
-        style_height_base_em = em;
-        apply_style_height = true;
+        // We always use the style height for <HR>, to actually have a height to fill
+        // with its color (as some of our css files render them via height)
+        bool apply_style_height = true;
+        css_length_t style_height = style->height;
         if ( is_empty_line_elem && style_height.type == css_val_unspecified ) {
             // No height specified: default to line-height, just like
             // if it were rendered final.
@@ -6699,22 +6719,43 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             style_height.value = line_h;
             style_height.type = css_val_screen_px;
         }
-    }
-    if ( apply_style_height && style_height.type != css_val_unspecified ) {
-        if ( !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
-                style_height.type != css_val_percent && style_height.type != css_val_em &&
-                style_height.type != css_val_ex && style_height.type != css_val_rem ) {
-            apply_style_height = false;
+        // We don't have a container height to apply heights in %, so ignore them
+        if ( style_height.type != css_val_unspecified && style_height.type != css_val_percent ) {
+            if ( !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                    style_height.type != css_val_screen_px && style_height.type != css_val_em &&
+                    style_height.type != css_val_ex && style_height.type != css_val_rem ) {
+                apply_style_height = false;
+            }
+            if ( is_hr || is_empty_line_elem || apply_style_height ) {
+                style_h = lengthToPx( style_height, 0, em );
+                if ( BLOCK_RENDERING(flags, USE_W3C_BOX_MODEL) ) {
+                    // If W3C box model requested, CSS height specifies the height
+                    // of the content box, so we just add paddings and borders
+                    // to the height we got from styles (paddings will be removed
+                    // when enforcing it below, but we keep the computation
+                    // common to both models doing it that way).
+                    style_h += padding_top + padding_bottom;
+                }
+            }
         }
-        if ( is_hr || is_empty_line_elem || apply_style_height ) {
-            style_h = lengthToPx( style_height, container_width, style_height_base_em );
-            if ( BLOCK_RENDERING(flags, USE_W3C_BOX_MODEL) ) {
-                // If W3C box model requested, CSS height specifies the height
-                // of the content box, so we just add paddings and borders
-                // to the height we got from styles (paddings will be removed
-                // when enforcing it below, but we keep the computation
-                // common to both models doing it that way).
-                style_h += padding_top + padding_bottom;
+        // We don't ensure max-height (we'll always use the height needed to show
+        // this block content without overflowing), but we can ensure min-height
+        css_length_t style_min_height = style->min_height;
+        if ( style_min_height.type != css_val_unspecified && style_min_height.type != css_val_percent
+                                                && BLOCK_RENDERING(flags, ENSURE_STYLE_HEIGHT) ) {
+            if ( !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                    style_min_height.type != css_val_screen_px && style_min_height.type != css_val_em &&
+                    style_min_height.type != css_val_ex && style_min_height.type != css_val_rem ) {
+                // Ignore it
+            }
+            else {
+                int style_min_h = lengthToPx( style_min_height, 0, em );
+                if ( BLOCK_RENDERING(flags, USE_W3C_BOX_MODEL) ) {
+                    style_min_h += padding_top + padding_bottom;
+                }
+                if ( style_h < style_min_h ) {
+                    style_h = style_min_h;
+                }
             }
         }
     }
@@ -6723,6 +6764,11 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     int width;
     bool auto_width = false;
     bool table_shrink_to_fit = false;
+    // Keep the computed values for min-width/max-width in case we need them
+    // (we do need min_width for tables with no width: that shrink to fit, and
+    // that we can just shrink less to ensure min-width)
+    int min_width = -1;
+    int max_width = -1;
 
     if ( is_floating || is_inline_box ) {
         // Floats width computation - which should also work as-is for inline block box
@@ -6752,13 +6798,56 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             }
         }
         // Same for width, as getRenderedWidths() won't ensure width in %
-        if ( child_style->width.type == css_val_percent ) {
+        if ( child->getNodeId() == el_img ) {
+            // For an image itself floating, get its computed width and height
+            // via getStyledImageSize() to properly ensure min/max-width/height
+            // and aspect ratio, and store them back as screen_px, so
+            // getRenderedWidths() and renderFinalBlock() can just use them.
             if (!style_changed) {
                 copystyle(child_style, newstyle);
                 style_changed = true;
             }
+            int img_width = 0;
+            int img_height = 0;
+            getStyledImageSize( child, img_width, img_height, container_width, -1 );
             newstyle->width.type = css_val_screen_px;
-            newstyle->width.value = lengthToPx( child_style->width, container_width, child_em );
+            newstyle->width.value = img_width;
+            newstyle->height.type = css_val_screen_px;
+            newstyle->height.value = img_height;
+            newstyle->min_width.type = css_val_unspecified;
+            newstyle->min_width.value = 0;
+            newstyle->min_height.type = css_val_unspecified;
+            newstyle->min_height.value = 0;
+            newstyle->max_width.type = css_val_unspecified;
+            newstyle->max_width.value = 0;
+            newstyle->max_height.type = css_val_unspecified;
+            newstyle->max_height.value = 0;
+        }
+        else {
+            if ( child_style->width.type == css_val_percent ) {
+                if (!style_changed) {
+                    copystyle(child_style, newstyle);
+                    style_changed = true;
+                }
+                newstyle->width.type = css_val_screen_px;
+                newstyle->width.value = lengthToPx( child_style->width, container_width, child_em );
+            }
+            if ( child_style->min_width.type == css_val_percent ) {
+                if (!style_changed) {
+                    copystyle(child_style, newstyle);
+                    style_changed = true;
+                }
+                newstyle->min_width.type = css_val_screen_px;
+                newstyle->min_width.value = lengthToPx( child_style->min_width, container_width, child_em );
+            }
+            if ( child_style->max_width.type == css_val_percent ) {
+                if (!style_changed) {
+                    copystyle(child_style, newstyle);
+                    style_changed = true;
+                }
+                newstyle->max_width.type = css_val_screen_px;
+                newstyle->max_width.value = lengthToPx( child_style->max_width, container_width, child_em );
+            }
         }
         // (We could do the same fot height if in %, but it looks like Firefox
         // just ignore floats height in %, so let's ignore them too.)
@@ -6822,7 +6911,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             width = container_width;
         }
         auto_width = true; // no more width tweaks (nor any x adjustment if is_rtl)
-        // printf("floatBox width: max_w=%d min_w=%d => %d", max_content_width, min_content_width, width);
+        // printf("floatBox width: max_w=%d min_w=%d => %d\n", max_content_width, min_content_width, width);
     }
     else if ( is_floatbox_child || is_inline_box_child ) {
         // The float style or rendered width has been applied to the wrapping
@@ -6845,6 +6934,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             if ( style_width.type != css_val_unspecified ) {
                 apply_style_width = BLOCK_RENDERING(flags, ENSURE_STYLE_WIDTH);
                 if ( apply_style_width && !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                        style_width.type != css_val_screen_px && // in case it was converted to screen_px beforehand
                         style_width.type != css_val_percent && style_width.type != css_val_em &&
                         style_width.type != css_val_ex && style_width.type != css_val_rem ) {
                     apply_style_width = false;
@@ -6889,6 +6979,50 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             width = container_width - margin_left - margin_right;
             auto_width = true; // no more width tweaks
         }
+        if ( BLOCK_RENDERING(flags, ENSURE_STYLE_WIDTH) ) {
+            // Whether there was a style width or not, we need to ensure the computed
+            // width fits between min-width and max-width if any specified.
+            // (we do that here only for regular elements - for floatBox and floatBox child,
+            // this is ensured naturally by the inner content measurement)
+            // We do max-width first, and then min-width (https://www.w3.org/TR/CSS2/visudet.html#min-max-widths)
+            css_length_t style_max_width = style->max_width;
+            if ( style_max_width.type != css_val_unspecified ) {
+                if ( !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                        style_max_width.type != css_val_screen_px && // in case it was converted to screen_px beforehand
+                        style_max_width.type != css_val_percent && style_max_width.type != css_val_em &&
+                        style_max_width.type != css_val_ex && style_max_width.type != css_val_rem ) {
+                    // Ignore it
+                }
+                else {
+                    max_width = lengthToPx( style_max_width, container_width, em );
+                    if ( style->display != css_d_table && BLOCK_RENDERING(flags, USE_W3C_BOX_MODEL) )
+                        max_width += padding_left + padding_right;
+                    if ( width > max_width ) {
+                        width = max_width;
+                        auto_width = false;
+                    }
+                }
+            }
+            css_length_t style_min_width = style->min_width;
+            if ( style_min_width.type != css_val_unspecified ) {
+                if ( !BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                        style_min_width.type != css_val_screen_px && // in case it was converted to screen_px beforehand
+                        style_min_width.type != css_val_percent && style_min_width.type != css_val_em &&
+                        style_min_width.type != css_val_ex && style_min_width.type != css_val_rem ) {
+                    // Ignore it
+                }
+                else {
+                    // As just above if apply_style_width
+                    min_width = lengthToPx( style_min_width, container_width, em );
+                    if ( style->display != css_d_table && BLOCK_RENDERING(flags, USE_W3C_BOX_MODEL) )
+                        min_width += padding_left + padding_right;
+                    if ( width < min_width ) {
+                        width = min_width;
+                        auto_width = false; // we may need to adjust x, ensure auto margins...
+                    }
+                }
+            }
+        }
     }
 
     // What about a width with a negative value?
@@ -6911,8 +7045,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     //   confused with such rect, and not travel thru them, or
     //   skip them.
     // - A table with a zero or negative width (which can happen
-    //   with very busy imbricated tables) won't be drawn, and
-    //   it's rendering method will be switched to erm_killed
+    //   with very crowded imbricated tables) won't be drawn, and
+    //   its rendering method will be switched to erm_killed
     //   to display some small visual indicator.
     // - Legacy rendering code keeps a negative width in
     //   RenderRectAccessor, and, with erm_final nodes, provides
@@ -7232,7 +7366,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // renderTable has not been updated to use 'flow', and it looks
                 // like it does not really need to.
                 int h = renderTable( *(flow->getPageContext()), enode, 0, flow->getCurrentRelativeY(),
-                            table_width, table_shrink_to_fit, fitted_width, direction, avoid_pb_inside, true, is_ruby_table );
+                            table_width, table_shrink_to_fit, min_width, fitted_width,
+                            direction, avoid_pb_inside, true, is_ruby_table );
                 // Reload fmt, as renderTable() may have set some flags
                 fmt = RenderRectAccessor( enode );
                 // (It feels like we don't need to ensure a table specified height.)
@@ -9927,6 +10062,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         }
 
         css_style_ref_t style = node->getStyle();
+        int em = node->getFont()->getSize();
 
         // Get image size early
         bool is_img = false;
@@ -10063,8 +10199,8 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 if ( style_width.type != css_val_unspecified && style_width.type != css_val_percent ) {
                     use_style_width = true;
                     if ( !BLOCK_RENDERING(rendFlags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
-                            style_width.type != css_val_percent && style_width.type != css_val_em &&
-                            style_width.type != css_val_ex && style_width.type != css_val_rem ) {
+                            style_width.type != css_val_screen_px && // when % converted to screen_px
+                            style_width.type != css_val_em && style_width.type != css_val_ex && style_width.type != css_val_rem ) {
                         use_style_width = false;
                     }
                     if ( node->getNodeId() == el_hr ) {
@@ -10076,7 +10212,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         }
 
         if ( use_style_width ) {
-            int em = node->getFont()->getSize();
             _maxWidth = lengthToPx( style_width, 0, em );
             _minWidth = _maxWidth;
         }
@@ -10095,7 +10230,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 curWordWidth = 0;
                 // We don't have any width yet to use for text-indent in % units,
                 // but this is very rare - use em as we must use something
-                int em = node->getFont()->getSize();
                 indent = lengthToPx(style->text_indent, em, em);
                 // First word will have text-indent as part of its width
                 if ( style->text_indent.value & 0x00000001 ) {
@@ -10369,7 +10503,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 int final_nb_cols = nb_columns;
                 if ( last_cell_start_column_idx < nb_columns-1 )
                     final_nb_cols = last_cell_start_column_idx + 1;
-                int em = node->getFont()->getSize();
                 int extra_width = lengthToPx(style->border_spacing[0], 0, em) * (final_nb_cols+1);
                 _minWidth += extra_width;
                 _maxWidth += extra_width;
@@ -10402,6 +10535,58 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             }
         }
 
+        // For all the previous cases, if ensuring width, ensure min-width and max-width, but at
+        // this point only. Now if USE_W3C_BOX_MODEL, later if not (after we've computed paddings)
+        int ensured_min_width_late = -1;
+        int ensured_max_width_late = -1;
+        if ( BLOCK_RENDERING(rendFlags, ENSURE_STYLE_WIDTH) && style->display <= css_d_table ) {
+            // We ignore width for table sub-elements.
+            // Table themselves, even when USE_W3C_BOX_MODEL, follow the border box model,
+            // so we'll apply them later.
+            bool ensure_min_max_width_later = !BLOCK_RENDERING(rendFlags, USE_W3C_BOX_MODEL) || style->display == css_d_table;
+            // Ignore widths in %, as we can't do much with them (for the starting node,
+            // they may have been converted to screen_px before calling us
+            // We do max-width first, and then min-width (https://www.w3.org/TR/CSS2/visudet.html#min-max-widths)
+            css_length_t style_max_width = style->max_width;
+            if ( style_max_width.type != css_val_unspecified && style_max_width.type != css_val_percent ) {
+                if ( !BLOCK_RENDERING(rendFlags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                        style_max_width.type != css_val_screen_px && // when % converted to screen_px
+                        style_max_width.type != css_val_em && style_max_width.type != css_val_ex && style_max_width.type != css_val_rem ) {
+                    // Ignore it
+                }
+                else {
+                    int max_width = lengthToPx( style_max_width, 0, em );
+                    if ( ensure_min_max_width_later )
+                        ensured_max_width_late = max_width;
+                    else {
+                        if ( _minWidth > max_width )
+                            _minWidth = max_width;
+                        if ( _maxWidth > max_width )
+                            _maxWidth = max_width;
+                    }
+                }
+            }
+            css_length_t style_min_width = style->min_width;
+            if ( style_min_width.type != css_val_unspecified && style_min_width.type != css_val_percent ) {
+                if ( !BLOCK_RENDERING(rendFlags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) &&
+                        style_min_width.type != css_val_screen_px && // when % converted to screen_px
+                        style_min_width.type != css_val_em && style_min_width.type != css_val_ex && style_min_width.type != css_val_rem ) {
+                    // Ignore it
+                }
+                else {
+                    int min_width = lengthToPx( style_min_width, 0, em );
+                    if ( ensure_min_max_width_later )
+                        ensured_min_width_late = min_width;
+                    else {
+                        if ( _minWidth < min_width )
+                            _minWidth = min_width;
+                        if ( _maxWidth < min_width )
+                            _maxWidth = min_width;
+                    }
+                }
+            }
+        }
+
         // For both erm_block or erm_final, adds padding/margin/border
         // to _maxWidth and _minWidth (see comment above)
 
@@ -10422,7 +10607,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         // below for each one to counterbalance rounding errors.)
         int padPct = 0; // cumulative percent
         int padPctNb = 0; // nb of styles in % (to add 1px)
-        int em = node->getFont()->getSize();
         // margin
         if (!ignoreMargin) {
             if (style->margin[0].type == css_val_percent) {
@@ -10467,6 +10651,20 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         // Add the non-pct values to make our base to invert-apply padPct
         _minWidth += padLeft + padRight;
         _maxWidth += padLeft + padRight;
+        // If we have some min/max-width to ensure late, do it now, before
+        // handling padPct that will change with the ensured widths
+        if ( ensured_max_width_late >= 0 ) {
+            if ( _minWidth > ensured_max_width_late )
+                _minWidth = ensured_max_width_late;
+            if ( _maxWidth > ensured_max_width_late )
+                _maxWidth = ensured_max_width_late;
+        }
+        if ( ensured_min_width_late >= 0 ) {
+            if ( _minWidth < ensured_min_width_late )
+                _minWidth = ensured_min_width_late;
+            if ( _maxWidth < ensured_min_width_late )
+                _maxWidth = ensured_min_width_late;
+        }
         // For length in %, the % (P, padPct) should be from the outer width (L),
         // but we have only the inner width (w). We have w and P, we want L-w (m).
         //   m = L*P  and  w = L - m

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2442,6 +2442,181 @@ int lengthToPx( css_length_t val, int base_px, int base_em, bool unspecified_as_
     return px;
 }
 
+#define DUMMY_IMAGE_SIZE 16
+bool getStyledImageSize( ldomNode * enode, int & img_width, int & img_height, int container_width, int container_height ) {
+    if ( enode->getNodeId() != el_img )
+        return false;
+    LVImageSourceRef img = enode->getObjectImageSource();
+    if ( img.isNull() )
+        img = LVCreateDummyImageSource( enode, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
+
+    // Get native image size
+    int native_width = img->GetWidth();
+    int native_height = img->GetHeight();
+    if ( native_width < 0 || native_height < 0 ) {
+        // Just to be sure we have positive sizes
+        return false;
+    }
+    // Scale image native size according to gRenderDPI
+    native_width = scaleForRenderDPI(native_width);
+    native_height = scaleForRenderDPI(native_height);
+
+    // Look at style widths/heights
+    int em = enode->getFont()->getSize();
+    css_style_ref_t style = enode->getStyle();
+
+    // These will stay -1 when the CSS property is not specified or ignored
+    // Below, for checks against min_width/height, this works literally,
+    // but for max_width/height, we need to check they are >= 0 before
+    // ensuring them.
+    int width = -1;
+    int height = -1;
+    int min_width = -1;
+    int min_height = -1;
+    int max_width = -1;
+    int max_height = -1;
+    // We don't apply values in % when no container width or height is provided
+    // which is what's suggested when they are not yet known:
+    // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
+    if ( style->width.type != css_val_unspecified && (container_width >= 0 || style->width.type != css_val_percent) )
+        width = lengthToPx(style->width, container_width, em);
+    if ( style->min_width.type != css_val_unspecified && (container_width >= 0 || style->min_width.type != css_val_percent) )
+        min_width = lengthToPx(style->min_width, container_width, em);
+    if ( style->max_width.type != css_val_unspecified && (container_width >= 0 || style->max_width.type != css_val_percent) )
+        max_width = lengthToPx(style->max_width, container_width, em);
+    if ( style->height.type != css_val_unspecified && (container_height >= 0 || style->height.type != css_val_percent) )
+        height = lengthToPx(style->height, container_height, em);
+    if ( style->min_height.type != css_val_unspecified && (container_height >= 0 || style->min_height.type != css_val_percent) )
+        min_height = lengthToPx(style->min_height, container_height, em);
+    if ( style->max_height.type != css_val_unspecified && (container_height >= 0 || style->max_height.type != css_val_percent) )
+        max_height = lengthToPx(style->max_height, container_height, em);
+
+    // Note: we are usually not provided a container_height.
+    // If we get above a *height with a value in %, we could think about doing
+    // the expensive job of walking the image parents to find a block container
+    // with an explicite CSS height not-in-%. We then could use that, removing
+    // all intermediate padding/margin/border, to get this image container height.
+    // But this parent container height might not even be enforced, and it feels
+    // really tedious - so let's think about that when if feels really needed.
+
+    // Get the width and height to use (the "used values" in the specs)
+    int w;
+    int h;
+    // This follows the specs from https://www.w3.org/TR/CSS21/visudet.html
+    // (which is different than the first intuitive way at going at it),
+    // confirmed by looking how it's implemented in WeasyPrint, and actually
+    // giving the same results as Firefox.
+    if ( width >= 0 || height >= 0 ) {
+        // We have at least one of width or height specified
+        // Get width
+        if ( width >= 0 ) { // We have a width
+            w = width;
+        }
+        else { // We have a height but no width: get width to keep aspect ratio
+            w = height * native_width / native_height;
+        }
+        // Ensure widths constraints
+        if ( max_width >= 0 && w > max_width)
+            w = max_width;
+        if ( w < min_width )
+            w = min_width;
+        // Get height
+        if ( height >= 0 ) { // We have a height
+            h = height;
+        }
+        else { // We have computed a width: get height to keep aspect ratio
+            h = w * native_height / native_width;
+        }
+        // Ensure heights constraints
+        if ( max_height >= 0 && h > max_height)
+            h = max_height;
+        if ( h < min_height )
+            h = min_height;
+    }
+    else {
+        // No CSS width nor height: use native image size
+        w = native_width;
+        h = native_height;
+        // We have the preferred image size, ensure min/max-width/height if any
+        // Follow the rules in case of constraint violations from:
+        // https://www.w3.org/TR/CSS2/visudet.html#min-max-widths
+        // "However, for replaced elements with an intrinsic ratio and *both* 'width'
+        // and 'height' specified as 'auto', the algorithm is as follows..."
+        // 10 rules (excluding none) in the table
+        // We follow them literally without thinking too much
+        if ( max_width >= 0 && w > max_width ) {
+            if ( max_height >= 0 && h > max_height ) {
+                if (max_width <= max_height * w / h ) { // rule 5
+                    int h2 = max_width * h / w;
+                    h = h2 > min_height ? h2 : min_height;
+                    w = max_width;
+                }
+                else { // rule 6
+                    int w2 = max_height * w / h;
+                    w = w2 > min_width ? w2 : min_width;
+                    h = max_height;
+                }
+            }
+            else if ( h < min_height ) { // rule 10
+                w = max_width;
+                h = min_height;
+            }
+            else { // rule 1 (similar to rule 5)
+                int h2 = max_width * h / w;
+                h = h2 > min_height ? h2 : min_height;
+                w = max_width;
+            }
+        }
+        else if ( max_height >= 0 && h > max_height ) {
+            if ( w < min_width ) { // rule 9
+                w = min_width;
+                h = max_height;
+            }
+            else { // rule 3 (similar to rule 6)
+                int w2 = max_height * w / h;
+                w = w2 > min_width ? w2 : min_width;
+                h = max_height;
+            }
+        }
+        else if ( w < min_width ) {
+            if ( h < min_height ) {
+                if (min_width <= min_height * w / h ) { // rule 7
+                    w = min_height * w / h;
+                    if ( max_width >= 0 && w > max_width) {
+                        w = max_width;
+                    }
+                    h = min_height;
+                }
+                else { // rule 8
+                    h = min_width * h / w;
+                    if ( max_height >= 0 && h > max_height) {
+                        h = max_height;
+                    }
+                    w = min_width;
+                }
+            }
+            else { // rule 2 (similar to rule 8)
+                h = min_width * h / w;
+                if ( max_height >= 0 && h > max_height) {
+                    h = max_height;
+                }
+                w = min_width;
+            }
+        }
+        else if ( h < min_height ) { // rule 4 (similar to rule 7)
+            w = min_height * w / h;
+            if ( max_width >= 0 && w > max_width) {
+                w = max_width;
+            }
+            h = min_height;
+        }
+    }
+
+    img_width = w;
+    img_height = h;
+    return true;
+}
+
 void SplitLines( const lString32 & str, lString32Collection & lines )
 {
     const lChar32 * s = str.c_str();
@@ -9755,56 +9930,20 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
 
         // Get image size early
         bool is_img = false;
-        lInt16 img_width = 0;
+        int img_width = 0;
         if ( node->getNodeId()==el_img ) {
             is_img = true;
-            // (as in lvtextfm.cpp LFormattedText::AddSourceObject)
-            #define DUMMY_IMAGE_SIZE 16
-            LVImageSourceRef img = node->getObjectImageSource();
-            if ( img.isNull() )
-                img = LVCreateDummyImageSource( node, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
-            lInt16 width = (lUInt16)img->GetWidth();
-            lInt16 height = (lUInt16)img->GetHeight();
-            // Scale image native size according to gRenderDPI
-            width = scaleForRenderDPI(width);
-            height = scaleForRenderDPI(height);
-            // Adjust if size defined by CSS
-            int w = 0, h = 0;
-            int em = node->getFont()->getSize();
-            w = lengthToPx(style->width, 100, em);
-            h = lengthToPx(style->height, 100, em);
-            if (style->width.type==css_val_percent) w = -w;
-            if (style->height.type==css_val_percent) h = w*height/width;
-            if ( w==0 ) {
-                if ( h==0 ) { // use image native size
-                    w = width;
-                } else { // use style height, keep aspect ratio
-                    w = width*h/height;
-                }
-            }
-            if (w > 0)
-                img_width = w;
-            else { // 0 or styles were in %
-                // This is a bit tricky...
-                // When w < 0, the style width was in %, which means % of the
-                // container width.
-                // So it does not influence the width we're trying to guess, and will
-                // adjust to the final width. So, we could let it to be 0.
-                // But, if this image is the single element of this block, we would
-                // end up with a minWidth of 0, with no room for the image, and the
-                // image would be scaled as a % of 0, so to 0.
-                // So, consider we want the image to be shown as a % of its original
-                // size: so, our width should be the original image width.
-                img_width = width;
-                // With that, it looks like we behave exactly as Firefox, whether
-                // the image is single in a cell, or surrounded, in this cell
-                // and/or sibling cells, by small or long text!
-                // We ensure a minimal size of 1em (so it shows as least the size
-                // of a letter).
-                int em = node->getFont()->getSize();
-                if (img_width < em)
-                    img_width = em;
-            }
+            int unused_height = 0;
+            // We have no container width/height to provide: CSS width and
+            // height in % won't apply and default to their initial value
+            // of none or auto, so as if there wasn't any.
+            // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
+            getStyledImageSize( node, img_width, unused_height );
+                // We got a single width (the normal image width, constrained
+                // between min-width and max-width if any): we use it to update
+                // both minWidth/maxWidth in here (the CSS properties with the
+                // same name should not influence the minWidth and maxWidth we
+                // try to compute int here).
         }
 
         if (m == erm_inline) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -65,6 +65,10 @@ enum css_decl_code {
     cssd_letter_spacing,
     cssd_width,
     cssd_height,
+    cssd_min_width,
+    cssd_min_height,
+    cssd_max_width,
+    cssd_max_height,
     cssd_margin_left,
     cssd_margin_right,
     cssd_margin_top,
@@ -158,6 +162,10 @@ static const char * css_decl_name[] = {
     "letter-spacing",
     "width",
     "height",
+    "min-width",
+    "min-height",
+    "max-width",
+    "max-height",
     "margin-left",
     "margin-right",
     "margin-top",
@@ -448,6 +456,7 @@ static bool parse_number_value( const char * & str, css_length_t & value,
                                     bool accept_percent=true,
                                     bool accept_negative=false,
                                     bool accept_auto=false,
+                                    bool accept_none=false,
                                     bool accept_normal=false,
                                     bool accept_contain_cover=false,
                                     bool is_font_size=false )
@@ -464,6 +473,11 @@ static bool parse_number_value( const char * & str, css_length_t & value,
     if ( accept_auto && substr_icompare( "auto", str ) ) {
         value.type = css_val_unspecified;
         value.value = css_generic_auto;
+        return true;
+    }
+    if ( accept_none && substr_icompare( "none", str ) ) {
+        value.type = css_val_unspecified;
+        value.value = css_generic_none;
         return true;
     }
     if ( accept_normal && substr_icompare( "normal", str ) ) {
@@ -2324,6 +2338,10 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
             case cssd_font_size:
             case cssd_width:
             case cssd_height:
+            case cssd_min_width:
+            case cssd_min_height:
+            case cssd_max_width:
+            case cssd_max_height:
             case cssd_margin_left:
             case cssd_margin_right:
             case cssd_margin_top:
@@ -2343,12 +2361,21 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                     if ( prop_code==cssd_margin_bottom || prop_code==cssd_margin_top ||
                             prop_code==cssd_margin_left || prop_code==cssd_margin_right )
                         accept_negative = true;
-                    // only margin, width and height accept keyword "auto"
+                    // only margin, width, height, min-width, min-height accept keyword "auto"
+                    // (also accept it with max-width, max-height for style tweaks user sake)
                     bool accept_auto = false;
                     if ( prop_code==cssd_margin_bottom || prop_code==cssd_margin_top ||
                             prop_code==cssd_margin_left || prop_code==cssd_margin_right ||
-                            prop_code==cssd_width || prop_code==cssd_height )
+                            prop_code==cssd_width || prop_code==cssd_height ||
+                            prop_code==cssd_min_width || prop_code==cssd_min_height ||
+                            prop_code==cssd_max_width || prop_code==cssd_max_height )
                         accept_auto = true;
+                    // only max-width, max-height accept keyword "none"
+                    // (also accepts it with min-width, min-height for style tweaks user sake)
+                    bool accept_none = false;
+                    if ( prop_code==cssd_max_width || prop_code==cssd_max_height ||
+                            prop_code==cssd_min_width || prop_code==cssd_min_height )
+                        accept_none = true;
                     // only line-height and letter-spacing accept keyword "normal"
                     bool accept_normal = false;
                     if ( prop_code==cssd_line_height || prop_code==cssd_letter_spacing )
@@ -2358,7 +2385,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                     if ( prop_code==cssd_font_size )
                         is_font_size = true;
                     css_length_t len;
-                    if ( parse_number_value( decl, len, accept_percent, accept_negative, accept_auto, accept_normal, false, is_font_size) ) {
+                    if ( parse_number_value( decl, len, accept_percent, accept_negative, accept_auto, accept_none, accept_normal, false, is_font_size) ) {
                         buf<<(lUInt32) (prop_code | importance | parse_important(decl));
                         buf<<(lUInt32) len.type;
                         buf<<(lUInt32) len.value;
@@ -2809,7 +2836,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                     css_length_t len[2];
                     int i;
                     for (i = 0; i < 2; i++) {
-                        if ( !parse_number_value( decl, len[i], true, false, true, false, true ) )
+                        if ( !parse_number_value( decl, len[i], true, false, true, false, false, true ) )
                             break;
                     }
                     if (i) {
@@ -3037,6 +3064,18 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_height:
             style->Apply( read_length(p), &style->height, imp_bit_height, is_important );
+            break;
+        case cssd_min_width:
+            style->Apply( read_length(p), &style->min_width, imp_bit_min_width, is_important );
+            break;
+        case cssd_min_height:
+            style->Apply( read_length(p), &style->min_height, imp_bit_min_height, is_important );
+            break;
+        case cssd_max_width:
+            style->Apply( read_length(p), &style->max_width, imp_bit_max_width, is_important );
+            break;
+        case cssd_max_height:
+            style->Apply( read_length(p), &style->max_height, imp_bit_max_height, is_important );
             break;
         case cssd_margin_left:
             style->Apply( read_length(p), &style->margin[0], imp_bit_margin_left, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,11 +44,13 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
+         + (lUInt32)rec.important[2]) * 31
          + (lUInt32)rec.importance[0]) * 31
          + (lUInt32)rec.importance[1]) * 31
+         + (lUInt32)rec.importance[2]) * 31
          + (lUInt32)rec.display) * 31
          + (lUInt32)rec.white_space) * 31
          + (lUInt32)rec.text_align) * 31
@@ -71,6 +73,10 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.background_color.pack()) * 31
          + (lUInt32)rec.width.pack()) * 31
          + (lUInt32)rec.height.pack()) * 31
+         + (lUInt32)rec.min_width.pack()) * 31
+         + (lUInt32)rec.min_height.pack()) * 31
+         + (lUInt32)rec.max_width.pack()) * 31
+         + (lUInt32)rec.max_height.pack()) * 31
          + (lUInt32)rec.text_indent.pack()) * 31
          + (lUInt32)rec.margin[0].pack()) * 31
          + (lUInt32)rec.margin[1].pack()) * 31
@@ -117,8 +123,10 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
     return 
            r1.important[0] == r2.important[0] &&
            r1.important[1] == r2.important[1] &&
+           r1.important[2] == r2.important[2] &&
            r1.importance[0] == r2.importance[0] &&
            r1.importance[1] == r2.importance[1] &&
+           r1.importance[2] == r2.importance[2] &&
            r1.display == r2.display &&
            r1.white_space == r2.white_space &&
            r1.text_align == r2.text_align &&
@@ -132,6 +140,10 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.line_height == r2.line_height &&
            r1.width == r2.width &&
            r1.height == r2.height &&
+           r1.min_width == r2.min_width &&
+           r1.min_height == r2.min_height &&
+           r1.max_width == r2.max_width &&
+           r1.max_height == r2.max_height &&
            r1.color == r2.color &&
            r1.background_color == r2.background_color &&
            r1.text_indent == r2.text_indent &&
@@ -317,8 +329,10 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     buf.putMagic(style_magic);
     buf << important[0];            //    lUInt32              important[0];
     buf << important[1];            //    lUInt32              important[1];
+    buf << important[2];            //    lUInt32              important[2];
     buf << importance[0];           //    lUInt32              importance[0];
     buf << importance[1];           //    lUInt32              importance[1];
+    buf << importance[2];           //    lUInt32              importance[2];
     ST_PUT_ENUM(display);           //    css_display_t        display;
     ST_PUT_ENUM(white_space);       //    css_white_space_t    white_space;
     ST_PUT_ENUM(text_align);        //    css_text_align_t     text_align;
@@ -336,6 +350,10 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
     ST_PUT_LEN(height);             //    css_length_t         height;
+    ST_PUT_LEN(min_width);          //    css_length_t         min_width;
+    ST_PUT_LEN(min_height);         //    css_length_t         min_height;
+    ST_PUT_LEN(max_width);          //    css_length_t         max_width;
+    ST_PUT_LEN(max_height);         //    css_length_t         max_height;
     ST_PUT_LEN4(margin);            //    css_length_t         margin[4]; ///< margin-left, -right, -top, -bottom
     ST_PUT_LEN4(padding);           //    css_length_t         padding[4]; ///< padding-left, -right, -top, -bottom
     ST_PUT_LEN(color);              //    css_length_t         color;
@@ -380,8 +398,10 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     buf.putMagic(style_magic);
     buf >> important[0];                                    //    lUInt32              important[0];
     buf >> important[1];                                    //    lUInt32              important[1];
+    buf >> important[2];                                    //    lUInt32              important[2];
     buf >> importance[0];                                   //    lUInt32              importance[0];
     buf >> importance[1];                                   //    lUInt32              importance[1];
+    buf >> importance[2];                                   //    lUInt32              importance[2];
     ST_GET_ENUM(css_display_t, display);                    //    css_display_t        display;
     ST_GET_ENUM(css_white_space_t, white_space);            //    css_white_space_t    white_space;
     ST_GET_ENUM(css_text_align_t, text_align);              //    css_text_align_t     text_align;
@@ -399,6 +419,10 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;
     ST_GET_LEN(height);                                     //    css_length_t         height;
+    ST_GET_LEN(min_width);                                  //    css_length_t         min_width;
+    ST_GET_LEN(min_height);                                 //    css_length_t         min_height;
+    ST_GET_LEN(max_width);                                  //    css_length_t         max_width;
+    ST_GET_LEN(max_height);                                 //    css_length_t         max_height;
     ST_GET_LEN4(margin);                                    //    css_length_t         margin[4]; ///< margin-left, -right, -top, -bottom
     ST_GET_LEN4(padding);                                   //    css_length_t         padding[4]; ///< padding-left, -right, -top, -bottom
     ST_GET_LEN(color);                                      //    css_length_t         color;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -305,8 +305,6 @@ void lvtextAddSourceObject(
 
 #ifdef __cplusplus
 
-#define DUMMY_IMAGE_SIZE 16
-
 void LFormattedText::AddSourceObject(
             lUInt32         flags,     /* flags */
             lInt16          interval,  /* line height in screen pixels */
@@ -322,71 +320,26 @@ void LFormattedText::AddSourceObject(
         TR("LFormattedText::AddSourceObject(): node is NULL!");
         return;
     }
-
-    if (flags & LTEXT_SRC_IS_FLOAT) { // not an image but a float:'ing node
-        // Nothing much to do with it at this point
-        lvtextAddSourceObject(m_pbuffer, 0, 0,
-            flags, interval, valign_dy, indent, object, lang_cfg, letter_spacing );
-            // lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT
-            // (only flags & object parameter will be used, the others are not,
-            // but they matter if this float is the first node in a paragraph,
-            // as the code may grab them from the first source)
-        return;
-    }
-    if (flags & LTEXT_SRC_IS_INLINE_BOX) { // not an image but a inline-block wrapping node
-        // Nothing much to do with it at this point: we can't yet render it to
-        // get its width & neight, as they might be in % of our main width, that
-        // we don't know yet (but only when ->Format() is called).
-        lvtextAddSourceObject(m_pbuffer, 0, 0,
-            flags, interval, valign_dy, indent, object, lang_cfg, letter_spacing );
-            // lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT
-        return;
-    }
-
-    LVImageSourceRef img = node->getObjectImageSource();
-    if ( img.isNull() )
-        img = LVCreateDummyImageSource( node, DUMMY_IMAGE_SIZE, DUMMY_IMAGE_SIZE );
-    lInt16 width = (lUInt16)img->GetWidth();
-    lInt16 height = (lUInt16)img->GetHeight();
-
-    // Scale image native size according to gRenderDPI
-    width = scaleForRenderDPI(width);
-    height = scaleForRenderDPI(height);
-
-    css_style_ref_t style = node->getStyle();
-    lInt16 w = 0, h = 0;
-    int em = node->getFont()->getSize();
-    w = lengthToPx(style->width, 100, em);
-    h = lengthToPx(style->height, 100, em);
-    // width in % will be computed in measureText() as a % of m_pbuffer->width
-    // For height in %, it's more complicated... see:
-    //   https://www.w3.org/TR/CSS2/visudet.html#the-width-property
-    //   https://www.w3.org/TR/CSS2/visudet.html#the-height-property
-    //   https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-height
-    //   https://drafts.csswg.org/css-sizing-3/#extrinsic
-    if (style->width.type == css_val_percent)
-        w = -w;
-    if (style->height.type == css_val_percent)
-        h = w*height/width;
-
-    if ( w*h==0 ) {
-        if ( w==0 ) {
-            if ( h==0 ) { // use image native size
-                h = height;
-                w = width;
-            } else { // use style height, keep aspect ratio
-                w = width*h/height;
-            }
-        } else if ( h==0 ) { // use style width, keep aspect ratio
-            h = w*height/width;
-            if (h == 0) h = height;
-        }
-    }
-    width = w;
-    height = h;
-
-    lvtextAddSourceObject(m_pbuffer, width, height,
+    // Whether the object is a float, an inline-block or an image,
+    // nothing much to do with it at this point: we add it with
+    // 0-width/height, they will be computed later.
+    // (lvtextAddSourceObject will itself add to flags: | LTEXT_SRC_IS_OBJECT)
+    lvtextAddSourceObject(m_pbuffer, 0, 0,
         flags, interval, valign_dy, indent, object, lang_cfg, letter_spacing );
+
+    // Notes about the 3 cases:
+    // if (flags & LTEXT_SRC_IS_FLOAT):
+    //   Only flags & object parameter will be used, the others are not,
+    //   but they matter if this float is the first node in a paragraph,
+    //   as the code may grab them from the first source
+    // if (flags & LTEXT_SRC_IS_INLINE_BOX):
+    //   We can't yet render it to get its width & neight, as they might
+    //   be in % of our main width, that we don't know yet (but only
+    //   when ->Format() is called).
+    // otherwise, it's an image:
+    //   Handling CSS width and height (and min/max-width/height) will be done
+    //   in measureText(), where we know about the buffer width (its container
+    //   width) and can better apply values in %
 }
 
 class LVFormatter {
@@ -2069,17 +2022,16 @@ public:
                     else {
                         // measure image
                         // assume i==start+1
-                        int width = m_srcs[start]->o.width;
-                        int height = m_srcs[start]->o.height;
-                        // Negative width and height mean the value is a % (of our final block width)
-                        width = width<0 ? (-width * (m_pbuffer->width) / 100) : width;
-                        height = height<0 ? (-height * (m_pbuffer->width) / 100) : height;
-                        /*
-                        printf("measureText img: o.w=%d o.h=%d > w=%d h=%d (max %d %d is_inline=%d) %s\n",
-                            m_srcs[start]->o.width, m_srcs[start]->o.height, width, height,
-                            m_pbuffer->width, m_max_img_height, m_length>1,
-                            UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
-                        */
+                        src_text_fragment_t * src = m_srcs[start];
+                        ldomNode * node = (ldomNode *) src->object;
+                        int width = 0;
+                        int height = 0;
+                        // We have yet no container height to provide for CSS heights in %,
+                        // so they won't apply
+                        getStyledImageSize( node, width, height, m_pbuffer->width, -1 );
+                        // Ensure they are constrained to this paragraph width and page height
+                        // Note: resizeImage() may do some additional scaling depending on image_scaling_options,
+                        // use mode=0 scale=1 for these if this is not desirable.
                         resizeImage(width, height, m_pbuffer->width, m_max_img_height, m_length>1);
                         if ( (m_srcs[start]->flags & LTEXT_STRUT_CONFINED) && m_allow_strut_confining ) {
                             // Text with "-cr-hint: strut-confined" might just be vertically shifted,
@@ -2092,12 +2044,16 @@ public:
                                 height = m_pbuffer->strut_height;
                             }
                         }
-                        // Store the possibly resized dimensions back, so we don't have
-                        // to recompute them later
+                        // Store the computed image dimensions
                         m_srcs[start]->o.width = width;
                         m_srcs[start]->o.height = height;
                         lastWidth += width;
                         m_widths[start] = lastWidth;
+                        /*
+                        printf("measureText img: o.w=%d o.h=%d (max %d %d is_inline=%d) %s\n",
+                            width, height, m_pbuffer->width, m_max_img_height, m_length>1,
+                            UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
+                        */
                     }
                 }
                 else {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -149,7 +149,6 @@ formatted_text_fragment_t * lvtextAllocFormatter( lUInt16 width )
     pbuffer->light_formatting = false;
     int defMode = MAX_IMAGE_SCALE_MUL > 1 ? (ARBITRARY_IMAGE_SCALE_ENABLED==1 ? 2 : 1) : 0;
     int defMult = MAX_IMAGE_SCALE_MUL;
-    // Notes from thornyreader:
     // mode: 0=disabled, 1=integer scaling factors, 2=free scaling
     // scale: 0=auto based on font size, 1=no zoom, 2=scale up to *2, 3=scale up to *3
     pbuffer->img_zoom_in_mode_block = defMode; /**< can zoom in block images: 0=disabled, 1=integer scale, 2=free scale */
@@ -1590,24 +1589,24 @@ public:
                 if ( m_pbuffer->img_zoom_in_mode_inline==0 )
                     return; // no zoom
                 arbitraryImageScaling = m_pbuffer->img_zoom_in_mode_inline == 2;
-                // maxScale = m_pbuffer->img_zoom_in_scale_inline;
+                maxScale = m_pbuffer->img_zoom_in_scale_inline;
             } else {
 //                if ( m_pbuffer->img_zoom_out_mode_inline==0 )
 //                    return; // no zoom
                 arbitraryImageScaling = m_pbuffer->img_zoom_out_mode_inline == 2;
-                // maxScale = m_pbuffer->img_zoom_out_scale_inline;
+                maxScale = m_pbuffer->img_zoom_out_scale_inline;
             }
         } else {
             if ( zoomIn ) {
                 if ( m_pbuffer->img_zoom_in_mode_block==0 )
                     return; // no zoom
                 arbitraryImageScaling = m_pbuffer->img_zoom_in_mode_block == 2;
-                // maxScale = m_pbuffer->img_zoom_in_scale_block;
+                maxScale = m_pbuffer->img_zoom_in_scale_block;
             } else {
 //                if ( m_pbuffer->img_zoom_out_mode_block==0 )
 //                    return; // no zoom
                 arbitraryImageScaling = m_pbuffer->img_zoom_out_mode_block == 2;
-                // maxScale = m_pbuffer->img_zoom_out_scale_block;
+                maxScale = m_pbuffer->img_zoom_out_scale_block;
             }
         }
         resizeImage( width, height, maxw, maxh, arbitraryImageScaling, maxScale );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.56k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.57k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0026
 


### PR DESCRIPTION
See https://github.com/koreader/crengine/issues/360#issuecomment-756810641. Closes #360.

`CSS: parse and store min/max-width/height`

Increase nb of bitmaps from 2 to 3 lUInt32 as we're going over 64 properties.

`Add getStyledImageSize() ensuring min/max-width/height`

Compute image size according to CSS2 specs, ensuring CSS `width`, `height`, `min-width`, `min-height`, `max-width` and `max-height`.
Used in lvtextfm when drawing images, and when estimating block widths in `getRenderedWidths()` instead of the previous wrong computation.
Limitation: heights in `%` are not supported and ignored.

`renderBlockElementEnhanced(): ensure min/max-width/height`

Ensure `min-width`, `min-height`, `max-width` (but not `max-height`) on block elements, inline-block/table, block floats and floating images (`min-height` in `%` not supported).
Ensure `min-width` on the table element itself (but not supported on the table inner elements like cells and cols).

----

Also includes:
`EPUB ncx TOC: allow items with an empty title`
No reason to ignore them - and they may have sub-items with non-empty titles that would all be ignored. https://github.com/koreader/koreader/issues/5961#issuecomment-761811168

`resizeImage(): restore original scaling options code`

It was hardcoded'ly removed as part of #35 9214bfc59 when implementing support for CSS width & height for images, so they don't get in the way.
Removed the hardcoding so the original CoolReader settings can work again. https://github.com/buggins/coolreader/pull/125#issuecomment-759421443
We can still disable that from frontend code with:
```lua
-- Disable crengine image scaling options (we prefer scaling them via crengine.render.dpi)
self._document:setIntProperty("crengine.image.scaling.zoomin.block.mode", 0)
self._document:setIntProperty("crengine.image.scaling.zoomin.block.scale", 1)
self._document:setIntProperty("crengine.image.scaling.zoomin.inline.mode", 0)
self._document:setIntProperty("crengine.image.scaling.zoomin.inline.scale", 1)
self._document:setIntProperty("crengine.image.scaling.zoomout.block.mode", 0)
self._document:setIntProperty("crengine.image.scaling.zoomout.block.scale", 1)
self._document:setIntProperty("crengine.image.scaling.zoomout.inline.mode", 0)
self._document:setIntProperty("crengine.image.scaling.zoomout.inline.scale", 1)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/409)
<!-- Reviewable:end -->
