### PR TITLE
CSS: add support for 'line-break' and 'word-break', and other fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -340,6 +340,25 @@ enum css_visibility_t {
     css_v_collapse // handled as "hidden" (but it should behave differently on tables, which we don't ensure)
 };
 
+/// line-break property values
+enum css_line_break_t {
+    css_lb_inherit,
+    css_lb_auto,
+    css_lb_normal,
+    css_lb_loose,
+    css_lb_strict,
+    css_lb_anywhere
+};
+
+/// word-break property values
+enum css_word_break_t {
+    css_wb_inherit,
+    css_wb_normal,
+    css_wb_break_word, // legacy, handled as "normal" (and "overflow-wrap: anywhere", which is our default behaviour)
+    css_wb_break_all,
+    css_wb_keep_all
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,        // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,      // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -87,10 +87,12 @@ enum css_style_rec_important_bit {
     imp_bit_clear,
     imp_bit_direction,
     imp_bit_visibility,
+    imp_bit_line_break,
+    imp_bit_word_break,
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 66 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 68 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[1]
@@ -167,6 +169,8 @@ struct css_style_rec_tag {
     css_clear_t            clear;
     css_direction_t        direction;
     css_visibility_t       visibility;
+    css_line_break_t       line_break;
+    css_word_break_t       word_break;
     lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
@@ -222,6 +226,8 @@ struct css_style_rec_tag {
     , clear(css_c_none)
     , direction(css_dir_inherit)
     , visibility(css_v_inherit)
+    , line_break(css_lb_inherit)
+    , word_break(css_wb_inherit)
     , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -90,7 +90,9 @@ extern "C" {
 // mostly used for rare inherited CSS properties that don't need us to waste a bit for
 // them in the above flags. The LTEXT_HAS_EXTRA signals one or more of these are set.
 enum ltext_extra_t {
-    LTEXT_EXTRA_CSS_HIDDEN = 1          // visibility: hidden
+    LTEXT_EXTRA_CSS_HIDDEN = 1,         // visibility: hidden
+    LTEXT_EXTRA_CSS_LINE_BREAK,         // line-break: anywhere, or loose/normal/strict (for lang=ja/zh)
+    LTEXT_EXTRA_CSS_WORD_BREAK,         // word-break: break-all or keep-all
 };
 
 /** \brief Source text line

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -80,10 +80,18 @@ extern "C" {
 
 #define LTEXT_FIT_GLYPHS             0x08000000  // Avoid glyph overflows and override at line edges and between text nodes
 
-#define LTEXT_HIDDEN                 0x10000000  // Do not draw (visibility:hidden)
+#define LTEXT_HAS_EXTRA              0x10000000  // Has extra properties (see below)
 #define LTEXT__AVAILABLE_BIT_30__    0x20000000
 #define LTEXT__AVAILABLE_BIT_31__    0x40000000
 #define LTEXT_LEGACY_RENDERING       0x80000000  // Legacy text rendering tweaks
+
+
+// Extra LTEXT properties we can request (via these values) and fetch from the node style,
+// mostly used for rare inherited CSS properties that don't need us to waste a bit for
+// them in the above flags. The LTEXT_HAS_EXTRA signals one or more of these are set.
+enum ltext_extra_t {
+    LTEXT_EXTRA_CSS_HIDDEN = 1          // visibility: hidden
+};
 
 /** \brief Source text line
 */
@@ -116,6 +124,7 @@ typedef struct
     };
 } src_text_fragment_t;
 
+int getLTextExtraProperty( src_text_fragment_t * srcline, ltext_extra_t extra_property );
 
 /** \brief Formatted word
 */

--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -119,6 +119,7 @@ class TextLangCfg
     #endif
 
     bool _duplicate_real_hyphen_on_next_line;
+    bool _is_ja_zh;
 
     void resetCounters();
 
@@ -155,6 +156,8 @@ public:
     bool hasLBCharSubFunc() const { return _lb_char_sub_func != NULL; }
     lb_char_sub_func_t getLBCharSubFunc() const { return _lb_char_sub_func; }
     struct LineBreakProperties * getLBProps() const { return (struct LineBreakProperties *)_lb_props; }
+    lChar32 getCssLbCharSub(css_line_break_t css_linebreak, css_word_break_t css_wordbreak,
+                struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable, lChar32 tweaked_ch);
     #endif
 
     bool duplicateRealHyphenOnNextLine() const { return _duplicate_real_hyphen_on_next_line; }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3196,6 +3196,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         if ( style->visibility >= css_v_hidden ) { // hidden
             flags |= LTEXT_HAS_EXTRA;
         }
+        if ( style->line_break > css_lb_auto ) { // normal, loose, strict
+            flags |= LTEXT_HAS_EXTRA;
+        }
+        if ( style->word_break > css_wb_break_word ) { // break-all or keep-all (break-word is handled as normal)
+            flags |= LTEXT_HAS_EXTRA;
+        }
 
         // Now, process styles that may differ between inline nodes, and
         // are needed to display any children text node.
@@ -4057,6 +4063,8 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->clear = source->clear;
     dest->direction = source->direction;
     dest->visibility = source->visibility;
+    dest->line_break = source->line_break;
+    dest->word_break = source->word_break;
     dest->content = source->content ;
     dest->cr_hint.type = source->cr_hint.type ;
     dest->cr_hint.value = source->cr_hint.value ;
@@ -9836,6 +9844,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( list_style_type, css_lst_inherit );
     UPDATE_STYLE_FIELD( list_style_position, css_lsp_inherit );
     UPDATE_STYLE_FIELD( visibility, css_v_inherit );
+    UPDATE_STYLE_FIELD( line_break, css_lb_inherit );
+    UPDATE_STYLE_FIELD( word_break, css_wb_inherit );
 
     // Note: we don't inherit "direction" (which should be inherited per specs);
     // We'll handle inheritance of direction in renderBlockEnhanced, because

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9861,6 +9861,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( font_weight, css_fw_inherit );
     if ( pstyle->font_family == css_ff_inherit ) {
         //UPDATE_STYLE_FIELD( font_name, "" );
+        // Just set the name of the font already resolved (via enode->initNodeFont)
+        // for the parent node
         pstyle->font_name = parent_font.get()->getTypeFace();
     }
     UPDATE_STYLE_FIELD( font_family, css_ff_inherit );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2881,7 +2881,7 @@ lString32 renderListItemMarker( ldomNode * enode, int & marker_width, LFormatted
         // in another LTR segment)
         if ( txform ) {
             TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( enode );
-            txform->AddSourceLine( marker.c_str(), marker.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, 0, 0);
+            txform->AddSourceLine( marker.c_str(), marker.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, 0, 0, enode);
         }
     }
     return marker;
@@ -3188,10 +3188,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // inside that strut.
             flags |= LTEXT_STRUT_CONFINED;
         }
-        if ( style->visibility >= css_v_hidden )
-            flags |= LTEXT_HIDDEN;
-        else
-            flags &= ~LTEXT_HIDDEN;
+
+        // Other inherited CSS properties that don't need a special flag.
+        // (We should not reset this flag when this properties becomes
+        // normal again, as this LTEXT_HAS_EXTRA can signal the presence
+        // of other properties.)
+        if ( style->visibility >= css_v_hidden ) { // hidden
+            flags |= LTEXT_HAS_EXTRA;
+        }
 
         // Now, process styles that may differ between inline nodes, and
         // are needed to display any children text node.
@@ -3423,7 +3427,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     margin = -marker_width; // will ensure negative/hanging indent-like rendering
                 marker += "\t";
                 txform->AddSourceLine( marker.c_str(), marker.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy,
-                                        margin, NULL );
+                                        margin, enode );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH;
             }
         }
@@ -3481,7 +3485,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     lString32Collection lines;
                     lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
-                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                 }
                 txform->AddSourceObject(flags, line_h, valign_dy, indent, enode, lang_cfg );
                 title = enode->getAttributeValue(attr_subtitle);
@@ -3489,14 +3493,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     lString32Collection lines;
                     lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
-                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                 }
                 title = enode->getAttributeValue(attr_title);
                 if ( !title.empty() ) {
                     lString32Collection lines;
                     lines.parse(title, cs32("\\n"), true);
                     for ( int i=0; i<lines.length(); i++ )
-                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                        txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                 }
             } else { // inline image
                 // We use the flags computed previously (and not baseflags) as they
@@ -3616,16 +3620,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  leaving  => PDF PDI
                     // but it then doesn't have the intended effect (fribidi bug or limitation?)
                     if ( dir.compare("rtl") == 0 ) {
-                        // txform->AddSourceLine( U"\x2068\x202E", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        // txform->AddSourceLine( U"\x2068\x202E", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         // closeWithPDFPDI = true;
-                        txform->AddSourceLine( U"\x202E", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x202E", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDF = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( dir.compare("ltr") == 0 ) {
-                        // txform->AddSourceLine( U"\x2068\x202D", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        // txform->AddSourceLine( U"\x2068\x202D", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         // closeWithPDFPDI = true;
-                        txform->AddSourceLine( U"\x202D", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x202D", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDF = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
@@ -3638,17 +3642,17 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  dir=auto => FSI     U+2068  FIRST STRONG ISOLATE
                     //  leaving  => PDI     U+2069  POP DIRECTIONAL ISOLATE
                     if ( dir.compare("rtl") == 0 ) {
-                        txform->AddSourceLine( U"\x2067", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2067", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( dir.compare("ltr") == 0 ) {
-                        txform->AddSourceLine( U"\x2066", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2066", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                     else if ( nodeElementId == el_bdi || dir.compare("auto") == 0 ) {
-                        txform->AddSourceLine( U"\x2068", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                        txform->AddSourceLine( U"\x2068", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
@@ -3677,7 +3681,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     if ( !content.empty() ) {
                         int em = font->getSize();
                         int letter_spacing = lengthToPx(enode, style->letter_spacing, em);
-                        txform->AddSourceLine( content.c_str(), content.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, NULL, 0, letter_spacing);
+                        txform->AddSourceLine( content.c_str(), content.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode, 0, letter_spacing);
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                 }
@@ -3703,15 +3707,15 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
                 // See comment above: these are the closing counterpart
                 if ( closeWithPDI ) {
-                    txform->AddSourceLine( U"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
                 else if ( closeWithPDFPDI ) {
-                    txform->AddSourceLine( U"\x202C\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x202C\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
                 else if ( closeWithPDF ) {
-                    txform->AddSourceLine( U"\x202C", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent);
+                    txform->AddSourceLine( U"\x202C", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                 }
             }
@@ -3726,14 +3730,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 css_style_ref_t style = enode->getStyle();
                 lUInt32 cl = getForegroundColor(style);
                 lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
-                txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy);
+                txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode);
                 /*
                 // We used to specify two UNICODE_NO_BREAK_SPACE (that would not collapse)
                 // mostly so we were able to detect them in lvtextfm.cpp and avoid this
                 // spacing to change width with text justification.
                 lChar32 delimiter[] = {UNICODE_NO_BREAK_SPACE, UNICODE_NO_BREAK_SPACE}; //160
                 txform->AddSourceLine( delimiter, sizeof(delimiter)/sizeof(lChar32), cl, bgcl, font.get(), lang_cfg,
-                                            LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                                            LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                 // Users who would like more spacing can use:
                 //   body[name="notes"] section title:after,
                 //   body[name="comments"] section title:after {
@@ -3779,7 +3783,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 lUInt32 bgcl = rm == erm_final ? 0xFFFFFFFF : getBackgroundColor(style);
                 txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                                         baseflags | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
-                                        line_h, valign_dy);
+                                        line_h, valign_dy, 0, enode);
                 // baseflags &= ~LTEXT_FLAG_NEWLINE; // clear newline flag
                 // No need to clear the flag, as we set it just below
                 // (any LTEXT_ALIGN_* set implies LTEXT_FLAG_NEWLINE)
@@ -3840,7 +3844,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             lUInt32 bgcl = 0xFFFFFFFF; // erm_final: any background will be drawn by DrawDocument
             txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                             baseflags | LTEXT_SRC_IS_CLEAR_LAST | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
-                            line_h, valign_dy);
+                            line_h, valign_dy, 0, enode);
         }
     }
     else if ( enode->isText() ) {
@@ -3937,7 +3941,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // To show the lang tag for the lang used for this text node AFTER it:
                 // lString32 lang_tag_txt = U"[" + (lang_cfg ? lang_cfg->getLangTag() : lString32("??")) + U"]";
                 // txform->AddSourceLine( lang_tag_txt.c_str(), lang_tag_txt.length(), cl, bgcl, font,
-                //          lang_cfg, baseflags|tflags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, NULL );
+                //          lang_cfg, baseflags|tflags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
             }
         }
     }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -123,6 +123,10 @@ enum css_decl_code {
     cssd_clear,
     cssd_direction,
     cssd_visibility,
+    cssd_line_break,
+    cssd_line_break2,
+    cssd_line_break3,
+    cssd_word_break,
     cssd_content,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
@@ -226,6 +230,10 @@ static const char * css_decl_name[] = {
     "clear",
     "direction",
     "visibility",
+    "line-break",
+    "-epub-line-break",
+    "-webkit-line-break",
+    "word-break",
     "content",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
@@ -1840,6 +1848,29 @@ static const char * css_v_names[] =
     NULL
 };
 
+// line-break value names
+static const char * css_lb_names[] =
+{
+    "inherit",
+    "auto",
+    "normal",
+    "loose",
+    "strict",
+    "anywhere",
+    NULL
+};
+
+// word-break value names
+static const char * css_wb_names[] =
+{
+    "inherit",
+    "normal",
+    "break-word",
+    "break-all",
+    "keep-all",
+    NULL
+};
+
 static const char * css_cr_only_if_names[]={
         "any",
         "always",
@@ -2993,6 +3024,15 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
             case cssd_visibility:
                 n = parse_name( decl, css_v_names, -1 );
                 break;
+            case cssd_line_break:
+            case cssd_line_break2:
+            case cssd_line_break3:
+                prop_code = cssd_line_break;
+                n = parse_name( decl, css_lb_names, -1 );
+                break;
+            case cssd_word_break:
+                n = parse_name( decl, css_wb_names, -1 );
+                break;
             case cssd_content:
                 {
                     lString32 parsed_content;
@@ -3309,6 +3349,12 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_visibility:
             style->Apply( (css_visibility_t) *p++, &style->visibility, imp_bit_visibility, is_important );
+            break;
+        case cssd_line_break:
+            style->Apply( (css_line_break_t) *p++, &style->line_break, imp_bit_line_break, is_important );
+            break;
+        case cssd_word_break:
+            style->Apply( (css_word_break_t) *p++, &style->word_break, imp_bit_word_break, is_important );
             break;
         case cssd_cr_hint:
             {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2140,32 +2140,82 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 {
                     lString8Collection list;
                     int processed = splitPropertyValueList( decl, list );
+                    // printf("font-family: %s\n", lString8(decl, processed).c_str());
                     decl += processed;
                     n = -1;
+                    bool check_for_important = true;
                     if ( list.length() ) {
                         for (int i=list.length()-1; i>=0; i--) {
                             const char * name = list[i].c_str();
+                            // printf("  %d: #%s#\n", i, name);
+                            if ( check_for_important ) {
+                                check_for_important = false;
+                                // The last item from splitPropertyValueList may be or include '!important':
+                                //   "serif !important"      (when generic family name)
+                                //   "Bitter !important"     (when unquoted font name)
+                                //   "Noto Sans !important"  (when unquoted font name)
+                                //   "!important"            (when preceded by a quoted font name)
+                                // We want to notice it and clean the previous part
+                                const char * str = name;
+                                bool drop_item = false;
+                                while (*str) {
+                                    parsed_important = parse_important(str);
+                                    if ( parsed_important ) {
+                                        // Found it
+                                        if ( name == str ) {
+                                            // No advance: standalone "!important"
+                                            // remove it from the list of font names
+                                            drop_item = true;
+                                        }
+                                        else {
+                                            // Otherwise, truncate name up to where we
+                                            // were when finding !important
+                                            list[i] = lString8(name, str - name);
+                                            name = list[i].c_str();
+                                        }
+                                        break;
+                                    }
+                                    else { // skip current char that might be a space
+                                        str++;
+                                    }
+                                    // skip next char until we find a space, that would start a new token
+                                    while (*str && *str != ' ' ) {
+                                        str++;
+                                    }
+                                }
+                                if ( drop_item ) {
+                                    list.erase( i, 1 );
+                                    continue;
+                                }
+                            }
                             int nn = parse_name( name, css_ff_names, -1 );
-                            // Ignore "inherit" (nn=0) in font-family, as its the default
-                            // behaviour, and it may prevent (the way we handle
-                            // it in setNodeStyle()) the use of the font names
-                            // specified alongside.
-                            if (n==-1 && nn!=-1 && nn!=0) {
-                                n = nn;
-                            }
-                            if (nn!=-1) {
-                                // remove family name from font list
+                            if ( nn != -1 ) {
+                                if ( nn == css_ff_inherit ) {
+                                    // "inherit" is invalid when not standalone
+                                    // We have seen books with 'font-family: "Some Font", inherit',
+                                    // that Calibre 3.x would render with "Some Font", while Firefox
+                                    // and Calibre 5.x would consider the whole declaration invalid.
+                                    // So, best to just ignore any non-standalone "inherit", and
+                                    // keep parsing the font names.
+                                    if ( i == 0 && list.length() == 1) {
+                                        // At start and single (we have removed "!important" from the list
+                                        // above, as well as any other generic name that was after)
+                                        n = css_ff_inherit;
+                                    }
+                                }
+                                else {
+                                    // As we browse list from the right, keep replacing
+                                    // the generic family name with the left most one
+                                    n = nn;
+                                }
+                                // remove generic family name from font list
                                 list.erase( i, 1 );
-                            }
-                            else if ( substr_icompare( "!important", name ) ) {
-                                // !important may be caught by splitPropertyValueList()
-                                list.erase( i, 1 );
-                                parsed_important = IMPORTANT_DECL_SET;
                             }
                         }
                         strValue = joinPropertyValueList( list );
                     }
-                    // default to sans-serif generic font-family (the default
+                    // printf("  n=%d imp=%x strValue=%s\n", n, parsed_important, strValue.c_str());
+                    // Default to sans-serif generic font-family (the default
                     // in lvfntman.cpp, as FreeType can't know the family of
                     // a font)
                     if (n == -1)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -33,13 +33,16 @@ enum css_decl_code {
     cssd_white_space,
     cssd_text_align,
     cssd_text_align_last,
+    cssd_text_align_last2, // -epub-text-align-last (mentioned in early versions of EPUB3)
     cssd_text_decoration,
+    cssd_text_decoration2, // -epub-text-decoration (WebKit css extension)
     cssd_text_transform,
     cssd_hyphenate,  // hyphens (proper css property name)
     cssd_hyphenate2, // -webkit-hyphens (used by authors as an alternative to adobe-hyphenate)
     cssd_hyphenate3, // adobe-hyphenate (used by late Adobe RMSDK)
     cssd_hyphenate4, // adobe-text-layout (used by earlier Adobe RMSDK)
     cssd_hyphenate5, // hyphenate (fb2? used in obsoleted css files))
+    cssd_hyphenate6, // -epub-hyphens (mentioned in early versions of EPUB3)
     cssd_color,
     cssd_border_top_color,
     cssd_border_right_color,
@@ -55,6 +58,7 @@ enum css_decl_code {
     cssd_font_features,           // font-feature-settings (not yet parsed)
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
+    cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
     cssd_font_variant_caps,
     cssd_font_variant_position,
     cssd_font_variant_numeric,
@@ -110,6 +114,7 @@ enum css_decl_code {
     cssd_background_repeat,
     cssd_background_position,
     cssd_background_size,
+    cssd_background_size2, // -webkit-background-size (former Webkit property)
     cssd_border_collapse,
     cssd_border_spacing,
     cssd_orphans,
@@ -131,13 +136,16 @@ static const char * css_decl_name[] = {
     "white-space",
     "text-align",
     "text-align-last",
+    "-epub-text-align-last",
     "text-decoration",
+    "-epub-text-decoration",
     "text-transform",
     "hyphens",
     "-webkit-hyphens",
     "adobe-hyphenate",
     "adobe-text-layout",
     "hyphenate",
+    "-epub-hyphens",
     "color",
     "border-top-color",
     "border-right-color",
@@ -153,6 +161,7 @@ static const char * css_decl_name[] = {
     "font-feature-settings",
     "font-variant",
     "font-variant-ligatures",
+    "-webkit-font-variant-ligatures",
     "font-variant-caps",
     "font-variant-position",
     "font-variant-numeric",
@@ -208,6 +217,7 @@ static const char * css_decl_name[] = {
     "background-repeat",
     "background-position",
     "background-size",
+    "-webkit-background-size",
     "border-collapse",
     "border-spacing",
     "orphans",
@@ -2043,9 +2053,13 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                     n = -1;
                 break;
             case cssd_text_align_last:
+            case cssd_text_align_last2:
+                prop_code = cssd_text_align_last;
                 n = parse_name( decl, css_ta_names, -1 );
                 break;
             case cssd_text_decoration:
+            case cssd_text_decoration2:
+                prop_code = cssd_text_decoration;
                 n = parse_name( decl, css_td_names, -1 );
                 break;
             case cssd_text_transform:
@@ -2056,6 +2070,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
             case cssd_hyphenate3:
             case cssd_hyphenate4:
             case cssd_hyphenate5:
+            case cssd_hyphenate6:
                 prop_code = cssd_hyphenate;
                 n = parse_name( decl, css_hyph_names, -1 );
                 if ( n==-1 )
@@ -2245,6 +2260,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
+            case cssd_font_variant_ligatures2:
             case cssd_font_variant_caps:
             case cssd_font_variant_position:
             case cssd_font_variant_numeric:
@@ -2253,7 +2269,8 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 {
                     // https://drafts.csswg.org/css-fonts-3/#propdef-font-variant
                     // https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant
-                    bool parse_ligatures =  prop_code == cssd_font_variant || prop_code == cssd_font_variant_ligatures;
+                    bool parse_ligatures =  prop_code == cssd_font_variant || prop_code == cssd_font_variant_ligatures
+                                                                           || prop_code == cssd_font_variant_ligatures2;
                     bool parse_caps =       prop_code == cssd_font_variant || prop_code == cssd_font_variant_caps;
                     bool parse_position =   prop_code == cssd_font_variant || prop_code == cssd_font_variant_position;
                     bool parse_numeric =    prop_code == cssd_font_variant || prop_code == cssd_font_variant_numeric;
@@ -2906,7 +2923,9 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 }
                 break;
             case cssd_background_size:
+            case cssd_background_size2:
                 {
+                    prop_code = cssd_background_size;
                     // https://developer.mozilla.org/en-US/docs/Web/CSS/background-size
                     css_length_t len[2];
                     int i;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -112,6 +112,8 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.clear) * 31
          + (lUInt32)rec.direction) * 31
          + (lUInt32)rec.visibility) * 31
+         + (lUInt32)rec.line_break) * 31
+         + (lUInt32)rec.word_break) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
@@ -189,6 +191,8 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.clear == r2.clear&&
            r1.direction == r2.direction&&
            r1.visibility == r2.visibility&&
+           r1.line_break == r2.line_break&&
+           r1.word_break == r2.word_break&&
            r1.content == r2.content&&
            r1.cr_hint==r2.cr_hint;
 }
@@ -387,6 +391,8 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(clear);
     ST_PUT_ENUM(direction);
     ST_PUT_ENUM(visibility);
+    ST_PUT_ENUM(line_break);
+    ST_PUT_ENUM(word_break);
     buf << content;
     ST_PUT_LEN(cr_hint);
     lUInt32 hash = calcHash(*this);
@@ -457,6 +463,8 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_clear_t, clear);
     ST_GET_ENUM(css_direction_t, direction);
     ST_GET_ENUM(css_visibility_t, visibility);
+    ST_GET_ENUM(css_line_break_t, line_break);
+    ST_GET_ENUM(css_word_break_t, word_break);
     buf>>content;
     ST_GET_LEN(cr_hint);
     lUInt32 hash = 0;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -320,6 +320,12 @@ int getLTextExtraProperty( src_text_fragment_t * srcline, ltext_extra_t extra_pr
     if ( extra_property == LTEXT_EXTRA_CSS_HIDDEN ) {
         return style->visibility >= css_v_hidden ? 1 : 0;
     }
+    if ( extra_property == LTEXT_EXTRA_CSS_LINE_BREAK ) {
+        return style->line_break; // more than 1 possibly interesting value
+    }
+    if ( extra_property == LTEXT_EXTRA_CSS_WORD_BREAK ) {
+        return style->word_break; // more than 1 possibly interesting value
+    }
     return 0;
 }
 
@@ -1112,6 +1118,19 @@ public:
                 }
             }
 
+            // CSS tweaks to line breaking via line-break: and word-break:
+            // ("white-space: nowrap" has precedence)
+            #if (USE_LIBUNIBREAK==1)
+            css_line_break_t css_linebreak = css_lb_auto; // no specific tweak
+            css_word_break_t css_wordbreak = css_wb_normal; // no specific tweak
+            bool has_css_line_breaking_tweaks = false;
+            if ( !nowrap && src->flags & LTEXT_HAS_EXTRA ) {
+                css_linebreak = (css_line_break_t)getLTextExtraProperty(src, LTEXT_EXTRA_CSS_LINE_BREAK);
+                css_wordbreak = (css_word_break_t)getLTextExtraProperty(src, LTEXT_EXTRA_CSS_WORD_BREAK);
+                has_css_line_breaking_tweaks = css_linebreak > css_lb_auto || css_wordbreak > css_wb_break_word;
+            }
+            #endif
+
             if ( src->flags & LTEXT_SRC_IS_FLOAT ) {
                 m_text[pos] = 0;
                 m_srcs[pos] = src;
@@ -1395,6 +1414,13 @@ public:
                         // Lang specific function may want to substitute char (for
                         // libunibreak only) to tweak line breaking around it
                         ch = src->lang_cfg->getLBCharSubFunc()(&lbCtx, m_text, pos, len-1 - k);
+                        // We do this before the following, to allow this lang specific function
+                        // to possibly tweak the more generic getCssLbCharSub()
+                    }
+                    if ( has_css_line_breaking_tweaks ) {
+                        // CSS line breaking tweaks by char substitution (we need to provide our 'ch'
+                        // as it may have been tweaked and differ from m_text[pos]...)
+                        ch = src->lang_cfg->getCssLbCharSub(css_linebreak, css_wordbreak, &lbCtx, m_text, pos, len-1 - k, ch);
                     }
                     int brk = lb_process_next_char(&lbCtx, (utf32_t)ch);
                     if ( pos > 0 ) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -302,6 +302,26 @@ void lvtextAddSourceObject(
 #define DEPRECATED_LINE_BREAK_WORD_COUNT    3
 #define DEPRECATED_LINE_BREAK_SPACE_LIMIT   64
 
+// Fetch some extra LTEXT properties from the node style (mostly used for rare inherited
+// CSS properties that don't require us to waste a bit in srcline->flags)
+int getLTextExtraProperty( src_text_fragment_t * srcline, ltext_extra_t extra_property ) {
+    // We return 0 when no property: be sure if returning one of multiple css_xx_something enums,
+    // the one with a value of 0 is the one that requires no specific handling (inherit, none, auto...)
+    if ( !(srcline->flags & LTEXT_HAS_EXTRA) )
+        return 0;
+    if ( !srcline->object )
+        return 0;
+    ldomNode * node = (ldomNode *) srcline->object;
+    if ( node->isText() )
+        node = node->getParentNode();
+    if ( !node || node->isNull() )
+        return 0;
+    css_style_ref_t style = node->getStyle();
+    if ( extra_property == LTEXT_EXTRA_CSS_HIDDEN ) {
+        return style->visibility >= css_v_hidden ? 1 : 0;
+    }
+    return 0;
+}
 
 #ifdef __cplusplus
 
@@ -4711,7 +4731,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             {
                 word = &frmline->words[j];
                 srcline = &m_pbuffer->srctext[word->src_text_index];
-                if ( srcline->flags & LTEXT_HIDDEN )
+                if ( srcline->flags & LTEXT_HAS_EXTRA && getLTextExtraProperty(srcline, LTEXT_EXTRA_CSS_HIDDEN) )
                     continue;
                 if (word->flags & LTEXT_WORD_IS_OBJECT)
                 {
@@ -4786,7 +4806,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             {
                 word = &frmline->words[j];
                 srcline = &m_pbuffer->srctext[word->src_text_index];
-                if ( srcline->flags & LTEXT_HIDDEN )
+                if ( srcline->flags & LTEXT_HAS_EXTRA && getLTextExtraProperty(srcline, LTEXT_EXTRA_CSS_HIDDEN) )
                     continue;
                 if (word->flags & LTEXT_WORD_IS_OBJECT)
                 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -86,7 +86,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.60k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.61k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0027
 
@@ -4773,6 +4773,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->clear = css_c_none;
     s->direction = css_dir_inherit;
     s->visibility = css_v_visible;
+    s->line_break = css_lb_auto;
+    s->word_break = css_wb_normal;
     s->cr_hint.type = css_val_unspecified;
     s->cr_hint.value = CSS_CR_HINT_NONE;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -88,7 +88,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.60k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0026
+#define FORMATTING_VERSION_ID 0x0027
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5596,25 +5596,29 @@ int LVTextFileBase::fillCharBuffer()
 
 bool LVXMLParser::ReadText()
 {
-    // TODO: remove tracking of file pos
-    //int text_start_pos = 0;
-    //int ch_start_pos = 0;
-    //int last_split_fpos = 0;
     int last_split_txtlen = 0;
     int tlen = 0;
-    //text_start_pos = (int)(m_buf_fpos + m_buf_pos);
     m_txt_buf.reset(TEXT_SPLIT_SIZE+1);
     lUInt32 flags = m_callback->getFlags();
     bool pre_para_splitting = ( flags & TXTFLG_PRE_PARA_SPLITTING )!=0;
     bool last_eol = false;
 
-    bool flgBreak = false;
+    bool flgBreak = false; // set when this text node should end
+    int nbCharToSkipOnFlgBreak = 0;
     bool splitParas = false;
     while ( !flgBreak ) {
-        int i=0;
-        if ( m_read_buffer_pos + 1 >= m_read_buffer_len ) {
-            if ( !fillCharBuffer() ) {
+        // We might have to peek at a few chars further away in the buffer:
+        // be sure we have 10 chars available (to get '</script') so we
+        // don't uneedlessly loop 8 times with needMoreData=true.
+        #define TEXT_READ_AHEAD_NEEDED_SIZE 10
+        bool needMoreData = false; // set when more buffer data needed to properly check for things
+        bool hasNoMoreData = false;
+        int available = m_read_buffer_len - m_read_buffer_pos;
+        if ( available < TEXT_READ_AHEAD_NEEDED_SIZE ) {
+            available = fillCharBuffer();
+            if ( available <= 0 ) {
                 m_eof = true;
+                hasNoMoreData = true;
                 bool done = true;
                 if ( tlen > 0 ) {
                     // We still have some text in m_txt_buf to handle.
@@ -5632,70 +5636,113 @@ bool LVXMLParser::ReadText()
                 if ( done )
                     return false;
             }
+            else {
+                // fillCharBuffer() ensures there's quite a bit of data available.
+                // If we're now with not much available, we're sure there's no more data to read
+                if ( available < TEXT_READ_AHEAD_NEEDED_SIZE ) {
+                    hasNoMoreData = true;
+                }
+            }
         }
-      if ( !m_eof ) { // just skip the following if m_eof but still some text in buffer to handle
+        // Walk buffer without updating m_read_buffer_pos
+        int i=0;
+        // If m_eof (m_read_buffer_pos == m_read_buffer_len), this 'for' won't loop
         for ( ; m_read_buffer_pos+i<m_read_buffer_len; i++ ) {
             lChar32 ch = m_read_buffer[m_read_buffer_pos + i];
-            lChar32 nextch = m_read_buffer_pos + i + 1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 1] : 0;
-            flgBreak = m_eof;
             if ( m_in_cdata ) { // we're done only when we meet ']]>'
-                if ( ch==']' && nextch==']') {
-                    lChar32 nextnextch = m_read_buffer_pos + i + 2 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos + i + 2] : 0;
-                    if ( nextnextch=='>' ) {
-                        flgBreak = true;
+                if ( ch==']' ) {
+                    if ( m_read_buffer_pos+i+1 < m_read_buffer_len ) {
+                        if ( m_read_buffer[m_read_buffer_pos+i+1] == ']' ) {
+                            if ( m_read_buffer_pos+i+2 < m_read_buffer_len ) {
+                                if ( m_read_buffer[m_read_buffer_pos+i+2] == '>' ) {
+                                    flgBreak = true;
+                                    nbCharToSkipOnFlgBreak = 3;
+                                }
+                            }
+                            else if ( !hasNoMoreData ) {
+                                needMoreData = true;
+                            }
+                        }
+                    }
+                    else if ( !hasNoMoreData ) {
+                        needMoreData = true;
                     }
                 }
             }
             else if ( ch=='<' ) {
                 if ( m_in_html_script_tag ) { // we're done only when we meet </script>
-                    if ( nextch=='/' && m_read_buffer_pos + i + 7 < m_read_buffer_len ) {
-                        const lChar32 * buf = (const lChar32 *)(m_read_buffer + m_read_buffer_pos + i + 2);
-                        lString32 tag(buf, 6);
-                        if ( tag.lowercase() == U"script" ) {
-                            flgBreak = true;
+                    if ( m_read_buffer_pos+i+1 < m_read_buffer_len ) {
+                        if ( m_read_buffer[m_read_buffer_pos+i+1] == '/' ) {
+                            if ( m_read_buffer_pos+i+7 < m_read_buffer_len ) {
+                                const lChar32 * buf = (const lChar32 *)(m_read_buffer + m_read_buffer_pos + i + 2);
+                                lString32 tag(buf, 6);
+                                if ( tag.lowercase() == U"script" ) {
+                                    flgBreak = true;
+                                    nbCharToSkipOnFlgBreak = 1;
+                                }
+                            }
+                            else if ( !hasNoMoreData ) {
+                                needMoreData = true;
+                            }
                         }
                     }
+                    else if ( !hasNoMoreData ) {
+                        needMoreData = true;
+                    }
                 }
-                else {
+                else { // '<' marks the end of this text node
                     flgBreak = true;
+                    nbCharToSkipOnFlgBreak = 1;
                 }
             }
-            if ( flgBreak && !tlen ) {
-                m_read_buffer_pos++;
-                if ( m_in_cdata ) {
-                    m_read_buffer_pos+=2;
-                }
+            if ( flgBreak && !tlen ) { // no passed-by text content to provide to callback
+                m_read_buffer_pos += nbCharToSkipOnFlgBreak;
                 return false;
             }
             splitParas = false;
-            if (last_eol && pre_para_splitting && (ch==' ' || ch=='\t' || ch==160) && tlen>0 ) //!!!
+            if (pre_para_splitting && last_eol && (ch==' ' || ch=='\t' || ch==160) && tlen>0 ) {
+                // In Lib.ru books, lines are split at ~76 bytes. The start of a paragraph is indicated
+                // by a line starting with a few spaces.
                 splitParas = true;
-            if (!flgBreak && !splitParas)
-            {
+            }
+            if (!flgBreak && !splitParas && !needMoreData) { // regular char, passed-by text content
                 tlen++;
             }
-            if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas)
-            {
+            if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas || needMoreData ) {
+                // m_txt_buf filled, end of text node, para splitting, or need more data
                 if ( last_split_txtlen==0 || flgBreak || splitParas )
                     last_split_txtlen = tlen;
                 break;
             }
-            else if (ch==' ' || (ch=='\r' && nextch!='\n')
-                || (ch=='\n' && nextch!='\r') )
-            {
-                //last_split_fpos = (int)(m_buf_fpos + m_buf_pos);
+            else if (ch==' ') {
+                // Not sure what this last_split_txtlen is about: may be to avoid spliting
+                // a word into multiple text nodes (when tlen > TEXT_SPLIT_SIZE), so splitting
+                // on spaces, \r and \n when giving the text to the callback?
                 last_split_txtlen = tlen;
+                last_eol = false;
             }
-            last_eol = (ch=='\r' || ch=='\n');
+            else if (ch=='\r' || ch=='\n') {
+                // Not sure what happens when \r\n at buffer boundary, and we would have \r at end
+                // of a first text node, and the next one starting with \n.
+                // We could just 'break' if !hasNoMoreData and go fetch more char - but as this
+                // is hard to test, just be conservative and keep doing it this way.
+                lChar32 nextch = m_read_buffer_pos+i+1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos+i+1] : 0;
+                if ( (ch=='\r' && nextch!='\n') || (ch=='\n' && nextch!='\r') ) {
+                    last_split_txtlen = tlen;
+                }
+                last_eol = true; // Keep track of them to allow splitting paragraphs
+            }
+            else {
+                last_eol = false;
+            }
         }
-        if ( i>0 ) {
+        if ( i>0 ) { // Append passed-by regular text content to m_txt_buf
             m_txt_buf.append( m_read_buffer + m_read_buffer_pos, i );
             m_read_buffer_pos += i;
         }
-      }
-        if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas)
-        {
+        if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas) {
             //=====================================================
+            // Provide accumulated text to callback
             lChar32 * buf = m_txt_buf.modify();
 
             const lChar32 * enc_table = NULL;
@@ -5734,25 +5781,13 @@ bool LVXMLParser::ReadText()
             last_split_txtlen = 0;
 
             //=====================================================
-            if (flgBreak)
-            {
-                // TODO:LVE???
-                if ( PeekCharFromBuffer()=='<' )
-                    m_read_buffer_pos++;
-                else if ( m_in_cdata && PeekCharFromBuffer()==']' )
-                    m_read_buffer_pos += 3; // skip ']]>'
-                //if ( m_read_buffer_pos < m_read_buffer_len )
-                //    m_read_buffer_pos++;
+            if (flgBreak) {
+                m_read_buffer_pos += nbCharToSkipOnFlgBreak;
                 break;
             }
-            //text_start_pos = last_split_fpos; //m_buf_fpos + m_buf_pos;
-            //last_split_fpos = 0;
         }
     }
 
-
-    //if (!Eof())
-    //    m_buf_pos++;
     return (!m_eof);
 }
 

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -8,6 +8,10 @@
 #include "../include/textlang.h"
 #include "../include/hyphman.h"
 
+#if (USE_UTF8PROC==1)
+#include <utf8proc.h>
+#endif
+
 // Uncomment to see which lang_tags are seen and lang_cfg created
 // #define DEBUG_LANG_USAGE
 
@@ -630,6 +634,146 @@ lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
     }
     return text[pos];
 }
+
+// (Mostly) non-language specific char substitution to ensure CSS line-break and word-break properties
+//
+// Note: the (hardcoded in many places) default behaviour (without these tweaks) in crengine
+// resembles "word-break: break-word; overflow-wrap: break-word", that is: we don't let text
+// overflow their container. So, we don't differentiate "word-break: normal" from "break-word",
+// and we don't handle "overflow-wrap" (normal/break-word/anywhere).
+//
+// Specs:
+//   https://drafts.csswg.org/css-text-3/#word-break-property
+//   https://drafts.csswg.org/css-text-3/#line-break-property
+// Also see:
+//   https://florian.rivoal.net/talks/line-breaking/
+// Rust implementation of UAX#14 and these CSS properties:
+//   https://github.com/makotokato/uax14_rs
+// WebKit:
+//   https://bugs.webkit.org/show_bug.cgi?id=89235
+//   https://trac.webkit.org/changeset/176473/webkit
+//   https://trac.webkit.org/wiki/LineBreakingCSS3Mapping
+// Firefox:
+//   https://bugzilla.mozilla.org/show_bug.cgi?id=1011369
+//   https://bugzilla.mozilla.org/show_bug.cgi?id=1531715
+//   https://hg.mozilla.org/integration/autoland/rev/436e3199c386
+//   https://hg.mozilla.org/releases/mozilla-esr78/file/tip/intl/lwbrk/LineBreaker.cpp
+//
+// Most of these implementation handles line breaking themselves, which we do not
+// exactly do here: we just masquerade an original char with another one with
+// different line-breaking properties, before invoking libunibreak pure UAX#14
+// implementation, expecting this to exhibit the wished behaviour.
+// Below, we mostly always use a random LBP_ID (CJK ideographic char) that should
+// break on both sides: this allows breaking on the unbreakable side, but it may
+// change the original LB class behaviour on the other side...
+//
+lChar32 TextLangCfg::getCssLbCharSub(css_line_break_t css_linebreak, css_word_break_t css_wordbreak,
+                struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable, lChar32 tweaked_ch) {
+    // "line-break: anywhere" has precedence over everything
+    if ( css_linebreak == css_lb_anywhere ) {
+        return 0x5000; // Random CJK ideographic character LBP_ID
+                       // Everything becoming ID, it can break anywhere
+    }
+    lChar32 ch = tweaked_ch ? tweaked_ch : text[pos];
+    enum LineBreakClass lbc = lb_get_char_class(lbpCtx, ch);
+    if ( css_wordbreak == css_wb_break_all ) {
+        if ( lbc == LBP_AI || lbc == LBP_AL || lbc == LBP_NU || lbc == LBP_SA ) {
+            // Alphabetic, ambiguous (ID in CJK lang, AL otherwise) numeric, south-east asian:
+            // treated as ideographic
+            // (Note: Firefox includes others: CJ H2 H3 JL JT JV
+            return 0x5000; // Random CJK ideographic character LBP_ID
+        }
+    }
+    else if ( css_wordbreak == css_wb_keep_all ) {
+	// A char of classes AI AL ID NU HY H2 H3 JL JV JT CJ shouldn't break
+        // between another char of any of these class.
+        // (Note: uax14_rs includes LBP_HY but Firefox does not)
+        // Feels like treating a char of these classes just as AL
+        if ( lbc == LBP_AI || lbc == LBP_AL || lbc == LBP_ID || lbc == LBP_NU || lbc == LBP_HY || lbc == LBP_H2 ||
+                    lbc == LBP_H3 || lbc == LBP_JL || lbc == LBP_JV || lbc == LBP_JT || lbc == LBP_CJ ) {
+            return 0x41; // 'A' LBP_AL
+        }
+    }
+    if ( css_linebreak > css_lb_auto ) {
+        // Following rules from https://drafts.csswg.org/css-text-3/#line-break-property:
+
+        // "The following breaks are forbidden in strict line breaking and allowed in normal and loose:
+        // - breaks before Japanese small kana or the Katakana-Hiragana prolonged sound mark,
+        // i.e. character from the Unicode line breaking class CJ [UAX14]."
+        if ( css_linebreak == css_lb_strict && lbc == LBP_CJ) {
+            // Conditional Japanese Starter => Nonstarter (as done by libunibreak itself
+            // when the lang tag ends with "-strict')
+            return 0x2047; // '⁇' LBP_NS
+        }
+
+        // "The following breaks are allowed for normal and loose line breaking if the writing
+        // system is Chinese or Japanese, and are otherwise forbidden:
+        // - breaks before certain CJK hyphen-like characters: U+301C,  U+30A0"
+        if ( _is_ja_zh && css_linebreak != css_lb_strict && ( ch==0x301C || ch==0x30A0 ) ) {
+            // By default, libunibreak considers them LBP_NS (Nonstarter, non breakable before).
+            // https://unicode.org/reports/tr14/#NS: "Optionally, the NS restriction may be relaxed
+            // by tailoring, with some or all characters treated like ID to achieve a more permissive
+            // style of line breaking, especially in some East Asian document styles"
+            return 0x5000; // Random CJK ideographic character LBP_ID
+        }
+
+        // "The following breaks are allowed for loose line breaking if the preceding character
+        // belongs to the Unicode line breaking class ID [UAX14] (including when the preceding
+        // character is treated as ID due to word-break: break-all), and are otherwise forbidden:
+        // - breaks before hyphens: U+2010, U+2013"
+        if ( css_linebreak == css_lb_loose && pos > 1 && ( ch==0x2010 || ch==0x2013 ) ) {
+            // By default, libunibreak considers them LBP_NS (Nonstarter, non breakable before).
+            enum LineBreakClass plbc = lb_get_char_class(lbpCtx, text[pos-1]);
+            if ( plbc == LBP_ID || (css_wordbreak == css_wb_break_all &&
+                                    ( plbc == LBP_AI || plbc == LBP_AL || plbc == LBP_NU || plbc == LBP_SA )) ) {
+                return 0x5000; // Random CJK ideographic character LBP_ID
+            }
+        }
+
+        // "The following breaks are forbidden for normal and strict line breaking and allowed in loose:
+        // - breaks before iteration marks: U+3005, U+303B, U+309D, U+309E, U+30FD, U+30FE
+        // - breaks between inseparable characters (such as U+2025, U+2026) i.e. characters
+        //   from the Unicode line breaking class IN [UAX14]. "
+        if ( css_linebreak == css_lb_loose && ( ch==0x3005 || ch==0x303B || ch==0x309D ||
+                                                ch==0x309E || ch==0x30FD || ch==0x30FE ||
+                                                lbc == LBP_IN ) ) {
+            // By default, libunibreak considers these codepoints LBP_NS (Nonstarter, non breakable before).
+            // LBP_IN are inseparable from other of the same class, so making them ID should allow breaking.
+            return 0x5000; // Random CJK ideographic character LBP_ID
+        }
+
+        // "The following breaks are allowed for loose if the writing system is Chinese or Japanese
+        // and are otherwise forbidden:
+        // - breaks before certain centered punctuation marks: U+30FB, U+FF1A, U+FF1B, U+FF65, U+203C,
+        //   U+2047, U+2048, U+2049, U+FF01, U+FF1F
+        // - breaks before suffixes: Characters with the Unicode line breaking class PO [UAX14]
+        //   and the East Asian Width property [UAX11] Ambiguous, Fullwidth, or Wide.
+        // - breaks after prefixes: Characters with the Unicode line breaking class PR [UAX14]
+        //   and the East Asian Width property [UAX11] Ambiguous, Fullwidth, or Wide."
+        if ( _is_ja_zh && css_linebreak == css_lb_loose ) {
+            // By default, libunibreak considers these codepoints LBP_NS (Nonstarter, non breakable before)
+            // or (the last 2 ones) LBP_EX (Exclamation, Interrogation, Prohibit line breaks before)
+            if ( ch==0x30FB || ch==0xFF1A || ch==0xFF1B || ch==0xFF65 ||
+                 ch==0x203C || ch==0x2047 || ch==0x2048 || ch==0x2049 ||
+                 ch==0xFF01 || ch==0xFF1F ) {
+                return 0x5000; // Random CJK ideographic character LBP_ID
+            }
+            // For the 2 last cases, we need utf8proc to know the East Asian Width property
+            #if (USE_UTF8PROC==1)
+            if ( lbc == LBP_PO || lbc == LBP_PR ) {
+                // LBP_PO are Postfix Numeric ("do not break following a numeric expression")
+                // LBP_PR are Prefix Numeric ("do not break in front of a numeric expression")
+                if ( utf8proc_charwidth(ch) == 2 ) {
+                    // Note: utf8proc returns 2 for Fullwidth and Wide, 1 or 0 otherwise.
+                    // It may return 1 for "Ambiguous", so we may not handle this case well.
+                    return 0x5000; // Random CJK ideographic character LBP_ID
+                }
+            }
+            #endif
+        }
+    }
+    return ch;
+}
 #endif
 
 // Instantiate a new TextLangCfg with properties adequate to the provided lang_tag
@@ -683,6 +827,9 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     // https://unicode.org/reports/tr14/#Hyphen : in Polish and Portuguese,
     // a real hyphen at end of line must be duplicated at start of next line.
     _duplicate_real_hyphen_on_next_line = false;
+
+    // getCssLbCharSub(), possibly called on each glyph, has some different behaviours with 'ja' and 'zh'
+    _is_ja_zh = LANG_STARTS_WITH(("ja") ("zh"));
 
 #if USE_HARFBUZZ==1
     _hb_language = hb_language_from_string(UnicodeToLocal(hb_lang_tag).c_str(), -1);

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -11,14 +11,36 @@
 // Uncomment to see which lang_tags are seen and lang_cfg created
 // #define DEBUG_LANG_USAGE
 
+// Check a lang tag (or its first part) against a lang (without subparts)
+static bool langStartsWith(const lString32 lang_tag, const char * prefix) {
+    if (!prefix || !prefix[0])
+        return true;
+    int prefix_len = 0;
+    for (const char * p=prefix; *p; p++)
+        prefix_len++;
+    int lang_len = lang_tag.length();
+    if ( lang_len < prefix_len )
+        return false;
+    const lChar32 * s1 = lang_tag.c_str();
+    const lChar8 * s2 = prefix;
+    for ( int i=0; i<prefix_len; i++ )
+        if (s1[i] != s2[i])
+            return false;
+    if ( lang_len == prefix_len ) // "en" starts with "en"
+        return true;
+    if ( s1[prefix_len] == '-' ) // "en-" starts with "en", but "eno" does not
+        return true;
+    return false;
+}
+
 // Some macros to expand: LANG_STARTS_WITH(("fr") ("es"))   (no comma!)
-// to: lang_tag.startsWith("fr") || lang_tag.startsWith("es") || false
+// to langStartsWith(lang_tag, "fr") || langStartsWith(lang_tag, "es") || false
 // (from https://stackoverflow.com/questions/19680962/translate-sequence-in-macro-parameters-to-separate-macros )
 #define PRIMITIVE_SEQ_ITERATE(...) __VA_ARGS__ ## _END
 #define SEQ_ITERATE(...) PRIMITIVE_SEQ_ITERATE(__VA_ARGS__)
 #define LANG_STARTS_WITH(seq) SEQ_ITERATE(LANG_STARTS_WITH_EACH_1 seq)
-#define LANG_STARTS_WITH_EACH_1(...) lang_tag.startsWith(__VA_ARGS__) || LANG_STARTS_WITH_EACH_2
-#define LANG_STARTS_WITH_EACH_2(...) lang_tag.startsWith(__VA_ARGS__) || LANG_STARTS_WITH_EACH_1
+#define LANG_STARTS_WITH_EACH_1(...) langStartsWith(lang_tag, __VA_ARGS__) || LANG_STARTS_WITH_EACH_2
+#define LANG_STARTS_WITH_EACH_2(...) langStartsWith(lang_tag, __VA_ARGS__) || LANG_STARTS_WITH_EACH_1
 #define LANG_STARTS_WITH_EACH_1_END false
 #define LANG_STARTS_WITH_EACH_2_END false
 
@@ -801,7 +823,7 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     //   "q::after  { content: close-quote }"
     quotes_spec * quotes = &_quotes_spec_default;
     for (int i=0; _quotes_spec_table[i].lang_tag!=NULL; i++) {
-        if ( lang_tag.startsWith( _quotes_spec_table[i].lang_tag ) ) {
+        if ( langStartsWith(lang_tag, _quotes_spec_table[i].lang_tag ) ) {
             quotes = &_quotes_spec_table[i];
             break;
         }


### PR DESCRIPTION
#### LVXMLParser::ReadText(): fix parsing at buffer boundaries

Avoid '`</sc`' at buffer end to miss matching '`</script>`' if it would come next when reading from file stream.
A bit of clean up of this part of the code, added comments as I understand what bits are supposed to do.
A bit risky though - spent hours on this, but not 100% sure I didn't break anything.
See https://github.com/koreader/crengine/pull/405#issuecomment-781570875 and follow ups.

#### TextLang: fix lang_tag first part comparison

"en" and "en-US" do start with "en", but "eno" should not.

#### CSS font-family: fix parsing of 'inherit' and '!important'

Proper parsing of "!important" at end of font-family.  Also try to handle "inherit" in the most compatible way, even if not per current specs: "inherit" is nowadays invalid when not standalone.
We have seen books with '`font-family: "Some Font", inherit`', that Calibre 3.x would render with "Some Font", while Firefox and Calibre 5.x would consider the whole declaration invalid.
So, best to just ignore any non-standalone "inherit", and keep parsing the font names.
See https://github.com/koreader/crengine/issues/362#issuecomment-778697971 and follow-ups.
Closes #362. Will allow closing https://github.com/koreader/koreader/issues/6886.

#### CSS: support a few -epub-* and -webkit-* properties

Mentionned in early specs of EPUB3 (and later deprecated), or only supported as -webkit- at some point in the past, so these can be found in some books without the newer alternatives.
See https://github.com/koreader/crengine/issues/420#issuecomment-779417965 and follow-ups.

#### Text fragment flags: add LTEXT_HAS_EXTRA

Replace LTEXT_HIDDEN and have "visibility: hidden" use it.
This might allow adding support for rare CSS text properties (like "visibility", "line-break) without wasting a bit in the LTEXT_ flags.
Have any generated content (list item markes, pseudo elements, BiDi markers) pass their originated node to AddSourceLine() so we always have access to the node to fetch these extra properties.

#### CSS: add support for 'line-break' and 'word-break'

See comment in the code for how/why we do it a bit differently than other implementations, with possibly not the same results (in hopefully only edge cases).
See https://github.com/koreader/crengine/issues/420#issuecomment-780547104 and around.
Closes #420.

Firefox (top) / KOReader (bottom):

<kbd>![image](https://user-images.githubusercontent.com/24273478/108771040-598fc480-755b-11eb-86cf-8806ccdd2ad3.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/24273478/108771105-76c49300-755b-11eb-8d79-7497f7cc2db7.png)</kbd>

Same with smaller width, which should exhibit some differences
<kbd>![image](https://user-images.githubusercontent.com/24273478/108771616-3a456700-755c-11eb-97ab-94b565b18e39.png)</kbd>
For the CJK stuff, we differ on auto - which is ok per-specs :) but are similar on others, so we must do that loose/normal/strict stuff quite alright.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/423)
<!-- Reviewable:end -->
