### PR TITLE
CSS: adds support for "visibility: hidden", and other fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -332,6 +332,14 @@ enum css_direction_t {
     css_dir_rtl
 };
 
+/// visibility property values
+enum css_visibility_t {
+    css_v_inherit,
+    css_v_visible,
+    css_v_hidden,
+    css_v_collapse // handled as "hidden" (but it should behave differently on tables, which we don't ensure)
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,        // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,      // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -367,6 +367,8 @@ class LVRendPageContext
     LVRendPageList * page_list;
     // page height
     int page_h;
+    // document default font size (= root node font size)
+    int doc_font_size;
     // Whether to gather lines or not (only footnote links will be gathered if not)
     bool gather_lines;
     // Links gathered when !gather_lines
@@ -425,10 +427,14 @@ public:
     /// returns page height
     int getPageHeight() { return page_h; }
 
+    /// returns document font size
+    int getDocFontSize() { return doc_font_size; }
+
     /// returns page list pointer
     LVRendPageList * getPageList() { return page_list; }
 
-    LVRendPageContext(LVRendPageList * pageList, int pageHeight, bool gatherLines=true);
+    /// constructor (docFontSize is only needed for with main context actually used to split pages)
+    LVRendPageContext(LVRendPageList * pageList, int pageHeight, int docFontSize=0, bool gatherLines=true);
 
     /// add source line
     void AddLine( int starty, int endy, int flags );

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -86,10 +86,11 @@ enum css_style_rec_important_bit {
     imp_bit_float,
     imp_bit_clear,
     imp_bit_direction,
+    imp_bit_visibility,
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 65 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 66 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[1]
@@ -165,6 +166,7 @@ struct css_style_rec_tag {
     css_float_t            float_; // "float" is a C++ keyword...
     css_clear_t            clear;
     css_direction_t        direction;
+    css_visibility_t       visibility;
     lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
@@ -219,6 +221,7 @@ struct css_style_rec_tag {
     , float_(css_f_none)
     , clear(css_c_none)
     , direction(css_dir_inherit)
+    , visibility(css_v_inherit)
     , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -80,11 +80,10 @@ extern "C" {
 
 #define LTEXT_FIT_GLYPHS             0x08000000  // Avoid glyph overflows and override at line edges and between text nodes
 
-#define LTEXT_LEGACY_RENDERING       0x10000000  // Legacy rendering exceptions: new line processing: set indentation for **each** new line, etc.
-
+#define LTEXT_HIDDEN                 0x10000000  // Do not draw (visibility:hidden)
 #define LTEXT__AVAILABLE_BIT_30__    0x20000000
 #define LTEXT__AVAILABLE_BIT_31__    0x40000000
-#define LTEXT__AVAILABLE_BIT_32__    0x80000000
+#define LTEXT_LEGACY_RENDERING       0x80000000  // Legacy text rendering tweaks
 
 /** \brief Source text line
 */

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -209,7 +209,6 @@ LVDocView::LVDocView(int bitsPerPixel, bool noDefaultDocument) :
                     U"Welcome to CoolReader! Please select file to open"));
 
     m_font_size = scaleFontSizeForDPI(m_requested_font_size);
-    gRootFontSize = m_font_size; // stored as global (for 'rem' css unit)
     m_font = fontMan->GetFont(m_font_size, 400, false, DEFAULT_FONT_FAMILY,
 			m_defaultFontFace);
 	m_infoFont = fontMan->GetFont(m_status_font_size, 700, false,
@@ -2051,7 +2050,7 @@ void LVDocView::drawPageTo(LVDrawBuf * drawbuf, LVRendPageInfo & page,
 			//CRLog::trace("Done DrawDocument() for main text");
 			// draw footnotes
 #define FOOTNOTE_MARGIN_REM 1 // as in lvpagesplitter.cpp
-			int footnote_margin = FOOTNOTE_MARGIN_REM * gRootFontSize;
+			int footnote_margin = FOOTNOTE_MARGIN_REM * m_font_size;
 			int fny = clip.top + (page.height ? page.height + footnote_margin
 					: footnote_margin);
 			// Try to push footnotes to the bottom of page if possible
@@ -2825,7 +2824,6 @@ void LVDocView::setRenderProps(int dx, int dy) {
 
 	lString8 fontName = lString8(DEFAULT_FONT_NAME);
 	m_font_size = scaleFontSizeForDPI(m_requested_font_size);
-	gRootFontSize = m_font_size; // stored as global (for 'rem' css unit)
 	m_font = fontMan->GetFont(m_font_size, 400 + LVRendGetFontEmbolden(),
 			false, DEFAULT_FONT_FAMILY, m_defaultFontFace);
 	//m_font = LVCreateFontTransform( m_font, LVFONT_TRANSFORM_EMBOLDEN );
@@ -3623,7 +3621,6 @@ void LVDocView::setFontSize(int newSize) {
         m_requested_font_size = findBestFit(m_font_sizes, newSize);
         propsGetCurrent()->setInt(PROP_FONT_SIZE, m_requested_font_size);
         m_font_size = scaleFontSizeForDPI(m_requested_font_size);
-        gRootFontSize = m_font_size; // stored as global (for 'rem' css unit)
         CRLog::debug("New requested font size: %d (asked: %d)", m_requested_font_size, newSize);
         REQUEST_RENDER("setFontSize")
     }

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -43,10 +43,10 @@ int LVRendPageList::FindNearestPage( int y, int direction )
     return length()-1;
 }
 
-LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, bool gatherLines)
+LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, int docFontSize, bool gatherLines)
     : callback(NULL), totalFinalBlocks(0)
     , renderedFinalBlocks(0), lastPercent(-1), page_list(pageList), page_h(pageHeight)
-    , gather_lines(gatherLines), footNotes(64), curr_note(NULL)
+    , doc_font_size(docFontSize), gather_lines(gatherLines), footNotes(64), curr_note(NULL)
     , current_flow(0), max_flow(0)
 {
     if ( callback ) {
@@ -156,14 +156,14 @@ void LVRendPageContext::AddLine( int starty, int endy, int flags )
 }
 
 // We use 1.0rem (1x root font size) as the footnote margin (vertical margin
-// between text and first foornote)
+// between text and first footnote)
 #define FOOTNOTE_MARGIN_REM 1
-extern int gRootFontSize;
 
 // helper class
 struct PageSplitState {
 public:
     int page_h;
+    int doc_font_size;
     LVRendPageList * page_list;
     const LVRendLineInfo * pagestart;
     const LVRendLineInfo * pageend;
@@ -184,8 +184,9 @@ public:
     int nb_footnotes_lines_rtl;
     int current_flow;
 
-    PageSplitState(LVRendPageList * pl, int pageHeight)
+    PageSplitState(LVRendPageList * pl, int pageHeight, int docFontSize)
         : page_h(pageHeight)
+        , doc_font_size(docFontSize)
         , page_list(pl)
         , pagestart(NULL)
         , pageend(NULL)
@@ -310,7 +311,7 @@ public:
                 page_list->length(), start, start+h, h);
             if (footheight || hasFootnotes)
                 printf(" (+ %d footnotes, fh=%d => h=%d)", footnotes.length(),
-                    footheight, h+footheight+FOOTNOTE_MARGIN_REM*gRootFontSize);
+                    footheight, h+footheight+FOOTNOTE_MARGIN_REM*doc_font_size);
             printf(" [rtl l:%d/%d fl:%d/%d]\n", nb_lines_rtl, nb_lines, nb_footnotes_lines_rtl, nb_footnotes_lines);
         #endif
         LVRendPageInfo * page = new LVRendPageInfo(start, h, page_list->length());
@@ -358,7 +359,7 @@ public:
             h = 0;
         int footh = 0 /*currentFootnoteHeight()*/ + footheight;
         if ( footh )
-            h += FOOTNOTE_MARGIN_REM*gRootFontSize + footh;
+            h += FOOTNOTE_MARGIN_REM*doc_font_size + footh;
         return h;
     }
     void SplitLineIfOverflowPage( LVRendLineInfo * line )
@@ -662,7 +663,7 @@ public:
     {
         int dh = line->getEnd()
             - (footstart ? footstart->getStart() : line->getStart())
-            + (footheight==0 ? FOOTNOTE_MARGIN_REM*gRootFontSize : 0);
+            + (footheight==0 ? FOOTNOTE_MARGIN_REM*doc_font_size : 0);
         int h = currentHeight(NULL); //next
         #ifdef DEBUG_FOOTNOTES
             CRLog::trace("Add footnote line %d  footheight=%d  h=%d  dh=%d  page_h=%d",
@@ -756,7 +757,7 @@ void LVRendPageContext::split()
 {
     if ( !page_list )
         return;
-    PageSplitState s(page_list, page_h);
+    PageSplitState s(page_list, page_h, doc_font_size);
     #ifdef DEBUG_PAGESPLIT
         printf("PS: splitting lines into pages, page height=%d\n", page_h);
     #endif

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -52,7 +52,6 @@
 
 int gRenderDPI = DEF_RENDER_DPI; // if 0: old crengine behaviour: 1px/pt=1px, 1in/cm/pc...=0px
 bool gRenderScaleFontWithDPI = DEF_RENDER_SCALE_FONT_WITH_DPI;
-int gRootFontSize = 24; // will be reset as soon as font size is set
 
 int scaleForRenderDPI( int value ) {
     // if gRenderDPI == 0 or 96, use value as is (1px = 1px)
@@ -1733,7 +1732,7 @@ public:
                             rend_flags &= ~BLOCK_RENDERING_ALLOW_NEGATIVE_COLLAPSED_MARGINS;
                         }
                         else {
-                            cell_context = new LVRendPageContext( NULL, context.getPageHeight(), false );
+                            cell_context = new LVRendPageContext( NULL, context.getPageHeight(), 0, false );
                         }
                         // We request renderBlockElement() to give us back the baseline
                         // of the block as expected for tables
@@ -2456,7 +2455,7 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
     }
 
     case css_val_rem: // value = rem*256 (font size of the root element)
-        px = (gRootFontSize * val.value) >> 8;
+        px = (node->getDocument()->getDefaultFont()->getSize() * val.value) >> 8;
         break;
 
     /* absolute value, less often used - value = unit*256 */
@@ -7686,7 +7685,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                         // to the page splitting context. The non-floating nodes will,
                         // and if !DO_NOT_CLEAR_OWN_FLOATS, we'll fill the remaining
                         // height taken by floats if any.
-                        LVRendPageContext alt_context( NULL, flow->getPageHeight(), false );
+                        LVRendPageContext alt_context( NULL, flow->getPageHeight(), 0, false );
                         // For floats too, the provided x must be the padding-left of the
                         // parent container of the float (and width must exclude the parent's
                         // padding-left/right) for the flow to correctly position inner floats
@@ -9554,9 +9553,6 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
 
     // display before stylesheet is applied (for fallback below if legacy mode)
     css_display_t orig_elem_display = pstyle->display;
-
-    // not used (could be used for 'rem', but we have it in gRootFontSize)
-    // int baseFontSize = enode->getDocument()->getDefaultFont()->getSize();
 
     //////////////////////////////////////////////////////
     // apply style sheet

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2295,6 +2295,20 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
     return fnt;
 }
 
+inline lUInt32 getBackgroundColor(const css_style_ref_t style)
+{
+        return style->background_color.type == css_val_color ? style->background_color.value : 0xFFFFFFFF;
+}
+
+inline lUInt32 getForegroundColor(const css_style_ref_t style)
+{
+        if ( style->color.type == css_val_color )
+            return style->color.value;
+        if ( style->color.value == css_generic_transparent && style->color.type == css_val_unspecified )
+            return 0xDDFFFFFF; // Handled by LFormattedText::Draw(), which will skip drawing this fragment
+        return 0xFFFFFFFF;
+}
+
 lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction )
 {
     lUInt32 flg = oldflags;
@@ -2833,8 +2847,8 @@ lString32 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
             marker_width = listProps->maxWidth;
         css_style_ref_t style = enode->getStyle();
         LVFontRef font = enode->getFont();
-        lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-        lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+        lUInt32 cl = getForegroundColor(style);
+        lUInt32 bgcl = getBackgroundColor(style);
         if (line_h < 0) { // -1, not specified by caller: find it out from the node
             if ( style->line_height.type == css_val_unspecified &&
                         style->line_height.value == css_generic_normal ) {
@@ -3403,8 +3417,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     marker_width = listProps->maxWidth;
                 css_list_style_position_t sp = style->list_style_position;
                 LVFontRef font = enode->getFont();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                lUInt32 bgcl = getBackgroundColor(style);
                 int margin = 0;
                 if ( sp==css_lsp_outside )
                     margin = -marker_width; // will ensure negative/hanging indent-like rendering
@@ -3458,8 +3472,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
                 //txform->AddSourceLine(U"title", 5, 0x000000, 0xffffff, font, baseflags, interval, margin, NULL, 0, 0);
                 LVFontRef font = enode->getFont();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                lUInt32 bgcl = 0xFFFFFFFF; // erm_final: any background will be drawn by DrawDocument
                 lString32 title;
                 //txform->AddSourceLine( title.c_str(), title.length(), cl, bgcl, font, LTEXT_FLAG_OWNTEXT|LTEXT_FLAG_NEWLINE, line_h, 0, NULL );
                 //baseflags
@@ -3578,8 +3592,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // any txform->AddSourceLine(). If we delay that and add another
                 // char before, this other char would generate a new line.
                 LVFontRef font = enode->getFont();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                // If erm_final, the background will be drawn by DrawDocument, and should not
+                // be drawn by the LFormattedText txform
+                lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
 
                 // The following is needed for fribidi to do the right thing when the content creator
                 // has provided hints to explicite ambiguous cases.
@@ -3684,8 +3700,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
 
             if ( addGeneratedContent ) {
                 LVFontRef font = enode->getFont();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
                 // See comment above: these are the closing counterpart
                 if ( closeWithPDI ) {
                     txform->AddSourceLine( U"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
@@ -3709,8 +3725,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // and we don't use UNICODE_NO_BREAK_SPACE.
                 LVFontRef font = enode->getFont();
                 css_style_ref_t style = enode->getStyle();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
                 txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
                 /*
                 // We used to specify two UNICODE_NO_BREAK_SPACE (that would not collapse)
@@ -3760,8 +3776,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // as wanted by a <BR/>.
                 // (This makes consecutive and stuck <br><br><br> work)
                 LVFontRef font = enode->getFont();
-                lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-                lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+                lUInt32 cl = getForegroundColor(style);
+                lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
                 txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                                         baseflags | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                                         line_h, valign_dy);
@@ -3821,8 +3837,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // by lvtextfm.cpp splitParagraphs() to not add this empty
             // string to text, and just call floatClearText().
             LVFontRef font = enode->getFont();
-            lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-            lUInt32 bgcl = style->background_color.type!=css_val_color ? 0xFFFFFFFF : style->background_color.value;
+            lUInt32 cl = getForegroundColor(style);
+            lUInt32 bgcl = 0xFFFFFFFF; // erm_final: any background will be drawn by DrawDocument
             txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                             baseflags | LTEXT_SRC_IS_CLEAR_LAST | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                             line_h, valign_dy);
@@ -3852,19 +3868,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
             LVFontRef const font = parent->getFont();
             css_style_ref_t style = parent->getStyle();
-            lUInt32 cl = style->color.type!=css_val_color ? 0xFFFFFFFF : style->color.value;
-            lUInt32 bgcl = 0xFFFFFFFF;
-            if ( style->background_color.type == css_val_color && (lUInt32)style->background_color.value != 0xFFFFFFFF ) {
-                bgcl = style->background_color.value;
-                // Avoid painting same background color as upper node, as it may cover any background image
-                ldomNode * gparent = parent->getParentNode();
-                if( gparent && !gparent->isNull() ) {
-                    css_length_t gparent_bgcolor = gparent->getStyle()->background_color;
-                    if ( gparent_bgcolor.type == css_val_color && (lUInt32)gparent_bgcolor.value == bgcl ) {
-                        bgcl=0xFFFFFFFF;
-                    }
-                }
-            }
+
+            lUInt32 cl = getForegroundColor(style);
+            // If erm_final, the background will be drawn by DrawDocument, and should not
+            // be drawn over each word by the LFormattedText txform
+            lUInt32 bgcl = parent->getRendMethod() == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
 
             switch (style->text_transform) {
             case css_tt_uppercase:
@@ -10019,7 +10027,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
              pstyle->letter_spacing.value != css_generic_normal) )
         pstyle->letter_spacing = parent_style->letter_spacing;
 
-    spreadParent( pstyle->color, parent_style->color );
+    // Don't inherit when (css_val_unspecified, css_generic_transparent) used with "color: transparent"
+    if ( pstyle->color.type != css_val_unspecified || pstyle->color.value != css_generic_transparent )
+        spreadParent( pstyle->color, parent_style->color );
 
     // background_color
     // Should not be inherited: elements start with unspecified.

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3175,6 +3175,10 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // inside that strut.
             flags |= LTEXT_STRUT_CONFINED;
         }
+        if ( style->visibility >= css_v_hidden )
+            flags |= LTEXT_HIDDEN;
+        else
+            flags &= ~LTEXT_HIDDEN;
 
         // Now, process styles that may differ between inline nodes, and
         // are needed to display any children text node.
@@ -4041,6 +4045,7 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->float_ = source->float_;
     dest->clear = source->clear;
     dest->direction = source->direction;
+    dest->visibility = source->visibility;
     dest->content = source->content ;
     dest->cr_hint.type = source->cr_hint.type ;
     dest->cr_hint.value = source->cr_hint.value ;
@@ -8983,7 +8988,17 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
 
         css_style_ref_t style = enode->getStyle();
 
+        // When a node has "visibility: hidden", it should take its normal space
+        // (so, we have rendered and sized it as if it was visible) - we should just
+        // not draw it. But we can't just simply return and not draw sub-children, as
+        // some inner content might have "visibility: visible" and has to be drawn.
+        // For non-final nodes, being hidden just mean we should not draw its
+        // border and background. For final nodes, text fragments will carry a
+        // flag and won't be drawn.
+        bool isHidden = style->visibility >= css_v_hidden;
+
         // Check and draw background
+        bool restoreBackgroundColor = false;
         css_length_t bg = style->background_color;
         lUInt32 oldColor = 0;
         // Don't draw background color for TR and THEAD/TFOOT/TBODY as it could
@@ -8991,16 +9006,17 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         // the TR bgcolor to its TDs that must have it, as it should be done (the
         // border spacing between cells does not have the bg color of the TR: only
         // cells have it).
-        if ( bg.type==css_val_color && !isTableRowLike ) {
+        if ( bg.type==css_val_color && !isTableRowLike && !isHidden ) {
             // Even if we don't draw/fill background, we may need to
             // drawbuf.SetBackgroundColor() for the text to be correctly
             // drawn over this background color
             oldColor = drawbuf.GetBackgroundColor();
             drawbuf.SetBackgroundColor( bg.value );
+            restoreBackgroundColor = true;
             if ( draw_background )
                 drawbuf.FillRect( x0 + doc_x, y0 + doc_y, x0 + doc_x+fmt.getWidth(), y0+doc_y+fmt.getHeight(), bg.value );
         }
-        if ( draw_background && !style->background_image.empty() ) {
+        if ( draw_background && !style->background_image.empty() && !isHidden ) {
             if ( enode->getNodeId() == el_body ) {
                 // CSS specific: <body> background does not obey margin rules
                 // We don't draw on the fmt width, but on the drawbuf width.
@@ -9084,7 +9100,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                         DrawDocument( drawbuf, child, x0, y0, dx, dy, doc_x, doc_y, page_height, marks, bookmarks, false, true );
                     }
                     // Cleanup and return
-                    if ( bg.type==css_val_color ) {
+                    if ( restoreBackgroundColor ) {
                         drawbuf.SetBackgroundColor( oldColor );
                     }
                     return;
@@ -9098,14 +9114,14 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // Don't draw border for TR TBODY... as their borders are never directly
                 // rendered by Firefox (they are rendered only when border-collapse, when
                 // they did collapse to the cell, and made out the cell border)
-                if ( !isTableRowLike )
+                if ( !isTableRowLike && !isHidden )
                     DrawBorder(enode,drawbuf,x0,y0,doc_x,doc_y,fmt);
 
                 // List item marker drawing when css_d_list_item_block and list-style-position = outside
                 // and list_item_block rendered as block (containing text and block elements)
                 // Rendering hack (in renderAsListStylePositionInside(): not when text-align "right"
                 // or "center", we treat it just as "inside", and drawing is managed by renderFinalBlock())
-                if ( style->display == css_d_list_item_block && !renderAsListStylePositionInside(style, is_rtl) ) {
+                if ( style->display == css_d_list_item_block && !renderAsListStylePositionInside(style, is_rtl) && !isHidden ) {
                     int width = fmt.getWidth();
                     int base_width = 0; // for padding_top in %
                     ldomNode * parent = enode->getParentNode();
@@ -9264,7 +9280,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // drawn above, before the switch())
                 if ( !draw_content ) {
                     // Cleanup and return
-                    if ( bg.type==css_val_color ) {
+                    if ( restoreBackgroundColor ) {
                         drawbuf.SetBackgroundColor( oldColor );
                     }
                     return;
@@ -9273,7 +9289,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // Draw borders before content, so inner content can bleed if necessary on
                 // the border (some glyphs like 'J' at start or 'f' at end may be drawn
                 // outside the text content box).
-                DrawBorder(enode, drawbuf, x0, y0, doc_x, doc_y, fmt);
+                if ( !isHidden )
+                    DrawBorder(enode, drawbuf, x0, y0, doc_x, doc_y, fmt);
 
                 // Get ready to create a LFormattedText with the correct content width
                 // and position: we'll have it draw itself at the right coordinates.
@@ -9301,7 +9318,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // and list_item_block rendered as final (containing only text and inline elements)
                 // Rendering hack (in renderAsListStylePositionInside(): not when text-align "right"
                 // or "center", we treat it just as "inside", and drawing is managed by renderFinalBlock())
-                if ( style->display == css_d_list_item_block && !renderAsListStylePositionInside(style, is_rtl) ) {
+                if ( style->display == css_d_list_item_block && !renderAsListStylePositionInside(style, is_rtl) && !isHidden ) {
                     // We already adjusted our block X and width in renderBlockElement(),
                     // we just need to draw the marker in the space we made on the left of
                     // this node.
@@ -9397,8 +9414,8 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
             // don't draw invisible blocks
             break;
         case erm_killed:
-            if ( !draw_content ) {
-                if ( bg.type==css_val_color ) {
+            if ( !draw_content || isHidden ) {
+                if ( restoreBackgroundColor ) {
                     drawbuf.SetBackgroundColor( oldColor );
                 }
                 return;
@@ -9415,7 +9432,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
             break;
             //crFatalError(); // error
         }
-        if ( bg.type==css_val_color ) {
+        if ( restoreBackgroundColor ) {
             drawbuf.SetBackgroundColor( oldColor );
         }
     }
@@ -9810,6 +9827,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( widows, css_orphans_widows_inherit );
     UPDATE_STYLE_FIELD( list_style_type, css_lst_inherit );
     UPDATE_STYLE_FIELD( list_style_position, css_lsp_inherit );
+    UPDATE_STYLE_FIELD( visibility, css_v_inherit );
 
     // Note: we don't inherit "direction" (which should be inherited per specs);
     // We'll handle inheritance of direction in renderBlockEnhanced, because

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10883,6 +10883,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 }
                 lChar32 c = *(txt + start + i);
                 lChar32 next_c = *(txt + start + i + 1); // might be 0 at end of string
+                bool is_collapsable_space = (c == ' '); // We only collapse the classic ASCII spaces in lvtextfm.cpp
                 if ( lang_cfg->hasLBCharSubFunc() ) {
                     next_c = lang_cfg->getLBCharSubFunc()(&lbCtx, txt+start, i+1, len-1 - (i+1));
                 }
@@ -10896,10 +10897,13 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     // collapse; this might still not be right with pre-wrap though).
                 // printf("between <%c%c>: brk %d\n", c, next_c, brk);
                 if (brk == LINEBREAK_ALLOWBREAK && !nowrap) {
-                    if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // a breakable/collapsible space (flag set by measureText()
-                        if (collapseNextSpace) // ignore this space
-                            continue;
-                        collapseNextSpace = true; // ignore next spaces, even if in another node
+                    if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // a breakable space (flag set by measureText()
+                        // We can break on it, and if breaking, it's width would not be accounted anywhere
+                        if (is_collapsable_space) { // a collapsable ascii space
+                            if (collapseNextSpace) // ignore this space
+                                continue;
+                            collapseNextSpace = true; // ignore next spaces, even if in another node
+                        }
                         lastSpaceWidth = pre ? 0 : w; // Don't remove last space width if 'pre'
                         curMaxWidth += w; // add this space to non-wrap width
                         if (fit_glyphs && curWordWidth > 0) { // there was a word before this space
@@ -10965,11 +10969,13 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 else { // break not allowed: this char is part of a word
                     // But it can be a space followed by another space (with libunibreak,
                     // only the last space will get LINEBREAK_ALLOWBREAK).
-                    if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // a breakable/collapsible space (flag set by measureText()
-                        if (collapseNextSpace) { // space before (and space after)
-                            continue; // ignore it
+                    if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // a breakable space (flag set by measureText()
+                        if (is_collapsable_space) { // a collapsable ascii space
+                            if (collapseNextSpace) { // space before (and space after)
+                                continue; // ignore it
+                            }
+                            collapseNextSpace = true; // ignore next ones
                         }
-                        collapseNextSpace = true; // ignore next ones
                         lastSpaceWidth = pre ? 0 : w; // Don't remove last space width if 'pre'
                     }
                     else { // Not a space
@@ -10995,6 +11001,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             for (int i=0; i<chars_measured; i++) {
                 int w = widths[i] - (i>0 ? widths[i-1] : 0);
                 lChar32 c = *(txt + start + i);
+                bool is_collapsable_space = (c == ' '); // We only collapse the classic ASCII spaces in lvtextfm.cpp
                 if ( (flags[i] & LCHAR_IS_SPACE) && (space_width_scale_percent != 100) ) {
                     w = w * space_width_scale_percent / 100;
                 }
@@ -11009,9 +11016,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     // But Firefox does that too, may be a bit less radically than
                     // us, so our table algorithm may need some tweaking...
                 if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // A space
-                    if (collapseNextSpace) // ignore this space
-                        continue;
-                    collapseNextSpace = true; // ignore next spaces, even if in another node
+                    if (is_collapsable_space) { // a collapsable ascii space
+                        if (collapseNextSpace) // ignore this space
+                            continue;
+                        collapseNextSpace = true; // ignore next spaces, even if in another node
+                    }
                     lastSpaceWidth = w;
                     curMaxWidth += w; // add this space to non-wrap width
                     if (fit_glyphs && curWordWidth > 0) { // there was a word before this space

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -117,6 +117,7 @@ enum css_decl_code {
     cssd_float,
     cssd_clear,
     cssd_direction,
+    cssd_visibility,
     cssd_content,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
@@ -214,6 +215,7 @@ static const char * css_decl_name[] = {
     "float",
     "clear",
     "direction",
+    "visibility",
     "content",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
@@ -1818,6 +1820,16 @@ static const char * css_dir_names[] =
     NULL
 };
 
+// visibility value names
+static const char * css_v_names[] =
+{
+    "inherit",
+    "visible",
+    "hidden",
+    "collapse",
+    NULL
+};
+
 static const char * css_cr_only_if_names[]={
         "any",
         "always",
@@ -2909,6 +2921,9 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
             case cssd_direction:
                 n = parse_name( decl, css_dir_names, -1 );
                 break;
+            case cssd_visibility:
+                n = parse_name( decl, css_v_names, -1 );
+                break;
             case cssd_content:
                 {
                     lString32 parsed_content;
@@ -3222,6 +3237,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_direction:
             style->Apply( (css_direction_t) *p++, &style->direction, imp_bit_direction, is_important );
+            break;
+        case cssd_visibility:
+            style->Apply( (css_visibility_t) *p++, &style->visibility, imp_bit_visibility, is_important );
             break;
         case cssd_cr_hint:
             {

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -111,6 +111,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.float_) * 31
          + (lUInt32)rec.clear) * 31
          + (lUInt32)rec.direction) * 31
+         + (lUInt32)rec.visibility) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
@@ -187,6 +188,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.float_ == r2.float_&&
            r1.clear == r2.clear&&
            r1.direction == r2.direction&&
+           r1.visibility == r2.visibility&&
            r1.content == r2.content&&
            r1.cr_hint==r2.cr_hint;
 }
@@ -384,6 +386,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(float_);
     ST_PUT_ENUM(clear);
     ST_PUT_ENUM(direction);
+    ST_PUT_ENUM(visibility);
     buf << content;
     ST_PUT_LEN(cr_hint);
     lUInt32 hash = calcHash(*this);
@@ -453,6 +456,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_float_t, float_);
     ST_GET_ENUM(css_clear_t, clear);
     ST_GET_ENUM(css_direction_t, direction);
+    ST_GET_ENUM(css_visibility_t, visibility);
     buf>>content;
     ST_GET_LEN(cr_hint);
     lUInt32 hash = 0;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4888,8 +4888,12 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                     lUInt32 oldBgColor = buf->GetBackgroundColor();
                     lUInt32 cl = srcline->color;
                     lUInt32 bgcl = srcline->bgcolor;
-                    if ( cl!=0xFFFFFFFF )
-                        buf->SetTextColor( cl );
+                    if ( cl!=0xFFFFFFFF ) {
+                        if ( cl==0xDDFFFFFF ) // color: transparent
+                            continue; // Don't draw this word
+                        else
+                            buf->SetTextColor( cl );
+                    }
                     if ( bgcl!=0xFFFFFFFF )
                         buf->SetBackgroundColor( bgcl );
                     // Add drawing flags: text decoration (underline...)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4710,6 +4710,8 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             {
                 word = &frmline->words[j];
                 srcline = &m_pbuffer->srctext[word->src_text_index];
+                if ( srcline->flags & LTEXT_HIDDEN )
+                    continue;
                 if (word->flags & LTEXT_WORD_IS_OBJECT)
                 {
                     // no background, TODO
@@ -4782,9 +4784,11 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             for (j=0; j<frmline->word_count; j++)
             {
                 word = &frmline->words[j];
+                srcline = &m_pbuffer->srctext[word->src_text_index];
+                if ( srcline->flags & LTEXT_HIDDEN )
+                    continue;
                 if (word->flags & LTEXT_WORD_IS_OBJECT)
                 {
-                    srcline = &m_pbuffer->srctext[word->src_text_index];
                     ldomNode * node = (ldomNode *) srcline->object;
                     if (node) {
                         LVImageSourceRef img = node->getObjectImageSource();
@@ -4798,7 +4802,6 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 }
                 else if (word->flags & LTEXT_WORD_IS_INLINE_BOX)
                 {
-                    srcline = &m_pbuffer->srctext[word->src_text_index];
                     ldomNode * node = (ldomNode *) srcline->object;
                     // Logically, the coordinates of the top left of the box are:
                     // int x0 = x + frmline->x + word->x;
@@ -4860,7 +4863,6 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         else if (frmline->flags & LTEXT_LINE_IS_BIDI)
                             flgHyphen = true;
                     }
-                    srcline = &m_pbuffer->srctext[word->src_text_index];
                     font = (LVFont *) srcline->t.font;
                     str = srcline->t.text + word->t.start;
                     /*

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -570,7 +570,7 @@ public:
             // But let's be fully deterministic with that, and redo it.
         }
         if ( !already_rendered ) {
-            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, false );
+            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, 0, false );
             // We render the float with the specified direction (from upper dir=), even
             // if UNSET (and not with the direction determined by fribidi from the text).
             // We provide 0,0 as the usable left/right overflows, so no glyph/hanging
@@ -1955,7 +1955,7 @@ public:
                             }
                         }
                         if ( !already_rendered ) {
-                            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, false );
+                            LVRendPageContext alt_context( NULL, m_pbuffer->page_height, 0, false );
                             // inline-block and inline-table have a baseline, that renderBlockElement()
                             // will compute and give us back.
                             int baseline = REQ_BASELINE_FOR_INLINE_BLOCK;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -870,8 +870,13 @@ public:
                         m_max_img_height = m_pbuffer->page_height;
                         // remove parent nodes' margin/border/padding
                         m_max_img_height -= node->getSurroundingAddedHeight();
-                        // remove height taken by the strut baseline
-                        m_max_img_height -= (m_pbuffer->strut_height - m_pbuffer->strut_baseline);
+                        // remove height taken by the strut baseline (but not
+                        // if negative, ie. when a small line-height has pushed
+                        // the baseline below the line box)
+                        int baseline_to_bottom = m_pbuffer->strut_height - m_pbuffer->strut_baseline;
+                        if ( baseline_to_bottom > 0 ) {
+                            m_max_img_height -= baseline_to_bottom;
+                        }
                         m_has_images = true;
                     }
                 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -392,7 +392,6 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     if ( LVRendGetFontEmbolden() )
         hash = hash * 75 + 2384761;
     hash = hash * 31 + gRenderDPI;
-    hash = hash * 31 + gRootFontSize;
     // If not yet rendered (initial loading with XML parsing), we can
     // ignore some global flags that have not yet produced any effect,
     // so they can possibly be updated between loading and rendering
@@ -5011,7 +5010,7 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
         pages->clear();
         if ( showCover )
             pages->add( new LVRendPageInfo( _page_height ) );
-        LVRendPageContext context( pages, _page_height );
+        LVRendPageContext context( pages, _page_height, _def_font->getSize() );
         int numFinalBlocks = calcFinalBlocks();
         CRLog::info("Final block count: %d", numFinalBlocks);
         context.setCallback(callback, numFinalBlocks);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.59k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.60k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0026
 
@@ -4773,6 +4773,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->float_ = css_f_none;
     s->clear = css_c_none;
     s->direction = css_dir_inherit;
+    s->visibility = css_v_visible;
     s->cr_hint.type = css_val_unspecified;
     s->cr_hint.value = CSS_CR_HINT_NONE;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
@@ -11513,6 +11514,14 @@ bool ldomXPointerEx::isVisible()
     while ( p ) {
         if ( p->getRendMethod() == erm_invisible )
             return false;
+        /* This would feel needed now that we added support for visibility:hidden.
+         * But it may have side effects that I don't want to investigate.
+         * Let's say that hidden (not visible) does not mean it should not be
+         * audible, searchable and selectable; if it's hidden, we should be
+         * allowed to find it :)
+        if ( p->getStyle()->visibility >= css_v_hidden )
+            return false;
+        */
         p = p->getParentNode();
     }
     return true;


### PR DESCRIPTION
#### Text: fix max img height when small line-height

An image having its bottom on the baseline, don't account for the strut added space below when this space would be negative (ie. with line-height: 0, which might be explicitely used to kill that strut added bottom blank space).
See https://github.com/koreader/koreader/issues/7257#issuecomment-774648460. Will allow closing https://github.com/koreader/koreader/issues/7257

#### getRenderedWidths(): fix consecutive non-collapsable spaces

Measured widths could be wrong when other unicode space chars are used, which should not collapse.
Noticed with some MathML book abusing that kind of thing to add spacing:
```html
<mtext>&#8201;</mtext><mtext>&#8201;</mtext><mtext>&#8201;</mtext>
```

#### CSS: adds support for "visibility: hidden"

Will be needed for MathML `<mphantom>`. Feels totally uneeded with eBooks, but I figure it can be nice to have, allowing hiding some content via style tweaks, for example translations in a language learning book...

#### Text: fix some bgcolor issues, handle fgcolor transparent

This sample had rendering issues:
```html
<div style="background-color: red; padding: 1em;">
    More text
    <div style="background-color: yellow; padding: 1em; background-image: url(Lac_sevan_armenie.png)">
        More text2
        <span style="background-color: red;">some red</span>
        and
        <span style="background-color: yellow;">some yellow</span>
        and some transparent
        <span style="color: transparent;">transparent</span>
        and
        <span style="background-color: red; color: transparent;">red</span>
        and
        <span style="background-color: yellow; color: transparent"> yellow</span>
        and done.
    </div>
</div>
```

Before:
![image](https://user-images.githubusercontent.com/24273478/107360580-6bdb1e80-6ad6-11eb-89da-a1f97ca276a0.png)

After (just as Firefox):
![image](https://user-images.githubusercontent.com/24273478/107360414-320a1800-6ad6-11eb-9a7d-95a639493397.png)

My previous attempt/hack https://github.com/koreader/crengine/pull/318/commits/05036537bb21d6b52e7a2ece4f852f0fb704a422 seems wrong - don't remember what test case I attempted to solve with it :/
Closes #418 with added support for `color: transparent` (although it doesn't solve the related issue #417).

#### remove global gRootFontSize

Since #413, `lengthToPx()` can access the document and get the root font size. But we need to pass it to lvpagesplitter though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/419)
<!-- Reviewable:end -->
