### PR TITLE
Various fixes and tweaks before MathML support

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -239,6 +239,7 @@ enum css_value_type_t {
     css_val_pc,   // 12 pt     6pc = 96 css px
     css_val_em,   // relative to font size of the current element
     css_val_ex,   // 1ex =~ 0.5em in many fonts (https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+    css_val_ch,   // 1ch assumed to be 0.5em for widths when impractical to determine (same url)
     css_val_rem,  // 'root em', relative to font-size of the root element (typically <html>)
     css_val_vw,   // 1 percent of the screen width
     css_val_vh,   // 1 percent of the screen height

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -360,12 +360,13 @@ enum css_word_break_t {
 };
 
 enum css_generic_value_t {
-    css_generic_auto = -1,        // (css_val_unspecified, css_generic_auto), for "margin: auto"
-    css_generic_normal = -2,      // (css_val_unspecified, css_generic_normal), for "line-height: normal"
-    css_generic_transparent = -3, // (css_val_unspecified, css_generic_transparent), for "color: transparent"
-    css_generic_contain = -4,     // (css_val_unspecified, css_generic_contain), for "background-size: contain"
-    css_generic_cover = -5,       // (css_val_unspecified, css_generic_cover), for "background-size: cover"
-    css_generic_none = -6         // (css_val_unspecified, css_generic_none), for "max-width: none"
+    css_generic_auto = -1,         // (css_val_unspecified, css_generic_auto), for "margin: auto"
+    css_generic_normal = -2,       // (css_val_unspecified, css_generic_normal), for "line-height: normal"
+    css_generic_transparent = -3,  // (css_val_unspecified, css_generic_transparent), for "color: transparent"
+    css_generic_currentcolor = -4, // (css_val_unspecified, css_generic_currentcolor), for "color: currentcolor"
+    css_generic_contain = -5,      // (css_val_unspecified, css_generic_contain), for "background-size: contain"
+    css_generic_cover = -6,        // (css_val_unspecified, css_generic_cover), for "background-size: cover"
+    css_generic_none = -7          // (css_val_unspecified, css_generic_none), for "max-width: none"
 };
 
 // -cr-hint is a non standard property for providing hints to crengine via style tweaks

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -153,7 +153,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * node, int x0, int y0, int dx,
 // full function for recursive use:
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction, bool ignorePadding, int rendFlags,
             int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth,
-            int indent, TextLangCfg * lang_cfg, bool processNodeAsText=false, bool isStartNode=false);
+            int indent, bool nowrap, TextLangCfg * lang_cfg, bool processNodeAsText=false, bool isStartNode=false);
 // simpler function for first call:
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction=REND_DIRECTION_UNSET, bool ignorePadding=false, int rendFlags=0);
 

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -243,6 +243,11 @@ struct css_style_rec_tag {
         border_width[3] = css_length_t(css_val_unspecified, 0);
         background_size[0] = css_length_t(css_val_unspecified, 0);
         background_size[1] = css_length_t(css_val_unspecified, 0);
+        // Also initialize border colors
+        border_color[0] = css_length_t(css_val_unspecified, css_generic_currentcolor);
+        border_color[1] = css_length_t(css_val_unspecified, css_generic_currentcolor);
+        border_color[2] = css_length_t(css_val_unspecified, css_generic_currentcolor);
+        border_color[3] = css_length_t(css_val_unspecified, css_generic_currentcolor);
     }
     void AddRef() { refCount++; }
     int Release() { return --refCount; }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5556,13 +5556,19 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef, bool useBias )
     LVFontDef def(*fntdef);
     lString8Collection list;
     splitPropertyValueList( fntdef->getTypeFace().c_str(), list );
-    for (int nindex=0; nindex==0 || nindex<list.length(); nindex++) {
-        if ( nindex<list.length() )
+    int nlen = list.length();
+    for (int nindex=0; nindex==0 || nindex<nlen; nindex++) {
+        // Give more weight to first fonts, so we don't risk (with the test at end)
+        // picking an already instantiated second font over a not yet instantiated
+        // first font with the same match.
+        int ordering_weight = nlen - nindex;
+        if ( nindex < nlen )
             def.setTypeFace( list[nindex] );
         else
             def.setTypeFace(lString8::empty_str);
         for (i=0; i<_instance_list.length(); i++) {
             int match = _instance_list[i]->_def.CalcMatch( def, useBias );
+            match = match * 256 + ordering_weight;
             if (match > best_instance_match) {
                 best_instance_match = match;
                 best_instance_index = i;
@@ -5570,6 +5576,7 @@ LVFontCacheItem * LVFontCache::find( const LVFontDef * fntdef, bool useBias )
         }
         for (i=0; i<_registered_list.length(); i++) {
             int match = _registered_list[i]->_def.CalcMatch( def, useBias );
+            match = match * 256 + ordering_weight;
             if (match > best_match) {
                 best_match = match;
                 best_index = i;

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1780,33 +1780,15 @@ int LVSvgImageSource::DecodeFromBuffer(const unsigned char *buf, int buf_size, L
                 nsvgRasterize(rast, image, 1, 1, 1, img, w, h, w*4); // offsets of 1 pixel, scale = 1
                 // stbi_write_png("/tmp/svg.png", w, h, 4, img, w*4); // for debug
                 callback->OnStartDecode(this);
+                lUInt32 * __restrict src = (lUInt32 *)img;
                 lUInt32 * __restrict row = new lUInt32 [ _width ];
-                lUInt8 * __restrict p = img;
                 for (int y=0; y<_height; y++) {
-                    for (int x=0; x<_width; x++) {
-                        // We mostly get full white or full black when using alpha channel like this:
-                        //   row[x] = (((lUInt32)p[3])<<24) | (((lUInt32)p[0])<<16) | (((lUInt32)p[1])<<8) | (((lUInt32)p[2])<<0);
-                        // We can ignore the alpha channel but we get a black background for transparent pixels with:
-                        //   row[x] = (((lUInt32)p[0])<<16) | (((lUInt32)p[1])<<8) | (((lUInt32)p[2])<<0);
-                        // It's better to use alpha channel here to blend pixels over a white background and set opacity to full
-                        // """ To perform a source-over blend between two colors that use straight alpha format:
-                        //           result = (source.RGB * source.A) + (dest.RGB * (1 - source.A))        """
-                        const lUInt8 r = (lUInt8)p[0];
-                        const lUInt8 g = (lUInt8)p[1];
-                        const lUInt8 b = (lUInt8)p[2];
-                        const lUInt8 a = (lUInt8)p[3];
-                        const lUInt8 ia = a ^ 0xFF;
-                        lUInt32 ro = (lUInt32)( r*a + 0xff*ia );
-                        lUInt32 go = (lUInt32)( g*a + 0xff*ia );
-                        lUInt32 bo = (lUInt32)( b*a + 0xff*ia );
-                        // More accurate divide by 256 than just >> 8 (255 becomes 254 with just >> 8)
-                        ro = (ro+1 + (ro >> 8)) >> 8;
-                        go = (go+1 + (go >> 8)) >> 8;
-                        bo = (bo+1 + (bo >> 8)) >> 8;
-                        row[x] = ro<<16|go<<8|bo;
-                        // if (y == 80) // output bytes for a single row
-                        // printf("SVG: byte colors %d %d %d %d > %d %d %d\n", (int)a, (int)r, (int)g, (int)b, (int)ro, (int)go, (int)bo);
-                        p += 4;
+                    size_t px_count = _width;
+                    lUInt32 * __restrict dst = row;
+                    while (px_count--) {
+                        // nanosvg outputs straight RGBA; lvimg expects BGRA, with inverted alpha,
+                        const lUInt32 cl = *src++ ^ 0xFF000000;
+                        *dst++ = ((cl<<16)&0x00FF0000) | ((cl>>16)&0x000000FF) | (cl&0xFF00FF00);
                     }
                     callback->OnLineDecoded( this, y, row );
                 }

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -43,6 +43,8 @@ int LVRendPageList::FindNearestPage( int y, int direction )
     return length()-1;
 }
 
+static LVRendPageContext * main_context = NULL;
+
 LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, int docFontSize, bool gatherLines)
     : callback(NULL), totalFinalBlocks(0)
     , renderedFinalBlocks(0), lastPercent(-1), page_list(pageList), page_h(pageHeight)
@@ -56,6 +58,17 @@ LVRendPageContext::LVRendPageContext(LVRendPageList * pageList, int pageHeight, 
 
 bool LVRendPageContext::updateRenderProgress( int numFinalBlocksRendered )
 {
+    if ( !callback ) {
+        if ( main_context ) {
+            main_context->updateRenderProgress( numFinalBlocksRendered );
+        }
+        return false;
+    }
+    if ( !main_context && callback ) {
+        // Save the main context (with the progress callback), so other
+        // flows' contexts can forward their progress to it
+        main_context = this;
+    }
     renderedFinalBlocks += numFinalBlocksRendered;
     int percent = totalFinalBlocks>0 ? renderedFinalBlocks * 100 / totalFinalBlocks : 0;
     if ( percent<0 )
@@ -805,6 +818,9 @@ void LVRendPageContext::Finalize()
     split();
     lines.clear();
     footNotes.clear();
+    if ( main_context == this ) {
+        main_context = NULL;
+    }
 }
 
 static const char * pagelist_magic = "PageList";

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10138,10 +10138,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
     int lastSpaceWidth = 0; // trailing spaces width to remove
     // These do not need to be passed by reference, as they are only valid for inner nodes/calls
     int indent = 0;         // text-indent: used on first text, and set again on <BR/>
+    bool nowrap = false;    // from upper node's white-space
     bool isStartNode = true; // we are starting measurement on that node
     // Start measurements and recursions:
     getRenderedWidths(node, maxWidth, minWidth, direction, ignoreMargin, rendFlags,
-        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, NULL, false, isStartNode);
+        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap, NULL, false, isStartNode);
     // We took more care with including side bearings into minWidth when considering
     // single words, than into maxWidth: so trust minWidth if larger than maxWidth.
     if ( maxWidth < minWidth)
@@ -10150,7 +10151,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
 
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction, bool ignoreMargin, int rendFlags,
     int &curMaxWidth, int &curWordWidth, bool &collapseNextSpace, int &lastSpaceWidth,
-    int indent, TextLangCfg * lang_cfg, bool processNodeAsText, bool isStartNode)
+    int indent, bool nowrap, TextLangCfg * lang_cfg, bool processNodeAsText, bool isStartNode)
 {
     // This does mostly what renderBlockElement, renderFinalBlock and lvtextfm.cpp
     // do, but only with widths and horizontal margin/border/padding and indent
@@ -10191,6 +10192,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
 
         css_style_ref_t style = node->getStyle();
 
+        // nowrap to provide to children (only useful when inside erm_final, between erm_inline and text nodes)
+        bool nowrap_in = (style->white_space == css_ws_nowrap) || (style->white_space == css_ws_pre);
+            // When getting min width, ensure non free wrap for "white-space: pre" (even if we
+            // don't when rendering). Others like "pre-wrap" and "pre-line" are allowed to wrap.
+
         // Get image size early
         bool is_img = false;
         int img_width = 0;
@@ -10210,20 +10216,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         }
 
         if (m == erm_inline) {
-            if ( is_img ) {
-                // Get done with previous word
-                if (curWordWidth > minWidth)
-                    minWidth = curWordWidth;
-                curWordWidth = 0;
-                collapseNextSpace = false;
-                lastSpaceWidth = 0;
-                if (img_width > 0) { // inline img with a fixed width
-                    maxWidth += img_width;
-                    if (img_width > minWidth)
-                        minWidth = img_width;
-                }
-                return;
-            }
             if ( nodeElementId == el_br ) {
                 #ifdef DEBUG_GETRENDEREDWIDTHS
                     printf("GRW: BR\n");
@@ -10246,27 +10238,41 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 lastSpaceWidth = 0;
                 return;
             }
-            if ( node->isBoxingInlineBox() ) {
-                // Get done with previous word
-                if (curWordWidth > minWidth)
-                    minWidth = curWordWidth;
-                curWordWidth = 0;
+            if ( is_img || node->isBoxingInlineBox() ) {
+                if (!nowrap) {
+                    // Get done with previous word
+                    if (curWordWidth > minWidth)
+                        minWidth = curWordWidth;
+                    curWordWidth = 0;
+                }
                 collapseNextSpace = false;
                 lastSpaceWidth = 0;
-                // Get the rendered width of the inlineBox
                 int _maxw = 0;
                 int _minw = 0;
-                getRenderedWidths(node, _maxw, _minw, direction, false, rendFlags);
+                if ( is_img && img_width > 0) {
+                    // Inline img with a fixed width
+                    _maxw = img_width;
+                    _minw = img_width;
+                }
+                else {
+                    // Get the rendered width of the inlineBox
+                    getRenderedWidths(node, _maxw, _minw, direction, false, rendFlags);
+                }
                 curMaxWidth += _maxw;
-                if (_minw > minWidth)
-                    minWidth = _minw;
+                if (nowrap) {
+                    curWordWidth += _minw;
+                }
+                else {
+                    if (_minw > minWidth)
+                        minWidth = _minw;
+                }
                 return;
             }
             if ( nodeElementId == el_pseudoElem ) {
                 // pseudoElem has no children: reprocess this same node
                 // with processNodeAsText=true, to process its text content.
                 getRenderedWidths(node, maxWidth, minWidth, direction, false, rendFlags,
-                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg, true);
+                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg, true);
                 return;
             }
             // Contains only other inline or text nodes:
@@ -10276,7 +10282,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 // Nothing more to do with inline elements: they just carry some
                 // styles that will be grabbed by children text nodes
                 getRenderedWidths(child, maxWidth, minWidth, direction, false, rendFlags,
-                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg);
+                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg);
             }
             return;
         }
@@ -10388,14 +10394,14 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 for (int i = 0; i < node->getChildCount(); i++) {
                     ldomNode * child = node->getChildNode(i);
                     getRenderedWidths(child, _maxWidth, _minWidth, direction, false, rendFlags,
-                        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg);
+                        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg);
                     // A <BR/> can happen deep among our children, so we deal with that when erm_inline above
                 }
                 if ( nodeElementId == el_pseudoElem ) {
                     // erm_final pseudoElem (which has no children): reprocess this same
                     // node with processNodeAsText=true, to process its text content.
                     getRenderedWidths(node, _maxWidth, _minWidth, direction, false, rendFlags,
-                        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg, true);
+                        curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg, true);
                 }
                 if (lastSpaceWidth)
                     curMaxWidth -= lastSpaceWidth;
@@ -10471,7 +10477,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                                 bool _collapseNextSpace = true;
                                 int _lastSpaceWidth = 0;
                                 getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
-                                    _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, lang_cfg);
+                                    _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, nowrap_in, lang_cfg);
                                 int cspan = StrToIntPercent( child->getAttributeValue(attr_colspan).c_str() );
                                 if ( !cspan ) { // 0 if no attribute
                                     // also check obsolete rbspan attribute for <ruby> tables
@@ -10502,7 +10508,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                             bool _collapseNextSpace = true;
                             int _lastSpaceWidth = 0;
                             getRenderedWidths(n, _maxw, _minw, direction, false, rendFlags,
-                                _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, lang_cfg);
+                                _curMaxWidth, _curWordWidth, _collapseNextSpace, _lastSpaceWidth, indent, nowrap_in, lang_cfg);
                             if ( _minw > caption_min_width )
                                 caption_min_width = _minw;
                             if ( _maxw > caption_max_width )
@@ -10652,7 +10658,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     continue;
                 }
                 getRenderedWidths(child, _maxw, _minw, direction, false, rendFlags,
-                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, lang_cfg);
+                    curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg);
                 if (_maxw > _maxWidth)
                     _maxWidth = _maxw;
                 if (_minw > _minWidth)
@@ -10857,10 +10863,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             case css_tt_inherit:
                 break;
         }
-        // white-space
-        // When getting min width, ensure non free wrap for "white-space: pre" (even if we
-        // don't when rendering). Others like "pre-wrap" and "pre-line" are allowed to wrap.
-        bool nowrap = (parent_style->white_space == css_ws_nowrap) || (parent_style->white_space == css_ws_pre);
+        // white-space (nowrap provided by parent with sub-call)
         bool pre = parent_style->white_space >= css_ws_pre;
         int space_width_scale_percent = pre ? 100 : parent->getDocument()->getSpaceWidthScalePercent();
 
@@ -11039,7 +11042,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             }
             #else // not USE_LIBUNIBREAK==1
             // (This has not been updated to handle nowrap & pre)
-            (void)nowrap; // avoid clang warning: value stored is never read
             for (int i=0; i<chars_measured; i++) {
                 int w = widths[i] - (i>0 ? widths[i-1] : 0);
                 lChar32 c = *(txt + start + i);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2278,8 +2278,8 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
 {
     int sz;
     if ( style->font_size.type == css_val_em || style->font_size.type == css_val_ex ||
-            style->font_size.type == css_val_percent ) {
-        // font_size.type can't be em/ex/%, it should have been converted to px
+            style->font_size.type == css_val_ch || style->font_size.type == css_val_percent ) {
+        // font_size.type can't be em/ex/ch/%, it should have been converted to px
         // or screen_px while in setNodeStyle().
         printf("CRE WARNING: getFont: %d of unit %d\n", style->font_size.value>>8, style->font_size.type);
         sz = style->font_size.value >> 8; // set some value anyway
@@ -2465,8 +2465,10 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
     case css_val_percent:
         px = ( base_px * val.value / 100 ) >> 8;
         break;
-    case css_val_ex: {
-        // value = ex*512 (approximated with base_em, 1ex =~ 0.5em in many fonts)
+    case css_val_ex:
+    case css_val_ch: {
+        // value = ex*512 (approximated with base_em, 1ex =~ 0.5em in many fonts,
+        // and 1ch can be assumed to be 0.5em wide when impractical to determine)
         // Default the base em using the node if not supplied.
         if (base_em < 0)
             base_em = node->getFont()->getSize();
@@ -2537,7 +2539,7 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
 bool is_length_relative_unit(css_length_t val)
 {
     return (val.type == css_val_percent || val.type == css_val_em ||
-            val.type == css_val_ex || val.type == css_val_rem ||
+            val.type == css_val_ex || val.type == css_val_ch || val.type == css_val_rem ||
             val.type == css_val_vw || val.type == css_val_vh ||
             val.type == css_val_vmin || val.type == css_val_vmax);
 }
@@ -9836,6 +9838,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             pstyle->fld.value = parent_style->font_size.value * pstyle->fld.value / 256; \
             break; \
         case css_val_ex: \
+        case css_val_ch: \
             pstyle->fld.type = parent_style->fld.type; \
             pstyle->fld.value = parent_style->font_size.value * pstyle->fld.value / 512; \
             break; \
@@ -9984,6 +9987,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->font_size.value = parent_style->font_size.value * pstyle->font_size.value / 256;
         break;
     case css_val_ex: // value = ex*256 ; 512 = 2ex = 1em = x1
+    case css_val_ch: // value = ch*256 ; 512 = 2ch = 1em = x1
         pstyle->font_size.type = parent_style->font_size.type;
         pstyle->font_size.value = parent_style->font_size.value * pstyle->font_size.value / 512;
         break;
@@ -10024,6 +10028,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             case css_val_percent:
             case css_val_em:
             case css_val_ex:
+            case css_val_ch:
                 {
                 int pem = parent_font->getSize(); // value in screen px
                 int line_h = lengthToPx(enode, parent_style->line_height, pem, pem);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1207,30 +1207,40 @@ public:
             for (int x=0; x<cols.length(); x++)
                 printf("TABLE WIDTHS step2: cols[%d]: %d%% %dpx\n",
                     x, cols[x]->percent, cols[x]->width);
+            printf("TABLE WIDTHS step2: sumwidth=%d, sum_auto_max_width=%d sum_auto_mean_max_content_width=%d\n",
+                    sumwidth, sum_auto_max_width, sum_auto_mean_max_content_width);
         #endif
         // At this point, all columns with specified width or percent has been
         // set accordingly, or reduced to fit table width
         // We need to compute a width for columns with unspecified width.
         // nrest = cols.length() - nwidth;
         int restwidth = assignable_width - sumwidth;
+        bool canFitMaxWidths = sum_auto_max_width <= restwidth;
         int sumMinWidths = 0;
         // new pass: convert text len percent into width
         for (i=0; i<cols.length(); i++) {
             if (cols[i]->width==0) { // unspecified (or width scaled down and rounded to 0)
-                // We have multiple options:
-                // Either distribute remaining width according to max_width ratio
-                // (so larger content gets more width to use less height)
-                //     if (sum_auto_max_width > 0)
-                //         cols[i]->width = cols[i]->max_width * restwidth / sum_auto_max_width;
-                // Or better: distribute remaining width according to the mean
-                // of cells' max_content_width, so a single large cell among
-                // many smaller cells doesn't request all the width for this
-                // column (which would give less to others, which could make
-                // them use more height). This should help getting more
-                // reasonable heights across all rows.
-                if (sum_auto_mean_max_content_width > 0)
-                    cols[i]->width = cols[i]->sum_max_content_width / cols[i]->nb_sum_max_content_width * restwidth / sum_auto_mean_max_content_width;
-                // else stays at 0
+                if ( canFitMaxWidths ) {
+                    // All max content widths fit: use them
+                    cols[i]->width = cols[i]->max_width;
+                }
+                else {
+                    // Max content widths do overflow: smaller widths need to be decided (content will wrap).
+                    // We have multiple options:
+                    // Either distribute remaining width according to max_width ratio
+                    // (so larger content gets more width to use less height)
+                    //     if (sum_auto_max_width > 0)
+                    //         cols[i]->width = cols[i]->max_width * restwidth / sum_auto_max_width;
+                    // Or better: distribute remaining width according to the mean
+                    // of cells' max_content_width, so a single large cell among
+                    // many smaller cells doesn't request all the width for this
+                    // column (which would give less to others, which could make
+                    // them use more height). This should help getting more
+                    // reasonable heights across all rows.
+                    if (sum_auto_mean_max_content_width > 0)
+                        cols[i]->width = cols[i]->sum_max_content_width / cols[i]->nb_sum_max_content_width * restwidth / sum_auto_mean_max_content_width;
+                    // else stays at 0
+                }
                 sumwidth += cols[i]->width;
                 nwidth++;
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10063,6 +10063,12 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     if ( pstyle->color.type != css_val_unspecified || pstyle->color.value != css_generic_transparent )
         spreadParent( pstyle->color, parent_style->color );
 
+    // Border colors are not inherited, and default to "currentcolor": the just computed pstyle->color
+    for ( int i=0; i < 4; i++ ) {
+        if ( pstyle->border_color[i].type == css_val_unspecified && pstyle->border_color[i].value == css_generic_currentcolor )
+            pstyle->border_color[i] = pstyle->color;
+    }
+
     // background_color
     // Should not be inherited: elements start with unspecified.
     // The code will fill the rect of a parent element, and will
@@ -10086,6 +10092,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         spread_background_color = true;
     if ( spread_background_color )
         spreadParent( pstyle->background_color, parent_style->background_color, true );
+    // Except for the mostly useless case css_generic_currentcolor
+    if ( pstyle->background_color.type == css_val_unspecified && pstyle->background_color.value == css_generic_currentcolor )
+        pstyle->background_color = pstyle->color;
 
     // See if applying styles requires pseudo element before/after
     bool requires_pseudo_element_before = false;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -979,7 +979,8 @@ public:
             for (j=0; j<rows[i]->cells.length(); j++) {
                 // rows[i]->cells contains only real cells made from node elements
                 CCRTableCell * cell = (rows[i]->cells[j]);
-                getRenderedWidths(cell->elem, cell->max_content_width, cell->min_content_width, cell->direction);
+                int rend_flags = cell->elem->getDocument()->getRenderBlockRenderingFlags();
+                getRenderedWidths(cell->elem, cell->max_content_width, cell->min_content_width, cell->direction, true, rend_flags);
                 #ifdef DEBUG_TABLE_RENDERING
                     printf("TABLE: cell[%d,%d] getRenderedWidths: %d (min %d)\n",
                         j, i, cell->max_content_width, cell->min_content_width);
@@ -1118,6 +1119,13 @@ public:
             assignable_width = table_width;
             borderspacing_h = 0;
         }
+        // todo: there's an issue with TD's style->width being usually explicitely ignored
+        // in getRenderedWidths() as a rule to not impose these widths because here,
+        // we just use them as a first hint, and it is not the final cell/column width.
+        // But with inline-table, whose table_width has been estimated without
+        // TD's style->width, having them used below as a hint that influence
+        // the sizing of all columns with distribution to compensate these
+        // style->widths can give really bad results.
 
         // Find best width for each column
         // Note: support for CSS min-width/max-width on table cells and cols

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1509,6 +1509,7 @@ public:
             }
             fmt.push();
             caption_h = caption->renderFinalBlock( txform, &fmt, w - padding_left - padding_right );
+            context.updateRenderProgress(1);
             caption_h += padding_top + padding_bottom;
             // Reload fmt, as enode->renderFinalBlock() may have updated it.
             fmt = RenderRectAccessor( caption );
@@ -1625,6 +1626,7 @@ public:
                         }
                         fmt.push();
                         int h = cell->elem->renderFinalBlock( txform, &fmt, cell->width - padding_left - padding_right);
+                        context.updateRenderProgress(1);
                         cell->height = padding_top + h + padding_bottom;
                         // A cell baseline is the baseline of its first line of text (or
                         // the bottom of content edge of the cell if no line)

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -991,8 +991,8 @@ lString32 & lString32::insert(size_type p0, size_type count, lChar32 ch)
     if (p0>pchunk->len)
         p0 = pchunk->len;
     reserve( pchunk->len+count );
-    for (size_type i=pchunk->len+count; i>p0; i--)
-        pchunk->buf32[i] = pchunk->buf32[i-1];
+    for (size_type i=pchunk->len-1; i>=p0; i--)
+        pchunk->buf32[i+count] = pchunk->buf32[i];
     _lStr_memset(pchunk->buf32+p0, ch, count);
     pchunk->len += count;
     pchunk->buf32[pchunk->len] = 0;
@@ -1005,8 +1005,8 @@ lString32 & lString32::insert(size_type p0, const lString32 & str)
         p0 = pchunk->len;
     int count = str.length();
     reserve( pchunk->len+count );
-    for (size_type i=pchunk->len+count; i>p0; i--)
-        pchunk->buf32[i] = pchunk->buf32[i-1];
+    for (size_type i=pchunk->len-1; i>=p0; i--)
+        pchunk->buf32[i+count] = pchunk->buf32[i];
     _lStr_memcpy(pchunk->buf32 + p0, str.c_str(), count);
     pchunk->len += count;
     pchunk->buf32[pchunk->len] = 0;
@@ -2070,8 +2070,8 @@ lString8 & lString8::insert(size_type p0, size_type count, lChar8 ch)
     if (p0>pchunk->len)
         p0 = pchunk->len;
     reserve( pchunk->len+count );
-    for (size_type i=pchunk->len+count; i>p0; i--)
-        pchunk->buf8[i] = pchunk->buf8[i-1];
+    for (size_type i=pchunk->len-1; i>=p0; i--)
+        pchunk->buf8[i+count] = pchunk->buf8[i];
     //_lStr_memset(pchunk->buf8+p0, ch, count);
     memset(pchunk->buf8+p0, ch, count);
     pchunk->len += count;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -606,6 +606,8 @@ bool parse_number_value( const char * & str, css_length_t & value,
         value.type = css_val_pt;
     else if ( substr_icompare( "ex", str ) )
         value.type = css_val_ex;
+    else if ( substr_icompare( "ch", str ) )
+        value.type = css_val_ch;
     else if ( substr_icompare( "rem", str ) )
         value.type = css_val_rem;
     else if ( substr_icompare( "px", str ) )

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1055,6 +1055,11 @@ bool parse_color_value( const char * & str, css_length_t & value )
         value.value = css_generic_transparent;
         return true;
     }
+    if ( substr_icompare( "currentcolor", str ) ) {
+        value.type = css_val_unspecified;
+        value.value = css_generic_currentcolor;
+        return true;
+    }
     if ( substr_compare( "inherit", str ) )
     {
         value.type = css_val_inherited;
@@ -2759,9 +2764,8 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                             width.value = 3*256;
                         }
                         if ( !found_color ) {
-                            // We don't support "currentColor": fallback to black
-                            color.type = css_val_color;
-                            color.value = 0x000000;
+                            color.type = css_val_unspecified;
+                            color.value = css_generic_currentcolor;
                         }
                         if ( prop_code==cssd_border ) {
                             buf<<(lUInt32) (cssd_border_style | importance | parsed_important);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9816,10 +9816,18 @@ lString32 ldomXPointer::toStringV2()
         }
     }
     else {
-        if ( offset < p->getChildCount() )
+        // Be really sure we get a non boxing node
+        if ( offset < p->getChildCount() ) {
             p = p->getChildNode(offset);
-        else
-            p = p->getParentNode();
+            if ( p->isBoxingNode(true) ) {
+                p = p->getUnboxedFirstChild();
+                if ( !p )
+                    p = node->getUnboxedParent();
+            }
+        }
+        else {
+            p = p->getUnboxedParent();
+        }
     }
     ldomNode * mainNode = node->getDocument()->getRootNode();
     while (p && p!=mainNode) {


### PR DESCRIPTION
A few fix and tweaks I needed for MathML support, but that aren't MathML specific - so here in an independant PR.

#### LVString: fix ::insert(pos, count, char)

It was working somehow as we mostly use them with count=1, but it was wrong when count >=2. See https://github.com/koreader/crengine/pull/71#issuecomment-798798891

#### toStringV2(): fix (again) when target node is a boxing node

Follow up to 5330750b: when getting a non-boxing parent or child, be sure we actually get one (as we can have nested boxing elements, like tabularBoxes with completed incomplete tables).

#### LVFontCache::find(): give more weight to first fonts in list

When there are multiple font names in a list (ie, with CSS 'font-family: "Font1", "Font2"', multiple fonts may get the same higher score. We keep the first best match in the loop, but at the end, we prefer an instantiated font to a not yet instantiated one with the same math.  Depending on various things, it may not be the first one.  So, provide an additional weight to font by their order in the list.

#### Page splitting: more accurate rendering progress

Fix accounting of erm_final rendering by not ignoring those done in sub-flows/contexts (floats, inline-blocks, tables).

#### getRenderedWidths(): fix nowrap around image/inlineBoxes


#### Table cells getRenderedWidths(): provide rend_flags

To be consistent, as it will be drawn with these rend_flags.

#### Tables rendering: tweak column widths algorithm

Use the cells max content width as the column widths when all these max widths fit (instead of using some heuristics about the sum of the means, which could lead to uneeded smaller widths and wraps).

#### CSS: parse/handle "currentcolor", default for border-color

Allow parsing color value "currentcolor".  Can be used with "color:" and "background-color:" even if useless, but it is the initial value for border-color, and the default when no color value is found in "border:" (ie. "border: solid thin").

#### CSS: add units 'ch' (just like 'ex')

Represents the width, or more precisely the advance measure, of the glyph "0" (zero) in the element's font.
In the cases where it is impractical to determine, it must be assumed to be 0.5em wide by 1em tall.
So, let's handle it just as 'ex', assuming 0.5em.

#### SVG images: proper alpha blending

Allow transparent SVG images to blend, instead of drawing them on a white background. See https://github.com/koreader/crengine/pull/71#issuecomment-798709553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/428)
<!-- Reviewable:end -->
