### PR TITLE
2-pages mode: twoVisiblePagesAsOnePageNumber, single wide header

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -940,6 +940,11 @@ public:
     void Render( int dx=0, int dy=0, LVRendPageList * pages=NULL );
     /// set properties before rendering
     void setRenderProps( int dx, int dy );
+    /// Return a hash accounting for the rendering and the pages layout
+    /// A changed hash let frontends know their cached values of some document
+    /// properties (full height, TOC pages...) may have changed and that they
+    /// need to fetch them again
+    lUInt32 getDocumentRenderingHash();
 
     /// Constructor
     LVDocView( int bitsPerPixel=-1, bool noDefaultDocument=false );

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -402,7 +402,7 @@ protected:
     bool getCursorDocRect( ldomXPointer ptr, lvRect & rc );
 public:
     /// get outer (before margins are applied) page rectangle
-    virtual void getPageRectangle( int pageIndex, lvRect & pageRect );
+    virtual void getPageRectangle( int pageIndex, lvRect & pageRect, bool mergeTwoPages=false );
     /// get screen rectangle for specified cursor position, returns false if not visible
     bool getCursorRect( ldomXPointer ptr, lvRect & rc, bool scrollToCursor = false );
     /// set status bar and clock mode
@@ -604,7 +604,7 @@ public:
     /// returns number of images on current page
     int getCurrentPageImageCount();
     /// calculate page header rectangle
-    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc );
+    virtual void getPageHeaderRectangle( int pageIndex, lvRect & headerRc, bool mergeTwoHeaders=false );
     /// calculate page header height
     virtual int getPageHeaderHeight( );
     /// set list of icons to display at left side of header

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -41,6 +41,7 @@
 #define PROP_BOOKMARK_ICONS          "crengine.bookmarks.icons"
 #define PROP_FOOTNOTES               "crengine.footnotes"
 #define PROP_SHOW_TIME               "window.status.clock"
+#define PROP_SHOW_TIME_12HOURS       "window.status.clock.12hours"
 #define PROP_SHOW_TITLE              "window.status.title"
 #define PROP_STATUS_CHAPTER_MARKS    "crengine.page.header.chapter.marks"
 #define PROP_SHOW_BATTERY            "window.status.battery"

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -50,6 +50,7 @@
 #define PROP_SHOW_BATTERY_PERCENT    "window.status.battery.percent"
 //#define PROP_FONT_KERNING_ENABLED    "font.kerning.enabled"
 #define PROP_LANDSCAPE_PAGES         "window.landscape.pages"
+#define PROP_PAGES_TWO_VISIBLE_AS_ONE_PAGE_NUMBER         "window.pages.two.visible.as.one.page.number"
 #define PROP_AUTOSAVE_BOOKMARKS      "crengine.autosave.bookmarks"
 
 // Obsolete hyph settings:

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2419,6 +2419,7 @@ private:
     bool _toc_from_cache_valid;
     lUInt32 _warnings_seen_bitmap;
     ldomXRangeList _selections;
+    lUInt32 _doc_rendering_hash;
 #endif
 
     lString32 _docStylesheetFileName;
@@ -2453,6 +2454,7 @@ protected:
 public:
 
 #if BUILD_LITE!=1
+    lUInt32 getDocumentRenderingHash() { return _doc_rendering_hash; }
     void forceReinitStyles() {
         dropStyles();
         _hdr.render_style_hash = 0;

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2243,8 +2243,10 @@ public:
     bool hasAlternativeTocFlag() { return _level==0 && _page==1; }
 
     /// When page numbers have been calculated, LVDocView::updatePageNumbers()
-    /// sets the root toc item _percent to -1. So let's use it to know that fact.
-    bool hasValidPageNumbers() { return _level==0 && _percent == -1; }
+    /// sets the root toc item _percent to -visible_page_numbers.
+    bool hasValidPageNumbers(int current_visible_page_numbers) {
+        return _level==0 && _percent == -current_visible_page_numbers;
+    }
     void invalidatePageNumbers() { if (_level==0) _percent = 0; }
 };
 
@@ -2292,7 +2294,7 @@ class LVPageMap
     friend class LVDocView;
 private:
     ldomDocument *  _doc;
-    bool            _page_info_valid;
+    int             _valid_for_visible_page_numbers;
     lString32       _source;
     LVPtrVector<LVPageMapItem> _children;
     void addPage( LVPageMapItem * item ) {
@@ -2317,14 +2319,19 @@ public:
         return item;
     }
     void clear() { _children.clear(); }
-    bool hasValidPageInfo() { return _page_info_valid; }
-    void invalidatePageInfo() { _page_info_valid = false; }
+    bool hasValidPageInfo(int current_visible_page_numbers) {
+        return _valid_for_visible_page_numbers == current_visible_page_numbers;
+    }
+    void setPageValidForVisiblePageNumbers(int visible_page_numbers) {
+        _valid_for_visible_page_numbers = visible_page_numbers;
+    }
+    void invalidatePageInfo() { _valid_for_visible_page_numbers = 0; }
     // Page source (info about the book paper version the page labels reference)
     void setSource( lString32 source ) { _source = source; }
     lString32 getSource() const { return _source; }
     // root node constructor
     LVPageMap( ldomDocument * doc )
-        : _doc(doc), _page_info_valid(false) { }
+        : _doc(doc), _valid_for_visible_page_numbers(0) { }
     ~LVPageMap() { clear(); }
 };
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1344,7 +1344,12 @@ lString32 LVDocView::getTimeString() {
 	time_t t = (time_t) time(0);
 	tm * bt = localtime(&t);
 	char str[12];
-	sprintf(str, "%02d:%02d", bt->tm_hour, bt->tm_min);
+	if ( m_props->getBoolDef(PROP_SHOW_TIME_12HOURS, false) ) {
+		sprintf(str, "%d:%02d", bt->tm_hour > 12 ? bt->tm_hour % 12 : bt->tm_hour, bt->tm_min);
+	}
+	else {
+		sprintf(str, "%02d:%02d", bt->tm_hour, bt->tm_min);
+	}
 	return Utf8ToUnicode(lString8(str));
 }
 
@@ -6284,6 +6289,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	props->setIntDef(PROP_STATUS_LINE, 0);
 	props->setIntDef(PROP_SHOW_TITLE, 1);
 	props->setIntDef(PROP_SHOW_TIME, 1);
+	props->setIntDef(PROP_SHOW_TIME_12HOURS, 0);
 	props->setIntDef(PROP_SHOW_BATTERY, 1);
     props->setIntDef(PROP_SHOW_BATTERY_PERCENT, 0);
     props->setIntDef(PROP_SHOW_PAGE_COUNT, 1);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2927,6 +2927,22 @@ void LVDocView::Render(int dx, int dy, LVRendPageList * pages) {
 	}
 }
 
+/// Return a hash accounting for the rendering and the pages layout
+/// A changed hash let frontends know their cached values of some document
+/// properties (full height, TOC pages...) may have changed and that they
+/// need to fetch them again
+lUInt32 LVDocView::getDocumentRenderingHash() {
+    if (m_doc) {
+        // Also account for the number of pages, as toggling m_twoVisiblePagesAsOnePageNumber
+        // does not change the document rendering hash, but it does change page numbers
+        // Also account for the document height, just to be sure
+        return ((( (lUInt32)m_doc->getDocumentRenderingHash()) * 31
+                 + (lUInt32)m_doc->getFullHeight()) * 31
+                 + (lUInt32)getPageCount());
+    }
+    return 0;
+}
+
 /// sets selection for whole element, clears previous selection
 void LVDocView::selectElement(ldomNode * elem) {
 	ldomXRangeList & sel = getDocument()->getSelections();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2651,8 +2651,8 @@ void LVDocView::updateLayout() {
                 // We will ensure a max middle margin the size of a single
                 // left or right margin, whichever is the greatest.
 		// We still want to ensure a minimal middle margin in case
-		// the requested pageMargins are really small. Say 1.2em.
-		int min_middle_margin = 1.2 * m_font_size;
+		// the requested pageMargins are really small. Say 0.8em.
+		int min_middle_margin = m_font_size * 80 / 100;
 		int max_middle_margin = m_pageMargins.left > m_pageMargins.right ? m_pageMargins.left : m_pageMargins.right;
 		int additional_middle_margin = 0;
 		int middle_margin = m_pageMargins.right + m_pageMargins.left;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19168,7 +19168,7 @@ bool LVPageMapItem::deserialize( ldomDocument * doc, SerialBuf & buf )
 /// serialize to byte array (pointer will be incremented by number of bytes written)
 bool LVPageMap::serialize( SerialBuf & buf )
 {
-    buf << (lUInt32)_page_info_valid << (lUInt32)_children.length() << _source;
+    buf << (lUInt32)_valid_for_visible_page_numbers << (lUInt32)_children.length() << _source;
     if ( buf.error() )
         return false;
     for ( int i=0; i<_children.length(); i++ ) {
@@ -19185,11 +19185,11 @@ bool LVPageMap::deserialize( ldomDocument * doc, SerialBuf & buf )
     if ( buf.error() )
         return false;
     lUInt32 childCount = 0;
-    lUInt32 pageInfoValid = 0;
-    buf >> pageInfoValid >> childCount >> _source;
+    lUInt32 validForVisiblePageNumbers = 0;
+    buf >> validForVisiblePageNumbers >> childCount >> _source;
     if ( buf.error() )
         return false;
-    _page_info_valid = (bool)pageInfoValid;
+    _valid_for_visible_page_numbers = (int)validForVisiblePageNumbers;
     for ( int i=0; i<childCount; i++ ) {
         LVPageMapItem * item = new LVPageMapItem(doc);
         if ( !item->deserialize( doc, buf ) ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3884,6 +3884,7 @@ ldomDocument::ldomDocument()
 , _just_rendered_from_cache(false)
 , _toc_from_cache_valid(false)
 , _warnings_seen_bitmap(0)
+, _doc_rendering_hash(0)
 #endif
 , lists(100)
 {
@@ -15977,6 +15978,13 @@ void ldomDocument::updateRenderContext()
     _hdr.node_displaystyle_hash = _nodeDisplayStyleHashInitial; // we keep using the initial one
     CRLog::info("Updating render properties: styleHash=%x, stylesheetHash=%x, docflags=%x, width=%x, height=%x, nodeDisplayStyleHash=%x",
                 _hdr.render_style_hash, _hdr.stylesheet_hash, _hdr.render_docflags, _hdr.render_dx, _hdr.render_dy, _hdr.node_displaystyle_hash);
+    _doc_rendering_hash = ((((((
+         + (lUInt32)dx) * 31
+         + (lUInt32)dy) * 31
+         + (lUInt32)_docFlags) * 31
+         + (lUInt32)_nodeDisplayStyleHashInitial) * 31
+         + (lUInt32)stylesheetHash) * 31
+         + (lUInt32)styleHash);
 }
 
 /// check document formatting parameters before render - whether we need to reformat; returns false if render is necessary


### PR DESCRIPTION
The 3 first commits will allow more proper support for "Dual page" mode in KOReader, actually making it feel more as "Two columns".
Previous related discussions in https://github.com/koreader/koreader/issues/7129 and https://github.com/koreader/crengine/pull/408
Supercedes https://github.com/koreader/crengine/pull/408.

#### 2-pages mode: add option twoVisiblePagesAsOnePageNumber
Can be set by frontends to get one page number per view instead of 2 when in 2-pages mode, actually making it feel like 2-columns on 1 page.
Updating 4 public methods is all it needs: `getCurPage()`, `getPageCount()`, `getBookmarkPage()` and `goToPage()`. They now return or accept the "external" page number (which differs from the "internal" page number when `VisiblePageCount=2` and `m_twoVisiblePagesAsOnePageNumber=true`.
As the crengine code itself use these methods, some of them now provide internal=true to get back internal page numbers where it is needed.
This adds a bit of noise, but it should be a no-op when `m_twoVisiblePagesAsOnePageNumber` is let to be `false`. I tried to update all the things needed, even if not used by KOReader, so this should also work with CoolReader.
With KOReader, we'll probably stay with a non-user-toggable `m_twoVisiblePagesAsOnePageNumber=true`.


#### TOC, PageMap: save the visible pages number they were build for
So we can notice they are no longer valid when toggling twoVisiblePagesAsOnePageNumber (which does not change the rendering).

#### 2-pages mode: tweak header drawing
When `m_twoVisiblePagesAsOnePageNumber=true`, draw header as one single wide header like when in 1-page mode.
Also show the external current page number and pages count.

#### Header: add option to display time as 12-hours clock
No AM/PM to not have the need for them to be translated. Should allow closing https://github.com/koreader/koreader/issues/7171.

#### 2-pages mode: decrease min middle margin from 1.2 to 0.8em
Discussion and screenshots in https://github.com/koreader/koreader/discussions/7177

#### Add `LVDocView::getDocumentRenderingHash()`
So frontends can know if the rendering or the number of pages have changed (instead of relying of the document height, which is not a strictly accurate indicator of changes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/410)
<!-- Reviewable:end -->
