### PR TITLE
Minor upstream fixes: keep last word space if pre, replacement char on last fallback font only

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -93,6 +93,10 @@ int    lStr_cmp(const lChar8 * str1, const lChar32 * str2);
 /// strcmp for lChar8
 int    lStr_cmp(const lChar8 * str1, const lChar8 * str2);
 /// convert string to uppercase
+void lStr_uppercase( lChar8 * str, int len );
+/// convert string to lowercase
+void lStr_lowercase( lChar8 * str, int len );
+/// convert string to uppercase
 void lStr_uppercase( lChar32 * str, int len );
 /// convert string to lowercase
 void lStr_lowercase( lChar32 * str, int len );
@@ -323,6 +327,10 @@ public:
     lString8 & replace(size_type p0, size_type n0, const lString8 & str, size_type offset, size_type count);
     /// replace fragment with repeated character
     lString8 & replace(size_type p0, size_type n0, size_type count, value_type ch);
+    /// make string uppercase
+    lString8 & uppercase();
+    /// make string lowercase
+    lString8 & lowercase();
     /// compare with another string
     int compare(const lString8& str) const { return lStr_cmp(pchunk->buf8, str.pchunk->buf8); }
     /// compare part of string with another string
@@ -335,6 +343,10 @@ public:
     int compare(size_type p0, size_type n0, const value_type *s) const;
     /// compare part of string with C-string fragment
     int compare(size_type p0, size_type n0, const value_type *s, size_type pos) const;
+    /// find position of char inside string, -1 if not found
+    int pos(lChar8 ch) const;
+    /// find position of char inside string starting from specified position, -1 if not found
+    int pos(lChar8 ch, int start) const;
     /// find position of substring inside string, -1 if not found
     int pos(const lString8 & subStr) const;
     /// find position of substring inside string, -1 if not found

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1738,12 +1738,12 @@ public:
                 FT_Select_Charmap(_face, FT_ENCODING_UNICODE);
             }
         }
-        if ( ch_glyph_index==0 ) {
+        if ( ch_glyph_index==0 && def_char != 0 ) {
             bool can_be_ignored = false;
             lUInt32 replacement = getReplacementChar( code, &can_be_ignored );
             if ( replacement )
                 ch_glyph_index = FT_Get_Char_Index( _face, replacement );
-            if ( ch_glyph_index==0 && def_char && !can_be_ignored ) {
+            if ( ch_glyph_index==0 && !can_be_ignored ) {
                 // if neither the index of this character nor the index of the replacement character is found,
                 // and if this character can be safely ignored,
                 // we simply skip it so as not to draw the unnecessary replacement character.

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -2088,6 +2088,32 @@ lString8 lString8::substr(size_type pos, size_type n) const
     return lString8( pchunk->buf8+pos, n );
 }
 
+int lString8::pos(lChar8 ch) const
+{
+    for (int i = 0; i < length(); i++)
+    {
+        if (pchunk->buf8[i] == ch)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+int lString8::pos(lChar8 ch, int start) const
+{
+    if (length() - start < 1)
+        return -1;
+    for (int i = start; i < length(); i++)
+    {
+        if (pchunk->buf8[i] == ch)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
 int lString8::pos(const lString8 & subStr) const
 {
     if (subStr.length()>length())
@@ -2603,6 +2629,17 @@ bool lvUnicodeIsAlpha( lChar32 ch )
     return false;
 }
 
+lString8 & lString8::uppercase()
+{
+    lStr_uppercase( modify(), length() );
+    return *this;
+}
+
+lString8 & lString8::lowercase()
+{
+    lStr_lowercase( modify(), length() );
+    return *this;
+}
 
 lString32 & lString32::uppercase()
 {
@@ -2626,6 +2663,30 @@ lString32 & lString32::fullWidthChars()
 {
     lStr_fullWidthChars( modify(), length() );
     return *this;
+}
+
+void lStr_uppercase( lChar8 * str, int len )
+{
+    for ( int i=0; i<len; i++ ) {
+        lChar32 ch = str[i];
+        if ( ch>='a' && ch<='z' ) {
+            str[i] = ch - 0x20;
+        } else if ( ch>=0xE0 && ch<=0xFF ) {
+            str[i] = ch - 0x20;
+        }
+    }
+}
+
+void lStr_lowercase( lChar8 * str, int len )
+{
+    for ( int i=0; i<len; i++ ) {
+        lChar32 ch = str[i];
+        if ( ch>='A' && ch<='Z' ) {
+            str[i] = ch + 0x20;
+        } else if ( ch>=0xC0 && ch<=0xDF ) {
+            str[i] = ch + 0x20;
+        }
+    }
 }
 
 void lStr_uppercase( lChar32 * str, int len )

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3254,7 +3254,10 @@ public:
                         word->min_width = word->width;
                         word->flags |= LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER;
                     }
-                    if ( m_flags[i-1] & LCHAR_IS_SPACE) { // Current word ends with a space
+
+                    bool preformatted = srcline->flags & LTEXT_FLAG_PREFORMATTED;
+                    if ( m_flags[i-1] & LCHAR_IS_SPACE ) {
+                        // Current word ends with a space.
                         // Each word ending with a space (except in some conditions) can
                         // have its width reduced by a fraction of this space width or
                         // increased if needed (for text justification), so actually
@@ -3270,8 +3273,11 @@ public:
                                 word->min_width = word->width - dw;
                             }
                         }
-                        if ( lastWord ) {
-                            // If last word of line, remove any trailing space from word's width
+                        if ( lastWord && !preformatted ) {
+                            // If last word of line, remove any trailing space
+                            // from word's width (but not with preformatted, in
+                            // case of text-align:right where we don't want to
+                            // lose any trailing space)
                             word->width = m_widths[i>1 ? i-2 : 0] - (wstart>0 ? m_widths[wstart-1] : 0);
                             word->min_width = word->width;
                         }


### PR DESCRIPTION
`(Upstream) Text: don't remove trailing space on last word if pre`
From https://github.com/buggins/coolreader/pull/236

`(Upstream) Text: replace notfound glyphs only on last fallback font`
Make non-Harfbuzz drawing similar to Harfbuzz drawing:
Changed the search logic for missing glyphs: first, we search for a glyph in all fallback fonts without replacing missing ones, and at the end, if a glyph is not found, we replace it with a replacement one.
From 2nd commit of https://github.com/buggins/coolreader/pull/239

`(Upstream) Add a few lString8 methods`
Needed by upstream QT frontend for checking language tags.
From https://github.com/buggins/coolreader/pull/235

----
Considered but not (yet) picked:
`(Upstream) Ordered list markers: add a decimal point suffix`
https://github.com/buggins/coolreader/commit/821a6ecf80009f01b5c77a4b1508b085d59c3add from https://github.com/buggins/coolreader/pull/226
Because it feels ugly in Wikipedia EPUBs where in-page footnotes are such OL>LI (which are probably the use of the OL>LI I see every day :)
It would need either them to be right aligned (but still a bit ugly), or having such markers use `font-variant: tabular-nums` (which we can't set on LI markers only via CSS) so digts have a constant width and these decimal points would be aligned with each others (if the font supports that, which is not the case for most).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/411)
<!-- Reviewable:end -->
