### PR TITLE
Small fixes: crash on missing items in EPUB, 2-pages mode/1-page number alt title/author

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1290,8 +1290,8 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                     if ( !item )
                         break;
                     EpubItem * epubItem = epubItems.findById( item->getAttributeValue("idref") );
-                    epubItem->nonlinear = lString32(item->getAttributeValue("linear")).lowercase() == U"no";
                     if ( epubItem ) {
+                        epubItem->nonlinear = lString32(item->getAttributeValue("linear")).lowercase() == U"no";
                         // TODO: add to document
                         spineItems.add( epubItem );
                     }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1920,7 +1920,8 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		}
 		int w = info.width() - 10;
 		if (authorsw + titlew + 10 > w) {
-			if ((pageIndex & 1))
+			// Not enough room for both: alternate them
+			if (getExternalPageNumber(pageIndex) & 1)
 				text = title;
 			else {
 				text = authors;


### PR DESCRIPTION
#### 2-pages mode/1-page number: fix title/author alternation
See https://github.com/koreader/koreader/pull/7204#issuecomment-769661194

#### EPUB: fix segfault on missing items in opf manifest
See https://github.com/koreader/koreader/issues/7219#issuecomment-770442114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/415)
<!-- Reviewable:end -->
