### PR TITLE
new patterns based on dehyph-exptl 0.7

### DIFF
--- a/cr3gui/data/hyph/German.pattern
+++ b/cr3gui/data/hyph/German.pattern
@@ -37,22 +37,22 @@ Nikolay Pultsin (geometer@fbreader.org)
 generated from pat-gen by Martin.zwicknagl@kirchbichl.net
 
 
-preamble of de-1996_hyphenmin3-2021-01-08.pat
+preamble of de-1996_hyphenmin3-2021-03-21.pat
 % title: German Hyphenation Patterns (Reformed Orthography, 2006)
 %
 % notice: TeX-Trennmuster für die reformierte (2006) deutsche Rechtschreibung
 %
-% version: @DATE@
+% version: 2021-03-21
 %
 % authors:
 %   -
 %     name:    Deutschsprachige Trennmustermannschaft
 %     contact: trennmuster@dante.de
 %
-% copyright: Copyright (c) 2013-2018
+% copyright: Copyright (c) 2013-2021
 %            Stephan Hennig, Werner Lemberg, Günter Milde,
 %            Sander van Geloven, Georg Pfeiffer, Gisbert W. Selke,
-%            Tobias Wendorf
+%            Tobias Wendorf, Keno Wehr
 %
 % licence:
 %     name: MIT
@@ -79,7 +79,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 %           FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 %           OTHER DEALINGS IN THE SOFTWARE.
 %
-% source: http://repo.or.cz/w/wortliste.git?a=commit;h=@GIT_VERSION@
+% source: http://repo.or.cz/w/wortliste.git?a=commit;h=4821a166d3ba605a6996de4c8e72f67670097e1c
 %
 % language:
 %     name: German, reformed spelling
@@ -87,15 +87,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 %
 % hyphenmins:
 %     generation:
-%         left:  @LEFTHYPHENMIN@
-%         right: @RIGHTHYPHENMIN@
+%         left:   2
+%         right:  2
 %     typesetting:
-%         left:  @LEFTHYPHENMIN@
-%         right: @RIGHTHYPHENMIN@
+%         left:   2
+%         right:  2
 %
 % ===========================================================================
 
-\message{German Hyphenation Patterns (Reformed Orthography, 2006) `dehyphn-x' @DATE@ (WL)}
+\message{German Hyphenation Patterns (Reformed Orthography, 2006) `dehyphn-x' 2021-03-21 (WL)}
 
 %
 % The used patgen parameters are
@@ -235,7 +235,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> anni4</pattern>
 <pattern> an4ora</pattern>
 <pattern> an3r</pattern>
-<pattern> an5sa</pattern>
 <pattern> ansch6</pattern>
 <pattern> ans6pa</pattern>
 <pattern> ans4t</pattern>
@@ -336,7 +335,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ber6g5eb</pattern>
 <pattern> ber6gesc</pattern>
 <pattern> ber6g5in</pattern>
-<pattern> ber4gl</pattern>
+<pattern> ber4g5l</pattern>
 <pattern> ber4g5o</pattern>
 <pattern> ber4g5r</pattern>
 <pattern> ber4st</pattern>
@@ -355,6 +354,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> be5tont </pattern>
 <pattern> be5tonte</pattern>
 <pattern> be5tonun</pattern>
+<pattern> be6t5raum</pattern>
 <pattern> be4ve</pattern>
 <pattern> be3w</pattern>
 <pattern> be5we4</pattern>
@@ -383,11 +383,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> bo4r</pattern>
 <pattern> bord5i</pattern>
 <pattern> bos3k</pattern>
-<pattern> brecher6</pattern>
 <pattern> brid4</pattern>
 <pattern> brie6f5end</pattern>
 <pattern> bruch5s</pattern>
-<pattern> brut5s</pattern>
 <pattern> bu2</pattern>
 <pattern> bu4c</pattern>
 <pattern> buster6</pattern>
@@ -461,6 +459,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> do3d</pattern>
 <pattern> doku3</pattern>
 <pattern> dor4f3</pattern>
+<pattern> dra5se</pattern>
 <pattern> dr6eig</pattern>
 <pattern> drü3b</pattern>
 <pattern> du2</pattern>
@@ -469,6 +468,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> dys3</pattern>
 <pattern> eb2</pattern>
 <pattern> ebe4r</pattern>
+<pattern> echo3</pattern>
 <pattern> ed2</pattern>
 <pattern> ede2</pattern>
 <pattern> edu3s</pattern>
@@ -493,6 +493,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ei2n3</pattern>
 <pattern> eingear6</pattern>
 <pattern> eingezo6</pattern>
+<pattern> eins6tem</pattern>
 <pattern> einzel6lig</pattern>
 <pattern> einzu6</pattern>
 <pattern> ei2s</pattern>
@@ -544,8 +545,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ep3od</pattern>
 <pattern> era2</pattern>
 <pattern> erbe4</pattern>
-<pattern> er4b5ei</pattern>
+<pattern> er4b5ei4</pattern>
 <pattern> er4ben</pattern>
+<pattern> er4ber</pattern>
 <pattern> er4bes</pattern>
 <pattern> er4bin</pattern>
 <pattern> er4biu</pattern>
@@ -583,6 +585,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> er3in4</pattern>
 <pattern> er4ker</pattern>
 <pattern> erko4</pattern>
+<pattern> er5kr</pattern>
 <pattern> er4lac</pattern>
 <pattern> er6lang </pattern>
 <pattern> er5lau</pattern>
@@ -607,7 +610,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> er4z5el4</pattern>
 <pattern> er4zen4</pattern>
 <pattern> erz5eng</pattern>
-<pattern> er4zer</pattern>
+<pattern> er4z5er</pattern>
 <pattern> er4zes</pattern>
 <pattern> erzo4</pattern>
 <pattern> es2</pattern>
@@ -627,7 +630,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> eu5ryt</pattern>
 <pattern> eu2t</pattern>
 <pattern> eute4</pattern>
-<pattern> eve4r3</pattern>
+<pattern> eve4r</pattern>
 <pattern> evo3</pattern>
 <pattern> ex3a</pattern>
 <pattern> ex3em4</pattern>
@@ -638,14 +641,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> expo4</pattern>
 <pattern> exte4</pattern>
 <pattern> ex5trakt</pattern>
+<pattern> fang5l</pattern>
 <pattern> fang5s4</pattern>
+<pattern> faus6t5r</pattern>
 <pattern> fe2</pattern>
 <pattern> fela3</pattern>
 <pattern> fel4d5r</pattern>
 <pattern> fel6lau</pattern>
+<pattern> fel4sa</pattern>
 <pattern> fel4sp</pattern>
 <pattern> fel4st</pattern>
 <pattern> fern5o</pattern>
+<pattern> fe4s</pattern>
 <pattern> fi2</pattern>
 <pattern> film5a</pattern>
 <pattern> fil4s3</pattern>
@@ -656,7 +663,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> flu2</pattern>
 <pattern> flug3</pattern>
 <pattern> flus6s5en6</pattern>
-<pattern> fo2</pattern>
 <pattern> for5tu</pattern>
 <pattern> fra4s</pattern>
 <pattern> fu2</pattern>
@@ -672,10 +678,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ge6bend</pattern>
 <pattern> ge4ber</pattern>
 <pattern> gebe4t</pattern>
-<pattern> ge3bl</pattern>
 <pattern> gebo4</pattern>
 <pattern> ge3d</pattern>
-<pattern> gee2</pattern>
 <pattern> ge3ek</pattern>
 <pattern> ge3f</pattern>
 <pattern> gefü4</pattern>
@@ -700,6 +704,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ge3lu</pattern>
 <pattern> gemä4</pattern>
 <pattern> gemi4</pattern>
+<pattern> gen6aug</pattern>
 <pattern> ge5nec</pattern>
 <pattern> ge5n4ei</pattern>
 <pattern> ge4nen</pattern>
@@ -722,6 +727,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ge3s4a</pattern>
 <pattern> ge3s4e</pattern>
 <pattern> ges4i</pattern>
+<pattern> ge3so</pattern>
 <pattern> ges4ö</pattern>
 <pattern> ges6tem</pattern>
 <pattern> gesu6c</pattern>
@@ -738,7 +744,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> gi4n</pattern>
 <pattern> glas5c</pattern>
 <pattern> gli5che</pattern>
-<pattern> gn2</pattern>
 <pattern> go2</pattern>
 <pattern> gol6der</pattern>
 <pattern> go4s</pattern>
@@ -749,11 +754,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> gun3t</pattern>
 <pattern> ha2</pattern>
 <pattern> hafe4</pattern>
-<pattern> haf4tr</pattern>
+<pattern> haf6ter</pattern>
+<pattern> haft5s</pattern>
 <pattern> halb5r</pattern>
 <pattern> hal4s</pattern>
 <pattern> halte5s</pattern>
 <pattern> ha4n</pattern>
+<pattern> han4a</pattern>
 <pattern> ha4r</pattern>
 <pattern> hau4sa</pattern>
 <pattern> haut5o</pattern>
@@ -780,12 +787,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> hil4f</pattern>
 <pattern> hin3s</pattern>
 <pattern> hin5te</pattern>
-<pattern> hit4ze</pattern>
+<pattern> hit4ze5</pattern>
 <pattern> ho2</pattern>
 <pattern> ho4c</pattern>
 <pattern> ho4d</pattern>
 <pattern> hof5en</pattern>
 <pattern> hof3r</pattern>
+<pattern> hof3s</pattern>
 <pattern> ho4l</pattern>
 <pattern> hor4t5r</pattern>
 <pattern> hö2</pattern>
@@ -821,8 +829,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> indi4k</pattern>
 <pattern> in6disc</pattern>
 <pattern> indi4z</pattern>
+<pattern> indu4</pattern>
 <pattern> iner4</pattern>
 <pattern> in4fam</pattern>
+<pattern> in4fr</pattern>
 <pattern> inge4</pattern>
 <pattern> in4geb</pattern>
 <pattern> in4gel</pattern>
@@ -857,13 +867,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> irri4t</pattern>
 <pattern> ir4ru</pattern>
 <pattern> is2a</pattern>
+<pattern> isa4r3</pattern>
 <pattern> is2f</pattern>
 <pattern> is2m</pattern>
+<pattern> iso3</pattern>
 <pattern> is2w</pattern>
 <pattern> it2</pattern>
 <pattern> ite3</pattern>
 <pattern> ja2k</pattern>
 <pattern> ja2n</pattern>
+<pattern> ja2s</pattern>
 <pattern> jo2</pattern>
 <pattern> jor3</pattern>
 <pattern> ka2</pattern>
@@ -879,6 +892,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> kho3</pattern>
 <pattern> ki2</pattern>
 <pattern> ki4t</pattern>
+<pattern> klo5r</pattern>
 <pattern> ko2b</pattern>
 <pattern> ko2d</pattern>
 <pattern> koef4</pattern>
@@ -917,6 +931,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> lede4</pattern>
 <pattern> leh4m5e</pattern>
 <pattern> lei4bl</pattern>
+<pattern> leider6</pattern>
 <pattern> lei5ern</pattern>
 <pattern> lei5ert</pattern>
 <pattern> lei5sen</pattern>
@@ -926,7 +941,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> le4t</pattern>
 <pattern> li2</pattern>
 <pattern> lich6tersc</pattern>
-<pattern> liga3</pattern>
+<pattern> lim3b</pattern>
 <pattern> lo2</pattern>
 <pattern> log5in</pattern>
 <pattern> lo4s</pattern>
@@ -940,12 +955,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> ly2</pattern>
 <pattern> lys3</pattern>
 <pattern> ma2</pattern>
+<pattern> mal5ec</pattern>
 <pattern> ma4m</pattern>
 <pattern> man3d</pattern>
 <pattern> ma4r</pattern>
 <pattern> ma4s</pattern>
+<pattern> mas4s5u</pattern>
+<pattern> maß3u</pattern>
+<pattern> maßun4</pattern>
 <pattern> mat4c</pattern>
 <pattern> mate3</pattern>
+<pattern> mäh3l</pattern>
+<pattern> märz3</pattern>
 <pattern> md2</pattern>
 <pattern> me2</pattern>
 <pattern> mee4ru</pattern>
@@ -962,6 +983,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> mi4n</pattern>
 <pattern> mis3a</pattern>
 <pattern> misch5r</pattern>
+<pattern> misch5w</pattern>
 <pattern> mise3</pattern>
 <pattern> mm2</pattern>
 <pattern> mo2</pattern>
@@ -980,13 +1002,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> na4m</pattern>
 <pattern> namens5</pattern>
 <pattern> nas4s5c</pattern>
-<pattern> na4t</pattern>
 <pattern> nat4h</pattern>
 <pattern> näs3c</pattern>
 <pattern> ne2</pattern>
 <pattern> neapo5</pattern>
 <pattern> nebe4n</pattern>
 <pattern> neh5run</pattern>
+<pattern> neider6</pattern>
+<pattern> nei6d5err</pattern>
 <pattern> ner4f</pattern>
 <pattern> neu5er6b</pattern>
 <pattern> ni2</pattern>
@@ -1030,6 +1053,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> op4pe</pattern>
 <pattern> op3pr</pattern>
 <pattern> or2</pattern>
+<pattern> orde4</pattern>
 <pattern> ori3</pattern>
 <pattern> ort4s5a</pattern>
 <pattern> ort4s5e</pattern>
@@ -1065,6 +1089,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> par5th</pattern>
 <pattern> pas6sers</pattern>
 <pattern> pas3t</pattern>
+<pattern> paulet6</pattern>
 <pattern> pe2</pattern>
 <pattern> pech3</pattern>
 <pattern> pel4za</pattern>
@@ -1082,8 +1107,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> piesa5</pattern>
 <pattern> pla3c</pattern>
 <pattern> plem4</pattern>
+<pattern> ple3r</pattern>
 <pattern> po2</pattern>
 <pattern> poo2</pattern>
+<pattern> pop3l</pattern>
 <pattern> por5ta</pattern>
 <pattern> po4s</pattern>
 <pattern> prach4</pattern>
@@ -1095,6 +1122,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> rad5ei</pattern>
 <pattern> rad3r</pattern>
 <pattern> rae2</pattern>
+<pattern> ra4m</pattern>
 <pattern> ran4d5r</pattern>
 <pattern> ran6g5eb</pattern>
 <pattern> rang5l</pattern>
@@ -1108,7 +1136,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> re3ag</pattern>
 <pattern> re3ak4</pattern>
 <pattern> re4ben</pattern>
-<pattern> reb3l</pattern>
+<pattern> re4b3l</pattern>
 <pattern> reb3s</pattern>
 <pattern> re5cha</pattern>
 <pattern> re4che</pattern>
@@ -1116,7 +1144,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> re4ck</pattern>
 <pattern> re4den</pattern>
 <pattern> re4der</pattern>
-<pattern> redu6z</pattern>
+<pattern> redu4</pattern>
 <pattern> re3f</pattern>
 <pattern> refe4</pattern>
 <pattern> re2g</pattern>
@@ -1143,12 +1171,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> re4sc</pattern>
 <pattern> re3se</pattern>
 <pattern> re3sk</pattern>
-<pattern> re5sol</pattern>
-<pattern> re5so4n</pattern>
+<pattern> reso4n</pattern>
 <pattern> re5stau</pattern>
 <pattern> res6ter6</pattern>
 <pattern> rest5ers</pattern>
 <pattern> re5stit</pattern>
+<pattern> rest5re</pattern>
 <pattern> re5stri</pattern>
 <pattern> re3su</pattern>
 <pattern> re4ti</pattern>
@@ -1159,8 +1187,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> rezi4</pattern>
 <pattern> ri2</pattern>
 <pattern> ri4c</pattern>
+<pattern> rie3</pattern>
 <pattern> ro2</pattern>
 <pattern> ro4c</pattern>
+<pattern> roh3a</pattern>
 <pattern> roh5erz</pattern>
 <pattern> ro4l</pattern>
 <pattern> rom4a</pattern>
@@ -1204,6 +1234,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> se4r</pattern>
 <pattern> seve3</pattern>
 <pattern> sex5tan</pattern>
+<pattern> sex5tr</pattern>
 <pattern> si2</pattern>
 <pattern> si4e</pattern>
 <pattern> si4g</pattern>
@@ -1281,10 +1312,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> tri5es</pattern>
 <pattern> tro3c</pattern>
 <pattern> trü5ben</pattern>
-<pattern> ts2</pattern>
 <pattern> tsa3</pattern>
 <pattern> tse3</pattern>
-<pattern> tsu3</pattern>
+<pattern> ts4u3</pattern>
 <pattern> tu2</pattern>
 <pattern> tur4m3</pattern>
 <pattern> tü4c</pattern>
@@ -1327,7 +1357,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> un6zen </pattern>
 <pattern> up3t</pattern>
 <pattern> ur3ad</pattern>
-<pattern> ural4</pattern>
+<pattern> ur3af</pattern>
 <pattern> ur3am</pattern>
 <pattern> ur3at</pattern>
 <pattern> ur4ba</pattern>
@@ -1375,7 +1405,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern> wei5ser</pattern>
 <pattern> welt5s</pattern>
 <pattern> wer4b</pattern>
-<pattern> wer6ker</pattern>
+<pattern> wer6k5er6</pattern>
 <pattern> wer4k5r</pattern>
 <pattern> wer4tr</pattern>
 <pattern> wese4</pattern>
@@ -1442,9 +1472,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aal3ö</pattern>
 <pattern>aals4t</pattern>
 <pattern>aal5ste</pattern>
+<pattern>a1am2</pattern>
 <pattern>a1an2</pattern>
 <pattern>a2an </pattern>
 <pattern>a2anä</pattern>
+<pattern>aaneu3</pattern>
 <pattern>aange3</pattern>
 <pattern>a1a2q</pattern>
 <pattern>aar3a</pattern>
@@ -1453,7 +1485,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aa5ren </pattern>
 <pattern>aa5rend</pattern>
 <pattern>aar5ers</pattern>
-<pattern>aa3res</pattern>
+<pattern>aa5res </pattern>
 <pattern>3aarg</pattern>
 <pattern>aar3in</pattern>
 <pattern>aar3ö</pattern>
@@ -1486,12 +1518,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>abat4t5a</pattern>
 <pattern>2abau</pattern>
 <pattern>abän2</pattern>
+<pattern>2abär</pattern>
 <pattern>ab4bas</pattern>
 <pattern>4abbat</pattern>
 <pattern>ab3be4p</pattern>
 <pattern>4abber</pattern>
 <pattern>abbewe4</pattern>
-<pattern>4ab5bin</pattern>
+<pattern>4abbine</pattern>
 <pattern>abb5ler</pattern>
 <pattern>3abbu</pattern>
 <pattern>1abd</pattern>
@@ -1508,7 +1541,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>abel5ad</pattern>
 <pattern>abe5las</pattern>
 <pattern>abe4le</pattern>
-<pattern>abel5in</pattern>
 <pattern>a2bem</pattern>
 <pattern>4aben </pattern>
 <pattern>abengene5</pattern>
@@ -1529,7 +1561,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>abe5tha</pattern>
 <pattern>abe4ti</pattern>
 <pattern>abe5tre</pattern>
-<pattern>abet3s</pattern>
 <pattern>abe4wo</pattern>
 <pattern>2abex</pattern>
 <pattern>1abf</pattern>
@@ -1549,8 +1580,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1abk</pattern>
 <pattern>a2bla</pattern>
 <pattern>ab3las</pattern>
+<pattern>3ablau</pattern>
 <pattern>4able </pattern>
 <pattern>3abled</pattern>
+<pattern>a4bleg</pattern>
 <pattern>4a3blem</pattern>
 <pattern>a5blen </pattern>
 <pattern>4abler</pattern>
@@ -1566,17 +1599,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2a3bod</pattern>
 <pattern>2abol</pattern>
 <pattern>a2bon</pattern>
+<pattern>abor5ang</pattern>
 <pattern>a4bore</pattern>
 <pattern>a4bor3s</pattern>
 <pattern>2abot</pattern>
 <pattern>ab2ö</pattern>
 <pattern>ab4öl</pattern>
-<pattern>ab1r</pattern>
+<pattern>a2b1r</pattern>
 <pattern>abra2</pattern>
 <pattern>abre2</pattern>
 <pattern>abreak4</pattern>
 <pattern>abre6ch</pattern>
 <pattern>4abres</pattern>
+<pattern>a3brev</pattern>
 <pattern>a3brö</pattern>
 <pattern>abru4d</pattern>
 <pattern>3abruf</pattern>
@@ -1621,8 +1656,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ach3au</pattern>
 <pattern>ach3än4</pattern>
 <pattern>2achb</pattern>
-<pattern>ach3ec</pattern>
+<pattern>ach5eck</pattern>
 <pattern>ache5f</pattern>
+<pattern>ach5ehe</pattern>
 <pattern>achei4</pattern>
 <pattern>ach5eic</pattern>
 <pattern>ach5ein</pattern>
@@ -1631,22 +1667,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ach5erbe </pattern>
 <pattern>ach5er6ben</pattern>
 <pattern>ach5erbes</pattern>
-<pattern>ach5erfa</pattern>
 <pattern>ach5erfü</pattern>
 <pattern>ach5erke</pattern>
+<pattern>ach5erkr</pattern>
 <pattern>ach5er4l</pattern>
 <pattern>ach5er4w</pattern>
 <pattern>ach5er4z</pattern>
 <pattern>ache5str</pattern>
 <pattern>ach5eta</pattern>
+<pattern>ach3eu</pattern>
 <pattern>2achf</pattern>
 <pattern>achgezo6</pattern>
 <pattern>2achh</pattern>
-<pattern>2achi</pattern>
+<pattern>4achi</pattern>
 <pattern>a3chi </pattern>
 <pattern>ach3i4d</pattern>
 <pattern>a3chig</pattern>
 <pattern>ach5ind</pattern>
+<pattern>a3chip</pattern>
+<pattern>2achk</pattern>
 <pattern>2ach3l</pattern>
 <pattern>achla4</pattern>
 <pattern>achle4</pattern>
@@ -1668,15 +1707,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4achsc</pattern>
 <pattern>4achses</pattern>
 <pattern>4achso</pattern>
-<pattern>ach5sor</pattern>
 <pattern>4achsp</pattern>
 <pattern>achst4</pattern>
 <pattern>ach5stre</pattern>
 <pattern>ach3su</pattern>
+<pattern>acht5erte</pattern>
 <pattern>4achtg</pattern>
 <pattern>ach4t5in</pattern>
 <pattern>4achtk</pattern>
-<pattern>acht5or4</pattern>
+<pattern>achtor4</pattern>
 <pattern>ach6träume </pattern>
 <pattern>ach6träumen </pattern>
 <pattern>ach6trit</pattern>
@@ -1696,18 +1735,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4a4ck </pattern>
 <pattern>4acken</pattern>
 <pattern>acken5s</pattern>
+<pattern>a6ckerd</pattern>
 <pattern>4ackes</pattern>
 <pattern>a3cki </pattern>
 <pattern>ack3in4</pattern>
 <pattern>a3ckis</pattern>
 <pattern>a4ckr</pattern>
 <pattern>4a4cks</pattern>
+<pattern>acksau4</pattern>
 <pattern>ack4sin</pattern>
 <pattern>ack5sta</pattern>
 <pattern>ack5sti</pattern>
 <pattern>2acl</pattern>
 <pattern>2aco</pattern>
 <pattern>ac2p</pattern>
+<pattern>acre2</pattern>
 <pattern>ac2ti</pattern>
 <pattern>2a3cu</pattern>
 <pattern>a1ça</pattern>
@@ -1740,6 +1782,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>adel6spo</pattern>
 <pattern>3adelu</pattern>
 <pattern>ade3m</pattern>
+<pattern>a4dema</pattern>
 <pattern>a5denei</pattern>
 <pattern>a5denfa</pattern>
 <pattern>a5dengl</pattern>
@@ -1757,15 +1800,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ade5ram</pattern>
 <pattern>ade5rau</pattern>
 <pattern>ad3er4f</pattern>
+<pattern>ad3erg</pattern>
 <pattern>a4deric</pattern>
 <pattern>a4derl</pattern>
 <pattern>a4de3ro</pattern>
 <pattern>ad3er4z</pattern>
+<pattern>2ades</pattern>
 <pattern>a4desc</pattern>
 <pattern>a4de3se</pattern>
 <pattern>a3desk</pattern>
 <pattern>a4deso</pattern>
 <pattern>ade3s4p</pattern>
+<pattern>ade5sta</pattern>
+<pattern>ade5stä</pattern>
 <pattern>ade5stel</pattern>
 <pattern>ade5sto</pattern>
 <pattern>ade5str</pattern>
@@ -1800,6 +1847,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2dre</pattern>
 <pattern>ad3rec</pattern>
 <pattern>3adres</pattern>
+<pattern>4adro</pattern>
+<pattern>a3droh</pattern>
 <pattern>ad3rot</pattern>
 <pattern>ad3run</pattern>
 <pattern>ad3rü</pattern>
@@ -1812,7 +1861,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3dui</pattern>
 <pattern>a3dus</pattern>
 <pattern>adu3z</pattern>
-<pattern>a2dü</pattern>
 <pattern>1adv</pattern>
 <pattern>a2dy</pattern>
 <pattern>a1e2b</pattern>
@@ -1835,9 +1883,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3erf</pattern>
 <pattern>a3erh</pattern>
 <pattern>a3erk</pattern>
-<pattern>3aero3</pattern>
+<pattern>aero3</pattern>
 <pattern>a3ers</pattern>
 <pattern>aer3t</pattern>
+<pattern>a3erw</pattern>
 <pattern>aes2a</pattern>
 <pattern>aes2s</pattern>
 <pattern>aes3t</pattern>
@@ -1858,19 +1907,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3fei</pattern>
 <pattern>a4f5einh</pattern>
 <pattern>a4f5einr</pattern>
+<pattern>afel3e</pattern>
 <pattern>afen5sp</pattern>
 <pattern>a4fentl</pattern>
 <pattern>af3e2p</pattern>
 <pattern>a2fe2r</pattern>
-<pattern>af3ere</pattern>
 <pattern>afer4l</pattern>
-<pattern>af3eu</pattern>
 <pattern>a2fex</pattern>
 <pattern>3affär</pattern>
 <pattern>af4fei4</pattern>
 <pattern>3affek</pattern>
 <pattern>aff4th</pattern>
 <pattern>2afi</pattern>
+<pattern>afia3</pattern>
 <pattern>afi2e</pattern>
 <pattern>afie3i</pattern>
 <pattern>afie3s</pattern>
@@ -1893,8 +1942,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4f3or4t</pattern>
 <pattern>afo3s</pattern>
 <pattern>a3fot</pattern>
-<pattern>a2fö</pattern>
+<pattern>af3ov</pattern>
 <pattern>2afra</pattern>
+<pattern>a3frag</pattern>
+<pattern>af3rat</pattern>
 <pattern>af3rau</pattern>
 <pattern>af3rä</pattern>
 <pattern>af3red</pattern>
@@ -1906,13 +1957,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>af1s</pattern>
 <pattern>af2si</pattern>
 <pattern>afs4ke</pattern>
-<pattern>af2s3o</pattern>
 <pattern>afs2t</pattern>
 <pattern>af4t3ak4</pattern>
+<pattern>aft5anz</pattern>
 <pattern>af3tat</pattern>
 <pattern>aft3au</pattern>
 <pattern>af4t3el</pattern>
 <pattern>aft5ent</pattern>
+<pattern>aft5erfa</pattern>
 <pattern>af4terl</pattern>
 <pattern>af3t2h</pattern>
 <pattern>af4tin</pattern>
@@ -1922,13 +1974,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aftra4</pattern>
 <pattern>aft5rad</pattern>
 <pattern>aft5rei</pattern>
-<pattern>aft5res</pattern>
-<pattern>aft5ric</pattern>
+<pattern>af4t5res</pattern>
+<pattern>af4t5ric</pattern>
 <pattern>aft5rin</pattern>
 <pattern>af4tur</pattern>
-<pattern>a1fu2</pattern>
-<pattern>a2f3um2</pattern>
-<pattern>a2f3ur2</pattern>
+<pattern>afu2</pattern>
+<pattern>af3um2</pattern>
+<pattern>a3fung</pattern>
+<pattern>af3ur2</pattern>
 <pattern>2afü</pattern>
 <pattern>afür3</pattern>
 <pattern>2aga</pattern>
@@ -1940,7 +1993,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>agar2</pattern>
 <pattern>aga3th</pattern>
 <pattern>ag3au</pattern>
+<pattern>a3gä</pattern>
+<pattern>ag3ärm</pattern>
 <pattern>ag4d3an</pattern>
+<pattern>ag4d3ar</pattern>
 <pattern>ag4del</pattern>
 <pattern>ag4dre</pattern>
 <pattern>ag2du</pattern>
@@ -1955,13 +2011,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2gee</pattern>
 <pattern>a2ge3f</pattern>
 <pattern>age3gr</pattern>
-<pattern>a2ge3h</pattern>
+<pattern>age3h</pattern>
+<pattern>a4geha</pattern>
+<pattern>a4geim</pattern>
 <pattern>age5inf</pattern>
+<pattern>age5inh</pattern>
 <pattern>age5ins</pattern>
 <pattern>a2ge3k</pattern>
 <pattern>2a2gel</pattern>
 <pattern>age5lan</pattern>
-<pattern>agele4</pattern>
+<pattern>agele4g</pattern>
+<pattern>age5leh</pattern>
 <pattern>age3li</pattern>
 <pattern>age3lo</pattern>
 <pattern>a4ge3ma</pattern>
@@ -1972,12 +2032,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4genac</pattern>
 <pattern>agend4</pattern>
 <pattern>age4n5eb</pattern>
+<pattern>a6generg</pattern>
 <pattern>agen5erw</pattern>
 <pattern>a5genet</pattern>
 <pattern>a4genr</pattern>
-<pattern>agen5sp</pattern>
+<pattern>agen5s4p</pattern>
+<pattern>5agent </pattern>
 <pattern>5agenten</pattern>
-<pattern>5agentu</pattern>
 <pattern>a4genz</pattern>
 <pattern>agenzu4</pattern>
 <pattern>a4geor</pattern>
@@ -1986,11 +2047,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>agerap4</pattern>
 <pattern>age5räu</pattern>
 <pattern>a4gerec</pattern>
-<pattern>ag5ereig</pattern>
 <pattern>agerhe4</pattern>
 <pattern>a4ge3ro</pattern>
 <pattern>a4ge3rü</pattern>
-<pattern>4ages</pattern>
 <pattern>a4gesa</pattern>
 <pattern>age4s5am</pattern>
 <pattern>age4s5an</pattern>
@@ -2000,6 +2059,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4gesp</pattern>
 <pattern>ages6sen</pattern>
 <pattern>a4gesu</pattern>
+<pattern>age3ta</pattern>
 <pattern>age3u</pattern>
 <pattern>a2gez</pattern>
 <pattern>a1gé</pattern>
@@ -2017,6 +2077,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>agi3t</pattern>
 <pattern>2agl</pattern>
 <pattern>ag4lan</pattern>
+<pattern>ag3lat</pattern>
 <pattern>ag3loc</pattern>
 <pattern>ag3lö</pattern>
 <pattern>ag2n2</pattern>
@@ -2025,10 +2086,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a1go</pattern>
 <pattern>3agog</pattern>
 <pattern>a3gons</pattern>
-<pattern>ag3op</pattern>
+<pattern>ag3opf</pattern>
 <pattern>ago2r</pattern>
 <pattern>a2gou</pattern>
-<pattern>2agr</pattern>
 <pattern>agra3s</pattern>
 <pattern>a2grä</pattern>
 <pattern>a2gre</pattern>
@@ -2047,8 +2107,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>agsent5</pattern>
 <pattern>ag4sin</pattern>
 <pattern>ag4spa</pattern>
+<pattern>ag5spal</pattern>
 <pattern>ag5s6porta</pattern>
 <pattern>ag5stel</pattern>
+<pattern>ag5steu</pattern>
 <pattern>ags4top</pattern>
 <pattern>ag5s6tras</pattern>
 <pattern>2agt</pattern>
@@ -2077,9 +2139,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ah5lenz</pattern>
 <pattern>ahler4</pattern>
 <pattern>ah4l5erd</pattern>
+<pattern>ahl5erf</pattern>
 <pattern>ahl5erg</pattern>
 <pattern>ah4l5erh</pattern>
-<pattern>ah4lerz</pattern>
+<pattern>ah4l5erz</pattern>
 <pattern>ah3les</pattern>
 <pattern>ahl3o2</pattern>
 <pattern>ahl4sal</pattern>
@@ -2102,11 +2165,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ah4n3ä</pattern>
 <pattern>ah4neb</pattern>
 <pattern>ahn3el</pattern>
-<pattern>ah4n5erd</pattern>
 <pattern>ahn5er4h</pattern>
 <pattern>ahn5erk</pattern>
 <pattern>ahner4l</pattern>
 <pattern>ah6nerle</pattern>
+<pattern>ah4n5erp</pattern>
+<pattern>ah6n5ersa</pattern>
 <pattern>ah6n5ersc</pattern>
 <pattern>ah4net</pattern>
 <pattern>ah4n3eu</pattern>
@@ -2117,15 +2181,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aho2l</pattern>
 <pattern>a2hom</pattern>
 <pattern>a3hop</pattern>
-<pattern>a2hor</pattern>
+<pattern>3a2hor</pattern>
 <pattern>ah3ost</pattern>
 <pattern>a3ho2t</pattern>
 <pattern>a1hö</pattern>
+<pattern>ahr3ab</pattern>
+<pattern>ahr3a4g</pattern>
 <pattern>ah3rai</pattern>
+<pattern>ahr5ang</pattern>
 <pattern>ahr3as4</pattern>
 <pattern>ahr3au</pattern>
+<pattern>ahren6se</pattern>
+<pattern>ahren6s5o</pattern>
+<pattern>ahr6ere</pattern>
 <pattern>ah3ri</pattern>
 <pattern>ahr4tal</pattern>
+<pattern>ahrt5ei</pattern>
+<pattern>ahrt3h</pattern>
 <pattern>ahr4tin</pattern>
 <pattern>ahr4t5ri</pattern>
 <pattern>ahr4tro</pattern>
@@ -2181,6 +2253,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ain3ab4</pattern>
 <pattern>ai3nac</pattern>
 <pattern>ai3nal</pattern>
+<pattern>a3indu</pattern>
 <pattern>ai4neb</pattern>
 <pattern>ainen4</pattern>
 <pattern>ai3ner</pattern>
@@ -2200,7 +2273,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ai3sam</pattern>
 <pattern>a5isch </pattern>
 <pattern>ai4schi</pattern>
-<pattern>ai4sel</pattern>
+<pattern>ai4se3l</pattern>
 <pattern>ais4o</pattern>
 <pattern>ais3to</pattern>
 <pattern>ai3ta</pattern>
@@ -2213,11 +2286,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2kad2</pattern>
 <pattern>2akam</pattern>
 <pattern>2akan</pattern>
+<pattern>akan4b</pattern>
 <pattern>2akar</pattern>
 <pattern>aka4t5er4</pattern>
 <pattern>3akaz</pattern>
 <pattern>2akä</pattern>
 <pattern>2a4ke </pattern>
+<pattern>ake3h</pattern>
 <pattern>ak3eis</pattern>
 <pattern>ake3li</pattern>
 <pattern>ak3em</pattern>
@@ -2233,10 +2308,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4akko </pattern>
 <pattern>3akku</pattern>
 <pattern>ak4kul</pattern>
-<pattern>ak1l</pattern>
-<pattern>ak2la2</pattern>
-<pattern>ak4lin</pattern>
-<pattern>ak2lo</pattern>
+<pattern>akla2</pattern>
+<pattern>ak3lis</pattern>
 <pattern>ak2n</pattern>
 <pattern>a3kna</pattern>
 <pattern>3akne3</pattern>
@@ -2245,6 +2318,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2kod</pattern>
 <pattern>a2kok</pattern>
 <pattern>a2kol</pattern>
+<pattern>ako3r</pattern>
 <pattern>a2kot</pattern>
 <pattern>2akra</pattern>
 <pattern>akra3c</pattern>
@@ -2252,6 +2326,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ak3rei</pattern>
 <pattern>ak3ren</pattern>
 <pattern>ak3res</pattern>
+<pattern>2akri</pattern>
 <pattern>a3krie</pattern>
 <pattern>3akro5b</pattern>
 <pattern>akro3s</pattern>
@@ -2305,9 +2380,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3afr</pattern>
 <pattern>ala2g</pattern>
 <pattern>2alai</pattern>
-<pattern>ala3k4l</pattern>
+<pattern>ala3kl</pattern>
 <pattern>al3akr</pattern>
-<pattern>alal2</pattern>
 <pattern>al3ame</pattern>
 <pattern>alami3</pattern>
 <pattern>ala6misc</pattern>
@@ -2316,6 +2390,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>alan4d</pattern>
 <pattern>al5ande</pattern>
 <pattern>alan4f</pattern>
+<pattern>al5angel</pattern>
 <pattern>al5angr</pattern>
 <pattern>al3an4k</pattern>
 <pattern>al3anm</pattern>
@@ -2347,6 +2422,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3äu</pattern>
 <pattern>al4bär</pattern>
 <pattern>3albb</pattern>
+<pattern>4albe </pattern>
 <pattern>alb5eink</pattern>
 <pattern>al4b5erh</pattern>
 <pattern>al4b5er4w</pattern>
@@ -2356,7 +2432,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al4bon</pattern>
 <pattern>al4b3rä</pattern>
 <pattern>al4brec</pattern>
+<pattern>alb5rie</pattern>
 <pattern>alb5rin</pattern>
+<pattern>alb5ros</pattern>
 <pattern>alb4s3p</pattern>
 <pattern>alb3st</pattern>
 <pattern>3album</pattern>
@@ -2366,17 +2444,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aldar4m</pattern>
 <pattern>al2dä</pattern>
 <pattern>5aldehy</pattern>
-<pattern>al3dem</pattern>
 <pattern>alden4k</pattern>
 <pattern>al4d5ere</pattern>
-<pattern>al4d5erh</pattern>
+<pattern>al4d5er4h</pattern>
 <pattern>al4d5erl</pattern>
 <pattern>al4d5er4n</pattern>
 <pattern>al4d5erw</pattern>
 <pattern>ald5ese</pattern>
 <pattern>aldin4</pattern>
 <pattern>ald5inn</pattern>
-<pattern>al4dop</pattern>
 <pattern>al4d3ot4</pattern>
 <pattern>al4drä</pattern>
 <pattern>ald3s4t</pattern>
@@ -2401,14 +2477,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4l3e4mi</pattern>
 <pattern>a4l3emo</pattern>
 <pattern>al3emp</pattern>
+<pattern>ale5nas</pattern>
 <pattern>alende4</pattern>
+<pattern>alender5</pattern>
 <pattern>al5endr</pattern>
 <pattern>al5ends</pattern>
 <pattern>a4l5en4du</pattern>
 <pattern>a4lenga</pattern>
 <pattern>a4l5engl</pattern>
 <pattern>a4lent</pattern>
-<pattern>alent4e</pattern>
+<pattern>alent6ei</pattern>
 <pattern>al5enth</pattern>
 <pattern>a4lenz</pattern>
 <pattern>alen6z5ei</pattern>
@@ -2418,7 +2496,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4lerei</pattern>
 <pattern>a4lerf</pattern>
 <pattern>al5er4fo</pattern>
-<pattern>a4lerg</pattern>
+<pattern>a4l4erg</pattern>
 <pattern>a4lerh</pattern>
 <pattern>al5erhe</pattern>
 <pattern>alerho5</pattern>
@@ -2426,12 +2504,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4lerk</pattern>
 <pattern>aler4kr</pattern>
 <pattern>a4lerl</pattern>
-<pattern>al5er4la</pattern>
 <pattern>al5erlä</pattern>
 <pattern>a4lerm</pattern>
-<pattern>aler4mi</pattern>
-<pattern>aler4mü5</pattern>
+<pattern>al5er4mi</pattern>
 <pattern>aler4n</pattern>
+<pattern>a4l3erö</pattern>
 <pattern>a4lerp</pattern>
 <pattern>a4lerr</pattern>
 <pattern>alerre5</pattern>
@@ -2439,7 +2516,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a4lert</pattern>
 <pattern>al5er4tr</pattern>
 <pattern>a4l5er4wä</pattern>
-<pattern>a6l5erwer</pattern>
+<pattern>a6lerwer</pattern>
 <pattern>a4l3er4z</pattern>
 <pattern>a3les</pattern>
 <pattern>ale5sen</pattern>
@@ -2452,7 +2529,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3ext</pattern>
 <pattern>a1lé</pattern>
 <pattern>2alf</pattern>
-<pattern>3alge </pattern>
 <pattern>alge4d</pattern>
 <pattern>alge4re</pattern>
 <pattern>alge4w</pattern>
@@ -2469,6 +2545,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2li3l</pattern>
 <pattern>a2lim2</pattern>
 <pattern>alima3</pattern>
+<pattern>alim3b</pattern>
 <pattern>al3imm</pattern>
 <pattern>al3imp</pattern>
 <pattern>a4l3in4f</pattern>
@@ -2477,6 +2554,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3in4t</pattern>
 <pattern>al3inv</pattern>
 <pattern>a2lio</pattern>
+<pattern>ali2r</pattern>
+<pattern>al3ira</pattern>
 <pattern>ali3sp</pattern>
 <pattern>a3list</pattern>
 <pattern>a4li5str</pattern>
@@ -2497,6 +2576,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>all5an4s</pattern>
 <pattern>all5anz</pattern>
 <pattern>al4l3a4r4</pattern>
+<pattern>al4lass</pattern>
+<pattern>al4laus</pattern>
 <pattern>al4lec</pattern>
 <pattern>3allee</pattern>
 <pattern>all5ei4m</pattern>
@@ -2507,13 +2588,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>all5erho</pattern>
 <pattern>al4lerm</pattern>
 <pattern>all5ermü</pattern>
-<pattern>al4l5erz</pattern>
+<pattern>al4l5er4r</pattern>
+<pattern>al6lersc</pattern>
+<pattern>al4l5er4z</pattern>
 <pattern>3allgä</pattern>
 <pattern>3allia</pattern>
 <pattern>al4l3id</pattern>
 <pattern>alli5ers </pattern>
 <pattern>3allii</pattern>
 <pattern>allin4</pattern>
+<pattern>al4l5inh</pattern>
 <pattern>all5ink</pattern>
 <pattern>allo3c</pattern>
 <pattern>all5ora</pattern>
@@ -2523,6 +2607,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>alm5aus</pattern>
 <pattern>alm2e</pattern>
 <pattern>almi4n</pattern>
+<pattern>almi4s</pattern>
 <pattern>almor4</pattern>
 <pattern>al3n2</pattern>
 <pattern>2alo</pattern>
@@ -2543,6 +2628,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3orc</pattern>
 <pattern>al3ord</pattern>
 <pattern>al3ort</pattern>
+<pattern>alo3tr</pattern>
 <pattern>al2ov</pattern>
 <pattern>a3lo2w</pattern>
 <pattern>alö2</pattern>
@@ -2569,6 +2655,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3sex</pattern>
 <pattern>2alsk</pattern>
 <pattern>alsor4t</pattern>
+<pattern>als5tau</pattern>
+<pattern>al5s6temp</pattern>
 <pattern>al3sti</pattern>
 <pattern>altal4</pattern>
 <pattern>alt5alg</pattern>
@@ -2590,6 +2678,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>alt5or4t</pattern>
 <pattern>al4t5rat</pattern>
 <pattern>alt5ric</pattern>
+<pattern>alt5rit</pattern>
 <pattern>alt5ro6c</pattern>
 <pattern>alt5ros</pattern>
 <pattern>alt5rus</pattern>
@@ -2603,13 +2692,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>al3ums</pattern>
 <pattern>a3lup</pattern>
 <pattern>al3use</pattern>
+<pattern>aluta3</pattern>
 <pattern>alü2</pattern>
 <pattern>a3lüg</pattern>
 <pattern>2alv</pattern>
 <pattern>2aly</pattern>
+<pattern>2alz</pattern>
 <pattern>al4z3ap</pattern>
 <pattern>al4z3ar</pattern>
-<pattern>al4zäp</pattern>
 <pattern>2am </pattern>
 <pattern>am3a4ba</pattern>
 <pattern>a3mac</pattern>
@@ -2629,9 +2719,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>amazo5nen</pattern>
 <pattern>a1mä</pattern>
 <pattern>am3bis</pattern>
+<pattern>3ambiv</pattern>
 <pattern>2ame </pattern>
 <pattern>a4me3c</pattern>
 <pattern>am3ein</pattern>
+<pattern>am4eis</pattern>
 <pattern>amei5sen</pattern>
 <pattern>a3mek</pattern>
 <pattern>ame5len</pattern>
@@ -2653,8 +2745,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ame3s4p</pattern>
 <pattern>am3es4s</pattern>
 <pattern>ame2t</pattern>
+<pattern>am3e2v</pattern>
 <pattern>2amf</pattern>
 <pattern>amhal4</pattern>
+<pattern>a4mi </pattern>
 <pattern>a3mie</pattern>
 <pattern>ami5ern</pattern>
 <pattern>a2mig</pattern>
@@ -2672,8 +2766,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>amm5ass</pattern>
 <pattern>am4m3au</pattern>
 <pattern>am2mä</pattern>
-<pattern>amm5edi</pattern>
-<pattern>am4m3ei</pattern>
+<pattern>amm5eis</pattern>
 <pattern>amme4n</pattern>
 <pattern>am6m5es6sen</pattern>
 <pattern>amm3id</pattern>
@@ -2693,6 +2786,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>amo3s</pattern>
 <pattern>amotte5s</pattern>
 <pattern>amp4f3a</pattern>
+<pattern>amp7fer </pattern>
+<pattern>amp7ferk</pattern>
+<pattern>amp7ferö</pattern>
 <pattern>ampf5la</pattern>
 <pattern>ampf3o</pattern>
 <pattern>am4pho</pattern>
@@ -2737,6 +2833,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>amt3ob</pattern>
 <pattern>amt3op4</pattern>
 <pattern>amt5rat</pattern>
+<pattern>amt5rei</pattern>
 <pattern>amt5ren</pattern>
 <pattern>amt5ric</pattern>
 <pattern>am4tro</pattern>
@@ -2746,6 +2843,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>amt3ur4</pattern>
 <pattern>2amtv</pattern>
 <pattern>2amu</pattern>
+<pattern>am3uf</pattern>
 <pattern>3amul</pattern>
 <pattern>a3mü</pattern>
 <pattern>amü3s</pattern>
@@ -2755,6 +2853,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>anabde5</pattern>
 <pattern>a3n2ac</pattern>
 <pattern>ana5che</pattern>
+<pattern>an2ag</pattern>
 <pattern>ana3h</pattern>
 <pattern>ana4l5in</pattern>
 <pattern>an4alk</pattern>
@@ -2769,6 +2868,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an4are</pattern>
 <pattern>ana5ren</pattern>
 <pattern>ana5rer</pattern>
+<pattern>an4arr</pattern>
 <pattern>2an2as</pattern>
 <pattern>an2at</pattern>
 <pattern>a3nat </pattern>
@@ -2777,41 +2877,43 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3nats</pattern>
 <pattern>anat3t</pattern>
 <pattern>3anäm</pattern>
+<pattern>an3är2</pattern>
 <pattern>3anäs</pattern>
 <pattern>an3äu</pattern>
 <pattern>5anbaue</pattern>
 <pattern>3anbie</pattern>
-<pattern>4anbö</pattern>
+<pattern>2anc</pattern>
 <pattern>an3cht</pattern>
-<pattern>2and </pattern>
+<pattern>4and </pattern>
+<pattern>3andac</pattern>
 <pattern>4andal</pattern>
 <pattern>and5amm</pattern>
 <pattern>4andan</pattern>
 <pattern>and5anz</pattern>
 <pattern>an4d5ar4m</pattern>
 <pattern>and5ass</pattern>
+<pattern>andat4</pattern>
+<pattern>and5att</pattern>
 <pattern>2andd</pattern>
 <pattern>4ande </pattern>
 <pattern>and3ei</pattern>
 <pattern>an4dek</pattern>
 <pattern>and5elfe</pattern>
 <pattern>and5ente </pattern>
-<pattern>and5erho</pattern>
 <pattern>and5erhö</pattern>
-<pattern>and5erob</pattern>
 <pattern>anderzu5</pattern>
 <pattern>4an3des</pattern>
 <pattern>an4d3ex</pattern>
 <pattern>2andf</pattern>
 <pattern>2andg</pattern>
 <pattern>an3dig</pattern>
-<pattern>an4d3il</pattern>
 <pattern>andin4g</pattern>
 <pattern>and5inge</pattern>
 <pattern>an4doo</pattern>
 <pattern>an4dop</pattern>
 <pattern>an4drec</pattern>
 <pattern>and5rei</pattern>
+<pattern>an4d5res</pattern>
 <pattern>an4drog</pattern>
 <pattern>an4drom</pattern>
 <pattern>an4dron</pattern>
@@ -2839,7 +2941,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an3emp</pattern>
 <pattern>a5nens</pattern>
 <pattern>a4nenz</pattern>
-<pattern>a4n5erfa</pattern>
 <pattern>anergene5</pattern>
 <pattern>a3neri</pattern>
 <pattern>an5er4sc</pattern>
@@ -2854,6 +2955,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1anf</pattern>
 <pattern>2anf </pattern>
 <pattern>4anfab</pattern>
+<pattern>anf3ak4</pattern>
 <pattern>an3fäh</pattern>
 <pattern>2anfi</pattern>
 <pattern>an3fli</pattern>
@@ -2882,7 +2984,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>angera4</pattern>
 <pattern>ang5erf</pattern>
 <pattern>ang5erg</pattern>
-<pattern>an4g5er4h</pattern>
+<pattern>ang5erhe</pattern>
 <pattern>an6gerin</pattern>
 <pattern>ang5erk</pattern>
 <pattern>anger4l</pattern>
@@ -2906,7 +3008,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4angs </pattern>
 <pattern>ang5sti</pattern>
 <pattern>ang5stro</pattern>
-<pattern>an3gu</pattern>
 <pattern>anha2</pattern>
 <pattern>an4haus</pattern>
 <pattern>an3ho</pattern>
@@ -2921,13 +3022,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2nij</pattern>
 <pattern>ani4ka</pattern>
 <pattern>3a2nim</pattern>
-<pattern>an4in3h</pattern>
 <pattern>a4n3iso</pattern>
 <pattern>a4ni5sta</pattern>
 <pattern>an2it</pattern>
 <pattern>2ank </pattern>
 <pattern>2anka</pattern>
 <pattern>an4k3ak</pattern>
+<pattern>ank5alt</pattern>
 <pattern>ankan4</pattern>
 <pattern>ank5ant</pattern>
 <pattern>ank5anz</pattern>
@@ -2949,6 +3050,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an4krü</pattern>
 <pattern>2anks</pattern>
 <pattern>ank3s4k</pattern>
+<pattern>ank3sp</pattern>
+<pattern>ankt2</pattern>
 <pattern>an4kum</pattern>
 <pattern>an4küb</pattern>
 <pattern>3ankün</pattern>
@@ -3015,6 +3118,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an4seu</pattern>
 <pattern>3ansic</pattern>
 <pattern>ansicht6</pattern>
+<pattern>an4sim</pattern>
 <pattern>ans5par</pattern>
 <pattern>ans3po</pattern>
 <pattern>5anstal</pattern>
@@ -3023,6 +3127,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an5stra</pattern>
 <pattern>5anstri</pattern>
 <pattern>3anstu</pattern>
+<pattern>an4s3ur</pattern>
 <pattern>an3s2z</pattern>
 <pattern>ant2a</pattern>
 <pattern>an3tac</pattern>
@@ -3035,7 +3140,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3antei</pattern>
 <pattern>an5tel</pattern>
 <pattern>an4tenn</pattern>
-<pattern>ant5eta</pattern>
+<pattern>ant5e4ta</pattern>
 <pattern>an5teu</pattern>
 <pattern>an2th</pattern>
 <pattern>5anthro</pattern>
@@ -3046,7 +3151,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an4tiö</pattern>
 <pattern>3antiq</pattern>
 <pattern>5antise</pattern>
-<pattern>anton4s</pattern>
 <pattern>ant5räu</pattern>
 <pattern>2a1nu</pattern>
 <pattern>anu3r</pattern>
@@ -3055,10 +3159,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4anwert</pattern>
 <pattern>2anwi</pattern>
 <pattern>a2ny</pattern>
+<pattern>any3l4</pattern>
 <pattern>an4z3an4</pattern>
 <pattern>an4z5art</pattern>
 <pattern>an4zau</pattern>
 <pattern>an4zäp</pattern>
+<pattern>2anzb</pattern>
 <pattern>an4z3ed</pattern>
 <pattern>anz5elf</pattern>
 <pattern>anze4m</pattern>
@@ -3069,12 +3175,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2anzg</pattern>
 <pattern>2anzh</pattern>
 <pattern>2anzi</pattern>
-<pattern>anz3id</pattern>
-<pattern>an4z3i4n4</pattern>
+<pattern>anz3i4d</pattern>
+<pattern>anzi4n4</pattern>
+<pattern>an4z5inf</pattern>
+<pattern>an4z5ins</pattern>
+<pattern>anz5int</pattern>
 <pattern>anzi3p</pattern>
 <pattern>2anzk</pattern>
 <pattern>2anzm</pattern>
 <pattern>2anzr</pattern>
+<pattern>2anzs</pattern>
+<pattern>2anzt</pattern>
 <pattern>anzu4l</pattern>
 <pattern>anzu4s</pattern>
 <pattern>anzu4w</pattern>
@@ -3083,6 +3194,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>an4zwä</pattern>
 <pattern>2ao</pattern>
 <pattern>aob2</pattern>
+<pattern>a1of</pattern>
 <pattern>ao1i</pattern>
 <pattern>a3okt</pattern>
 <pattern>ao1m</pattern>
@@ -3098,6 +3210,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aot2t</pattern>
 <pattern>a1ö</pattern>
 <pattern>2ap </pattern>
+<pattern>ap2a</pattern>
 <pattern>apa3b</pattern>
 <pattern>apa3c</pattern>
 <pattern>a3pad</pattern>
@@ -3120,6 +3233,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>apher4</pattern>
 <pattern>aph5ers</pattern>
 <pattern>aph3t</pattern>
+<pattern>2api</pattern>
+<pattern>apie3l</pattern>
 <pattern>apie3s</pattern>
 <pattern>2apl</pattern>
 <pattern>a3plä</pattern>
@@ -3135,7 +3250,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2pri</pattern>
 <pattern>a2ps</pattern>
 <pattern>ap3sa</pattern>
-<pattern>ap3so</pattern>
+<pattern>ap2s3p</pattern>
 <pattern>ap3su</pattern>
 <pattern>a3psy</pattern>
 <pattern>a2p1t</pattern>
@@ -3155,14 +3270,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ar3adr</pattern>
 <pattern>arad4s</pattern>
 <pattern>arad4v</pattern>
-<pattern>ara5gen</pattern>
+<pattern>arafor4</pattern>
 <pattern>ar3ag4g</pattern>
+<pattern>ar4ah</pattern>
+<pattern>2arak</pattern>
 <pattern>4aral</pattern>
 <pattern>ara3le</pattern>
 <pattern>ara3li</pattern>
 <pattern>ar3all</pattern>
 <pattern>ara3me</pattern>
 <pattern>2aran</pattern>
+<pattern>ar3ana</pattern>
 <pattern>aran4d</pattern>
 <pattern>ar3an4r</pattern>
 <pattern>aran4w</pattern>
@@ -3178,8 +3296,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2arau</pattern>
 <pattern>ar3aue</pattern>
 <pattern>ar3auf</pattern>
+<pattern>a3raum</pattern>
 <pattern>ar3aus</pattern>
 <pattern>arauto4</pattern>
+<pattern>ar3ax</pattern>
 <pattern>a3ray</pattern>
 <pattern>2arä</pattern>
 <pattern>ar3äs</pattern>
@@ -3203,13 +3323,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4arbi</pattern>
 <pattern>ar5big</pattern>
 <pattern>arbi4s</pattern>
+<pattern>ar4b3le</pattern>
 <pattern>2arbo</pattern>
 <pattern>ar4bor</pattern>
 <pattern>ar3bos</pattern>
 <pattern>2arbr</pattern>
 <pattern>2arbs</pattern>
 <pattern>arb3sk</pattern>
-<pattern>arb5so</pattern>
 <pattern>2arbt2</pattern>
 <pattern>2arbu</pattern>
 <pattern>ar3bun</pattern>
@@ -3228,12 +3348,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ar3di</pattern>
 <pattern>ar4dop</pattern>
 <pattern>2ardö</pattern>
-<pattern>ar4d3ri</pattern>
 <pattern>ar4dro</pattern>
 <pattern>4are </pattern>
 <pattern>are5ba</pattern>
-<pattern>a3rec</pattern>
-<pattern>a4red</pattern>
 <pattern>are3e2</pattern>
 <pattern>ar3eff</pattern>
 <pattern>are3gl</pattern>
@@ -3243,6 +3360,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3rei </pattern>
 <pattern>ar3eid</pattern>
 <pattern>a3reie</pattern>
+<pattern>ar3ei4g</pattern>
 <pattern>a3reih</pattern>
 <pattern>arei4s</pattern>
 <pattern>are3li</pattern>
@@ -3255,7 +3373,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>arens4</pattern>
 <pattern>aren5st</pattern>
 <pattern>a4rent</pattern>
+<pattern>ar5entn</pattern>
 <pattern>arenzu4</pattern>
+<pattern>aren4zy5</pattern>
 <pattern>4arer</pattern>
 <pattern>are3r4a</pattern>
 <pattern>arerau5</pattern>
@@ -3267,10 +3387,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ar3ert</pattern>
 <pattern>ar3er4z</pattern>
 <pattern>2ares</pattern>
-<pattern>a4resc</pattern>
 <pattern>are3se</pattern>
 <pattern>a4r3esk</pattern>
 <pattern>are3sp</pattern>
+<pattern>ar3es4s</pattern>
 <pattern>are5str</pattern>
 <pattern>2aret</pattern>
 <pattern>are5the</pattern>
@@ -3287,6 +3407,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>argene5</pattern>
 <pattern>4argo</pattern>
 <pattern>arg4r</pattern>
+<pattern>ar2gu</pattern>
 <pattern>2arh</pattern>
 <pattern>ar2i</pattern>
 <pattern>2a4ri </pattern>
@@ -3316,20 +3437,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ariu</pattern>
 <pattern>ari2v</pattern>
 <pattern>3arkad</pattern>
-<pattern>ar4kak</pattern>
+<pattern>ar4k3ak</pattern>
 <pattern>ar4kal</pattern>
 <pattern>ark5aue</pattern>
 <pattern>ar4käh</pattern>
+<pattern>arker4</pattern>
 <pattern>ar4k5erh</pattern>
 <pattern>ar4k5erl</pattern>
-<pattern>arker4s</pattern>
+<pattern>ar6k5erne</pattern>
 <pattern>ar6k5ersc</pattern>
+<pattern>ar4k5erw</pattern>
 <pattern>ar4kid</pattern>
 <pattern>ar4k3ne</pattern>
 <pattern>ar4kni</pattern>
 <pattern>2arko</pattern>
 <pattern>ark5opt</pattern>
 <pattern>ar4kor</pattern>
+<pattern>ar5kred</pattern>
+<pattern>ark5rin</pattern>
 <pattern>ark5she</pattern>
 <pattern>ark5spe</pattern>
 <pattern>arks4t</pattern>
@@ -3418,7 +3543,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ar6schab</pattern>
 <pattern>ar6sch5ac</pattern>
 <pattern>arscher6</pattern>
-<pattern>arsch5wi</pattern>
+<pattern>arsch5erl</pattern>
 <pattern>ar3set</pattern>
 <pattern>ars4ha</pattern>
 <pattern>2arsi</pattern>
@@ -3437,6 +3562,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2arsy</pattern>
 <pattern>artal4s5</pattern>
 <pattern>art3am4</pattern>
+<pattern>artan4</pattern>
 <pattern>artat4</pattern>
 <pattern>art5att</pattern>
 <pattern>art5auf</pattern>
@@ -3525,17 +3651,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>as3eie</pattern>
 <pattern>ase3li</pattern>
 <pattern>asena4</pattern>
+<pattern>asene4s</pattern>
+<pattern>asen5esc</pattern>
 <pattern>asen3o</pattern>
-<pattern>a6sensem</pattern>
-<pattern>asen5sp</pattern>
+<pattern>asen5s4p</pattern>
 <pattern>a3senv</pattern>
-<pattern>a3senz</pattern>
 <pattern>a3seo</pattern>
 <pattern>aser3a</pattern>
 <pattern>aser5eig</pattern>
+<pattern>ase4ren</pattern>
 <pattern>as4erh</pattern>
 <pattern>a5serki</pattern>
 <pattern>aser3t</pattern>
+<pattern>as3er4w</pattern>
 <pattern>as4es</pattern>
 <pattern>as3eta3</pattern>
 <pattern>as3eva</pattern>
@@ -3544,6 +3672,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2asf</pattern>
 <pattern>asgene5</pattern>
 <pattern>a3s4hen</pattern>
+<pattern>a3s4hig</pattern>
 <pattern>a4siak</pattern>
 <pattern>3asiat</pattern>
 <pattern>a3sid</pattern>
@@ -3551,6 +3680,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a2s3ik</pattern>
 <pattern>asi3l</pattern>
 <pattern>asin2</pattern>
+<pattern>asing3</pattern>
 <pattern>as3inn</pattern>
 <pattern>as3int</pattern>
 <pattern>asis3a</pattern>
@@ -3561,12 +3691,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>asle5ri</pattern>
 <pattern>a3slip</pattern>
 <pattern>as4masc</pattern>
+<pattern>as3mi</pattern>
 <pattern>as4mode</pattern>
 <pattern>aso3c</pattern>
 <pattern>as3ofe</pattern>
 <pattern>aso3li</pattern>
-<pattern>as3op</pattern>
-<pattern>asor4g</pattern>
+<pattern>a2s3op</pattern>
+<pattern>as3orc</pattern>
+<pattern>as3or4g</pattern>
 <pattern>as3ori</pattern>
 <pattern>aso3zi</pattern>
 <pattern>as3ped</pattern>
@@ -3588,14 +3720,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>as4sek</pattern>
 <pattern>as4sema</pattern>
 <pattern>assens6k</pattern>
-<pattern>assen5sp</pattern>
+<pattern>assen5s6p</pattern>
 <pattern>asser5ec</pattern>
 <pattern>5assess</pattern>
 <pattern>as4sim</pattern>
 <pattern>as3ski</pattern>
 <pattern>as4sof</pattern>
-<pattern>as4sor</pattern>
-<pattern>ass5ora</pattern>
+<pattern>as4s5ora</pattern>
 <pattern>as4sou</pattern>
 <pattern>3as4soz</pattern>
 <pattern>as2sö</pattern>
@@ -3606,28 +3737,29 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>as5stau</pattern>
 <pattern>ass5tir</pattern>
 <pattern>as3str</pattern>
-<pattern>as3stu</pattern>
 <pattern>as3stü</pattern>
 <pattern>ast5abs</pattern>
 <pattern>a3stad</pattern>
 <pattern>ast4af</pattern>
+<pattern>ast5ann</pattern>
 <pattern>ast5ans</pattern>
 <pattern>as3tap</pattern>
 <pattern>ast5arb</pattern>
 <pattern>asta3s</pattern>
 <pattern>as5tatt</pattern>
 <pattern>ast5auf</pattern>
-<pattern>ast5eing</pattern>
 <pattern>ast5einl</pattern>
 <pattern>as3tel</pattern>
 <pattern>ast5ents</pattern>
 <pattern>as3tep</pattern>
 <pattern>as6t5erhö</pattern>
 <pattern>as4t5ese</pattern>
+<pattern>as5teth</pattern>
 <pattern>as4tex</pattern>
 <pattern>astgema5</pattern>
 <pattern>as5tie</pattern>
 <pattern>ast5orc</pattern>
+<pattern>as5trad</pattern>
 <pattern>as5tran</pattern>
 <pattern>as4tras</pattern>
 <pattern>ast5raum</pattern>
@@ -3643,7 +3775,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>as3tür</pattern>
 <pattern>asum2</pattern>
 <pattern>as3umg</pattern>
-<pattern>as3una</pattern>
 <pattern>asu3t</pattern>
 <pattern>2asy </pattern>
 <pattern>a2syl</pattern>
@@ -3681,7 +3812,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>at3aus</pattern>
 <pattern>atä2</pattern>
 <pattern>atän4d</pattern>
-<pattern>at3är</pattern>
+<pattern>at3är2</pattern>
 <pattern>2atb</pattern>
 <pattern>4a4te </pattern>
 <pattern>ate5gi</pattern>
@@ -3689,22 +3820,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ateien6d</pattern>
 <pattern>atei3f</pattern>
 <pattern>atei3s</pattern>
-<pattern>a3tel </pattern>
 <pattern>ate3la</pattern>
 <pattern>ate3le</pattern>
 <pattern>3a4teli</pattern>
 <pattern>4atell</pattern>
-<pattern>atel6l5er6k</pattern>
+<pattern>atel6l5erk</pattern>
 <pattern>a4teme</pattern>
 <pattern>3a4temg</pattern>
 <pattern>a4tems</pattern>
 <pattern>2aten</pattern>
 <pattern>a4tenam</pattern>
 <pattern>atens6e</pattern>
+<pattern>atentan6</pattern>
+<pattern>aten6t5ank</pattern>
 <pattern>a4tente</pattern>
 <pattern>aten6t5ri</pattern>
 <pattern>a4tenz</pattern>
 <pattern>ate5ral</pattern>
+<pattern>a4terdä</pattern>
 <pattern>aterzu4</pattern>
 <pattern>4ates</pattern>
 <pattern>ate3v</pattern>
@@ -3712,6 +3845,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2atg</pattern>
 <pattern>ath4a</pattern>
 <pattern>at3hee</pattern>
+<pattern>athe3l</pattern>
 <pattern>at5herd</pattern>
 <pattern>ath5in </pattern>
 <pattern>at3hir</pattern>
@@ -3762,10 +3896,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a1tö1</pattern>
 <pattern>2atp</pattern>
 <pattern>atra6ch</pattern>
+<pattern>a3trag</pattern>
 <pattern>atra4t</pattern>
 <pattern>at3rau</pattern>
 <pattern>at3ra4v</pattern>
 <pattern>at3rän</pattern>
+<pattern>at3rät</pattern>
 <pattern>at3räu</pattern>
 <pattern>at3rec</pattern>
 <pattern>a3trib</pattern>
@@ -3774,6 +3910,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>at3rol</pattern>
 <pattern>at3rom</pattern>
 <pattern>4atron</pattern>
+<pattern>3atrop</pattern>
 <pattern>atro5sen</pattern>
 <pattern>at3ro4t</pattern>
 <pattern>at3ruh</pattern>
@@ -3784,7 +3921,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>at6schma</pattern>
 <pattern>ats3eh</pattern>
 <pattern>at4s3in4</pattern>
-<pattern>at3sol</pattern>
+<pattern>at4sof</pattern>
 <pattern>ats3pa</pattern>
 <pattern>at5spei</pattern>
 <pattern>ats5per</pattern>
@@ -3798,7 +3935,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>at4tak4</pattern>
 <pattern>att5akt</pattern>
 <pattern>atta4l</pattern>
-<pattern>at4tale</pattern>
+<pattern>at5tal </pattern>
 <pattern>at4tar</pattern>
 <pattern>at4ta3s</pattern>
 <pattern>at4t3au</pattern>
@@ -3820,8 +3957,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>att3s2</pattern>
 <pattern>2atu</pattern>
 <pattern>a2tum</pattern>
+<pattern>atu2n</pattern>
 <pattern>atu5rat</pattern>
 <pattern>atur5er</pattern>
+<pattern>atur3s</pattern>
 <pattern>atur5z</pattern>
 <pattern>atus3e</pattern>
 <pattern>at3was</pattern>
@@ -3831,6 +3970,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>at2zä</pattern>
 <pattern>at4z3ec</pattern>
 <pattern>at4z3ed</pattern>
+<pattern>at4z3eh</pattern>
 <pattern>atz5eig</pattern>
 <pattern>atz5ela</pattern>
 <pattern>atz5el4t</pattern>
@@ -3838,12 +3978,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>atzer4</pattern>
 <pattern>at5zer </pattern>
 <pattern>atz5erb</pattern>
-<pattern>at4zere</pattern>
-<pattern>atz5erfa</pattern>
+<pattern>atz5erf</pattern>
 <pattern>atz5erg</pattern>
 <pattern>atz5erh</pattern>
 <pattern>atz5erke</pattern>
 <pattern>atz5erkl</pattern>
+<pattern>atz5erkr</pattern>
 <pattern>atz5erla</pattern>
 <pattern>atz5erlö</pattern>
 <pattern>atz5erp</pattern>
@@ -3865,6 +4005,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2aub</pattern>
 <pattern>aub3ab</pattern>
 <pattern>aub5ele</pattern>
+<pattern>aub5eul</pattern>
 <pattern>aub5ins</pattern>
 <pattern>au4blä</pattern>
 <pattern>aub5lic</pattern>
@@ -3873,6 +4014,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aub5re6c</pattern>
 <pattern>aub5rin</pattern>
 <pattern>aub4spo</pattern>
+<pattern>au4b3um</pattern>
 <pattern>2auc</pattern>
 <pattern>au3che</pattern>
 <pattern>auch5ec</pattern>
@@ -3884,6 +4026,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3au4dit</pattern>
 <pattern>2aue</pattern>
 <pattern>au3e2b</pattern>
+<pattern>au3ed</pattern>
+<pattern>au3ep</pattern>
 <pattern>aue2s</pattern>
 <pattern>au3esc</pattern>
 <pattern>au3eta</pattern>
@@ -3897,10 +4041,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aufer4</pattern>
 <pattern>auf5erf</pattern>
 <pattern>auf5erh</pattern>
+<pattern>au4f5eri</pattern>
 <pattern>auf5erkr</pattern>
 <pattern>auf5erla</pattern>
 <pattern>auf5erm</pattern>
-<pattern>3auffü</pattern>
 <pattern>auf5ind</pattern>
 <pattern>3auflö</pattern>
 <pattern>3aufn</pattern>
@@ -3916,11 +4060,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>auf3ta</pattern>
 <pattern>auf3th</pattern>
 <pattern>5aufträ</pattern>
-<pattern>3aufzü</pattern>
 <pattern>au3gar</pattern>
 <pattern>4augeh</pattern>
 <pattern>au4geni</pattern>
-<pattern>4augeno</pattern>
 <pattern>5au4ges </pattern>
 <pattern>2augl</pattern>
 <pattern>au3glo</pattern>
@@ -3947,11 +4089,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aum5ents</pattern>
 <pattern>aume4r4</pattern>
 <pattern>au4m5eri</pattern>
+<pattern>au4m5ern</pattern>
 <pattern>au4m5ers</pattern>
 <pattern>aum5erz</pattern>
 <pattern>aumes4</pattern>
 <pattern>aum3id</pattern>
-<pattern>aumi4n4</pattern>
+<pattern>aumi4n</pattern>
 <pattern>aum5ins</pattern>
 <pattern>aumo2</pattern>
 <pattern>aum3or</pattern>
@@ -3981,7 +4124,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>au3pen</pattern>
 <pattern>au3p2f</pattern>
 <pattern>au3pr</pattern>
-<pattern>aup4ter</pattern>
+<pattern>aup4t5er</pattern>
 <pattern>au1r2</pattern>
 <pattern>aur4a</pattern>
 <pattern>au4ral</pattern>
@@ -4008,6 +4151,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>au3sel</pattern>
 <pattern>aus5ele</pattern>
 <pattern>au3sem</pattern>
+<pattern>4ausen</pattern>
 <pattern>au5ser </pattern>
 <pattern>aus5erb</pattern>
 <pattern>au5sere</pattern>
@@ -4017,16 +4161,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>aus5erl</pattern>
 <pattern>aus5erpr</pattern>
 <pattern>aus5erw</pattern>
-<pattern>3ausg</pattern>
 <pattern>au4s3in4</pattern>
+<pattern>aus5kr</pattern>
 <pattern>2auso</pattern>
-<pattern>au3so </pattern>
-<pattern>aus3or4</pattern>
+<pattern>au4s3or4</pattern>
 <pattern>au5spec</pattern>
 <pattern>aus3pu4</pattern>
 <pattern>3ausrü</pattern>
 <pattern>5aussag</pattern>
+<pattern>ausse4r</pattern>
 <pattern>auss4t</pattern>
+<pattern>5aussta</pattern>
 <pattern>aus3sz</pattern>
 <pattern>4aust </pattern>
 <pattern>au5stab</pattern>
@@ -4041,6 +4186,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4austen</pattern>
 <pattern>4austes</pattern>
 <pattern>aus5toc</pattern>
+<pattern>au4stö</pattern>
 <pattern>5austrag</pattern>
 <pattern>au5strah</pattern>
 <pattern>au5s6tras</pattern>
@@ -4049,6 +4195,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>au3sus</pattern>
 <pattern>3auswu</pattern>
 <pattern>3auszu</pattern>
+<pattern>3auszü</pattern>
 <pattern>auße2</pattern>
 <pattern>außer3</pattern>
 <pattern>au3ßes</pattern>
@@ -4060,10 +4207,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4aute</pattern>
 <pattern>aut5ein</pattern>
 <pattern>au4t3el4</pattern>
+<pattern>aut5erhe</pattern>
 <pattern>aut5erkr</pattern>
 <pattern>auter4n</pattern>
 <pattern>aut5erne</pattern>
-<pattern>au4t5ero</pattern>
+<pattern>au4tero</pattern>
 <pattern>au4t5er4s</pattern>
 <pattern>aut3ex</pattern>
 <pattern>2auti</pattern>
@@ -4074,13 +4222,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>auto6rens</pattern>
 <pattern>auto6rent</pattern>
 <pattern>auto6rinn</pattern>
+<pattern>aut5ran</pattern>
 <pattern>aut5rau</pattern>
 <pattern>aut5rin</pattern>
 <pattern>aut5roc</pattern>
 <pattern>aut5rot</pattern>
 <pattern>auts2</pattern>
 <pattern>aut3sk</pattern>
-<pattern>aut3sp</pattern>
 <pattern>aut3z</pattern>
 <pattern>2auu</pattern>
 <pattern>au3ü</pattern>
@@ -4106,6 +4254,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ax3emp</pattern>
 <pattern>ax3er4w</pattern>
 <pattern>3a4xio</pattern>
+<pattern>axi2s</pattern>
 <pattern>axo1</pattern>
 <pattern>2ay</pattern>
 <pattern>ay3ak</pattern>
@@ -4113,6 +4262,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ay1l</pattern>
 <pattern>ay1m2</pattern>
 <pattern>ay3of</pattern>
+<pattern>ayou2</pattern>
 <pattern>ay1r</pattern>
 <pattern>ay1s2</pattern>
 <pattern>ay1t</pattern>
@@ -4131,6 +4281,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>a3ziu</pattern>
 <pattern>azo3b</pattern>
 <pattern>2a2zu1</pattern>
+<pattern>3azub</pattern>
 <pattern>azu4bl</pattern>
 <pattern>azugege5</pattern>
 <pattern>azugehö5ren</pattern>
@@ -4162,9 +4313,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ä3chi</pattern>
 <pattern>ä2ch3l</pattern>
 <pattern>äch4s3a</pattern>
-<pattern>ächs3o</pattern>
+<pattern>äch4s3o</pattern>
 <pattern>äch4s3p</pattern>
 <pattern>ä3chu</pattern>
+<pattern>äcke5rei</pattern>
 <pattern>äck3sp</pattern>
 <pattern>ä2da</pattern>
 <pattern>äde2l</pattern>
@@ -4214,7 +4366,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ägd2</pattern>
 <pattern>äge3a</pattern>
 <pattern>ägear4</pattern>
-<pattern>äge3b</pattern>
 <pattern>äge3f</pattern>
 <pattern>ä2gei</pattern>
 <pattern>äge3k</pattern>
@@ -4227,7 +4378,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ä4gest</pattern>
 <pattern>ä2ge3t</pattern>
 <pattern>äg1l</pattern>
-<pattern>ä1gn2</pattern>
+<pattern>ä1gn</pattern>
 <pattern>ä2g3ne</pattern>
 <pattern>äg2ni</pattern>
 <pattern>ä2g1r</pattern>
@@ -4243,19 +4394,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>äh3el</pattern>
 <pattern>äh3in</pattern>
 <pattern>ähis3</pattern>
-<pattern>ähl3a</pattern>
+<pattern>äh4l3a</pattern>
 <pattern>ählap4</pattern>
 <pattern>ähl5ebe</pattern>
-<pattern>ähl3ei</pattern>
+<pattern>ähl5ein</pattern>
 <pattern>äh3let</pattern>
 <pattern>äh3li</pattern>
+<pattern>ähl5ins</pattern>
 <pattern>2ähm</pattern>
 <pattern>äh3mes</pattern>
 <pattern>äh3na</pattern>
 <pattern>äh4neb</pattern>
+<pattern>2ähni</pattern>
 <pattern>3ähnl</pattern>
 <pattern>ähr5sa</pattern>
 <pattern>2ähs2</pattern>
+<pattern>äh3stu</pattern>
 <pattern>2äht</pattern>
 <pattern>ä1hu</pattern>
 <pattern>äh3w</pattern>
@@ -4291,8 +4445,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ä1lu2</pattern>
 <pattern>2ä2ma</pattern>
 <pattern>äma5tom</pattern>
-<pattern>ä3mer</pattern>
-<pattern>ämer4st</pattern>
+<pattern>ä4me </pattern>
 <pattern>ä1mi</pattern>
 <pattern>2äm3l</pattern>
 <pattern>ä3mos</pattern>
@@ -4307,11 +4460,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ände5la</pattern>
 <pattern>än4dene</pattern>
 <pattern>än6derel</pattern>
+<pattern>ändes4</pattern>
 <pattern>än4desc</pattern>
 <pattern>än4dese</pattern>
-<pattern>än4desp</pattern>
+<pattern>än4de5sp</pattern>
 <pattern>än2dr</pattern>
 <pattern>2äne</pattern>
+<pattern>ä2nea</pattern>
 <pattern>ä2ne3l</pattern>
 <pattern>äne2n</pattern>
 <pattern>änen3e</pattern>
@@ -4322,6 +4477,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>än4geg</pattern>
 <pattern>än4gei</pattern>
 <pattern>än4ge3k</pattern>
+<pattern>än3gel</pattern>
 <pattern>än4ge3m</pattern>
 <pattern>än3gen</pattern>
 <pattern>än4gene</pattern>
@@ -4331,7 +4487,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>änge3t</pattern>
 <pattern>än4geta</pattern>
 <pattern>än4getr</pattern>
-<pattern>2ängl</pattern>
 <pattern>än2gr</pattern>
 <pattern>2äni</pattern>
 <pattern>änk4e</pattern>
@@ -4339,6 +4494,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>än4kela</pattern>
 <pattern>än2k3l</pattern>
 <pattern>än2kr</pattern>
+<pattern>änk4th</pattern>
 <pattern>änne2</pattern>
 <pattern>än3ner3</pattern>
 <pattern>ä1no</pattern>
@@ -4352,7 +4508,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>änspa4</pattern>
 <pattern>än4te5le</pattern>
 <pattern>ä1nu2</pattern>
-<pattern>2änz</pattern>
 <pattern>äo1</pattern>
 <pattern>äolo2</pattern>
 <pattern>äon2</pattern>
@@ -4377,7 +4532,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ärak2</pattern>
 <pattern>äral2</pattern>
 <pattern>äram2</pattern>
-<pattern>är3an2</pattern>
+<pattern>är3a4n2</pattern>
+<pattern>ärana3</pattern>
 <pattern>äranga5</pattern>
 <pattern>ärange5</pattern>
 <pattern>ära4r</pattern>
@@ -4425,17 +4581,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>är4ket</pattern>
 <pattern>ärma2</pattern>
 <pattern>ärm5arm</pattern>
-<pattern>är4mau</pattern>
+<pattern>är4m3au</pattern>
 <pattern>är4mea</pattern>
 <pattern>är4me3e4</pattern>
-<pattern>är4me3i</pattern>
-<pattern>ärmein4</pattern>
+<pattern>är4mei</pattern>
 <pattern>är4mel</pattern>
 <pattern>är4mem</pattern>
 <pattern>är4mene</pattern>
 <pattern>är4m5ent</pattern>
 <pattern>ärm5erz</pattern>
 <pattern>är4met</pattern>
+<pattern>är4m3in</pattern>
 <pattern>ärm3o</pattern>
 <pattern>är3no</pattern>
 <pattern>är3o2b</pattern>
@@ -4453,10 +4609,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>är2sz</pattern>
 <pattern>ärt2s3</pattern>
 <pattern>ä1ru</pattern>
-<pattern>är4zau</pattern>
-<pattern>ärz5en4t</pattern>
+<pattern>ärz3au</pattern>
+<pattern>ärzen4t</pattern>
 <pattern>ärzer4</pattern>
-<pattern>ärz5err</pattern>
+<pattern>är3zes</pattern>
 <pattern>ärzu2</pattern>
 <pattern>ärzuge5</pattern>
 <pattern>äsa3re</pattern>
@@ -4466,18 +4622,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>äse3e</pattern>
 <pattern>äse3g</pattern>
 <pattern>äse3h</pattern>
-<pattern>äse3i2</pattern>
+<pattern>äs4e3i2</pattern>
 <pattern>ä2sek</pattern>
 <pattern>äse3la</pattern>
 <pattern>äse3m</pattern>
+<pattern>äsemi4</pattern>
 <pattern>äsen4s</pattern>
 <pattern>ä4serad</pattern>
 <pattern>äse3re</pattern>
 <pattern>äse4ren</pattern>
 <pattern>äse5r4i</pattern>
 <pattern>äse3t</pattern>
+<pattern>äse3u</pattern>
 <pattern>ä3s2kr</pattern>
+<pattern>ä2so</pattern>
 <pattern>äs1p</pattern>
+<pattern>2äss</pattern>
 <pattern>äs2s3c</pattern>
 <pattern>äs3ser</pattern>
 <pattern>äss5erkr</pattern>
@@ -4501,6 +4661,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ät4eb</pattern>
 <pattern>äte5be</pattern>
 <pattern>ä2te3e2</pattern>
+<pattern>äteer4</pattern>
 <pattern>ä2tei</pattern>
 <pattern>ätein4</pattern>
 <pattern>ät3eis</pattern>
@@ -4554,9 +4715,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>äu4dea</pattern>
 <pattern>äu4def</pattern>
 <pattern>äu4del</pattern>
+<pattern>äu4dem</pattern>
 <pattern>äu4der4</pattern>
 <pattern>äu4dest</pattern>
 <pattern>äu4det</pattern>
+<pattern>äuel3</pattern>
 <pattern>äu3ers</pattern>
 <pattern>2äuf</pattern>
 <pattern>äu2fl</pattern>
@@ -4569,8 +4732,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>äu2ma</pattern>
 <pattern>äum3p</pattern>
 <pattern>äumpf4</pattern>
-<pattern>äums3p</pattern>
-<pattern>äums3t</pattern>
+<pattern>äums3</pattern>
+<pattern>äums4c</pattern>
 <pattern>äun2e</pattern>
 <pattern>äun5ter</pattern>
 <pattern>äu3nu</pattern>
@@ -4583,13 +4746,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2äus </pattern>
 <pattern>äu4scha</pattern>
 <pattern>äu4schä</pattern>
+<pattern>äu6sch5ei</pattern>
 <pattern>äu6schel</pattern>
+<pattern>äusch5erz</pattern>
 <pattern>äu4schi</pattern>
 <pattern>äu4schl</pattern>
 <pattern>äu4schm</pattern>
+<pattern>äu4schn</pattern>
 <pattern>äu4sch5o</pattern>
 <pattern>äu4schr</pattern>
 <pattern>äu4schü</pattern>
+<pattern>äu4schw</pattern>
 <pattern>äu4se3h</pattern>
 <pattern>äu4s4e3i</pattern>
 <pattern>äu3sel</pattern>
@@ -4615,7 +4782,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2bab2f</pattern>
 <pattern>2b3ab2g</pattern>
 <pattern>2babl</pattern>
-<pattern>2b3a2b2r</pattern>
+<pattern>2b3ab2r</pattern>
 <pattern>2b3ab2s</pattern>
 <pattern>babwi3</pattern>
 <pattern>4b5achse</pattern>
@@ -4631,10 +4798,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2b3adm</pattern>
 <pattern>ba3do</pattern>
 <pattern>bad3t</pattern>
-<pattern>2b1af2</pattern>
+<pattern>2b1a2f2</pattern>
 <pattern>ba2g</pattern>
 <pattern>b3age</pattern>
 <pattern>2b3ahl</pattern>
+<pattern>5bahn </pattern>
 <pattern>bahn5eb</pattern>
 <pattern>bah6nene</pattern>
 <pattern>bah6n5ent</pattern>
@@ -4651,6 +4819,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ba3kri</pattern>
 <pattern>ba3kro</pattern>
 <pattern>2baks</pattern>
+<pattern>bak4ti</pattern>
 <pattern>2baku</pattern>
 <pattern>2bakz</pattern>
 <pattern>bak4ze</pattern>
@@ -4661,7 +4830,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ba4lin4</pattern>
 <pattern>bal5ins</pattern>
 <pattern>bal3k4a</pattern>
-<pattern>bal4lau</pattern>
+<pattern>bal4l5au</pattern>
 <pattern>bal4l5eh4</pattern>
 <pattern>bal4l5ei</pattern>
 <pattern>ba2lo3</pattern>
@@ -4670,6 +4839,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b4am3az</pattern>
 <pattern>3b2amb</pattern>
 <pattern>ban2a</pattern>
+<pattern>banae3</pattern>
 <pattern>3band</pattern>
 <pattern>ban4d5al</pattern>
 <pattern>ban4d5an</pattern>
@@ -4680,6 +4850,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ban6d5en6des</pattern>
 <pattern>ban6deng</pattern>
 <pattern>bander4</pattern>
+<pattern>ban6d5erf</pattern>
 <pattern>ban6d5erk</pattern>
 <pattern>ban6d5erz</pattern>
 <pattern>ban4dr</pattern>
@@ -4720,6 +4891,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bar5ast</pattern>
 <pattern>bar3at</pattern>
 <pattern>bar5ein</pattern>
+<pattern>bar4en</pattern>
 <pattern>ba5rena</pattern>
 <pattern>ba3re4p</pattern>
 <pattern>ba3ret</pattern>
@@ -4759,7 +4931,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bau3b</pattern>
 <pattern>baube4</pattern>
 <pattern>bau6ch5el</pattern>
-<pattern>bau6ch5er6</pattern>
+<pattern>bau6ch5er</pattern>
 <pattern>bauch5t</pattern>
 <pattern>ba4ue</pattern>
 <pattern>bau3el</pattern>
@@ -4773,7 +4945,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4b3aufg</pattern>
 <pattern>b3aufh</pattern>
 <pattern>bau3f4r</pattern>
-<pattern>b3aufs</pattern>
+<pattern>b3auf3s</pattern>
 <pattern>4b3auft</pattern>
 <pattern>bau3fu</pattern>
 <pattern>b3aufw</pattern>
@@ -4797,6 +4969,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3ausr</pattern>
 <pattern>4b3auss</pattern>
 <pattern>bau3s4t</pattern>
+<pattern>baus6ta</pattern>
 <pattern>bau3ta</pattern>
 <pattern>bau3tä</pattern>
 <pattern>bau3tr</pattern>
@@ -4831,8 +5004,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bbe2t</pattern>
 <pattern>bbe2w</pattern>
 <pattern>bbe2z</pattern>
+<pattern>b5bine</pattern>
 <pattern>bblo5cke</pattern>
 <pattern>bblo5cku</pattern>
+<pattern>bblu2</pattern>
 <pattern>bbre3c</pattern>
 <pattern>b2by</pattern>
 <pattern>b3bys </pattern>
@@ -4848,6 +5023,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bdi2</pattern>
 <pattern>b3dia</pattern>
 <pattern>bdo2</pattern>
+<pattern>bdu2</pattern>
 <pattern>b2dul</pattern>
 <pattern>b3dus</pattern>
 <pattern>2be </pattern>
@@ -4862,6 +5038,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be3arr</pattern>
 <pattern>be3art</pattern>
 <pattern>2be3as</pattern>
+<pattern>bea4ten</pattern>
 <pattern>be4au </pattern>
 <pattern>be5aufr</pattern>
 <pattern>4be3aus</pattern>
@@ -4874,7 +5051,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be4ben</pattern>
 <pattern>4beber</pattern>
 <pattern>4bebet</pattern>
-<pattern>2be3bl</pattern>
+<pattern>2bebl</pattern>
 <pattern>2bebo</pattern>
 <pattern>2bebr</pattern>
 <pattern>3bebt</pattern>
@@ -4892,7 +5069,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2be3dä</pattern>
 <pattern>bede2</pattern>
 <pattern>4be3deb</pattern>
-<pattern>4b3edel3</pattern>
+<pattern>4b3edel</pattern>
 <pattern>2b3edl</pattern>
 <pattern>3bedü</pattern>
 <pattern>be3eh</pattern>
@@ -4900,11 +5077,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be3ela</pattern>
 <pattern>been2</pattern>
 <pattern>bee4r5ei</pattern>
-<pattern>bee6r5es</pattern>
 <pattern>bee4ri</pattern>
 <pattern>be4erk</pattern>
 <pattern>beer4tr</pattern>
-<pattern>be3eta</pattern>
+<pattern>be5erzi</pattern>
 <pattern>be3eti</pattern>
 <pattern>be3eu</pattern>
 <pattern>be1f2</pattern>
@@ -4931,6 +5107,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4b3eier</pattern>
 <pattern>bei5ers</pattern>
 <pattern>bei3f</pattern>
+<pattern>beig2</pattern>
 <pattern>beigela5d</pattern>
 <pattern>bei3gl</pattern>
 <pattern>3beih</pattern>
@@ -4943,7 +5120,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be3imp</pattern>
 <pattern>bei6nerk</pattern>
 <pattern>4beinf</pattern>
-<pattern>bein4fo</pattern>
+<pattern>be5in4fo</pattern>
+<pattern>4b3eing</pattern>
 <pattern>be5in6hal</pattern>
 <pattern>be5in4hi</pattern>
 <pattern>beira4</pattern>
@@ -4957,7 +5135,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3bei3tr</pattern>
 <pattern>4beits</pattern>
 <pattern>beit4s5e</pattern>
-<pattern>beits5o</pattern>
+<pattern>beit4s5o</pattern>
 <pattern>beitsor6</pattern>
 <pattern>beits5p</pattern>
 <pattern>beit4st</pattern>
@@ -4970,6 +5148,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2bekr</pattern>
 <pattern>b2el</pattern>
 <pattern>bela2</pattern>
+<pattern>bel5achs</pattern>
 <pattern>be5lack</pattern>
 <pattern>be5land</pattern>
 <pattern>bel5ano</pattern>
@@ -4989,6 +5168,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bel3e4t</pattern>
 <pattern>belgene5</pattern>
 <pattern>be5lini</pattern>
+<pattern>be5link</pattern>
 <pattern>bel5inn</pattern>
 <pattern>bel5inst</pattern>
 <pattern>4belis</pattern>
@@ -5004,6 +5184,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bel3or</pattern>
 <pattern>2belö</pattern>
 <pattern>bel3öf</pattern>
+<pattern>bel5öse</pattern>
 <pattern>2belp</pattern>
 <pattern>bel3sk</pattern>
 <pattern>bels4p</pattern>
@@ -5038,10 +5219,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be4n5end</pattern>
 <pattern>be4n5en4t</pattern>
 <pattern>be4nerf</pattern>
+<pattern>6benergi</pattern>
+<pattern>be5nergr</pattern>
 <pattern>be4n5ers</pattern>
 <pattern>ben5ert</pattern>
 <pattern>be4n5er4w</pattern>
-<pattern>be4ness</pattern>
+<pattern>benes4</pattern>
+<pattern>be4n5ess</pattern>
 <pattern>ben3g</pattern>
 <pattern>beni2</pattern>
 <pattern>be4nis</pattern>
@@ -5050,6 +5234,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>beno2</pattern>
 <pattern>ben3or</pattern>
 <pattern>benot4</pattern>
+<pattern>ben4san</pattern>
 <pattern>ben4s5au</pattern>
 <pattern>ben4s5el</pattern>
 <pattern>ben6sere</pattern>
@@ -5077,7 +5262,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ber5abl</pattern>
 <pattern>ber5abs</pattern>
 <pattern>ber3ac</pattern>
-<pattern>4bera4d4</pattern>
+<pattern>4bera4d</pattern>
 <pattern>beradmi6</pattern>
 <pattern>ber3af4</pattern>
 <pattern>beram4</pattern>
@@ -5113,6 +5298,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be4r5ene</pattern>
 <pattern>be4reng</pattern>
 <pattern>ber5ens</pattern>
+<pattern>berer4s</pattern>
+<pattern>ber5ersa</pattern>
 <pattern>be4rer4z</pattern>
 <pattern>3bere4s</pattern>
 <pattern>be5res </pattern>
@@ -5158,6 +5345,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ber6stic</pattern>
 <pattern>ber5tab</pattern>
 <pattern>ber5tau</pattern>
+<pattern>5bertia</pattern>
 <pattern>ber5ums</pattern>
 <pattern>be3rus</pattern>
 <pattern>berva4</pattern>
@@ -5207,6 +5395,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4be5stuf</pattern>
 <pattern>be3s4ze</pattern>
 <pattern>be3tan</pattern>
+<pattern>be4t5ant</pattern>
 <pattern>beta5sp</pattern>
 <pattern>be4tate</pattern>
 <pattern>bet5auf</pattern>
@@ -5217,6 +5406,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>be3thi</pattern>
 <pattern>be4tin</pattern>
 <pattern>be2t4o</pattern>
+<pattern>3betri</pattern>
 <pattern>bets3p</pattern>
 <pattern>bet4t3r</pattern>
 <pattern>2betü</pattern>
@@ -5225,6 +5415,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2be3um</pattern>
 <pattern>2be3un2</pattern>
 <pattern>3beur2</pattern>
+<pattern>beu3ro</pattern>
 <pattern>beu6tere</pattern>
 <pattern>2beü</pattern>
 <pattern>b2ev</pattern>
@@ -5275,13 +5466,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2b1h</pattern>
 <pattern>bha2</pattern>
 <pattern>b3haf</pattern>
-<pattern>bh4au</pattern>
 <pattern>bhä2</pattern>
 <pattern>b3ho2</pattern>
 <pattern>bhö2</pattern>
 <pattern>bhu2</pattern>
 <pattern>2bi </pattern>
 <pattern>bi2a</pattern>
+<pattern>2bi3ab</pattern>
 <pattern>2bi3ak</pattern>
 <pattern>bi2b</pattern>
 <pattern>2bi3ba</pattern>
@@ -5289,9 +5480,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bibel3</pattern>
 <pattern>biber3</pattern>
 <pattern>bid2</pattern>
+<pattern>bi3dj</pattern>
 <pattern>bi2do</pattern>
+<pattern>bi2e</pattern>
 <pattern>bie4gel</pattern>
 <pattern>bie4ge5s</pattern>
+<pattern>bie3i</pattern>
+<pattern>biein4</pattern>
 <pattern>bien3s4</pattern>
 <pattern>bi3ent</pattern>
 <pattern>bier3a</pattern>
@@ -5320,8 +5515,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bi2lu</pattern>
 <pattern>b3imb</pattern>
 <pattern>2b3im2p</pattern>
-<pattern>2b3in2b</pattern>
-<pattern>binbe3</pattern>
+<pattern>binbe5t</pattern>
 <pattern>4b3indi</pattern>
 <pattern>2binf</pattern>
 <pattern>bin4fe</pattern>
@@ -5349,14 +5543,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b2is</pattern>
 <pattern>3bis </pattern>
 <pattern>bi2sa</pattern>
-<pattern>bi4schl</pattern>
 <pattern>bischö5fen</pattern>
 <pattern>bis3ei</pattern>
 <pattern>bi3sel</pattern>
 <pattern>3bish</pattern>
 <pattern>bi3shi</pattern>
 <pattern>bi3si</pattern>
-<pattern>bi4so</pattern>
+<pattern>bi2so</pattern>
 <pattern>bis3p</pattern>
 <pattern>bis4s3c</pattern>
 <pattern>bi2st</pattern>
@@ -5382,7 +5575,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bko2</pattern>
 <pattern>bl2</pattern>
 <pattern>2bl </pattern>
-<pattern>bl4a3b</pattern>
+<pattern>2b3l4a2b</pattern>
+<pattern>bla3bl</pattern>
 <pattern>2b3lac</pattern>
 <pattern>b3lad</pattern>
 <pattern>blade5s</pattern>
@@ -5394,7 +5588,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>blan4ko</pattern>
 <pattern>bla5ses</pattern>
 <pattern>blas6serk</pattern>
-<pattern>b4last</pattern>
 <pattern>bl4at</pattern>
 <pattern>bla4ter</pattern>
 <pattern>3blatt</pattern>
@@ -5404,13 +5597,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3laut</pattern>
 <pattern>2bla2w</pattern>
 <pattern>b3lay</pattern>
+<pattern>2bläd</pattern>
 <pattern>2b3län</pattern>
 <pattern>bläs3c</pattern>
+<pattern>b4lät</pattern>
 <pattern>b2le</pattern>
 <pattern>b4le </pattern>
 <pattern>3blec</pattern>
 <pattern>2blee</pattern>
-<pattern>b3le2g</pattern>
+<pattern>b3leg</pattern>
+<pattern>ble4ge</pattern>
+<pattern>ble4gu</pattern>
 <pattern>2b3leh</pattern>
 <pattern>ble4i</pattern>
 <pattern>bleich6a</pattern>
@@ -5440,7 +5637,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2blig</pattern>
 <pattern>bli2m</pattern>
 <pattern>bl4in</pattern>
-<pattern>4b3ling4</pattern>
+<pattern>4b3ling</pattern>
 <pattern>bli4ni</pattern>
 <pattern>blin4k5a</pattern>
 <pattern>b3lins</pattern>
@@ -5448,6 +5645,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3list</pattern>
 <pattern>b3lite</pattern>
 <pattern>4b3loch</pattern>
+<pattern>bloch5s</pattern>
 <pattern>blo5cke </pattern>
 <pattern>blo5cken </pattern>
 <pattern>blo5cker</pattern>
@@ -5458,8 +5656,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3lud</pattern>
 <pattern>3blum</pattern>
 <pattern>4blun</pattern>
+<pattern>blut3a</pattern>
 <pattern>blut3o</pattern>
-<pattern>3blüt</pattern>
 <pattern>2b1m</pattern>
 <pattern>bma2</pattern>
 <pattern>bmai3</pattern>
@@ -5467,6 +5665,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bmä2</pattern>
 <pattern>bme2</pattern>
 <pattern>bmei5ern</pattern>
+<pattern>bmei5ert</pattern>
 <pattern>bmen2</pattern>
 <pattern>b3mi2</pattern>
 <pattern>bmillionenfa5</pattern>
@@ -5500,7 +5699,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>boh4r5ei</pattern>
 <pattern>bo3is</pattern>
 <pattern>2bok</pattern>
-<pattern>bo3ku</pattern>
 <pattern>bo2l</pattern>
 <pattern>bol3an</pattern>
 <pattern>bo3las</pattern>
@@ -5526,6 +5724,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bo3pu</pattern>
 <pattern>2bor </pattern>
 <pattern>bo3rah</pattern>
+<pattern>bor3al</pattern>
+<pattern>boran4g</pattern>
+<pattern>borange5</pattern>
 <pattern>bo5rant</pattern>
 <pattern>bor3as4</pattern>
 <pattern>bo3rat</pattern>
@@ -5535,7 +5736,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bor4d3r</pattern>
 <pattern>bo4rei</pattern>
 <pattern>bo4rig</pattern>
-<pattern>bo4r3in</pattern>
+<pattern>bo4r3in4</pattern>
 <pattern>bo3ro</pattern>
 <pattern>bor2s</pattern>
 <pattern>bor4ti</pattern>
@@ -5543,13 +5744,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bor4tu</pattern>
 <pattern>2bosc</pattern>
 <pattern>bo3sen</pattern>
+<pattern>bose3s</pattern>
 <pattern>2bosp</pattern>
 <pattern>bote4r3</pattern>
+<pattern>bo3tr</pattern>
 <pattern>4botsb</pattern>
-<pattern>4bot4se</pattern>
+<pattern>bot4se</pattern>
 <pattern>4botsf</pattern>
 <pattern>4botsm</pattern>
-<pattern>4botso</pattern>
+<pattern>4bot4so</pattern>
 <pattern>bots3p</pattern>
 <pattern>bot4s3t</pattern>
 <pattern>4botsü</pattern>
@@ -5579,15 +5782,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bra4de</pattern>
 <pattern>bra4di</pattern>
 <pattern>b2rah</pattern>
+<pattern>bra5i4sc</pattern>
 <pattern>b2ra3k</pattern>
 <pattern>bral5t</pattern>
 <pattern>b2ram2</pattern>
 <pattern>bran6dent</pattern>
 <pattern>brander6</pattern>
+<pattern>bran4d5r</pattern>
 <pattern>b3rat </pattern>
 <pattern>b3ratg</pattern>
 <pattern>brat3h</pattern>
-<pattern>brat3r</pattern>
+<pattern>bra4t3r</pattern>
 <pattern>5braun</pattern>
 <pattern>bra5unte</pattern>
 <pattern>2b3räd</pattern>
@@ -5597,7 +5802,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6b5rechte</pattern>
 <pattern>6brechtl</pattern>
 <pattern>6brechts</pattern>
-<pattern>2bre2d</pattern>
+<pattern>bre2d</pattern>
 <pattern>b4redu</pattern>
 <pattern>2b3re2f</pattern>
 <pattern>2b3reg</pattern>
@@ -5610,24 +5815,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2b3re2k</pattern>
 <pattern>brem4sc</pattern>
 <pattern>brem6sei</pattern>
+<pattern>brems5tel</pattern>
 <pattern>4b3rent</pattern>
 <pattern>2b3re2p</pattern>
 <pattern>3b2rer</pattern>
 <pattern>bre5ros</pattern>
 <pattern>4b3rest</pattern>
+<pattern>breti3</pattern>
 <pattern>bret6t5en</pattern>
 <pattern>2b3reu</pattern>
 <pattern>b2rev</pattern>
 <pattern>bri4da</pattern>
-<pattern>4brieb</pattern>
 <pattern>brie4fa</pattern>
 <pattern>brie6f5er6</pattern>
 <pattern>4b3riem</pattern>
+<pattern>3brien</pattern>
 <pattern>bri6kans</pattern>
 <pattern>bri4ker</pattern>
 <pattern>bri4ku</pattern>
 <pattern>4b3rind</pattern>
-<pattern>4briss</pattern>
+<pattern>3brisc</pattern>
 <pattern>3brit</pattern>
 <pattern>bri3ta</pattern>
 <pattern>4b3ritt</pattern>
@@ -5645,12 +5852,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>brot5ei</pattern>
 <pattern>bro4t3h</pattern>
 <pattern>brot3o4</pattern>
-<pattern>bro4t3r</pattern>
+<pattern>brot3r</pattern>
 <pattern>brot3t</pattern>
 <pattern>2b3rou</pattern>
 <pattern>b2rö</pattern>
 <pattern>b2ruc</pattern>
-<pattern>2bruf</pattern>
 <pattern>3br4un</pattern>
 <pattern>4b3rund</pattern>
 <pattern>bru3ne</pattern>
@@ -5663,7 +5869,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2bry</pattern>
 <pattern>2bs</pattern>
 <pattern>b1sa2</pattern>
-<pattern>bs3ach</pattern>
 <pattern>b2s3ad</pattern>
 <pattern>b2sak</pattern>
 <pattern>bs3all</pattern>
@@ -5682,7 +5887,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b4s5chec</pattern>
 <pattern>b4schef</pattern>
 <pattern>b5schm</pattern>
-<pattern>bs4cho</pattern>
 <pattern>b5schrec</pattern>
 <pattern>bs2cu</pattern>
 <pattern>b1se2</pattern>
@@ -5690,6 +5894,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3sehe</pattern>
 <pattern>b4s3ehr</pattern>
 <pattern>b4s3ein</pattern>
+<pattern>b2s3ep</pattern>
 <pattern>bs3erd</pattern>
 <pattern>bs3ere</pattern>
 <pattern>b4s3er4f</pattern>
@@ -5709,6 +5914,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bsi2</pattern>
 <pattern>b4s3ide</pattern>
 <pattern>b2s3im2</pattern>
+<pattern>bs3inf</pattern>
 <pattern>bsin4t</pattern>
 <pattern>bs5inte</pattern>
 <pattern>bs3iso</pattern>
@@ -5716,11 +5922,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bs4kur</pattern>
 <pattern>bsku5ren</pattern>
 <pattern>bsma2</pattern>
-<pattern>b1so2</pattern>
+<pattern>bso2</pattern>
 <pattern>bs3off</pattern>
 <pattern>b2s3op</pattern>
 <pattern>bs3orc</pattern>
-<pattern>bs3ori</pattern>
+<pattern>b4s3ori</pattern>
 <pattern>bs5ort </pattern>
 <pattern>bs5orts</pattern>
 <pattern>bs2öf</pattern>
@@ -5729,7 +5935,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b5spannu</pattern>
 <pattern>bspi3c</pattern>
 <pattern>b4spro</pattern>
-<pattern>bs5rei</pattern>
+<pattern>bsprun4</pattern>
 <pattern>bs3s2</pattern>
 <pattern>bs2t</pattern>
 <pattern>b4st </pattern>
@@ -5739,20 +5945,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bst3al4</pattern>
 <pattern>bst5anb</pattern>
 <pattern>bst5ank</pattern>
+<pattern>bst5ann</pattern>
 <pattern>bst5arbe</pattern>
 <pattern>bst5art</pattern>
 <pattern>bst3as4</pattern>
 <pattern>b5statu</pattern>
 <pattern>bs5tauc</pattern>
 <pattern>bst5au4f5</pattern>
+<pattern>bst5aus</pattern>
 <pattern>bstä2</pattern>
 <pattern>b3stär</pattern>
 <pattern>bs5teil</pattern>
+<pattern>bst5eis</pattern>
 <pattern>bst3ek</pattern>
 <pattern>bste4m</pattern>
 <pattern>bst5ema</pattern>
 <pattern>bst5emi</pattern>
+<pattern>bs5ten </pattern>
 <pattern>bst5ent</pattern>
+<pattern>bst5enz</pattern>
 <pattern>bs5ter </pattern>
 <pattern>bst5ere</pattern>
 <pattern>bst5er4f</pattern>
@@ -5778,8 +5989,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bsto4r</pattern>
 <pattern>bsto4t</pattern>
 <pattern>b4strac</pattern>
-<pattern>b4strau</pattern>
-<pattern>bst5rauc</pattern>
 <pattern>b4s3trä</pattern>
 <pattern>bst5rep</pattern>
 <pattern>bst5ret</pattern>
@@ -5829,8 +6038,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>buch5erz</pattern>
 <pattern>buch3r</pattern>
 <pattern>buch5so</pattern>
+<pattern>buch5str</pattern>
 <pattern>buch5th</pattern>
 <pattern>bu2d</pattern>
+<pattern>budo3</pattern>
 <pattern>bue1</pattern>
 <pattern>b3ufe</pattern>
 <pattern>bug1</pattern>
@@ -5855,6 +6066,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bun4da</pattern>
 <pattern>bun4dä</pattern>
 <pattern>b4undd</pattern>
+<pattern>bund5ent</pattern>
 <pattern>bun4d5er4</pattern>
 <pattern>bunde4s5</pattern>
 <pattern>b4undn</pattern>
@@ -5925,6 +6137,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>bwi2</pattern>
 <pattern>by1</pattern>
 <pattern>2by </pattern>
+<pattern>byauto4</pattern>
 <pattern>by3b</pattern>
 <pattern>2byf</pattern>
 <pattern>3byin</pattern>
@@ -5946,8 +6159,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>b3zuz</pattern>
 <pattern>bzwa3c</pattern>
 <pattern>2ca </pattern>
-<pattern>1ca2b2</pattern>
-<pattern>ca3bl</pattern>
+<pattern>1cab2</pattern>
 <pattern>1cac</pattern>
 <pattern>2cad</pattern>
 <pattern>ca2e3</pattern>
@@ -5955,6 +6167,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1cag2</pattern>
 <pattern>2ca1h</pattern>
 <pattern>1cal</pattern>
+<pattern>cala3b</pattern>
 <pattern>1ca2m</pattern>
 <pattern>cam4p3l</pattern>
 <pattern>3can </pattern>
@@ -5975,6 +6188,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>cat2h</pattern>
 <pattern>catte3</pattern>
 <pattern>ca3ur</pattern>
+<pattern>cau2s</pattern>
+<pattern>caust3</pattern>
 <pattern>cay2</pattern>
 <pattern>cä2</pattern>
 <pattern>cäs2</pattern>
@@ -6023,8 +6238,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ce1p</pattern>
 <pattern>ce2ph</pattern>
 <pattern>1cer</pattern>
+<pattern>2cera</pattern>
 <pattern>4cerinn</pattern>
 <pattern>ce3s2h</pattern>
+<pattern>2cest</pattern>
 <pattern>ce3sti</pattern>
 <pattern>3cet </pattern>
 <pattern>cet3am</pattern>
@@ -6069,6 +6286,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ch3atm</pattern>
 <pattern>ch5ausf</pattern>
 <pattern>chau5spo</pattern>
+<pattern>ch5ausr</pattern>
 <pattern>ch5ausst</pattern>
 <pattern>ch5austr</pattern>
 <pattern>ch5ausw</pattern>
@@ -6086,13 +6304,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5chebei</pattern>
 <pattern>che5bel</pattern>
 <pattern>ch5e4ben</pattern>
+<pattern>5checha</pattern>
 <pattern>che5che</pattern>
 <pattern>ch5echt</pattern>
 <pattern>che4el</pattern>
 <pattern>che5er4s</pattern>
 <pattern>3chef </pattern>
 <pattern>5chefeh</pattern>
-<pattern>3chefi</pattern>
+<pattern>che4fei</pattern>
+<pattern>5chefin</pattern>
 <pattern>3che4fr</pattern>
 <pattern>3chefs</pattern>
 <pattern>cheh4r</pattern>
@@ -6102,15 +6322,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ch5eintö</pattern>
 <pattern>ch5einze</pattern>
 <pattern>ch5eis </pattern>
+<pattern>ch5eise</pattern>
 <pattern>che3k</pattern>
+<pattern>ch5elek</pattern>
 <pattern>ch4emi</pattern>
 <pattern>5chemik</pattern>
 <pattern>3chemö</pattern>
 <pattern>4chemp</pattern>
 <pattern>ch5enge </pattern>
+<pattern>chen3o</pattern>
 <pattern>6chensem</pattern>
-<pattern>chen5sk</pattern>
-<pattern>chen5sp</pattern>
+<pattern>chen5s4p</pattern>
 <pattern>chen6ten</pattern>
 <pattern>4chents</pattern>
 <pattern>6chentw</pattern>
@@ -6156,7 +6378,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3chiru</pattern>
 <pattern>chi5sta</pattern>
 <pattern>2chj</pattern>
-<pattern>2chla</pattern>
+<pattern>2chl4a</pattern>
 <pattern>ch5lade</pattern>
 <pattern>ch3lat</pattern>
 <pattern>ch5lauf </pattern>
@@ -6167,6 +6389,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ch5lein</pattern>
 <pattern>ch4len</pattern>
 <pattern>chle4re</pattern>
+<pattern>4chli</pattern>
 <pattern>ch6lick</pattern>
 <pattern>ch5lini</pattern>
 <pattern>chl4o</pattern>
@@ -6188,14 +6411,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>cho5cken</pattern>
 <pattern>cho5cker </pattern>
 <pattern>chof4</pattern>
-<pattern>ch5ofen</pattern>
 <pattern>ch3off</pattern>
 <pattern>chofs3</pattern>
 <pattern>cho3fu</pattern>
 <pattern>chol4a</pattern>
 <pattern>cho5lar</pattern>
 <pattern>cho3me</pattern>
-<pattern>3chor </pattern>
 <pattern>ch3orc</pattern>
 <pattern>chor4de</pattern>
 <pattern>cho6rens</pattern>
@@ -6235,14 +6456,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2chrö</pattern>
 <pattern>2chru</pattern>
 <pattern>2chs</pattern>
+<pattern>chspa4n</pattern>
+<pattern>ch6spani</pattern>
 <pattern>ch6spart</pattern>
 <pattern>2cht</pattern>
 <pattern>4cht </pattern>
-<pattern>ch5tank</pattern>
+<pattern>ch5t4ank</pattern>
+<pattern>ch4tea</pattern>
 <pattern>cht6en </pattern>
 <pattern>ch4t5ruh</pattern>
 <pattern>chts5trä</pattern>
-<pattern>chu3be</pattern>
+<pattern>chu5bert</pattern>
+<pattern>chu5bes</pattern>
 <pattern>4chuf</pattern>
 <pattern>chu5fen</pattern>
 <pattern>chu3ma</pattern>
@@ -6279,15 +6504,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ck </pattern>
 <pattern>ck1a</pattern>
 <pattern>3cka </pattern>
+<pattern>cka4b</pattern>
 <pattern>ck3ac</pattern>
-<pattern>3ck2ad</pattern>
-<pattern>ck3adr</pattern>
+<pattern>ck2ad</pattern>
 <pattern>ckak2</pattern>
 <pattern>ckal2</pattern>
 <pattern>ckan2</pattern>
+<pattern>4ckar</pattern>
 <pattern>ckar4m</pattern>
-<pattern>3ckat2</pattern>
-<pattern>ck3atm</pattern>
+<pattern>ckat2</pattern>
 <pattern>ck1ä</pattern>
 <pattern>ckäl2</pattern>
 <pattern>2ckc</pattern>
@@ -6297,6 +6522,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4ck3ei4</pattern>
 <pattern>ckelti4</pattern>
 <pattern>4ckemp</pattern>
+<pattern>cken4s5o</pattern>
+<pattern>ckensor6</pattern>
+<pattern>ckens5tur</pattern>
 <pattern>ck5enten</pattern>
 <pattern>6ckentf</pattern>
 <pattern>cken6trop</pattern>
@@ -6304,17 +6532,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6ckergeb</pattern>
 <pattern>4ckerhö</pattern>
 <pattern>4ckerke</pattern>
-<pattern>cker6ken</pattern>
+<pattern>ck5er6ken</pattern>
 <pattern>cker6ker</pattern>
 <pattern>4ckerkr</pattern>
 <pattern>4ckerla</pattern>
-<pattern>ck5erlau</pattern>
 <pattern>5ckerlp</pattern>
-<pattern>4ck5erni</pattern>
+<pattern>4ckerni</pattern>
 <pattern>ck5ernst</pattern>
 <pattern>ck3ero</pattern>
 <pattern>ck6ers </pattern>
-<pattern>6ckerzeu</pattern>
+<pattern>4ckerz</pattern>
+<pattern>5ckerzen</pattern>
 <pattern>cker6zeugn</pattern>
 <pattern>ck3ese</pattern>
 <pattern>ck3eu2</pattern>
@@ -6345,11 +6573,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ck3sal</pattern>
 <pattern>ck4sar</pattern>
 <pattern>ck4s5int</pattern>
-<pattern>ck3so</pattern>
 <pattern>cks5tate</pattern>
 <pattern>ck6stee</pattern>
-<pattern>ck5s4to</pattern>
-<pattern>ck3str</pattern>
+<pattern>cks4to</pattern>
 <pattern>ck4tar</pattern>
 <pattern>ck3tei</pattern>
 <pattern>ck3ti</pattern>
@@ -6360,7 +6586,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ck3ums</pattern>
 <pattern>4ck3una</pattern>
 <pattern>ck3unf</pattern>
-<pattern>ck3up</pattern>
+<pattern>ck3uni</pattern>
+<pattern>ck3up3</pattern>
 <pattern>ck3ur2</pattern>
 <pattern>c2l2</pattern>
 <pattern>clet2</pattern>
@@ -6394,6 +6621,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>co3ku</pattern>
 <pattern>cola3s</pattern>
 <pattern>col3c</pattern>
+<pattern>co4le</pattern>
 <pattern>col4o</pattern>
 <pattern>commo5du</pattern>
 <pattern>2co3mu</pattern>
@@ -6409,6 +6637,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2cora</pattern>
 <pattern>co3ram</pattern>
 <pattern>cor4da</pattern>
+<pattern>core3</pattern>
 <pattern>cor3t</pattern>
 <pattern>cosi3</pattern>
 <pattern>cos4t</pattern>
@@ -6427,11 +6656,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>cra5cke</pattern>
 <pattern>c3rau</pattern>
 <pattern>c1rä</pattern>
-<pattern>c2re</pattern>
-<pattern>3crem</pattern>
+<pattern>1c2re</pattern>
 <pattern>cre4me</pattern>
-<pattern>3cres2</pattern>
-<pattern>3crew</pattern>
+<pattern>cres2</pattern>
 <pattern>cri3c</pattern>
 <pattern>1cru</pattern>
 <pattern>crui3</pattern>
@@ -6470,7 +6697,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d3aal</pattern>
 <pattern>daar2</pattern>
 <pattern>2d1ab2</pattern>
-<pattern>d2abä</pattern>
+<pattern>dabän3</pattern>
 <pattern>dabde3</pattern>
 <pattern>d2abe2</pattern>
 <pattern>da3bel</pattern>
@@ -6481,7 +6708,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dable5s</pattern>
 <pattern>dablö3</pattern>
 <pattern>da2bo</pattern>
-<pattern>d4abrü</pattern>
+<pattern>da3bra</pattern>
+<pattern>da5brie</pattern>
+<pattern>da3bro</pattern>
+<pattern>d4a3brü</pattern>
 <pattern>dabzü5gen</pattern>
 <pattern>d1a2c</pattern>
 <pattern>da3ca</pattern>
@@ -6489,6 +6719,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3d4ache4</pattern>
 <pattern>dach5er</pattern>
 <pattern>dach3o</pattern>
+<pattern>dach5stu</pattern>
 <pattern>4dachtz</pattern>
 <pattern>da4ck</pattern>
 <pattern>2d1ad2</pattern>
@@ -6519,7 +6750,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dal3ad</pattern>
 <pattern>da3lag</pattern>
 <pattern>dalar4</pattern>
-<pattern>6dalenas</pattern>
 <pattern>da3let</pattern>
 <pattern>dal4gen</pattern>
 <pattern>dal2k</pattern>
@@ -6552,14 +6782,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d3anal</pattern>
 <pattern>da3na4m</pattern>
 <pattern>d3ana3t</pattern>
-<pattern>2d3an2b</pattern>
-<pattern>danbe3</pattern>
+<pattern>dan4be3</pattern>
 <pattern>dand2</pattern>
 <pattern>4d3anda</pattern>
 <pattern>dan2e</pattern>
 <pattern>4daneb</pattern>
 <pattern>4d3anei</pattern>
-<pattern>2dan2f</pattern>
+<pattern>4d3a4neu3</pattern>
+<pattern>dan2f</pattern>
 <pattern>4d3anga</pattern>
 <pattern>d5an4geb</pattern>
 <pattern>dange4l</pattern>
@@ -6576,8 +6806,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dan2l</pattern>
 <pattern>4danle</pattern>
 <pattern>danle5g</pattern>
-<pattern>dan2n</pattern>
-<pattern>4d3anna</pattern>
+<pattern>4d3an4na</pattern>
 <pattern>4danns</pattern>
 <pattern>2d3ano</pattern>
 <pattern>2dan2s</pattern>
@@ -6607,6 +6836,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dar3as</pattern>
 <pattern>dar4be</pattern>
 <pattern>dar5ben</pattern>
+<pattern>dar5ber</pattern>
 <pattern>5darbi</pattern>
 <pattern>2d3arc</pattern>
 <pattern>dar4dar</pattern>
@@ -6622,7 +6852,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dar5emi</pattern>
 <pattern>da5ren </pattern>
 <pattern>dar5ene</pattern>
-<pattern>dar5erf</pattern>
 <pattern>da3res</pattern>
 <pattern>da3ri</pattern>
 <pattern>d5arist</pattern>
@@ -6630,7 +6859,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dar4ma</pattern>
 <pattern>dar4mem</pattern>
 <pattern>darmen6d</pattern>
-<pattern>dar4m3i</pattern>
+<pattern>dar4mi</pattern>
 <pattern>dar4mu</pattern>
 <pattern>2daro</pattern>
 <pattern>da3rom</pattern>
@@ -6682,7 +6911,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2d3au2g</pattern>
 <pattern>2d3auk</pattern>
 <pattern>da3unt</pattern>
-<pattern>2d3aus3</pattern>
+<pattern>2d3aus</pattern>
 <pattern>d3auß</pattern>
 <pattern>dau3ta</pattern>
 <pattern>4dauto</pattern>
@@ -6714,6 +6943,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dbela3</pattern>
 <pattern>dbeob3</pattern>
 <pattern>dber4gl</pattern>
+<pattern>dbi2</pattern>
+<pattern>dbla2</pattern>
 <pattern>dbo2</pattern>
 <pattern>dbre3c</pattern>
 <pattern>d3by3</pattern>
@@ -6744,7 +6975,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2dean</pattern>
 <pattern>deange5</pattern>
 <pattern>2de3ar2</pattern>
-<pattern>de3a2t</pattern>
+<pattern>2de3a2t</pattern>
 <pattern>deau2</pattern>
 <pattern>4de3auf</pattern>
 <pattern>4deaut</pattern>
@@ -6755,7 +6986,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2debe2</pattern>
 <pattern>d5e4bene</pattern>
 <pattern>de4bil</pattern>
-<pattern>de3bl</pattern>
 <pattern>de4bor</pattern>
 <pattern>2debr</pattern>
 <pattern>de4but</pattern>
@@ -6772,11 +7002,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de4der</pattern>
 <pattern>de4dit</pattern>
 <pattern>dedrü3</pattern>
+<pattern>dedu2</pattern>
 <pattern>2dee2</pattern>
 <pattern>de3eb</pattern>
 <pattern>de3eg</pattern>
 <pattern>de3em</pattern>
 <pattern>dee4n</pattern>
+<pattern>de3ep</pattern>
 <pattern>de3er2</pattern>
 <pattern>de3es</pattern>
 <pattern>de3et</pattern>
@@ -6821,6 +7053,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dei2d</pattern>
 <pattern>de5iden</pattern>
 <pattern>d3eie</pattern>
+<pattern>d3ei2f</pattern>
 <pattern>d3ei2g</pattern>
 <pattern>dei2l</pattern>
 <pattern>de3i2m2</pattern>
@@ -6837,8 +7070,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d3einm</pattern>
 <pattern>d3eino</pattern>
 <pattern>d3einr</pattern>
+<pattern>d5einsa</pattern>
 <pattern>de5in4se</pattern>
-<pattern>dein4v</pattern>
+<pattern>d4e3in4v</pattern>
 <pattern>d3einw</pattern>
 <pattern>de3io</pattern>
 <pattern>dei2s</pattern>
@@ -6855,6 +7089,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4dekop</pattern>
 <pattern>de4kor</pattern>
 <pattern>2dekö</pattern>
+<pattern>de5krem</pattern>
 <pattern>2deku</pattern>
 <pattern>de3kü</pattern>
 <pattern>2dekz</pattern>
@@ -6865,7 +7100,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4delad</pattern>
 <pattern>4dela4g</pattern>
 <pattern>de3lai</pattern>
-<pattern>de3lak</pattern>
 <pattern>del3am</pattern>
 <pattern>del5anz</pattern>
 <pattern>de3las</pattern>
@@ -6896,12 +7130,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4delfm</pattern>
 <pattern>4de3lie</pattern>
 <pattern>3delik</pattern>
-<pattern>4de3lit</pattern>
+<pattern>4delit</pattern>
 <pattern>4de3liz</pattern>
 <pattern>del4lan</pattern>
 <pattern>del4lar</pattern>
 <pattern>dellän4</pattern>
 <pattern>del4l5eb</pattern>
+<pattern>dell5eic</pattern>
 <pattern>del6lein</pattern>
 <pattern>del4l5er</pattern>
 <pattern>delmi4</pattern>
@@ -6909,18 +7144,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>del3op</pattern>
 <pattern>2de2lö</pattern>
 <pattern>de4ls</pattern>
-<pattern>del4s5in</pattern>
+<pattern>del6sein</pattern>
+<pattern>del6s5int</pattern>
 <pattern>del4spa</pattern>
 <pattern>dels5pan</pattern>
 <pattern>del4spr</pattern>
 <pattern>del5tei</pattern>
-<pattern>2dem2a</pattern>
-<pattern>de3mac</pattern>
-<pattern>de3map</pattern>
+<pattern>dem2a</pattern>
+<pattern>4de3map</pattern>
+<pattern>4demas</pattern>
 <pattern>2demä</pattern>
 <pattern>4demei</pattern>
 <pattern>dement4</pattern>
-<pattern>de6mentg</pattern>
+<pattern>de6m5entg</pattern>
 <pattern>4demes</pattern>
 <pattern>de4met</pattern>
 <pattern>3demi</pattern>
@@ -6958,16 +7194,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de4n5end</pattern>
 <pattern>de4n5en4g</pattern>
 <pattern>den5erei</pattern>
-<pattern>4d5ener5g</pattern>
+<pattern>4d5energ</pattern>
 <pattern>den5erö</pattern>
 <pattern>den5ers</pattern>
 <pattern>de4n5ert</pattern>
-<pattern>den5erw</pattern>
+<pattern>de4n5er4w</pattern>
 <pattern>4deneu</pattern>
 <pattern>3denfi</pattern>
 <pattern>4d5enge </pattern>
 <pattern>6d5engeln</pattern>
 <pattern>6d5en6gels</pattern>
+<pattern>den6gen </pattern>
+<pattern>4d5engli</pattern>
 <pattern>3dengu</pattern>
 <pattern>de4n3im</pattern>
 <pattern>de5nin </pattern>
@@ -6976,6 +7214,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>den4k5ak</pattern>
 <pattern>den6kerl</pattern>
 <pattern>denk5ob</pattern>
+<pattern>denks4</pattern>
 <pattern>4denkul</pattern>
 <pattern>de2no</pattern>
 <pattern>4denorm</pattern>
@@ -6983,6 +7222,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d2ens</pattern>
 <pattern>3denso</pattern>
 <pattern>densor6te</pattern>
+<pattern>den5spra</pattern>
+<pattern>dens5tor</pattern>
 <pattern>den4sur</pattern>
 <pattern>denta4t</pattern>
 <pattern>4d3entd</pattern>
@@ -6990,6 +7231,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4d3entg</pattern>
 <pattern>4d3entk</pattern>
 <pattern>4d3entn</pattern>
+<pattern>4dentro</pattern>
+<pattern>den6trop</pattern>
 <pattern>4dentw</pattern>
 <pattern>4d3entz</pattern>
 <pattern>den6z5er6f</pattern>
@@ -7016,6 +7259,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de5rabi</pattern>
 <pattern>der5ade</pattern>
 <pattern>der3af</pattern>
+<pattern>der3a4g</pattern>
 <pattern>4de3rah</pattern>
 <pattern>der3ak</pattern>
 <pattern>deral4</pattern>
@@ -7039,7 +7283,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>derbe4</pattern>
 <pattern>4d3erbs</pattern>
 <pattern>4derco</pattern>
-<pattern>4d3erdb</pattern>
+<pattern>4derdb</pattern>
 <pattern>der3e4b</pattern>
 <pattern>4derech</pattern>
 <pattern>der5eck</pattern>
@@ -7049,12 +7293,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de5rei </pattern>
 <pattern>der5ei4c</pattern>
 <pattern>de5reie</pattern>
-<pattern>der5ei4f</pattern>
+<pattern>der5eife</pattern>
 <pattern>6dereigni</pattern>
 <pattern>4dereih</pattern>
 <pattern>der6eini</pattern>
-<pattern>derei6s</pattern>
 <pattern>der5eis </pattern>
+<pattern>derei6se</pattern>
 <pattern>de4reiz</pattern>
 <pattern>derel4</pattern>
 <pattern>de4r5ele</pattern>
@@ -7073,8 +7317,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4dereo</pattern>
 <pattern>dere4p</pattern>
 <pattern>der6er </pattern>
+<pattern>de6rerei</pattern>
 <pattern>de4r5erh</pattern>
 <pattern>der5ero</pattern>
+<pattern>der5erre</pattern>
 <pattern>de4r5ert</pattern>
 <pattern>de4ret</pattern>
 <pattern>der5eta</pattern>
@@ -7084,8 +7330,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6dergebn</pattern>
 <pattern>dergege6</pattern>
 <pattern>4der4heb</pattern>
-<pattern>der3id</pattern>
+<pattern>de4r3id</pattern>
 <pattern>de4r3i4m</pattern>
+<pattern>der5inb</pattern>
 <pattern>6derind </pattern>
 <pattern>4dering</pattern>
 <pattern>de6r5in6nu</pattern>
@@ -7094,13 +7341,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>derk2</pattern>
 <pattern>4derklä</pattern>
 <pattern>der5lan</pattern>
-<pattern>derm4</pattern>
 <pattern>dermi4n</pattern>
 <pattern>derna4</pattern>
 <pattern>der4nal</pattern>
 <pattern>4dernf</pattern>
 <pattern>4dernt</pattern>
-<pattern>de5robo</pattern>
+<pattern>4de5robo</pattern>
 <pattern>de3rog</pattern>
 <pattern>4derohl</pattern>
 <pattern>de3ron</pattern>
@@ -7117,7 +7363,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4derss</pattern>
 <pattern>4dersw</pattern>
 <pattern>dert5ende </pattern>
-<pattern>6der6trage</pattern>
+<pattern>6dertrage</pattern>
 <pattern>4derud</pattern>
 <pattern>de4ruh</pattern>
 <pattern>derum4</pattern>
@@ -7148,6 +7394,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4desän</pattern>
 <pattern>4desäu</pattern>
 <pattern>desche4</pattern>
+<pattern>de6schef</pattern>
 <pattern>6deschei</pattern>
 <pattern>4deschl</pattern>
 <pattern>de4scho</pattern>
@@ -7189,10 +7436,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4de3sit</pattern>
 <pattern>3desme</pattern>
 <pattern>deso2</pattern>
-<pattern>de3so </pattern>
 <pattern>4desoh</pattern>
-<pattern>de3sol</pattern>
-<pattern>4de3son</pattern>
+<pattern>4deson</pattern>
 <pattern>des3pa</pattern>
 <pattern>4despez</pattern>
 <pattern>4despi</pattern>
@@ -7210,7 +7455,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dest5al6t</pattern>
 <pattern>6destang</pattern>
 <pattern>4destap</pattern>
-<pattern>des5tät</pattern>
+<pattern>de5stec</pattern>
 <pattern>4desteg</pattern>
 <pattern>dest5eige</pattern>
 <pattern>dest5einsa</pattern>
@@ -7222,7 +7467,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>des4tex</pattern>
 <pattern>4destif</pattern>
 <pattern>6destran</pattern>
-<pattern>de5stras</pattern>
 <pattern>6de5strei</pattern>
 <pattern>4destri</pattern>
 <pattern>de5strö</pattern>
@@ -7247,12 +7491,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de3tra</pattern>
 <pattern>de3tre</pattern>
 <pattern>de3tri</pattern>
+<pattern>det2s</pattern>
 <pattern>2detu</pattern>
 <pattern>2d3et2w</pattern>
+<pattern>de3u2f</pattern>
 <pattern>2de3uh</pattern>
 <pattern>2d3eul</pattern>
 <pattern>2deum</pattern>
-<pattern>2de3un2</pattern>
+<pattern>2de3u2n2</pattern>
 <pattern>deur2</pattern>
 <pattern>de3url</pattern>
 <pattern>d3euro</pattern>
@@ -7261,6 +7507,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>de4ven</pattern>
 <pattern>de2vi</pattern>
 <pattern>d3evid</pattern>
+<pattern>de3vil</pattern>
 <pattern>de4von</pattern>
 <pattern>2dew</pattern>
 <pattern>dewe2</pattern>
@@ -7293,15 +7540,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dget3e</pattern>
 <pattern>dgla3s</pattern>
 <pattern>dg4lo</pattern>
-<pattern>d3gu</pattern>
 <pattern>2d1h2</pattern>
 <pattern>dha2g</pattern>
-<pattern>dh4au</pattern>
 <pattern>dhek2</pattern>
 <pattern>3dhi </pattern>
 <pattern>dhis3</pattern>
 <pattern>dho2</pattern>
-<pattern>dhof2</pattern>
 <pattern>dh4un</pattern>
 <pattern>dhun3t</pattern>
 <pattern>2di </pattern>
@@ -7314,6 +7558,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2dib</pattern>
 <pattern>di3ca</pattern>
 <pattern>dich4l</pattern>
+<pattern>dichtgene5</pattern>
 <pattern>dick5el</pattern>
 <pattern>2d3i2co</pattern>
 <pattern>4d3idea</pattern>
@@ -7327,30 +7572,32 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dien5eb</pattern>
 <pattern>dien5ev</pattern>
 <pattern>die4ni</pattern>
-<pattern>dienst5ra</pattern>
 <pattern>dienst5rä</pattern>
 <pattern>dienter6mi</pattern>
 <pattern>die3nu</pattern>
 <pattern>di5enz </pattern>
 <pattern>die2p3</pattern>
 <pattern>die4rei</pattern>
+<pattern>4dierg</pattern>
 <pattern>di5ern </pattern>
 <pattern>diese4</pattern>
 <pattern>3diff</pattern>
 <pattern>di3ga</pattern>
 <pattern>dige4n</pattern>
-<pattern>4digene</pattern>
 <pattern>dige4s</pattern>
 <pattern>2digi</pattern>
 <pattern>2digo</pattern>
 <pattern>dig4ta</pattern>
+<pattern>dig4tr</pattern>
 <pattern>dik4a</pattern>
 <pattern>di3kar</pattern>
 <pattern>di3kü</pattern>
 <pattern>di2l</pattern>
 <pattern>dil3au</pattern>
 <pattern>di3len</pattern>
+<pattern>4d3illu</pattern>
 <pattern>dil4s3t</pattern>
+<pattern>2d3il2t</pattern>
 <pattern>2d3imb</pattern>
 <pattern>2di2mi</pattern>
 <pattern>dimi3n</pattern>
@@ -7362,10 +7609,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>di3nä</pattern>
 <pattern>2d3in2d</pattern>
 <pattern>di3nen</pattern>
-<pattern>din4far</pattern>
-<pattern>d3in4fe</pattern>
-<pattern>4d3in4fo</pattern>
-<pattern>4d3in4fr</pattern>
+<pattern>din2f</pattern>
+<pattern>d3infe</pattern>
+<pattern>4d3infl</pattern>
+<pattern>4d3info</pattern>
+<pattern>4d3infr</pattern>
 <pattern>2d3in2h</pattern>
 <pattern>2dini</pattern>
 <pattern>2d3in2j</pattern>
@@ -7406,7 +7654,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dis3a</pattern>
 <pattern>4di4sch5r</pattern>
 <pattern>diskan4</pattern>
-<pattern>2di2so</pattern>
+<pattern>2diso</pattern>
 <pattern>dis5pen</pattern>
 <pattern>di5sper</pattern>
 <pattern>d3isr</pattern>
@@ -7472,6 +7720,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d3nei</pattern>
 <pattern>dne3p</pattern>
 <pattern>d3ner</pattern>
+<pattern>dnet2</pattern>
 <pattern>dne5ten</pattern>
 <pattern>dni2g</pattern>
 <pattern>dn2j</pattern>
@@ -7490,6 +7739,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>do4berr</pattern>
 <pattern>do3chi</pattern>
 <pattern>do3chr</pattern>
+<pattern>doch4t5r</pattern>
 <pattern>2dod</pattern>
 <pattern>2doe2</pattern>
 <pattern>doerin4</pattern>
@@ -7501,13 +7751,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>do3he</pattern>
 <pattern>2d3ohr3</pattern>
 <pattern>3doi</pattern>
+<pattern>do2k</pattern>
 <pattern>2doka</pattern>
+<pattern>do3kap</pattern>
+<pattern>do3kas</pattern>
 <pattern>do3ki</pattern>
-<pattern>2dokr</pattern>
+<pattern>2do3kr</pattern>
 <pattern>do2le</pattern>
 <pattern>4do3lei</pattern>
 <pattern>do3les</pattern>
-<pattern>do3leu</pattern>
 <pattern>do3lid</pattern>
 <pattern>do3lin</pattern>
 <pattern>2dolo</pattern>
@@ -7526,7 +7778,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>doo5fen</pattern>
 <pattern>doo3g</pattern>
 <pattern>2do3pa</pattern>
-<pattern>2d3ope</pattern>
+<pattern>2dope</pattern>
 <pattern>2d3op2f</pattern>
 <pattern>2dopo</pattern>
 <pattern>dop4po3</pattern>
@@ -7575,7 +7827,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2dotr</pattern>
 <pattern>3doui</pattern>
 <pattern>2dout</pattern>
-<pattern>dou2v</pattern>
+<pattern>2d3ou2v</pattern>
 <pattern>2doü</pattern>
 <pattern>2dov</pattern>
 <pattern>2dowi</pattern>
@@ -7587,13 +7839,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2d1öf</pattern>
 <pattern>2d1ök</pattern>
 <pattern>2d1öl1</pattern>
+<pattern>dör4fl</pattern>
 <pattern>dös3c</pattern>
 <pattern>dö3sem</pattern>
 <pattern>dö3ser</pattern>
 <pattern>2d1p2</pattern>
 <pattern>dpa2</pattern>
 <pattern>dpla3c</pattern>
-<pattern>dpo2</pattern>
+<pattern>d3po2</pattern>
 <pattern>dpu2</pattern>
 <pattern>2dq</pattern>
 <pattern>dr2</pattern>
@@ -7613,8 +7866,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dr4an</pattern>
 <pattern>4d3rand</pattern>
 <pattern>dran5ga</pattern>
-<pattern>4drangl</pattern>
-<pattern>dra3se</pattern>
+<pattern>4d5rangl</pattern>
+<pattern>d3rase</pattern>
 <pattern>d3rass</pattern>
 <pattern>4d3rast</pattern>
 <pattern>drat3a</pattern>
@@ -7623,7 +7876,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4d3rauc</pattern>
 <pattern>4d3raum</pattern>
 <pattern>4d3raup</pattern>
-<pattern>d3raus</pattern>
+<pattern>4d3raus</pattern>
 <pattern>drau3ß</pattern>
 <pattern>4d3raut</pattern>
 <pattern>drä2</pattern>
@@ -7663,7 +7916,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2d3rem</pattern>
 <pattern>2d3ren</pattern>
 <pattern>drenn5s</pattern>
-<pattern>2d3re2p</pattern>
+<pattern>4d3re2p</pattern>
 <pattern>2d3rer</pattern>
 <pattern>d2res</pattern>
 <pattern>4d3res </pattern>
@@ -7680,6 +7933,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2d2ré</pattern>
 <pattern>2d1rh</pattern>
 <pattern>drho3</pattern>
+<pattern>dri2a</pattern>
 <pattern>2d3ric</pattern>
 <pattern>4d3rieg</pattern>
 <pattern>drie4n3</pattern>
@@ -7692,7 +7946,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4d3riss</pattern>
 <pattern>d2rit</pattern>
 <pattern>drit6terf</pattern>
-<pattern>4dri4tu</pattern>
+<pattern>4d3ri4tu</pattern>
 <pattern>4dritz</pattern>
 <pattern>d2ro</pattern>
 <pattern>2drob</pattern>
@@ -7705,7 +7959,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4drohr</pattern>
 <pattern>2droi</pattern>
 <pattern>4d3roll</pattern>
-<pattern>4d3roma</pattern>
 <pattern>droma4t</pattern>
 <pattern>4d3rose</pattern>
 <pattern>4drost</pattern>
@@ -7715,12 +7968,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2d3ro2v</pattern>
 <pattern>d3row</pattern>
 <pattern>drö2</pattern>
+<pattern>2d3röc</pattern>
 <pattern>drös3c</pattern>
 <pattern>2d3ru2b</pattern>
+<pattern>d2ruc</pattern>
 <pattern>2d3ru2d</pattern>
 <pattern>2d3ruh</pattern>
 <pattern>4drund</pattern>
-<pattern>drun3t</pattern>
+<pattern>d4run3t</pattern>
 <pattern>2d3rut</pattern>
 <pattern>2d3rüb</pattern>
 <pattern>drü5cke</pattern>
@@ -7739,6 +7994,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d4s3ang</pattern>
 <pattern>dsanga5</pattern>
 <pattern>dsanle5g</pattern>
+<pattern>ds3anr</pattern>
 <pattern>d4s3an4t</pattern>
 <pattern>ds3anz</pattern>
 <pattern>d2sar</pattern>
@@ -7753,7 +8009,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d4schin</pattern>
 <pattern>dsch4r</pattern>
 <pattern>5d4schun</pattern>
-<pattern>d2s3cr</pattern>
+<pattern>d2scr</pattern>
 <pattern>dse2</pattern>
 <pattern>ds3eb</pattern>
 <pattern>dsee3i</pattern>
@@ -7763,11 +8019,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ds4eign</pattern>
 <pattern>ds5eint</pattern>
 <pattern>d4sele</pattern>
-<pattern>dsem2</pattern>
-<pattern>ds3emb</pattern>
+<pattern>ds3em4b</pattern>
 <pattern>ds5emis</pattern>
 <pattern>ds5ende </pattern>
 <pattern>d4s3en4g</pattern>
+<pattern>dsen3s</pattern>
 <pattern>d4s3ent</pattern>
 <pattern>d4s3ere</pattern>
 <pattern>d4s3er4f</pattern>
@@ -7781,8 +8037,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ds3eta</pattern>
 <pattern>dseta5gen</pattern>
 <pattern>ds3ev</pattern>
-<pattern>dsex2</pattern>
-<pattern>d4sexe</pattern>
+<pattern>d2sex2</pattern>
 <pattern>dsgesu5</pattern>
 <pattern>ds4hak</pattern>
 <pattern>d4shal</pattern>
@@ -7792,10 +8047,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d4sill</pattern>
 <pattern>d4sind</pattern>
 <pattern>d4s3in4t</pattern>
-<pattern>ds4kal</pattern>
 <pattern>d2ske</pattern>
 <pattern>d3s4kel</pattern>
 <pattern>d4skir</pattern>
+<pattern>d4skis</pattern>
 <pattern>dskla4</pattern>
 <pattern>d5s4klav</pattern>
 <pattern>d2sko</pattern>
@@ -7810,6 +8065,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d4s3ori</pattern>
 <pattern>d2sö</pattern>
 <pattern>d4s5peri</pattern>
+<pattern>d4sphi</pattern>
 <pattern>d2spl</pattern>
 <pattern>ds4por</pattern>
 <pattern>d6sporto</pattern>
@@ -7829,6 +8085,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d4s5täti</pattern>
 <pattern>d2ste</pattern>
 <pattern>d3stec</pattern>
+<pattern>d3stei</pattern>
+<pattern>d4steil</pattern>
 <pattern>d5stell</pattern>
 <pattern>d3step</pattern>
 <pattern>d5s4tern</pattern>
@@ -7846,15 +8104,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ds5treu </pattern>
 <pattern>ds5treue</pattern>
 <pattern>ds4tur</pattern>
+<pattern>d2sty</pattern>
 <pattern>d4s3uml</pattern>
 <pattern>d4s3ums</pattern>
+<pattern>d4s3um4z</pattern>
 <pattern>d2s3un</pattern>
 <pattern>d4s3url</pattern>
 <pattern>2dt</pattern>
 <pattern>d1ta2</pattern>
 <pattern>d2tad</pattern>
 <pattern>dtag2</pattern>
-<pattern>dt3agg</pattern>
 <pattern>d2tam2</pattern>
 <pattern>dtan4s</pattern>
 <pattern>dtan4z</pattern>
@@ -7863,6 +8122,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>dt2ax</pattern>
 <pattern>d1tä2</pattern>
 <pattern>dte3ac</pattern>
+<pattern>d3tec</pattern>
 <pattern>dte3e</pattern>
 <pattern>dte3f</pattern>
 <pattern>dtei4g</pattern>
@@ -7879,8 +8139,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>d3t2es</pattern>
 <pattern>dte3t</pattern>
 <pattern>d3them</pattern>
-<pattern>dtho2</pattern>
 <pattern>d3thy</pattern>
+<pattern>d2t3id</pattern>
 <pattern>d2t3il</pattern>
 <pattern>dti2m</pattern>
 <pattern>d2t3in2</pattern>
@@ -7916,6 +8176,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>du4l5art</pattern>
 <pattern>du4l3au</pattern>
 <pattern>dul3ei</pattern>
+<pattern>du4lin</pattern>
 <pattern>du2lo</pattern>
 <pattern>du2m</pattern>
 <pattern>3dum </pattern>
@@ -7960,8 +8221,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2du2p</pattern>
 <pattern>du3pr</pattern>
 <pattern>dur2</pattern>
-<pattern>du3ra</pattern>
-<pattern>du4rau</pattern>
+<pattern>du3ran</pattern>
+<pattern>du3ras</pattern>
 <pattern>dur3b</pattern>
 <pattern>durch3</pattern>
 <pattern>du3re3</pattern>
@@ -7978,7 +8239,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>duse3</pattern>
 <pattern>du3s4ta</pattern>
 <pattern>du3ta</pattern>
-<pattern>du2z</pattern>
+<pattern>du2ze</pattern>
 <pattern>d3über</pattern>
 <pattern>dü2n</pattern>
 <pattern>dürn3</pattern>
@@ -8008,6 +8269,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3dyna</pattern>
 <pattern>2dyne</pattern>
 <pattern>2dynu</pattern>
+<pattern>2dy1o2</pattern>
 <pattern>2dy1p</pattern>
 <pattern>2dyse</pattern>
 <pattern>dy3sei</pattern>
@@ -8026,7 +8288,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ea2be</pattern>
 <pattern>e2abi</pattern>
 <pattern>ea2bl</pattern>
-<pattern>ea2br</pattern>
 <pattern>eace3</pattern>
 <pattern>ea3chi</pattern>
 <pattern>e3ada</pattern>
@@ -8038,6 +8299,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ea3gl</pattern>
 <pattern>ea2k</pattern>
 <pattern>eak3e</pattern>
+<pattern>eak3l</pattern>
 <pattern>ea3kr</pattern>
 <pattern>e3ak4tu</pattern>
 <pattern>eal3ac</pattern>
@@ -8049,6 +8311,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ea2lo</pattern>
 <pattern>eal3on</pattern>
 <pattern>ea3los</pattern>
+<pattern>eals4p</pattern>
 <pattern>e5alste</pattern>
 <pattern>eal3ti</pattern>
 <pattern>eal3u</pattern>
@@ -8056,7 +8319,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eam3ä</pattern>
 <pattern>e2ame</pattern>
 <pattern>ea3mer</pattern>
-<pattern>ea2mi</pattern>
 <pattern>eamin4</pattern>
 <pattern>ea5ming</pattern>
 <pattern>eam3o</pattern>
@@ -8074,7 +8336,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eanga3</pattern>
 <pattern>eange5h</pattern>
 <pattern>eange5s</pattern>
-<pattern>eanla6gent</pattern>
+<pattern>eanla6gente</pattern>
 <pattern>eanle5g</pattern>
 <pattern>ean3n</pattern>
 <pattern>ean3o4b</pattern>
@@ -8082,6 +8344,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eap2</pattern>
 <pattern>e1a2q</pattern>
 <pattern>e4ara</pattern>
+<pattern>ear3ac</pattern>
 <pattern>ear3ak4</pattern>
 <pattern>ear3an4</pattern>
 <pattern>ea3rat</pattern>
@@ -8100,11 +8363,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ear3u</pattern>
 <pattern>e3a2sc</pattern>
 <pattern>ea3sen</pattern>
-<pattern>easing5</pattern>
 <pattern>ea2sp</pattern>
 <pattern>eas2s</pattern>
+<pattern>ea3str</pattern>
 <pattern>e2ate2</pattern>
 <pattern>ea3ten</pattern>
+<pattern>eat5ens</pattern>
 <pattern>eater3</pattern>
 <pattern>ea3the</pattern>
 <pattern>eat2m</pattern>
@@ -8115,10 +8379,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eau3e</pattern>
 <pattern>e3auff</pattern>
 <pattern>eau5f4re</pattern>
+<pattern>eauf3s</pattern>
 <pattern>e3aufw</pattern>
 <pattern>eau2g</pattern>
 <pattern>eau3gl</pattern>
-<pattern>ea4u3n</pattern>
 <pattern>e3auss</pattern>
 <pattern>eaussen6dung </pattern>
 <pattern>eau5ste</pattern>
@@ -8132,6 +8396,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eäs2</pattern>
 <pattern>eäu2</pattern>
 <pattern>eba2b</pattern>
+<pattern>ebah6ner</pattern>
 <pattern>ebam2</pattern>
 <pattern>eban4g</pattern>
 <pattern>eb3ant</pattern>
@@ -8140,13 +8405,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eba3ra</pattern>
 <pattern>e5bauc</pattern>
 <pattern>ebbe4r</pattern>
+<pattern>e4be </pattern>
 <pattern>e4beab</pattern>
 <pattern>e4be3ar</pattern>
 <pattern>e2beb</pattern>
 <pattern>ebe2d</pattern>
 <pattern>ebe5dac</pattern>
 <pattern>ebee2</pattern>
-<pattern>ebe3er4</pattern>
+<pattern>ebeer4</pattern>
 <pattern>e2bef</pattern>
 <pattern>e3beg</pattern>
 <pattern>ebe4ga3</pattern>
@@ -8174,6 +8440,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4bemi</pattern>
 <pattern>e4benab</pattern>
 <pattern>e4benä</pattern>
+<pattern>e4benp</pattern>
 <pattern>ebe5rad</pattern>
 <pattern>eber5as</pattern>
 <pattern>e4berau</pattern>
@@ -8190,12 +8457,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ebe6schü</pattern>
 <pattern>ebes5eh</pattern>
 <pattern>e3besi</pattern>
+<pattern>ebe4sor</pattern>
 <pattern>e4bespi</pattern>
 <pattern>ebesu5che</pattern>
 <pattern>e4beta</pattern>
 <pattern>ebe4tei</pattern>
 <pattern>e3betr</pattern>
-<pattern>ebets3</pattern>
+<pattern>ebet4s3</pattern>
 <pattern>e2bev</pattern>
 <pattern>ebe4weg</pattern>
 <pattern>ebe4wi</pattern>
@@ -8204,10 +8472,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ebe4zi</pattern>
 <pattern>e2bia</pattern>
 <pattern>e3bib</pattern>
-<pattern>e2bl</pattern>
+<pattern>e4b3in4b</pattern>
 <pattern>eb3lag</pattern>
 <pattern>eb3lan</pattern>
-<pattern>e3blat</pattern>
 <pattern>eb3lau</pattern>
 <pattern>eble3c</pattern>
 <pattern>eb5lich</pattern>
@@ -8220,7 +8487,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4born</pattern>
 <pattern>ebo2t</pattern>
 <pattern>eb3rah</pattern>
-<pattern>eb4sac</pattern>
+<pattern>eb4s3ac</pattern>
 <pattern>eb4s5ang</pattern>
 <pattern>eb4s3as4</pattern>
 <pattern>eb4s3au</pattern>
@@ -8235,7 +8502,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ebs5panne</pattern>
 <pattern>ebs5par</pattern>
 <pattern>ebs3pe</pattern>
-<pattern>eb3spi</pattern>
 <pattern>ebs3pr</pattern>
 <pattern>eb5stan</pattern>
 <pattern>ebs5tät</pattern>
@@ -8274,8 +8540,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e6ch5er6zi</pattern>
 <pattern>e3ches</pattern>
 <pattern>e3chet</pattern>
+<pattern>e3chif</pattern>
+<pattern>e3chip</pattern>
 <pattern>e3chis</pattern>
-<pattern>e4ch3l</pattern>
+<pattern>ech3l</pattern>
+<pattern>e3ch4lo</pattern>
 <pattern>ech3m</pattern>
 <pattern>ech3na</pattern>
 <pattern>ech5nit</pattern>
@@ -8288,6 +8557,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ech3ra</pattern>
 <pattern>ech3rä</pattern>
 <pattern>e3chri</pattern>
+<pattern>e4chs</pattern>
 <pattern>ech6s5en6d</pattern>
 <pattern>e4cht</pattern>
 <pattern>ech5tab</pattern>
@@ -8296,12 +8566,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>echt5erha</pattern>
 <pattern>echt6s5ac</pattern>
 <pattern>echts5ag</pattern>
+<pattern>echt6s5eid</pattern>
 <pattern>ech3uh</pattern>
 <pattern>ech3w</pattern>
 <pattern>e1ci</pattern>
 <pattern>e2ck</pattern>
 <pattern>e4ck </pattern>
-<pattern>e4cka</pattern>
 <pattern>e4ckel</pattern>
 <pattern>e4ckem</pattern>
 <pattern>ecke4n</pattern>
@@ -8311,6 +8581,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eckle4</pattern>
 <pattern>ec4ko</pattern>
 <pattern>e4cks</pattern>
+<pattern>eck5spo</pattern>
 <pattern>3eckzä</pattern>
 <pattern>e1cl</pattern>
 <pattern>ecommu5</pattern>
@@ -8333,7 +8604,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ede5n4er</pattern>
 <pattern>eden4sa</pattern>
 <pattern>eden4s5e</pattern>
-<pattern>edens5p</pattern>
 <pattern>edens5ta</pattern>
 <pattern>edens5tu</pattern>
 <pattern>edenzu5</pattern>
@@ -8342,7 +8612,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eder5as4</pattern>
 <pattern>ede4re4</pattern>
 <pattern>ede5rec</pattern>
-<pattern>eder5eis</pattern>
 <pattern>ede5ren </pattern>
 <pattern>eder5er4</pattern>
 <pattern>ede5rer </pattern>
@@ -8370,6 +8639,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ed2o</pattern>
 <pattern>e2doc</pattern>
 <pattern>e3dos </pattern>
+<pattern>edo3t</pattern>
 <pattern>e2do3x</pattern>
 <pattern>e3drei</pattern>
 <pattern>ed3rik</pattern>
@@ -8394,24 +8664,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eear2</pattern>
 <pattern>eeb2</pattern>
 <pattern>eebe4r</pattern>
-<pattern>ee3bl</pattern>
 <pattern>ee3bs</pattern>
 <pattern>e2e1c</pattern>
 <pattern>eede5re</pattern>
+<pattern>ee2d3r</pattern>
 <pattern>eed3s2</pattern>
 <pattern>ee1e2</pattern>
 <pattern>ee1f2</pattern>
 <pattern>e3eff</pattern>
+<pattern>ee3fo</pattern>
 <pattern>eef3s</pattern>
 <pattern>ee1g</pattern>
 <pattern>eege2</pattern>
 <pattern>eegra3</pattern>
-<pattern>eeh2</pattern>
-<pattern>ee3ha</pattern>
-<pattern>ee3hä</pattern>
-<pattern>ee3her</pattern>
-<pattern>ee3hi</pattern>
-<pattern>ee3ho</pattern>
+<pattern>ee1h2</pattern>
 <pattern>e1ei2</pattern>
 <pattern>eeim2</pattern>
 <pattern>ee3imp</pattern>
@@ -8420,7 +8686,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ee5in4se</pattern>
 <pattern>eei4s</pattern>
 <pattern>ee3isc</pattern>
-<pattern>e2ej</pattern>
+<pattern>e2e3j</pattern>
 <pattern>e2e1k</pattern>
 <pattern>eeka2</pattern>
 <pattern>ee3la</pattern>
@@ -8443,12 +8709,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ee3nä</pattern>
 <pattern>een2d</pattern>
 <pattern>een3da</pattern>
-<pattern>een4e</pattern>
+<pattern>een4er</pattern>
 <pattern>eener5g</pattern>
-<pattern>eene3s</pattern>
+<pattern>een3e4v</pattern>
 <pattern>een4gi</pattern>
 <pattern>ee3ni</pattern>
-<pattern>ee3n4o2</pattern>
+<pattern>ee3n4o</pattern>
 <pattern>eenot3</pattern>
 <pattern>een3sh</pattern>
 <pattern>een3sp</pattern>
@@ -8456,7 +8722,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>een3tr</pattern>
 <pattern>ee3o2</pattern>
 <pattern>ee1p</pattern>
-<pattern>ee3po</pattern>
+<pattern>eer3ad4</pattern>
 <pattern>eer3al4</pattern>
 <pattern>eer3an4</pattern>
 <pattern>eer4ar</pattern>
@@ -8465,16 +8731,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ee3rat</pattern>
 <pattern>ee3räu</pattern>
 <pattern>eer4ben</pattern>
-<pattern>e2ere</pattern>
 <pattern>eer5eis </pattern>
+<pattern>eer5eisa</pattern>
 <pattern>ee4r5en4g</pattern>
-<pattern>ee5r4e4s3</pattern>
+<pattern>eere4s3</pattern>
 <pattern>eere4t</pattern>
 <pattern>eer5eti</pattern>
 <pattern>eer4fol</pattern>
 <pattern>ee3rhi</pattern>
 <pattern>e3erhö</pattern>
-<pattern>eer4ke</pattern>
 <pattern>eer5lan</pattern>
 <pattern>e3er4lö</pattern>
 <pattern>eerlö5sen</pattern>
@@ -8482,22 +8747,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e3eröf</pattern>
 <pattern>eer4sat</pattern>
 <pattern>eersu3</pattern>
+<pattern>eeru2</pattern>
+<pattern>ee4r3uf</pattern>
 <pattern>eer3um4</pattern>
 <pattern>ee3rü</pattern>
+<pattern>eerz2</pattern>
 <pattern>e5er4zeu</pattern>
+<pattern>eer4zie</pattern>
 <pattern>eerzu3</pattern>
 <pattern>ee1s2</pattern>
 <pattern>ee3sl</pattern>
+<pattern>ee3sp</pattern>
 <pattern>e3ess</pattern>
 <pattern>e2et</pattern>
-<pattern>ee3ta2</pattern>
-<pattern>ee4tat</pattern>
+<pattern>eeta2</pattern>
+<pattern>ee3tal</pattern>
+<pattern>e3etat</pattern>
 <pattern>ee3t4r</pattern>
 <pattern>ee2tu</pattern>
 <pattern>ee1u2</pattern>
 <pattern>eeun2</pattern>
 <pattern>eeur2</pattern>
-<pattern>ee2va</pattern>
 <pattern>eewe2</pattern>
 <pattern>e1ex2</pattern>
 <pattern>2ef </pattern>
@@ -8513,10 +8783,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ef3auf</pattern>
 <pattern>ef3aus</pattern>
 <pattern>e4fähn</pattern>
+<pattern>e4fe </pattern>
 <pattern>ef3ebe</pattern>
 <pattern>efecht4</pattern>
 <pattern>ef3edi</pattern>
 <pattern>e4f5eing</pattern>
+<pattern>ef5eink</pattern>
 <pattern>e2fek</pattern>
 <pattern>e3fel</pattern>
 <pattern>efel5ei</pattern>
@@ -8526,15 +8798,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4f3enk</pattern>
 <pattern>e4f3ent</pattern>
 <pattern>efer5eg</pattern>
+<pattern>ef3eta</pattern>
 <pattern>e2fex</pattern>
 <pattern>ef4f3as4</pattern>
 <pattern>3effek</pattern>
 <pattern>ef3flu</pattern>
-<pattern>efgela5d</pattern>
 <pattern>e3fib</pattern>
 <pattern>e3fina</pattern>
 <pattern>efi3ni</pattern>
 <pattern>e4f3ins</pattern>
+<pattern>ef3int</pattern>
 <pattern>efi2s</pattern>
 <pattern>efla4g</pattern>
 <pattern>eflo5ck</pattern>
@@ -8547,7 +8820,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ef3of</pattern>
 <pattern>e3fon</pattern>
 <pattern>e4f3ora</pattern>
+<pattern>efpas4</pattern>
 <pattern>e1fr</pattern>
+<pattern>ef3rat</pattern>
+<pattern>ef3red</pattern>
 <pattern>ef3ren</pattern>
 <pattern>ef3rol</pattern>
 <pattern>ef3rom</pattern>
@@ -8565,16 +8841,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ef4t3ro</pattern>
 <pattern>efts2</pattern>
 <pattern>ef3ums</pattern>
-<pattern>efzu3l</pattern>
 <pattern>ega3bi</pattern>
 <pattern>ega3br</pattern>
 <pattern>ega3d</pattern>
 <pattern>e3gag</pattern>
+<pattern>ega4l5in</pattern>
 <pattern>ega3re</pattern>
 <pattern>egas5tr</pattern>
 <pattern>eg2äh</pattern>
 <pattern>egä5ren</pattern>
 <pattern>egbewe4</pattern>
+<pattern>e4ge </pattern>
 <pattern>e2ge3a</pattern>
 <pattern>egear4</pattern>
 <pattern>e3ge4bä</pattern>
@@ -8584,13 +8861,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ege4br</pattern>
 <pattern>ege4bu</pattern>
 <pattern>ege4bü</pattern>
-<pattern>e3ged</pattern>
 <pattern>e5ge4da</pattern>
 <pattern>e2gee</pattern>
 <pattern>ege2f</pattern>
 <pattern>ege5fal</pattern>
 <pattern>ege5fäl</pattern>
-<pattern>e4gefl</pattern>
 <pattern>ege3hi</pattern>
 <pattern>ege5ins</pattern>
 <pattern>ege5int</pattern>
@@ -8618,8 +8893,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ege4pu</pattern>
 <pattern>e2geq</pattern>
 <pattern>eger3a</pattern>
-<pattern>e4gerad</pattern>
 <pattern>egeras4</pattern>
+<pattern>e4ge5rau</pattern>
 <pattern>ege6r5ing</pattern>
 <pattern>ege4ru</pattern>
 <pattern>e3gesa</pattern>
@@ -8642,6 +8917,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4gine</pattern>
 <pattern>eg3ins</pattern>
 <pattern>e3gisc</pattern>
+<pattern>2egl</pattern>
 <pattern>egler5e</pattern>
 <pattern>e2glu</pattern>
 <pattern>eg3nä</pattern>
@@ -8655,7 +8931,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>egsau5f</pattern>
 <pattern>egsau5g</pattern>
 <pattern>eg3seh</pattern>
-<pattern>eg3s4el</pattern>
 <pattern>eg3set</pattern>
 <pattern>eg3spe</pattern>
 <pattern>e2gua</pattern>
@@ -8683,32 +8958,37 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4harz</pattern>
 <pattern>eh3au4g</pattern>
 <pattern>ehau5su</pattern>
+<pattern>eh5ausw</pattern>
 <pattern>eh5ausz</pattern>
 <pattern>e2hav</pattern>
 <pattern>ehä2</pattern>
 <pattern>e3häf</pattern>
 <pattern>e4he </pattern>
 <pattern>eh3eff</pattern>
-<pattern>3e4heli</pattern>
+<pattern>ehe3id</pattern>
+<pattern>eh5elek</pattern>
 <pattern>eh3el4t</pattern>
 <pattern>3ehema</pattern>
+<pattern>e5henerm</pattern>
 <pattern>ehen4se</pattern>
 <pattern>ehens5ei</pattern>
 <pattern>ehen4st</pattern>
 <pattern>eh5en4te</pattern>
 <pattern>ehen4tr</pattern>
 <pattern>ehe3o</pattern>
-<pattern>3e2hep</pattern>
+<pattern>3ehep</pattern>
 <pattern>eh3epi</pattern>
-<pattern>e4h3er4f</pattern>
+<pattern>e4her4f</pattern>
+<pattern>eh5erfah</pattern>
 <pattern>e4h3er4l</pattern>
 <pattern>eh5ersta</pattern>
 <pattern>ehe5str</pattern>
-<pattern>eh3id</pattern>
+<pattern>eh3i2d</pattern>
 <pattern>eh3ill</pattern>
 <pattern>e2him</pattern>
 <pattern>eh3imb</pattern>
 <pattern>eh3inf</pattern>
+<pattern>eh3in4h</pattern>
 <pattern>eh3ins</pattern>
 <pattern>ehis2</pattern>
 <pattern>e3hit</pattern>
@@ -8716,7 +8996,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eh3lag</pattern>
 <pattern>eh3lam</pattern>
 <pattern>eh4l3as</pattern>
-<pattern>eh3lat</pattern>
 <pattern>ehl3au</pattern>
 <pattern>eh3lä</pattern>
 <pattern>ehl5ent</pattern>
@@ -8728,7 +9007,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eh3lic</pattern>
 <pattern>ehlo2</pattern>
 <pattern>ehl3or</pattern>
-<pattern>ehl3ö</pattern>
+<pattern>ehl3öf</pattern>
 <pattern>ehl4se</pattern>
 <pattern>ehl4sto</pattern>
 <pattern>2eh1m</pattern>
@@ -8770,10 +9049,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eh3roc</pattern>
 <pattern>ehr3of</pattern>
 <pattern>eh3rö</pattern>
+<pattern>ehr4s5ag</pattern>
 <pattern>ehr6sein</pattern>
 <pattern>ehr4sel</pattern>
 <pattern>ehr4ser</pattern>
-<pattern>ehr6s5tur</pattern>
 <pattern>ehr3ta</pattern>
 <pattern>ehs2</pattern>
 <pattern>ehse2</pattern>
@@ -8804,7 +9083,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eib5las</pattern>
 <pattern>ei4blu</pattern>
 <pattern>ei4b5rau</pattern>
-<pattern>ei4brö</pattern>
+<pattern>ei4b5rea</pattern>
 <pattern>eibu2</pattern>
 <pattern>ei4b5ute</pattern>
 <pattern>ei3ce</pattern>
@@ -8827,6 +9106,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ei3e4be</pattern>
 <pattern>ei3ec</pattern>
 <pattern>ei3e2d</pattern>
+<pattern>eie3f4</pattern>
 <pattern>ei3el</pattern>
 <pattern>eie2m</pattern>
 <pattern>ei3emi</pattern>
@@ -8852,6 +9132,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4eige </pattern>
 <pattern>e5igel </pattern>
 <pattern>5ei6gene </pattern>
+<pattern>ei4g5erf</pattern>
 <pattern>eigo2</pattern>
 <pattern>ei4g5rad</pattern>
 <pattern>ei4g5rat</pattern>
@@ -8860,10 +9141,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eigs4p</pattern>
 <pattern>eig5str</pattern>
 <pattern>2eigt</pattern>
-<pattern>2ei3gu</pattern>
+<pattern>2eigu</pattern>
 <pattern>ei5gun</pattern>
 <pattern>eika2</pattern>
-<pattern>eik5abl</pattern>
 <pattern>ei4kank</pattern>
 <pattern>ei3kar</pattern>
 <pattern>ei3kin</pattern>
@@ -8877,7 +9157,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ei3lad</pattern>
 <pattern>eil5ane</pattern>
 <pattern>eil5ang</pattern>
-<pattern>eil5ant</pattern>
 <pattern>eil5anz</pattern>
 <pattern>eil3c</pattern>
 <pattern>eild2</pattern>
@@ -8887,6 +9166,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ei4l5inf</pattern>
 <pattern>ei4l5ins</pattern>
 <pattern>ei3l4ip</pattern>
+<pattern>eil3op</pattern>
 <pattern>ei3los</pattern>
 <pattern>ei3lö</pattern>
 <pattern>ei4m3ag</pattern>
@@ -8904,6 +9184,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eimi4n</pattern>
 <pattern>eimmo3</pattern>
 <pattern>eimor4</pattern>
+<pattern>eim5org</pattern>
+<pattern>2eimp</pattern>
 <pattern>eim3sa</pattern>
 <pattern>eim5str</pattern>
 <pattern>e4in </pattern>
@@ -8926,7 +9208,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ein4dik</pattern>
 <pattern>ein4di5v</pattern>
 <pattern>ein4duk</pattern>
-<pattern>eindu5z</pattern>
 <pattern>4eineb</pattern>
 <pattern>eine5inn</pattern>
 <pattern>ei4nel</pattern>
@@ -8936,19 +9217,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ein6er </pattern>
 <pattern>eine5ras</pattern>
 <pattern>ein5erbe</pattern>
-<pattern>ei4n5erf</pattern>
 <pattern>ein5erkr</pattern>
 <pattern>ein5erla</pattern>
 <pattern>ei6n5er6sc</pattern>
 <pattern>ei6n5ertr</pattern>
 <pattern>ei4n5ess</pattern>
 <pattern>ein5e4ti</pattern>
-<pattern>ei4n3eu</pattern>
+<pattern>ei4neu</pattern>
 <pattern>ein6fant</pattern>
 <pattern>ein4fek</pattern>
 <pattern>ein4fi5z</pattern>
 <pattern>ein6flue</pattern>
 <pattern>4einfo</pattern>
+<pattern>e5infra</pattern>
 <pattern>ein3g</pattern>
 <pattern>e3ing </pattern>
 <pattern>einge4</pattern>
@@ -8958,7 +9239,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ei4n3id</pattern>
 <pattern>4einie</pattern>
 <pattern>e3init</pattern>
-<pattern>e4ink2</pattern>
+<pattern>e4ink4</pattern>
 <pattern>ein6karn</pattern>
 <pattern>ein5ko</pattern>
 <pattern>3einmi</pattern>
@@ -8966,19 +9247,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ein4nen</pattern>
 <pattern>ein6nere</pattern>
 <pattern>ein3o4</pattern>
+<pattern>5einord</pattern>
 <pattern>ei3not</pattern>
 <pattern>e4inr</pattern>
 <pattern>ei4ns</pattern>
 <pattern>e4insa</pattern>
-<pattern>ein6sel </pattern>
 <pattern>ein6seln</pattern>
 <pattern>ein4si5d</pattern>
 <pattern>ein5stand</pattern>
-<pattern>ein6star</pattern>
-<pattern>ein6stit</pattern>
-<pattern>ein4sz</pattern>
 <pattern>ei4nt</pattern>
 <pattern>ein6tens</pattern>
+<pattern>ein6terf</pattern>
 <pattern>5eintrag</pattern>
 <pattern>ein6trig</pattern>
 <pattern>5eintrit</pattern>
@@ -9006,9 +9285,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eis5alt</pattern>
 <pattern>eis5ane</pattern>
 <pattern>ei4s5an4t</pattern>
-<pattern>eisch5er6k</pattern>
+<pattern>eisch5erk</pattern>
 <pattern>eisch5war</pattern>
 <pattern>ei5sel </pattern>
+<pattern>eis5elas</pattern>
 <pattern>eise5mi</pattern>
 <pattern>ei6seno</pattern>
 <pattern>ei6sent</pattern>
@@ -9025,11 +9305,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eis5erst</pattern>
 <pattern>eis5er4w</pattern>
 <pattern>eis5erz</pattern>
-<pattern>3eisho</pattern>
 <pattern>ei4s3id</pattern>
 <pattern>ei3sky</pattern>
-<pattern>ei2so2</pattern>
-<pattern>eis3or4</pattern>
+<pattern>eiso2</pattern>
+<pattern>ei4som</pattern>
+<pattern>ei4s3or4</pattern>
 <pattern>ei2sö</pattern>
 <pattern>ei3spr</pattern>
 <pattern>ei4ss</pattern>
@@ -9038,11 +9318,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eis5tab</pattern>
 <pattern>ei5stel</pattern>
 <pattern>ei5steu</pattern>
-<pattern>eis3um</pattern>
 <pattern>eita4</pattern>
 <pattern>eit3ab</pattern>
 <pattern>eital4</pattern>
 <pattern>eit5alb</pattern>
+<pattern>eit5alk</pattern>
 <pattern>eit3an4</pattern>
 <pattern>eitange5</pattern>
 <pattern>eit3ar</pattern>
@@ -9061,10 +9341,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ei3tie</pattern>
 <pattern>ei4t3in4</pattern>
 <pattern>eito2</pattern>
+<pattern>eit5rin</pattern>
 <pattern>eit3ro</pattern>
 <pattern>ei3trü</pattern>
 <pattern>4eits</pattern>
 <pattern>eits5ag</pattern>
+<pattern>eitt4</pattern>
 <pattern>eit5tr</pattern>
 <pattern>ei4t3um</pattern>
 <pattern>ei4t3ur4</pattern>
@@ -9094,8 +9376,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eka5ren</pattern>
 <pattern>eka3ri</pattern>
 <pattern>e3kas</pattern>
+<pattern>ek2ä</pattern>
 <pattern>1ekd</pattern>
-<pattern>e2kel</pattern>
 <pattern>e3ken </pattern>
 <pattern>e3key</pattern>
 <pattern>e1ki</pattern>
@@ -9145,14 +9427,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4la </pattern>
 <pattern>el3aa</pattern>
 <pattern>el3abb</pattern>
-<pattern>ela4br</pattern>
 <pattern>el3abu</pattern>
 <pattern>elad2</pattern>
 <pattern>el3af2</pattern>
 <pattern>elag2</pattern>
-<pattern>el3aho</pattern>
 <pattern>el3ak2</pattern>
-<pattern>el3al2</pattern>
+<pattern>e3lake</pattern>
+<pattern>el3al</pattern>
 <pattern>el3ama</pattern>
 <pattern>el3amb</pattern>
 <pattern>el3ame</pattern>
@@ -9160,12 +9441,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el3amm</pattern>
 <pattern>el3ana</pattern>
 <pattern>el3an4b</pattern>
-<pattern>el5and4a</pattern>
+<pattern>eland4a</pattern>
 <pattern>e5lands</pattern>
 <pattern>elan4f</pattern>
 <pattern>e5lang </pattern>
 <pattern>el3anh</pattern>
-<pattern>ela3ni</pattern>
+<pattern>ela3n4i</pattern>
 <pattern>el3an4k</pattern>
 <pattern>el3anm</pattern>
 <pattern>el3an4p</pattern>
@@ -9213,7 +9494,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el4dek</pattern>
 <pattern>el4del</pattern>
 <pattern>el4dem</pattern>
-<pattern>elden5s</pattern>
 <pattern>el4dere</pattern>
 <pattern>el4d5er4f</pattern>
 <pattern>eld5erhe</pattern>
@@ -9225,12 +9505,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eld5ersp</pattern>
 <pattern>eld5erst</pattern>
 <pattern>eld5ertr</pattern>
-<pattern>eld5erwe</pattern>
+<pattern>el6d5er6we</pattern>
 <pattern>el4desa</pattern>
 <pattern>el4desk</pattern>
 <pattern>el6deste</pattern>
 <pattern>el4dez</pattern>
 <pattern>eldgehe5</pattern>
+<pattern>eldo2</pattern>
 <pattern>elds2</pattern>
 <pattern>eld3st</pattern>
 <pattern>e4le </pattern>
@@ -9239,8 +9520,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ele3br</pattern>
 <pattern>el5echt</pattern>
 <pattern>ele2d</pattern>
+<pattern>el3edi</pattern>
 <pattern>e4lee </pattern>
-<pattern>eleg5er</pattern>
+<pattern>eleg5er4</pattern>
 <pattern>el5ehe </pattern>
 <pattern>e3lei </pattern>
 <pattern>elei4c</pattern>
@@ -9256,7 +9538,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el5einl</pattern>
 <pattern>el5einr</pattern>
 <pattern>el5eins</pattern>
-<pattern>el6einw</pattern>
 <pattern>el5eisf</pattern>
 <pattern>e5leitu</pattern>
 <pattern>el3eiw</pattern>
@@ -9279,7 +9560,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el5ener</pattern>
 <pattern>e3lenh</pattern>
 <pattern>ele5nid</pattern>
-<pattern>elen4ka</pattern>
 <pattern>elen6k5lo</pattern>
 <pattern>e4l5ense</pattern>
 <pattern>el5ents</pattern>
@@ -9289,6 +9569,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el3epe</pattern>
 <pattern>e6l5ereig</pattern>
 <pattern>e6l5er6fah</pattern>
+<pattern>e6lerfin</pattern>
 <pattern>e4l5erfo</pattern>
 <pattern>e4l5er4gä</pattern>
 <pattern>e6lergeb</pattern>
@@ -9297,11 +9578,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4lerke</pattern>
 <pattern>e4l5erla</pattern>
 <pattern>el5ernä</pattern>
-<pattern>e4l3er4r</pattern>
+<pattern>e4l3erö</pattern>
+<pattern>el3er4r</pattern>
+<pattern>e4lerru</pattern>
 <pattern>el5ersa</pattern>
 <pattern>el3eru</pattern>
 <pattern>el3er4w</pattern>
-<pattern>el3er4z</pattern>
+<pattern>e4l3er4z</pattern>
 <pattern>eles2</pattern>
 <pattern>e5les </pattern>
 <pattern>e3lesf</pattern>
@@ -9321,6 +9604,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el3exk</pattern>
 <pattern>el3ext</pattern>
 <pattern>e3ley</pattern>
+<pattern>elf2a</pattern>
 <pattern>3elfd</pattern>
 <pattern>3elfm</pattern>
 <pattern>elge2</pattern>
@@ -9339,6 +9623,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eli2n</pattern>
 <pattern>e3lin </pattern>
 <pattern>e5lina</pattern>
+<pattern>elin4do</pattern>
 <pattern>e3line</pattern>
 <pattern>el3inh</pattern>
 <pattern>el5init</pattern>
@@ -9354,7 +9639,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el3iso</pattern>
 <pattern>eli4tes</pattern>
 <pattern>elit3h</pattern>
-<pattern>eli4tu</pattern>
+<pattern>e3li4tu</pattern>
 <pattern>e3litz</pattern>
 <pattern>e2liz</pattern>
 <pattern>eli4ze</pattern>
@@ -9368,6 +9653,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el4l5art</pattern>
 <pattern>ell5aufb</pattern>
 <pattern>el6l5auft</pattern>
+<pattern>ellei4c</pattern>
+<pattern>ell5einf</pattern>
 <pattern>ell5eing</pattern>
 <pattern>ell5einh</pattern>
 <pattern>ell5einr</pattern>
@@ -9383,9 +9670,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>elm4stu</pattern>
 <pattern>2eln</pattern>
 <pattern>eln2a</pattern>
+<pattern>elner4</pattern>
 <pattern>el3oa</pattern>
 <pattern>elo2b</pattern>
 <pattern>e4lof</pattern>
+<pattern>elon2</pattern>
 <pattern>e3loo</pattern>
 <pattern>elop2</pattern>
 <pattern>el3opf</pattern>
@@ -9406,9 +9695,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>elp2</pattern>
 <pattern>elpe2</pattern>
 <pattern>el3r</pattern>
-<pattern>3elsas</pattern>
 <pattern>el4sb</pattern>
-<pattern>el4s5ein</pattern>
+<pattern>els5eins</pattern>
 <pattern>els4kla</pattern>
 <pattern>el3sla</pattern>
 <pattern>el4s3ol</pattern>
@@ -9418,14 +9706,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>el4tai</pattern>
 <pattern>el4t5ans</pattern>
 <pattern>elta5ra</pattern>
-<pattern>elt5art</pattern>
+<pattern>elt5ar4t</pattern>
 <pattern>elta4t</pattern>
 <pattern>elt3eb</pattern>
 <pattern>el4t3ek</pattern>
 <pattern>elt5eli</pattern>
 <pattern>elte4m</pattern>
 <pattern>el5ten </pattern>
-<pattern>elt5ent</pattern>
 <pattern>elt5er4b</pattern>
 <pattern>elt5er4f</pattern>
 <pattern>elt5erhe</pattern>
@@ -9442,12 +9729,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>elt3ib</pattern>
 <pattern>eltin4</pattern>
 <pattern>elt5inn</pattern>
-<pattern>elt5spo</pattern>
+<pattern>elt5s4po</pattern>
 <pattern>eltur4a</pattern>
 <pattern>e1lu2</pattern>
 <pattern>e2lug</pattern>
 <pattern>e2lul</pattern>
-<pattern>e2l3um</pattern>
+<pattern>e2l3um2</pattern>
 <pattern>e5lung </pattern>
 <pattern>e2l3ur</pattern>
 <pattern>el3use</pattern>
@@ -9498,7 +9785,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>em2dr</pattern>
 <pattern>em2dü</pattern>
 <pattern>e1me</pattern>
-<pattern>em3e2b</pattern>
 <pattern>e3med</pattern>
 <pattern>e3meh</pattern>
 <pattern>emei3e</pattern>
@@ -9513,28 +9799,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>emen6tan</pattern>
 <pattern>ement5h</pattern>
 <pattern>emen4to</pattern>
-<pattern>emen4tu</pattern>
 <pattern>e4m5erei</pattern>
 <pattern>e4m3er4f</pattern>
-<pattern>e4merg</pattern>
-<pattern>eme3ri</pattern>
 <pattern>e4m3er4l</pattern>
 <pattern>emer4n</pattern>
-<pattern>e4m3er4w</pattern>
+<pattern>emer4s</pattern>
+<pattern>em3er4w</pattern>
 <pattern>eme3se</pattern>
 <pattern>emes3t</pattern>
-<pattern>e4me3ti</pattern>
+<pattern>eme3ti</pattern>
 <pattern>emgas3</pattern>
 <pattern>emgene5</pattern>
 <pattern>e1mi</pattern>
-<pattern>e2mid</pattern>
 <pattern>emi2e</pattern>
 <pattern>emie3i</pattern>
 <pattern>emie3l</pattern>
 <pattern>emie3s</pattern>
 <pattern>emie3t</pattern>
 <pattern>emi3k2</pattern>
+<pattern>4emil</pattern>
 <pattern>e2mim</pattern>
+<pattern>2emin</pattern>
 <pattern>e4min4a</pattern>
 <pattern>e4m3inf</pattern>
 <pattern>emin4g</pattern>
@@ -9550,7 +9835,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>emi3tr</pattern>
 <pattern>em4l3ei</pattern>
 <pattern>emman4</pattern>
-<pattern>emm3ap</pattern>
+<pattern>em4m3ap</pattern>
 <pattern>em4m3ei</pattern>
 <pattern>emm5ste</pattern>
 <pattern>em3n</pattern>
@@ -9566,6 +9851,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e1mö</pattern>
 <pattern>e2möl</pattern>
 <pattern>em3pa</pattern>
+<pattern>emp3fä</pattern>
 <pattern>em3pfl</pattern>
 <pattern>3em3ph</pattern>
 <pattern>em4pir</pattern>
@@ -9576,12 +9862,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>em4po5st</pattern>
 <pattern>em3r</pattern>
 <pattern>ems3au</pattern>
-<pattern>em4sim</pattern>
 <pattern>em4s3pa</pattern>
 <pattern>ems4por</pattern>
 <pattern>ems5tau</pattern>
 <pattern>ems5tri</pattern>
 <pattern>ems5tro</pattern>
+<pattern>em3stu</pattern>
 <pattern>em1t2</pattern>
 <pattern>2e1mu</pattern>
 <pattern>3emuls</pattern>
@@ -9604,12 +9890,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>enal2</pattern>
 <pattern>e3nal </pattern>
 <pattern>e3nale</pattern>
-<pattern>ena2m</pattern>
+<pattern>ena2m2</pattern>
 <pattern>e5namen</pattern>
+<pattern>en3ams</pattern>
 <pattern>ena2n2</pattern>
 <pattern>enange5</pattern>
 <pattern>e4nant</pattern>
 <pattern>enap2</pattern>
+<pattern>enar4g</pattern>
 <pattern>en3ark</pattern>
 <pattern>enas4s</pattern>
 <pattern>enas4t</pattern>
@@ -9624,7 +9912,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>enäh4r</pattern>
 <pattern>e3näp</pattern>
 <pattern>enär2</pattern>
-<pattern>enäs2</pattern>
+<pattern>enäs4t</pattern>
 <pattern>2enb</pattern>
 <pattern>enbeob5</pattern>
 <pattern>enda2</pattern>
@@ -9639,6 +9927,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ende5int</pattern>
 <pattern>4endel</pattern>
 <pattern>endel5ä</pattern>
+<pattern>en4dema</pattern>
+<pattern>endergene5</pattern>
 <pattern>end5er6mi</pattern>
 <pattern>end5erze</pattern>
 <pattern>en4desc</pattern>
@@ -9651,17 +9941,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>endo4b</pattern>
 <pattern>4endor</pattern>
 <pattern>en5d4ort</pattern>
+<pattern>end6rif</pattern>
+<pattern>end5rom</pattern>
 <pattern>end5s4au5</pattern>
 <pattern>end3s4l</pattern>
 <pattern>end3t</pattern>
 <pattern>en3dus</pattern>
 <pattern>end2ü</pattern>
 <pattern>endzu4</pattern>
-<pattern>en3ech</pattern>
+<pattern>e2nea</pattern>
 <pattern>e2ned</pattern>
 <pattern>en3eff</pattern>
-<pattern>ene2g</pattern>
-<pattern>en3ege</pattern>
+<pattern>ene4gr</pattern>
 <pattern>ene5hen</pattern>
 <pattern>en3ehr</pattern>
 <pattern>e5neien</pattern>
@@ -9669,6 +9960,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e2nek</pattern>
 <pattern>e2nel</pattern>
 <pattern>en3elb</pattern>
+<pattern>en3el4c</pattern>
 <pattern>en3e4le</pattern>
 <pattern>en3el4f</pattern>
 <pattern>en3eli</pattern>
@@ -9679,7 +9971,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>en3emu</pattern>
 <pattern>enens4</pattern>
 <pattern>en5envi</pattern>
-<pattern>e4n5enzi</pattern>
 <pattern>enen4zy</pattern>
 <pattern>enenzy5k</pattern>
 <pattern>en3epe</pattern>
@@ -9689,7 +9980,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ene6ra </pattern>
 <pattern>e4n3erb</pattern>
 <pattern>ener4be</pattern>
-<pattern>e4n3erd</pattern>
+<pattern>e4n3er4d</pattern>
 <pattern>en5ereig</pattern>
 <pattern>e4n5erek</pattern>
 <pattern>en3er4f</pattern>
@@ -9716,6 +10007,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4n3err</pattern>
 <pattern>ener4s</pattern>
 <pattern>e4n5ersa</pattern>
+<pattern>e4n5ersp</pattern>
 <pattern>ener4t</pattern>
 <pattern>e4n3eru</pattern>
 <pattern>e4n3er4z</pattern>
@@ -9724,10 +10016,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4nesi</pattern>
 <pattern>e4nesk</pattern>
 <pattern>e4nesp</pattern>
-<pattern>en3es4s</pattern>
 <pattern>e5nes5te</pattern>
 <pattern>e4neta</pattern>
-<pattern>ene4tag</pattern>
 <pattern>e4nete</pattern>
 <pattern>e4n3eth</pattern>
 <pattern>e4nett</pattern>
@@ -9738,6 +10028,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>en3eva</pattern>
 <pattern>e2nez</pattern>
 <pattern>2en1f</pattern>
+<pattern>enf2a</pattern>
 <pattern>en4f5erz</pattern>
 <pattern>enf2u</pattern>
 <pattern>en3gab</pattern>
@@ -9755,6 +10046,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5en4gelc</pattern>
 <pattern>5en4gelh</pattern>
 <pattern>en4gelk</pattern>
+<pattern>engel6st</pattern>
 <pattern>engena5ge</pattern>
 <pattern>engese5h</pattern>
 <pattern>engewi5ck</pattern>
@@ -9807,26 +10099,28 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4nius</pattern>
 <pattern>e3niv</pattern>
 <pattern>2enj</pattern>
-<pattern>en4k5aus</pattern>
+<pattern>en4kaus</pattern>
 <pattern>en4k5er4f</pattern>
 <pattern>enk5erg</pattern>
 <pattern>enk5er6ha</pattern>
-<pattern>enk5er6kr</pattern>
-<pattern>enker4s</pattern>
-<pattern>enk5ersa</pattern>
+<pattern>enk5erkr</pattern>
+<pattern>enk5er6sa</pattern>
 <pattern>enkgene5</pattern>
 <pattern>en3kla</pattern>
 <pattern>5enklav</pattern>
 <pattern>en4k5ort</pattern>
 <pattern>enk4ser</pattern>
-<pattern>enks4p</pattern>
+<pattern>enk5spa</pattern>
+<pattern>enk5spo</pattern>
 <pattern>enks4t</pattern>
+<pattern>enk4th</pattern>
 <pattern>2enku</pattern>
 <pattern>enk2ü</pattern>
 <pattern>2enl</pattern>
 <pattern>en3la2</pattern>
 <pattern>2enm</pattern>
 <pattern>en4neg</pattern>
+<pattern>en3neh</pattern>
 <pattern>en4nel</pattern>
 <pattern>en3ner</pattern>
 <pattern>en6n5erfa</pattern>
@@ -9875,6 +10169,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ensa</pattern>
 <pattern>ensam4t</pattern>
 <pattern>en4sanf</pattern>
+<pattern>en4s5ang</pattern>
 <pattern>ensau4</pattern>
 <pattern>ensche6f</pattern>
 <pattern>en5schen</pattern>
@@ -9896,22 +10191,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>en5spas</pattern>
 <pattern>en3spe</pattern>
 <pattern>en5s6pen</pattern>
-<pattern>ens4por</pattern>
 <pattern>en5spru</pattern>
 <pattern>en3spu</pattern>
 <pattern>2enst</pattern>
 <pattern>en5staf</pattern>
-<pattern>enst5ak</pattern>
 <pattern>enstal4</pattern>
 <pattern>enst5alt</pattern>
-<pattern>en5stam</pattern>
 <pattern>en5stand</pattern>
-<pattern>en6st5arb</pattern>
+<pattern>enst5arb</pattern>
 <pattern>en3stä</pattern>
 <pattern>en5steu</pattern>
-<pattern>en5strö</pattern>
+<pattern>en5strom</pattern>
 <pattern>en5strü</pattern>
 <pattern>en4s5umf</pattern>
+<pattern>ens5umg</pattern>
 <pattern>ens5um4v</pattern>
 <pattern>enszusa5g</pattern>
 <pattern>4entaf</pattern>
@@ -9923,19 +10216,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ente4n</pattern>
 <pattern>en6t5ende </pattern>
 <pattern>enten6den </pattern>
-<pattern>en6t5en6des</pattern>
+<pattern>en6t5en6des </pattern>
 <pattern>enten5e</pattern>
 <pattern>5en4tera</pattern>
 <pattern>ent5erben</pattern>
+<pattern>en4t5er4f</pattern>
 <pattern>en4tero</pattern>
 <pattern>en6terre</pattern>
 <pattern>ente4t</pattern>
 <pattern>ent5eta</pattern>
 <pattern>3entfl</pattern>
 <pattern>4entfo</pattern>
-<pattern>3entfü</pattern>
-<pattern>5entgeg</pattern>
 <pattern>3entgi</pattern>
+<pattern>3entgl</pattern>
 <pattern>5entheb</pattern>
 <pattern>4entheo</pattern>
 <pattern>en3thr</pattern>
@@ -9946,15 +10239,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3entla</pattern>
 <pattern>5entloh</pattern>
 <pattern>3entlü</pattern>
-<pattern>3entna</pattern>
+<pattern>5entnah</pattern>
+<pattern>en3toa</pattern>
 <pattern>ent3o4b</pattern>
 <pattern>en4t3os</pattern>
-<pattern>5entrah</pattern>
 <pattern>ent5rest</pattern>
 <pattern>5entrieg</pattern>
 <pattern>5entropi</pattern>
 <pattern>3entso</pattern>
-<pattern>4entss</pattern>
 <pattern>ent4sto</pattern>
 <pattern>en3tü</pattern>
 <pattern>3entw</pattern>
@@ -9978,18 +10270,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2env</pattern>
 <pattern>2enw</pattern>
 <pattern>e1ny</pattern>
-<pattern>enz4äp</pattern>
-<pattern>2enze</pattern>
+<pattern>enz2ä</pattern>
 <pattern>en4zele</pattern>
 <pattern>enze4m</pattern>
 <pattern>enze4n</pattern>
+<pattern>enz5erfo</pattern>
 <pattern>enz5erha</pattern>
 <pattern>en4z5er4k</pattern>
 <pattern>enz5erla</pattern>
+<pattern>enz5er6mi</pattern>
 <pattern>enz5erte</pattern>
 <pattern>enz5erwe</pattern>
+<pattern>en4z5er4z</pattern>
 <pattern>en4zf</pattern>
-<pattern>enz3id</pattern>
+<pattern>enz3i4d</pattern>
 <pattern>enzlan4</pattern>
 <pattern>enzle4</pattern>
 <pattern>enzu3a</pattern>
@@ -9998,7 +10292,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>enzu3h</pattern>
 <pattern>enzu5le</pattern>
 <pattern>enzu5ne</pattern>
-<pattern>enzu3p</pattern>
+<pattern>enz5uni</pattern>
 <pattern>enzusa5g</pattern>
 <pattern>enzu5se</pattern>
 <pattern>enzu5sp</pattern>
@@ -10018,12 +10312,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eof2</pattern>
 <pattern>e3off</pattern>
 <pattern>eo1g</pattern>
+<pattern>e1oh</pattern>
 <pattern>eo3ha</pattern>
 <pattern>eo3he</pattern>
 <pattern>eo3in</pattern>
 <pattern>eok2</pattern>
 <pattern>e3okk</pattern>
-<pattern>eo3ku</pattern>
 <pattern>e2o1l</pattern>
 <pattern>eo3la</pattern>
 <pattern>eolo2</pattern>
@@ -10045,8 +10339,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eor2d</pattern>
 <pattern>e5orden</pattern>
 <pattern>e2ore</pattern>
-<pattern>eo4r3ei</pattern>
-<pattern>eorei6s</pattern>
+<pattern>eor5ei6s</pattern>
 <pattern>e3orga</pattern>
 <pattern>e3ors</pattern>
 <pattern>e3or2t2</pattern>
@@ -10054,8 +10347,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eos4e</pattern>
 <pattern>eo3si</pattern>
 <pattern>e3o4ste</pattern>
-<pattern>eot2</pattern>
-<pattern>eo3ta</pattern>
+<pattern>eo1t2</pattern>
 <pattern>eo3uls</pattern>
 <pattern>e3ous</pattern>
 <pattern>eou2t</pattern>
@@ -10081,6 +10373,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ep2f</pattern>
 <pattern>eph3el</pattern>
 <pattern>eph3em</pattern>
+<pattern>ephi4</pattern>
 <pattern>3e4pid</pattern>
 <pattern>e3pie</pattern>
 <pattern>3e2pig</pattern>
@@ -10093,7 +10386,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e3pist</pattern>
 <pattern>3e2pit</pattern>
 <pattern>e3piz</pattern>
-<pattern>e2po3c</pattern>
+<pattern>epo3c</pattern>
 <pattern>epo2k</pattern>
 <pattern>3e4pos </pattern>
 <pattern>ep2p3a</pattern>
@@ -10109,6 +10402,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ep3ta</pattern>
 <pattern>ep4tal</pattern>
 <pattern>ep4tau</pattern>
+<pattern>ept3ä</pattern>
 <pattern>epter4s</pattern>
 <pattern>ept5erst</pattern>
 <pattern>ep3ti</pattern>
@@ -10118,6 +10412,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>epu3ta</pattern>
 <pattern>e1pü</pattern>
 <pattern>e1py</pattern>
+<pattern>2eque</pattern>
 <pattern>2er </pattern>
 <pattern>e4ra </pattern>
 <pattern>e2rab</pattern>
@@ -10129,14 +10424,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e3rad </pattern>
 <pattern>erad4d</pattern>
 <pattern>e3radi</pattern>
-<pattern>er3adr</pattern>
+<pattern>e4r3adr</pattern>
 <pattern>e4rae</pattern>
 <pattern>era5fra</pattern>
-<pattern>era2g</pattern>
-<pattern>er3age4</pattern>
-<pattern>era5ges</pattern>
+<pattern>erage4</pattern>
 <pattern>er3agi</pattern>
-<pattern>er3a4ho</pattern>
+<pattern>er3ahl</pattern>
+<pattern>era4ho</pattern>
 <pattern>er3aic</pattern>
 <pattern>erak2</pattern>
 <pattern>e3rake</pattern>
@@ -10146,6 +10440,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e2ral</pattern>
 <pattern>e3ral </pattern>
 <pattern>era5leb</pattern>
+<pattern>era6ling</pattern>
 <pattern>e5ralis</pattern>
 <pattern>er5alke</pattern>
 <pattern>er5allo</pattern>
@@ -10156,6 +10451,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eram4t</pattern>
 <pattern>er4an </pattern>
 <pattern>er3a4na</pattern>
+<pattern>erand4</pattern>
 <pattern>e5rand </pattern>
 <pattern>er5ander</pattern>
 <pattern>eran4e</pattern>
@@ -10168,8 +10464,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er3apf</pattern>
 <pattern>er3a4po</pattern>
 <pattern>erar4</pattern>
-<pattern>era3ra</pattern>
-<pattern>er3are</pattern>
 <pattern>er3ari</pattern>
 <pattern>er3aro</pattern>
 <pattern>er3art</pattern>
@@ -10204,9 +10498,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erbe5dr</pattern>
 <pattern>erbeer4</pattern>
 <pattern>erbe5ers</pattern>
+<pattern>erb5er4k</pattern>
+<pattern>3erbg</pattern>
 <pattern>3er4big</pattern>
 <pattern>5erbreg</pattern>
-<pattern>erb4sa</pattern>
 <pattern>erb4th</pattern>
 <pattern>erb2u</pattern>
 <pattern>er1c</pattern>
@@ -10217,7 +10512,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erd5ant</pattern>
 <pattern>erd5anz</pattern>
 <pattern>3erdäp</pattern>
-<pattern>er4d5en4g</pattern>
+<pattern>3erdb</pattern>
+<pattern>er4deng</pattern>
+<pattern>erd5enge</pattern>
 <pattern>er4denl</pattern>
 <pattern>er4denr</pattern>
 <pattern>er4dere</pattern>
@@ -10234,7 +10531,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3erdöl</pattern>
 <pattern>erd3st</pattern>
 <pattern>e1re</pattern>
-<pattern>e4re </pattern>
+<pattern>2e4re </pattern>
 <pattern>ereb2</pattern>
 <pattern>er5e4ben</pattern>
 <pattern>er2e4c</pattern>
@@ -10251,12 +10548,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ere2g</pattern>
 <pattern>e2reh</pattern>
 <pattern>er3ehe</pattern>
+<pattern>ere3hi</pattern>
 <pattern>ere3ho</pattern>
 <pattern>er3ehr</pattern>
 <pattern>e3rei </pattern>
 <pattern>e3reib</pattern>
 <pattern>ereibe4</pattern>
 <pattern>erei4de</pattern>
+<pattern>e5reiga</pattern>
 <pattern>e5reigeb</pattern>
 <pattern>e5reigeh</pattern>
 <pattern>e5reiges</pattern>
@@ -10269,7 +10568,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4reink</pattern>
 <pattern>e4reinl</pattern>
 <pattern>e4reins</pattern>
-<pattern>ereins5tre</pattern>
 <pattern>ereinzu5s</pattern>
 <pattern>er5eisar</pattern>
 <pattern>e4r5eisb</pattern>
@@ -10304,14 +10602,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4renö</pattern>
 <pattern>erens4</pattern>
 <pattern>e4r5ense</pattern>
+<pattern>eren5sk</pattern>
 <pattern>eren5st</pattern>
 <pattern>er5entg</pattern>
-<pattern>e4rentn</pattern>
+<pattern>e4r5entn</pattern>
 <pattern>e4rents</pattern>
 <pattern>er5entz</pattern>
 <pattern>eren6z5en6d</pattern>
 <pattern>eren6z5er6</pattern>
-<pattern>erenzy5k</pattern>
+<pattern>eren6zy5k</pattern>
 <pattern>ere4o</pattern>
 <pattern>ereor3</pattern>
 <pattern>erepa5r</pattern>
@@ -10320,11 +10619,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ere2q</pattern>
 <pattern>e3rer </pattern>
 <pattern>e4r5erde</pattern>
+<pattern>e6rergeb</pattern>
 <pattern>e4rergo</pattern>
 <pattern>e4r5erho</pattern>
 <pattern>er3erk</pattern>
-<pattern>e4r3er4l</pattern>
-<pattern>er5ermi</pattern>
+<pattern>er3erl</pattern>
+<pattern>e4rerle</pattern>
+<pattern>e4r5ermi</pattern>
 <pattern>erer4n</pattern>
 <pattern>e4r5erne</pattern>
 <pattern>e4rero</pattern>
@@ -10336,11 +10637,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er5er6ste</pattern>
 <pattern>e4r5erwa</pattern>
 <pattern>er3erz</pattern>
+<pattern>e4rer4zi</pattern>
 <pattern>ere4sp</pattern>
 <pattern>e4r3es4s</pattern>
+<pattern>e6resse</pattern>
 <pattern>eres5sk</pattern>
 <pattern>e5res5so</pattern>
 <pattern>ere5star</pattern>
+<pattern>ere5stre</pattern>
 <pattern>e4reti</pattern>
 <pattern>ere3tr</pattern>
 <pattern>er3eul</pattern>
@@ -10351,7 +10655,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ere2z</pattern>
 <pattern>erf2a</pattern>
 <pattern>5erfahru</pattern>
-<pattern>er5fam</pattern>
+<pattern>4er5fam</pattern>
 <pattern>erf4e2</pattern>
 <pattern>er5fes</pattern>
 <pattern>erfla5den</pattern>
@@ -10359,13 +10663,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5erfolgr</pattern>
 <pattern>4erform</pattern>
 <pattern>4erfort</pattern>
+<pattern>er5fut</pattern>
 <pattern>4er5füh</pattern>
 <pattern>er4g5are</pattern>
 <pattern>5ergebn</pattern>
-<pattern>6ergebü</pattern>
 <pattern>erg5ein</pattern>
 <pattern>ergela5d</pattern>
 <pattern>ergele5s</pattern>
+<pattern>er4g5elf</pattern>
 <pattern>5er6genar</pattern>
 <pattern>5er4genb</pattern>
 <pattern>5er6gene </pattern>
@@ -10373,7 +10678,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5ergenk</pattern>
 <pattern>5er4genl</pattern>
 <pattern>5er4genp</pattern>
-<pattern>er5gil</pattern>
+<pattern>er4g5erf</pattern>
 <pattern>ergli5che</pattern>
 <pattern>3ergom</pattern>
 <pattern>erg3op</pattern>
@@ -10381,6 +10686,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erg3s4o</pattern>
 <pattern>erg3s4p</pattern>
 <pattern>erg3s4t</pattern>
+<pattern>erg3su</pattern>
 <pattern>e2rh</pattern>
 <pattern>er3hei</pattern>
 <pattern>4erhin</pattern>
@@ -10391,7 +10697,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erich6ter</pattern>
 <pattern>ericht5er6s</pattern>
 <pattern>er3ico</pattern>
-<pattern>e2rid</pattern>
+<pattern>e4ridi</pattern>
 <pattern>4erie</pattern>
 <pattern>erie3b</pattern>
 <pattern>eriebe6s</pattern>
@@ -10421,7 +10727,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er3io4n</pattern>
 <pattern>e3risi</pattern>
 <pattern>er3isl</pattern>
-<pattern>er3iso</pattern>
+<pattern>er3i4so</pattern>
 <pattern>er3isr</pattern>
 <pattern>3eritr</pattern>
 <pattern>e2riv</pattern>
@@ -10433,8 +10739,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erkan4s</pattern>
 <pattern>er5kat</pattern>
 <pattern>erk5ends</pattern>
-<pattern>er4kerf</pattern>
-<pattern>erk5er6fa</pattern>
 <pattern>4er5ket</pattern>
 <pattern>4erki</pattern>
 <pattern>er5kol</pattern>
@@ -10446,6 +10750,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erkti4</pattern>
 <pattern>5erkundu</pattern>
 <pattern>4erlag</pattern>
+<pattern>4er5land</pattern>
+<pattern>4erlän</pattern>
 <pattern>5erläut</pattern>
 <pattern>5erlebn</pattern>
 <pattern>5erledi</pattern>
@@ -10453,19 +10759,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4erli</pattern>
 <pattern>er5lie</pattern>
 <pattern>erli4g</pattern>
-<pattern>er5lis</pattern>
 <pattern>er5löh</pattern>
 <pattern>5erlös </pattern>
+<pattern>erls2</pattern>
 <pattern>er5lüc</pattern>
 <pattern>er3mag</pattern>
 <pattern>er4mak</pattern>
 <pattern>erma4l</pattern>
+<pattern>er5mee</pattern>
+<pattern>er5men</pattern>
 <pattern>er4mers</pattern>
 <pattern>erm3t</pattern>
 <pattern>erm2u</pattern>
 <pattern>ermun3</pattern>
 <pattern>4ernac</pattern>
-<pattern>er4nalg</pattern>
+<pattern>er4n5alg</pattern>
 <pattern>er4n5all</pattern>
 <pattern>er4n5alt</pattern>
 <pattern>erna4m</pattern>
@@ -10475,9 +10783,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er4neg</pattern>
 <pattern>er4n5er4b</pattern>
 <pattern>ern5erei</pattern>
-<pattern>er4n5erf</pattern>
+<pattern>er4nerf</pattern>
 <pattern>er4n5er4k</pattern>
 <pattern>er4n5erl</pattern>
+<pattern>erner4s</pattern>
+<pattern>ern5erst</pattern>
 <pattern>4ernerv</pattern>
 <pattern>4ernis</pattern>
 <pattern>er3nit</pattern>
@@ -10513,9 +10823,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er3opf</pattern>
 <pattern>4er3o2r4</pattern>
 <pattern>e3rosa</pattern>
-<pattern>ero3si</pattern>
-<pattern>5erosio</pattern>
-<pattern>e5rosit</pattern>
+<pattern>3ero3si</pattern>
+<pattern>4e5rosit</pattern>
+<pattern>ero5sto</pattern>
+<pattern>eros5tr</pattern>
 <pattern>er3osz</pattern>
 <pattern>e3rote</pattern>
 <pattern>er5ot6ter</pattern>
@@ -10540,9 +10851,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erra5tio</pattern>
 <pattern>er3rä</pattern>
 <pattern>er3reb</pattern>
-<pattern>4errec</pattern>
 <pattern>5erregt</pattern>
 <pattern>5erringu</pattern>
+<pattern>4errü</pattern>
+<pattern>er5rüc</pattern>
 <pattern>ersch4</pattern>
 <pattern>5erscheinu</pattern>
 <pattern>erschli5che</pattern>
@@ -10575,7 +10887,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>er3ten</pattern>
 <pattern>er3ter</pattern>
 <pattern>er6terei</pattern>
-<pattern>er4t5er4f</pattern>
+<pattern>er4t5erf</pattern>
 <pattern>er4t5er4h</pattern>
 <pattern>er4t5erk</pattern>
 <pattern>4erterm</pattern>
@@ -10603,7 +10915,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4ertrü</pattern>
 <pattern>er4ts</pattern>
 <pattern>ert3sk</pattern>
-<pattern>ert3sp</pattern>
+<pattern>ert3s4p</pattern>
 <pattern>4ertu</pattern>
 <pattern>4erty</pattern>
 <pattern>e1ru</pattern>
@@ -10611,15 +10923,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eru2d</pattern>
 <pattern>eruf4s3</pattern>
 <pattern>e4r3uhr</pattern>
+<pattern>eru2m3</pattern>
 <pattern>er3und</pattern>
 <pattern>er3unf</pattern>
 <pattern>erung4</pattern>
 <pattern>e5rung </pattern>
+<pattern>er5unga</pattern>
+<pattern>er5ungl</pattern>
 <pattern>er3unk</pattern>
 <pattern>erun4t</pattern>
 <pattern>er3up </pattern>
 <pattern>3erupt</pattern>
 <pattern>eru2t</pattern>
+<pattern>er3uto</pattern>
 <pattern>er3uz</pattern>
 <pattern>erüb2</pattern>
 <pattern>e3rü4d</pattern>
@@ -10642,10 +10958,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>erzu5tra</pattern>
 <pattern>4erzü</pattern>
 <pattern>er5züc</pattern>
-<pattern>erz2w</pattern>
+<pattern>erz4wi</pattern>
 <pattern>4erzy</pattern>
 <pattern>2es </pattern>
 <pattern>e1sa</pattern>
+<pattern>e4sa </pattern>
 <pattern>esa5cher</pattern>
 <pattern>e2s3ad</pattern>
 <pattern>esah2</pattern>
@@ -10654,8 +10971,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e4s3alt</pattern>
 <pattern>e4s3ami</pattern>
 <pattern>esam4t</pattern>
-<pattern>es4and</pattern>
 <pattern>esan5zu4</pattern>
+<pattern>e4sap</pattern>
 <pattern>es4a3pa</pattern>
 <pattern>e2sar</pattern>
 <pattern>esa3ra</pattern>
@@ -10674,12 +10991,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>esche4m</pattern>
 <pattern>eschli5che</pattern>
 <pattern>esch4n</pattern>
+<pattern>es2cr</pattern>
 <pattern>e4se </pattern>
 <pattern>ese3er</pattern>
 <pattern>eseh2</pattern>
 <pattern>ese3hi</pattern>
 <pattern>es3ehr</pattern>
-<pattern>e4sein</pattern>
 <pattern>es4ek</pattern>
 <pattern>ese4len</pattern>
 <pattern>ese4ler</pattern>
@@ -10688,7 +11005,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ese4neu</pattern>
 <pattern>esen4se</pattern>
 <pattern>esen5th</pattern>
-<pattern>e4sep</pattern>
 <pattern>es3epi</pattern>
 <pattern>ese5ras</pattern>
 <pattern>ese5rat</pattern>
@@ -10709,61 +11025,66 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e5signie</pattern>
 <pattern>e2s3ik</pattern>
 <pattern>esi4li3</pattern>
+<pattern>e4simp</pattern>
 <pattern>e4sine</pattern>
 <pattern>e4s3in4f</pattern>
 <pattern>es3ini</pattern>
 <pattern>es3in4t</pattern>
-<pattern>e3s4kel</pattern>
 <pattern>e4skü</pattern>
 <pattern>esli2</pattern>
 <pattern>e3slip</pattern>
 <pattern>eso2b</pattern>
-<pattern>es3od</pattern>
+<pattern>e2s3od</pattern>
 <pattern>es3ofe</pattern>
 <pattern>eso2g</pattern>
+<pattern>e2sop</pattern>
 <pattern>eso3pa</pattern>
-<pattern>es3orc</pattern>
+<pattern>e4s3orc</pattern>
 <pattern>esor4d</pattern>
-<pattern>es3ori</pattern>
-<pattern>e3sorp</pattern>
+<pattern>e4s3ori</pattern>
+<pattern>es3ost</pattern>
 <pattern>2esp</pattern>
 <pattern>e3spek</pattern>
-<pattern>es3ph</pattern>
+<pattern>es3pha</pattern>
 <pattern>espi5cke</pattern>
 <pattern>es6portp</pattern>
+<pattern>es6portv</pattern>
 <pattern>es3ps</pattern>
 <pattern>es4put</pattern>
-<pattern>es5rei</pattern>
 <pattern>es4s3ad</pattern>
 <pattern>ess5ala</pattern>
 <pattern>ess5alt</pattern>
-<pattern>es5sam</pattern>
+<pattern>4essau</pattern>
 <pattern>essau4s</pattern>
 <pattern>3essay</pattern>
 <pattern>4essä</pattern>
 <pattern>es5säu</pattern>
 <pattern>4essc</pattern>
 <pattern>es6se5nac</pattern>
-<pattern>es4senz</pattern>
+<pattern>5es4senz</pattern>
 <pattern>es6serec</pattern>
 <pattern>es6serfah</pattern>
+<pattern>ess5er6mi</pattern>
 <pattern>es6ser6sa</pattern>
 <pattern>es6ser6sä</pattern>
-<pattern>es5sic</pattern>
+<pattern>4es5sic</pattern>
 <pattern>4essk</pattern>
 <pattern>4esso</pattern>
 <pattern>es4sof</pattern>
 <pattern>es4som</pattern>
 <pattern>es5sou</pattern>
-<pattern>es2sö</pattern>
 <pattern>4essp</pattern>
 <pattern>ess5par</pattern>
 <pattern>es4sph</pattern>
-<pattern>es4spu</pattern>
+<pattern>es4s3pu</pattern>
+<pattern>4essta</pattern>
 <pattern>es4stab</pattern>
+<pattern>es4stec</pattern>
+<pattern>4essti</pattern>
 <pattern>essti4s</pattern>
 <pattern>es4s5top</pattern>
-<pattern>es5s4tu</pattern>
+<pattern>4esstr</pattern>
+<pattern>4es5s4tu</pattern>
 <pattern>es3sua</pattern>
 <pattern>e4st </pattern>
 <pattern>est5abb</pattern>
@@ -10778,12 +11099,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>esta4s</pattern>
 <pattern>est5asc</pattern>
 <pattern>es5tat </pattern>
-<pattern>esta4te</pattern>
+<pattern>es5ta4te</pattern>
 <pattern>e6st5auf</pattern>
 <pattern>es2tä</pattern>
 <pattern>e3stäl</pattern>
 <pattern>e3stär</pattern>
 <pattern>e5stätt</pattern>
+<pattern>est3eb</pattern>
 <pattern>es4tec</pattern>
 <pattern>e5steif</pattern>
 <pattern>est5eing</pattern>
@@ -10799,6 +11121,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>est5empo</pattern>
 <pattern>e4sten</pattern>
 <pattern>est5engl</pattern>
+<pattern>es6tense</pattern>
 <pattern>est5entr</pattern>
 <pattern>est5ents</pattern>
 <pattern>est5erkr</pattern>
@@ -10812,6 +11135,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>estin4</pattern>
 <pattern>es4tina</pattern>
 <pattern>est5ing</pattern>
+<pattern>es6t5org</pattern>
 <pattern>est5ort</pattern>
 <pattern>es5trac</pattern>
 <pattern>e5strang</pattern>
@@ -10819,6 +11143,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e6stris</pattern>
 <pattern>es5trisc</pattern>
 <pattern>es5tros</pattern>
+<pattern>e3stub</pattern>
 <pattern>est5ums</pattern>
 <pattern>est5uri</pattern>
 <pattern>est5urk</pattern>
@@ -10855,33 +11180,37 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eße3re</pattern>
 <pattern>eß3erl</pattern>
 <pattern>eß3ti</pattern>
-<pattern>e2tab</pattern>
+<pattern>e2tab4</pattern>
 <pattern>e3tab </pattern>
 <pattern>eta4bel</pattern>
 <pattern>et5a4ben</pattern>
 <pattern>et3abh</pattern>
-<pattern>e5table</pattern>
 <pattern>etablo5</pattern>
 <pattern>et3abs</pattern>
 <pattern>et2ac</pattern>
 <pattern>e3taf</pattern>
 <pattern>etage4s</pattern>
+<pattern>et3agi</pattern>
 <pattern>e3talb</pattern>
 <pattern>e3tals</pattern>
 <pattern>e2tam</pattern>
 <pattern>et3ami</pattern>
+<pattern>eta3na</pattern>
 <pattern>et3anb</pattern>
 <pattern>eta6nere</pattern>
 <pattern>et3anh</pattern>
 <pattern>e3tani</pattern>
 <pattern>et3ann</pattern>
 <pattern>et3ano</pattern>
+<pattern>et3anp</pattern>
 <pattern>etan4w</pattern>
+<pattern>etan4za</pattern>
 <pattern>e3tar</pattern>
 <pattern>et3arb</pattern>
 <pattern>eta3re</pattern>
 <pattern>eta5rie</pattern>
 <pattern>et3ar4t</pattern>
+<pattern>e3tasc</pattern>
 <pattern>eta3th</pattern>
 <pattern>etat3r</pattern>
 <pattern>et5aufs</pattern>
@@ -10889,9 +11218,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>e1tä</pattern>
 <pattern>et3äh</pattern>
 <pattern>etä2t</pattern>
+<pattern>e4te </pattern>
 <pattern>e3tea</pattern>
 <pattern>e3tec</pattern>
 <pattern>et3ef</pattern>
+<pattern>etei4g</pattern>
 <pattern>e5teil </pattern>
 <pattern>e4t3ei4m</pattern>
 <pattern>et3ein</pattern>
@@ -10922,11 +11253,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>et2hu3</pattern>
 <pattern>e3thys</pattern>
 <pattern>e2t3i2d</pattern>
+<pattern>e4tina</pattern>
 <pattern>eti5nal</pattern>
 <pattern>et3inf</pattern>
 <pattern>eting3</pattern>
 <pattern>e4t3in4h</pattern>
 <pattern>et3ini</pattern>
+<pattern>e3tio</pattern>
 <pattern>etit3a</pattern>
 <pattern>eti4th</pattern>
 <pattern>2eto</pattern>
@@ -10944,20 +11277,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eto2t</pattern>
 <pattern>e3tow</pattern>
 <pattern>e1tö2</pattern>
+<pattern>et5rade</pattern>
 <pattern>e3trak</pattern>
 <pattern>e3tran</pattern>
-<pattern>e6t5raum </pattern>
 <pattern>et3rec</pattern>
-<pattern>et3res</pattern>
+<pattern>etre4s</pattern>
 <pattern>e3triu</pattern>
 <pattern>etrü5ben</pattern>
+<pattern>et3sar</pattern>
 <pattern>etscher5e</pattern>
 <pattern>etsch5wu</pattern>
 <pattern>etsor6te</pattern>
 <pattern>et3sö</pattern>
-<pattern>et2st</pattern>
-<pattern>et3s4tu</pattern>
-<pattern>et3stü</pattern>
+<pattern>ets4tu</pattern>
+<pattern>ets3u</pattern>
 <pattern>et4t3ab</pattern>
 <pattern>ett3ak</pattern>
 <pattern>et4t3am</pattern>
@@ -10988,7 +11321,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ett5rat</pattern>
 <pattern>ett5res</pattern>
 <pattern>ett5rom</pattern>
-<pattern>ett3so</pattern>
 <pattern>et4t3um</pattern>
 <pattern>2etu</pattern>
 <pattern>etu2b</pattern>
@@ -11034,7 +11366,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eue6r5eig</pattern>
 <pattern>euer5eis</pattern>
 <pattern>eu3eti</pattern>
-<pattern>eufel4s</pattern>
 <pattern>eu4fer</pattern>
 <pattern>eu3f2r</pattern>
 <pattern>eu3fu</pattern>
@@ -11051,6 +11382,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eugs2</pattern>
 <pattern>eug3se</pattern>
 <pattern>eug3sp</pattern>
+<pattern>eug5ste</pattern>
 <pattern>eug5sti</pattern>
 <pattern>eu1h</pattern>
 <pattern>eui2</pattern>
@@ -11072,6 +11404,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eums5tü</pattern>
 <pattern>e3um2w</pattern>
 <pattern>eum2z</pattern>
+<pattern>eu3nas</pattern>
 <pattern>eun2e</pattern>
 <pattern>eun3ei</pattern>
 <pattern>eu4nel</pattern>
@@ -11098,20 +11431,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eu3reb</pattern>
 <pattern>eu3rec</pattern>
 <pattern>eu3reg</pattern>
+<pattern>eur5eis</pattern>
 <pattern>eu3ren</pattern>
 <pattern>eu4r5ens</pattern>
 <pattern>eu3rer</pattern>
+<pattern>eurer5l</pattern>
+<pattern>eur5ins</pattern>
 <pattern>e2uro</pattern>
 <pattern>3europ</pattern>
 <pattern>eur4so</pattern>
 <pattern>eur4stä</pattern>
+<pattern>3euryt</pattern>
 <pattern>2eus</pattern>
 <pattern>eus4e2</pattern>
 <pattern>eu3see</pattern>
 <pattern>eu3sei</pattern>
 <pattern>eu3sel</pattern>
 <pattern>eu3ser</pattern>
-<pattern>eu3so</pattern>
 <pattern>eu3sp</pattern>
 <pattern>eust4</pattern>
 <pattern>eu3sta</pattern>
@@ -11129,6 +11465,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eu4tre</pattern>
 <pattern>euts4</pattern>
 <pattern>eut6scha</pattern>
+<pattern>eut6schl</pattern>
 <pattern>eut6schm</pattern>
 <pattern>eut6schn</pattern>
 <pattern>eut6schr</pattern>
@@ -11137,6 +11474,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2eux</pattern>
 <pattern>eu1y</pattern>
 <pattern>eu2za</pattern>
+<pattern>eu4zec</pattern>
+<pattern>eu4z5ent</pattern>
 <pattern>eu2zo</pattern>
 <pattern>eu3zu</pattern>
 <pattern>euzusa5</pattern>
@@ -11145,7 +11484,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>eübli3</pattern>
 <pattern>e1üs2</pattern>
 <pattern>3e2vak</pattern>
-<pattern>eval4s</pattern>
+<pattern>eval4s3</pattern>
 <pattern>evanz3</pattern>
 <pattern>eva4s</pattern>
 <pattern>eva2t</pattern>
@@ -11176,12 +11515,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ewi2s</pattern>
 <pattern>ewo2</pattern>
 <pattern>e2wo </pattern>
-<pattern>ew2s3e</pattern>
 <pattern>ew3ung</pattern>
 <pattern>ewurs3</pattern>
 <pattern>2ex </pattern>
 <pattern>e2xa</pattern>
 <pattern>3exa2m</pattern>
+<pattern>2exan</pattern>
 <pattern>3exek</pattern>
 <pattern>exer2</pattern>
 <pattern>2exes</pattern>
@@ -11207,6 +11546,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ey2e</pattern>
 <pattern>eym2</pattern>
 <pattern>ey2ne</pattern>
+<pattern>eyo2</pattern>
 <pattern>eyreu3</pattern>
 <pattern>eys2</pattern>
 <pattern>2ez2</pattern>
@@ -11268,19 +11608,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f3abh</pattern>
 <pattern>2f3abl</pattern>
 <pattern>2fabn</pattern>
-<pattern>3fabr</pattern>
 <pattern>f3abre</pattern>
 <pattern>2f3abs</pattern>
 <pattern>2f3abt</pattern>
 <pattern>2fabw</pattern>
 <pattern>2fabz</pattern>
 <pattern>fach3a</pattern>
+<pattern>fach5ec</pattern>
 <pattern>fach5en6z</pattern>
 <pattern>facher4</pattern>
 <pattern>fach5erf</pattern>
 <pattern>fach3i</pattern>
 <pattern>fachin4</pattern>
 <pattern>fach3o</pattern>
+<pattern>fach5sk</pattern>
 <pattern>fachs4p</pattern>
 <pattern>fad2d</pattern>
 <pattern>fade4m</pattern>
@@ -11294,13 +11635,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fa3fa</pattern>
 <pattern>fa3ha</pattern>
 <pattern>fah6l5ent</pattern>
+<pattern>5fahrer</pattern>
 <pattern>fai5res</pattern>
 <pattern>2faka</pattern>
 <pattern>fa3kan</pattern>
 <pattern>fak4tiv</pattern>
 <pattern>fa3leh</pattern>
 <pattern>fal4kl</pattern>
-<pattern>falk3s</pattern>
 <pattern>fal4la</pattern>
 <pattern>fall5au</pattern>
 <pattern>fal4l5ei</pattern>
@@ -11331,7 +11672,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fan4gei</pattern>
 <pattern>fan4gel</pattern>
 <pattern>fan4ger</pattern>
-<pattern>fang3l</pattern>
 <pattern>fan4gr</pattern>
 <pattern>fang6stü</pattern>
 <pattern>f3an2h</pattern>
@@ -11351,7 +11691,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fan4tr</pattern>
 <pattern>2fan2w</pattern>
 <pattern>2f3an2z</pattern>
-<pattern>fan5zi</pattern>
 <pattern>2f1ap</pattern>
 <pattern>fa3pl</pattern>
 <pattern>far4a</pattern>
@@ -11368,7 +11707,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>farb3s</pattern>
 <pattern>far4b3u</pattern>
 <pattern>fa3ren</pattern>
-<pattern>far4m3a</pattern>
+<pattern>far4ma</pattern>
+<pattern>farm5an</pattern>
 <pattern>far4mem</pattern>
 <pattern>far4mes</pattern>
 <pattern>f3armi</pattern>
@@ -11401,7 +11741,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2fäf</pattern>
 <pattern>fäh4r3u</pattern>
 <pattern>1fäk</pattern>
+<pattern>3fällu</pattern>
 <pattern>fäl4tes</pattern>
+<pattern>f1äm2</pattern>
 <pattern>2fäq</pattern>
 <pattern>3färbe</pattern>
 <pattern>fä3ren</pattern>
@@ -11425,6 +11767,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fberich6</pattern>
 <pattern>fbeu3</pattern>
 <pattern>fbild5e</pattern>
+<pattern>fbilder6</pattern>
 <pattern>fbre3c</pattern>
 <pattern>fbrü3</pattern>
 <pattern>2f1c</pattern>
@@ -11438,6 +11781,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fe1a</pattern>
 <pattern>feak2</pattern>
 <pattern>2feb</pattern>
+<pattern>f3ebb</pattern>
 <pattern>fe4ben</pattern>
 <pattern>febe4z</pattern>
 <pattern>fecht6e</pattern>
@@ -11446,6 +11790,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2fedi</pattern>
 <pattern>fe3die</pattern>
 <pattern>feer2</pattern>
+<pattern>fee3t</pattern>
 <pattern>2fef</pattern>
 <pattern>fe3fä</pattern>
 <pattern>fef4e</pattern>
@@ -11501,18 +11846,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4f3elef</pattern>
 <pattern>fel3eg4</pattern>
 <pattern>fe3leh</pattern>
+<pattern>fel5ein</pattern>
 <pattern>4f3elek</pattern>
 <pattern>fel3el</pattern>
 <pattern>fel3en</pattern>
 <pattern>fel3er4</pattern>
 <pattern>fe3let</pattern>
 <pattern>fe3lie</pattern>
+<pattern>fe5linn</pattern>
+<pattern>fel5ins</pattern>
 <pattern>fellan4</pattern>
 <pattern>fell5ans</pattern>
 <pattern>feller4</pattern>
 <pattern>fel4lin</pattern>
 <pattern>felmu4</pattern>
 <pattern>fel3o</pattern>
+<pattern>fel6sein</pattern>
+<pattern>fel6spir</pattern>
 <pattern>felt4</pattern>
 <pattern>fel5tei</pattern>
 <pattern>6f5el6tern</pattern>
@@ -11528,11 +11878,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fen5en4d</pattern>
 <pattern>fe4n5ent</pattern>
 <pattern>4f5energ</pattern>
+<pattern>fen5erö</pattern>
 <pattern>fen5er4w</pattern>
 <pattern>fene4t</pattern>
+<pattern>fengene5</pattern>
 <pattern>fen3gl</pattern>
 <pattern>4fengp</pattern>
+<pattern>feni2</pattern>
 <pattern>fe3nia</pattern>
+<pattern>fen3it</pattern>
 <pattern>4feniv</pattern>
 <pattern>fen4ke</pattern>
 <pattern>fenn2</pattern>
@@ -11541,7 +11895,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fen7schl</pattern>
 <pattern>fen3sh</pattern>
 <pattern>fen5s4kl</pattern>
-<pattern>fen5spo</pattern>
+<pattern>fen5s4po</pattern>
 <pattern>fen5sta</pattern>
 <pattern>fen5stec</pattern>
 <pattern>fen5sto</pattern>
@@ -11552,6 +11906,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4f3ents</pattern>
 <pattern>4fentw</pattern>
 <pattern>4f3entz</pattern>
+<pattern>fen3u</pattern>
 <pattern>4fenzi</pattern>
 <pattern>fenzu3</pattern>
 <pattern>2fe1o</pattern>
@@ -11578,9 +11933,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4fe5ree</pattern>
 <pattern>4feref</pattern>
 <pattern>fere4g</pattern>
-<pattern>ferei4</pattern>
 <pattern>fe4rein</pattern>
 <pattern>fe4r5ei6s</pattern>
+<pattern>fer5eiw</pattern>
 <pattern>ferel4</pattern>
 <pattern>fer5ell</pattern>
 <pattern>fe4r5erd</pattern>
@@ -11590,17 +11945,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fe4rev</pattern>
 <pattern>fer6fahru</pattern>
 <pattern>fer6folg</pattern>
-<pattern>fer4fül</pattern>
-<pattern>4fergeb</pattern>
+<pattern>f5er4fül</pattern>
 <pattern>fer4hö3</pattern>
 <pattern>4feric</pattern>
 <pattern>ferich7t</pattern>
-<pattern>fer3i4d</pattern>
+<pattern>fe4r3i4d</pattern>
 <pattern>feri4e</pattern>
 <pattern>ferien5</pattern>
 <pattern>fer3k</pattern>
+<pattern>fer6lebn</pattern>
 <pattern>fermi4</pattern>
 <pattern>fer4mit</pattern>
+<pattern>fern6au </pattern>
 <pattern>fer4neu</pattern>
 <pattern>4fe3rol</pattern>
 <pattern>fer4öff</pattern>
@@ -11631,17 +11987,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fe3sty</pattern>
 <pattern>2fe3su</pattern>
 <pattern>2fesy</pattern>
-<pattern>2f3e2ta</pattern>
+<pattern>2fe2ta</pattern>
 <pattern>feta5gen</pattern>
+<pattern>fe3tas</pattern>
 <pattern>fe3tei</pattern>
-<pattern>2f3eth</pattern>
+<pattern>2feth</pattern>
+<pattern>fe3the</pattern>
+<pattern>fe4tis</pattern>
 <pattern>fe3trä</pattern>
 <pattern>fet4t3a</pattern>
 <pattern>fet4t3r</pattern>
 <pattern>fett3s</pattern>
 <pattern>2feu </pattern>
 <pattern>2feun</pattern>
-<pattern>feu2t</pattern>
+<pattern>f3eu2t</pattern>
 <pattern>2fev</pattern>
 <pattern>2few</pattern>
 <pattern>f1ex2</pattern>
@@ -11678,6 +12037,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f4fensi</pattern>
 <pattern>ffe3ro</pattern>
 <pattern>ffer5w</pattern>
+<pattern>ffet3r</pattern>
 <pattern>f2fex</pattern>
 <pattern>ff1f</pattern>
 <pattern>ffflo3</pattern>
@@ -11686,6 +12046,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ff3im</pattern>
 <pattern>f3fina</pattern>
 <pattern>ffi3ni</pattern>
+<pattern>f4fink</pattern>
 <pattern>ffi4sc</pattern>
 <pattern>ffi5xen</pattern>
 <pattern>ffi5xes</pattern>
@@ -11698,14 +12059,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ff3ott</pattern>
 <pattern>f2f3ox</pattern>
 <pattern>f1fr</pattern>
+<pattern>ff3rak</pattern>
+<pattern>ff3rev</pattern>
+<pattern>ff3roa</pattern>
+<pattern>ff3rol</pattern>
 <pattern>ffs3au</pattern>
-<pattern>ffs5end</pattern>
-<pattern>ff3set</pattern>
+<pattern>ffs5en4d</pattern>
 <pattern>ff4sin</pattern>
-<pattern>ff3sol</pattern>
 <pattern>ffsor4</pattern>
 <pattern>ffs5per</pattern>
-<pattern>ff4spu</pattern>
 <pattern>ff4stau</pattern>
 <pattern>ffs5tie</pattern>
 <pattern>ff4sto</pattern>
@@ -11718,6 +12080,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ff3urs</pattern>
 <pattern>ffu3se</pattern>
 <pattern>2f1g2</pattern>
+<pattern>fgas5er</pattern>
 <pattern>fgas5te</pattern>
 <pattern>fge2</pattern>
 <pattern>fgege4</pattern>
@@ -11755,6 +12118,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fien3</pattern>
 <pattern>fi3er4f</pattern>
 <pattern>2fif</pattern>
+<pattern>2figo</pattern>
 <pattern>fi2g3r</pattern>
 <pattern>fi2gu</pattern>
 <pattern>2fih</pattern>
@@ -11804,19 +12168,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2f3in2h</pattern>
 <pattern>2f3in2j</pattern>
 <pattern>4f3in4se</pattern>
+<pattern>fin4ta</pattern>
 <pattern>2f3in2v</pattern>
 <pattern>finva3</pattern>
 <pattern>2fio</pattern>
 <pattern>2fiö</pattern>
 <pattern>2fira</pattern>
 <pattern>2fire</pattern>
+<pattern>2f3i2ri</pattern>
 <pattern>fi3sa</pattern>
 <pattern>fisch5a</pattern>
 <pattern>fisch5ei</pattern>
+<pattern>fisch5le</pattern>
 <pattern>fisch5o</pattern>
 <pattern>fisch5w</pattern>
 <pattern>fis2h</pattern>
-<pattern>2f3iso</pattern>
+<pattern>2f3i2so</pattern>
 <pattern>2fi3s2p</pattern>
 <pattern>fis3t</pattern>
 <pattern>fi2t</pattern>
@@ -11843,6 +12210,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fkatio4</pattern>
 <pattern>fko2</pattern>
 <pattern>2fl </pattern>
+<pattern>fl2a</pattern>
 <pattern>f3la2b</pattern>
 <pattern>fla5cher </pattern>
 <pattern>fla3ck</pattern>
@@ -11870,7 +12238,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4f3lein</pattern>
 <pattern>flei6sch5r</pattern>
 <pattern>flek5t</pattern>
+<pattern>2fler</pattern>
 <pattern>1flé</pattern>
+<pattern>2fli </pattern>
 <pattern>2flig</pattern>
 <pattern>2flil</pattern>
 <pattern>3f4lim</pattern>
@@ -11905,6 +12275,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f2lug</pattern>
 <pattern>flug3a</pattern>
 <pattern>flu4ger</pattern>
+<pattern>3flugz</pattern>
+<pattern>f3lup</pattern>
 <pattern>fl4u2r</pattern>
 <pattern>flur3i</pattern>
 <pattern>f4luss</pattern>
@@ -11928,33 +12300,39 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fna2</pattern>
 <pattern>f3ni2</pattern>
 <pattern>fno2</pattern>
-<pattern>1fo</pattern>
+<pattern>1fo2</pattern>
 <pattern>2fo </pattern>
-<pattern>2foa2</pattern>
-<pattern>2fob2</pattern>
+<pattern>2fo3a2</pattern>
+<pattern>2f1ob2</pattern>
 <pattern>fobe2</pattern>
+<pattern>fo3bl</pattern>
+<pattern>fo3bo</pattern>
+<pattern>fo3bu</pattern>
 <pattern>2foce</pattern>
-<pattern>2fod</pattern>
+<pattern>2fo3d</pattern>
+<pattern>2fo3e</pattern>
 <pattern>2fof2</pattern>
+<pattern>fo3fl</pattern>
 <pattern>fo3ha</pattern>
-<pattern>2fo1i</pattern>
+<pattern>2fo3i</pattern>
 <pattern>2fo3la</pattern>
 <pattern>4folg </pattern>
 <pattern>fol2k</pattern>
-<pattern>2folo2</pattern>
+<pattern>2fo3lo2</pattern>
 <pattern>2f3oly</pattern>
 <pattern>2fom2</pattern>
-<pattern>foma2</pattern>
-<pattern>f2o2n</pattern>
+<pattern>fo3ma2</pattern>
+<pattern>fo3mo</pattern>
+<pattern>f2on</pattern>
 <pattern>fon3al</pattern>
 <pattern>fon3an</pattern>
-<pattern>fond4s</pattern>
+<pattern>fond4s3</pattern>
 <pattern>fon3in4</pattern>
 <pattern>fon3st</pattern>
 <pattern>f1op</pattern>
 <pattern>2f3ope</pattern>
 <pattern>fop2f</pattern>
-<pattern>fo2r</pattern>
+<pattern>fo3po</pattern>
 <pattern>fo3rad</pattern>
 <pattern>4f3ordn</pattern>
 <pattern>2f3or2g</pattern>
@@ -11974,7 +12352,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5fortb</pattern>
 <pattern>for4t5ei4</pattern>
 <pattern>for4t5er4</pattern>
-<pattern>fort3h</pattern>
 <pattern>for4tin</pattern>
 <pattern>for4t3r</pattern>
 <pattern>fort3s</pattern>
@@ -11985,14 +12362,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2fosy</pattern>
 <pattern>2fo3ta</pattern>
 <pattern>2fote</pattern>
-<pattern>2foth</pattern>
+<pattern>fo3tel</pattern>
+<pattern>fo3ten</pattern>
+<pattern>2fo3th</pattern>
 <pattern>3foto3</pattern>
-<pattern>2fotr</pattern>
+<pattern>2fo3tr</pattern>
 <pattern>fotre3</pattern>
 <pattern>2fott</pattern>
 <pattern>2fov</pattern>
 <pattern>2fow</pattern>
-<pattern>2foz</pattern>
+<pattern>2fo3z</pattern>
 <pattern>1fö2</pattern>
 <pattern>föde3</pattern>
 <pattern>2f1öf</pattern>
@@ -12000,6 +12379,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2f1öl</pattern>
 <pattern>för2s</pattern>
 <pattern>förs5t</pattern>
+<pattern>f1ös</pattern>
 <pattern>2f1p2</pattern>
 <pattern>fpa2</pattern>
 <pattern>fpi2</pattern>
@@ -12009,6 +12389,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>frach6t5r</pattern>
 <pattern>fra5cke</pattern>
 <pattern>2f3ra2d</pattern>
+<pattern>f3raf</pattern>
+<pattern>frage5i</pattern>
 <pattern>fra4gem</pattern>
 <pattern>fra4ges</pattern>
 <pattern>2f3rah</pattern>
@@ -12018,13 +12400,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f3rand</pattern>
 <pattern>f3rap3</pattern>
 <pattern>2frar</pattern>
-<pattern>4frasc</pattern>
 <pattern>f3rase</pattern>
 <pattern>fra4si</pattern>
 <pattern>4fra3st</pattern>
 <pattern>fras5ta</pattern>
 <pattern>3fraß</pattern>
-<pattern>2f3rat</pattern>
+<pattern>f3rat </pattern>
+<pattern>f3rats</pattern>
 <pattern>f3raum</pattern>
 <pattern>fraus4</pattern>
 <pattern>frau5se</pattern>
@@ -12033,7 +12415,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f3re2c</pattern>
 <pattern>fre5che</pattern>
 <pattern>frecy3</pattern>
-<pattern>fre4du3</pattern>
+<pattern>fre4du</pattern>
 <pattern>fre2f</pattern>
 <pattern>fre2g</pattern>
 <pattern>fre3ga</pattern>
@@ -12079,6 +12461,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f2ron</pattern>
 <pattern>fro4n3a</pattern>
 <pattern>fro4s</pattern>
+<pattern>f3rose</pattern>
 <pattern>fro2t</pattern>
 <pattern>frö2c</pattern>
 <pattern>frö3sc</pattern>
@@ -12091,8 +12474,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fsa2</pattern>
 <pattern>f3sag</pattern>
 <pattern>f3sai</pattern>
-<pattern>fsal2</pattern>
-<pattern>fsal5ben</pattern>
+<pattern>f3salb</pattern>
 <pattern>fs3all</pattern>
 <pattern>fs3alt</pattern>
 <pattern>fs3am4p</pattern>
@@ -12113,23 +12495,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f4schan</pattern>
 <pattern>f4schef</pattern>
 <pattern>f4schro</pattern>
-<pattern>f2s3cr</pattern>
+<pattern>f2scr</pattern>
 <pattern>f1se2</pattern>
 <pattern>fs3eb</pattern>
 <pattern>fsee3i</pattern>
 <pattern>f4s3ehr</pattern>
 <pattern>f4s3ein3</pattern>
 <pattern>f2s3el</pattern>
-<pattern>fsen4de</pattern>
+<pattern>fsen6des</pattern>
 <pattern>f4s3ene</pattern>
 <pattern>f4s3ent</pattern>
 <pattern>f2s3e4r2</pattern>
 <pattern>f3serv</pattern>
 <pattern>fs3eth</pattern>
+<pattern>f2sex</pattern>
 <pattern>fsgene5</pattern>
 <pattern>f2sha</pattern>
 <pattern>fsi2</pattern>
 <pattern>fs5iden</pattern>
+<pattern>f2s3im2</pattern>
 <pattern>fs3in4f</pattern>
 <pattern>fs3in4g</pattern>
 <pattern>fs3in4t</pattern>
@@ -12137,8 +12521,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f3s2ky</pattern>
 <pattern>fsma2</pattern>
 <pattern>fs1o2</pattern>
+<pattern>f2soc</pattern>
+<pattern>fs3och</pattern>
 <pattern>fsof2</pattern>
-<pattern>f3son</pattern>
+<pattern>f3soh</pattern>
+<pattern>f2sop</pattern>
+<pattern>f2sor</pattern>
 <pattern>fsor4d</pattern>
 <pattern>f1sp</pattern>
 <pattern>fspa2</pattern>
@@ -12146,18 +12534,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f4spat</pattern>
 <pattern>f4spel</pattern>
 <pattern>f2sph</pattern>
+<pattern>fsport5e</pattern>
 <pattern>f4spot</pattern>
 <pattern>fs3pre</pattern>
 <pattern>fs5prie</pattern>
 <pattern>f4spro</pattern>
+<pattern>f4spun</pattern>
 <pattern>fs3s2</pattern>
 <pattern>f3sta</pattern>
 <pattern>f4stag</pattern>
 <pattern>f4s3tak</pattern>
 <pattern>fs5tale</pattern>
-<pattern>fstand4</pattern>
 <pattern>f4s5tank</pattern>
-<pattern>f4stas</pattern>
+<pattern>f4s3tas</pattern>
 <pattern>f3stä2</pattern>
 <pattern>f4s5täti</pattern>
 <pattern>f3steh</pattern>
@@ -12177,9 +12566,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f3sto</pattern>
 <pattern>fsto5cke</pattern>
 <pattern>fs5tren</pattern>
-<pattern>fs5tres</pattern>
+<pattern>fs5trol</pattern>
 <pattern>f5strom</pattern>
 <pattern>f3strö</pattern>
+<pattern>fs5trub</pattern>
 <pattern>fs3trü</pattern>
 <pattern>f3stuf</pattern>
 <pattern>fstu4t</pattern>
@@ -12188,6 +12578,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fs3ums</pattern>
 <pattern>f2s3un2</pattern>
 <pattern>f2s3ur</pattern>
+<pattern>fs3ut</pattern>
 <pattern>fszu2</pattern>
 <pattern>fszusa5</pattern>
 <pattern>2ft</pattern>
@@ -12201,9 +12592,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ft3ang</pattern>
 <pattern>ft3ano</pattern>
 <pattern>ft3an4s</pattern>
-<pattern>ft3an4t</pattern>
 <pattern>ftan4w</pattern>
-<pattern>ftap2</pattern>
 <pattern>ft3apf</pattern>
 <pattern>ft3ar2</pattern>
 <pattern>f3tas</pattern>
@@ -12213,7 +12602,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f2t3äu</pattern>
 <pattern>fte4c</pattern>
 <pattern>ft3eck</pattern>
-<pattern>ft3edi</pattern>
 <pattern>f2teg</pattern>
 <pattern>ft3e4he</pattern>
 <pattern>ft3ei4g</pattern>
@@ -12226,12 +12614,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f5ten </pattern>
 <pattern>f2tep</pattern>
 <pattern>fter3a</pattern>
+<pattern>fter6fah</pattern>
 <pattern>fter4ke</pattern>
 <pattern>fter4la</pattern>
 <pattern>fter6lei</pattern>
-<pattern>ft5er4sa</pattern>
+<pattern>ftersau6</pattern>
 <pattern>f4terz</pattern>
-<pattern>f4tesp</pattern>
+<pattern>f4te3sp</pattern>
 <pattern>f4t3es4s</pattern>
 <pattern>fte5stei</pattern>
 <pattern>ft3e4ti</pattern>
@@ -12255,19 +12644,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>f1to2</pattern>
 <pattern>ft3ob</pattern>
 <pattern>f2t3of</pattern>
+<pattern>ft3ora</pattern>
 <pattern>ft3ord</pattern>
 <pattern>ft3or4g</pattern>
 <pattern>f2t3ot2</pattern>
 <pattern>f1tö</pattern>
 <pattern>f1tr</pattern>
+<pattern>f5tran</pattern>
 <pattern>ft3rau</pattern>
+<pattern>ft5riem</pattern>
 <pattern>ft3ril</pattern>
 <pattern>ftro4</pattern>
 <pattern>ftru2</pattern>
 <pattern>ft3ruh</pattern>
 <pattern>fts1</pattern>
 <pattern>ft6sachs</pattern>
-<pattern>ft5salb</pattern>
 <pattern>ft4sam</pattern>
 <pattern>ft4sän</pattern>
 <pattern>ft4seh</pattern>
@@ -12280,12 +12671,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ft4seu</pattern>
 <pattern>ft4sim</pattern>
 <pattern>ft4sin4</pattern>
+<pattern>ft2so</pattern>
 <pattern>ftsor4</pattern>
 <pattern>ft2sp</pattern>
 <pattern>ft4staf</pattern>
 <pattern>ft6stier</pattern>
 <pattern>ft6streu</pattern>
-<pattern>ftto2</pattern>
+<pattern>ft6strop</pattern>
 <pattern>f2t3um</pattern>
 <pattern>ft3unb</pattern>
 <pattern>ft3un4d</pattern>
@@ -12309,6 +12701,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fum3i</pattern>
 <pattern>fum2k</pattern>
 <pattern>fum4le</pattern>
+<pattern>f2umm</pattern>
 <pattern>fum2s</pattern>
 <pattern>fum2w</pattern>
 <pattern>fun6derg</pattern>
@@ -12324,9 +12717,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>fun4k3o</pattern>
 <pattern>fun4k3r</pattern>
 <pattern>f3un2l</pattern>
-<pattern>2f3un2m</pattern>
+<pattern>f3un2m</pattern>
 <pattern>fun2r</pattern>
 <pattern>2funt</pattern>
+<pattern>fun2w</pattern>
 <pattern>1f2u2r</pattern>
 <pattern>fu3ren</pattern>
 <pattern>2f3ur2k</pattern>
@@ -12335,7 +12729,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1fus</pattern>
 <pattern>2fusc</pattern>
 <pattern>fu4schw</pattern>
-<pattern>fu3so</pattern>
 <pattern>fus4sa</pattern>
 <pattern>fus4ser</pattern>
 <pattern>fus4s3p</pattern>
@@ -12356,6 +12749,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2fw</pattern>
 <pattern>fwe6cke</pattern>
 <pattern>fwerk4</pattern>
+<pattern>fwes3</pattern>
 <pattern>fwi2</pattern>
 <pattern>f1y</pattern>
 <pattern>2fz2</pattern>
@@ -12394,6 +12788,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4g3absc</pattern>
 <pattern>4g5absta</pattern>
 <pattern>4g5abstä</pattern>
+<pattern>4g5abste</pattern>
 <pattern>g5abstu</pattern>
 <pattern>g5abstü</pattern>
 <pattern>g3abtr</pattern>
@@ -12427,7 +12822,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gal4be</pattern>
 <pattern>ga4l5en4d</pattern>
 <pattern>g3algo</pattern>
-<pattern>ga4l3in</pattern>
 <pattern>gal4les</pattern>
 <pattern>g3allt</pattern>
 <pattern>3galo</pattern>
@@ -12471,6 +12865,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gan6g5erb</pattern>
 <pattern>gan6gerg</pattern>
 <pattern>gan4gr</pattern>
+<pattern>gang4sa</pattern>
 <pattern>gang4sp</pattern>
 <pattern>gan4g3u</pattern>
 <pattern>gangun4</pattern>
@@ -12489,6 +12884,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gan3o4b</pattern>
 <pattern>ga3non</pattern>
 <pattern>ga3nos</pattern>
+<pattern>2g3an2p</pattern>
 <pattern>2g3an2r</pattern>
 <pattern>4g3an4si</pattern>
 <pattern>gan5spe</pattern>
@@ -12533,7 +12929,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gas3em</pattern>
 <pattern>gas5endr</pattern>
 <pattern>gas5ent</pattern>
+<pattern>4ga5seri</pattern>
 <pattern>gaser4s</pattern>
+<pattern>gas3is</pattern>
 <pattern>gas4ke</pattern>
 <pattern>gas3pa</pattern>
 <pattern>gas3pe</pattern>
@@ -12574,7 +12972,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ga3unt</pattern>
 <pattern>g3ausb</pattern>
 <pattern>4g3ausf</pattern>
-<pattern>4gausg</pattern>
+<pattern>4g3ausg</pattern>
 <pattern>4g3ausr</pattern>
 <pattern>4g3auss</pattern>
 <pattern>g3ausw</pattern>
@@ -12590,6 +12988,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gä3res</pattern>
 <pattern>gär3th</pattern>
 <pattern>2g3ärz</pattern>
+<pattern>gä4st</pattern>
 <pattern>gäste3</pattern>
 <pattern>gäs5ten </pattern>
 <pattern>2g1ät2</pattern>
@@ -12615,19 +13014,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gda2t</pattern>
 <pattern>g2deb</pattern>
 <pattern>g3de2g</pattern>
-<pattern>g2dei</pattern>
-<pattern>gd3eid</pattern>
-<pattern>gd3ein</pattern>
+<pattern>g2d3ei</pattern>
 <pattern>gde2k</pattern>
 <pattern>gdeko3</pattern>
 <pattern>gd3els</pattern>
 <pattern>g4d3ent</pattern>
 <pattern>gde2p</pattern>
 <pattern>g2d3er2</pattern>
-<pattern>g2d3et</pattern>
 <pattern>gd3ins</pattern>
 <pattern>g2dop</pattern>
-<pattern>g2d3ou</pattern>
 <pattern>gd3rec</pattern>
 <pattern>gd3roc</pattern>
 <pattern>g2d3rö</pattern>
@@ -12664,13 +13059,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3gedd</pattern>
 <pattern>gedi2</pattern>
 <pattern>ge3dig</pattern>
-<pattern>ge1e</pattern>
+<pattern>ge1e2</pattern>
 <pattern>3gee </pattern>
 <pattern>3geef</pattern>
 <pattern>4ge3ein</pattern>
 <pattern>2geel2</pattern>
 <pattern>2ge3em</pattern>
-<pattern>gee2n2</pattern>
+<pattern>geen2</pattern>
 <pattern>geer2</pattern>
 <pattern>3ge2es</pattern>
 <pattern>geest3</pattern>
@@ -12792,7 +13187,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4gelru</pattern>
 <pattern>gel5sa</pattern>
 <pattern>4gelsä</pattern>
-<pattern>gel6scho</pattern>
+<pattern>gel6s5cho</pattern>
 <pattern>4gelspo</pattern>
 <pattern>gels4t</pattern>
 <pattern>gel5ste</pattern>
@@ -12805,7 +13200,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gem4a2</pattern>
 <pattern>4gemän</pattern>
 <pattern>2g3em2b</pattern>
-<pattern>gem4e</pattern>
 <pattern>4gemed</pattern>
 <pattern>ge3men</pattern>
 <pattern>4gemenü</pattern>
@@ -12823,18 +13217,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>genbesu6</pattern>
 <pattern>gend5in</pattern>
 <pattern>4gendm</pattern>
+<pattern>gend5ri</pattern>
+<pattern>gen6drit</pattern>
+<pattern>gen3e4g</pattern>
 <pattern>gen3el</pattern>
 <pattern>gen5en6de</pattern>
 <pattern>gen5erei</pattern>
 <pattern>ge4nerf</pattern>
-<pattern>4g5energ</pattern>
 <pattern>5generi</pattern>
 <pattern>gen5erin</pattern>
 <pattern>ge4n5erk</pattern>
 <pattern>ge4n5ern</pattern>
+<pattern>gen5ersc</pattern>
 <pattern>gen5erst</pattern>
 <pattern>ge4n5ert</pattern>
 <pattern>gen5esk</pattern>
+<pattern>gen5ess</pattern>
+<pattern>4genetz</pattern>
 <pattern>gen3g</pattern>
 <pattern>gengene5r</pattern>
 <pattern>ge4nier</pattern>
@@ -12842,7 +13241,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ge3nik</pattern>
 <pattern>gen3in</pattern>
 <pattern>4geniv</pattern>
-<pattern>gen3k</pattern>
 <pattern>4genke</pattern>
 <pattern>gen3n2</pattern>
 <pattern>4genob</pattern>
@@ -12858,15 +13256,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gen5stu</pattern>
 <pattern>genta4</pattern>
 <pattern>4g3entf</pattern>
-<pattern>g3entg</pattern>
 <pattern>gen3th</pattern>
 <pattern>genti4s</pattern>
 <pattern>4gentl</pattern>
 <pattern>gento4</pattern>
 <pattern>gen3tr</pattern>
 <pattern>4g5entst</pattern>
-<pattern>4gentu</pattern>
-<pattern>4gentü</pattern>
 <pattern>4gentw</pattern>
 <pattern>genü2</pattern>
 <pattern>gen6z5art</pattern>
@@ -12879,8 +13274,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2geös</pattern>
 <pattern>gep2</pattern>
 <pattern>ge3ps</pattern>
+<pattern>g4er </pattern>
 <pattern>gerab4</pattern>
 <pattern>ger5abe</pattern>
+<pattern>4gerad </pattern>
 <pattern>ger5all</pattern>
 <pattern>ger5alp</pattern>
 <pattern>ger5am4p</pattern>
@@ -12903,6 +13300,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ge5reie</pattern>
 <pattern>gerei4g</pattern>
 <pattern>ger5eige</pattern>
+<pattern>g5ereign</pattern>
 <pattern>gerei4m</pattern>
 <pattern>gerein5s</pattern>
 <pattern>4g5eremi</pattern>
@@ -12914,10 +13312,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gerer4</pattern>
 <pattern>ger5erh</pattern>
 <pattern>ge4rerk</pattern>
+<pattern>ge4rerl</pattern>
 <pattern>ger5ersa</pattern>
 <pattern>ge4r5erw</pattern>
 <pattern>ge4rerz</pattern>
 <pattern>ge3res</pattern>
+<pattern>4gerheb</pattern>
 <pattern>gerich7ter</pattern>
 <pattern>ge5rin </pattern>
 <pattern>ge5rinne</pattern>
@@ -12947,10 +13347,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ger5um4d</pattern>
 <pattern>ger5ums</pattern>
 <pattern>ge6runi</pattern>
+<pattern>gerunsi5</pattern>
 <pattern>4gerute</pattern>
 <pattern>gerva4</pattern>
 <pattern>4gerwar</pattern>
+<pattern>ger6wart</pattern>
 <pattern>ger6weit</pattern>
+<pattern>gerz2</pattern>
 <pattern>ger4zeu</pattern>
 <pattern>gerzu4</pattern>
 <pattern>g2es</pattern>
@@ -12972,7 +13375,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ges5erf</pattern>
 <pattern>ges5erz</pattern>
 <pattern>ge4sf</pattern>
-<pattern>ges3ou</pattern>
+<pattern>ge4s3ou</pattern>
 <pattern>ges2p</pattern>
 <pattern>ges5pla</pattern>
 <pattern>gesse4r</pattern>
@@ -12993,6 +13396,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2gesy</pattern>
 <pattern>4getag</pattern>
 <pattern>getan4</pattern>
+<pattern>4getat</pattern>
 <pattern>ge3tär</pattern>
 <pattern>4getec</pattern>
 <pattern>geter4s</pattern>
@@ -13005,9 +13409,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ge5tras</pattern>
 <pattern>ge5träg</pattern>
 <pattern>3getre</pattern>
+<pattern>get5res</pattern>
 <pattern>get3sa</pattern>
-<pattern>get3sp</pattern>
-<pattern>get3st</pattern>
+<pattern>get3s4p</pattern>
 <pattern>2g3eul</pattern>
 <pattern>2geun2</pattern>
 <pattern>ge3unk</pattern>
@@ -13043,15 +13447,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ghafe4</pattern>
 <pattern>3ghale</pattern>
 <pattern>gham3</pattern>
-<pattern>gh4au</pattern>
 <pattern>ghä2</pattern>
 <pattern>ghe2b</pattern>
 <pattern>3g2het</pattern>
 <pattern>gh1l</pattern>
 <pattern>gho2</pattern>
 <pattern>gh2r</pattern>
-<pattern>gh1s</pattern>
+<pattern>ghs2</pattern>
+<pattern>gh3sc</pattern>
+<pattern>ght1</pattern>
 <pattern>gh2t3i</pattern>
+<pattern>gh2tr</pattern>
 <pattern>gh3w</pattern>
 <pattern>g2i</pattern>
 <pattern>2gi </pattern>
@@ -13061,9 +13467,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1gib</pattern>
 <pattern>gich2</pattern>
 <pattern>gicht3</pattern>
-<pattern>gichter6</pattern>
 <pattern>gi2e</pattern>
-<pattern>2giea</pattern>
+<pattern>4gieab</pattern>
+<pattern>4gieag</pattern>
+<pattern>4giear</pattern>
+<pattern>4gieau</pattern>
 <pattern>gie3b</pattern>
 <pattern>4giebä</pattern>
 <pattern>giebe4</pattern>
@@ -13082,7 +13490,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>giein4</pattern>
 <pattern>2gie3l</pattern>
 <pattern>2giem</pattern>
-<pattern>gien4e</pattern>
+<pattern>gie5nac</pattern>
+<pattern>4gien4e</pattern>
 <pattern>3gienk</pattern>
 <pattern>4gieno</pattern>
 <pattern>gi3ens</pattern>
@@ -13115,9 +13524,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1gil</pattern>
 <pattern>gi4mes</pattern>
 <pattern>gi4me3t</pattern>
+<pattern>4g3impf</pattern>
 <pattern>gi3na</pattern>
 <pattern>3gi3nä</pattern>
-<pattern>2g3ind</pattern>
+<pattern>2g3in2d</pattern>
 <pattern>gi3nee</pattern>
 <pattern>2g3in2f</pattern>
 <pattern>6g5in6geni</pattern>
@@ -13132,7 +13542,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4g3insp</pattern>
 <pattern>g3in2t</pattern>
 <pattern>2g3in2v</pattern>
-<pattern>gi2r</pattern>
+<pattern>1gi2r</pattern>
 <pattern>gi4sch5w</pattern>
 <pattern>4g3isel</pattern>
 <pattern>gi3sen</pattern>
@@ -13162,9 +13572,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gla5des</pattern>
 <pattern>2g3la2g</pattern>
 <pattern>2g3lah</pattern>
-<pattern>2g3lam</pattern>
 <pattern>g3land</pattern>
 <pattern>glan4dr</pattern>
+<pattern>glan6zen</pattern>
 <pattern>glan6z5er</pattern>
 <pattern>g3lap</pattern>
 <pattern>3glas </pattern>
@@ -13180,10 +13590,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gla5sur</pattern>
 <pattern>gla2t</pattern>
 <pattern>g3late</pattern>
+<pattern>g5laubs</pattern>
 <pattern>4g3lauc</pattern>
 <pattern>g3laue</pattern>
 <pattern>4g3lauf</pattern>
+<pattern>g3laus</pattern>
 <pattern>g3laut</pattern>
+<pattern>2g3la2v</pattern>
 <pattern>gla2w</pattern>
 <pattern>1glä</pattern>
 <pattern>4g3länd</pattern>
@@ -13235,6 +13648,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2g2lik</pattern>
 <pattern>2glil</pattern>
 <pattern>g2li2m</pattern>
+<pattern>3glimm</pattern>
 <pattern>g3limo</pattern>
 <pattern>2gli2n</pattern>
 <pattern>gling4</pattern>
@@ -13274,6 +13688,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>g4ma3ri</pattern>
 <pattern>gmen4tr</pattern>
 <pattern>gmen4tu</pattern>
+<pattern>gmi2s</pattern>
 <pattern>gm4un</pattern>
 <pattern>g3nac</pattern>
 <pattern>gna2g</pattern>
@@ -13286,6 +13701,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gna3ta</pattern>
 <pattern>1gnä</pattern>
 <pattern>g3näp</pattern>
+<pattern>gn2e</pattern>
 <pattern>2gneb</pattern>
 <pattern>g3neh</pattern>
 <pattern>4gnei</pattern>
@@ -13295,19 +13711,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4gn3ent</pattern>
 <pattern>gne5ser</pattern>
 <pattern>gnet3a</pattern>
-<pattern>gne4tr</pattern>
+<pattern>gne4t3r</pattern>
 <pattern>2gneu3</pattern>
 <pattern>g2nie</pattern>
 <pattern>g2nif</pattern>
 <pattern>g2nin2</pattern>
+<pattern>gnin3a</pattern>
 <pattern>gn3ing</pattern>
 <pattern>gnin3s</pattern>
-<pattern>2g3ni4s</pattern>
+<pattern>2g3ni2s</pattern>
 <pattern>gnis3o</pattern>
 <pattern>gno3l</pattern>
 <pattern>gno3mi</pattern>
 <pattern>gn2on</pattern>
-<pattern>gno3r</pattern>
+<pattern>gno3ra</pattern>
 <pattern>g3no2t</pattern>
 <pattern>gn1s</pattern>
 <pattern>g1nu</pattern>
@@ -13326,9 +13743,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>go2c</pattern>
 <pattern>2god</pattern>
 <pattern>go3den</pattern>
-<pattern>go2e1</pattern>
-<pattern>go3ei</pattern>
-<pattern>go3en</pattern>
+<pattern>goe1</pattern>
 <pattern>2g1of2</pattern>
 <pattern>go2fe</pattern>
 <pattern>go1g</pattern>
@@ -13342,6 +13757,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gol4d3a</pattern>
 <pattern>gol6d5eng</pattern>
 <pattern>golder4</pattern>
+<pattern>gol4d3o</pattern>
 <pattern>gol4dr</pattern>
 <pattern>golen3</pattern>
 <pattern>gol4fa</pattern>
@@ -13363,7 +13779,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2goo</pattern>
 <pattern>2gop2</pattern>
 <pattern>go3pa</pattern>
-<pattern>g3opf</pattern>
+<pattern>go3pfl</pattern>
+<pattern>go3pi</pattern>
 <pattern>go4pos</pattern>
 <pattern>3gor </pattern>
 <pattern>go3ras</pattern>
@@ -13372,13 +13789,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>g3org</pattern>
 <pattern>g4o3ro</pattern>
 <pattern>2g3or2t</pattern>
-<pattern>go2s</pattern>
+<pattern>go2s1</pattern>
+<pattern>gos3a</pattern>
 <pattern>go3s2l</pattern>
 <pattern>go3ste</pattern>
 <pattern>g3osz</pattern>
-<pattern>go2te</pattern>
+<pattern>go2t</pattern>
 <pattern>4goth</pattern>
-<pattern>go2ti</pattern>
+<pattern>go3the</pattern>
+<pattern>go3tr</pattern>
 <pattern>got4ter4</pattern>
 <pattern>gott5erb</pattern>
 <pattern>gott5erg</pattern>
@@ -13487,7 +13906,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gro3n2</pattern>
 <pattern>grono4</pattern>
 <pattern>4g3rose</pattern>
-<pattern>gros4sc</pattern>
+<pattern>gross5a</pattern>
+<pattern>gros4s5c</pattern>
 <pattern>gros6s5el</pattern>
 <pattern>gros6senk</pattern>
 <pattern>3grot</pattern>
@@ -13510,7 +13930,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>g5sage </pattern>
 <pattern>gsah2</pattern>
 <pattern>g3sai</pattern>
-<pattern>gs3ak</pattern>
 <pattern>gsal2</pattern>
 <pattern>g3sal </pattern>
 <pattern>g3sali</pattern>
@@ -13539,12 +13958,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>g2sce</pattern>
 <pattern>gsch4</pattern>
 <pattern>gs5chec</pattern>
-<pattern>g4sche4f</pattern>
+<pattern>g4s5che4f</pattern>
 <pattern>gschli5che</pattern>
 <pattern>gs3d</pattern>
+<pattern>gsdeut4</pattern>
 <pattern>gse2</pattern>
 <pattern>g3see</pattern>
-<pattern>g3seg</pattern>
+<pattern>g3sege</pattern>
+<pattern>g3segl</pattern>
 <pattern>gs2eh2</pattern>
 <pattern>gs3ehr</pattern>
 <pattern>g3seil</pattern>
@@ -13586,16 +14007,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gsma2</pattern>
 <pattern>gsmo2</pattern>
 <pattern>gs3n</pattern>
-<pattern>gso2</pattern>
+<pattern>g2so2</pattern>
+<pattern>g3soc</pattern>
 <pattern>gsof2</pattern>
 <pattern>g3s2ol</pattern>
 <pattern>g3sond</pattern>
 <pattern>g3sonn</pattern>
 <pattern>gsor2</pattern>
 <pattern>gsou2</pattern>
+<pattern>g3soz</pattern>
 <pattern>g3spac</pattern>
 <pattern>g5sparten</pattern>
 <pattern>g3spek</pattern>
+<pattern>gs4perr</pattern>
 <pattern>gspho3</pattern>
 <pattern>g4spio</pattern>
 <pattern>g5sporn</pattern>
@@ -13635,7 +14059,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gs6t5erei</pattern>
 <pattern>gs4terz</pattern>
 <pattern>gs3tes</pattern>
-<pattern>g3steu</pattern>
+<pattern>g5steue</pattern>
+<pattern>g3stew</pattern>
 <pattern>gs5the</pattern>
 <pattern>g3stic</pattern>
 <pattern>g3stir</pattern>
@@ -13650,6 +14075,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>g5strec</pattern>
 <pattern>gst5reit</pattern>
 <pattern>gs4t5rit</pattern>
+<pattern>g5s4trop</pattern>
 <pattern>g5ström</pattern>
 <pattern>g3stuf</pattern>
 <pattern>g3stut</pattern>
@@ -13660,6 +14086,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gs3un2</pattern>
 <pattern>gsunre5</pattern>
 <pattern>gsur2</pattern>
+<pattern>gs3us</pattern>
 <pattern>gs3ut</pattern>
 <pattern>gszu2</pattern>
 <pattern>gszusa5gen</pattern>
@@ -13686,26 +14113,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gu2d</pattern>
 <pattern>gud3r</pattern>
 <pattern>gu2e</pattern>
-<pattern>4gued</pattern>
+<pattern>2gued</pattern>
 <pattern>guet2</pattern>
 <pattern>g1u2f</pattern>
 <pattern>gu2g</pattern>
 <pattern>2g1uh2</pattern>
+<pattern>3guin</pattern>
 <pattern>gu3ins</pattern>
 <pattern>2gu3is</pattern>
 <pattern>2g3ul2m</pattern>
-<pattern>2gum2</pattern>
-<pattern>g3umb</pattern>
+<pattern>gum2</pattern>
+<pattern>2g3umb</pattern>
 <pattern>gum4e</pattern>
-<pattern>g3umf</pattern>
-<pattern>g3umg</pattern>
+<pattern>2g3umf</pattern>
+<pattern>2g3umg</pattern>
 <pattern>gumge3</pattern>
-<pattern>g3umk</pattern>
-<pattern>g3uml</pattern>
-<pattern>3gumm</pattern>
-<pattern>g3umr</pattern>
-<pattern>g3ums</pattern>
-<pattern>g3umw</pattern>
+<pattern>2g3umk</pattern>
+<pattern>2g3uml</pattern>
+<pattern>2g3umr</pattern>
+<pattern>2g3ums</pattern>
+<pattern>2g3umw</pattern>
 <pattern>g3una</pattern>
 <pattern>gun5del</pattern>
 <pattern>2gun2e</pattern>
@@ -13742,7 +14169,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gus4s3t</pattern>
 <pattern>gu4st</pattern>
 <pattern>gust5a4b</pattern>
-<pattern>gus4tei</pattern>
 <pattern>gust5ein</pattern>
 <pattern>gus6t5en6de</pattern>
 <pattern>gus6terl</pattern>
@@ -13752,11 +14178,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>gut3a2</pattern>
 <pattern>gut3ei</pattern>
 <pattern>gut5er4h</pattern>
+<pattern>guter4k</pattern>
 <pattern>guter4s</pattern>
 <pattern>gut3h</pattern>
 <pattern>gut3i</pattern>
 <pattern>gut3r</pattern>
-<pattern>guts3p</pattern>
+<pattern>gut4s3p</pattern>
 <pattern>gutzu3</pattern>
 <pattern>1gü2</pattern>
 <pattern>2güb</pattern>
@@ -13791,11 +14218,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3ab2h</pattern>
 <pattern>3habi</pattern>
 <pattern>hab4l</pattern>
+<pattern>h3abla</pattern>
 <pattern>ha4blä</pattern>
 <pattern>hablö5su</pattern>
 <pattern>h3a4blu</pattern>
 <pattern>2habn</pattern>
-<pattern>h3a2b2r</pattern>
+<pattern>h3ab2r</pattern>
 <pattern>hab4sa</pattern>
 <pattern>hab4sc</pattern>
 <pattern>hab4so</pattern>
@@ -13826,14 +14254,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>haf3fl</pattern>
 <pattern>haf3l</pattern>
 <pattern>haf3r</pattern>
+<pattern>haftan4</pattern>
 <pattern>3haftb</pattern>
 <pattern>haft5erl</pattern>
 <pattern>3haftg</pattern>
 <pattern>haf4t3o</pattern>
 <pattern>3haftp</pattern>
-<pattern>haf4t5rä</pattern>
-<pattern>haf4tre</pattern>
-<pattern>haf4tri</pattern>
+<pattern>haf4tr</pattern>
+<pattern>haft5rä</pattern>
 <pattern>haft6stem</pattern>
 <pattern>ha3gas</pattern>
 <pattern>hage4l</pattern>
@@ -13844,9 +14272,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3ah2m</pattern>
 <pattern>2hai3l</pattern>
 <pattern>ha2j</pattern>
+<pattern>h3ak2k</pattern>
 <pattern>h3akro</pattern>
 <pattern>hak4ti</pattern>
 <pattern>2hal </pattern>
+<pattern>hal3ab</pattern>
 <pattern>ha3lam</pattern>
 <pattern>hal5ang</pattern>
 <pattern>h5alarm</pattern>
@@ -13861,7 +14291,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hal4b5rü</pattern>
 <pattern>hal4bu</pattern>
 <pattern>2hale</pattern>
-<pattern>ha5len</pattern>
+<pattern>ha5lenti</pattern>
+<pattern>hal5ents</pattern>
 <pattern>hale3s</pattern>
 <pattern>ha3let</pattern>
 <pattern>2halh</pattern>
@@ -13873,12 +14304,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hall5einf</pattern>
 <pattern>hal5lelu</pattern>
 <pattern>hal6l5ere</pattern>
+<pattern>haller6s</pattern>
+<pattern>hall5ersc</pattern>
+<pattern>hall5erw</pattern>
 <pattern>2halp</pattern>
 <pattern>hal4pe</pattern>
 <pattern>hal4sp</pattern>
-<pattern>hal4su</pattern>
+<pattern>hal4sta</pattern>
 <pattern>hal4ta</pattern>
 <pattern>halt5an</pattern>
+<pattern>haltar4</pattern>
 <pattern>hal4tel</pattern>
 <pattern>halt5erfo</pattern>
 <pattern>hal4th</pattern>
@@ -13895,11 +14330,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3ampf</pattern>
 <pattern>2h3amt</pattern>
 <pattern>2h4an </pattern>
-<pattern>2han2a</pattern>
+<pattern>2hana</pattern>
 <pattern>ha3nae</pattern>
 <pattern>ha3nas</pattern>
 <pattern>2hanc</pattern>
-<pattern>han4d3a</pattern>
+<pattern>han4d3a4</pattern>
 <pattern>h4ande</pattern>
 <pattern>han4d5er</pattern>
 <pattern>hando4</pattern>
@@ -13910,6 +14345,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>han4ek</pattern>
 <pattern>ha4nem</pattern>
 <pattern>han2f</pattern>
+<pattern>hanf3i</pattern>
 <pattern>hanf3l</pattern>
 <pattern>han4geb</pattern>
 <pattern>han6g5en6d</pattern>
@@ -13917,7 +14353,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hange5st</pattern>
 <pattern>han4gr</pattern>
 <pattern>2hani</pattern>
-<pattern>han4k5er</pattern>
+<pattern>han4ker</pattern>
 <pattern>han4kr</pattern>
 <pattern>2han2l</pattern>
 <pattern>2ha3no</pattern>
@@ -13939,7 +14375,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3ap2f</pattern>
 <pattern>ha2pl</pattern>
 <pattern>h3a2po</pattern>
-<pattern>ha3ra</pattern>
+<pattern>ha3r2a</pattern>
 <pattern>ha4rab</pattern>
 <pattern>2h3ar2b</pattern>
 <pattern>har3bi</pattern>
@@ -13968,6 +14404,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3arom</pattern>
 <pattern>ha3ron</pattern>
 <pattern>ha3ros</pattern>
+<pattern>har4ra</pattern>
 <pattern>4h3arti</pattern>
 <pattern>har4tik</pattern>
 <pattern>har4tr</pattern>
@@ -13976,7 +14413,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ha2sc</pattern>
 <pattern>hasen3</pattern>
 <pattern>has2h3</pattern>
-<pattern>ha3so</pattern>
 <pattern>ha3spo</pattern>
 <pattern>has4sa</pattern>
 <pattern>hasser4</pattern>
@@ -14014,7 +14450,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>haul4</pattern>
 <pattern>hau4men</pattern>
 <pattern>hausa4</pattern>
-<pattern>hau4s5an</pattern>
+<pattern>hau4san</pattern>
 <pattern>hau4s3c</pattern>
 <pattern>hau4sel</pattern>
 <pattern>hau6s5ent</pattern>
@@ -14028,10 +14464,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hauten4</pattern>
 <pattern>hau6t5eng</pattern>
 <pattern>hauter4</pattern>
+<pattern>hau6terh</pattern>
 <pattern>hau6terk</pattern>
 <pattern>hau6tern</pattern>
 <pattern>hau4t3i</pattern>
-<pattern>haut5s</pattern>
 <pattern>ha3vi</pattern>
 <pattern>1ha2w</pattern>
 <pattern>hä3che</pattern>
@@ -14046,6 +14482,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hän6gere</pattern>
 <pattern>hän6gero</pattern>
 <pattern>hän4ges</pattern>
+<pattern>hän5se</pattern>
 <pattern>här2m</pattern>
 <pattern>h3ärz</pattern>
 <pattern>1hä2s</pattern>
@@ -14092,15 +14529,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he4ber </pattern>
 <pattern>hebe3s</pattern>
 <pattern>he3bet</pattern>
-<pattern>heb3l</pattern>
+<pattern>he2b3l</pattern>
 <pattern>he3blu</pattern>
 <pattern>hebre3</pattern>
 <pattern>3hebs</pattern>
 <pattern>3hebt</pattern>
+<pattern>he3cha</pattern>
 <pattern>hech4e</pattern>
 <pattern>he3chi</pattern>
 <pattern>h3echs</pattern>
-<pattern>he3cki</pattern>
+<pattern>he5ckig</pattern>
 <pattern>heck5sp</pattern>
 <pattern>hede2</pattern>
 <pattern>hed2g</pattern>
@@ -14109,6 +14547,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hee2n2</pattern>
 <pattern>he3eng</pattern>
 <pattern>hee4rei</pattern>
+<pattern>hee5res</pattern>
 <pattern>hee2t</pattern>
 <pattern>he3eti</pattern>
 <pattern>he4fan</pattern>
@@ -14116,7 +14555,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he3fäc</pattern>
 <pattern>he3fäh</pattern>
 <pattern>he3fäs</pattern>
-<pattern>he4f3ei</pattern>
 <pattern>he4fen</pattern>
 <pattern>hefe4r</pattern>
 <pattern>he4f5erm</pattern>
@@ -14149,13 +14587,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hei4mar</pattern>
 <pattern>hei4mau</pattern>
 <pattern>hei4mei</pattern>
+<pattern>hei4min</pattern>
 <pattern>heim3o</pattern>
 <pattern>heim3p</pattern>
 <pattern>hei4mu</pattern>
 <pattern>2hein</pattern>
 <pattern>hein3a</pattern>
 <pattern>hein3d</pattern>
-<pattern>h5eindr</pattern>
 <pattern>hei4n5eb</pattern>
 <pattern>hein5ec</pattern>
 <pattern>hei6nene</pattern>
@@ -14172,10 +14610,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4he3is4m</pattern>
 <pattern>heis4st</pattern>
 <pattern>he3is4t</pattern>
+<pattern>h5eitei</pattern>
 <pattern>he3i4ti</pattern>
 <pattern>heit4s3</pattern>
 <pattern>h3eiw</pattern>
 <pattern>hei6zene</pattern>
+<pattern>hei4zw</pattern>
+<pattern>he4kau</pattern>
 <pattern>he3ken</pattern>
 <pattern>he3ker</pattern>
 <pattern>he3kr</pattern>
@@ -14190,17 +14631,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he3leb</pattern>
 <pattern>hel3ec</pattern>
 <pattern>he3leh</pattern>
-<pattern>h3elek</pattern>
 <pattern>helen4</pattern>
+<pattern>hel5end</pattern>
 <pattern>hel5ent</pattern>
 <pattern>heler4</pattern>
 <pattern>hel5ers</pattern>
-<pattern>he3lic</pattern>
+<pattern>4he3lic</pattern>
 <pattern>he3lie</pattern>
 <pattern>hel5ing</pattern>
 <pattern>hel4l5au</pattern>
 <pattern>hel4m5an</pattern>
 <pattern>hel4mei</pattern>
+<pattern>3helms</pattern>
 <pattern>he3lo</pattern>
 <pattern>hel4or</pattern>
 <pattern>2hels</pattern>
@@ -14211,6 +14653,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he3mac</pattern>
 <pattern>he3mal</pattern>
 <pattern>he3man</pattern>
+<pattern>2hemä</pattern>
 <pattern>3hemd</pattern>
 <pattern>2heme</pattern>
 <pattern>h5e4miss</pattern>
@@ -14232,10 +14675,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he6n5erei</pattern>
 <pattern>he4nerf</pattern>
 <pattern>he4n5erk</pattern>
-<pattern>he4n5erm</pattern>
-<pattern>hen5ero</pattern>
 <pattern>hen5erö</pattern>
 <pattern>hen5ersc</pattern>
+<pattern>hen5erst</pattern>
 <pattern>hen5ert</pattern>
 <pattern>he4n5er4w</pattern>
 <pattern>hen5eta</pattern>
@@ -14250,13 +14692,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hen6k5rin</pattern>
 <pattern>henmen6s</pattern>
 <pattern>henne5c</pattern>
-<pattern>hen3or</pattern>
 <pattern>hen6s5erk</pattern>
 <pattern>hen5sla</pattern>
 <pattern>hen5spa</pattern>
 <pattern>hen5sta</pattern>
 <pattern>hen5sto</pattern>
 <pattern>hen5str</pattern>
+<pattern>2hent</pattern>
 <pattern>henta4</pattern>
 <pattern>h3entc</pattern>
 <pattern>h5ente </pattern>
@@ -14275,7 +14717,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>henzy5klo</pattern>
 <pattern>2heo</pattern>
 <pattern>heor2</pattern>
-<pattern>he1p</pattern>
+<pattern>2he1p</pattern>
 <pattern>her2a</pattern>
 <pattern>hera4b3</pattern>
 <pattern>herab5s</pattern>
@@ -14286,12 +14728,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he3raz</pattern>
 <pattern>he3rä</pattern>
 <pattern>herbewe6</pattern>
+<pattern>herb4st</pattern>
 <pattern>3herd </pattern>
 <pattern>3herds</pattern>
 <pattern>her3e4b</pattern>
 <pattern>her5eck</pattern>
 <pattern>h5ereign</pattern>
 <pattern>he5reigr</pattern>
+<pattern>her6eini</pattern>
 <pattern>he6r5eis </pattern>
 <pattern>her5eises</pattern>
 <pattern>he4rel</pattern>
@@ -14299,10 +14743,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>he4r5ene</pattern>
 <pattern>her5ent</pattern>
 <pattern>herer4</pattern>
-<pattern>he4r5erf</pattern>
+<pattern>he4rerf</pattern>
 <pattern>he4r5erh</pattern>
 <pattern>he6r5ersc</pattern>
 <pattern>he4r5erw</pattern>
+<pattern>he4rerz</pattern>
 <pattern>h5erfolg</pattern>
 <pattern>hergege6</pattern>
 <pattern>hergeru6</pattern>
@@ -14310,14 +14755,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>herhe4</pattern>
 <pattern>h5er4heb</pattern>
 <pattern>her4hit</pattern>
-<pattern>her3id</pattern>
+<pattern>he4r3id</pattern>
 <pattern>4he3rif</pattern>
 <pattern>he4r3il</pattern>
 <pattern>he6r5in6nu</pattern>
+<pattern>herk2</pattern>
 <pattern>her6kennu</pattern>
 <pattern>h5er4klä</pattern>
 <pattern>h5erlaub</pattern>
-<pattern>h5er4leb</pattern>
+<pattern>her6lebn</pattern>
 <pattern>herli4</pattern>
 <pattern>her6löse</pattern>
 <pattern>hermi4n</pattern>
@@ -14336,7 +14782,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>her3th</pattern>
 <pattern>her3to</pattern>
 <pattern>her3tr</pattern>
-<pattern>herum3</pattern>
 <pattern>he4r5ute</pattern>
 <pattern>he3rüc</pattern>
 <pattern>her4wä5g</pattern>
@@ -14414,7 +14859,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hgemü5ses</pattern>
 <pattern>hgene4r</pattern>
 <pattern>h3gev</pattern>
-<pattern>hgo2</pattern>
 <pattern>2h1h</pattern>
 <pattern>hh4au2</pattern>
 <pattern>hhe2</pattern>
@@ -14457,15 +14901,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hi3ga</pattern>
 <pattern>hige4b</pattern>
 <pattern>h3i4gel</pattern>
-<pattern>hii3</pattern>
 <pattern>1hi2j</pattern>
 <pattern>2hik</pattern>
 <pattern>hikan4</pattern>
 <pattern>hik3r</pattern>
 <pattern>hil3ad</pattern>
-<pattern>hil3an</pattern>
 <pattern>hi3lau</pattern>
 <pattern>hil3c</pattern>
+<pattern>hil4da</pattern>
 <pattern>hil4dr</pattern>
 <pattern>hilen4</pattern>
 <pattern>hile5ni</pattern>
@@ -14493,9 +14936,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hi5nas </pattern>
 <pattern>hi5nati</pattern>
 <pattern>hin5dus </pattern>
-<pattern>hi3nea</pattern>
 <pattern>hinen3</pattern>
 <pattern>hin4fo</pattern>
+<pattern>hin4fr</pattern>
 <pattern>hin3ga</pattern>
 <pattern>hingear6</pattern>
 <pattern>hinge4r</pattern>
@@ -14509,9 +14952,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hi3nos</pattern>
 <pattern>hins2</pattern>
 <pattern>hin4sek</pattern>
-<pattern>hin4sel</pattern>
 <pattern>hinse5ra</pattern>
-<pattern>hin4ta</pattern>
+<pattern>h4insp</pattern>
+<pattern>hin4tan</pattern>
 <pattern>hinü3</pattern>
 <pattern>hin4va3</pattern>
 <pattern>3hinw</pattern>
@@ -14541,6 +14984,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hi2pu</pattern>
 <pattern>2hire</pattern>
 <pattern>hi3ren</pattern>
+<pattern>hi3res</pattern>
 <pattern>2hirm</pattern>
 <pattern>hir4m3a</pattern>
 <pattern>hir4m3i</pattern>
@@ -14554,7 +14998,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hi4schl</pattern>
 <pattern>hi4schr</pattern>
 <pattern>hise3</pattern>
-<pattern>h3iso</pattern>
+<pattern>h3i2so</pattern>
 <pattern>his2p</pattern>
 <pattern>hi3spo</pattern>
 <pattern>hi3spr</pattern>
@@ -14578,13 +15022,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hko2a</pattern>
 <pattern>hkonzi4</pattern>
 <pattern>hkrü3</pattern>
-<pattern>hku2</pattern>
+<pattern>h3ku2</pattern>
+<pattern>hk4uh</pattern>
 <pattern>2hl</pattern>
 <pattern>hla2b</pattern>
 <pattern>h3labo</pattern>
 <pattern>h5lache</pattern>
 <pattern>hla5cke</pattern>
 <pattern>hla5cki</pattern>
+<pattern>hla4gä</pattern>
 <pattern>hla4g3r</pattern>
 <pattern>h3lai</pattern>
 <pattern>h3lake</pattern>
@@ -14595,6 +15041,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hlan4f</pattern>
 <pattern>hlange5s</pattern>
 <pattern>hlan6gest</pattern>
+<pattern>hl3ano</pattern>
 <pattern>hl3an4p</pattern>
 <pattern>hl3an4s</pattern>
 <pattern>hlan4z</pattern>
@@ -14603,6 +15050,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hl3art</pattern>
 <pattern>h3larv</pattern>
 <pattern>h3la2s</pattern>
+<pattern>hl3ato</pattern>
 <pattern>h5laub </pattern>
 <pattern>h5laus </pattern>
 <pattern>h3laut</pattern>
@@ -14649,7 +15097,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hler3a</pattern>
 <pattern>hler5eig</pattern>
 <pattern>hl5ernä</pattern>
-<pattern>hl3erz</pattern>
 <pattern>h3les </pattern>
 <pattern>hl3es4s</pattern>
 <pattern>h3leuc</pattern>
@@ -14690,9 +15137,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3löt</pattern>
 <pattern>hl3sab</pattern>
 <pattern>hls5alt</pattern>
-<pattern>hl4sau</pattern>
+<pattern>hl4samb</pattern>
 <pattern>hls2e</pattern>
 <pattern>hl4sel</pattern>
+<pattern>hls5int</pattern>
 <pattern>hl4sph</pattern>
 <pattern>hl5stec</pattern>
 <pattern>hl5s6tern</pattern>
@@ -14701,6 +15149,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hlta2</pattern>
 <pattern>hl3tei</pattern>
 <pattern>hlti2</pattern>
+<pattern>hl3tr</pattern>
 <pattern>h3luf</pattern>
 <pattern>h3luk</pattern>
 <pattern>h5lumpe</pattern>
@@ -14745,13 +15194,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hmen4sa</pattern>
 <pattern>hmens5em</pattern>
 <pattern>hme4r5ei</pattern>
-<pattern>hmer5id</pattern>
+<pattern>hme4r5id</pattern>
 <pattern>h3mes </pattern>
 <pattern>hme3se</pattern>
 <pattern>h4mete</pattern>
 <pattern>h3mex</pattern>
 <pattern>h3mic</pattern>
-<pattern>h2mid</pattern>
 <pattern>hmi2n</pattern>
 <pattern>h3mind</pattern>
 <pattern>h3mini</pattern>
@@ -14789,6 +15237,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hn3äh</pattern>
 <pattern>hn3är</pattern>
 <pattern>h3näs</pattern>
+<pattern>hnd2</pattern>
+<pattern>hn3da</pattern>
 <pattern>hnde4b</pattern>
 <pattern>hn3dep</pattern>
 <pattern>hndrü3</pattern>
@@ -14804,15 +15254,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hn3emp</pattern>
 <pattern>hne2n</pattern>
 <pattern>h2ne3o</pattern>
+<pattern>hn3epo</pattern>
 <pattern>h3ner</pattern>
 <pattern>hne4r3a</pattern>
+<pattern>hn5erde</pattern>
+<pattern>h4n5erdu</pattern>
 <pattern>hner4kr</pattern>
 <pattern>h4n3ero</pattern>
 <pattern>h4n3er4ö</pattern>
 <pattern>hner5z</pattern>
 <pattern>h4neso</pattern>
-<pattern>hn3e4ta</pattern>
 <pattern>hne3to</pattern>
+<pattern>hnet4s</pattern>
 <pattern>hn3ex</pattern>
 <pattern>h2nez</pattern>
 <pattern>hn1f2</pattern>
@@ -14864,7 +15317,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ho4bel</pattern>
 <pattern>hobel5e</pattern>
 <pattern>h5o4berf</pattern>
+<pattern>ho4berk</pattern>
 <pattern>hoch3</pattern>
+<pattern>hocher4</pattern>
 <pattern>hochs4</pattern>
 <pattern>hock5ere</pattern>
 <pattern>ho3cki</pattern>
@@ -14874,12 +15329,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ho3di</pattern>
 <pattern>ho2f</pattern>
 <pattern>hof3a4</pattern>
+<pattern>hofan4</pattern>
 <pattern>hof3ed</pattern>
+<pattern>hof3ei</pattern>
 <pattern>hof3f4a</pattern>
 <pattern>hoffens6</pattern>
 <pattern>hof3fr</pattern>
 <pattern>hof3in4</pattern>
 <pattern>hof3l</pattern>
+<pattern>hof3or</pattern>
 <pattern>hof3ra</pattern>
 <pattern>ho3g</pattern>
 <pattern>hoge2</pattern>
@@ -14888,8 +15346,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ho3hö</pattern>
 <pattern>h3oh2r</pattern>
 <pattern>2hoi</pattern>
-<pattern>hoko3</pattern>
-<pattern>ho4kom</pattern>
 <pattern>ho4kos</pattern>
 <pattern>h3okt</pattern>
 <pattern>hola2</pattern>
@@ -14905,12 +15361,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ho3li</pattern>
 <pattern>holin4</pattern>
 <pattern>hol5int</pattern>
+<pattern>3holst</pattern>
 <pattern>h3olym</pattern>
 <pattern>hol6zene</pattern>
 <pattern>homa2</pattern>
 <pattern>h2on</pattern>
 <pattern>2hon </pattern>
 <pattern>ho4nar</pattern>
+<pattern>ho4nau</pattern>
 <pattern>2hone</pattern>
 <pattern>hone3b</pattern>
 <pattern>2hong</pattern>
@@ -14945,7 +15403,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hor3ta</pattern>
 <pattern>hor4ter</pattern>
 <pattern>hor4t5rä</pattern>
-<pattern>hor3um</pattern>
+<pattern>hor3um4</pattern>
 <pattern>ho3rus</pattern>
 <pattern>ho3ry</pattern>
 <pattern>hos3ei</pattern>
@@ -14960,10 +15418,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ho4ß5ene</pattern>
 <pattern>2hot </pattern>
 <pattern>hot4e</pattern>
-<pattern>ho4tel</pattern>
 <pattern>3hotl</pattern>
 <pattern>hoto3p</pattern>
 <pattern>ho5tos </pattern>
+<pattern>ho3tr</pattern>
 <pattern>2hot3s2</pattern>
 <pattern>hou2s</pattern>
 <pattern>ho2va</pattern>
@@ -14986,7 +15444,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hpu2</pattern>
 <pattern>hqu6ers</pattern>
 <pattern>2hr</pattern>
-<pattern>hr3a2b2</pattern>
+<pattern>hra2b2</pattern>
 <pattern>hr3ac</pattern>
 <pattern>hra2d</pattern>
 <pattern>h3rago</pattern>
@@ -15012,10 +15470,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h1re</pattern>
 <pattern>h4re </pattern>
 <pattern>h3rea</pattern>
+<pattern>hre4bl</pattern>
 <pattern>h3rech</pattern>
 <pattern>hre6cker</pattern>
 <pattern>h3re2d</pattern>
-<pattern>hredu3</pattern>
 <pattern>hre2f</pattern>
 <pattern>hr3eff</pattern>
 <pattern>h3re4g</pattern>
@@ -15039,15 +15497,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3reiz</pattern>
 <pattern>h2rel</pattern>
 <pattern>hreli5q</pattern>
+<pattern>hr3emb</pattern>
 <pattern>hr3emp</pattern>
 <pattern>hren3g</pattern>
 <pattern>hre4no</pattern>
-<pattern>hren6sei</pattern>
-<pattern>hren6s5or6</pattern>
+<pattern>hrensor6</pattern>
 <pattern>h3re2p</pattern>
+<pattern>h4rerfa</pattern>
 <pattern>h5rerfor</pattern>
 <pattern>hr5erke</pattern>
-<pattern>h6r5er6leb</pattern>
+<pattern>h6r5erleb</pattern>
 <pattern>hre4s3</pattern>
 <pattern>hresen4</pattern>
 <pattern>hres5k</pattern>
@@ -15059,6 +15518,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3re2z</pattern>
 <pattern>hrg2</pattern>
 <pattern>hrgene5r</pattern>
+<pattern>hrgut3</pattern>
 <pattern>h3ric</pattern>
 <pattern>h4rick</pattern>
 <pattern>h5riesl</pattern>
@@ -15074,6 +15534,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hrli2</pattern>
 <pattern>hrma2</pattern>
 <pattern>hrme2</pattern>
+<pattern>h3robo</pattern>
 <pattern>hro3c</pattern>
 <pattern>h5rock </pattern>
 <pattern>hr3ofe</pattern>
@@ -15123,9 +15584,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hrta2</pattern>
 <pattern>hrt3an4</pattern>
 <pattern>hr4t3än4</pattern>
-<pattern>hr3tei</pattern>
 <pattern>hr4t3el</pattern>
-<pattern>hr4t5er4f</pattern>
+<pattern>hr4t5erf</pattern>
 <pattern>hr4t5erl</pattern>
 <pattern>hr4t5erz</pattern>
 <pattern>hrt3ho</pattern>
@@ -15133,8 +15593,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hrt5ins</pattern>
 <pattern>hr4top</pattern>
 <pattern>hr4t5ram</pattern>
+<pattern>hrt5rol</pattern>
 <pattern>hrt6s5ein</pattern>
 <pattern>hrt4sin</pattern>
+<pattern>hrt4sto</pattern>
 <pattern>hr4tung</pattern>
 <pattern>h1ru2</pattern>
 <pattern>h2rub</pattern>
@@ -15151,6 +15613,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hrva2</pattern>
 <pattern>hrwe2</pattern>
 <pattern>hrz2</pattern>
+<pattern>hrzah4</pattern>
+<pattern>hrzahl5</pattern>
 <pattern>hrzeu6ger</pattern>
 <pattern>hrzu3m</pattern>
 <pattern>2hs</pattern>
@@ -15159,6 +15623,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hs5acht</pattern>
 <pattern>h2s3ad</pattern>
 <pattern>h2sak</pattern>
+<pattern>h4s5alar</pattern>
 <pattern>h4s3alk</pattern>
 <pattern>hs3all</pattern>
 <pattern>hs5alte</pattern>
@@ -15177,13 +15642,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hsau2</pattern>
 <pattern>h4s3aud</pattern>
 <pattern>h4s3auf</pattern>
-<pattern>h4s3aus</pattern>
 <pattern>h4saut</pattern>
 <pattern>h2s3äb</pattern>
 <pattern>h2säh</pattern>
 <pattern>h4säug</pattern>
-<pattern>h3s2c</pattern>
 <pattern>h4schan</pattern>
+<pattern>hs2cr</pattern>
 <pattern>h1se</pattern>
 <pattern>hs3e2b</pattern>
 <pattern>h2s3ec</pattern>
@@ -15198,15 +15662,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h6s5einst</pattern>
 <pattern>hsel3a</pattern>
 <pattern>h4selä</pattern>
-<pattern>hs4e4le</pattern>
+<pattern>hse4le</pattern>
 <pattern>hsel5ei</pattern>
 <pattern>hsel5in4</pattern>
 <pattern>hs5elit</pattern>
+<pattern>hsels4</pattern>
 <pattern>hse2m</pattern>
 <pattern>hs5emis</pattern>
 <pattern>h4s5endw</pattern>
 <pattern>hse4n5eb</pattern>
-<pattern>h6sensem</pattern>
 <pattern>hsen5st</pattern>
 <pattern>h6s5entar</pattern>
 <pattern>hs3epi</pattern>
@@ -15228,28 +15692,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h4sexe</pattern>
 <pattern>hs4ext</pattern>
 <pattern>hsgene5r</pattern>
+<pattern>hs4hak</pattern>
 <pattern>h2s3id</pattern>
 <pattern>h4sind</pattern>
 <pattern>h5sinni</pattern>
 <pattern>hs3in4t</pattern>
 <pattern>hs3ita</pattern>
+<pattern>h5skala</pattern>
 <pattern>h5skand</pattern>
 <pattern>hsma2</pattern>
 <pattern>hso2</pattern>
-<pattern>h3so </pattern>
 <pattern>hsof2</pattern>
-<pattern>hs3ofe</pattern>
-<pattern>hs3off</pattern>
-<pattern>h3sol</pattern>
-<pattern>hs3op</pattern>
+<pattern>h4s3ofe</pattern>
+<pattern>h4s3off</pattern>
+<pattern>h2s3op</pattern>
 <pattern>hsor2</pattern>
 <pattern>hs5ort </pattern>
 <pattern>hs6orti</pattern>
 <pattern>hs5orts</pattern>
 <pattern>h1sö</pattern>
 <pattern>h1sp</pattern>
-<pattern>hspa2</pattern>
-<pattern>h4s5pani</pattern>
 <pattern>h4sparl</pattern>
 <pattern>h4sparz</pattern>
 <pattern>h4spat</pattern>
@@ -15294,6 +15756,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h5s4terb</pattern>
 <pattern>h5stere</pattern>
 <pattern>h5s4tern</pattern>
+<pattern>hste3t</pattern>
+<pattern>h5steth</pattern>
 <pattern>h5steue</pattern>
 <pattern>hs3the</pattern>
 <pattern>h3stic</pattern>
@@ -15303,7 +15767,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3sto</pattern>
 <pattern>hsto4l</pattern>
 <pattern>h4stole</pattern>
-<pattern>h4s3tor</pattern>
 <pattern>h5straf</pattern>
 <pattern>h5strah</pattern>
 <pattern>h5stras</pattern>
@@ -15320,6 +15783,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3stun</pattern>
 <pattern>hs1u</pattern>
 <pattern>h3suc</pattern>
+<pattern>h3sul</pattern>
 <pattern>hsum2</pattern>
 <pattern>hs4ung</pattern>
 <pattern>hs3ut</pattern>
@@ -15330,6 +15794,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>htab4</pattern>
 <pattern>h3taba</pattern>
 <pattern>htad2</pattern>
+<pattern>ht5agent</pattern>
 <pattern>htak2</pattern>
 <pattern>h5t4akt </pattern>
 <pattern>h5t4akte</pattern>
@@ -15342,13 +15807,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>htan2</pattern>
 <pattern>htange5</pattern>
 <pattern>h5tanz </pattern>
+<pattern>h5tanzb</pattern>
 <pattern>h5tanzg</pattern>
 <pattern>h5tanzh</pattern>
 <pattern>h5tanzk</pattern>
 <pattern>h5tanzm</pattern>
 <pattern>h5tanzr</pattern>
+<pattern>h5tanzs</pattern>
+<pattern>h5tanzt</pattern>
 <pattern>hta4r2</pattern>
 <pattern>ht5aris</pattern>
+<pattern>h3tasc</pattern>
 <pattern>htas4s</pattern>
 <pattern>h3tast</pattern>
 <pattern>h3tat </pattern>
@@ -15410,6 +15879,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ht5entf</pattern>
 <pattern>ht5entg</pattern>
 <pattern>ht5ents</pattern>
+<pattern>hte4ra</pattern>
 <pattern>ht5erbe </pattern>
 <pattern>h6t5er6ben</pattern>
 <pattern>h6tereic</pattern>
@@ -15435,9 +15905,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h6ter6prob</pattern>
 <pattern>h6ter6spar</pattern>
 <pattern>hter6stat</pattern>
-<pattern>h6t5er6tei</pattern>
 <pattern>ht5er6trä</pattern>
-<pattern>h4t5erwä</pattern>
+<pattern>h4t5er4wä</pattern>
 <pattern>h4tese</pattern>
 <pattern>h4t3es4s</pattern>
 <pattern>h4te5sta</pattern>
@@ -15459,6 +15928,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h2t3i2d</pattern>
 <pattern>ht3im</pattern>
 <pattern>hti2n</pattern>
+<pattern>h4t3ina</pattern>
 <pattern>h4t3ind</pattern>
 <pattern>h4t3ine</pattern>
 <pattern>ht3inf</pattern>
@@ -15498,7 +15968,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ht3ös</pattern>
 <pattern>h1tr</pattern>
 <pattern>ht5rand</pattern>
-<pattern>h5trans</pattern>
 <pattern>h4t3ras</pattern>
 <pattern>h4t5ra4ti</pattern>
 <pattern>h4t5ratt</pattern>
@@ -15512,14 +15981,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ht5reit</pattern>
 <pattern>htre4p</pattern>
 <pattern>h4t3res</pattern>
-<pattern>ht2ri2</pattern>
+<pattern>ht2ri</pattern>
 <pattern>h4t5rieg</pattern>
 <pattern>ht5ring</pattern>
-<pattern>h5trio</pattern>
-<pattern>h5trit</pattern>
 <pattern>h4t3riv</pattern>
 <pattern>htro2</pattern>
-<pattern>h4t3rol</pattern>
 <pattern>h4t3ros</pattern>
 <pattern>ht5rote</pattern>
 <pattern>ht3röm</pattern>
@@ -15529,7 +15995,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hts5ana</pattern>
 <pattern>hts5aug</pattern>
 <pattern>ht4scr</pattern>
-<pattern>ht4s5eid</pattern>
 <pattern>ht4s5en4d</pattern>
 <pattern>ht4s5en4g</pattern>
 <pattern>ht4ser</pattern>
@@ -15538,12 +16003,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>htska4</pattern>
 <pattern>hts5kr</pattern>
 <pattern>ht5slaw</pattern>
+<pattern>ht4sof</pattern>
 <pattern>hts5par</pattern>
 <pattern>ht5spei</pattern>
 <pattern>ht5spen</pattern>
 <pattern>ht5sprec</pattern>
 <pattern>ht5sprü</pattern>
 <pattern>ht4staf</pattern>
+<pattern>ht6s5tate</pattern>
 <pattern>hts5täu</pattern>
 <pattern>ht4stip</pattern>
 <pattern>ht6s5treue</pattern>
@@ -15568,15 +16035,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hub3a</pattern>
 <pattern>hub3ei</pattern>
 <pattern>hub3en</pattern>
-<pattern>hu4b5er4z</pattern>
+<pattern>hub5er4z</pattern>
 <pattern>hub3l</pattern>
 <pattern>hub3o</pattern>
 <pattern>hub3r</pattern>
 <pattern>hude3</pattern>
 <pattern>hu2f</pattern>
+<pattern>huf3a</pattern>
 <pattern>huf3ä</pattern>
 <pattern>huf5er4k</pattern>
 <pattern>hu3fes</pattern>
+<pattern>huf3o</pattern>
 <pattern>hu2g</pattern>
 <pattern>huge3</pattern>
 <pattern>hu2h</pattern>
@@ -15603,6 +16072,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hu2l3a</pattern>
 <pattern>hulan4</pattern>
 <pattern>hular4</pattern>
+<pattern>hulat4</pattern>
 <pattern>hu2lä</pattern>
 <pattern>hul3eb</pattern>
 <pattern>hul3ei</pattern>
@@ -15618,7 +16088,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>huls2</pattern>
 <pattern>hul5se</pattern>
 <pattern>hul5ste</pattern>
-<pattern>hum2a</pattern>
+<pattern>hum4a</pattern>
 <pattern>hu3ma3c</pattern>
 <pattern>h3umb</pattern>
 <pattern>hum4ba</pattern>
@@ -15637,6 +16107,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hun6desc</pattern>
 <pattern>hun6desp</pattern>
 <pattern>hun6dest</pattern>
+<pattern>hund3r</pattern>
 <pattern>hun2e</pattern>
 <pattern>2hunf</pattern>
 <pattern>hun4fa</pattern>
@@ -15676,7 +16147,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hut3i</pattern>
 <pattern>hut3o2</pattern>
 <pattern>hut3r</pattern>
-<pattern>hut5sc</pattern>
 <pattern>hut4ta</pattern>
 <pattern>hut4zeh</pattern>
 <pattern>hut4zei</pattern>
@@ -15686,13 +16156,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hü3ben</pattern>
 <pattern>h3über</pattern>
 <pattern>h2übs</pattern>
-<pattern>hüf4t5er4</pattern>
+<pattern>hüf4t5er</pattern>
 <pattern>hü2g</pattern>
 <pattern>hüh5ne4</pattern>
 <pattern>hühner5</pattern>
 <pattern>hü2n</pattern>
 <pattern>hüpp3</pattern>
 <pattern>hü3ren</pattern>
+<pattern>hür4fr</pattern>
 <pattern>2hü3ri</pattern>
 <pattern>hüs3t</pattern>
 <pattern>hü2t</pattern>
@@ -15740,9 +16211,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>h3wild</pattern>
 <pattern>h3wirk</pattern>
 <pattern>h3wirt</pattern>
+<pattern>h3wiss</pattern>
 <pattern>hwo3f</pattern>
 <pattern>h3woh</pattern>
-<pattern>hwurs3</pattern>
 <pattern>h3wüh</pattern>
 <pattern>h3würf</pattern>
 <pattern>h3würg</pattern>
@@ -15766,7 +16237,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>hzu3ru</pattern>
 <pattern>hzu5rüt</pattern>
 <pattern>hz2w</pattern>
-<pattern>ia1a</pattern>
+<pattern>ia1a2</pattern>
 <pattern>iab2</pattern>
 <pattern>iabe2</pattern>
 <pattern>ia4ben</pattern>
@@ -15800,9 +16271,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ial5erb</pattern>
 <pattern>ial5er4f</pattern>
 <pattern>ial5erh</pattern>
+<pattern>ia4l5e4ri</pattern>
 <pattern>ial5erk</pattern>
 <pattern>ial5erl</pattern>
-<pattern>ial5erm</pattern>
+<pattern>ial5er4m</pattern>
 <pattern>ia4l5ers</pattern>
 <pattern>ial3et</pattern>
 <pattern>ialge4</pattern>
@@ -15810,6 +16282,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ial3id</pattern>
 <pattern>ialin4</pattern>
 <pattern>ial5ind</pattern>
+<pattern>ial5ing</pattern>
 <pattern>ial5ins</pattern>
 <pattern>ial4ler</pattern>
 <pattern>ialli4</pattern>
@@ -15848,9 +16321,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ia2op</pattern>
 <pattern>ia1p2</pattern>
 <pattern>i1ar</pattern>
+<pattern>ia3rau</pattern>
 <pattern>iar2b</pattern>
 <pattern>iar4c</pattern>
 <pattern>i2are</pattern>
+<pattern>ia3rec</pattern>
 <pattern>iar5ein</pattern>
 <pattern>ia3rer</pattern>
 <pattern>ia3res</pattern>
@@ -15860,14 +16335,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iar2m</pattern>
 <pattern>ia3ro</pattern>
 <pattern>iar2t</pattern>
-<pattern>ia3sa</pattern>
-<pattern>ia3se2</pattern>
+<pattern>iase2</pattern>
 <pattern>ia3sh</pattern>
 <pattern>i3asm</pattern>
-<pattern>ia3so</pattern>
 <pattern>ia3s2p</pattern>
 <pattern>i3aspo</pattern>
 <pattern>i3ast </pattern>
+<pattern>ia3sta</pattern>
 <pattern>ia3str</pattern>
 <pattern>ia3tan</pattern>
 <pattern>ia3tei</pattern>
@@ -15924,14 +16398,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ibel3i</pattern>
 <pattern>i2b3em</pattern>
 <pattern>ibe2n</pattern>
+<pattern>i4b5ener</pattern>
 <pattern>iben3s</pattern>
 <pattern>ibe3ra</pattern>
 <pattern>ibe4rab</pattern>
 <pattern>i4berec</pattern>
+<pattern>ibe4ren</pattern>
 <pattern>i6b5er6fah</pattern>
 <pattern>i6bergeb</pattern>
 <pattern>i4b5erla</pattern>
 <pattern>ibe5ros</pattern>
+<pattern>i4b5er4sc</pattern>
 <pattern>ibe4ru</pattern>
 <pattern>ibe2s</pattern>
 <pattern>i4be5sen</pattern>
@@ -15951,24 +16428,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4b3leu</pattern>
 <pattern>i2bli</pattern>
 <pattern>ib3lic</pattern>
-<pattern>ib2o</pattern>
 <pattern>i3bor</pattern>
 <pattern>i4b3ort</pattern>
 <pattern>i2böl</pattern>
 <pattern>ib2r</pattern>
 <pattern>i4brat</pattern>
-<pattern>i4b3rea</pattern>
 <pattern>ibre3c</pattern>
 <pattern>i4b3roc</pattern>
 <pattern>ib3rol</pattern>
 <pattern>ibrö2</pattern>
-<pattern>ib3röc</pattern>
+<pattern>i4b3röc</pattern>
 <pattern>ib4ser</pattern>
 <pattern>ib3s4kl</pattern>
 <pattern>ib3sta</pattern>
 <pattern>ib5stel</pattern>
 <pattern>ib3sti</pattern>
 <pattern>ib3str</pattern>
+<pattern>ib3stu</pattern>
 <pattern>i4b3unk</pattern>
 <pattern>i4bunt</pattern>
 <pattern>ibus3c</pattern>
@@ -15981,6 +16457,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ice1</pattern>
 <pattern>ice3i</pattern>
 <pattern>ich3ac</pattern>
+<pattern>ich3ag</pattern>
 <pattern>ich3al4</pattern>
 <pattern>ich3an</pattern>
 <pattern>ich3ar4</pattern>
@@ -16004,24 +16481,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ichser4</pattern>
 <pattern>ich6s5ern</pattern>
 <pattern>ich4si</pattern>
-<pattern>ichs5or</pattern>
+<pattern>ich4s5or</pattern>
 <pattern>ich4spo</pattern>
 <pattern>ich5stä</pattern>
 <pattern>ich4sto</pattern>
+<pattern>ich5stri</pattern>
 <pattern>i4cht</pattern>
 <pattern>icht5eig</pattern>
 <pattern>ich7ten </pattern>
 <pattern>ich4t5in4</pattern>
-<pattern>ich4tr</pattern>
 <pattern>ichtra4</pattern>
-<pattern>icht5rat</pattern>
+<pattern>ich6t5rat</pattern>
+<pattern>ich4tro</pattern>
 <pattern>ich3uf</pattern>
 <pattern>i4chur</pattern>
 <pattern>ich3w</pattern>
 <pattern>ichzu3</pattern>
 <pattern>i1ci</pattern>
-<pattern>i4ckad</pattern>
-<pattern>ic3kos</pattern>
+<pattern>ic3k4os</pattern>
 <pattern>ick3s4k</pattern>
 <pattern>ick3sp</pattern>
 <pattern>ick5sta</pattern>
@@ -16050,11 +16527,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i2def</pattern>
 <pattern>i2deh</pattern>
 <pattern>i2dei</pattern>
+<pattern>ide5inst</pattern>
 <pattern>i2de3k</pattern>
 <pattern>i4de3la</pattern>
 <pattern>i4de3lä</pattern>
 <pattern>i4de5lei</pattern>
 <pattern>i4de3li</pattern>
+<pattern>i4dema</pattern>
 <pattern>i4deme</pattern>
 <pattern>ide4mi</pattern>
 <pattern>ide4mo</pattern>
@@ -16062,7 +16541,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4de5nad</pattern>
 <pattern>iden3g</pattern>
 <pattern>iden3o</pattern>
-<pattern>iden4se</pattern>
 <pattern>iden5str</pattern>
 <pattern>4identz</pattern>
 <pattern>iden4zi</pattern>
@@ -16071,17 +16549,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4de5rau</pattern>
 <pattern>i4derä</pattern>
 <pattern>ide4rel</pattern>
+<pattern>i6derfah</pattern>
 <pattern>i4derfü</pattern>
 <pattern>ider6fül</pattern>
 <pattern>4iderk</pattern>
 <pattern>ide5ros</pattern>
 <pattern>i4de3rö</pattern>
-<pattern>i6d5er6reg</pattern>
 <pattern>i4desa</pattern>
 <pattern>i4dese</pattern>
 <pattern>ide5sen</pattern>
 <pattern>i4de3si</pattern>
-<pattern>i4de3so</pattern>
+<pattern>i4deso</pattern>
 <pattern>i4de3s4p</pattern>
 <pattern>i4de5sta</pattern>
 <pattern>i4destä</pattern>
@@ -16099,7 +16577,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3dis</pattern>
 <pattern>i2div</pattern>
 <pattern>idi5ven</pattern>
-<pattern>i3d2j</pattern>
 <pattern>i3dod</pattern>
 <pattern>i2dol</pattern>
 <pattern>3idol </pattern>
@@ -16110,7 +16587,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3dot</pattern>
 <pattern>i2d1r</pattern>
 <pattern>id4ro</pattern>
-<pattern>id2ru</pattern>
+<pattern>id4san</pattern>
 <pattern>id2sh</pattern>
 <pattern>id2sk</pattern>
 <pattern>id1t</pattern>
@@ -16124,19 +16601,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ie4bee</pattern>
 <pattern>ie4beka</pattern>
 <pattern>iebe5la</pattern>
-<pattern>iebe5ner</pattern>
 <pattern>iebe5ur</pattern>
-<pattern>ieb3l</pattern>
+<pattern>ie2b3l</pattern>
+<pattern>ie3blä</pattern>
+<pattern>ie4bs</pattern>
 <pattern>ieb4sen</pattern>
 <pattern>ieb4so</pattern>
+<pattern>ie4bt</pattern>
 <pattern>ie3che</pattern>
 <pattern>ie3chi</pattern>
-<pattern>iech3o</pattern>
+<pattern>ie4ch3o</pattern>
 <pattern>ie4d3an</pattern>
+<pattern>ie4db</pattern>
 <pattern>ie4dem</pattern>
 <pattern>ieden6sc</pattern>
 <pattern>ie4dep</pattern>
+<pattern>ie4dg</pattern>
+<pattern>ie4dm</pattern>
 <pattern>ie2dr</pattern>
+<pattern>ie4ds</pattern>
+<pattern>ie4dv</pattern>
+<pattern>ie4dw</pattern>
 <pattern>ie1e2</pattern>
 <pattern>ieer2</pattern>
 <pattern>ief3ad</pattern>
@@ -16147,13 +16632,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ie3fäl</pattern>
 <pattern>iefe4m</pattern>
 <pattern>ief5emi</pattern>
-<pattern>ie5fer</pattern>
 <pattern>ief3f</pattern>
 <pattern>ief3l</pattern>
 <pattern>ie3flü</pattern>
 <pattern>ie4fonk</pattern>
 <pattern>ief5rea</pattern>
 <pattern>ie4f3ro</pattern>
+<pattern>ie4fs</pattern>
+<pattern>ie4ft</pattern>
 <pattern>ief3ta</pattern>
 <pattern>ie3fun</pattern>
 <pattern>ie4gem</pattern>
@@ -16171,6 +16657,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ie1h</pattern>
 <pattern>ieh5eis</pattern>
 <pattern>ie4h3in</pattern>
+<pattern>ieh3la</pattern>
 <pattern>iehr4</pattern>
 <pattern>i1ei2</pattern>
 <pattern>iei4c</pattern>
@@ -16182,7 +16669,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ie3kr</pattern>
 <pattern>iela4</pattern>
 <pattern>ielab4</pattern>
-<pattern>ie3l4am</pattern>
 <pattern>ie3län</pattern>
 <pattern>iel3äs</pattern>
 <pattern>ield4</pattern>
@@ -16228,18 +16714,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ie3lü</pattern>
 <pattern>ie3ma</pattern>
 <pattern>ie3mä</pattern>
-<pattern>i5emeti</pattern>
+<pattern>ie4mc</pattern>
+<pattern>i5e4meti</pattern>
 <pattern>iemi2</pattern>
+<pattern>ie3mo</pattern>
 <pattern>iena2</pattern>
-<pattern>ie3n4ac</pattern>
 <pattern>ien3ag</pattern>
 <pattern>ie3nam</pattern>
 <pattern>ie4neb</pattern>
-<pattern>ie4neh</pattern>
+<pattern>ien3ec</pattern>
 <pattern>ien5ekl</pattern>
 <pattern>ien5erwe</pattern>
-<pattern>ien5eta</pattern>
+<pattern>ienes4</pattern>
+<pattern>ien5e4ve</pattern>
 <pattern>ien3g2</pattern>
+<pattern>iengene5</pattern>
 <pattern>ieni3c</pattern>
 <pattern>ie4n3im</pattern>
 <pattern>ien3in4</pattern>
@@ -16251,10 +16740,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iense5rin</pattern>
 <pattern>ien3s4k</pattern>
 <pattern>ien3s4p</pattern>
+<pattern>ienst5än</pattern>
 <pattern>ienst5ein</pattern>
 <pattern>iens6ter</pattern>
 <pattern>ienst5erl</pattern>
+<pattern>ienst5erw</pattern>
 <pattern>ienst5op</pattern>
+<pattern>ienst5or</pattern>
 <pattern>ienst5rän</pattern>
 <pattern>ienst5ri</pattern>
 <pattern>ien3sz</pattern>
@@ -16278,6 +16770,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iera2</pattern>
 <pattern>ier3ab4</pattern>
 <pattern>ierad4</pattern>
+<pattern>ier3ae</pattern>
 <pattern>ier3af</pattern>
 <pattern>ie3rah</pattern>
 <pattern>ier3al</pattern>
@@ -16290,11 +16783,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i5er4ben</pattern>
 <pattern>ier5eck</pattern>
 <pattern>ier6eini</pattern>
-<pattern>ier5emi</pattern>
+<pattern>ier5e4mi</pattern>
 <pattern>ie4ret</pattern>
 <pattern>ie4reu</pattern>
-<pattern>ier3g</pattern>
-<pattern>ier3id</pattern>
+<pattern>ie4r3id</pattern>
 <pattern>ie4r3il</pattern>
 <pattern>ie4r5in4g</pattern>
 <pattern>ierk2</pattern>
@@ -16306,6 +16798,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ier3ni</pattern>
 <pattern>i3erns</pattern>
 <pattern>ier5obe</pattern>
+<pattern>ie5robo</pattern>
 <pattern>ie3roh</pattern>
 <pattern>ie3ron</pattern>
 <pattern>ier3ö</pattern>
@@ -16328,15 +16821,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3erzg</pattern>
 <pattern>i3erzl</pattern>
 <pattern>ie4s3au</pattern>
-<pattern>ie3s4e</pattern>
 <pattern>ies5ein</pattern>
+<pattern>ie3sek</pattern>
+<pattern>ie3s4el</pattern>
+<pattern>ie3sem</pattern>
+<pattern>ie3sen</pattern>
 <pattern>iesend4</pattern>
 <pattern>iesen5s4</pattern>
+<pattern>ie3ser</pattern>
+<pattern>ie3ses</pattern>
 <pattern>ie2sk</pattern>
 <pattern>ie3ska</pattern>
 <pattern>ies4ko</pattern>
-<pattern>ie3sol</pattern>
+<pattern>ie4sl</pattern>
 <pattern>ie3sp</pattern>
+<pattern>ie4ss</pattern>
 <pattern>ies4sel</pattern>
 <pattern>ies6s5ent</pattern>
 <pattern>ies6s5erl</pattern>
@@ -16350,12 +16849,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ieta2</pattern>
 <pattern>iet3ak4</pattern>
 <pattern>ie3tal</pattern>
-<pattern>iet5ang</pattern>
+<pattern>iet5an4g</pattern>
 <pattern>iet5ans</pattern>
+<pattern>iet5anz</pattern>
 <pattern>iet3ap</pattern>
 <pattern>ie3tas</pattern>
 <pattern>iet5ent</pattern>
 <pattern>iet5ert</pattern>
+<pattern>iet5hel</pattern>
 <pattern>iet5her</pattern>
 <pattern>iet3ho</pattern>
 <pattern>ietin4</pattern>
@@ -16366,10 +16867,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iet5räu</pattern>
 <pattern>iet5ren</pattern>
 <pattern>iet3ri</pattern>
-<pattern>iet5str</pattern>
+<pattern>ietru4</pattern>
+<pattern>iet5rud</pattern>
+<pattern>ie4ts</pattern>
 <pattern>i3ett</pattern>
 <pattern>ietz4a</pattern>
 <pattern>iet3zw</pattern>
+<pattern>ie3uh</pattern>
 <pattern>ie3um2</pattern>
 <pattern>ie3un2</pattern>
 <pattern>ieur3a</pattern>
@@ -16396,9 +16900,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4felem</pattern>
 <pattern>ifel4s5o</pattern>
 <pattern>ife2m</pattern>
-<pattern>i3fe2n</pattern>
+<pattern>ife2n</pattern>
 <pattern>ifen3e</pattern>
 <pattern>ife3ra</pattern>
+<pattern>if3er4f</pattern>
 <pattern>i4ferg</pattern>
 <pattern>if3erh</pattern>
 <pattern>ifes5tat</pattern>
@@ -16406,7 +16911,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iff3l</pattern>
 <pattern>if3flu</pattern>
 <pattern>if4fro</pattern>
+<pattern>if4f3rü</pattern>
 <pattern>iff4sen</pattern>
+<pattern>iffs5et</pattern>
 <pattern>iff4sid</pattern>
 <pattern>iff4spe</pattern>
 <pattern>iff4spr</pattern>
@@ -16428,7 +16935,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iflo3c</pattern>
 <pattern>i3flug</pattern>
 <pattern>i3flü</pattern>
-<pattern>ifo2</pattern>
 <pattern>i2fö</pattern>
 <pattern>if1r</pattern>
 <pattern>i3freu</pattern>
@@ -16436,11 +16942,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3fron</pattern>
 <pattern>if3sa</pattern>
 <pattern>ift3a</pattern>
+<pattern>ift3ed</pattern>
 <pattern>ift3ef</pattern>
 <pattern>if4t3ei4</pattern>
 <pattern>ift3ep</pattern>
 <pattern>if4t5erk</pattern>
 <pattern>ift5erl</pattern>
+<pattern>ifter4s</pattern>
 <pattern>ift5erz</pattern>
 <pattern>ifte4s</pattern>
 <pattern>ift5esc</pattern>
@@ -16477,6 +16985,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4gebet</pattern>
 <pattern>ige4bie</pattern>
 <pattern>ige6bild</pattern>
+<pattern>ige4bl</pattern>
 <pattern>ige4br</pattern>
 <pattern>i6gebrau</pattern>
 <pattern>ige4bu</pattern>
@@ -16513,6 +17022,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ige4mis</pattern>
 <pattern>i4gemo</pattern>
 <pattern>i4gemö</pattern>
+<pattern>igen5eb</pattern>
 <pattern>i4genem</pattern>
 <pattern>ige6nene</pattern>
 <pattern>igene5ra</pattern>
@@ -16521,6 +17031,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4genn</pattern>
 <pattern>i4gensc</pattern>
 <pattern>i5genschal</pattern>
+<pattern>i4gentu</pattern>
+<pattern>i4gentü</pattern>
 <pattern>i4genu</pattern>
 <pattern>ige4pä</pattern>
 <pattern>igepä5cke</pattern>
@@ -16528,8 +17040,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4gepr</pattern>
 <pattern>igeran4</pattern>
 <pattern>ige4re5d</pattern>
+<pattern>iger4fa</pattern>
 <pattern>ige4ric</pattern>
 <pattern>i4gero</pattern>
+<pattern>ige4ruc</pattern>
 <pattern>ige4ruf</pattern>
 <pattern>i4ge3rü</pattern>
 <pattern>ige2s2</pattern>
@@ -16549,6 +17063,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4gezu</pattern>
 <pattern>i4gezü</pattern>
 <pattern>iggas5t</pattern>
+<pattern>igh3s</pattern>
 <pattern>i1gi</pattern>
 <pattern>i2g3im2</pattern>
 <pattern>ig3ins</pattern>
@@ -16562,12 +17077,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ig3les</pattern>
 <pattern>ig3lim</pattern>
 <pattern>ign3ag</pattern>
-<pattern>ignei4</pattern>
+<pattern>ign3ei4</pattern>
 <pattern>i6gnerge</pattern>
 <pattern>i3g4neu</pattern>
 <pattern>i3gog</pattern>
+<pattern>ig3oli</pattern>
 <pattern>igo2n</pattern>
-<pattern>ig4o3p</pattern>
+<pattern>igo3p</pattern>
 <pattern>i3gos</pattern>
 <pattern>i4grams</pattern>
 <pattern>i2grä</pattern>
@@ -16581,6 +17097,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ig3s4ag</pattern>
 <pattern>ig3sar</pattern>
 <pattern>ig4s5cha</pattern>
+<pattern>ig3sem</pattern>
+<pattern>igs2i</pattern>
+<pattern>igsin5</pattern>
 <pattern>ig3s4or</pattern>
 <pattern>ig3s4pe</pattern>
 <pattern>ig3spr</pattern>
@@ -16590,7 +17109,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>igs6tras</pattern>
 <pattern>ig4stür</pattern>
 <pattern>ig4tin</pattern>
-<pattern>ig4t3re</pattern>
 <pattern>i2gü</pattern>
 <pattern>i1gy</pattern>
 <pattern>igzu3</pattern>
@@ -16608,11 +17126,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ihe3in4</pattern>
 <pattern>i2hek</pattern>
 <pattern>ih3el4t</pattern>
-<pattern>i2hem</pattern>
 <pattern>ihe2n</pattern>
 <pattern>ihenk4</pattern>
 <pattern>ihen3s4</pattern>
-<pattern>i2hep</pattern>
+<pattern>ih3ent</pattern>
 <pattern>ihe3s</pattern>
 <pattern>i4hest</pattern>
 <pattern>i2he3u</pattern>
@@ -16629,29 +17146,28 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ihu2</pattern>
 <pattern>i4h3um </pattern>
 <pattern>ih3w</pattern>
-<pattern>ii2</pattern>
 <pattern>i1ia</pattern>
-<pattern>i3ic</pattern>
-<pattern>i1id</pattern>
+<pattern>i3i2c</pattern>
+<pattern>i1i2d</pattern>
 <pattern>i1ie</pattern>
-<pattern>ii3h</pattern>
+<pattern>ii2g</pattern>
+<pattern>ii3gi4</pattern>
 <pattern>i1im2</pattern>
 <pattern>iimpe4</pattern>
 <pattern>i1in2</pattern>
-<pattern>ii4ns</pattern>
-<pattern>i1ir</pattern>
-<pattern>i1is</pattern>
-<pattern>ii3to</pattern>
+<pattern>i1i2r</pattern>
+<pattern>i1i2s</pattern>
 <pattern>1ijs</pattern>
 <pattern>i4ka </pattern>
 <pattern>ikab2</pattern>
 <pattern>ika6ben</pattern>
-<pattern>ik5abla</pattern>
 <pattern>ik5ablä</pattern>
+<pattern>i2kac</pattern>
 <pattern>i4kada</pattern>
 <pattern>ika5del</pattern>
 <pattern>i2kae</pattern>
 <pattern>i2kaf</pattern>
+<pattern>ika4gen</pattern>
 <pattern>i2kah</pattern>
 <pattern>ika3in</pattern>
 <pattern>i2kak2</pattern>
@@ -16678,12 +17194,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i2kau</pattern>
 <pattern>ik3aus</pattern>
 <pattern>i3kaz</pattern>
-<pattern>i2k3äh</pattern>
+<pattern>i2käh</pattern>
 <pattern>i2k3är</pattern>
 <pattern>i1ke</pattern>
 <pattern>ik3ebe</pattern>
 <pattern>ik3e2d</pattern>
 <pattern>ik3ei4m</pattern>
+<pattern>ikei4n3</pattern>
 <pattern>ike4l</pattern>
 <pattern>ike2n</pattern>
 <pattern>iken3e</pattern>
@@ -16725,7 +17242,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iko3ma</pattern>
 <pattern>iko3nu</pattern>
 <pattern>iko3pa</pattern>
-<pattern>iko3pt</pattern>
 <pattern>ik3o4ri</pattern>
 <pattern>iko5sem</pattern>
 <pattern>iko5sen</pattern>
@@ -16734,6 +17250,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ik3öf2</pattern>
 <pattern>ik3öl</pattern>
 <pattern>ik3rea</pattern>
+<pattern>ik3red</pattern>
 <pattern>ik3res</pattern>
 <pattern>ik3rin</pattern>
 <pattern>ikro3m</pattern>
@@ -16748,10 +17265,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ikt5er4z</pattern>
 <pattern>ik4t5esk</pattern>
 <pattern>ikt3o4b</pattern>
-<pattern>ikt5res</pattern>
+<pattern>ik4t5res</pattern>
 <pattern>i4k3umf</pattern>
 <pattern>i4k3unf</pattern>
 <pattern>i2kup</pattern>
+<pattern>i2k3u2t</pattern>
 <pattern>i3kür</pattern>
 <pattern>2il</pattern>
 <pattern>ila2b2</pattern>
@@ -16770,6 +17288,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>il3anm</pattern>
 <pattern>il3ano</pattern>
 <pattern>il3an4s</pattern>
+<pattern>il3ant</pattern>
 <pattern>ilan4w</pattern>
 <pattern>ilan6zer</pattern>
 <pattern>ilar2</pattern>
@@ -16781,27 +17300,30 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>il5aufl</pattern>
 <pattern>ilauf6ruf </pattern>
 <pattern>il5auft</pattern>
+<pattern>il5aufw</pattern>
 <pattern>il5aufz</pattern>
 <pattern>ilau4g</pattern>
 <pattern>il3aus</pattern>
 <pattern>i1lä2</pattern>
 <pattern>i2l3är</pattern>
 <pattern>ilbe3l</pattern>
-<pattern>ilch3a</pattern>
+<pattern>ilch5au</pattern>
 <pattern>il5chen </pattern>
 <pattern>ilch3o</pattern>
 <pattern>ilch3r</pattern>
 <pattern>ilch3t</pattern>
 <pattern>ilda4t</pattern>
+<pattern>ild5au </pattern>
 <pattern>il2dä</pattern>
 <pattern>ild5ebe</pattern>
 <pattern>ild3ed</pattern>
 <pattern>ildei4</pattern>
+<pattern>ild5ele</pattern>
 <pattern>il6dense</pattern>
 <pattern>il4d5en4t</pattern>
-<pattern>ilder6ha</pattern>
 <pattern>ild5ese</pattern>
 <pattern>il4d5ess</pattern>
+<pattern>ildi2</pattern>
 <pattern>il4did</pattern>
 <pattern>il4dil</pattern>
 <pattern>ildin4</pattern>
@@ -16831,6 +17353,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4le5nam</pattern>
 <pattern>ilenen6d</pattern>
 <pattern>ilen5st</pattern>
+<pattern>il5entb</pattern>
 <pattern>i4l5ente</pattern>
 <pattern>il5entf</pattern>
 <pattern>i4l5entl</pattern>
@@ -16843,13 +17366,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i6lergeb</pattern>
 <pattern>i4l5erhe</pattern>
 <pattern>i3leri</pattern>
-<pattern>i4l5erkl</pattern>
+<pattern>i4l5er4kl</pattern>
 <pattern>i4l5erla</pattern>
 <pattern>i4l5erlö</pattern>
+<pattern>i6l5er6sta</pattern>
 <pattern>i4l5erwä</pattern>
-<pattern>i6l5erwei</pattern>
-<pattern>i5lerz</pattern>
 <pattern>i4le3se</pattern>
+<pattern>i4lesp</pattern>
 <pattern>i4le5sta</pattern>
 <pattern>ile4ta</pattern>
 <pattern>i4l3eur</pattern>
@@ -16862,7 +17385,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>il5fen </pattern>
 <pattern>il4fere</pattern>
 <pattern>il4fet</pattern>
-<pattern>ilf4s3</pattern>
+<pattern>ilfs3</pattern>
+<pattern>ilf4st</pattern>
 <pattern>ilga3m</pattern>
 <pattern>ilge2</pattern>
 <pattern>ilgene5r</pattern>
@@ -16898,13 +17422,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>illzu3</pattern>
 <pattern>ilm5age</pattern>
 <pattern>il4mak</pattern>
-<pattern>il4mal</pattern>
 <pattern>il4mam</pattern>
 <pattern>ilmange5</pattern>
 <pattern>ilm5ans</pattern>
 <pattern>il4m3ap</pattern>
 <pattern>ilm5att</pattern>
-<pattern>il4m3au</pattern>
 <pattern>ilm5ein</pattern>
 <pattern>ilm5ent</pattern>
 <pattern>il4m5enz</pattern>
@@ -16932,6 +17454,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>il5stemp</pattern>
 <pattern>il5stern</pattern>
 <pattern>il3sti</pattern>
+<pattern>ils4to</pattern>
 <pattern>i1lu2</pattern>
 <pattern>i2l3um</pattern>
 <pattern>i2l3ur</pattern>
@@ -16946,6 +17469,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>im3abl</pattern>
 <pattern>im3abr</pattern>
 <pattern>im2ad</pattern>
+<pattern>i2maf</pattern>
 <pattern>i4mage</pattern>
 <pattern>ima3gi</pattern>
 <pattern>i2ma3i</pattern>
@@ -16976,6 +17500,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>im3br</pattern>
 <pattern>i1me</pattern>
 <pattern>im5eins</pattern>
+<pattern>im5ein4w</pattern>
 <pattern>i4m3ele</pattern>
 <pattern>i4m3elf</pattern>
 <pattern>i4mens</pattern>
@@ -16991,7 +17516,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>imhau4</pattern>
 <pattern>i1mi</pattern>
 <pattern>i2mia</pattern>
-<pattern>i2mi2d</pattern>
+<pattern>imi2d</pattern>
 <pattern>i2mik</pattern>
 <pattern>i2m3im</pattern>
 <pattern>i4m3inf</pattern>
@@ -16999,9 +17524,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4mi3se4</pattern>
 <pattern>imi3tr</pattern>
 <pattern>imman4</pattern>
-<pattern>imm3ap</pattern>
 <pattern>im4m3au</pattern>
-<pattern>im4mei</pattern>
+<pattern>im4m3ei</pattern>
 <pattern>im3me4n</pattern>
 <pattern>immen5e</pattern>
 <pattern>im6mense</pattern>
@@ -17012,6 +17536,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>im5mern</pattern>
 <pattern>imm3id</pattern>
 <pattern>im4m3or</pattern>
+<pattern>5immuni</pattern>
 <pattern>i4mo </pattern>
 <pattern>im3ob</pattern>
 <pattern>imo5nad</pattern>
@@ -17045,7 +17570,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3mut</pattern>
 <pattern>imy2</pattern>
 <pattern>imzu3</pattern>
-<pattern>imzu4l</pattern>
 <pattern>2in </pattern>
 <pattern>2ina</pattern>
 <pattern>4i4na </pattern>
@@ -17056,11 +17580,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in4abz</pattern>
 <pattern>in5ach </pattern>
 <pattern>in3ack</pattern>
+<pattern>in3aer</pattern>
 <pattern>ina3ha</pattern>
 <pattern>inahe3</pattern>
-<pattern>in3aho</pattern>
 <pattern>i4nak</pattern>
-<pattern>ina4l5in4</pattern>
+<pattern>4inal</pattern>
+<pattern>inalin4</pattern>
+<pattern>ina6l5ins</pattern>
 <pattern>inam2</pattern>
 <pattern>inama5r</pattern>
 <pattern>in3amb</pattern>
@@ -17106,9 +17632,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in4desä</pattern>
 <pattern>in4desc</pattern>
 <pattern>in4desi</pattern>
-<pattern>inde5spa</pattern>
-<pattern>inde5spo</pattern>
-<pattern>inde5spr</pattern>
 <pattern>5index </pattern>
 <pattern>5indexe</pattern>
 <pattern>in4dh</pattern>
@@ -17125,6 +17648,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in4drec</pattern>
 <pattern>ind4spe</pattern>
 <pattern>ind4sta</pattern>
+<pattern>3induk</pattern>
 <pattern>3indus</pattern>
 <pattern>ind2ü</pattern>
 <pattern>i4ne </pattern>
@@ -17139,6 +17663,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ine3el</pattern>
 <pattern>i3neen</pattern>
 <pattern>in3eff</pattern>
+<pattern>ine4g</pattern>
 <pattern>i2neh</pattern>
 <pattern>in5ehen</pattern>
 <pattern>i3nehm</pattern>
@@ -17149,9 +17674,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4nemi</pattern>
 <pattern>in3emp</pattern>
 <pattern>i4ne3nä</pattern>
-<pattern>ine4ner</pattern>
+<pattern>inens4</pattern>
 <pattern>i2neo2</pattern>
 <pattern>ine3p</pattern>
+<pattern>i5nerar</pattern>
 <pattern>i4n5erbi</pattern>
 <pattern>i6n5er6hal</pattern>
 <pattern>i4n5erhe</pattern>
@@ -17167,15 +17693,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iner6zen</pattern>
 <pattern>iner6zes</pattern>
 <pattern>iner6zeu</pattern>
+<pattern>i4nesim</pattern>
 <pattern>ine3sk</pattern>
 <pattern>i4neso</pattern>
 <pattern>i4nesp</pattern>
 <pattern>ines4s</pattern>
 <pattern>ines5sen </pattern>
-<pattern>i4nest</pattern>
+<pattern>i4n4est</pattern>
 <pattern>ine5str</pattern>
 <pattern>i4ne3ta</pattern>
 <pattern>i4neti</pattern>
+<pattern>ineu2</pattern>
+<pattern>ine3uf</pattern>
 <pattern>ine3un</pattern>
 <pattern>i2nev</pattern>
 <pattern>i2nez</pattern>
@@ -17185,8 +17714,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>infei3</pattern>
 <pattern>3infek</pattern>
 <pattern>3infiz</pattern>
+<pattern>5influe</pattern>
 <pattern>3info </pattern>
-<pattern>inf4r</pattern>
+<pattern>in5frag</pattern>
 <pattern>4in3fre</pattern>
 <pattern>inga2</pattern>
 <pattern>ing3af4</pattern>
@@ -17197,7 +17727,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ingela4</pattern>
 <pattern>in5gen </pattern>
 <pattern>inge4t</pattern>
-<pattern>in4g3im</pattern>
 <pattern>in5g4ler</pattern>
 <pattern>ing3n</pattern>
 <pattern>ing3or</pattern>
@@ -17216,7 +17745,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ini3ck</pattern>
 <pattern>i4nie </pattern>
 <pattern>ini5ern</pattern>
-<pattern>in4ig</pattern>
 <pattern>ini3ga</pattern>
 <pattern>ini5kri</pattern>
 <pattern>ini3l</pattern>
@@ -17226,7 +17754,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3niq</pattern>
 <pattern>i4nisa</pattern>
 <pattern>ini3se</pattern>
-<pattern>ini3sk</pattern>
+<pattern>ini3s4k</pattern>
 <pattern>ini3sl</pattern>
 <pattern>i6nister</pattern>
 <pattern>i4nisz</pattern>
@@ -17238,17 +17766,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in4kav</pattern>
 <pattern>in3kel</pattern>
 <pattern>inkels6t</pattern>
-<pattern>in4k5en4t</pattern>
+<pattern>ink5ente</pattern>
 <pattern>ink5erd</pattern>
-<pattern>in4k5er4z</pattern>
+<pattern>inker4z</pattern>
 <pattern>ink4sin</pattern>
-<pattern>ink6spar</pattern>
 <pattern>ink2ü</pattern>
 <pattern>inla2</pattern>
 <pattern>2inn </pattern>
 <pattern>inna2</pattern>
 <pattern>4inne </pattern>
 <pattern>inne4n</pattern>
+<pattern>in6nenho</pattern>
+<pattern>in4nerh</pattern>
 <pattern>in4nerm</pattern>
 <pattern>in6nersc</pattern>
 <pattern>in4nerw</pattern>
@@ -17277,7 +17806,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>insch6l</pattern>
 <pattern>inschli5che</pattern>
 <pattern>inse2</pattern>
-<pattern>ins3eb</pattern>
+<pattern>ins5ebe</pattern>
 <pattern>ins5eke</pattern>
 <pattern>insem4</pattern>
 <pattern>ins5emb</pattern>
@@ -17287,6 +17816,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3insid</pattern>
 <pattern>inso4w</pattern>
 <pattern>in5s4por</pattern>
+<pattern>in5spre</pattern>
 <pattern>in5spri</pattern>
 <pattern>in5spru</pattern>
 <pattern>ins5tak</pattern>
@@ -17294,17 +17824,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in5stap</pattern>
 <pattern>in5stau</pattern>
 <pattern>in5stec</pattern>
-<pattern>ins6temp</pattern>
 <pattern>in5steu</pattern>
 <pattern>in5stie</pattern>
 <pattern>5instin</pattern>
 <pattern>ins4tip</pattern>
-<pattern>in3sto</pattern>
+<pattern>in5stoc</pattern>
+<pattern>in5stol</pattern>
 <pattern>in5strä</pattern>
 <pattern>in5strec</pattern>
 <pattern>inst5rol</pattern>
 <pattern>in5strom</pattern>
-<pattern>in5strö</pattern>
+<pattern>in3stu</pattern>
+<pattern>in4stun</pattern>
 <pattern>3insuf</pattern>
 <pattern>3in4su3l</pattern>
 <pattern>in4s5umw</pattern>
@@ -17313,13 +17844,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4insy</pattern>
 <pattern>ins4ze</pattern>
 <pattern>in3ta4</pattern>
-<pattern>in5tat</pattern>
 <pattern>intä2</pattern>
 <pattern>4inte </pattern>
 <pattern>3integ</pattern>
 <pattern>in3tei</pattern>
 <pattern>in4tel</pattern>
-<pattern>in4tent</pattern>
 <pattern>5interp</pattern>
 <pattern>inter7re</pattern>
 <pattern>in5tert</pattern>
@@ -17329,6 +17858,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>in3thr</pattern>
 <pattern>in3to</pattern>
 <pattern>into4n</pattern>
+<pattern>inton5s4</pattern>
 <pattern>4intö</pattern>
 <pattern>in5tön</pattern>
 <pattern>in5trä</pattern>
@@ -17339,12 +17869,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4nuf</pattern>
 <pattern>in3unz</pattern>
 <pattern>in3ver</pattern>
+<pattern>3inves</pattern>
 <pattern>in3vi</pattern>
 <pattern>4invo</pattern>
 <pattern>inz4el</pattern>
+<pattern>inzel5a</pattern>
 <pattern>inzel5e</pattern>
 <pattern>inzel6ler</pattern>
 <pattern>inze4m</pattern>
+<pattern>inzen3</pattern>
 <pattern>inz5int</pattern>
 <pattern>in3z4sc</pattern>
 <pattern>inzu4fi</pattern>
@@ -17375,7 +17908,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>io2j</pattern>
 <pattern>io3kr</pattern>
 <pattern>iok3s</pattern>
-<pattern>io3ku</pattern>
 <pattern>io1l</pattern>
 <pattern>io3lo2</pattern>
 <pattern>i3ols </pattern>
@@ -17409,10 +17941,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3o2pf</pattern>
 <pattern>i3opt</pattern>
 <pattern>ior3ak</pattern>
+<pattern>i3oral</pattern>
 <pattern>io3rat</pattern>
-<pattern>ior4e</pattern>
+<pattern>ior4e2</pattern>
 <pattern>ioreak4</pattern>
-<pattern>io5rei3</pattern>
+<pattern>io5rei</pattern>
 <pattern>ioren3</pattern>
 <pattern>i3or2g</pattern>
 <pattern>io3r2h</pattern>
@@ -17442,14 +17975,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ip3ein</pattern>
 <pattern>ipe5len</pattern>
 <pattern>ipe3li</pattern>
-<pattern>ipf4a</pattern>
 <pattern>i3pfan</pattern>
 <pattern>i3pi3el</pattern>
 <pattern>i3pie4n3</pattern>
+<pattern>ipir4</pattern>
 <pattern>ipli3</pattern>
 <pattern>ip2lu</pattern>
-<pattern>i2po3c</pattern>
-<pattern>i3pol</pattern>
+<pattern>ipo3c</pattern>
 <pattern>i2po3m</pattern>
 <pattern>ipo3si</pattern>
 <pattern>ip2pa</pattern>
@@ -17460,9 +17992,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ip4pos</pattern>
 <pattern>i1pr</pattern>
 <pattern>ip4sei</pattern>
+<pattern>ip2si</pattern>
 <pattern>ip2sp</pattern>
 <pattern>ips3tr</pattern>
-<pattern>ip4stü</pattern>
+<pattern>ip4s3tü</pattern>
 <pattern>ip3tas</pattern>
 <pattern>ip4ter4</pattern>
 <pattern>ipt5ers</pattern>
@@ -17489,7 +18022,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ir4ch3o</pattern>
 <pattern>ir2d</pattern>
 <pattern>i4re </pattern>
-<pattern>ire3b</pattern>
 <pattern>ire2d</pattern>
 <pattern>i3ree</pattern>
 <pattern>ire4fe</pattern>
@@ -17504,7 +18036,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i1ri</pattern>
 <pattern>iri5ern</pattern>
 <pattern>iri5ers </pattern>
-<pattern>ir4in</pattern>
+<pattern>i4r3in4t</pattern>
 <pattern>ir2k3l</pattern>
 <pattern>ir4k3or</pattern>
 <pattern>irks3c</pattern>
@@ -17529,7 +18061,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>irn3an4</pattern>
 <pattern>irn3au</pattern>
 <pattern>irner4</pattern>
-<pattern>irn5erf</pattern>
 <pattern>irn5erk</pattern>
 <pattern>irn5ers</pattern>
 <pattern>irn3o</pattern>
@@ -17544,6 +18075,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ir4ret</pattern>
 <pattern>ir4rig</pattern>
 <pattern>irsch5ar6</pattern>
+<pattern>irsch5au</pattern>
+<pattern>ir6schei</pattern>
 <pattern>ir4schl</pattern>
 <pattern>ir4sch5m</pattern>
 <pattern>ir4schn</pattern>
@@ -17554,6 +18087,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ir4st3r</pattern>
 <pattern>ir3ta</pattern>
 <pattern>ir4t3er4</pattern>
+<pattern>irt4s3e</pattern>
 <pattern>irt4s3t</pattern>
 <pattern>iru2f</pattern>
 <pattern>ir3um</pattern>
@@ -17582,7 +18116,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i2s3au2</pattern>
 <pattern>is4aue</pattern>
 <pattern>i2s3än</pattern>
-<pattern>is2är</pattern>
 <pattern>i2sca</pattern>
 <pattern>i2sce</pattern>
 <pattern>i4schab</pattern>
@@ -17590,6 +18123,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ischar4</pattern>
 <pattern>i4schäh</pattern>
 <pattern>isch5e4h</pattern>
+<pattern>isch5einh</pattern>
 <pattern>ische4m</pattern>
 <pattern>ische4n</pattern>
 <pattern>i4schep</pattern>
@@ -17598,7 +18132,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>isch5im</pattern>
 <pattern>i4schin</pattern>
 <pattern>isch5lap</pattern>
-<pattern>isch5lei</pattern>
 <pattern>isch5lin</pattern>
 <pattern>i4sch5ma</pattern>
 <pattern>i4schmä</pattern>
@@ -17609,14 +18142,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ischo5c</pattern>
 <pattern>ischot4</pattern>
 <pattern>i4schö</pattern>
-<pattern>isch5rip</pattern>
+<pattern>i6sch5rip</pattern>
 <pattern>isch5ru</pattern>
 <pattern>i4schüb</pattern>
 <pattern>i4schwo</pattern>
 <pattern>i4sch5wö</pattern>
 <pattern>isch5wun</pattern>
 <pattern>i4schwü</pattern>
-<pattern>i2s3cr</pattern>
+<pattern>i2scr</pattern>
 <pattern>2ise</pattern>
 <pattern>i4se </pattern>
 <pattern>is5e4ben</pattern>
@@ -17635,7 +18168,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3sekü</pattern>
 <pattern>ise5lad</pattern>
 <pattern>ise5lan</pattern>
-<pattern>is5elas</pattern>
 <pattern>i3seld</pattern>
 <pattern>i5sele </pattern>
 <pattern>ise5lei</pattern>
@@ -17665,6 +18197,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iserei4</pattern>
 <pattern>ise6r5eic</pattern>
 <pattern>is3erm</pattern>
+<pattern>iser4mi</pattern>
 <pattern>is5ernt</pattern>
 <pattern>i5sers </pattern>
 <pattern>i3serv</pattern>
@@ -17676,6 +18209,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i5sete </pattern>
 <pattern>i5seten</pattern>
 <pattern>i3setz</pattern>
+<pattern>i2seu</pattern>
 <pattern>isex2</pattern>
 <pattern>is4exi</pattern>
 <pattern>isgas3</pattern>
@@ -17685,6 +18219,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>is3imp</pattern>
 <pattern>i4sind</pattern>
 <pattern>i4s3in4f</pattern>
+<pattern>i3sing</pattern>
 <pattern>i4s3in4t</pattern>
 <pattern>isis4</pattern>
 <pattern>i4si3st</pattern>
@@ -17692,24 +18227,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>is4kis</pattern>
 <pattern>3islam</pattern>
 <pattern>4isli2</pattern>
+<pattern>i2so </pattern>
 <pattern>iso5den</pattern>
-<pattern>is3of2</pattern>
-<pattern>iso3l</pattern>
+<pattern>i2s3of2</pattern>
+<pattern>i2so3l</pattern>
 <pattern>i3sold</pattern>
 <pattern>iso3ma</pattern>
 <pattern>iso3me</pattern>
-<pattern>2i3son</pattern>
+<pattern>2ison</pattern>
 <pattern>isonen4</pattern>
 <pattern>iso6n5end</pattern>
 <pattern>isono4</pattern>
-<pattern>iso3s</pattern>
+<pattern>i2sop</pattern>
+<pattern>i4sori</pattern>
 <pattern>3isot</pattern>
-<pattern>is3ou</pattern>
-<pattern>is3ov</pattern>
+<pattern>i2s3ou</pattern>
+<pattern>i2s3ov</pattern>
 <pattern>iso2w</pattern>
 <pattern>2i1sö</pattern>
 <pattern>isö5ren</pattern>
 <pattern>2isp</pattern>
+<pattern>i3spal</pattern>
 <pattern>is3pan</pattern>
 <pattern>is3par</pattern>
 <pattern>is5peri</pattern>
@@ -17717,6 +18255,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>is3pic</pattern>
 <pattern>is3pir</pattern>
 <pattern>is4ple</pattern>
+<pattern>i3s4por</pattern>
 <pattern>i3spra</pattern>
 <pattern>is5pres</pattern>
 <pattern>i4spro</pattern>
@@ -17724,10 +18263,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>is3pü</pattern>
 <pattern>iss3ac</pattern>
 <pattern>iss5aus</pattern>
-<pattern>issens5p</pattern>
 <pattern>issens5tu</pattern>
 <pattern>issen6s5tü</pattern>
 <pattern>iss5erf</pattern>
+<pattern>is4s5erk</pattern>
 <pattern>iss5erz</pattern>
 <pattern>isse3t</pattern>
 <pattern>issi4l</pattern>
@@ -17736,18 +18275,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>isso3z</pattern>
 <pattern>iss4po</pattern>
 <pattern>is4stec</pattern>
+<pattern>is6steil</pattern>
 <pattern>i4st </pattern>
 <pattern>ist3a4c</pattern>
 <pattern>is3tal</pattern>
 <pattern>i5stand</pattern>
 <pattern>ist3ap</pattern>
+<pattern>is3tas</pattern>
 <pattern>i3s4tat</pattern>
 <pattern>ist5auf</pattern>
 <pattern>is3täu</pattern>
-<pattern>i2st4e</pattern>
+<pattern>i2ste</pattern>
 <pattern>i3steh</pattern>
 <pattern>ist5ein</pattern>
-<pattern>iste4n</pattern>
+<pattern>ist4e4n</pattern>
 <pattern>ister5a</pattern>
 <pattern>ister6ras</pattern>
 <pattern>ist4hal</pattern>
@@ -17791,6 +18332,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>iszuge5</pattern>
 <pattern>iszu3m</pattern>
 <pattern>i1ß</pattern>
+<pattern>i4ß3erk</pattern>
 <pattern>iß3erl</pattern>
 <pattern>iß5erse</pattern>
 <pattern>ißlich6t</pattern>
@@ -17818,7 +18360,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>itan5at</pattern>
 <pattern>it3an4g</pattern>
 <pattern>i3tank</pattern>
-<pattern>itan4z</pattern>
 <pattern>ita2p</pattern>
 <pattern>it3app</pattern>
 <pattern>it3arb</pattern>
@@ -17833,6 +18374,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>it5aus </pattern>
 <pattern>itauto6r</pattern>
 <pattern>i1tä</pattern>
+<pattern>i2t3äf</pattern>
 <pattern>it3än4d</pattern>
 <pattern>i2t3äs</pattern>
 <pattern>ität2</pattern>
@@ -17845,13 +18387,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>it3eff</pattern>
 <pattern>i2teg</pattern>
 <pattern>it3ehe</pattern>
-<pattern>it3ei4g</pattern>
+<pattern>itei4g</pattern>
+<pattern>it5eige</pattern>
 <pattern>it3ein</pattern>
 <pattern>i4t3eis</pattern>
 <pattern>i4tela</pattern>
 <pattern>itel5an</pattern>
 <pattern>itel3ä</pattern>
 <pattern>itelän4</pattern>
+<pattern>it5elef</pattern>
 <pattern>ite5le4g</pattern>
 <pattern>itel5eh4</pattern>
 <pattern>it5elek</pattern>
@@ -17864,6 +18408,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ite4n5er4</pattern>
 <pattern>i3tenn</pattern>
 <pattern>iten3s4</pattern>
+<pattern>i6tensem</pattern>
 <pattern>iten5th</pattern>
 <pattern>it5ents</pattern>
 <pattern>i2tep</pattern>
@@ -17887,10 +18432,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ite5spr</pattern>
 <pattern>ite5sta</pattern>
 <pattern>it3e4ti</pattern>
+<pattern>it3eva</pattern>
 <pattern>itgear4</pattern>
 <pattern>itgege4</pattern>
 <pattern>itgezo4</pattern>
 <pattern>i3tha </pattern>
+<pattern>i3t4ha3g</pattern>
 <pattern>it3hem</pattern>
 <pattern>ithi4u</pattern>
 <pattern>i2t3id</pattern>
@@ -17929,7 +18476,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>it3rah</pattern>
 <pattern>i3trak</pattern>
 <pattern>i3tram</pattern>
-<pattern>it4ran</pattern>
 <pattern>it5rand</pattern>
 <pattern>it5rang</pattern>
 <pattern>i5trans</pattern>
@@ -17949,6 +18495,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>it3roc</pattern>
 <pattern>it3rol</pattern>
 <pattern>it3rom</pattern>
+<pattern>i4trö</pattern>
 <pattern>it3ruc</pattern>
 <pattern>it3run</pattern>
 <pattern>it3rut</pattern>
@@ -17957,11 +18504,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>it4s3eh</pattern>
 <pattern>it4s5eif</pattern>
 <pattern>it4s5ein</pattern>
-<pattern>it4s3el</pattern>
 <pattern>it4s3es4</pattern>
 <pattern>its3id</pattern>
 <pattern>itska4</pattern>
-<pattern>it3sol</pattern>
 <pattern>its5tab</pattern>
 <pattern>it4staf</pattern>
 <pattern>it4stec</pattern>
@@ -17976,6 +18521,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ittä5gi</pattern>
 <pattern>it4tän</pattern>
 <pattern>itt3eb</pattern>
+<pattern>itt5eige</pattern>
+<pattern>it4t3il</pattern>
 <pattern>ittle5ri</pattern>
 <pattern>itt3o4b</pattern>
 <pattern>it4t3op</pattern>
@@ -18017,7 +18564,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2i1u2</pattern>
 <pattern>i2u3l</pattern>
 <pattern>ium1</pattern>
-<pattern>iuma2</pattern>
 <pattern>iuman4</pattern>
 <pattern>iumar4</pattern>
 <pattern>i2umb</pattern>
@@ -18026,11 +18572,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i2umh</pattern>
 <pattern>ium3i</pattern>
 <pattern>i2umk</pattern>
+<pattern>i2umm</pattern>
 <pattern>i4umsc</pattern>
-<pattern>iums5en4</pattern>
+<pattern>ium4s5en4</pattern>
 <pattern>ium4ste</pattern>
 <pattern>i2umt</pattern>
-<pattern>ium3u</pattern>
 <pattern>i2umv</pattern>
 <pattern>iun2</pattern>
 <pattern>iup2</pattern>
@@ -18069,7 +18615,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i4v3ind</pattern>
 <pattern>iv3ins</pattern>
 <pattern>i4v3int</pattern>
-<pattern>ivi3so</pattern>
 <pattern>i3vit</pattern>
 <pattern>i2vl</pattern>
 <pattern>ivo5len</pattern>
@@ -18105,6 +18650,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>i3zas</pattern>
 <pattern>iz3au</pattern>
 <pattern>i4zaus</pattern>
+<pattern>iz1ä</pattern>
 <pattern>i2zän</pattern>
 <pattern>ize3c</pattern>
 <pattern>izein4t</pattern>
@@ -18113,8 +18659,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ize3la</pattern>
 <pattern>i4zele</pattern>
 <pattern>ize2n</pattern>
+<pattern>izen3s</pattern>
 <pattern>i4z5entz</pattern>
 <pattern>i4zenz</pattern>
+<pattern>izen6zer</pattern>
+<pattern>izen4zw</pattern>
 <pattern>i4z3er4l</pattern>
 <pattern>i4z3er4r</pattern>
 <pattern>i4z5er4sc</pattern>
@@ -18144,6 +18693,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>izu3sp</pattern>
 <pattern>i2zwe</pattern>
 <pattern>i3zwec</pattern>
+<pattern>iz3wic</pattern>
 <pattern>i2zwö</pattern>
 <pattern>izzwe3</pattern>
 <pattern>í1</pattern>
@@ -18152,7 +18702,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ja </pattern>
 <pattern>ja1a</pattern>
 <pattern>jaal2</pattern>
-<pattern>jab2</pattern>
+<pattern>ja3b2</pattern>
 <pattern>ja2c</pattern>
 <pattern>jacht5s4</pattern>
 <pattern>ja1e</pattern>
@@ -18202,7 +18752,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>je2tä</pattern>
 <pattern>je2te</pattern>
 <pattern>je4t3in</pattern>
-<pattern>jet3s2</pattern>
+<pattern>jets2</pattern>
 <pattern>je2tu</pattern>
 <pattern>ji2</pattern>
 <pattern>2j1m</pattern>
@@ -18260,6 +18810,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2kab2d</pattern>
 <pattern>kabde3</pattern>
 <pattern>kabel5a</pattern>
+<pattern>kabel5i</pattern>
 <pattern>4k3aben</pattern>
 <pattern>ka3ber</pattern>
 <pattern>2kab2f</pattern>
@@ -18293,14 +18844,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ka4dez</pattern>
 <pattern>k3adm</pattern>
 <pattern>ka2do3</pattern>
-<pattern>2kadr</pattern>
+<pattern>2k3adr</pattern>
 <pattern>2kad2v</pattern>
 <pattern>ka1e</pattern>
 <pattern>2ka3fe</pattern>
 <pattern>k3af4fi</pattern>
 <pattern>ka3fl</pattern>
 <pattern>ka3fr</pattern>
-<pattern>kaf3t</pattern>
+<pattern>kaf3t4</pattern>
 <pattern>2kag2</pattern>
 <pattern>ka3ga</pattern>
 <pattern>k2age2</pattern>
@@ -18319,7 +18870,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ka3ken</pattern>
 <pattern>k3ak2k</pattern>
 <pattern>kakku3</pattern>
-<pattern>ka3k2l</pattern>
+<pattern>ka3kl</pattern>
 <pattern>4k3akt </pattern>
 <pattern>kak4ten</pattern>
 <pattern>4k3ak4ti</pattern>
@@ -18354,8 +18905,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kal3op</pattern>
 <pattern>kalori6e</pattern>
 <pattern>kal3os</pattern>
-<pattern>ka3lö</pattern>
+<pattern>4kalp </pattern>
 <pattern>4kalta</pattern>
+<pattern>k3altä</pattern>
 <pattern>kal4t5ex</pattern>
 <pattern>kal4th</pattern>
 <pattern>kal4tre</pattern>
@@ -18365,20 +18917,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kalva3</pattern>
 <pattern>2kama</pattern>
 <pattern>ka3mei</pattern>
-<pattern>kam4i</pattern>
 <pattern>kamp6f5en</pattern>
-<pattern>kamp6f5er6f</pattern>
-<pattern>kamp6ferp</pattern>
+<pattern>kamp6fer</pattern>
+<pattern>kampf5er6f</pattern>
 <pattern>kam2t</pattern>
 <pattern>k3amte</pattern>
+<pattern>kan3an</pattern>
 <pattern>kan3as</pattern>
 <pattern>4ka3nat</pattern>
 <pattern>kanäs3</pattern>
-<pattern>2k3an2b</pattern>
+<pattern>kan4bau</pattern>
 <pattern>kan3d</pattern>
 <pattern>4kanda</pattern>
 <pattern>kandal5a</pattern>
 <pattern>4kandä</pattern>
+<pattern>4kandin</pattern>
 <pattern>4k3an4dr</pattern>
 <pattern>kanen4</pattern>
 <pattern>ka4n5ent</pattern>
@@ -18434,8 +18987,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2k3arm</pattern>
 <pattern>karni3</pattern>
 <pattern>ka3ron</pattern>
+<pattern>ka3rö</pattern>
 <pattern>kar4pf</pattern>
 <pattern>k2ars</pattern>
+<pattern>k3arsc</pattern>
 <pattern>k4arta</pattern>
 <pattern>karten5</pattern>
 <pattern>k3arti</pattern>
@@ -18447,21 +19002,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4karui</pattern>
 <pattern>ka3rum</pattern>
 <pattern>ka3rü</pattern>
-<pattern>ka2s</pattern>
 <pattern>2kasa</pattern>
+<pattern>ka4sche</pattern>
+<pattern>kas4ei</pattern>
 <pattern>ka3sen</pattern>
 <pattern>ka3ses</pattern>
 <pattern>ka3sie</pattern>
-<pattern>ka3sis</pattern>
-<pattern>2ka3so</pattern>
-<pattern>kas3p</pattern>
-<pattern>kas4pr</pattern>
+<pattern>2kaso</pattern>
+<pattern>kas3pa</pattern>
+<pattern>kas3pe</pattern>
 <pattern>kass4a</pattern>
 <pattern>kas4sa5g</pattern>
 <pattern>kassen5</pattern>
 <pattern>kas3si</pattern>
 <pattern>kas4sis</pattern>
 <pattern>kasso3</pattern>
+<pattern>kas4sor</pattern>
 <pattern>4k3ast </pattern>
 <pattern>kas3ta</pattern>
 <pattern>4k5as4ter</pattern>
@@ -18469,13 +19025,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kas3tr</pattern>
 <pattern>4kastu</pattern>
 <pattern>ka3sz</pattern>
-<pattern>k2at</pattern>
 <pattern>kat3a4b</pattern>
 <pattern>katak4</pattern>
 <pattern>kat5akt</pattern>
 <pattern>kat5ans</pattern>
+<pattern>k2ate</pattern>
 <pattern>kat2h</pattern>
 <pattern>kat4mu</pattern>
+<pattern>k2ato</pattern>
 <pattern>kat3ri</pattern>
 <pattern>kat3tu</pattern>
 <pattern>katu3</pattern>
@@ -18486,19 +19043,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kau4f5er</pattern>
 <pattern>k5auffa</pattern>
 <pattern>k5aufga</pattern>
-<pattern>k5aufla</pattern>
+<pattern>4k5aufla</pattern>
 <pattern>k5aufli</pattern>
 <pattern>kau4f3o</pattern>
 <pattern>k3aufr</pattern>
 <pattern>kauf6s5ag</pattern>
+<pattern>kauf4s5e</pattern>
+<pattern>kaufsen6</pattern>
 <pattern>kauf4sp</pattern>
-<pattern>kau3g</pattern>
+<pattern>4k3aufw</pattern>
 <pattern>kaum2</pattern>
 <pattern>ka3umr</pattern>
 <pattern>k4aus </pattern>
 <pattern>kau3sa</pattern>
-<pattern>4kausg</pattern>
-<pattern>k3ausk</pattern>
+<pattern>4k3ausf</pattern>
+<pattern>4k3ausg</pattern>
 <pattern>4k3auss</pattern>
 <pattern>kaussen6</pattern>
 <pattern>4k3ausw</pattern>
@@ -18512,6 +19071,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ka2w</pattern>
 <pattern>2kaz</pattern>
 <pattern>1kä2</pattern>
+<pattern>k1äh</pattern>
 <pattern>käl4tel</pattern>
 <pattern>2k3ä3mi</pattern>
 <pattern>käm2t</pattern>
@@ -18562,8 +19122,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kehl3s</pattern>
 <pattern>ke3ho</pattern>
 <pattern>keh6rert</pattern>
+<pattern>keh6r5erz</pattern>
 <pattern>kehr4s5o</pattern>
 <pattern>kehr6s5po</pattern>
+<pattern>kehr6s5tu</pattern>
 <pattern>2k3ei4c</pattern>
 <pattern>2k3ei2g</pattern>
 <pattern>kei4l3i</pattern>
@@ -18590,7 +19152,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kel3au</pattern>
 <pattern>4keläd</pattern>
 <pattern>kel3än4</pattern>
-<pattern>keld4</pattern>
+<pattern>keld2</pattern>
 <pattern>ke2le</pattern>
 <pattern>kelei4</pattern>
 <pattern>kel5eim</pattern>
@@ -18618,7 +19180,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4kenac</pattern>
 <pattern>ken3au</pattern>
 <pattern>3kenä</pattern>
-<pattern>kend2</pattern>
+<pattern>3kenc</pattern>
+<pattern>4k3endg</pattern>
+<pattern>kend4s</pattern>
 <pattern>ken5dsc</pattern>
 <pattern>4kendst</pattern>
 <pattern>ke4n3eb</pattern>
@@ -18645,17 +19209,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4kenläd</pattern>
 <pattern>kenne5c</pattern>
 <pattern>5kennz</pattern>
+<pattern>ken3om</pattern>
 <pattern>ke3nos</pattern>
 <pattern>kenrevo5</pattern>
 <pattern>4kenru</pattern>
 <pattern>4k5ensem</pattern>
-<pattern>ken4s5or4</pattern>
 <pattern>ken3sp</pattern>
 <pattern>ken5stan</pattern>
 <pattern>ken5stap</pattern>
 <pattern>ken5s6tei</pattern>
-<pattern>kens5tur</pattern>
-<pattern>k5ente </pattern>
+<pattern>ken5s6temp</pattern>
+<pattern>4k5ente </pattern>
 <pattern>ken6ten </pattern>
 <pattern>ken6tene</pattern>
 <pattern>4k3entf</pattern>
@@ -18666,6 +19230,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4k3ents</pattern>
 <pattern>4kentw</pattern>
 <pattern>4k3entz</pattern>
+<pattern>kenwin4</pattern>
 <pattern>kenzu4g</pattern>
 <pattern>2ke1o2</pattern>
 <pattern>2kep</pattern>
@@ -18696,9 +19261,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kerer4</pattern>
 <pattern>ker5erd</pattern>
 <pattern>ke4rerk</pattern>
+<pattern>ke4r5ers</pattern>
 <pattern>ke4rerz</pattern>
 <pattern>4kerez</pattern>
-<pattern>4kerfe</pattern>
 <pattern>4kerfo</pattern>
 <pattern>ker6folg</pattern>
 <pattern>5kerfot</pattern>
@@ -18711,16 +19276,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ke6r5in6nu</pattern>
 <pattern>4kerken</pattern>
 <pattern>kerla5ken</pattern>
+<pattern>k5erlau</pattern>
 <pattern>ker4leb</pattern>
 <pattern>ker3m</pattern>
-<pattern>ker4mit</pattern>
 <pattern>ker4nar</pattern>
 <pattern>ker6nere</pattern>
-<pattern>4k5er4neu</pattern>
-<pattern>ker4nie</pattern>
+<pattern>ker6ners</pattern>
+<pattern>ker6neur</pattern>
+<pattern>k5er4nie</pattern>
 <pattern>kern3o</pattern>
 <pattern>4kerod</pattern>
 <pattern>ke5rode</pattern>
+<pattern>2k3er2ö</pattern>
 <pattern>4kerpf</pattern>
 <pattern>4kerpl</pattern>
 <pattern>k6erren</pattern>
@@ -18734,7 +19301,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4k3erz </pattern>
 <pattern>4kerza</pattern>
 <pattern>4kerzä</pattern>
-<pattern>ker4zes</pattern>
+<pattern>4k5er4zes</pattern>
 <pattern>k5er6zeugu</pattern>
 <pattern>4kerzi</pattern>
 <pattern>kerzu4</pattern>
@@ -18762,7 +19329,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2keth</pattern>
 <pattern>ketin4</pattern>
 <pattern>ket3r</pattern>
-<pattern>ket3st</pattern>
 <pattern>ketter4</pattern>
 <pattern>ket6t5erz</pattern>
 <pattern>2ketu</pattern>
@@ -18788,15 +19354,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kgla3</pattern>
 <pattern>kg4lo</pattern>
 <pattern>k2gog</pattern>
-<pattern>k3gu</pattern>
 <pattern>2k1h</pattern>
 <pattern>kha2</pattern>
-<pattern>kh4au</pattern>
 <pattern>khis3</pattern>
 <pattern>kho2</pattern>
 <pattern>2ki </pattern>
 <pattern>2ki1a</pattern>
 <pattern>ki2ad</pattern>
+<pattern>ki2ag</pattern>
 <pattern>kian2</pattern>
 <pattern>ki3ar</pattern>
 <pattern>2kicl</pattern>
@@ -18807,6 +19372,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kiel3i</pattern>
 <pattern>kiel3o</pattern>
 <pattern>4ki3ern</pattern>
+<pattern>kie4so</pattern>
 <pattern>kie4s3p</pattern>
 <pattern>2kiez</pattern>
 <pattern>kie4ze</pattern>
@@ -18846,6 +19412,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kin4ha</pattern>
 <pattern>2kini3</pattern>
 <pattern>ki5nis </pattern>
+<pattern>k3ink</pattern>
+<pattern>kin4ka</pattern>
 <pattern>kino3</pattern>
 <pattern>4k3in4se</pattern>
 <pattern>kin3sh</pattern>
@@ -18864,7 +19432,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ki3ses</pattern>
 <pattern>ki3s2h</pattern>
 <pattern>3kisi</pattern>
-<pattern>2k3iso</pattern>
+<pattern>2k3i2so</pattern>
 <pattern>2ki3s2p</pattern>
 <pattern>3kiss</pattern>
 <pattern>kissen5</pattern>
@@ -18880,8 +19448,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2kj</pattern>
 <pattern>2k1k2</pattern>
 <pattern>kka3la</pattern>
+<pattern>kka3lö</pattern>
 <pattern>kka2m</pattern>
 <pattern>k3kar</pattern>
+<pattern>kka2s</pattern>
 <pattern>kko2e</pattern>
 <pattern>k2kok</pattern>
 <pattern>kko4l</pattern>
@@ -18899,6 +19469,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k2kut</pattern>
 <pattern>kl2</pattern>
 <pattern>2kl </pattern>
+<pattern>kla3br</pattern>
 <pattern>2k3lac</pattern>
 <pattern>kla5cke</pattern>
 <pattern>4klade</pattern>
@@ -18908,6 +19479,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k2lam</pattern>
 <pattern>kl4an</pattern>
 <pattern>4k3land</pattern>
+<pattern>klan4ga</pattern>
+<pattern>klan6ger</pattern>
 <pattern>klang5r</pattern>
 <pattern>k2lar</pattern>
 <pattern>kla3ta</pattern>
@@ -18915,6 +19488,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4k3laug</pattern>
 <pattern>2kläd</pattern>
 <pattern>2k3läh</pattern>
+<pattern>kl4är</pattern>
 <pattern>5klära</pattern>
 <pattern>2k3läu</pattern>
 <pattern>4k4le </pattern>
@@ -18923,7 +19497,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kle5ber</pattern>
 <pattern>kleb3r</pattern>
 <pattern>kle3bu</pattern>
-<pattern>3k2lec</pattern>
 <pattern>kle5cke</pattern>
 <pattern>kle2d</pattern>
 <pattern>4k3leer</pattern>
@@ -18939,10 +19512,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kl4ep</pattern>
 <pattern>kler3a</pattern>
 <pattern>4klero</pattern>
+<pattern>kles3t</pattern>
 <pattern>k2let</pattern>
 <pattern>2kleu</pattern>
 <pattern>4k3lich</pattern>
-<pattern>k2lid</pattern>
 <pattern>k3lied</pattern>
 <pattern>k3lieg</pattern>
 <pattern>kli3en</pattern>
@@ -18966,13 +19539,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3klod</pattern>
 <pattern>k2lop</pattern>
 <pattern>k3lor4</pattern>
-<pattern>klo4re3</pattern>
 <pattern>4klose </pattern>
 <pattern>4klosem</pattern>
 <pattern>4klosen</pattern>
 <pattern>4kloser</pattern>
 <pattern>4kloses</pattern>
 <pattern>kloss5t</pattern>
+<pattern>klo2t</pattern>
 <pattern>4k3lot </pattern>
 <pattern>4k3lote</pattern>
 <pattern>4k3lots</pattern>
@@ -19014,6 +19587,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kne3e</pattern>
 <pattern>knen4a</pattern>
 <pattern>2knes</pattern>
+<pattern>kne4ta</pattern>
+<pattern>kne4t3r</pattern>
 <pattern>knet3t</pattern>
 <pattern>4knetz</pattern>
 <pattern>2k3neu</pattern>
@@ -19041,12 +19616,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2koä</pattern>
 <pattern>2kob2</pattern>
 <pattern>kobal4</pattern>
+<pattern>kobalt5</pattern>
 <pattern>koba3r</pattern>
 <pattern>kobe2</pattern>
 <pattern>kober4e</pattern>
 <pattern>ko2bl</pattern>
 <pattern>ko2bo</pattern>
 <pattern>ko2br</pattern>
+<pattern>kob4s</pattern>
 <pattern>koch3i</pattern>
 <pattern>koch3r</pattern>
 <pattern>koe2</pattern>
@@ -19057,15 +19634,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ko3gr</pattern>
 <pattern>ko3ha</pattern>
 <pattern>koh4ler</pattern>
+<pattern>kohle5t</pattern>
 <pattern>koh3lu</pattern>
 <pattern>2koho</pattern>
 <pattern>ko3hö</pattern>
 <pattern>k3ohr</pattern>
+<pattern>koi3k</pattern>
 <pattern>ko3in</pattern>
 <pattern>ko2j</pattern>
 <pattern>2koka</pattern>
 <pattern>koka3s</pattern>
 <pattern>2kokä</pattern>
+<pattern>koke3r</pattern>
 <pattern>ko2kl</pattern>
 <pattern>ko2ko</pattern>
 <pattern>koko3l</pattern>
@@ -19099,10 +19679,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ko2on</pattern>
 <pattern>2kop </pattern>
 <pattern>2kopa2</pattern>
+<pattern>kop3an</pattern>
+<pattern>ko3pas</pattern>
 <pattern>ko3pat</pattern>
 <pattern>4koper</pattern>
 <pattern>kop4f5en4</pattern>
-<pattern>kopf5er6k</pattern>
+<pattern>kopf5erk</pattern>
 <pattern>kopf5err</pattern>
 <pattern>kopf3l</pattern>
 <pattern>2koph</pattern>
@@ -19110,11 +19692,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2kopl</pattern>
 <pattern>2kopr</pattern>
 <pattern>2kop3s</pattern>
+<pattern>ko3pte</pattern>
 <pattern>2kopz</pattern>
 <pattern>2kor2a</pattern>
 <pattern>ko3rat</pattern>
 <pattern>kor4ba</pattern>
-<pattern>korb5er4</pattern>
+<pattern>kor4b5er4</pattern>
 <pattern>kor4b3r</pattern>
 <pattern>2k3orc</pattern>
 <pattern>kor4dar</pattern>
@@ -19128,15 +19711,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2kori</pattern>
 <pattern>kor4k3a</pattern>
 <pattern>kor4ker</pattern>
-<pattern>kor4kr</pattern>
+<pattern>kor4k3r</pattern>
 <pattern>kor4na</pattern>
 <pattern>kor4n3ä</pattern>
+<pattern>kor4n5eb</pattern>
 <pattern>korn3o4</pattern>
 <pattern>2koro</pattern>
 <pattern>ko3rom</pattern>
 <pattern>4korpi</pattern>
+<pattern>kor3ti</pattern>
 <pattern>k3or4tu</pattern>
-<pattern>ko3ru</pattern>
 <pattern>3k4os </pattern>
 <pattern>2kosc</pattern>
 <pattern>ko3sel</pattern>
@@ -19146,7 +19730,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ko3sin</pattern>
 <pattern>ko2sk</pattern>
 <pattern>2koso</pattern>
-<pattern>k4o2st</pattern>
+<pattern>ko2st</pattern>
 <pattern>ko5stei</pattern>
 <pattern>koster4</pattern>
 <pattern>kost5erz</pattern>
@@ -19169,8 +19753,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2koz</pattern>
 <pattern>1kö2</pattern>
 <pattern>kö3ren</pattern>
+<pattern>2k3ört</pattern>
 <pattern>2k1p2</pattern>
 <pattern>kpa2</pattern>
+<pattern>kpfo3</pattern>
 <pattern>kpi4t3</pattern>
 <pattern>2kq</pattern>
 <pattern>kr2</pattern>
@@ -19183,6 +19769,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kr4am</pattern>
 <pattern>k3rand</pattern>
 <pattern>5krankh</pattern>
+<pattern>4kranku</pattern>
 <pattern>kranzü6</pattern>
 <pattern>k3rats</pattern>
 <pattern>k3raub</pattern>
@@ -19219,16 +19806,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kreis5ei</pattern>
 <pattern>krei5sern</pattern>
 <pattern>krei5ses</pattern>
-<pattern>krei4s5i</pattern>
-<pattern>kreisin6</pattern>
+<pattern>krei6s5in6</pattern>
 <pattern>kreis5ta</pattern>
 <pattern>2krel</pattern>
 <pattern>kre5len</pattern>
-<pattern>3kreme</pattern>
 <pattern>kre4mi</pattern>
 <pattern>3kreo</pattern>
 <pattern>kre2p</pattern>
 <pattern>k3repo</pattern>
+<pattern>kre2s</pattern>
+<pattern>k3rese</pattern>
 <pattern>kreso3</pattern>
 <pattern>k5resso</pattern>
 <pattern>4kresu</pattern>
@@ -19237,7 +19824,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2krez</pattern>
 <pattern>kre4ze</pattern>
 <pattern>2k1rh</pattern>
-<pattern>2krib</pattern>
 <pattern>2k3ric</pattern>
 <pattern>4k3rieb</pattern>
 <pattern>4k3ries</pattern>
@@ -19263,11 +19849,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2kros</pattern>
 <pattern>kro3sa</pattern>
 <pattern>2krot</pattern>
+<pattern>kro3ta</pattern>
+<pattern>kro3tr</pattern>
 <pattern>2krou</pattern>
 <pattern>2kröh</pattern>
 <pattern>krö5ten</pattern>
 <pattern>2k3ruc</pattern>
 <pattern>2kru2f</pattern>
+<pattern>krum4ma</pattern>
 <pattern>4k3rump</pattern>
 <pattern>2k3run</pattern>
 <pattern>3krus</pattern>
@@ -19285,10 +19874,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ks5ankä</pattern>
 <pattern>k4s3an4t</pattern>
 <pattern>ksa4r</pattern>
-<pattern>ks3as2</pattern>
+<pattern>k2s3a2s2</pattern>
 <pattern>ksau2</pattern>
 <pattern>k4s3auf3</pattern>
-<pattern>k4s3aus</pattern>
+<pattern>ks3aus</pattern>
 <pattern>k4saut</pattern>
 <pattern>k2s3a2v</pattern>
 <pattern>k2säh</pattern>
@@ -19302,23 +19891,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k2s3ec</pattern>
 <pattern>ks2ed</pattern>
 <pattern>ks3eie</pattern>
-<pattern>ks3ein3</pattern>
+<pattern>ks3ein</pattern>
 <pattern>k4sele</pattern>
 <pattern>ks3elf</pattern>
 <pattern>k4s3en4g</pattern>
 <pattern>ks5ense</pattern>
 <pattern>k4s3ent</pattern>
+<pattern>kser2</pattern>
 <pattern>kse3re</pattern>
-<pattern>k4s3er4f</pattern>
-<pattern>k4s3er4g</pattern>
-<pattern>k4s3er4h</pattern>
-<pattern>k4s3er4k</pattern>
-<pattern>k4s3er4l</pattern>
-<pattern>kser4n</pattern>
-<pattern>k4s3er4p</pattern>
-<pattern>ks3er4s</pattern>
-<pattern>k4s3er4w</pattern>
-<pattern>k4s3er4z</pattern>
+<pattern>k4s3erf</pattern>
+<pattern>k4s3erg</pattern>
+<pattern>k4s3erh</pattern>
+<pattern>k4s3erk</pattern>
+<pattern>k4s3erl</pattern>
+<pattern>k4s3erp</pattern>
+<pattern>k4s3err</pattern>
+<pattern>ks3ers</pattern>
+<pattern>k4s3ert</pattern>
+<pattern>k4s3erw</pattern>
+<pattern>k4s3erz</pattern>
 <pattern>ks3eta</pattern>
 <pattern>ks3ev</pattern>
 <pattern>k2sex2</pattern>
@@ -19331,9 +19922,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k2s3is</pattern>
 <pattern>ksli2</pattern>
 <pattern>kso2</pattern>
-<pattern>ks3ofe</pattern>
+<pattern>k4s3ofe</pattern>
 <pattern>k3son</pattern>
-<pattern>k4s3op</pattern>
+<pattern>k2s3op</pattern>
 <pattern>ks3org</pattern>
 <pattern>ks3ori</pattern>
 <pattern>ks5ort </pattern>
@@ -19341,16 +19932,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ks3pal</pattern>
 <pattern>ks4paz</pattern>
 <pattern>k3spec</pattern>
-<pattern>k3spei</pattern>
+<pattern>k5speic</pattern>
 <pattern>k3spek</pattern>
 <pattern>k3s4pel</pattern>
 <pattern>ks3per</pattern>
 <pattern>k3spra3</pattern>
 <pattern>k4s3prä</pattern>
 <pattern>k3spri</pattern>
+<pattern>k4spro</pattern>
 <pattern>k3spru</pattern>
 <pattern>k3spul</pattern>
 <pattern>ks3s2</pattern>
+<pattern>k4st </pattern>
 <pattern>k3stab</pattern>
 <pattern>k3stac</pattern>
 <pattern>k3stad</pattern>
@@ -19378,18 +19971,30 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k3stew</pattern>
 <pattern>k3stic</pattern>
 <pattern>k5stieg</pattern>
+<pattern>k5sties</pattern>
 <pattern>k3stil</pattern>
 <pattern>k3sto</pattern>
 <pattern>k4stod</pattern>
 <pattern>k4ston</pattern>
 <pattern>ksto4r</pattern>
 <pattern>k4s3tot</pattern>
-<pattern>k4strän</pattern>
+<pattern>kst2r</pattern>
+<pattern>k3stra</pattern>
+<pattern>k5sträu</pattern>
 <pattern>ks5tref</pattern>
+<pattern>k5strei</pattern>
 <pattern>ks5tren</pattern>
-<pattern>k4s5tres</pattern>
-<pattern>kstrom5</pattern>
-<pattern>k4s5trop</pattern>
+<pattern>ks5tres</pattern>
+<pattern>k5streu</pattern>
+<pattern>k5stric</pattern>
+<pattern>k5strie</pattern>
+<pattern>ks5troc</pattern>
+<pattern>k5strom5</pattern>
+<pattern>ks5trop</pattern>
+<pattern>k5ström</pattern>
+<pattern>k3stru</pattern>
+<pattern>k3strü</pattern>
+<pattern>k3stub</pattern>
 <pattern>k3stuf</pattern>
 <pattern>k3stut</pattern>
 <pattern>k4s3tüt</pattern>
@@ -19412,7 +20017,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kt3al4l</pattern>
 <pattern>ktal3s4</pattern>
 <pattern>kt3ana</pattern>
-<pattern>kt3an4b</pattern>
+<pattern>kt3anb</pattern>
 <pattern>kt3an4g</pattern>
 <pattern>ktan4k</pattern>
 <pattern>kt3ano</pattern>
@@ -19433,7 +20038,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kt3asp</pattern>
 <pattern>ktau2</pattern>
 <pattern>k4t3auf</pattern>
-<pattern>kt5aust</pattern>
+<pattern>kt3aus</pattern>
 <pattern>ktauto4</pattern>
 <pattern>ktä2</pattern>
 <pattern>ktän4d</pattern>
@@ -19486,6 +20091,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kt1h</pattern>
 <pattern>k4thei</pattern>
 <pattern>k2thi</pattern>
+<pattern>k2thy</pattern>
 <pattern>k2t3i2d</pattern>
 <pattern>kti4e</pattern>
 <pattern>k4tie </pattern>
@@ -19516,6 +20122,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k4t3ref</pattern>
 <pattern>kt5reic</pattern>
 <pattern>ktre4p</pattern>
+<pattern>ktro5b</pattern>
 <pattern>ktro3c</pattern>
 <pattern>ktro3s</pattern>
 <pattern>k4t3run</pattern>
@@ -19535,6 +20142,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>k4tuns</pattern>
 <pattern>k2tup</pattern>
 <pattern>ktu6rens</pattern>
+<pattern>ktu6r5en6z</pattern>
 <pattern>ktz2</pattern>
 <pattern>1ku</pattern>
 <pattern>2ku </pattern>
@@ -19552,6 +20160,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ku3in</pattern>
 <pattern>kuit3t</pattern>
 <pattern>ku2j</pattern>
+<pattern>kul2a</pattern>
 <pattern>kulan4z</pattern>
 <pattern>ku3le2</pattern>
 <pattern>ku4lis</pattern>
@@ -19561,6 +20170,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kul4t3o</pattern>
 <pattern>kul4t3r</pattern>
 <pattern>k3um4ba</pattern>
+<pattern>2k3um2d</pattern>
 <pattern>ku3m4e</pattern>
 <pattern>kum4fa</pattern>
 <pattern>kum4fe</pattern>
@@ -19573,7 +20183,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kum4se</pattern>
 <pattern>kum4si</pattern>
 <pattern>kum4s3p</pattern>
+<pattern>k3um2w</pattern>
 <pattern>2k3um2z</pattern>
+<pattern>kund4a</pattern>
+<pattern>kun5dar</pattern>
 <pattern>kunde5i</pattern>
 <pattern>k3un2e</pattern>
 <pattern>kun2f</pattern>
@@ -19590,6 +20203,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kunwe3</pattern>
 <pattern>2k3up </pattern>
 <pattern>ku2pa</pattern>
+<pattern>kupas4</pattern>
 <pattern>kup2d</pattern>
 <pattern>ku3pfl</pattern>
 <pattern>ku2pi</pattern>
@@ -19609,6 +20223,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2k3url</pattern>
 <pattern>kur3o</pattern>
 <pattern>kursa5c</pattern>
+<pattern>kurs5an</pattern>
 <pattern>kur4sei</pattern>
 <pattern>kur4ser</pattern>
 <pattern>kur4sin</pattern>
@@ -19620,7 +20235,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>kur5tsc</pattern>
 <pattern>kur4zel</pattern>
 <pattern>ku2s</pattern>
+<pattern>kus3el</pattern>
 <pattern>kus3er</pattern>
+<pattern>kus3ev</pattern>
 <pattern>ku3spa</pattern>
 <pattern>kus3pi</pattern>
 <pattern>2kust</pattern>
@@ -19696,11 +20313,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4abor</pattern>
 <pattern>l3ab2p</pattern>
 <pattern>2lab4r</pattern>
+<pattern>la5bres</pattern>
+<pattern>la3bro</pattern>
 <pattern>2l3ab2s</pattern>
 <pattern>lab4ta</pattern>
 <pattern>lab4tei</pattern>
 <pattern>2labu</pattern>
 <pattern>lab4we</pattern>
+<pattern>l4aby</pattern>
 <pattern>lab2z</pattern>
 <pattern>labzü5gen</pattern>
 <pattern>3la3ca</pattern>
@@ -19743,10 +20363,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lafs2</pattern>
 <pattern>laft4</pattern>
 <pattern>laf3ta</pattern>
-<pattern>la2fu</pattern>
 <pattern>la2g3a</pattern>
-<pattern>la2g3ä</pattern>
+<pattern>2lagä</pattern>
 <pattern>la4ge3g</pattern>
+<pattern>la4geh</pattern>
 <pattern>la4gei</pattern>
 <pattern>lag5eis</pattern>
 <pattern>la4gem</pattern>
@@ -19768,6 +20388,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>la2g3n</pattern>
 <pattern>la2go2</pattern>
 <pattern>lag5s6eid</pattern>
+<pattern>lag5spa</pattern>
 <pattern>lag5s4ta</pattern>
 <pattern>lag5sto</pattern>
 <pattern>lag5stre</pattern>
@@ -19782,23 +20403,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>la4k3ar4</pattern>
 <pattern>l4ake</pattern>
 <pattern>lak2k</pattern>
+<pattern>l3akko</pattern>
 <pattern>lakku3</pattern>
 <pattern>l4ako</pattern>
 <pattern>l3akt </pattern>
 <pattern>l3ak4te</pattern>
 <pattern>l3akts</pattern>
 <pattern>lak2z</pattern>
-<pattern>l1a2l</pattern>
+<pattern>l1a2l2</pattern>
 <pattern>3lala </pattern>
 <pattern>lal3ab</pattern>
-<pattern>lal2b</pattern>
-<pattern>lal2g</pattern>
 <pattern>l2ali</pattern>
-<pattern>lal2k</pattern>
-<pattern>lal2m</pattern>
+<pattern>lal5len</pattern>
 <pattern>4la3lo</pattern>
-<pattern>lal2p</pattern>
-<pattern>2lal2t</pattern>
+<pattern>2lalt</pattern>
 <pattern>2lamb</pattern>
 <pattern>lament4</pattern>
 <pattern>la4met</pattern>
@@ -19810,6 +20428,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lam4mo</pattern>
 <pattern>l3amn</pattern>
 <pattern>2la3mo</pattern>
+<pattern>l4ampe</pattern>
 <pattern>l3ampl</pattern>
 <pattern>2l3am2t</pattern>
 <pattern>lamt4s</pattern>
@@ -19821,7 +20440,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lan4äm</pattern>
 <pattern>lanäs3</pattern>
 <pattern>lan4bi</pattern>
-<pattern>l4and</pattern>
 <pattern>landa4</pattern>
 <pattern>lan4dam</pattern>
 <pattern>lan4dan</pattern>
@@ -19846,7 +20464,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lan2e</pattern>
 <pattern>l3anek</pattern>
 <pattern>l3anem</pattern>
-<pattern>la4n5ent</pattern>
+<pattern>lan5ente</pattern>
 <pattern>lan5erd</pattern>
 <pattern>la4n5erf</pattern>
 <pattern>laner4s</pattern>
@@ -19855,6 +20473,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lan4fl</pattern>
 <pattern>lan6ford</pattern>
 <pattern>lan4fr</pattern>
+<pattern>4langab</pattern>
 <pattern>lang5an4</pattern>
 <pattern>lan4gä</pattern>
 <pattern>lan4ge5b</pattern>
@@ -19863,9 +20482,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lan6ge5le</pattern>
 <pattern>6l5an6geln</pattern>
 <pattern>5langem</pattern>
-<pattern>langer4</pattern>
-<pattern>lan6g5ere</pattern>
-<pattern>lan6g5ers</pattern>
+<pattern>lan6g5er6s</pattern>
 <pattern>lan6gesc</pattern>
 <pattern>lan4gew</pattern>
 <pattern>lan4g3i</pattern>
@@ -19909,6 +20526,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5l4antin</pattern>
 <pattern>lan4tr</pattern>
 <pattern>4l3antw</pattern>
+<pattern>lan3um</pattern>
 <pattern>4lan4wä</pattern>
 <pattern>lan4wei</pattern>
 <pattern>lan4wen</pattern>
@@ -19921,6 +20539,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lan6z5erf</pattern>
 <pattern>lan6zerg</pattern>
 <pattern>lan6z5erh</pattern>
+<pattern>lan4zin</pattern>
 <pattern>lan4zug</pattern>
 <pattern>4lan4zü</pattern>
 <pattern>lan4zw</pattern>
@@ -19936,6 +20555,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lar3ab</pattern>
 <pattern>lar3ac</pattern>
 <pattern>la3raf</pattern>
+<pattern>lar3a4g</pattern>
 <pattern>lar3an4</pattern>
 <pattern>la3ras</pattern>
 <pattern>la3rat</pattern>
@@ -19948,6 +20568,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lar3el</pattern>
 <pattern>la3rem</pattern>
 <pattern>la3ren</pattern>
+<pattern>la4r5enz</pattern>
 <pattern>la3rer</pattern>
 <pattern>la3res</pattern>
 <pattern>lare3t</pattern>
@@ -19970,6 +20591,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4aru</pattern>
 <pattern>la3rus</pattern>
 <pattern>l4arv</pattern>
+<pattern>4larzn</pattern>
 <pattern>larzu3</pattern>
 <pattern>lar3zw</pattern>
 <pattern>la2sa</pattern>
@@ -19984,20 +20606,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2lash</pattern>
 <pattern>la4sin</pattern>
 <pattern>las3is</pattern>
-<pattern>las3o</pattern>
-<pattern>2la2sp</pattern>
+<pattern>la4sor</pattern>
+<pattern>2lasp</pattern>
 <pattern>las3pr</pattern>
 <pattern>las4se5l</pattern>
 <pattern>lass5erkl</pattern>
+<pattern>las5stu</pattern>
 <pattern>la2st</pattern>
 <pattern>last5an4</pattern>
 <pattern>last5ar</pattern>
 <pattern>last3ä</pattern>
 <pattern>lastän4</pattern>
-<pattern>las3ti</pattern>
-<pattern>las5tra</pattern>
-<pattern>las5tro</pattern>
-<pattern>la4stu</pattern>
+<pattern>last5ein</pattern>
+<pattern>las5til</pattern>
 <pattern>3lastw</pattern>
 <pattern>3lastz</pattern>
 <pattern>la5sung</pattern>
@@ -20012,18 +20633,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l3a4tel</pattern>
 <pattern>late5ra</pattern>
 <pattern>la5tes</pattern>
+<pattern>3latè</pattern>
 <pattern>2lath</pattern>
 <pattern>4latin</pattern>
 <pattern>2l3atl</pattern>
 <pattern>2l3at2m</pattern>
-<pattern>l3atom</pattern>
+<pattern>4l3atom</pattern>
 <pattern>la2tö</pattern>
 <pattern>2latr</pattern>
 <pattern>lat3ra</pattern>
 <pattern>lat6schn</pattern>
 <pattern>lat6schw</pattern>
-<pattern>lat6tals</pattern>
-<pattern>lat4t5an</pattern>
+<pattern>lat4ta</pattern>
+<pattern>latt5an</pattern>
 <pattern>lat4tex</pattern>
 <pattern>lat4t5in</pattern>
 <pattern>4lattr</pattern>
@@ -20037,7 +20659,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lau4bre</pattern>
 <pattern>laub4se</pattern>
 <pattern>lauch5a</pattern>
-<pattern>lauch5s</pattern>
 <pattern>lau5ensc</pattern>
 <pattern>l4auer</pattern>
 <pattern>lau4f3a</pattern>
@@ -20057,6 +20678,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4aur</pattern>
 <pattern>l4aus </pattern>
 <pattern>lau6scha</pattern>
+<pattern>lau6schl</pattern>
+<pattern>l3ausg</pattern>
 <pattern>lau5spa</pattern>
 <pattern>l3auss</pattern>
 <pattern>4lausw</pattern>
@@ -20103,6 +20726,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2läx</pattern>
 <pattern>2lb</pattern>
 <pattern>lbab2</pattern>
+<pattern>l4b3alp</pattern>
+<pattern>l4b3ana</pattern>
 <pattern>l4b3an4g</pattern>
 <pattern>lb3ans</pattern>
 <pattern>l4b3an4t</pattern>
@@ -20137,6 +20762,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2b3i2d</pattern>
 <pattern>lbin4s</pattern>
 <pattern>lb3lag</pattern>
+<pattern>lb3las</pattern>
 <pattern>lble2</pattern>
 <pattern>l4b3led</pattern>
 <pattern>lb3lee</pattern>
@@ -20146,6 +20772,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4b3ora</pattern>
 <pattern>lb3ov</pattern>
 <pattern>l2böl</pattern>
+<pattern>lb5rank</pattern>
 <pattern>l4b3rea</pattern>
 <pattern>lbro3c</pattern>
 <pattern>lb4s3au4</pattern>
@@ -20154,7 +20781,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lbst5an</pattern>
 <pattern>lb3stä</pattern>
 <pattern>lb6stände</pattern>
-<pattern>lbst5im4</pattern>
+<pattern>lbstim4</pattern>
 <pattern>lbtro3</pattern>
 <pattern>lb2u2</pattern>
 <pattern>l2bum</pattern>
@@ -20166,10 +20793,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lch3ab</pattern>
 <pattern>lch5arm</pattern>
 <pattern>lchar4t</pattern>
+<pattern>lch3ec</pattern>
 <pattern>lch3ei</pattern>
 <pattern>lche4n</pattern>
 <pattern>lch5erh</pattern>
 <pattern>lch5er4s</pattern>
+<pattern>lch5er4t</pattern>
 <pattern>lch5erz</pattern>
 <pattern>lch3eu</pattern>
 <pattern>l3chig</pattern>
@@ -20182,7 +20811,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lcho2</pattern>
 <pattern>lch3ob</pattern>
 <pattern>lch3re</pattern>
-<pattern>lch3s2</pattern>
+<pattern>lch3sh</pattern>
+<pattern>lch3s4t</pattern>
 <pattern>lch3to</pattern>
 <pattern>lch3u</pattern>
 <pattern>lch3w</pattern>
@@ -20233,6 +20863,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ld5elef</pattern>
 <pattern>l4d3elf</pattern>
 <pattern>lde5lis</pattern>
+<pattern>ld5elit</pattern>
 <pattern>ldem2</pattern>
 <pattern>l4d3emb</pattern>
 <pattern>ld5e4mis</pattern>
@@ -20248,7 +20879,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lder3a</pattern>
 <pattern>l4derä</pattern>
 <pattern>l6d5er6fah</pattern>
-<pattern>lder4ho5</pattern>
+<pattern>lderho5l</pattern>
 <pattern>l6d5erlas</pattern>
 <pattern>lder4le</pattern>
 <pattern>lder6pro</pattern>
@@ -20263,13 +20894,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lde4tek</pattern>
 <pattern>l5dethe</pattern>
 <pattern>ld3eur</pattern>
-<pattern>l2dex</pattern>
+<pattern>l2d3ex</pattern>
 <pattern>lde2z</pattern>
 <pattern>lde3zi</pattern>
 <pattern>ldhof5s</pattern>
 <pattern>ldia3</pattern>
 <pattern>ldi2d</pattern>
 <pattern>l4d3ide</pattern>
+<pattern>ldien4</pattern>
 <pattern>ld3ill</pattern>
 <pattern>ldi2m</pattern>
 <pattern>ld3imi</pattern>
@@ -20280,10 +20912,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ld3iso</pattern>
 <pattern>ldle2</pattern>
 <pattern>ldmi2</pattern>
-<pattern>ldo2b</pattern>
-<pattern>ld3of</pattern>
 <pattern>l2d3oh</pattern>
 <pattern>l2dom</pattern>
+<pattern>ld3ope</pattern>
+<pattern>l4dopt</pattern>
 <pattern>ldo2r</pattern>
 <pattern>l4d3ori</pattern>
 <pattern>ldos3t</pattern>
@@ -20291,7 +20923,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ldpfa3</pattern>
 <pattern>ld3rab</pattern>
 <pattern>ld3ral</pattern>
-<pattern>ld3ran</pattern>
 <pattern>ld3ras</pattern>
 <pattern>ld3rat</pattern>
 <pattern>ld3rau</pattern>
@@ -20349,7 +20980,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le3che</pattern>
 <pattern>le4ch5ec</pattern>
 <pattern>le6chens</pattern>
-<pattern>lecho4</pattern>
+<pattern>lech5of</pattern>
 <pattern>lech5str</pattern>
 <pattern>lecht6st</pattern>
 <pattern>le2ci</pattern>
@@ -20358,6 +20989,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le3die</pattern>
 <pattern>le4dit</pattern>
 <pattern>ledi3v</pattern>
+<pattern>leer4k</pattern>
 <pattern>2lees</pattern>
 <pattern>lef2</pattern>
 <pattern>le3f4a</pattern>
@@ -20387,8 +21019,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le5gien</pattern>
 <pattern>le3gin</pattern>
 <pattern>le3gle</pattern>
-<pattern>2le3gr</pattern>
+<pattern>2legr</pattern>
 <pattern>le4gs2</pattern>
+<pattern>leg5sta</pattern>
 <pattern>leg5ste</pattern>
 <pattern>leg5str</pattern>
 <pattern>4le3ha</pattern>
@@ -20399,6 +21032,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lehm3s</pattern>
 <pattern>leh4rei</pattern>
 <pattern>3lehrf</pattern>
+<pattern>4leichu</pattern>
 <pattern>lei3dr</pattern>
 <pattern>5leien</pattern>
 <pattern>lei4fan</pattern>
@@ -20410,6 +21044,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lei4hau</pattern>
 <pattern>lei3k</pattern>
 <pattern>leil4</pattern>
+<pattern>le4im</pattern>
 <pattern>lei4mau</pattern>
 <pattern>leim3p</pattern>
 <pattern>le5im4po</pattern>
@@ -20417,6 +21052,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4leinb</pattern>
 <pattern>4leind</pattern>
 <pattern>l5eindr</pattern>
+<pattern>lei5ne5c</pattern>
 <pattern>lei6nerb</pattern>
 <pattern>4leing</pattern>
 <pattern>4leinh</pattern>
@@ -20425,7 +21061,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4leinl</pattern>
 <pattern>4leinn</pattern>
 <pattern>4leino</pattern>
-<pattern>l5einor</pattern>
 <pattern>4leinr</pattern>
 <pattern>4leinsa</pattern>
 <pattern>4leinsc</pattern>
@@ -20433,6 +21068,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4leint</pattern>
 <pattern>l5einto</pattern>
 <pattern>4leinz</pattern>
+<pattern>l5einzi</pattern>
 <pattern>leinzu5</pattern>
 <pattern>3leip</pattern>
 <pattern>lei6sch5a</pattern>
@@ -20447,7 +21083,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lei5ses</pattern>
 <pattern>lei3so</pattern>
 <pattern>leis6s5er6</pattern>
-<pattern>leis6ste</pattern>
 <pattern>lei5stro</pattern>
 <pattern>5leistu</pattern>
 <pattern>l3eisz</pattern>
@@ -20455,12 +21090,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lei4t5ag</pattern>
 <pattern>leit5ak</pattern>
 <pattern>lei4tel</pattern>
-<pattern>leit5er6kr</pattern>
+<pattern>leit5erkr</pattern>
 <pattern>lei4t3o</pattern>
 <pattern>leit5sk</pattern>
-<pattern>leit5so</pattern>
 <pattern>leit5s4p</pattern>
-<pattern>leits4t</pattern>
+<pattern>5leits4t</pattern>
 <pattern>3leitw</pattern>
 <pattern>3leiv</pattern>
 <pattern>le3ke</pattern>
@@ -20481,6 +21115,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le4lerk</pattern>
 <pattern>le4l5ers</pattern>
 <pattern>le3les</pattern>
+<pattern>lel3ex</pattern>
 <pattern>l3elf </pattern>
 <pattern>l3el4fe</pattern>
 <pattern>le3li</pattern>
@@ -20501,8 +21136,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le3min</pattern>
 <pattern>lem4man</pattern>
 <pattern>3lemmi</pattern>
-<pattern>lemo2</pattern>
-<pattern>lem3or</pattern>
+<pattern>lem3o4r</pattern>
+<pattern>l3emot</pattern>
 <pattern>4lemp</pattern>
 <pattern>lem4po</pattern>
 <pattern>lem3s</pattern>
@@ -20526,7 +21161,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lenen4g</pattern>
 <pattern>len5ente</pattern>
 <pattern>4l5energ</pattern>
-<pattern>len5ero</pattern>
 <pattern>len5ersc</pattern>
 <pattern>len5erst</pattern>
 <pattern>len5ert</pattern>
@@ -20551,15 +21185,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>len3or</pattern>
 <pattern>len3ot4</pattern>
 <pattern>len6s5ein</pattern>
+<pattern>6lensemb</pattern>
 <pattern>len6s5erk</pattern>
-<pattern>len5spo</pattern>
+<pattern>len5s4po</pattern>
 <pattern>len5spr</pattern>
 <pattern>len5sta</pattern>
 <pattern>len5stei</pattern>
 <pattern>len5s4ti</pattern>
 <pattern>len5str</pattern>
 <pattern>lenta4</pattern>
-<pattern>4l3entb</pattern>
+<pattern>4lentb</pattern>
 <pattern>4lentd</pattern>
 <pattern>5lentec</pattern>
 <pattern>l5enteig</pattern>
@@ -20583,7 +21218,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le4nz</pattern>
 <pattern>len5z6er</pattern>
 <pattern>len4zin</pattern>
+<pattern>len4zun</pattern>
 <pattern>lenzu4w</pattern>
+<pattern>len3zw</pattern>
+<pattern>lenz6wei</pattern>
 <pattern>4l3enzy</pattern>
 <pattern>le3of</pattern>
 <pattern>leo3no</pattern>
@@ -20599,6 +21237,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4era</pattern>
 <pattern>lerab4</pattern>
 <pattern>lerable5</pattern>
+<pattern>ler3a4g</pattern>
 <pattern>ler3al</pattern>
 <pattern>leran4g</pattern>
 <pattern>ler3a4s</pattern>
@@ -20608,6 +21247,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4l5erbe </pattern>
 <pattern>4l5er4ben</pattern>
 <pattern>lerber4</pattern>
+<pattern>lerb4l</pattern>
 <pattern>4lerbli</pattern>
 <pattern>ler6blin</pattern>
 <pattern>4l3erbs</pattern>
@@ -20622,7 +21262,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le4rei4n</pattern>
 <pattern>ler5eis </pattern>
 <pattern>le4r3el</pattern>
-<pattern>le3rem</pattern>
 <pattern>ler5eng</pattern>
 <pattern>le4r5ens</pattern>
 <pattern>lerer4</pattern>
@@ -20634,30 +21273,32 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>le4r3e4t</pattern>
 <pattern>lereta5gen</pattern>
 <pattern>ler6fass</pattern>
-<pattern>4ler4fin</pattern>
+<pattern>ler6find</pattern>
 <pattern>ler4fol</pattern>
 <pattern>ler4fül</pattern>
 <pattern>lerge5he</pattern>
 <pattern>l5er6gen </pattern>
 <pattern>l5er6genr</pattern>
 <pattern>5lergewe</pattern>
-<pattern>l3er4gi</pattern>
+<pattern>l3ergi</pattern>
+<pattern>ler4gie</pattern>
+<pattern>ler4gis</pattern>
 <pattern>l5ergol</pattern>
 <pattern>ler6halt</pattern>
 <pattern>4l5er4heb</pattern>
 <pattern>ler6ho5lu</pattern>
-<pattern>ler3i4d</pattern>
+<pattern>le4r3i4d</pattern>
 <pattern>lerin4g</pattern>
 <pattern>ler5inge</pattern>
 <pattern>ler3k</pattern>
 <pattern>l4er5ka</pattern>
 <pattern>ler4ken</pattern>
-<pattern>4l5er4klä</pattern>
 <pattern>l4erko</pattern>
 <pattern>ler5kre</pattern>
 <pattern>4lerkun</pattern>
 <pattern>ler6kund</pattern>
 <pattern>ler4las</pattern>
+<pattern>6l5erlaub</pattern>
 <pattern>ler4läg</pattern>
 <pattern>6ler6lebn</pattern>
 <pattern>l5er4leu</pattern>
@@ -20670,8 +21311,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ler3ob</pattern>
 <pattern>le3ros</pattern>
 <pattern>4l3erot</pattern>
-<pattern>2l3er2ö</pattern>
-<pattern>5ler5ra</pattern>
+<pattern>ler2ö</pattern>
+<pattern>4l5eröff</pattern>
+<pattern>ler5ra</pattern>
 <pattern>4l5er4ric</pattern>
 <pattern>le4rs</pattern>
 <pattern>ler4sat</pattern>
@@ -20680,35 +21322,38 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lers4t</pattern>
 <pattern>ler3sw</pattern>
 <pattern>ler3ta</pattern>
-<pattern>ler6trag</pattern>
+<pattern>l5er6trag</pattern>
 <pattern>ler3um4</pattern>
 <pattern>le4rup</pattern>
 <pattern>lerursa5</pattern>
 <pattern>4lerus</pattern>
+<pattern>le4r3ut</pattern>
 <pattern>4le3rüc</pattern>
 <pattern>ler4wäh</pattern>
-<pattern>ler6weit</pattern>
+<pattern>4lerwär</pattern>
+<pattern>ler6wärm</pattern>
+<pattern>6l5er6weit</pattern>
 <pattern>lerwo5g</pattern>
 <pattern>4l3erz </pattern>
-<pattern>l4erza</pattern>
-<pattern>4lerzä</pattern>
-<pattern>ler4zen</pattern>
+<pattern>5l4erza</pattern>
 <pattern>4l5er4zeu</pattern>
-<pattern>4ler4zo</pattern>
-<pattern>ler5zu4</pattern>
+<pattern>4l3er4zo</pattern>
+<pattern>5ler5zu4</pattern>
 <pattern>3lesb</pattern>
 <pattern>2lesc</pattern>
 <pattern>lese3h</pattern>
-<pattern>lese3i</pattern>
+<pattern>lese5in</pattern>
 <pattern>le5serv</pattern>
 <pattern>leses4</pattern>
 <pattern>lese5sk</pattern>
 <pattern>les5ess</pattern>
-<pattern>le3s2h</pattern>
+<pattern>l4e3s2h</pattern>
 <pattern>le3s4ki</pattern>
 <pattern>le3sko</pattern>
 <pattern>3lesky</pattern>
 <pattern>2lesn</pattern>
+<pattern>le3spe</pattern>
+<pattern>le3spü</pattern>
 <pattern>le4ss</pattern>
 <pattern>les2t</pattern>
 <pattern>lesta4</pattern>
@@ -20727,6 +21372,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4leue</pattern>
 <pattern>le3u2f</pattern>
 <pattern>2l3eu2l</pattern>
+<pattern>leum3i</pattern>
 <pattern>le3ur4l</pattern>
 <pattern>4l3euro</pattern>
 <pattern>2leva</pattern>
@@ -20743,7 +21389,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lex4kl</pattern>
 <pattern>lex2p</pattern>
 <pattern>lexpo5s</pattern>
-<pattern>lex2t</pattern>
+<pattern>lex2t2</pattern>
+<pattern>lex3th</pattern>
 <pattern>le3xus</pattern>
 <pattern>1ley</pattern>
 <pattern>2lez</pattern>
@@ -20751,6 +21398,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2lè</pattern>
 <pattern>2l1f</pattern>
 <pattern>lf3aka</pattern>
+<pattern>lfang5r</pattern>
 <pattern>lf2at</pattern>
 <pattern>lf3aus</pattern>
 <pattern>l2fea</pattern>
@@ -20796,6 +21444,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2gad</pattern>
 <pattern>lga2l</pattern>
 <pattern>lga5ren</pattern>
+<pattern>lga2s</pattern>
 <pattern>lgä5ren</pattern>
 <pattern>l2gea</pattern>
 <pattern>l3ge4bä</pattern>
@@ -20810,6 +21459,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2gee</pattern>
 <pattern>lge2f</pattern>
 <pattern>lge2h</pattern>
+<pattern>lge3in4</pattern>
 <pattern>l2gej</pattern>
 <pattern>l2ge3k</pattern>
 <pattern>lge2l</pattern>
@@ -20836,17 +21486,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lge4wa</pattern>
 <pattern>lgi5ern</pattern>
 <pattern>l2gik</pattern>
+<pattern>l4g3lam</pattern>
 <pattern>l3gle</pattern>
 <pattern>l4glic</pattern>
 <pattern>lgoa3</pattern>
 <pattern>lgo3l</pattern>
 <pattern>l2gor</pattern>
 <pattern>lg3rei</pattern>
-<pattern>l3gu</pattern>
 <pattern>2l1h</pattern>
 <pattern>lha2</pattern>
-<pattern>lhaf4tr</pattern>
-<pattern>lh4au</pattern>
 <pattern>l3he</pattern>
 <pattern>lhis3</pattern>
 <pattern>lho2</pattern>
@@ -20883,8 +21531,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li3chi</pattern>
 <pattern>3lichk</pattern>
 <pattern>lich3r</pattern>
+<pattern>lich4tr</pattern>
 <pattern>lichts4</pattern>
-<pattern>licht5so</pattern>
 <pattern>licht5sp</pattern>
 <pattern>3lichu</pattern>
 <pattern>4lick</pattern>
@@ -20893,7 +21541,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2id</pattern>
 <pattern>4lida</pattern>
 <pattern>l3idee</pattern>
-<pattern>liden3</pattern>
+<pattern>li3de4k</pattern>
 <pattern>l3i4dio</pattern>
 <pattern>2lido</pattern>
 <pattern>lie4be5d</pattern>
@@ -20902,8 +21550,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3liebh</pattern>
 <pattern>lie4br</pattern>
 <pattern>lie4f3a</pattern>
+<pattern>lie4fi</pattern>
 <pattern>lie4fr</pattern>
 <pattern>li5efs </pattern>
+<pattern>lie4gef</pattern>
 <pattern>lie4gel</pattern>
 <pattern>lie4ge5s</pattern>
 <pattern>lie4gew</pattern>
@@ -20935,6 +21585,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li2g3l</pattern>
 <pattern>lign4</pattern>
 <pattern>li3g4ne</pattern>
+<pattern>li2go</pattern>
 <pattern>li4g5rad</pattern>
 <pattern>li4gre</pattern>
 <pattern>lig3se</pattern>
@@ -20985,13 +21636,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4lin4dex</pattern>
 <pattern>linde5xi</pattern>
 <pattern>4l3in4di</pattern>
-<pattern>lin4do</pattern>
 <pattern>4l3indu</pattern>
 <pattern>line3s</pattern>
-<pattern>l3in4fe</pattern>
+<pattern>lin4fek</pattern>
 <pattern>lin4fla</pattern>
 <pattern>lin4fo</pattern>
 <pattern>lin4fu3</pattern>
+<pattern>ling4sc</pattern>
 <pattern>5lingsh</pattern>
 <pattern>5lingsr</pattern>
 <pattern>5lingsw</pattern>
@@ -21009,7 +21660,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lin4k5au</pattern>
 <pattern>lin4kla</pattern>
 <pattern>lin4kli</pattern>
-<pattern>li4nl</pattern>
+<pattern>2li4nl</pattern>
+<pattern>lin4la</pattern>
 <pattern>4l5in4ner</pattern>
 <pattern>li3noi</pattern>
 <pattern>2linq</pattern>
@@ -21018,6 +21670,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lin4sol</pattern>
 <pattern>lins4p</pattern>
 <pattern>4linspe</pattern>
+<pattern>lin5spr</pattern>
 <pattern>4l3insz</pattern>
 <pattern>2lint</pattern>
 <pattern>lin4ter</pattern>
@@ -21030,14 +21683,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li3ox</pattern>
 <pattern>2liö</pattern>
 <pattern>2lipa</pattern>
+<pattern>lip3he</pattern>
 <pattern>li3pin</pattern>
 <pattern>li2po</pattern>
+<pattern>li3pol</pattern>
 <pattern>lip3t4</pattern>
 <pattern>li2q</pattern>
 <pattern>2lir</pattern>
-<pattern>l3i2ra</pattern>
 <pattern>lire2</pattern>
 <pattern>li3res</pattern>
+<pattern>lir4t3r</pattern>
 <pattern>lis2a</pattern>
 <pattern>li3sab</pattern>
 <pattern>4lisal</pattern>
@@ -21045,6 +21700,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li4schl</pattern>
 <pattern>4lischm</pattern>
 <pattern>li4schn</pattern>
+<pattern>li4sch5r</pattern>
 <pattern>li4schu</pattern>
 <pattern>lise2</pattern>
 <pattern>4li3sek</pattern>
@@ -21057,7 +21713,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2l3isl</pattern>
 <pattern>2liso</pattern>
 <pattern>l3isol</pattern>
-<pattern>li3sor</pattern>
 <pattern>2lisp</pattern>
 <pattern>liss2</pattern>
 <pattern>l2it</pattern>
@@ -21074,7 +21729,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li4tel</pattern>
 <pattern>lite5rar</pattern>
 <pattern>li4tet</pattern>
-<pattern>3lith</pattern>
+<pattern>3lit2h</pattern>
 <pattern>2litr</pattern>
 <pattern>li3trä</pattern>
 <pattern>lit3s2</pattern>
@@ -21088,7 +21743,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>li3xi</pattern>
 <pattern>li2za</pattern>
 <pattern>liz3an</pattern>
-<pattern>li2z3ä</pattern>
+<pattern>li2zä</pattern>
 <pattern>lizei5t</pattern>
 <pattern>li2zo</pattern>
 <pattern>2lj</pattern>
@@ -21104,18 +21759,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lka4ner</pattern>
 <pattern>lka4n5in</pattern>
 <pattern>lkar4m</pattern>
+<pattern>lka2s</pattern>
 <pattern>lka2t</pattern>
-<pattern>l2k3äh</pattern>
+<pattern>l2käh</pattern>
 <pattern>l4k3ei4f</pattern>
 <pattern>lken3s4</pattern>
 <pattern>lke5rei</pattern>
 <pattern>lker5l</pattern>
 <pattern>lkfle3</pattern>
+<pattern>lkie3</pattern>
 <pattern>lk2l</pattern>
 <pattern>l3kla</pattern>
 <pattern>l4k3lad</pattern>
 <pattern>l3kle</pattern>
 <pattern>lkle3b</pattern>
+<pattern>lklore5</pattern>
 <pattern>lk2n</pattern>
 <pattern>lk3ner</pattern>
 <pattern>lknö3</pattern>
@@ -21125,6 +21783,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lk3ofe</pattern>
 <pattern>lkoma4</pattern>
 <pattern>lko2o</pattern>
+<pattern>l4k3res</pattern>
 <pattern>lk3rob</pattern>
 <pattern>lk3roc</pattern>
 <pattern>lks1</pattern>
@@ -21149,6 +21808,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lla2g2</pattern>
 <pattern>llage4</pattern>
 <pattern>l6lagena</pattern>
+<pattern>l6l5agent</pattern>
 <pattern>lla3gl</pattern>
 <pattern>l4lagr</pattern>
 <pattern>l2lak</pattern>
@@ -21157,6 +21817,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4l3ama</pattern>
 <pattern>ll3amb</pattern>
 <pattern>ll3amo</pattern>
+<pattern>lla6nent</pattern>
 <pattern>llan5gr</pattern>
 <pattern>llan4ke</pattern>
 <pattern>ll3ann</pattern>
@@ -21172,12 +21833,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4lase</pattern>
 <pattern>llas4s</pattern>
 <pattern>ll5attr</pattern>
-<pattern>l4lauff</pattern>
+<pattern>l4l5auff</pattern>
 <pattern>l4l5aufg</pattern>
 <pattern>ll5aufko</pattern>
 <pattern>ll5aufl</pattern>
-<pattern>l4laufn</pattern>
-<pattern>ll5aufr</pattern>
 <pattern>ll5aufsi</pattern>
 <pattern>ll5aufst</pattern>
 <pattern>ll3auk</pattern>
@@ -21221,13 +21880,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ller3a</pattern>
 <pattern>ller5ei6s</pattern>
 <pattern>l6l5erfas</pattern>
-<pattern>l6l5erlau</pattern>
+<pattern>ller6klä</pattern>
 <pattern>l4lerle</pattern>
 <pattern>l4l5ernt</pattern>
+<pattern>l4l3erö</pattern>
 <pattern>l6l5ersta</pattern>
-<pattern>l6l5ertra</pattern>
+<pattern>l6lertra</pattern>
 <pattern>l6lerwer</pattern>
 <pattern>llet5he</pattern>
+<pattern>lletter6</pattern>
+<pattern>llet6terf</pattern>
 <pattern>l2lex</pattern>
 <pattern>ll3exe</pattern>
 <pattern>ll3ext</pattern>
@@ -21244,14 +21906,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2lim2</pattern>
 <pattern>ll3imb</pattern>
 <pattern>ll3imp</pattern>
-<pattern>lli5nea</pattern>
-<pattern>l4l3inf</pattern>
+<pattern>l4l3in4f</pattern>
 <pattern>lling4s</pattern>
 <pattern>lli4nie</pattern>
 <pattern>l4l3inj</pattern>
 <pattern>llin4k</pattern>
+<pattern>ll3inl</pattern>
 <pattern>l4lino</pattern>
-<pattern>ll5insp</pattern>
 <pattern>l4l5inst</pattern>
 <pattern>ll3in4t</pattern>
 <pattern>llin4ve</pattern>
@@ -21278,6 +21939,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ll3ord</pattern>
 <pattern>l4l3o4ri</pattern>
 <pattern>ll3or4t</pattern>
+<pattern>ll3osz</pattern>
+<pattern>llo3tr</pattern>
 <pattern>l2l3ou</pattern>
 <pattern>ll3ox</pattern>
 <pattern>l1lö</pattern>
@@ -21290,9 +21953,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ll3sla</pattern>
 <pattern>ll3sli</pattern>
 <pattern>lls5par</pattern>
-<pattern>ll5stei</pattern>
 <pattern>ll5s6temp</pattern>
 <pattern>ll3sti</pattern>
+<pattern>ll4stor</pattern>
 <pattern>ll3ti2</pattern>
 <pattern>l1lu</pattern>
 <pattern>llu2d</pattern>
@@ -21313,7 +21976,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2l1m</pattern>
 <pattern>lma2</pattern>
 <pattern>lm3ab</pattern>
-<pattern>l2m3af</pattern>
 <pattern>lm3aka</pattern>
 <pattern>lmal2</pattern>
 <pattern>lm3alm</pattern>
@@ -21324,6 +21986,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lm3ar4t</pattern>
 <pattern>l5mas </pattern>
 <pattern>lma3ti</pattern>
+<pattern>lm5auss</pattern>
+<pattern>lm5ausw</pattern>
 <pattern>l2mäp</pattern>
 <pattern>lm3ärz</pattern>
 <pattern>lm3äst</pattern>
@@ -21350,11 +22014,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4messa</pattern>
 <pattern>lm4e2t</pattern>
 <pattern>lmgene5</pattern>
-<pattern>l2m3i2d</pattern>
+<pattern>lm3i2d</pattern>
 <pattern>lmi2k</pattern>
 <pattern>lm3iko</pattern>
 <pattern>lm3in4h</pattern>
-<pattern>lm3in4s</pattern>
+<pattern>lm3ins</pattern>
 <pattern>lm3in4t</pattern>
 <pattern>lmma2</pattern>
 <pattern>lm3obe</pattern>
@@ -21371,6 +22035,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lm3s2n</pattern>
 <pattern>lms2z</pattern>
 <pattern>lm1t2</pattern>
+<pattern>l4m3ums</pattern>
 <pattern>l4munt</pattern>
 <pattern>l2m3ur</pattern>
 <pattern>2ln</pattern>
@@ -21404,12 +22069,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lo4che</pattern>
 <pattern>locher4</pattern>
 <pattern>lochs4</pattern>
+<pattern>loch5str</pattern>
 <pattern>lo5ckes</pattern>
 <pattern>lo3dec</pattern>
 <pattern>lod2g</pattern>
 <pattern>lo2er</pattern>
 <pattern>2l1of2</pattern>
+<pattern>lo2fe</pattern>
 <pattern>lo3fj</pattern>
+<pattern>lofo3</pattern>
 <pattern>3loga</pattern>
 <pattern>3logb</pattern>
 <pattern>3logf</pattern>
@@ -21426,6 +22094,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3logw</pattern>
 <pattern>loh4e</pattern>
 <pattern>lohner4</pattern>
+<pattern>loh6ners</pattern>
 <pattern>loh6n5erw</pattern>
 <pattern>4l3oh2r</pattern>
 <pattern>lo2i</pattern>
@@ -21517,6 +22186,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>los3to</pattern>
 <pattern>los3tr</pattern>
 <pattern>los5tro</pattern>
+<pattern>3losu</pattern>
+<pattern>2losz</pattern>
 <pattern>l3oszi</pattern>
 <pattern>2loß</pattern>
 <pattern>lo3tä</pattern>
@@ -21524,9 +22195,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lot2h</pattern>
 <pattern>lo4the</pattern>
 <pattern>lo4tio</pattern>
+<pattern>lo3tro</pattern>
 <pattern>lot4ste</pattern>
 <pattern>lotte4n</pattern>
-<pattern>lot3tw</pattern>
 <pattern>lo2tu</pattern>
 <pattern>2lotz</pattern>
 <pattern>lour4s</pattern>
@@ -21552,7 +22223,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lö5ses </pattern>
 <pattern>l3östl</pattern>
 <pattern>3lösu</pattern>
-<pattern>2löß</pattern>
 <pattern>lö3ti</pattern>
 <pattern>1löw</pattern>
 <pattern>2l1p</pattern>
@@ -21565,6 +22235,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l3pet</pattern>
 <pattern>lpete4</pattern>
 <pattern>lp2f</pattern>
+<pattern>lpf4e</pattern>
+<pattern>lp3fen</pattern>
 <pattern>lp2ha</pattern>
 <pattern>lpha3t</pattern>
 <pattern>lphi3e</pattern>
@@ -21607,6 +22279,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2s3ad</pattern>
 <pattern>lsa3fe</pattern>
 <pattern>lsal2</pattern>
+<pattern>ls3alg</pattern>
 <pattern>lsa3mi</pattern>
 <pattern>l4s3amp</pattern>
 <pattern>lsan2</pattern>
@@ -21620,9 +22293,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4s3anr</pattern>
 <pattern>l4s3ant</pattern>
 <pattern>ls3anz</pattern>
+<pattern>ls2a3p</pattern>
 <pattern>lsa4r</pattern>
 <pattern>l4sari</pattern>
 <pattern>l2sas</pattern>
+<pattern>ls5assi</pattern>
 <pattern>lsau2</pattern>
 <pattern>l4s3au </pattern>
 <pattern>l4s3auf</pattern>
@@ -21639,12 +22314,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ls3eb</pattern>
 <pattern>l4s3eie</pattern>
 <pattern>lsei4n</pattern>
+<pattern>ls5eind</pattern>
 <pattern>ls5einf</pattern>
 <pattern>ls5eint</pattern>
 <pattern>l4s3eli</pattern>
 <pattern>ls3emb</pattern>
 <pattern>lsen3s</pattern>
-<pattern>ls5enzy</pattern>
+<pattern>l4s5en4zy5</pattern>
+<pattern>ls3epi</pattern>
 <pattern>l4s3ere</pattern>
 <pattern>l4s3er4f</pattern>
 <pattern>l4s3erg</pattern>
@@ -21661,7 +22338,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4s3er4z</pattern>
 <pattern>ls3eta</pattern>
 <pattern>lsex4t4</pattern>
-<pattern>l3s4ham</pattern>
 <pattern>l2s3id</pattern>
 <pattern>lsim2</pattern>
 <pattern>l4s3imp</pattern>
@@ -21671,7 +22347,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l5s4kele</pattern>
 <pattern>ls4klav</pattern>
 <pattern>ls4law</pattern>
-<pattern>l1so2</pattern>
+<pattern>lso2</pattern>
 <pattern>l2s3op</pattern>
 <pattern>lsor4d</pattern>
 <pattern>l4s5ort </pattern>
@@ -21680,7 +22356,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2söf</pattern>
 <pattern>l3s2öl</pattern>
 <pattern>l1sp</pattern>
-<pattern>l4spag</pattern>
 <pattern>l4spara</pattern>
 <pattern>l4späs</pattern>
 <pattern>l4s3piz</pattern>
@@ -21690,14 +22365,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lspra3</pattern>
 <pattern>l4s3prä</pattern>
 <pattern>l4spun</pattern>
+<pattern>l4sput</pattern>
 <pattern>ls3s2</pattern>
 <pattern>lsse2</pattern>
-<pattern>l4st </pattern>
 <pattern>l3sta</pattern>
 <pattern>ls5tabl</pattern>
 <pattern>l4stag</pattern>
 <pattern>lstahl5</pattern>
 <pattern>l4s3tak</pattern>
+<pattern>l4s5tanz</pattern>
 <pattern>l4s3tas</pattern>
 <pattern>l4s5tat </pattern>
 <pattern>l4s5ta4te</pattern>
@@ -21706,7 +22382,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l3stea</pattern>
 <pattern>l5steck</pattern>
 <pattern>l3steh</pattern>
-<pattern>l5stein</pattern>
+<pattern>l3stei</pattern>
+<pattern>l4steil</pattern>
 <pattern>l3stel</pattern>
 <pattern>ls3tem</pattern>
 <pattern>ls3ten</pattern>
@@ -21732,7 +22409,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l3s2tu</pattern>
 <pattern>l1su2</pattern>
 <pattern>l4s3umf</pattern>
-<pattern>ls3um4k</pattern>
+<pattern>l4s3um4k</pattern>
+<pattern>l4s3uml</pattern>
 <pattern>l4s3ums</pattern>
 <pattern>ls3um4v</pattern>
 <pattern>ls3um4z</pattern>
@@ -21754,9 +22432,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lt3al4t</pattern>
 <pattern>l4t3alu</pattern>
 <pattern>l2tam</pattern>
-<pattern>lt3ame</pattern>
 <pattern>ltan3d</pattern>
+<pattern>lt4anda</pattern>
 <pattern>ltan4e</pattern>
+<pattern>ltaner4</pattern>
+<pattern>lta6nerf</pattern>
 <pattern>ltanga5</pattern>
 <pattern>ltange5s</pattern>
 <pattern>lt3apo</pattern>
@@ -21773,13 +22453,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lt5arma</pattern>
 <pattern>l4tart</pattern>
 <pattern>lt5art </pattern>
-<pattern>lt5ar4te</pattern>
 <pattern>l4taru</pattern>
 <pattern>l4tarü</pattern>
 <pattern>lt3asp</pattern>
 <pattern>lt3ato</pattern>
 <pattern>lt5aufb</pattern>
 <pattern>lt5aufk</pattern>
+<pattern>ltau4g</pattern>
+<pattern>lt5auge</pattern>
 <pattern>l4taut</pattern>
 <pattern>ltä2</pattern>
 <pattern>lt3äh</pattern>
@@ -21791,6 +22472,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lt3eck</pattern>
 <pattern>l2te3e</pattern>
 <pattern>l2teg</pattern>
+<pattern>l4teim</pattern>
 <pattern>lt3ein</pattern>
 <pattern>l4teis</pattern>
 <pattern>ltel2</pattern>
@@ -21803,16 +22485,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l4temu</pattern>
 <pattern>lte5nas</pattern>
 <pattern>lten6gel</pattern>
+<pattern>lten6spo</pattern>
+<pattern>lt5ents</pattern>
 <pattern>lte3o</pattern>
 <pattern>l5tepp</pattern>
+<pattern>l4terah</pattern>
 <pattern>lter5an</pattern>
 <pattern>lte4rat</pattern>
 <pattern>lter6fah</pattern>
 <pattern>l5terg</pattern>
 <pattern>l4terie</pattern>
 <pattern>lter6leb</pattern>
+<pattern>l4terna</pattern>
 <pattern>lt5er4nä</pattern>
 <pattern>l4ternb</pattern>
+<pattern>lte5ros</pattern>
 <pattern>lter6wei</pattern>
 <pattern>lter6zie</pattern>
 <pattern>lte3se</pattern>
@@ -21824,7 +22511,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lte5stro</pattern>
 <pattern>l4te5stu</pattern>
 <pattern>lte5the</pattern>
+<pattern>lt3e4ti</pattern>
 <pattern>lt3eur</pattern>
+<pattern>lt5ger</pattern>
 <pattern>ltha2</pattern>
 <pattern>l3thas</pattern>
 <pattern>lt3heb</pattern>
@@ -21844,7 +22533,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>l2ti3l</pattern>
 <pattern>lti5mor</pattern>
 <pattern>l4tina4</pattern>
-<pattern>lt3ind</pattern>
+<pattern>l4t3ind</pattern>
 <pattern>lt3inf</pattern>
 <pattern>l4tino</pattern>
 <pattern>l4t3ins</pattern>
@@ -21888,12 +22577,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lt3ruc</pattern>
 <pattern>lt3rum</pattern>
 <pattern>lts5eins</pattern>
-<pattern>lt4s3el</pattern>
+<pattern>lts5ele</pattern>
 <pattern>lt5skal</pattern>
-<pattern>lts5or4t</pattern>
+<pattern>lt4s5or4t</pattern>
 <pattern>lt3s4ph</pattern>
 <pattern>lts5pin</pattern>
-<pattern>lts4por</pattern>
 <pattern>lt4staf</pattern>
 <pattern>lt4stie</pattern>
 <pattern>lt4s5tüt</pattern>
@@ -21901,10 +22589,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ltu2</pattern>
 <pattern>lt3uh</pattern>
 <pattern>l2t3um</pattern>
-<pattern>lturen4</pattern>
+<pattern>lt3uni</pattern>
 <pattern>ltu6rens</pattern>
 <pattern>ltu6r5ent</pattern>
-<pattern>ltu6r5enz</pattern>
+<pattern>ltu6r5en6z</pattern>
 <pattern>ltur5er</pattern>
 <pattern>ltur3i</pattern>
 <pattern>ltursa5c</pattern>
@@ -21921,8 +22609,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2luc</pattern>
 <pattern>lu3che</pattern>
 <pattern>luch4s5a</pattern>
+<pattern>luchs5ta</pattern>
 <pattern>luch4t5r</pattern>
-<pattern>luchts5o</pattern>
+<pattern>lucht6s5o</pattern>
 <pattern>luchtsor6</pattern>
 <pattern>lu3chu</pattern>
 <pattern>lu3cke</pattern>
@@ -21986,10 +22675,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2l3um2z</pattern>
 <pattern>1lu2n</pattern>
 <pattern>2luna</pattern>
+<pattern>2l3un2b</pattern>
+<pattern>lunbe3</pattern>
 <pattern>l3un2f</pattern>
 <pattern>lung2</pattern>
 <pattern>l4ung </pattern>
-<pattern>lun5gen</pattern>
 <pattern>lun4get</pattern>
 <pattern>4l3un4gl</pattern>
 <pattern>2l3uni</pattern>
@@ -22022,7 +22712,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lur3z2</pattern>
 <pattern>2luse</pattern>
 <pattern>2lu3si</pattern>
-<pattern>lu3so</pattern>
 <pattern>3lusq</pattern>
 <pattern>lus4s3a</pattern>
 <pattern>lus4s3c</pattern>
@@ -22034,9 +22723,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lus4st</pattern>
 <pattern>luss5ti</pattern>
 <pattern>luss5tr</pattern>
+<pattern>lus4sur</pattern>
 <pattern>lust5ak</pattern>
 <pattern>lust5ei</pattern>
 <pattern>luster4</pattern>
+<pattern>lus6t5erf</pattern>
 <pattern>lus6terl</pattern>
 <pattern>lust3o</pattern>
 <pattern>lus5tru</pattern>
@@ -22068,7 +22759,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lu3tos</pattern>
 <pattern>lu4t3r</pattern>
 <pattern>lut3sa</pattern>
-<pattern>lut5schl</pattern>
 <pattern>lut3s4k</pattern>
 <pattern>lu4t3ur</pattern>
 <pattern>lü3che</pattern>
@@ -22100,6 +22790,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ly3mo</pattern>
 <pattern>lyne2</pattern>
 <pattern>ly3no</pattern>
+<pattern>2l1yo</pattern>
 <pattern>ly3pe</pattern>
 <pattern>2lyps</pattern>
 <pattern>ly2s</pattern>
@@ -22144,6 +22835,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>lz3in4g</pattern>
 <pattern>lzin4n</pattern>
 <pattern>l4z5inst</pattern>
+<pattern>lz3int</pattern>
 <pattern>lzi3s</pattern>
 <pattern>lzi2t</pattern>
 <pattern>lzo2</pattern>
@@ -22184,35 +22876,37 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m3abm</pattern>
 <pattern>mabma3</pattern>
 <pattern>ma3bo</pattern>
+<pattern>ma3bra</pattern>
 <pattern>mabre5d</pattern>
 <pattern>m3abs</pattern>
 <pattern>m3abt</pattern>
 <pattern>ma2c</pattern>
 <pattern>mac3ar</pattern>
+<pattern>m5achse</pattern>
 <pattern>machter6</pattern>
 <pattern>mach6t5erg</pattern>
 <pattern>mach6t5erh</pattern>
 <pattern>mach6terr</pattern>
 <pattern>mach6t5ers</pattern>
+<pattern>mach6tert</pattern>
 <pattern>mach6t5erw</pattern>
-<pattern>mach4tr</pattern>
-<pattern>mack4st</pattern>
+<pattern>mach4t5r</pattern>
 <pattern>m3act</pattern>
 <pattern>2mad2</pattern>
 <pattern>ma3dac</pattern>
 <pattern>ma3dat</pattern>
 <pattern>ma3dä</pattern>
+<pattern>made5le</pattern>
 <pattern>m3adm</pattern>
 <pattern>m3a2dr</pattern>
 <pattern>2ma1e</pattern>
 <pattern>ma1f2</pattern>
-<pattern>2mafl</pattern>
-<pattern>2mafo</pattern>
+<pattern>2m3aff</pattern>
 <pattern>m3aft</pattern>
 <pattern>2mafu</pattern>
 <pattern>1ma2g</pattern>
 <pattern>ma3gar3</pattern>
-<pattern>2ma3gä</pattern>
+<pattern>2magä</pattern>
 <pattern>mage4n</pattern>
 <pattern>magen5e</pattern>
 <pattern>4maget</pattern>
@@ -22236,7 +22930,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ma3hu</pattern>
 <pattern>ma3hü</pattern>
 <pattern>mai4ler</pattern>
-<pattern>ma3ind</pattern>
+<pattern>mail4l</pattern>
 <pattern>mai4n3e</pattern>
 <pattern>main3s</pattern>
 <pattern>3maio</pattern>
@@ -22259,7 +22953,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mal3an4</pattern>
 <pattern>ma3las</pattern>
 <pattern>6maldehy</pattern>
-<pattern>4ma5lec</pattern>
+<pattern>4malec</pattern>
 <pattern>ma4lern</pattern>
 <pattern>ma4lers</pattern>
 <pattern>ma5lie</pattern>
@@ -22278,10 +22972,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ma2lu2</pattern>
 <pattern>mal3ut</pattern>
 <pattern>3malv</pattern>
+<pattern>mal4zä</pattern>
 <pattern>2mamä</pattern>
 <pattern>2m3am2b</pattern>
 <pattern>2mami</pattern>
-<pattern>ma4mid</pattern>
 <pattern>2m3a2mö</pattern>
 <pattern>m3am2p</pattern>
 <pattern>2m3amt</pattern>
@@ -22293,9 +22987,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2m3an2ä</pattern>
 <pattern>2manb</pattern>
 <pattern>man4bie</pattern>
-<pattern>mand2</pattern>
 <pattern>3manda</pattern>
 <pattern>mande4</pattern>
+<pattern>mand4o</pattern>
+<pattern>mand4s</pattern>
 <pattern>ma4net</pattern>
 <pattern>m4anfr</pattern>
 <pattern>4mangab</pattern>
@@ -22303,8 +22998,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4m5an4geb</pattern>
 <pattern>man4ge5h</pattern>
 <pattern>man4ge5s</pattern>
-<pattern>4m3angr</pattern>
-<pattern>man4gri</pattern>
+<pattern>4mangr</pattern>
 <pattern>m3angs</pattern>
 <pattern>2manh</pattern>
 <pattern>man4hä</pattern>
@@ -22314,13 +23008,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m4anle</pattern>
 <pattern>ma3nos</pattern>
 <pattern>3manö</pattern>
-<pattern>man4pa</pattern>
+<pattern>2manp</pattern>
+<pattern>m3an4pa</pattern>
 <pattern>man4pf</pattern>
 <pattern>manre5g</pattern>
 <pattern>4mansa</pattern>
+<pattern>m5an6satz</pattern>
 <pattern>4m3an4sä</pattern>
 <pattern>m5an6schl</pattern>
 <pattern>m3an4si</pattern>
+<pattern>m3ansp</pattern>
 <pattern>4man4st</pattern>
 <pattern>man4t3a</pattern>
 <pattern>man4tei</pattern>
@@ -22332,6 +23029,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>manu3s</pattern>
 <pattern>man4we</pattern>
 <pattern>2manz</pattern>
+<pattern>3manz </pattern>
 <pattern>m3an4za</pattern>
 <pattern>m5an6zeig</pattern>
 <pattern>m3an4zu</pattern>
@@ -22345,7 +23043,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ma3pfl</pattern>
 <pattern>2maph</pattern>
 <pattern>2mapo</pattern>
-<pattern>m3appa</pattern>
+<pattern>4m3appa</pattern>
 <pattern>3mappe</pattern>
 <pattern>m3appl</pattern>
 <pattern>2ma3pr</pattern>
@@ -22387,7 +23085,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mar6schn</pattern>
 <pattern>mar6scho</pattern>
 <pattern>mar6schr</pattern>
-<pattern>mar6schw</pattern>
+<pattern>mar6sch5w</pattern>
 <pattern>mar4sp</pattern>
 <pattern>mar4su</pattern>
 <pattern>4mart </pattern>
@@ -22415,6 +23113,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mas4ser</pattern>
 <pattern>mas4sis</pattern>
 <pattern>3massn</pattern>
+<pattern>4m3asso</pattern>
 <pattern>mast5an4</pattern>
 <pattern>4ma5s4tel</pattern>
 <pattern>4ma3str</pattern>
@@ -22430,7 +23129,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mat3ä</pattern>
 <pattern>4matec</pattern>
 <pattern>m3atel</pattern>
-<pattern>mate4n</pattern>
+<pattern>mate4n3</pattern>
 <pattern>ma4ter4</pattern>
 <pattern>mat5erd</pattern>
 <pattern>mat5erin</pattern>
@@ -22439,7 +23138,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4matit</pattern>
 <pattern>4m3atmo</pattern>
 <pattern>mato3d</pattern>
-<pattern>4matom</pattern>
+<pattern>4mato4m</pattern>
+<pattern>ma5toma</pattern>
 <pattern>4matop </pattern>
 <pattern>ma4t5opf</pattern>
 <pattern>ma4t5or4t</pattern>
@@ -22485,9 +23185,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mä3res</pattern>
 <pattern>3märk</pattern>
 <pattern>mär4kl</pattern>
-<pattern>mär4zen</pattern>
-<pattern>mär4zer</pattern>
-<pattern>mär4zw</pattern>
+<pattern>mär2z</pattern>
 <pattern>m2äs</pattern>
 <pattern>mät2</pattern>
 <pattern>1mäu</pattern>
@@ -22511,14 +23209,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mbi2n</pattern>
 <pattern>mbi3of</pattern>
 <pattern>m2bis</pattern>
-<pattern>m3bisc</pattern>
 <pattern>m4biti</pattern>
 <pattern>mbi3z</pattern>
 <pattern>m4blem </pattern>
 <pattern>m4bleme</pattern>
 <pattern>m4blems</pattern>
 <pattern>mble3s</pattern>
-<pattern>m3blet</pattern>
 <pattern>m2boj</pattern>
 <pattern>m2bud</pattern>
 <pattern>2mc</pattern>
@@ -22542,6 +23238,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m4d3ent</pattern>
 <pattern>mder2</pattern>
 <pattern>m4d3erf</pattern>
+<pattern>m4d3erk</pattern>
 <pattern>m4d3erl</pattern>
 <pattern>m4d3err</pattern>
 <pattern>mderre5</pattern>
@@ -22569,7 +23266,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>me3ba</pattern>
 <pattern>mebe2</pattern>
 <pattern>me4ben</pattern>
-<pattern>me3bl</pattern>
 <pattern>m2ec</pattern>
 <pattern>3mech</pattern>
 <pattern>mecha3</pattern>
@@ -22595,6 +23291,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>me3ene</pattern>
 <pattern>mee4rei4</pattern>
 <pattern>meer5eic</pattern>
+<pattern>mee5res</pattern>
 <pattern>meer3u</pattern>
 <pattern>2me1f2</pattern>
 <pattern>m3eff</pattern>
@@ -22608,18 +23305,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>meh4l5er</pattern>
 <pattern>meh6rert</pattern>
 <pattern>2meic</pattern>
-<pattern>mei5ert</pattern>
 <pattern>2m3ei2f</pattern>
 <pattern>2m3ei2g</pattern>
-<pattern>3meil4</pattern>
-<pattern>mei5ler</pattern>
+<pattern>3meil</pattern>
 <pattern>4meinb</pattern>
 <pattern>mein4da</pattern>
-<pattern>mein6de5s</pattern>
+<pattern>meinde5</pattern>
+<pattern>mein6des</pattern>
+<pattern>mei5ne5c</pattern>
 <pattern>mei6nenz</pattern>
 <pattern>mei6nerk</pattern>
 <pattern>mei6nerl</pattern>
 <pattern>mei5nes</pattern>
+<pattern>m3einf</pattern>
+<pattern>mein6hal</pattern>
+<pattern>4m3einl</pattern>
 <pattern>4meinr</pattern>
 <pattern>3mei3nu</pattern>
 <pattern>4m3eis </pattern>
@@ -22652,6 +23352,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>me3let</pattern>
 <pattern>me3leu</pattern>
 <pattern>4m3elf </pattern>
+<pattern>mel3id</pattern>
 <pattern>4m3elim</pattern>
 <pattern>mel4k5ei</pattern>
 <pattern>mel3ob</pattern>
@@ -22660,6 +23361,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6m5el6tern</pattern>
 <pattern>me3luc</pattern>
 <pattern>melu3k</pattern>
+<pattern>mel4zi</pattern>
 <pattern>m2em</pattern>
 <pattern>2me3ma</pattern>
 <pattern>2memi2</pattern>
@@ -22716,7 +23418,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>menter4</pattern>
 <pattern>men6t5ers</pattern>
 <pattern>mentge5g</pattern>
+<pattern>men6t5ins</pattern>
 <pattern>menti4s</pattern>
+<pattern>men6trau</pattern>
 <pattern>men6tres</pattern>
 <pattern>men6t5rol</pattern>
 <pattern>menzu3</pattern>
@@ -22778,11 +23482,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4merwäh</pattern>
 <pattern>mer6weit</pattern>
 <pattern>mer4zä</pattern>
-<pattern>mer4z5er</pattern>
 <pattern>mer4zeu</pattern>
 <pattern>merzo4</pattern>
 <pattern>merzu4</pattern>
 <pattern>4merzu </pattern>
+<pattern>mer4zwe</pattern>
 <pattern>m4es </pattern>
 <pattern>me3san</pattern>
 <pattern>4mesat</pattern>
@@ -22793,12 +23497,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>me3sen</pattern>
 <pattern>mese4r</pattern>
 <pattern>3mesf</pattern>
+<pattern>me2so</pattern>
 <pattern>mes3or4</pattern>
 <pattern>4me3spe</pattern>
 <pattern>mes3pr</pattern>
 <pattern>3mesr</pattern>
+<pattern>mes4s5ac</pattern>
 <pattern>mes4sal</pattern>
 <pattern>mes4s5an</pattern>
+<pattern>mes4sau</pattern>
 <pattern>mes4see</pattern>
 <pattern>mes4seg</pattern>
 <pattern>mes6sele</pattern>
@@ -22819,9 +23526,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mete2</pattern>
 <pattern>me3ten</pattern>
 <pattern>3met2h</pattern>
+<pattern>me4tier</pattern>
 <pattern>me3tim</pattern>
 <pattern>2meto</pattern>
 <pattern>me3tor</pattern>
+<pattern>met5res</pattern>
 <pattern>metro5s</pattern>
 <pattern>mett5en6de</pattern>
 <pattern>met4t3i4</pattern>
@@ -22849,12 +23558,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2m1g2</pattern>
 <pattern>mge2</pattern>
 <pattern>mgear4</pattern>
-<pattern>m3gebi</pattern>
 <pattern>mgela4</pattern>
 <pattern>m3gese</pattern>
 <pattern>mgeta4</pattern>
 <pattern>mglim4</pattern>
-<pattern>m3gu</pattern>
 <pattern>mgus2</pattern>
 <pattern>2m1h2</pattern>
 <pattern>mha2</pattern>
@@ -22866,7 +23573,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mho2</pattern>
 <pattern>m2i</pattern>
 <pattern>2mi </pattern>
-<pattern>mi3a2b</pattern>
+<pattern>mi3ab</pattern>
 <pattern>mia2m</pattern>
 <pattern>mi3ano</pattern>
 <pattern>2m3iat</pattern>
@@ -22874,20 +23581,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2mib</pattern>
 <pattern>mi2c</pattern>
 <pattern>mic3e</pattern>
-<pattern>1mid</pattern>
+<pattern>2mid</pattern>
 <pattern>mi3dab</pattern>
 <pattern>mi3deb</pattern>
+<pattern>m3ideo</pattern>
 <pattern>mi3d2r</pattern>
-<pattern>2m3idy</pattern>
+<pattern>m3idy</pattern>
 <pattern>miebe4</pattern>
 <pattern>mie3c</pattern>
 <pattern>mie3dr</pattern>
 <pattern>miege4</pattern>
 <pattern>mie3no</pattern>
 <pattern>mien3s</pattern>
+<pattern>mie4rei</pattern>
 <pattern>mier3n</pattern>
 <pattern>mie4t3i</pattern>
-<pattern>miet5st</pattern>
 <pattern>2mi1f</pattern>
 <pattern>1mig</pattern>
 <pattern>mi3gem</pattern>
@@ -22899,6 +23607,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mik3ar</pattern>
 <pattern>mi4kel</pattern>
 <pattern>mi4k5ens</pattern>
+<pattern>mik6erl</pattern>
 <pattern>mi4k5erz</pattern>
 <pattern>mik3in</pattern>
 <pattern>miko2</pattern>
@@ -22926,16 +23635,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4m3imp</pattern>
 <pattern>3mimt</pattern>
 <pattern>mi3na</pattern>
-<pattern>min3ab4</pattern>
+<pattern>min3a4b4</pattern>
 <pattern>4minac</pattern>
 <pattern>min5anze</pattern>
 <pattern>minbe5t</pattern>
 <pattern>min5de</pattern>
 <pattern>min4di5v</pattern>
-<pattern>4m3indu</pattern>
 <pattern>min5eck</pattern>
 <pattern>mi4neng</pattern>
 <pattern>min5e4ri</pattern>
+<pattern>m3in4fa</pattern>
 <pattern>min4fek</pattern>
 <pattern>m3in4fo</pattern>
 <pattern>min5gab</pattern>
@@ -22962,7 +23671,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4misa</pattern>
 <pattern>mi3s4au</pattern>
 <pattern>misch5erz</pattern>
-<pattern>misch5we</pattern>
 <pattern>mi3see</pattern>
 <pattern>mi3sei</pattern>
 <pattern>mise5ra</pattern>
@@ -23010,6 +23718,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m3leb</pattern>
 <pattern>mle2d</pattern>
 <pattern>mle2g</pattern>
+<pattern>mlein4g</pattern>
 <pattern>mli2b</pattern>
 <pattern>mli2n</pattern>
 <pattern>mlo2</pattern>
@@ -23026,7 +23735,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mm3ans</pattern>
 <pattern>m4manu</pattern>
 <pattern>mm3an4z</pattern>
-<pattern>m2ma2p</pattern>
+<pattern>mma2p</pattern>
 <pattern>mm3apo</pattern>
 <pattern>mmar2</pattern>
 <pattern>mm3art</pattern>
@@ -23036,9 +23745,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m2m3äu</pattern>
 <pattern>mmd2</pattern>
 <pattern>mm3e2b</pattern>
+<pattern>mm5edit</pattern>
 <pattern>m3mee</pattern>
 <pattern>mm3ef</pattern>
-<pattern>m4m3ein3</pattern>
+<pattern>mmein5s</pattern>
 <pattern>mm5eise</pattern>
 <pattern>m3mel</pattern>
 <pattern>mmel3a</pattern>
@@ -23062,7 +23772,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m2m3eu</pattern>
 <pattern>m2mex</pattern>
 <pattern>mmgene5</pattern>
-<pattern>m2mid</pattern>
 <pattern>mmi3el</pattern>
 <pattern>m5mieru</pattern>
 <pattern>mmi3k</pattern>
@@ -23079,7 +23788,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m3mis </pattern>
 <pattern>m4mi3s4t</pattern>
 <pattern>mmi3tw</pattern>
-<pattern>mm3m</pattern>
 <pattern>mmma2</pattern>
 <pattern>mmni2</pattern>
 <pattern>mm3obe</pattern>
@@ -23104,7 +23812,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mm3to</pattern>
 <pattern>m2m3um</pattern>
 <pattern>mmun3d</pattern>
-<pattern>mmun3f</pattern>
+<pattern>mm3unf</pattern>
 <pattern>mmu3r</pattern>
 <pattern>mmut3s4</pattern>
 <pattern>mmül2</pattern>
@@ -23153,6 +23861,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m2ol</pattern>
 <pattern>3molc</pattern>
 <pattern>molch5a</pattern>
+<pattern>mol3d4</pattern>
 <pattern>3mole</pattern>
 <pattern>moles3</pattern>
 <pattern>2molo2</pattern>
@@ -23169,7 +23878,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mon4d5el</pattern>
 <pattern>monder4</pattern>
 <pattern>mon6d5erk</pattern>
-<pattern>mon4dre</pattern>
+<pattern>mon4d5re</pattern>
 <pattern>mo4n3er4</pattern>
 <pattern>mon3g</pattern>
 <pattern>mons3t</pattern>
@@ -23194,11 +23903,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mor4dr</pattern>
 <pattern>mo4rei</pattern>
 <pattern>mo5ren </pattern>
-<pattern>mor5en4g</pattern>
+<pattern>mor5enge</pattern>
 <pattern>morgen5s6</pattern>
-<pattern>m3orgi</pattern>
 <pattern>mo5rier</pattern>
-<pattern>mor3in</pattern>
+<pattern>mor5int</pattern>
 <pattern>mort4</pattern>
 <pattern>mor3ta</pattern>
 <pattern>mor5to</pattern>
@@ -23218,9 +23926,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mo4ter</pattern>
 <pattern>mo4tet</pattern>
 <pattern>2mot4h</pattern>
-<pattern>mo3tio</pattern>
 <pattern>3motiv</pattern>
-<pattern>2motr</pattern>
+<pattern>2mo3tr</pattern>
 <pattern>m2o2u</pattern>
 <pattern>mou2v</pattern>
 <pattern>mo2v</pattern>
@@ -23241,6 +23948,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1mör</pattern>
 <pattern>2mp</pattern>
 <pattern>m1pa</pattern>
+<pattern>mpan4w</pattern>
 <pattern>mp2ar</pattern>
 <pattern>mp3ar4b</pattern>
 <pattern>mpa2t4</pattern>
@@ -23249,16 +23957,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m3pen</pattern>
 <pattern>m4p5ener</pattern>
 <pattern>mpen3s4</pattern>
+<pattern>m4pf </pattern>
+<pattern>mp4fab</pattern>
 <pattern>mpf3au</pattern>
 <pattern>mpf3ef</pattern>
 <pattern>mp4f3el</pattern>
 <pattern>mpf5enz</pattern>
-<pattern>mp6f5erfo</pattern>
+<pattern>mpf5erfo</pattern>
 <pattern>mpf5erpr</pattern>
 <pattern>mp4f5erz</pattern>
 <pattern>mpf3lä</pattern>
 <pattern>mpf3li</pattern>
 <pattern>mpfor4</pattern>
+<pattern>m4pfs</pattern>
 <pattern>m5pfusc</pattern>
 <pattern>mp3haf</pattern>
 <pattern>mph3au</pattern>
@@ -23273,7 +23984,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m4p5lem </pattern>
 <pattern>m4plen</pattern>
 <pattern>m4p3les</pattern>
-<pattern>m2plu</pattern>
 <pattern>mp3n</pattern>
 <pattern>m2poe</pattern>
 <pattern>m2pok</pattern>
@@ -23296,8 +24006,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mra2</pattern>
 <pattern>mrä2</pattern>
 <pattern>mre2</pattern>
-<pattern>mredu3</pattern>
-<pattern>m3reg</pattern>
 <pattern>mrei5ses</pattern>
 <pattern>mreli3</pattern>
 <pattern>mre4p</pattern>
@@ -23318,6 +24026,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ms3as2</pattern>
 <pattern>ms3auf</pattern>
 <pattern>m2s3än</pattern>
+<pattern>ms5chef</pattern>
 <pattern>m1se2</pattern>
 <pattern>ms3ef</pattern>
 <pattern>mse5gelu</pattern>
@@ -23330,24 +24039,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m4sentl</pattern>
 <pattern>ms3er4f</pattern>
 <pattern>m4s3er4k</pattern>
+<pattern>ms3er4t</pattern>
 <pattern>mser4wa</pattern>
 <pattern>ms3eti</pattern>
 <pattern>m2seu</pattern>
-<pattern>m2sex2</pattern>
+<pattern>msex2</pattern>
 <pattern>m2sh</pattern>
 <pattern>msim2</pattern>
-<pattern>ms3imp</pattern>
+<pattern>m4s3imp</pattern>
 <pattern>ms3ini</pattern>
 <pattern>ms3in4t</pattern>
 <pattern>msmo2</pattern>
-<pattern>m1so</pattern>
 <pattern>m2so </pattern>
 <pattern>m2s3od</pattern>
 <pattern>mso2r</pattern>
 <pattern>ms3orc</pattern>
-<pattern>m4sord</pattern>
 <pattern>m4s3ori</pattern>
 <pattern>msor4te</pattern>
+<pattern>m2s3ou2</pattern>
 <pattern>m1sp</pattern>
 <pattern>m4s3ped</pattern>
 <pattern>m2spl</pattern>
@@ -23377,7 +24086,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mtan4g</pattern>
 <pattern>mtan4s</pattern>
 <pattern>mtar2</pattern>
-<pattern>m3t4as</pattern>
+<pattern>mt4asc</pattern>
 <pattern>m2tat</pattern>
 <pattern>m1tä2</pattern>
 <pattern>mt3än4d</pattern>
@@ -23458,6 +24167,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>m4t3res</pattern>
 <pattern>m4t3ris</pattern>
 <pattern>mtro2</pattern>
+<pattern>mt3rob</pattern>
 <pattern>mt3rot</pattern>
 <pattern>mt3s2c</pattern>
 <pattern>mt3se</pattern>
@@ -23467,7 +24177,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mt5send</pattern>
 <pattern>mt5s4kel</pattern>
 <pattern>mts5kr</pattern>
-<pattern>mt3sor</pattern>
 <pattern>mt5spre</pattern>
 <pattern>mt3t2</pattern>
 <pattern>mtu2</pattern>
@@ -23485,9 +24194,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mucker4</pattern>
 <pattern>mu5cker </pattern>
 <pattern>mu5ckere </pattern>
+<pattern>mu5ckeren</pattern>
 <pattern>mu5ckerer</pattern>
+<pattern>muck5erk</pattern>
+<pattern>muck5ers</pattern>
 <pattern>muck5erz</pattern>
 <pattern>muck5sp</pattern>
+<pattern>mu2f</pattern>
 <pattern>m1u2h2</pattern>
 <pattern>muha3</pattern>
 <pattern>1mu2k</pattern>
@@ -23509,7 +24222,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mum2s</pattern>
 <pattern>mums3p</pattern>
 <pattern>m3umst</pattern>
-<pattern>2m3umt</pattern>
+<pattern>2mumt</pattern>
 <pattern>mum2w</pattern>
 <pattern>mum2z</pattern>
 <pattern>1mu2n</pattern>
@@ -23518,7 +24231,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>mun2f</pattern>
 <pattern>mung2</pattern>
 <pattern>4m5un4geb</pattern>
-<pattern>4muniv</pattern>
+<pattern>4m3univ</pattern>
 <pattern>mun3th</pattern>
 <pattern>mun4tr</pattern>
 <pattern>mun4ve</pattern>
@@ -23561,7 +24274,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2müdl</pattern>
 <pattern>3mü4hl</pattern>
 <pattern>mühl3a</pattern>
-<pattern>mühl3s</pattern>
 <pattern>mün3t</pattern>
 <pattern>mür4bet</pattern>
 <pattern>müse3</pattern>
@@ -23587,16 +24299,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2mz2</pattern>
 <pattern>mzo2</pattern>
 <pattern>mzu2b</pattern>
+<pattern>mzu5bew</pattern>
+<pattern>mzu3bu</pattern>
 <pattern>mzu2d</pattern>
 <pattern>mzu3fa</pattern>
 <pattern>mzu3fl</pattern>
 <pattern>mzu4fo</pattern>
 <pattern>mzu2l</pattern>
+<pattern>mzu4la</pattern>
+<pattern>mzu5lau</pattern>
 <pattern>mzu3ma</pattern>
-<pattern>mzu2n</pattern>
+<pattern>mzu5pfu</pattern>
 <pattern>mzu2r</pattern>
 <pattern>mzu3re</pattern>
 <pattern>mzu2s</pattern>
+<pattern>mzu5sit</pattern>
 <pattern>mzu3sp</pattern>
 <pattern>mzu2v</pattern>
 <pattern>mzu2w</pattern>
@@ -23618,7 +24335,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nab2m</pattern>
 <pattern>nab2n</pattern>
 <pattern>na4bor</pattern>
-<pattern>na2br</pattern>
 <pattern>n4a3brü</pattern>
 <pattern>2nab2s</pattern>
 <pattern>2n3ab2t</pattern>
@@ -23718,6 +24434,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nal3ed</pattern>
 <pattern>nal3ei4</pattern>
 <pattern>na4l5end</pattern>
+<pattern>na4l5ens</pattern>
 <pattern>nal5ents</pattern>
 <pattern>nal3ep</pattern>
 <pattern>naler4</pattern>
@@ -23734,7 +24451,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nalge4r</pattern>
 <pattern>n2ali</pattern>
 <pattern>nal3i4d</pattern>
-<pattern>nal5ini</pattern>
+<pattern>nal5insc</pattern>
 <pattern>nal6l5en6g</pattern>
 <pattern>nalli4t</pattern>
 <pattern>4nallt</pattern>
@@ -23747,6 +24464,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nal5skr</pattern>
 <pattern>nal4spu</pattern>
 <pattern>n3alt </pattern>
+<pattern>n3altd</pattern>
 <pattern>nal4tem</pattern>
 <pattern>nal4ten</pattern>
 <pattern>nal4tes</pattern>
@@ -23762,7 +24480,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>namenspa6</pattern>
 <pattern>n3amer</pattern>
 <pattern>na3mes</pattern>
-<pattern>n3a4mid</pattern>
+<pattern>n3amid</pattern>
 <pattern>na3mis</pattern>
 <pattern>2n3am2m</pattern>
 <pattern>na3mn</pattern>
@@ -23812,13 +24530,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nanzer4</pattern>
 <pattern>nan6z5erf</pattern>
 <pattern>nan6zerg</pattern>
+<pattern>nan6z5erm</pattern>
 <pattern>nan6z5ers</pattern>
 <pattern>4nanzf</pattern>
+<pattern>nan4zin</pattern>
 <pattern>4nanzk</pattern>
 <pattern>4nanzr</pattern>
 <pattern>nan4zu</pattern>
 <pattern>4nan4zü</pattern>
 <pattern>4nan4zw</pattern>
+<pattern>nao2</pattern>
 <pattern>na3ot</pattern>
 <pattern>na3pas</pattern>
 <pattern>3napf </pattern>
@@ -23833,6 +24554,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n1a2q</pattern>
 <pattern>n1ar</pattern>
 <pattern>n4ar </pattern>
+<pattern>nar3ak</pattern>
 <pattern>nar3an4</pattern>
 <pattern>na3rä</pattern>
 <pattern>nar2b</pattern>
@@ -23846,7 +24568,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>na3res</pattern>
 <pattern>na3ret</pattern>
 <pattern>2narg</pattern>
-<pattern>n4arge</pattern>
 <pattern>n2a3ri</pattern>
 <pattern>3narik</pattern>
 <pattern>3nariu</pattern>
@@ -23854,7 +24575,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4arle</pattern>
 <pattern>2nar2m</pattern>
 <pattern>4narm </pattern>
-<pattern>n4ar3ma</pattern>
 <pattern>4narme</pattern>
 <pattern>2naro</pattern>
 <pattern>na3rot</pattern>
@@ -23866,7 +24586,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nar4se3</pattern>
 <pattern>2nar2t</pattern>
 <pattern>n4arta</pattern>
-<pattern>3n4ar3th</pattern>
 <pattern>2naru</pattern>
 <pattern>na3rum</pattern>
 <pattern>3narv</pattern>
@@ -23880,7 +24599,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3nasg</pattern>
 <pattern>n2asi</pattern>
 <pattern>3nask</pattern>
-<pattern>na3so</pattern>
 <pattern>2na2sp</pattern>
 <pattern>nas4ph</pattern>
 <pattern>4n3as4si</pattern>
@@ -23891,6 +24609,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>na2sy</pattern>
 <pattern>nasy5la</pattern>
 <pattern>na3tab</pattern>
+<pattern>natal5s4</pattern>
 <pattern>nata3s</pattern>
 <pattern>nat3au</pattern>
 <pattern>3natä</pattern>
@@ -23902,9 +24621,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4natom</pattern>
 <pattern>3natos</pattern>
 <pattern>5natron</pattern>
-<pattern>nat4s5ac</pattern>
-<pattern>nat4s5en</pattern>
-<pattern>nat4sti</pattern>
+<pattern>nats5ac</pattern>
+<pattern>nats5en</pattern>
 <pattern>4n3atta</pattern>
 <pattern>nat5ter</pattern>
 <pattern>n4atu</pattern>
@@ -23968,7 +24686,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3näum</pattern>
 <pattern>2nb2</pattern>
 <pattern>nba2</pattern>
-<pattern>nbau5er6f</pattern>
 <pattern>nbau3f</pattern>
 <pattern>nbau3s</pattern>
 <pattern>n3bä</pattern>
@@ -23987,10 +24704,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nbesu5cher</pattern>
 <pattern>nbetä5t</pattern>
 <pattern>nbi2</pattern>
+<pattern>n3bl</pattern>
 <pattern>nboge4</pattern>
 <pattern>nbogen5</pattern>
 <pattern>nbo2t</pattern>
-<pattern>n3bö</pattern>
 <pattern>nbre3c</pattern>
 <pattern>nbro3c</pattern>
 <pattern>nbruchs5tr</pattern>
@@ -24005,7 +24722,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n2cab</pattern>
 <pattern>n2cei</pattern>
 <pattern>n2cem</pattern>
-<pattern>n3cen</pattern>
 <pattern>n2ceo</pattern>
 <pattern>n3cep</pattern>
 <pattern>nce3ra</pattern>
@@ -24029,6 +24745,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nda5lei</pattern>
 <pattern>n4d3all</pattern>
 <pattern>nda3ma</pattern>
+<pattern>nd3anb</pattern>
+<pattern>n4danf</pattern>
 <pattern>ndan4g</pattern>
 <pattern>ndanga5</pattern>
 <pattern>nd5ange</pattern>
@@ -24043,6 +24761,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nda5ren</pattern>
 <pattern>ndar4r</pattern>
 <pattern>n5das </pattern>
+<pattern>ndaus3</pattern>
 <pattern>n4daut</pattern>
 <pattern>n2dav</pattern>
 <pattern>n2daw</pattern>
@@ -24050,7 +24769,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nd3äng</pattern>
 <pattern>n2d3ät</pattern>
 <pattern>nd1c</pattern>
-<pattern>nd3d</pattern>
 <pattern>n4deak</pattern>
 <pattern>ndeal4</pattern>
 <pattern>nde5alt</pattern>
@@ -24079,12 +24797,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ndelän4</pattern>
 <pattern>nde5lec</pattern>
 <pattern>ndele6ge</pattern>
-<pattern>nde5lin</pattern>
+<pattern>nde4ler</pattern>
+<pattern>nde5lins</pattern>
 <pattern>ndel6s5am</pattern>
 <pattern>ndel6s5en</pattern>
-<pattern>ndel4s5o</pattern>
-<pattern>ndelsor6</pattern>
+<pattern>ndel6s5or6</pattern>
 <pattern>ndel5ster</pattern>
+<pattern>ndem5ac</pattern>
 <pattern>n4deme</pattern>
 <pattern>nde4mie</pattern>
 <pattern>nde4mon</pattern>
@@ -24110,15 +24829,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nder6ho5l</pattern>
 <pattern>n4deric</pattern>
 <pattern>n4deroh</pattern>
-<pattern>nd5eros</pattern>
+<pattern>nder6trage</pattern>
 <pattern>nderzu5h</pattern>
 <pattern>nde4sam</pattern>
 <pattern>nde4san</pattern>
 <pattern>n3desi</pattern>
+<pattern>ndes5tä</pattern>
 <pattern>n6de5strä</pattern>
 <pattern>nde5stri</pattern>
 <pattern>nde4tek</pattern>
 <pattern>n3deum</pattern>
+<pattern>nde6uts</pattern>
 <pattern>n2dez</pattern>
 <pattern>nde3zi</pattern>
 <pattern>n4dienr</pattern>
@@ -24167,7 +24888,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nd4s5erb</pattern>
 <pattern>nd4skl</pattern>
 <pattern>nd4spä</pattern>
-<pattern>nd4sph</pattern>
 <pattern>nd4szi</pattern>
 <pattern>nd3tei</pattern>
 <pattern>ndti2</pattern>
@@ -24178,18 +24898,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n2dym</pattern>
 <pattern>1ne</pattern>
 <pattern>2ne </pattern>
-<pattern>2nea</pattern>
-<pattern>3nea </pattern>
-<pattern>nea2b</pattern>
+<pattern>2nea2b</pattern>
+<pattern>2neal</pattern>
 <pattern>ne3als</pattern>
-<pattern>ne3am</pattern>
+<pattern>2ne3am</pattern>
+<pattern>2nean</pattern>
 <pattern>neange5</pattern>
 <pattern>nea5ren</pattern>
 <pattern>nea5res</pattern>
 <pattern>ne3art</pattern>
+<pattern>2neat</pattern>
 <pattern>ne3att</pattern>
-<pattern>ne3au</pattern>
-<pattern>3neaz</pattern>
+<pattern>2ne3au</pattern>
 <pattern>2neä</pattern>
 <pattern>ne2b</pattern>
 <pattern>2ne3ba</pattern>
@@ -24209,6 +24929,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3ne2ce</pattern>
 <pattern>ne3che</pattern>
 <pattern>ne3chr</pattern>
+<pattern>n3echs</pattern>
 <pattern>neck4a</pattern>
 <pattern>3neckt</pattern>
 <pattern>ned2</pattern>
@@ -24229,11 +24950,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>neg2</pattern>
 <pattern>ne3gal</pattern>
 <pattern>ne3gau</pattern>
-<pattern>2ne3gä</pattern>
+<pattern>2negä</pattern>
 <pattern>2nege</pattern>
 <pattern>n3egg</pattern>
 <pattern>ne3gle</pattern>
 <pattern>n3ego</pattern>
+<pattern>ne4gri</pattern>
 <pattern>ne3ha</pattern>
 <pattern>2ne3hä</pattern>
 <pattern>2nehe</pattern>
@@ -24242,23 +24964,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ne3he4r</pattern>
 <pattern>ne3hi</pattern>
 <pattern>n4ehm</pattern>
+<pattern>neh4min</pattern>
 <pattern>2ne3ho</pattern>
-<pattern>neh2r</pattern>
+<pattern>2neh2r</pattern>
 <pattern>nehr5er</pattern>
 <pattern>2n1ei</pattern>
 <pattern>3neia</pattern>
 <pattern>nei2b</pattern>
 <pattern>nei4c</pattern>
 <pattern>nei4da</pattern>
-<pattern>neid5ei</pattern>
 <pattern>5neige </pattern>
 <pattern>5neigu</pattern>
 <pattern>nei3k</pattern>
 <pattern>nei2l</pattern>
 <pattern>nei4me</pattern>
+<pattern>ne3imp</pattern>
 <pattern>neingebo5</pattern>
 <pattern>nei4ni</pattern>
-<pattern>nein3s</pattern>
 <pattern>ne5insel</pattern>
 <pattern>n4einsu</pattern>
 <pattern>nei3nu</pattern>
@@ -24277,7 +24999,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ne3lag</pattern>
 <pattern>n3elas</pattern>
 <pattern>2ne3lä</pattern>
-<pattern>n3el2c</pattern>
 <pattern>ne3leb</pattern>
 <pattern>4n3elek</pattern>
 <pattern>4nelem</pattern>
@@ -24288,9 +25009,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ne3lin</pattern>
 <pattern>3nelk</pattern>
 <pattern>n2ell</pattern>
-<pattern>nel4la</pattern>
-<pattern>nell5an</pattern>
-<pattern>nell5au</pattern>
+<pattern>nel4l3a</pattern>
 <pattern>nel4l5ei</pattern>
 <pattern>nel6l5erf</pattern>
 <pattern>nell5erk</pattern>
@@ -24303,6 +25022,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n3emai</pattern>
 <pattern>2ne3mä</pattern>
 <pattern>2n3emb</pattern>
+<pattern>4nemes</pattern>
 <pattern>n2emi</pattern>
 <pattern>ne4mig</pattern>
 <pattern>2nemo</pattern>
@@ -24330,14 +25050,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ne4n3eb</pattern>
 <pattern>nen3ec</pattern>
 <pattern>nen3ed</pattern>
-<pattern>ne4neh</pattern>
 <pattern>nenen4</pattern>
 <pattern>nen5end</pattern>
 <pattern>ne4n5ene</pattern>
 <pattern>nen5ens</pattern>
 <pattern>nen5ent</pattern>
 <pattern>ne4n5ers</pattern>
-<pattern>nen5er4w</pattern>
+<pattern>4nenerv</pattern>
+<pattern>ne4n5er4w</pattern>
+<pattern>nenes4</pattern>
+<pattern>nen5ess</pattern>
 <pattern>ne4n3eu</pattern>
 <pattern>n5enge </pattern>
 <pattern>nen6gen </pattern>
@@ -24376,6 +25098,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nen3u</pattern>
 <pattern>n2enz</pattern>
 <pattern>nenzer6sc</pattern>
+<pattern>4n5enzia</pattern>
 <pattern>nenzu4g</pattern>
 <pattern>nenz4w</pattern>
 <pattern>ne2o</pattern>
@@ -24389,19 +25112,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ne4pet</pattern>
 <pattern>ne4pos</pattern>
 <pattern>nepo3t</pattern>
+<pattern>3nepp</pattern>
 <pattern>nep3t</pattern>
 <pattern>ne3pu2</pattern>
 <pattern>n4er </pattern>
 <pattern>2nera</pattern>
 <pattern>ner3a4b</pattern>
 <pattern>ner3af</pattern>
+<pattern>ner3a4g</pattern>
 <pattern>ner3ak</pattern>
 <pattern>ne3ral</pattern>
 <pattern>ner3am</pattern>
 <pattern>ner3an4</pattern>
 <pattern>ner3ap</pattern>
-<pattern>3nerar</pattern>
-<pattern>neras4</pattern>
+<pattern>ner3ar</pattern>
+<pattern>nera4s4</pattern>
 <pattern>ne5rativ</pattern>
 <pattern>2ne3rä</pattern>
 <pattern>nerbe4</pattern>
@@ -24411,7 +25136,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ner4bin</pattern>
 <pattern>5n4erbr</pattern>
 <pattern>4nerbs</pattern>
-<pattern>4n3erdb</pattern>
+<pattern>4nerdb</pattern>
 <pattern>4nerde</pattern>
 <pattern>ner4dun</pattern>
 <pattern>n2ere2</pattern>
@@ -24425,11 +25150,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4nerel</pattern>
 <pattern>nerer4</pattern>
 <pattern>ne4r5ere</pattern>
-<pattern>ne4r5erf</pattern>
+<pattern>ne4rerf</pattern>
+<pattern>ne4r5erh</pattern>
 <pattern>ner5ers</pattern>
 <pattern>ner6fahr</pattern>
-<pattern>n5er4fas</pattern>
-<pattern>ner4fin</pattern>
+<pattern>4n5er4fin</pattern>
 <pattern>4n5er4fol</pattern>
 <pattern>ner4fül</pattern>
 <pattern>5nerges</pattern>
@@ -24448,7 +25173,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4neri4t</pattern>
 <pattern>ner4ker</pattern>
 <pattern>4n5er4klä</pattern>
-<pattern>ner6kran</pattern>
 <pattern>ner6läut</pattern>
 <pattern>ner6lebn</pattern>
 <pattern>ner4lö</pattern>
@@ -24467,9 +25191,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ner5ost</pattern>
 <pattern>2nerö</pattern>
 <pattern>nerös4</pattern>
+<pattern>ner4pre</pattern>
 <pattern>ner2q</pattern>
 <pattern>ner4re</pattern>
-<pattern>4n5er4sat</pattern>
+<pattern>ner4sat</pattern>
 <pattern>ner6schü</pattern>
 <pattern>ner4sk</pattern>
 <pattern>4n5ersts</pattern>
@@ -24482,7 +25207,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4erv</pattern>
 <pattern>5nervte</pattern>
 <pattern>4n3er4wä</pattern>
-<pattern>nerwe5ck</pattern>
+<pattern>ner6we5ck</pattern>
 <pattern>ner6weit</pattern>
 <pattern>ner4wid</pattern>
 <pattern>ner4zä</pattern>
@@ -24503,25 +25228,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4neserg</pattern>
 <pattern>4neses</pattern>
 <pattern>nes3ev</pattern>
-<pattern>ne4sim</pattern>
 <pattern>4nesit</pattern>
 <pattern>nes4ka</pattern>
 <pattern>ne5skan</pattern>
-<pattern>nes3of4</pattern>
-<pattern>ne3sol</pattern>
-<pattern>nes3or</pattern>
+<pattern>ne3so</pattern>
+<pattern>ne4s3of4</pattern>
 <pattern>nes3pa</pattern>
 <pattern>4ne3spe</pattern>
 <pattern>ne3spu</pattern>
 <pattern>4nessa</pattern>
-<pattern>nes5sel</pattern>
-<pattern>n4est</pattern>
+<pattern>nes4sen</pattern>
+<pattern>nes4ser</pattern>
 <pattern>4ne3sta</pattern>
 <pattern>nes5täu</pattern>
 <pattern>nes5telt</pattern>
 <pattern>4nesti</pattern>
 <pattern>nes5tie</pattern>
-<pattern>4nes3to</pattern>
+<pattern>nes5tor</pattern>
 <pattern>4nestr</pattern>
 <pattern>nest5ran</pattern>
 <pattern>nest5rau</pattern>
@@ -24531,23 +25254,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4nestü</pattern>
 <pattern>2ne3su</pattern>
 <pattern>2nesy</pattern>
+<pattern>n5e4tage</pattern>
 <pattern>ne3tal</pattern>
 <pattern>n3etap</pattern>
 <pattern>n3etat</pattern>
 <pattern>4netec</pattern>
+<pattern>net3ei</pattern>
 <pattern>ne4t3el</pattern>
 <pattern>nete4n</pattern>
 <pattern>net5erh</pattern>
 <pattern>net5er4s</pattern>
-<pattern>ne3the</pattern>
 <pattern>ne4t3in</pattern>
 <pattern>net3ob</pattern>
 <pattern>2ne3tr</pattern>
 <pattern>net3sp</pattern>
-<pattern>net5str</pattern>
 <pattern>net5ta</pattern>
 <pattern>ne4tus</pattern>
 <pattern>2netü</pattern>
+<pattern>3netz </pattern>
+<pattern>3netze</pattern>
 <pattern>net4z3i</pattern>
 <pattern>ne2u</pattern>
 <pattern>neu3c</pattern>
@@ -24558,6 +25283,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>neu5er4r</pattern>
 <pattern>neu5er4s</pattern>
 <pattern>neu5er4w</pattern>
+<pattern>2neuf</pattern>
 <pattern>neu3g4</pattern>
 <pattern>neu3k</pattern>
 <pattern>4n3eule</pattern>
@@ -24566,28 +25292,30 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>neu3mi</pattern>
 <pattern>2n3eup</pattern>
 <pattern>neur2</pattern>
+<pattern>neur3a</pattern>
 <pattern>neu5rei</pattern>
 <pattern>2neü</pattern>
 <pattern>ne4van</pattern>
-<pattern>n3e2ve</pattern>
 <pattern>ne4vid</pattern>
 <pattern>ne4vo5lu</pattern>
 <pattern>2n2ew</pattern>
 <pattern>newe2</pattern>
 <pattern>3newi</pattern>
+<pattern>new2s3</pattern>
 <pattern>2n1e2x2</pattern>
 <pattern>3ney</pattern>
 <pattern>ne3z</pattern>
 <pattern>nezo3</pattern>
 <pattern>1nés</pattern>
 <pattern>2nf</pattern>
-<pattern>nf2a</pattern>
 <pattern>n3fab</pattern>
 <pattern>nfah4l</pattern>
 <pattern>nfall6s5o</pattern>
 <pattern>nfallsor6</pattern>
 <pattern>nfalt4</pattern>
+<pattern>nf2an</pattern>
 <pattern>nf3an4b</pattern>
+<pattern>n3fas</pattern>
 <pattern>n4faut</pattern>
 <pattern>n3fäd</pattern>
 <pattern>n3fäu</pattern>
@@ -24607,8 +25335,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nf3län</pattern>
 <pattern>nf2lu</pattern>
 <pattern>nf2o</pattern>
+<pattern>nfo3b</pattern>
 <pattern>nfo3f</pattern>
-<pattern>n2fok</pattern>
+<pattern>n2fo3k</pattern>
 <pattern>n2fop</pattern>
 <pattern>n4fora</pattern>
 <pattern>n5ford </pattern>
@@ -24618,8 +25347,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n5fort</pattern>
 <pattern>n4fos </pattern>
 <pattern>nfo3st</pattern>
+<pattern>nfo3v</pattern>
 <pattern>n1fr</pattern>
-<pattern>nf1s2</pattern>
+<pattern>nf3s2</pattern>
 <pattern>nf3tau</pattern>
 <pattern>nf3tei</pattern>
 <pattern>nfter4</pattern>
@@ -24640,7 +25370,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n2gad</pattern>
 <pattern>ng3adr</pattern>
 <pattern>n5gage </pattern>
-<pattern>ng3ak</pattern>
+<pattern>ng3aka</pattern>
 <pattern>nga4ler</pattern>
 <pattern>ng3alm</pattern>
 <pattern>ng3ame</pattern>
@@ -24671,6 +25401,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nge4be</pattern>
 <pattern>n5ge4bi</pattern>
 <pattern>nge6bie</pattern>
+<pattern>nge4bl</pattern>
 <pattern>ngebo4</pattern>
 <pattern>nge4br</pattern>
 <pattern>nge4bur</pattern>
@@ -24699,7 +25430,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nge5lis</pattern>
 <pattern>n4ge5los</pattern>
 <pattern>n4gelsa</pattern>
-<pattern>ngel4st</pattern>
 <pattern>n4gelwe</pattern>
 <pattern>nge2m</pattern>
 <pattern>ngema5ches</pattern>
@@ -24709,6 +25439,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nge4neh</pattern>
 <pattern>nge5ner </pattern>
 <pattern>ngene5rato</pattern>
+<pattern>n6generg</pattern>
 <pattern>nge4net</pattern>
 <pattern>nge4no</pattern>
 <pattern>n6gensem</pattern>
@@ -24719,8 +25450,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nge4rec</pattern>
 <pattern>nge5reck</pattern>
 <pattern>nge6reif</pattern>
+<pattern>ng5ereig</pattern>
 <pattern>nge6rend</pattern>
 <pattern>nge6rers</pattern>
+<pattern>nger6heb</pattern>
 <pattern>nge4ruc</pattern>
 <pattern>nger4zä</pattern>
 <pattern>nge2s</pattern>
@@ -24752,16 +25485,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n3glio</pattern>
 <pattern>ng3log</pattern>
 <pattern>ng5lot </pattern>
-<pattern>ng3luc</pattern>
 <pattern>ng3lus</pattern>
 <pattern>ngma2</pattern>
 <pattern>ngn2</pattern>
+<pattern>ng3nar</pattern>
 <pattern>ng3ne</pattern>
 <pattern>ng3ni</pattern>
 <pattern>ng4nom</pattern>
 <pattern>n2gog</pattern>
 <pattern>ngo3la</pattern>
 <pattern>ng3ope</pattern>
+<pattern>ng3opf</pattern>
 <pattern>ngo2r</pattern>
 <pattern>n3gos </pattern>
 <pattern>ng3rai</pattern>
@@ -24780,17 +25514,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n5grup</pattern>
 <pattern>ngru3ß</pattern>
 <pattern>ng4sah</pattern>
-<pattern>ngs5alb</pattern>
 <pattern>ngs5aug</pattern>
 <pattern>ngsauto6r</pattern>
 <pattern>ng2sä</pattern>
 <pattern>ng4s5cho</pattern>
 <pattern>ng4scr</pattern>
+<pattern>ng2se</pattern>
 <pattern>ngs3eh</pattern>
 <pattern>ng5sere</pattern>
 <pattern>ng4sf</pattern>
 <pattern>ng2si</pattern>
-<pattern>ng4som</pattern>
 <pattern>ng5spei</pattern>
 <pattern>ngs5tec</pattern>
 <pattern>ng5stim</pattern>
@@ -24807,7 +25540,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n5halb</pattern>
 <pattern>n3hall</pattern>
 <pattern>nh4au</pattern>
-<pattern>nhaus6se</pattern>
 <pattern>nhä2</pattern>
 <pattern>n3häus</pattern>
 <pattern>nhe4be</pattern>
@@ -24821,6 +25553,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nhor4s</pattern>
 <pattern>1ni</pattern>
 <pattern>2ni </pattern>
+<pattern>ni3a2b</pattern>
 <pattern>ni2ak</pattern>
 <pattern>nia4lin</pattern>
 <pattern>ni2a3r</pattern>
@@ -24830,6 +25563,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ni3chr</pattern>
 <pattern>nich3s</pattern>
 <pattern>nichter6</pattern>
+<pattern>nich4tr</pattern>
 <pattern>nicht5sp</pattern>
 <pattern>ni3cku</pattern>
 <pattern>2nico</pattern>
@@ -24858,6 +25592,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ni3ell</pattern>
 <pattern>4niels</pattern>
 <pattern>nie2n</pattern>
+<pattern>nie4na</pattern>
 <pattern>nien3e</pattern>
 <pattern>nienen4</pattern>
 <pattern>niener4</pattern>
@@ -24865,25 +25600,38 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4niepl</pattern>
 <pattern>niere4</pattern>
 <pattern>nie4r5ei6</pattern>
+<pattern>nie6rerg</pattern>
 <pattern>ni5ern </pattern>
 <pattern>nie5sti</pattern>
 <pattern>nie3ta</pattern>
 <pattern>nife4</pattern>
 <pattern>2ni3fl</pattern>
+<pattern>ni3f2r</pattern>
+<pattern>n4ig </pattern>
 <pattern>nig3ab</pattern>
 <pattern>nig3am</pattern>
 <pattern>nig3an4</pattern>
-<pattern>4n5i4gel</pattern>
+<pattern>n4ige </pattern>
+<pattern>4n3i4gel</pattern>
+<pattern>n4igem</pattern>
+<pattern>n4igen</pattern>
+<pattern>n4iger</pattern>
+<pattern>nig5erz</pattern>
+<pattern>n4iges</pattern>
 <pattern>4niget</pattern>
+<pattern>n4igk</pattern>
 <pattern>ni3gla3</pattern>
 <pattern>nig3li</pattern>
 <pattern>2nign</pattern>
 <pattern>ni4gre</pattern>
+<pattern>n4igs</pattern>
 <pattern>nig4sam</pattern>
 <pattern>nig4spr</pattern>
+<pattern>n4igt</pattern>
+<pattern>n4igu</pattern>
 <pattern>nihi3</pattern>
 <pattern>n2ik</pattern>
-<pattern>4nikbr</pattern>
+<pattern>nik5anb</pattern>
 <pattern>4ni4kel</pattern>
 <pattern>ni4k5er4f</pattern>
 <pattern>2nikh</pattern>
@@ -24893,6 +25641,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ni2kr</pattern>
 <pattern>nik3ra</pattern>
 <pattern>nik3rä</pattern>
+<pattern>ni5krei</pattern>
 <pattern>2nil</pattern>
 <pattern>ni3las</pattern>
 <pattern>nil2l</pattern>
@@ -24907,8 +25656,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ni3mo</pattern>
 <pattern>2n3im2p</pattern>
 <pattern>ni3mu</pattern>
+<pattern>ninab4</pattern>
 <pattern>ni3nac</pattern>
-<pattern>nin3al</pattern>
 <pattern>ninan3</pattern>
 <pattern>ni3nä</pattern>
 <pattern>3ninba</pattern>
@@ -24942,13 +25691,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2n3in2v</pattern>
 <pattern>ninva3</pattern>
 <pattern>2nio</pattern>
-<pattern>nio2k</pattern>
+<pattern>nio2k3</pattern>
 <pattern>3niol</pattern>
 <pattern>2nip</pattern>
 <pattern>2nir</pattern>
 <pattern>n2ira2</pattern>
 <pattern>4n3irr</pattern>
-<pattern>ni4san</pattern>
 <pattern>n2isc</pattern>
 <pattern>ni4scha</pattern>
 <pattern>nise2</pattern>
@@ -24956,13 +25704,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nis3el</pattern>
 <pattern>nis3er4</pattern>
 <pattern>nis3id</pattern>
+<pattern>nis3ik</pattern>
 <pattern>ni4sim</pattern>
 <pattern>nis3in4</pattern>
 <pattern>nismi3</pattern>
-<pattern>ni2so</pattern>
 <pattern>4n3isol</pattern>
+<pattern>ni4som</pattern>
 <pattern>nis3or</pattern>
 <pattern>4nisot</pattern>
+<pattern>ni2sö</pattern>
 <pattern>nis3pe</pattern>
 <pattern>nis3pr</pattern>
 <pattern>nissa5gen</pattern>
@@ -24982,17 +25732,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ni3tho</pattern>
 <pattern>3nitis</pattern>
 <pattern>ni3tob</pattern>
+<pattern>ni4top</pattern>
 <pattern>3nitp</pattern>
 <pattern>nit3s</pattern>
 <pattern>nit4ta</pattern>
-<pattern>nitt5ei</pattern>
 <pattern>nit6tele</pattern>
 <pattern>nit6terg</pattern>
 <pattern>nit6t5er6k</pattern>
 <pattern>nit4tr</pattern>
 <pattern>nitt5ra</pattern>
 <pattern>nitt5ri</pattern>
-<pattern>nitt5so</pattern>
 <pattern>nitu3</pattern>
 <pattern>3ni2u</pattern>
 <pattern>ni3ums</pattern>
@@ -25004,12 +25753,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4k3abl</pattern>
 <pattern>nk3abo</pattern>
 <pattern>nk3abr</pattern>
-<pattern>nk3adr</pattern>
 <pattern>nk3age</pattern>
 <pattern>nk3alg</pattern>
 <pattern>nk3alp</pattern>
-<pattern>nk3alt</pattern>
 <pattern>nk3ama</pattern>
+<pattern>nk3an4b</pattern>
 <pattern>nk3an4g</pattern>
 <pattern>nkange5</pattern>
 <pattern>n4k3anh</pattern>
@@ -25026,7 +25774,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4kasta</pattern>
 <pattern>n4k3atm</pattern>
 <pattern>n4k3ato</pattern>
-<pattern>n2k3äh</pattern>
+<pattern>nk3aus</pattern>
+<pattern>n2käh</pattern>
 <pattern>n2k3äp</pattern>
 <pattern>n1ke</pattern>
 <pattern>n4k3ei </pattern>
@@ -25034,6 +25783,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n3ken</pattern>
 <pattern>nken5sk</pattern>
 <pattern>nken5str</pattern>
+<pattern>nken5stu</pattern>
 <pattern>n4kerd</pattern>
 <pattern>nkerei6</pattern>
 <pattern>nker5eis</pattern>
@@ -25053,11 +25803,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n1kl</pattern>
 <pattern>nk5lade</pattern>
 <pattern>n4k3laf</pattern>
-<pattern>nk5lamp</pattern>
+<pattern>n4k5lamp</pattern>
 <pattern>nk5leis</pattern>
 <pattern>nk3les</pattern>
 <pattern>nk3leu</pattern>
-<pattern>nklo2</pattern>
 <pattern>nkmes4</pattern>
 <pattern>n1kn</pattern>
 <pattern>nk5niet</pattern>
@@ -25065,6 +25814,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nk3nut</pattern>
 <pattern>nko2a</pattern>
 <pattern>nko2b</pattern>
+<pattern>nk5ober</pattern>
 <pattern>n3kobo</pattern>
 <pattern>nko2e</pattern>
 <pattern>nko2o</pattern>
@@ -25088,8 +25838,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nks5alt</pattern>
 <pattern>nk4s3el</pattern>
 <pattern>nks5int</pattern>
-<pattern>nk3sp</pattern>
+<pattern>nk2so</pattern>
 <pattern>nks4pa</pattern>
+<pattern>nk5spat</pattern>
+<pattern>nk3spe</pattern>
+<pattern>nk3spr</pattern>
 <pattern>nk3sta</pattern>
 <pattern>nk3s4ti</pattern>
 <pattern>nk3str</pattern>
@@ -25112,7 +25865,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nk4t5ers</pattern>
 <pattern>nk4t5ert</pattern>
 <pattern>nk4te5sk</pattern>
-<pattern>nk2th</pattern>
 <pattern>nk3tim</pattern>
 <pattern>nk4t3in</pattern>
 <pattern>nkto2</pattern>
@@ -25123,6 +25875,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nktre3</pattern>
 <pattern>nkt5rol</pattern>
 <pattern>nktu2</pattern>
+<pattern>n4k3umf</pattern>
 <pattern>n4k3ums</pattern>
 <pattern>nk3uni</pattern>
 <pattern>nk3ur4h</pattern>
@@ -25140,6 +25893,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nla6gens</pattern>
 <pattern>nla4ges</pattern>
 <pattern>nla4gu</pattern>
+<pattern>nlal3</pattern>
 <pattern>nlan4dr</pattern>
 <pattern>nla2t</pattern>
 <pattern>nl4au</pattern>
@@ -25147,7 +25901,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nlä2</pattern>
 <pattern>n3län</pattern>
 <pattern>nle2</pattern>
-<pattern>nleg3a</pattern>
 <pattern>n3legi</pattern>
 <pattern>n3leh</pattern>
 <pattern>n3leid</pattern>
@@ -25163,6 +25916,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nlü2</pattern>
 <pattern>2n1m2</pattern>
 <pattern>nma2</pattern>
+<pattern>nmaler4</pattern>
+<pattern>nmal5erl</pattern>
 <pattern>n3man</pattern>
 <pattern>nmä2</pattern>
 <pattern>nme2</pattern>
@@ -25177,6 +25932,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nn3abs</pattern>
 <pattern>n2nae</pattern>
 <pattern>nna4ge</pattern>
+<pattern>n5naht</pattern>
 <pattern>n2nal</pattern>
 <pattern>nna5len</pattern>
 <pattern>nn3alg</pattern>
@@ -25197,7 +25953,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nnda2</pattern>
 <pattern>nndar4</pattern>
 <pattern>nnde2</pattern>
-<pattern>n3nea</pattern>
 <pattern>n3nec</pattern>
 <pattern>nn3eff</pattern>
 <pattern>nneh3r</pattern>
@@ -25207,11 +25962,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nne3lu</pattern>
 <pattern>nne3m</pattern>
 <pattern>nnen3g</pattern>
-<pattern>nne3p</pattern>
+<pattern>nne3pf</pattern>
 <pattern>nne4r3a</pattern>
 <pattern>n6n5ereig</pattern>
 <pattern>nn5erfü</pattern>
 <pattern>n6nergeb</pattern>
+<pattern>nn5erhö</pattern>
 <pattern>nner3ö</pattern>
 <pattern>nner6war</pattern>
 <pattern>nnes3e</pattern>
@@ -25253,6 +26009,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nn4s3as4</pattern>
 <pattern>nn4sau</pattern>
 <pattern>nnse2</pattern>
+<pattern>nn5sel</pattern>
 <pattern>nn3sp</pattern>
 <pattern>nnspa4</pattern>
 <pattern>nn5stan</pattern>
@@ -25261,7 +26018,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nns5toc</pattern>
 <pattern>nn5stre</pattern>
 <pattern>nn3stu</pattern>
-<pattern>nnta2</pattern>
+<pattern>nnt4a2</pattern>
 <pattern>nn5ther</pattern>
 <pattern>nntzu5g</pattern>
 <pattern>n1nu2</pattern>
@@ -25275,8 +26032,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>noa2</pattern>
 <pattern>nob2</pattern>
 <pattern>2nob </pattern>
+<pattern>n3obd</pattern>
 <pattern>n4obel</pattern>
 <pattern>nobe4s</pattern>
+<pattern>n3obh</pattern>
 <pattern>2nobl</pattern>
 <pattern>no4bla</pattern>
 <pattern>nobli3</pattern>
@@ -25303,12 +26062,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>no3ke</pattern>
 <pattern>n3ok2k</pattern>
 <pattern>3nokt</pattern>
-<pattern>no3ku</pattern>
 <pattern>2n2ol</pattern>
 <pattern>3nol </pattern>
 <pattern>no3lad</pattern>
 <pattern>3nol3c</pattern>
-<pattern>n3o3leu</pattern>
+<pattern>n3oleu</pattern>
 <pattern>no2li</pattern>
 <pattern>nolo2</pattern>
 <pattern>no3lu</pattern>
@@ -25335,13 +26093,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>no3ped</pattern>
 <pattern>3nopel</pattern>
 <pattern>noppo5s</pattern>
+<pattern>nop2s</pattern>
 <pattern>no3pte</pattern>
 <pattern>no3pu</pattern>
 <pattern>no3py</pattern>
 <pattern>nor2a</pattern>
 <pattern>no3ral</pattern>
-<pattern>n3orb</pattern>
+<pattern>n3orbi</pattern>
 <pattern>nor2d</pattern>
+<pattern>3nord </pattern>
 <pattern>nord3a</pattern>
 <pattern>3nordb</pattern>
 <pattern>nor5ders</pattern>
@@ -25436,7 +26196,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n3rä2</pattern>
 <pattern>nre2</pattern>
 <pattern>nre4c</pattern>
-<pattern>nredu5z</pattern>
 <pattern>nrefe3</pattern>
 <pattern>n4regr</pattern>
 <pattern>n3reib</pattern>
@@ -25454,6 +26213,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nru2</pattern>
 <pattern>n3rud</pattern>
 <pattern>nr4un</pattern>
+<pattern>nrun3t</pattern>
 <pattern>n3rys</pattern>
 <pattern>2ns</pattern>
 <pattern>n1sa</pattern>
@@ -25468,15 +26228,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ns3all</pattern>
 <pattern>n4s3alm</pattern>
 <pattern>ns4alp</pattern>
-<pattern>n4s3alt</pattern>
+<pattern>ns5alte</pattern>
 <pattern>n4sama</pattern>
 <pattern>nsan2</pattern>
 <pattern>n4s3anb</pattern>
-<pattern>ns4and</pattern>
-<pattern>ns5anda</pattern>
 <pattern>nsan5de</pattern>
 <pattern>n4s3ane</pattern>
-<pattern>n4s3ang</pattern>
 <pattern>n4s3anh</pattern>
 <pattern>ns5anka</pattern>
 <pattern>n4s3ann</pattern>
@@ -25487,6 +26244,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4s3auf</pattern>
 <pattern>nsau4r</pattern>
 <pattern>n4saut</pattern>
+<pattern>n4säugl</pattern>
 <pattern>n5schac</pattern>
 <pattern>nscha5che</pattern>
 <pattern>n5sche </pattern>
@@ -25497,7 +26255,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4schl </pattern>
 <pattern>nsch5lic</pattern>
 <pattern>n6schobe</pattern>
+<pattern>ns5chor </pattern>
 <pattern>nsch5werd</pattern>
+<pattern>ns2cr</pattern>
 <pattern>n1se</pattern>
 <pattern>n4se </pattern>
 <pattern>nse2g</pattern>
@@ -25512,6 +26272,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ns5eint</pattern>
 <pattern>n5seit</pattern>
 <pattern>nse2l</pattern>
+<pattern>n4sel </pattern>
 <pattern>n4sela</pattern>
 <pattern>n4selc</pattern>
 <pattern>n4seld</pattern>
@@ -25531,10 +26292,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n2sem</pattern>
 <pattern>n3semi</pattern>
 <pattern>nsen6deter</pattern>
-<pattern>nsen5st</pattern>
 <pattern>n4s3en4z</pattern>
+<pattern>nsenzy5</pattern>
 <pattern>ns3epo</pattern>
-<pattern>ns4eq</pattern>
+<pattern>n3s4eq</pattern>
 <pattern>n4s5er4ar5</pattern>
 <pattern>nse5ras</pattern>
 <pattern>nse4rei</pattern>
@@ -25558,21 +26319,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4s3er4z</pattern>
 <pattern>ns3eur</pattern>
 <pattern>nsex2</pattern>
-<pattern>n4sexa</pattern>
 <pattern>nsgela5</pattern>
 <pattern>nsgene5</pattern>
 <pattern>n3s4hak</pattern>
 <pattern>ns4hir</pattern>
 <pattern>ns4hort</pattern>
 <pattern>ns4ic</pattern>
-<pattern>n4simp</pattern>
+<pattern>nsi2m</pattern>
+<pattern>n4s3ima</pattern>
+<pattern>n4s3im4p</pattern>
+<pattern>nsimpe4</pattern>
 <pattern>n4sind</pattern>
 <pattern>n4s3ini</pattern>
 <pattern>nsinns5</pattern>
 <pattern>n4s3in4t</pattern>
+<pattern>ns3iso</pattern>
 <pattern>nsi4t3e</pattern>
-<pattern>n5skala</pattern>
-<pattern>n5s4kale</pattern>
+<pattern>n3skal</pattern>
+<pattern>ns4kale</pattern>
 <pattern>ns4kali</pattern>
 <pattern>n3s4kel</pattern>
 <pattern>n5skrip</pattern>
@@ -25581,7 +26345,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nsma2</pattern>
 <pattern>n5smara</pattern>
 <pattern>ns3n</pattern>
-<pattern>n1so</pattern>
 <pattern>nso2b</pattern>
 <pattern>n2s3od</pattern>
 <pattern>nso2f2</pattern>
@@ -25614,19 +26377,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nssa2</pattern>
 <pattern>nsse2</pattern>
 <pattern>n4st </pattern>
+<pattern>n6stabl</pattern>
 <pattern>nst5abr</pattern>
 <pattern>nstab5sc</pattern>
 <pattern>n3stac</pattern>
 <pattern>n3stad</pattern>
 <pattern>ns6tagent</pattern>
-<pattern>nstak4</pattern>
 <pattern>nsta4l</pattern>
 <pattern>ns5talb</pattern>
 <pattern>ns5tale</pattern>
+<pattern>n5stamm</pattern>
 <pattern>nsta4n</pattern>
 <pattern>nst5ane</pattern>
 <pattern>n5stapeln</pattern>
-<pattern>n3star</pattern>
+<pattern>n5start</pattern>
+<pattern>ns3tas</pattern>
 <pattern>ns5tat </pattern>
 <pattern>nsta4te</pattern>
 <pattern>ns5taten</pattern>
@@ -25653,15 +26418,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nst5erke</pattern>
 <pattern>n5s6terne</pattern>
 <pattern>n5s6terns</pattern>
-<pattern>nst5erwei</pattern>
+<pattern>nst5er6sa</pattern>
 <pattern>nster4z</pattern>
 <pattern>ns4teu</pattern>
+<pattern>n6steul</pattern>
 <pattern>n3stew</pattern>
 <pattern>ns5them</pattern>
 <pattern>n3s4tic</pattern>
 <pattern>nsti5ck</pattern>
 <pattern>nst3id</pattern>
 <pattern>n4stief</pattern>
+<pattern>n5sties</pattern>
 <pattern>n3stil</pattern>
 <pattern>n3stim</pattern>
 <pattern>ns4tin</pattern>
@@ -25672,11 +26439,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n5stoll</pattern>
 <pattern>n3stop</pattern>
 <pattern>nsto4re</pattern>
-<pattern>nst5or4t</pattern>
+<pattern>nst5org</pattern>
+<pattern>nstor4t</pattern>
 <pattern>n3stos</pattern>
 <pattern>n3stoß</pattern>
 <pattern>nstö3r</pattern>
 <pattern>ns5trac</pattern>
+<pattern>n5straf</pattern>
 <pattern>n5strah</pattern>
 <pattern>n6strai</pattern>
 <pattern>n5stras</pattern>
@@ -25685,7 +26454,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n5streit</pattern>
 <pattern>nst5roc</pattern>
 <pattern>ns5tros</pattern>
+<pattern>n3strö</pattern>
 <pattern>ns2tu</pattern>
+<pattern>n3stub</pattern>
 <pattern>n3stuc</pattern>
 <pattern>n3stuf</pattern>
 <pattern>n3stum</pattern>
@@ -25695,8 +26466,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4stw</pattern>
 <pattern>n1su</pattern>
 <pattern>n2suf</pattern>
+<pattern>nsum3o4</pattern>
+<pattern>ns5umsa</pattern>
 <pattern>nsum5sc</pattern>
-<pattern>ns3una</pattern>
 <pattern>ns3urk</pattern>
 <pattern>ns3ur4t</pattern>
 <pattern>ns3ut</pattern>
@@ -25721,6 +26493,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ntal3a</pattern>
 <pattern>ntalent6</pattern>
 <pattern>nt5allt</pattern>
+<pattern>nt5alter</pattern>
+<pattern>nt5anna</pattern>
 <pattern>nt5ansa</pattern>
 <pattern>n4tan4tr</pattern>
 <pattern>ntan6wei</pattern>
@@ -25745,6 +26519,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nt3ärz</pattern>
 <pattern>ntä4ti</pattern>
 <pattern>n4te </pattern>
+<pattern>n4te5ame</pattern>
 <pattern>n4te3au</pattern>
 <pattern>n3tec</pattern>
 <pattern>nteer4</pattern>
@@ -25767,6 +26542,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ntene4</pattern>
 <pattern>n4tenpä</pattern>
 <pattern>nten3s4</pattern>
+<pattern>nt5ents</pattern>
 <pattern>ntera4</pattern>
 <pattern>nterbe4</pattern>
 <pattern>nt5erbe </pattern>
@@ -25788,11 +26564,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n3tes</pattern>
 <pattern>n4te3sa</pattern>
 <pattern>n4t3es4s</pattern>
+<pattern>n6te5stei</pattern>
 <pattern>n4testo</pattern>
 <pattern>ntest5r</pattern>
 <pattern>nt5estri</pattern>
 <pattern>nte3ta</pattern>
-<pattern>nte4tag</pattern>
+<pattern>ntgen5e</pattern>
 <pattern>n3tha </pattern>
 <pattern>nt4hals</pattern>
 <pattern>n3than</pattern>
@@ -25824,6 +26601,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n2tij</pattern>
 <pattern>nti3ka</pattern>
 <pattern>ntiker4</pattern>
+<pattern>ntik5erh</pattern>
 <pattern>nti5kri</pattern>
 <pattern>nti4lei</pattern>
 <pattern>nti4lin</pattern>
@@ -25866,7 +26644,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ntö5sen</pattern>
 <pattern>n1t2r</pattern>
 <pattern>nt4ral</pattern>
-<pattern>ntral5a</pattern>
 <pattern>nt5rand</pattern>
 <pattern>n5trans</pattern>
 <pattern>nt5ränd</pattern>
@@ -25891,7 +26668,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nt4sang</pattern>
 <pattern>nt4sau</pattern>
 <pattern>nt3sco</pattern>
-<pattern>nts2e</pattern>
 <pattern>nt2sk</pattern>
 <pattern>ntska4</pattern>
 <pattern>nts4pa</pattern>
@@ -25899,6 +26675,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ntt4a</pattern>
 <pattern>ntu2b</pattern>
 <pattern>ntu2m</pattern>
+<pattern>n4tumsc</pattern>
 <pattern>ntu2r</pattern>
 <pattern>ntur4la</pattern>
 <pattern>n3tus</pattern>
@@ -25944,7 +26721,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>num2k</pattern>
 <pattern>2n3um2l</pattern>
 <pattern>numla5gen</pattern>
-<pattern>3numm</pattern>
+<pattern>3n2umm</pattern>
 <pattern>n3um4ma</pattern>
 <pattern>n3um2r</pattern>
 <pattern>2num2s</pattern>
@@ -25976,6 +26753,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nunwe3</pattern>
 <pattern>n2unz</pattern>
 <pattern>nun4ze</pattern>
+<pattern>n3un4zu3</pattern>
 <pattern>3nuo</pattern>
 <pattern>2nup</pattern>
 <pattern>2nu2r</pattern>
@@ -25994,18 +26772,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nus6serl</pattern>
 <pattern>nus3t</pattern>
 <pattern>nut3a</pattern>
-<pattern>nute2</pattern>
 <pattern>nutens4</pattern>
 <pattern>nuti2</pattern>
 <pattern>2nuto</pattern>
 <pattern>n3utop</pattern>
+<pattern>3nutt</pattern>
 <pattern>nut4zei</pattern>
 <pattern>nutzer5e</pattern>
 <pattern>2nuv</pattern>
-<pattern>nux1</pattern>
+<pattern>nux3</pattern>
 <pattern>2nüb2</pattern>
 <pattern>nüberzu5</pattern>
 <pattern>nü1e</pattern>
+<pattern>nü3la</pattern>
 <pattern>nü1m</pattern>
 <pattern>nün2</pattern>
 <pattern>nü3na</pattern>
@@ -26031,9 +26810,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nwehr3</pattern>
 <pattern>n5werk</pattern>
 <pattern>nwi2</pattern>
+<pattern>nwind5er</pattern>
 <pattern>2ny </pattern>
 <pattern>2n1ya</pattern>
-<pattern>nyl1</pattern>
 <pattern>1nym</pattern>
 <pattern>n1yo</pattern>
 <pattern>ny1s2</pattern>
@@ -26059,7 +26838,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nze4di</pattern>
 <pattern>n2zeg</pattern>
 <pattern>n5zeic</pattern>
-<pattern>nz3ei4m</pattern>
+<pattern>n4z3ei4m</pattern>
 <pattern>nzem2</pattern>
 <pattern>nz3emb</pattern>
 <pattern>n3zen</pattern>
@@ -26068,6 +26847,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n6zenerg</pattern>
 <pattern>nzen5ev</pattern>
 <pattern>n6zensem</pattern>
+<pattern>nzen5st</pattern>
+<pattern>nz5ente </pattern>
 <pattern>n4z5entg</pattern>
 <pattern>n4zentl</pattern>
 <pattern>n4z5ents</pattern>
@@ -26075,11 +26856,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>n4z5entz</pattern>
 <pattern>nzer3a</pattern>
 <pattern>nzerei4</pattern>
-<pattern>n4zer4fo</pattern>
 <pattern>n4z5erlö</pattern>
 <pattern>nz3erö</pattern>
 <pattern>nz5erste</pattern>
 <pattern>nzer6tei</pattern>
+<pattern>n6z5er6trä</pattern>
 <pattern>n3zes</pattern>
 <pattern>n4ze3sa</pattern>
 <pattern>n4zesä</pattern>
@@ -26089,16 +26870,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nze5s4te</pattern>
 <pattern>nze5sti</pattern>
 <pattern>nze5str</pattern>
+<pattern>n4zete</pattern>
 <pattern>n4ze3u4t</pattern>
-<pattern>n2zi2d</pattern>
+<pattern>n2zid</pattern>
 <pattern>n3zig</pattern>
 <pattern>nzi4le</pattern>
 <pattern>nz5in4fo</pattern>
-<pattern>nz3inj</pattern>
-<pattern>nz5inte</pattern>
+<pattern>n4z3inj</pattern>
+<pattern>n4z5inte</pattern>
 <pattern>nzo2g</pattern>
 <pattern>nz3oli</pattern>
-<pattern>n2zor</pattern>
 <pattern>nz3r</pattern>
 <pattern>nzta2</pattern>
 <pattern>n2zu </pattern>
@@ -26136,7 +26917,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nzu2m</pattern>
 <pattern>nzu2n</pattern>
 <pattern>nzunru5</pattern>
-<pattern>nzup2</pattern>
 <pattern>nzu5pfu</pattern>
 <pattern>nzu4pr</pattern>
 <pattern>nzu2q</pattern>
@@ -26144,13 +26924,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>nzu2s</pattern>
 <pattern>nzu4sa</pattern>
 <pattern>nzu2t</pattern>
-<pattern>n4z3uti</pattern>
 <pattern>nzu2v</pattern>
 <pattern>nzu4we</pattern>
 <pattern>nzu4za</pattern>
 <pattern>n4zuzä</pattern>
 <pattern>nzuzu3</pattern>
-<pattern>nz4weit</pattern>
 <pattern>n4zwet</pattern>
 <pattern>nz4will</pattern>
 <pattern>n2zwö</pattern>
@@ -26206,6 +26984,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oa2z</pattern>
 <pattern>o1ä</pattern>
 <pattern>oär2</pattern>
+<pattern>2ob </pattern>
 <pattern>obab2</pattern>
 <pattern>ob2am</pattern>
 <pattern>oban4g</pattern>
@@ -26216,7 +26995,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2obea</pattern>
 <pattern>obe3au</pattern>
 <pattern>o2beb</pattern>
-<pattern>o3bec</pattern>
+<pattern>2o3bec</pattern>
 <pattern>obe4da</pattern>
 <pattern>o4bedi</pattern>
 <pattern>o4bedu</pattern>
@@ -26229,11 +27008,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ob5eins</pattern>
 <pattern>o2bej</pattern>
 <pattern>o3be2k</pattern>
+<pattern>obe2o</pattern>
+<pattern>obeob3</pattern>
 <pattern>ober3a</pattern>
 <pattern>o4beram</pattern>
 <pattern>oberap4</pattern>
 <pattern>o4berb</pattern>
-<pattern>obe4rei</pattern>
+<pattern>o5be4rei</pattern>
 <pattern>ober5eis</pattern>
 <pattern>obe4rel</pattern>
 <pattern>oberen4</pattern>
@@ -26256,7 +27037,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3obj</pattern>
 <pattern>obla4g</pattern>
 <pattern>oblas3</pattern>
+<pattern>ob4last</pattern>
 <pattern>ob3lau</pattern>
+<pattern>ob3leb</pattern>
 <pattern>ob3lei</pattern>
 <pattern>ob3n</pattern>
 <pattern>3oboe</pattern>
@@ -26289,7 +27072,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o1ca</pattern>
 <pattern>oc1c</pattern>
 <pattern>3occl</pattern>
-<pattern>o1ce2</pattern>
+<pattern>o3ce2</pattern>
 <pattern>o4ch </pattern>
 <pattern>och3a4b</pattern>
 <pattern>ochal4</pattern>
@@ -26301,9 +27084,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>och3ec</pattern>
 <pattern>och3eh</pattern>
 <pattern>och3ei</pattern>
+<pattern>och5ele</pattern>
 <pattern>ocher4f</pattern>
 <pattern>och5erg</pattern>
-<pattern>och5erl</pattern>
+<pattern>och5er4l</pattern>
 <pattern>ochgele6</pattern>
 <pattern>ochgezo6</pattern>
 <pattern>och3id</pattern>
@@ -26316,15 +27100,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>och3öf</pattern>
 <pattern>ochre4</pattern>
 <pattern>o4chs</pattern>
+<pattern>3ochse</pattern>
 <pattern>ochs4p</pattern>
 <pattern>och5stem</pattern>
-<pattern>och5str</pattern>
 <pattern>och3to</pattern>
-<pattern>och4t5ri</pattern>
 <pattern>och3ut</pattern>
 <pattern>och3w</pattern>
 <pattern>o2ck</pattern>
 <pattern>o4ck </pattern>
+<pattern>o3ckad</pattern>
 <pattern>ockar4</pattern>
 <pattern>o3ckem</pattern>
 <pattern>ock5ersa</pattern>
@@ -26333,6 +27117,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o3ckie</pattern>
 <pattern>o4ckn</pattern>
 <pattern>ock3s4p</pattern>
+<pattern>ock5str</pattern>
 <pattern>ock3sz</pattern>
 <pattern>ockzu4</pattern>
 <pattern>o1cl</pattern>
@@ -26342,6 +27127,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o2cu</pattern>
 <pattern>2od </pattern>
 <pattern>od2a</pattern>
+<pattern>oda3b</pattern>
 <pattern>od3ak</pattern>
 <pattern>o3das</pattern>
 <pattern>o2daw</pattern>
@@ -26355,6 +27141,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>odel5ag</pattern>
 <pattern>odel6lau</pattern>
 <pattern>odel4l5ä</pattern>
+<pattern>ode5mac</pattern>
 <pattern>ode2n</pattern>
 <pattern>oden3e</pattern>
 <pattern>oden3i</pattern>
@@ -26362,6 +27149,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oden3t</pattern>
 <pattern>o3derm</pattern>
 <pattern>ode5s4po</pattern>
+<pattern>ode5spr</pattern>
 <pattern>ode3th</pattern>
 <pattern>ode5xen</pattern>
 <pattern>ode5xes</pattern>
@@ -26386,6 +27174,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>od1t</pattern>
 <pattern>2odu</pattern>
 <pattern>o4dun</pattern>
+<pattern>odu2z</pattern>
 <pattern>2ody</pattern>
 <pattern>ody2m</pattern>
 <pattern>o1e</pattern>
@@ -26393,11 +27182,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oede3</pattern>
 <pattern>oe2du</pattern>
 <pattern>oei2</pattern>
+<pattern>oe2l</pattern>
 <pattern>oe2m</pattern>
 <pattern>oe3men</pattern>
 <pattern>oen2d</pattern>
-<pattern>oen4e</pattern>
 <pattern>oen2g</pattern>
+<pattern>o2enk</pattern>
 <pattern>oen2t</pattern>
 <pattern>oenze4</pattern>
 <pattern>oer2</pattern>
@@ -26416,19 +27206,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2of2a</pattern>
 <pattern>of3ad</pattern>
 <pattern>of3ag</pattern>
+<pattern>ofange5l</pattern>
 <pattern>o1fä</pattern>
 <pattern>of3är</pattern>
 <pattern>of3e2b</pattern>
 <pattern>of3ec</pattern>
-<pattern>of3ei</pattern>
 <pattern>o3fel</pattern>
 <pattern>ofe2m</pattern>
 <pattern>o2fen</pattern>
 <pattern>of3erb</pattern>
 <pattern>of3er4r</pattern>
 <pattern>oferre5</pattern>
-<pattern>ofer4s</pattern>
-<pattern>of5ersc</pattern>
+<pattern>of5er4sc</pattern>
 <pattern>ofe2t</pattern>
 <pattern>of3eti</pattern>
 <pattern>of3eun</pattern>
@@ -26443,8 +27232,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>off3in4</pattern>
 <pattern>3offiz</pattern>
 <pattern>off3l</pattern>
-<pattern>of4for</pattern>
-<pattern>of2f3r</pattern>
+<pattern>of2fr</pattern>
+<pattern>off3re</pattern>
+<pattern>off3rü</pattern>
+<pattern>off3se</pattern>
 <pattern>off3sh</pattern>
 <pattern>off3s4o</pattern>
 <pattern>offt2</pattern>
@@ -26452,7 +27243,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>offun4</pattern>
 <pattern>of4fur</pattern>
 <pattern>2ofi</pattern>
-<pattern>o2fig</pattern>
 <pattern>o2fik</pattern>
 <pattern>ofi3k4l</pattern>
 <pattern>ofili4</pattern>
@@ -26462,19 +27252,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ofi3s4</pattern>
 <pattern>o4fisc</pattern>
 <pattern>o4fist</pattern>
-<pattern>o1fl</pattern>
+<pattern>2o1fl</pattern>
 <pattern>2ofo</pattern>
 <pattern>of3orc</pattern>
-<pattern>of3ord</pattern>
-<pattern>o1fr</pattern>
+<pattern>2o1fr</pattern>
+<pattern>of3rat</pattern>
 <pattern>of3rä</pattern>
-<pattern>ofs3am</pattern>
+<pattern>of4s3am</pattern>
 <pattern>of4s3en4</pattern>
 <pattern>of4sin</pattern>
+<pattern>of4sof</pattern>
 <pattern>of4s3pa</pattern>
 <pattern>of4s3pe</pattern>
 <pattern>of4staf</pattern>
-<pattern>of4stei</pattern>
 <pattern>of4sto</pattern>
 <pattern>of2s3u</pattern>
 <pattern>of3ta</pattern>
@@ -26493,6 +27283,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ogan4s</pattern>
 <pattern>og3arb</pattern>
 <pattern>og3ari</pattern>
+<pattern>og3aus</pattern>
 <pattern>oge2b</pattern>
 <pattern>o3geg</pattern>
 <pattern>og3ein</pattern>
@@ -26500,7 +27291,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oge2m</pattern>
 <pattern>ogen5ec</pattern>
 <pattern>ogen4id</pattern>
-<pattern>ogen5sp</pattern>
+<pattern>ogen5s4p</pattern>
 <pattern>ogerä4</pattern>
 <pattern>og3er4f</pattern>
 <pattern>oge2s</pattern>
@@ -26519,19 +27310,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>og3ou</pattern>
 <pattern>og3rau</pattern>
 <pattern>og3reg</pattern>
-<pattern>og3s2e</pattern>
+<pattern>og3sen</pattern>
 <pattern>og3spr</pattern>
 <pattern>og2st</pattern>
 <pattern>og3ste</pattern>
 <pattern>og3sti</pattern>
+<pattern>ogu2</pattern>
 <pattern>o1gy</pattern>
-<pattern>oha2</pattern>
+<pattern>2oha2</pattern>
 <pattern>oh3alk</pattern>
 <pattern>oha3me</pattern>
 <pattern>oh2an</pattern>
 <pattern>oh3anr</pattern>
 <pattern>oh3ar</pattern>
-<pattern>o1hä</pattern>
+<pattern>o3hä</pattern>
 <pattern>o4he </pattern>
 <pattern>oh3e2d</pattern>
 <pattern>oh3ein</pattern>
@@ -26547,6 +27339,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ohl3ad</pattern>
 <pattern>ohl3an4</pattern>
 <pattern>ohle3b</pattern>
+<pattern>ohl5eint</pattern>
 <pattern>ohl5eis</pattern>
 <pattern>ohle3l</pattern>
 <pattern>oh6lenac</pattern>
@@ -26567,7 +27360,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ohn3d</pattern>
 <pattern>oh4n3eb</pattern>
 <pattern>oh6nense</pattern>
-<pattern>oh4net</pattern>
+<pattern>ohn5ersa</pattern>
+<pattern>oh4n3e4t</pattern>
 <pattern>oh4nin</pattern>
 <pattern>ohn3o</pattern>
 <pattern>o1ho2</pattern>
@@ -26584,7 +27378,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ohrei6s</pattern>
 <pattern>oh4r5erg</pattern>
 <pattern>ohr5erk</pattern>
-<pattern>ohr5ero</pattern>
 <pattern>oh6rersa</pattern>
 <pattern>oh6rersä</pattern>
 <pattern>oh3rie</pattern>
@@ -26625,6 +27418,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oin2j</pattern>
 <pattern>oin2l</pattern>
 <pattern>o3ins </pattern>
+<pattern>oinzi4</pattern>
 <pattern>o3io2</pattern>
 <pattern>oi2ra</pattern>
 <pattern>o5isch </pattern>
@@ -26647,7 +27441,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>okale4</pattern>
 <pattern>oka6lens</pattern>
 <pattern>okal5th</pattern>
+<pattern>okan4b</pattern>
 <pattern>oka3pf</pattern>
+<pattern>o3kä</pattern>
 <pattern>o4ke </pattern>
 <pattern>o5kerbe</pattern>
 <pattern>oke3s</pattern>
@@ -26663,13 +27459,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oko3d</pattern>
 <pattern>o2koe</pattern>
 <pattern>o2koh</pattern>
-<pattern>okop3t</pattern>
+<pattern>o4komi</pattern>
+<pattern>oko4p3t</pattern>
 <pattern>o1kr</pattern>
-<pattern>oks3o</pattern>
+<pattern>ok2sa</pattern>
+<pattern>ok2s3o</pattern>
 <pattern>oks3p</pattern>
 <pattern>ok2ta</pattern>
 <pattern>okt4o</pattern>
-<pattern>o2ku</pattern>
 <pattern>o3kurs</pattern>
 <pattern>o3kü</pattern>
 <pattern>2ola</pattern>
@@ -26702,13 +27499,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>olch3r</pattern>
 <pattern>oldam4</pattern>
 <pattern>old3an</pattern>
+<pattern>oldau5s</pattern>
 <pattern>ol2dä</pattern>
 <pattern>old3ed</pattern>
 <pattern>old5ersa</pattern>
 <pattern>old5ese</pattern>
 <pattern>ol4deu</pattern>
 <pattern>ol4dop</pattern>
-<pattern>ol4d3or</pattern>
 <pattern>ol4d3re</pattern>
 <pattern>ol4d3ri</pattern>
 <pattern>ol4d3ro</pattern>
@@ -26716,6 +27513,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>old3sa</pattern>
 <pattern>old4sk</pattern>
 <pattern>old3st</pattern>
+<pattern>old4s5tr</pattern>
 <pattern>o4le </pattern>
 <pattern>ol3eie</pattern>
 <pattern>ole3l</pattern>
@@ -26736,6 +27534,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ole4sti</pattern>
 <pattern>o3let</pattern>
 <pattern>oleta3</pattern>
+<pattern>o3leu</pattern>
 <pattern>o3lew</pattern>
 <pattern>olex2</pattern>
 <pattern>ol3ext</pattern>
@@ -26750,7 +27549,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ol4ge3g</pattern>
 <pattern>ol4ge3l</pattern>
 <pattern>ol4ge3m</pattern>
-<pattern>olgen5e</pattern>
 <pattern>ol4geo</pattern>
 <pattern>ol4ge3p</pattern>
 <pattern>ol4gera</pattern>
@@ -26788,6 +27586,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ol2kl</pattern>
 <pattern>ol4k3re</pattern>
 <pattern>olks3c</pattern>
+<pattern>olk6str</pattern>
 <pattern>oll5ach</pattern>
 <pattern>olla5gen </pattern>
 <pattern>oll3ak4</pattern>
@@ -26809,13 +27608,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ol4l5erz</pattern>
 <pattern>olles4</pattern>
 <pattern>ol4l5ess</pattern>
-<pattern>olli4n</pattern>
 <pattern>ol4l5ins</pattern>
 <pattern>oll5s4a</pattern>
 <pattern>ol4lum</pattern>
 <pattern>ol3mo</pattern>
 <pattern>2o1l2o</pattern>
 <pattern>o4lo </pattern>
+<pattern>olo3fe</pattern>
 <pattern>ol3off</pattern>
 <pattern>olo4ge</pattern>
 <pattern>o5loid </pattern>
@@ -26830,7 +27629,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>olo3t</pattern>
 <pattern>o1lö</pattern>
 <pattern>ol3s2k</pattern>
-<pattern>ol5stei</pattern>
 <pattern>olta5is</pattern>
 <pattern>olt3am4</pattern>
 <pattern>o2lu</pattern>
@@ -26851,7 +27649,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ol2zy</pattern>
 <pattern>2om </pattern>
 <pattern>om3a4bl</pattern>
-<pattern>om3a4br</pattern>
+<pattern>om3abr</pattern>
 <pattern>o3mac</pattern>
 <pattern>omag2</pattern>
 <pattern>o4m3age</pattern>
@@ -26864,6 +27662,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oman3d</pattern>
 <pattern>oma4n5er</pattern>
 <pattern>om3an4g</pattern>
+<pattern>om3an4k</pattern>
 <pattern>om5anst</pattern>
 <pattern>oma5ren</pattern>
 <pattern>o4m3ar4m</pattern>
@@ -26875,7 +27674,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o4ma3th</pattern>
 <pattern>omatin5</pattern>
 <pattern>o4matl</pattern>
-<pattern>om5atom</pattern>
+<pattern>om5atom </pattern>
+<pattern>om5atome</pattern>
 <pattern>o4ma3tr</pattern>
 <pattern>om3au</pattern>
 <pattern>o1mä</pattern>
@@ -26904,6 +27704,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2omi</pattern>
 <pattern>o4mi </pattern>
 <pattern>omic3</pattern>
+<pattern>o3mid</pattern>
 <pattern>omie3s</pattern>
 <pattern>o3mil</pattern>
 <pattern>omin2</pattern>
@@ -26946,10 +27747,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o2n3a2b2</pattern>
 <pattern>on2ac</pattern>
 <pattern>ona4ger</pattern>
+<pattern>o2na3h</pattern>
 <pattern>ona4l5in</pattern>
 <pattern>onalli4</pattern>
 <pattern>ona2m2</pattern>
 <pattern>on3amb</pattern>
+<pattern>on5amei</pattern>
 <pattern>onange5</pattern>
 <pattern>on3ann</pattern>
 <pattern>on3ano</pattern>
@@ -26968,7 +27771,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ona2s</pattern>
 <pattern>on3asp</pattern>
 <pattern>on5atom</pattern>
-<pattern>onat4st</pattern>
+<pattern>onat4s</pattern>
 <pattern>on3att</pattern>
 <pattern>o1nä</pattern>
 <pattern>onär4s</pattern>
@@ -26985,7 +27788,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>on4d3ex4</pattern>
 <pattern>ondi2</pattern>
 <pattern>ondo4b</pattern>
-<pattern>ond5rei</pattern>
 <pattern>on4d5ril</pattern>
 <pattern>on4d5rin</pattern>
 <pattern>on4d5rüc</pattern>
@@ -26997,7 +27799,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o3nee</pattern>
 <pattern>on3ef</pattern>
 <pattern>o2neh</pattern>
-<pattern>on3ein</pattern>
+<pattern>on3ein3</pattern>
 <pattern>one2n</pattern>
 <pattern>o4n5ends</pattern>
 <pattern>onen3g</pattern>
@@ -27016,6 +27818,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>on5ersa</pattern>
 <pattern>on3er4z</pattern>
 <pattern>one3se</pattern>
+<pattern>on3est3</pattern>
 <pattern>o4neta</pattern>
 <pattern>on2eu</pattern>
 <pattern>on3f2</pattern>
@@ -27029,7 +27832,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ongo3</pattern>
 <pattern>on3gos</pattern>
 <pattern>ong3s2</pattern>
-<pattern>on2gu</pattern>
 <pattern>on3gü</pattern>
 <pattern>on3h</pattern>
 <pattern>2on2i</pattern>
@@ -27041,11 +27843,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o4niet</pattern>
 <pattern>o2nig</pattern>
 <pattern>onig3a</pattern>
+<pattern>oni4ger</pattern>
 <pattern>onig3s</pattern>
 <pattern>o2nih</pattern>
-<pattern>o4nikan</pattern>
+<pattern>o4ni4kan</pattern>
 <pattern>o4nikba</pattern>
 <pattern>o4nikbe</pattern>
+<pattern>o4nikbr</pattern>
 <pattern>o4nikei</pattern>
 <pattern>o4nikf</pattern>
 <pattern>o4nikg</pattern>
@@ -27058,7 +27862,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o2nim</pattern>
 <pattern>o4nins</pattern>
 <pattern>o3nio</pattern>
-<pattern>o4ni3s4o</pattern>
+<pattern>o4nis4o</pattern>
 <pattern>onk2</pattern>
 <pattern>3on2ke</pattern>
 <pattern>on3ker</pattern>
@@ -27087,7 +27891,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>on3ord</pattern>
 <pattern>ono3s</pattern>
 <pattern>o3nos </pattern>
-<pattern>onot4</pattern>
+<pattern>onot4h</pattern>
 <pattern>on3ox</pattern>
 <pattern>on3p</pattern>
 <pattern>on3r</pattern>
@@ -27134,6 +27938,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1ony</pattern>
 <pattern>onz4e</pattern>
 <pattern>onze5in4</pattern>
+<pattern>onze5la</pattern>
 <pattern>onze5li</pattern>
 <pattern>on4zem</pattern>
 <pattern>on4zena</pattern>
@@ -27144,6 +27949,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2oo</pattern>
 <pattern>oob2</pattern>
 <pattern>oo1c</pattern>
+<pattern>oo2d3r</pattern>
+<pattern>oogene5</pattern>
 <pattern>oo3gi</pattern>
 <pattern>oo3ha</pattern>
 <pattern>oo2k</pattern>
@@ -27179,7 +27986,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oot3ei</pattern>
 <pattern>oo2th</pattern>
 <pattern>oot3he</pattern>
-<pattern>oo2t3r</pattern>
+<pattern>oot3r</pattern>
 <pattern>oot4s3a</pattern>
 <pattern>oot4s5en4</pattern>
 <pattern>oo4tur</pattern>
@@ -27196,26 +28003,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o3pale</pattern>
 <pattern>opa3m</pattern>
 <pattern>op2an</pattern>
-<pattern>op3ana</pattern>
 <pattern>op3anb</pattern>
+<pattern>op3an4t</pattern>
 <pattern>o2pap</pattern>
 <pattern>opa3pa</pattern>
 <pattern>opa5ran</pattern>
 <pattern>opa5ra4t</pattern>
 <pattern>opa3re</pattern>
-<pattern>o3pari</pattern>
+<pattern>opa5rin</pattern>
 <pattern>o3park</pattern>
 <pattern>op3ar4m</pattern>
 <pattern>opa5sch</pattern>
 <pattern>opassa5</pattern>
-<pattern>opa3s4t</pattern>
+<pattern>opas4t</pattern>
 <pattern>o4pato</pattern>
 <pattern>opa3tr</pattern>
 <pattern>o3pec</pattern>
 <pattern>op3ef</pattern>
 <pattern>op3eig</pattern>
 <pattern>ope3la</pattern>
-<pattern>ope3li</pattern>
 <pattern>open3s</pattern>
 <pattern>open5th</pattern>
 <pattern>op3er4h</pattern>
@@ -27226,19 +28032,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>op3ey</pattern>
 <pattern>op2fa</pattern>
 <pattern>opf3ac</pattern>
+<pattern>opf3af</pattern>
 <pattern>op3fah</pattern>
 <pattern>opf3al</pattern>
+<pattern>opf3ar</pattern>
 <pattern>opf3au</pattern>
 <pattern>op2fä</pattern>
 <pattern>o2pfe</pattern>
 <pattern>op4fem</pattern>
 <pattern>opfe4n</pattern>
+<pattern>opf5ent</pattern>
 <pattern>op4ferk</pattern>
 <pattern>op4f5erö</pattern>
 <pattern>op4ferr</pattern>
 <pattern>op4fin</pattern>
+<pattern>4opfl</pattern>
 <pattern>opf3lo</pattern>
-<pattern>op3flu</pattern>
 <pattern>op3flü</pattern>
 <pattern>2opfs</pattern>
 <pattern>opf5ste</pattern>
@@ -27290,10 +28099,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>op3sz</pattern>
 <pattern>1op2t2</pattern>
 <pattern>op3ta</pattern>
-<pattern>opt4e</pattern>
+<pattern>opt4e2</pattern>
 <pattern>op3tei</pattern>
 <pattern>op3th</pattern>
-<pattern>o4pti</pattern>
+<pattern>3optim</pattern>
 <pattern>op3tor</pattern>
 <pattern>op3ty</pattern>
 <pattern>opu2b</pattern>
@@ -27323,9 +28132,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>or3aku</pattern>
 <pattern>or3alm</pattern>
 <pattern>o3rals</pattern>
-<pattern>orama3</pattern>
 <pattern>ora4mar</pattern>
-<pattern>or3ami</pattern>
+<pattern>or3a4mi</pattern>
 <pattern>o2ran</pattern>
 <pattern>or3an4h</pattern>
 <pattern>oran4kü</pattern>
@@ -27365,13 +28173,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>orbe4t</pattern>
 <pattern>or4b5in4n</pattern>
 <pattern>3or4bit</pattern>
+<pattern>or4bla</pattern>
 <pattern>or3cha</pattern>
 <pattern>4ord </pattern>
 <pattern>4orda</pattern>
-<pattern>ord5arb</pattern>
+<pattern>or4d5arb</pattern>
 <pattern>ordat4</pattern>
 <pattern>ord3e4b</pattern>
 <pattern>ord3ei</pattern>
+<pattern>ord5els</pattern>
+<pattern>ord5engl</pattern>
 <pattern>or4dent</pattern>
 <pattern>or3deo</pattern>
 <pattern>4ordes</pattern>
@@ -27392,16 +28203,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>or3eff</pattern>
 <pattern>o3reg</pattern>
 <pattern>o2reh</pattern>
-<pattern>orei2</pattern>
-<pattern>or3eig</pattern>
+<pattern>or3ei4g</pattern>
+<pattern>orei4l</pattern>
 <pattern>o4r3ein</pattern>
-<pattern>orei5ni</pattern>
 <pattern>ore2k</pattern>
 <pattern>or3ela</pattern>
 <pattern>or3em4p</pattern>
 <pattern>or3emu</pattern>
 <pattern>o4rendu</pattern>
 <pattern>orengene5</pattern>
+<pattern>oren3i</pattern>
 <pattern>o4renki</pattern>
 <pattern>oren6nen </pattern>
 <pattern>o6rennet</pattern>
@@ -27425,6 +28236,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oreso4</pattern>
 <pattern>oret2</pattern>
 <pattern>or3eth</pattern>
+<pattern>ore3tr</pattern>
 <pattern>o2r3eu2</pattern>
 <pattern>ore3w</pattern>
 <pattern>o3ré</pattern>
@@ -27465,8 +28277,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>or3ima</pattern>
 <pattern>ori4mi</pattern>
 <pattern>o4r3in4d</pattern>
-<pattern>orin4g</pattern>
-<pattern>or5inge</pattern>
 <pattern>or3ins</pattern>
 <pattern>o4rint</pattern>
 <pattern>orin4te</pattern>
@@ -27480,7 +28290,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ork5ta</pattern>
 <pattern>orli2</pattern>
 <pattern>2orm</pattern>
-<pattern>or3man</pattern>
 <pattern>orm5ans</pattern>
 <pattern>orm5asp</pattern>
 <pattern>orm3eb</pattern>
@@ -27510,8 +28319,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>orna4t</pattern>
 <pattern>or4nau</pattern>
 <pattern>ornäh4</pattern>
-<pattern>orner4</pattern>
-<pattern>orn5erf</pattern>
 <pattern>or5nes</pattern>
 <pattern>or2no</pattern>
 <pattern>orno3s</pattern>
@@ -27537,6 +28344,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>orö3s2</pattern>
 <pattern>orpa2</pattern>
 <pattern>orp2f</pattern>
+<pattern>or2ps</pattern>
 <pattern>orrat4</pattern>
 <pattern>orr4e</pattern>
 <pattern>orre4p</pattern>
@@ -27552,6 +28360,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>or4se3s</pattern>
 <pattern>ors2k</pattern>
 <pattern>ors2p</pattern>
+<pattern>orspor4</pattern>
 <pattern>ors4tin</pattern>
 <pattern>orst5ob</pattern>
 <pattern>orstra6t</pattern>
@@ -27563,6 +28372,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ort5aus</pattern>
 <pattern>ortän4d</pattern>
 <pattern>or4tär</pattern>
+<pattern>ort5eiw</pattern>
 <pattern>ort5eli</pattern>
 <pattern>or4tenz</pattern>
 <pattern>ort5erb</pattern>
@@ -27572,13 +28382,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>or4t5er4l</pattern>
 <pattern>ort5ersa</pattern>
 <pattern>ort5er6sc</pattern>
+<pattern>or4t5erw</pattern>
 <pattern>or4t5er4z</pattern>
 <pattern>ort3e4v</pattern>
 <pattern>ort5her</pattern>
 <pattern>2orti</pattern>
 <pattern>or3tim</pattern>
 <pattern>ort3in4</pattern>
-<pattern>or3tis</pattern>
 <pattern>ort5obs</pattern>
 <pattern>or4tof4</pattern>
 <pattern>ort5off</pattern>
@@ -27587,19 +28397,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ort5ori</pattern>
 <pattern>ort5ort</pattern>
 <pattern>or2tö</pattern>
-<pattern>ort5res</pattern>
+<pattern>or4t5res</pattern>
 <pattern>ort5rin</pattern>
 <pattern>ort5rol</pattern>
 <pattern>ort5spe</pattern>
 <pattern>orts4ti</pattern>
 <pattern>or4t3um</pattern>
+<pattern>4ortü</pattern>
 <pattern>oru2</pattern>
 <pattern>o3ruf</pattern>
 <pattern>or3uhr</pattern>
-<pattern>orum2</pattern>
-<pattern>or3umb</pattern>
-<pattern>or3umd</pattern>
-<pattern>or3un2</pattern>
+<pattern>orum4d</pattern>
+<pattern>orun2</pattern>
+<pattern>or4us</pattern>
+<pattern>or3ut</pattern>
 <pattern>orü4bu</pattern>
 <pattern>orva2</pattern>
 <pattern>ory1</pattern>
@@ -27613,6 +28424,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>osa3mu</pattern>
 <pattern>osa3r</pattern>
 <pattern>os4a3s</pattern>
+<pattern>3o2sca</pattern>
 <pattern>osch5ar4</pattern>
 <pattern>oschau4</pattern>
 <pattern>osch5aug</pattern>
@@ -27643,6 +28455,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>osi3tr</pattern>
 <pattern>o1sk</pattern>
 <pattern>os2ko</pattern>
+<pattern>os3kol</pattern>
 <pattern>osko5pi</pattern>
 <pattern>o2skr</pattern>
 <pattern>o2sky</pattern>
@@ -27650,7 +28463,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1osm</pattern>
 <pattern>osma3r</pattern>
 <pattern>os4mo3n</pattern>
-<pattern>o1so</pattern>
 <pattern>oso2m</pattern>
 <pattern>o2sov</pattern>
 <pattern>os3pal</pattern>
@@ -27667,13 +28479,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>os4san4</pattern>
 <pattern>oss5and</pattern>
 <pattern>os2sä</pattern>
-<pattern>os4s5che</pattern>
 <pattern>os4s5enz</pattern>
 <pattern>oss3ep</pattern>
 <pattern>os4s5er4b</pattern>
 <pattern>os4s5erf</pattern>
-<pattern>osser4s</pattern>
-<pattern>os6s5ersc</pattern>
 <pattern>os4s5erz</pattern>
 <pattern>oss5esse</pattern>
 <pattern>os4sim</pattern>
@@ -27683,10 +28492,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>oss3or</pattern>
 <pattern>oss3o4v</pattern>
 <pattern>os4s5par</pattern>
+<pattern>os4s3pe</pattern>
 <pattern>os4spo</pattern>
 <pattern>os4spu</pattern>
 <pattern>os2st</pattern>
-<pattern>oss3ta4</pattern>
+<pattern>oss3ta</pattern>
 <pattern>os5stel</pattern>
 <pattern>oss3tr</pattern>
 <pattern>o4st </pattern>
@@ -27694,6 +28504,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ost3ac</pattern>
 <pattern>ost3ak4</pattern>
 <pattern>ost5an4g</pattern>
+<pattern>ost5ann</pattern>
+<pattern>ost5ans</pattern>
 <pattern>ost5apo</pattern>
 <pattern>ostas4</pattern>
 <pattern>ost5auf</pattern>
@@ -27722,7 +28534,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>osto5cke</pattern>
 <pattern>os3tol</pattern>
 <pattern>os3ton</pattern>
-<pattern>ost3rä</pattern>
+<pattern>ost5räu</pattern>
 <pattern>ost5res</pattern>
 <pattern>o3stro</pattern>
 <pattern>ost5roc</pattern>
@@ -27732,6 +28544,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>os4tune</pattern>
 <pattern>ostur4</pattern>
 <pattern>ost5urk</pattern>
+<pattern>o3stüc</pattern>
 <pattern>os3tüm</pattern>
 <pattern>o3sü</pattern>
 <pattern>osyri3</pattern>
@@ -27772,6 +28585,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ota5ren</pattern>
 <pattern>ota3ri</pattern>
 <pattern>ot3arm</pattern>
+<pattern>ot5astr</pattern>
 <pattern>ot3att</pattern>
 <pattern>ot3auf3</pattern>
 <pattern>otau4g</pattern>
@@ -27821,6 +28635,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o2thi</pattern>
 <pattern>ot3hin</pattern>
 <pattern>ot3hir</pattern>
+<pattern>ot3hof</pattern>
 <pattern>ot3hol</pattern>
 <pattern>otho5ra</pattern>
 <pattern>oti5ern</pattern>
@@ -27840,23 +28655,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>o3ton</pattern>
 <pattern>otoreak6</pattern>
 <pattern>otorgene5</pattern>
-<pattern>oto4rin</pattern>
+<pattern>oto4r5in</pattern>
 <pattern>oto3sz</pattern>
 <pattern>oto3t</pattern>
-<pattern>o1tr</pattern>
 <pattern>otra3c</pattern>
+<pattern>o3tran</pattern>
 <pattern>otra4t</pattern>
+<pattern>o3trä</pattern>
 <pattern>ot3rec</pattern>
 <pattern>ot3ret</pattern>
 <pattern>ot2ri</pattern>
 <pattern>ot3ric</pattern>
 <pattern>ot3rin</pattern>
 <pattern>ot3rut</pattern>
+<pattern>ot3sal</pattern>
 <pattern>ot4s3at</pattern>
 <pattern>ot4sel</pattern>
-<pattern>ots3ol</pattern>
+<pattern>ot4s3ol</pattern>
 <pattern>ots3pa</pattern>
-<pattern>ot4s5tau</pattern>
+<pattern>ot3spe</pattern>
 <pattern>ot4stei</pattern>
 <pattern>ot4s5tri</pattern>
 <pattern>ot4strü</pattern>
@@ -27865,13 +28682,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ottan4k</pattern>
 <pattern>ott3eb</pattern>
 <pattern>ott5erkl</pattern>
+<pattern>ott5erwä</pattern>
 <pattern>ott5rei</pattern>
 <pattern>ot4tri</pattern>
 <pattern>ot3ur4l</pattern>
 <pattern>o1tü</pattern>
 <pattern>oty3l</pattern>
 <pattern>ot2zä</pattern>
+<pattern>ot4z5er4k</pattern>
+<pattern>ot4z5er4r</pattern>
 <pattern>otzu3k</pattern>
+<pattern>ou1a</pattern>
 <pattern>ou3b</pattern>
 <pattern>ouch3e</pattern>
 <pattern>ou3chi</pattern>
@@ -27906,7 +28727,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ourta5gen</pattern>
 <pattern>ou2sa3</pattern>
 <pattern>ous4i</pattern>
-<pattern>ou3so</pattern>
 <pattern>ous3t</pattern>
 <pattern>outan4</pattern>
 <pattern>3outf</pattern>
@@ -27926,22 +28746,22 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ovo</pattern>
 <pattern>o2vu</pattern>
 <pattern>2ow</pattern>
+<pattern>o3wä</pattern>
 <pattern>o3wec</pattern>
 <pattern>ow3ef</pattern>
 <pattern>o4wer </pattern>
 <pattern>o2wh</pattern>
-<pattern>ows2</pattern>
 <pattern>oxan2</pattern>
 <pattern>oxi2k</pattern>
 <pattern>o3xim</pattern>
 <pattern>ox1l</pattern>
 <pattern>ox1t</pattern>
 <pattern>ox1u</pattern>
+<pattern>ox3v</pattern>
 <pattern>1oxy</pattern>
 <pattern>oy3ar</pattern>
 <pattern>oy3s2</pattern>
 <pattern>oz2a</pattern>
-<pattern>oz2ä</pattern>
 <pattern>oze2</pattern>
 <pattern>3ozea</pattern>
 <pattern>4oz4en</pattern>
@@ -28009,6 +28829,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ölak2</pattern>
 <pattern>ölan2</pattern>
 <pattern>ölar2</pattern>
+<pattern>ölas2</pattern>
 <pattern>öl3ba</pattern>
 <pattern>öl4be3d</pattern>
 <pattern>öl4bek</pattern>
@@ -28022,6 +28843,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ölfle3</pattern>
 <pattern>öl4f3li</pattern>
 <pattern>ölf3s</pattern>
+<pattern>1öli</pattern>
 <pattern>öl3im2</pattern>
 <pattern>öl3in</pattern>
 <pattern>öl4k3le</pattern>
@@ -28036,7 +28858,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1ölp</pattern>
 <pattern>2ölpe</pattern>
 <pattern>öl4ple</pattern>
-<pattern>1öl1s</pattern>
+<pattern>öl1s</pattern>
 <pattern>öls2z</pattern>
 <pattern>öl3tu</pattern>
 <pattern>1ö2lu</pattern>
@@ -28068,6 +28890,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ör1c</pattern>
 <pattern>ör4dem</pattern>
 <pattern>örden3</pattern>
+<pattern>ördens4</pattern>
 <pattern>ö4re </pattern>
 <pattern>ör3ec</pattern>
 <pattern>ör3ei</pattern>
@@ -28077,27 +28900,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ör3ene</pattern>
 <pattern>ö3renf</pattern>
 <pattern>ör3ent</pattern>
+<pattern>ö6rereig</pattern>
 <pattern>öre4rer</pattern>
-<pattern>ör5erfa</pattern>
 <pattern>ör3er4l</pattern>
 <pattern>ör5ermü</pattern>
 <pattern>öres2</pattern>
 <pattern>ör3ess</pattern>
-<pattern>ör2fl</pattern>
-<pattern>örf3le</pattern>
+<pattern>ör4fli</pattern>
 <pattern>örgla3</pattern>
 <pattern>ö2ri</pattern>
 <pattern>ör3il</pattern>
 <pattern>ör3im</pattern>
 <pattern>örma2</pattern>
 <pattern>örmi4n</pattern>
+<pattern>örn4e</pattern>
 <pattern>örner4v</pattern>
 <pattern>ör1o</pattern>
 <pattern>örop2</pattern>
 <pattern>örre2</pattern>
 <pattern>ör4seg</pattern>
 <pattern>ör4sek</pattern>
-<pattern>örs6ens</pattern>
+<pattern>ör5s6ens</pattern>
 <pattern>örs2k</pattern>
 <pattern>ö1ru</pattern>
 <pattern>ö4r3une</pattern>
@@ -28107,6 +28930,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ösche4r</pattern>
 <pattern>ösch5er6f</pattern>
 <pattern>ösch5eri</pattern>
+<pattern>ösch5erl</pattern>
 <pattern>ösch3l</pattern>
 <pattern>ösch3m</pattern>
 <pattern>ösch3o</pattern>
@@ -28118,7 +28942,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>öse3m</pattern>
 <pattern>öse5str</pattern>
 <pattern>öso3</pattern>
-<pattern>ös2s3c</pattern>
+<pattern>ös4s5che</pattern>
 <pattern>össe4n</pattern>
 <pattern>ös2st</pattern>
 <pattern>ö2st</pattern>
@@ -28133,12 +28957,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ö2t</pattern>
 <pattern>öt1a</pattern>
 <pattern>ötau2</pattern>
+<pattern>ötel2</pattern>
+<pattern>öteln3</pattern>
 <pattern>öte2n</pattern>
 <pattern>ö3ten3e</pattern>
 <pattern>ö3teng</pattern>
 <pattern>ö3tenk</pattern>
 <pattern>ö3tenm</pattern>
 <pattern>ö3tent</pattern>
+<pattern>öt1o2</pattern>
 <pattern>öt1r</pattern>
 <pattern>öts2</pattern>
 <pattern>öt2sc</pattern>
@@ -28151,10 +28978,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2pa </pattern>
 <pattern>1paa</pattern>
 <pattern>paa5ren</pattern>
+<pattern>paa5res</pattern>
 <pattern>pab2</pattern>
 <pattern>pabän3</pattern>
 <pattern>pab4l</pattern>
 <pattern>pab3re</pattern>
+<pattern>pa3brü</pattern>
 <pattern>pa3che</pattern>
 <pattern>pach6t5er6</pattern>
 <pattern>1p2ad</pattern>
@@ -28170,7 +28999,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pa3gn</pattern>
 <pattern>pa1h</pattern>
 <pattern>pah3l</pattern>
-<pattern>pain4s</pattern>
 <pattern>1pak</pattern>
 <pattern>paki3</pattern>
 <pattern>pa3kl</pattern>
@@ -28200,6 +29028,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>paner4</pattern>
 <pattern>pan3eu</pattern>
 <pattern>3panf</pattern>
+<pattern>5panier</pattern>
 <pattern>pa4nik</pattern>
 <pattern>pa3nil</pattern>
 <pattern>pan4ke</pattern>
@@ -28216,7 +29045,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3pan3t4h</pattern>
 <pattern>3panto</pattern>
 <pattern>p3an4tr</pattern>
-<pattern>2pan2w</pattern>
 <pattern>1pap</pattern>
 <pattern>pa2pa</pattern>
 <pattern>3pa2pi</pattern>
@@ -28227,6 +29055,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pa3pre</pattern>
 <pattern>paps2</pattern>
 <pattern>papst3</pattern>
+<pattern>3par </pattern>
 <pattern>5parade</pattern>
 <pattern>paraf4</pattern>
 <pattern>par5aff</pattern>
@@ -28236,6 +29065,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>par5ans</pattern>
 <pattern>2parb</pattern>
 <pattern>2pard</pattern>
+<pattern>pa3rec</pattern>
 <pattern>pa3ree</pattern>
 <pattern>par5ein</pattern>
 <pattern>pa3re4k</pattern>
@@ -28250,19 +29080,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pargel6d</pattern>
 <pattern>par3id</pattern>
 <pattern>par5ins</pattern>
+<pattern>3parit</pattern>
 <pattern>pa4rk</pattern>
 <pattern>3park </pattern>
 <pattern>par4k5am</pattern>
 <pattern>par4k5au</pattern>
 <pattern>par4kop</pattern>
 <pattern>3parkp</pattern>
-<pattern>par4k3r</pattern>
+<pattern>par4kr</pattern>
 <pattern>3parks</pattern>
 <pattern>3parl</pattern>
 <pattern>par3ne</pattern>
 <pattern>3parol</pattern>
 <pattern>parp2</pattern>
 <pattern>2parr</pattern>
+<pattern>pa4rt</pattern>
 <pattern>par3ta</pattern>
 <pattern>part4e</pattern>
 <pattern>5par5tei</pattern>
@@ -28289,9 +29121,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pass5ersa</pattern>
 <pattern>pass5ersä</pattern>
 <pattern>pas6s5ert</pattern>
-<pattern>3passi</pattern>
 <pattern>pas4sp</pattern>
 <pattern>pas4ta</pattern>
+<pattern>pa5ster</pattern>
 <pattern>pas3to</pattern>
 <pattern>pa3str</pattern>
 <pattern>pa3ße</pattern>
@@ -28309,7 +29141,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4patit</pattern>
 <pattern>pat2m</pattern>
 <pattern>pat3mo</pattern>
+<pattern>pat3sa</pattern>
 <pattern>4patz </pattern>
+<pattern>pat6zere</pattern>
 <pattern>1pau</pattern>
 <pattern>p3auf</pattern>
 <pattern>2paun</pattern>
@@ -28321,7 +29155,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3pazif</pattern>
 <pattern>pa3zu</pattern>
 <pattern>1pä</pattern>
-<pattern>päck5er</pattern>
+<pattern>päck5er4</pattern>
 <pattern>pä2d</pattern>
 <pattern>päde3</pattern>
 <pattern>päd3er</pattern>
@@ -28342,6 +29176,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pät3h</pattern>
 <pattern>pä2t3i</pattern>
 <pattern>pät3s</pattern>
+<pattern>pät3t</pattern>
 <pattern>2pb</pattern>
 <pattern>pbe2</pattern>
 <pattern>p1c</pattern>
@@ -28364,6 +29199,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2pee</pattern>
 <pattern>3peel</pattern>
 <pattern>pee2n</pattern>
+<pattern>peene3</pattern>
 <pattern>peer4k</pattern>
 <pattern>2pef2</pattern>
 <pattern>pe3fä</pattern>
@@ -28430,6 +29266,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pene2</pattern>
 <pattern>pen3ed</pattern>
 <pattern>pen3en4</pattern>
+<pattern>pen3es4</pattern>
 <pattern>3penf</pattern>
 <pattern>pe5ning</pattern>
 <pattern>pen3i4t</pattern>
@@ -28464,19 +29301,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pe4rau</pattern>
 <pattern>per3ä</pattern>
 <pattern>per3e4b</pattern>
+<pattern>pe4r3ec</pattern>
 <pattern>perei4g</pattern>
 <pattern>per3el</pattern>
 <pattern>peren4</pattern>
 <pattern>perer4</pattern>
 <pattern>pere3s</pattern>
-<pattern>pe3rid</pattern>
 <pattern>pe3rig</pattern>
 <pattern>peri3k4</pattern>
 <pattern>per4io</pattern>
 <pattern>pe4ris</pattern>
 <pattern>perla5c</pattern>
 <pattern>per6l5asc</pattern>
-<pattern>per4l5au</pattern>
+<pattern>per6l5aug</pattern>
 <pattern>3perlh</pattern>
 <pattern>per4mal</pattern>
 <pattern>permi4</pattern>
@@ -28511,10 +29348,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2pev</pattern>
 <pattern>2pew</pattern>
 <pattern>pex2</pattern>
-<pattern>peze3</pattern>
+<pattern>peze3r</pattern>
 <pattern>1pés</pattern>
 <pattern>2pf </pattern>
-<pattern>p2f3ab</pattern>
+<pattern>pf3abe</pattern>
 <pattern>p2fad</pattern>
 <pattern>pfa5den</pattern>
 <pattern>pfa5des</pattern>
@@ -28525,7 +29362,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pf3ans</pattern>
 <pattern>pf3an4t</pattern>
 <pattern>p2fa4r</pattern>
-<pattern>pf3ar4b</pattern>
+<pattern>pfar4b</pattern>
 <pattern>pf3are</pattern>
 <pattern>p2f3as2</pattern>
 <pattern>p2fau</pattern>
@@ -28550,13 +29387,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4pfer </pattern>
 <pattern>pfer3a</pattern>
 <pattern>pfe6ran</pattern>
-<pattern>p6f5ereig</pattern>
-<pattern>p4f5erfü</pattern>
+<pattern>p4ferc</pattern>
+<pattern>pf5ereig</pattern>
+<pattern>p4ferfü</pattern>
 <pattern>pfer6prob</pattern>
 <pattern>p4ferre</pattern>
 <pattern>pfer6rec</pattern>
 <pattern>p4feru</pattern>
-<pattern>p3fes3</pattern>
+<pattern>p3fes</pattern>
+<pattern>pfe5str</pattern>
 <pattern>p2f3et</pattern>
 <pattern>pf3e2v</pattern>
 <pattern>p2fex</pattern>
@@ -28581,7 +29420,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pf3luc</pattern>
 <pattern>pf3lus</pattern>
 <pattern>pf3ly</pattern>
-<pattern>pf3o2b</pattern>
 <pattern>pf3of</pattern>
 <pattern>p2fop</pattern>
 <pattern>p2for</pattern>
@@ -28597,7 +29435,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pf3s4e</pattern>
 <pattern>pf3sk</pattern>
 <pattern>pf3s4l</pattern>
-<pattern>pf3so</pattern>
+<pattern>pfspor4</pattern>
 <pattern>pfs5ter</pattern>
 <pattern>pf3str</pattern>
 <pattern>pf3stu</pattern>
@@ -28667,6 +29505,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2phz</pattern>
 <pattern>2pi </pattern>
 <pattern>1pi2a</pattern>
+<pattern>pia3b</pattern>
 <pattern>pia3g</pattern>
 <pattern>pia3k</pattern>
 <pattern>pia3li</pattern>
@@ -28688,6 +29527,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3piep</pattern>
 <pattern>pier3a</pattern>
 <pattern>pie4rei</pattern>
+<pattern>pie6r5enz</pattern>
 <pattern>pierer4</pattern>
 <pattern>pie6rerz</pattern>
 <pattern>pier3o</pattern>
@@ -28739,7 +29579,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3piro</pattern>
 <pattern>pi3s2k</pattern>
 <pattern>3pism</pattern>
-<pattern>2pi3so</pattern>
+<pattern>2piso</pattern>
 <pattern>pis4st</pattern>
 <pattern>pi3ta</pattern>
 <pattern>pi4ta </pattern>
@@ -28783,7 +29623,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2plok</pattern>
 <pattern>plo3r</pattern>
 <pattern>p1lu</pattern>
-<pattern>plu2s3</pattern>
+<pattern>2plun</pattern>
+<pattern>p2lu2s3</pattern>
+<pattern>plus5s</pattern>
 <pattern>ply1</pattern>
 <pattern>2p1m2</pattern>
 <pattern>p3ma</pattern>
@@ -28795,6 +29637,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2pob2</pattern>
 <pattern>po3ba</pattern>
 <pattern>pobe2</pattern>
+<pattern>2poc</pattern>
 <pattern>3po4ck</pattern>
 <pattern>po4die</pattern>
 <pattern>2podr</pattern>
@@ -28810,6 +29653,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>poin5ter</pattern>
 <pattern>poka2</pattern>
 <pattern>2pokr</pattern>
+<pattern>po2ku</pattern>
 <pattern>pol3an</pattern>
 <pattern>pol3au</pattern>
 <pattern>pol4d3a</pattern>
@@ -28817,6 +29661,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pol5ein</pattern>
 <pattern>pol5eis</pattern>
 <pattern>po2li</pattern>
+<pattern>polli4</pattern>
 <pattern>polo3s</pattern>
 <pattern>pol3z2</pattern>
 <pattern>pome3</pattern>
@@ -28825,9 +29670,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>po3o2b</pattern>
 <pattern>pop3ak</pattern>
 <pattern>pop3ar</pattern>
-<pattern>pop3la</pattern>
 <pattern>pop3li4</pattern>
-<pattern>pop3s</pattern>
+<pattern>pop3s2</pattern>
 <pattern>po3rad</pattern>
 <pattern>po3ral</pattern>
 <pattern>po3rat</pattern>
@@ -28838,12 +29682,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4porei</pattern>
 <pattern>porgeho6</pattern>
 <pattern>po3rie</pattern>
+<pattern>porno3</pattern>
 <pattern>porta5gen </pattern>
 <pattern>port5ak</pattern>
 <pattern>portbewe5</pattern>
-<pattern>5portfo</pattern>
+<pattern>port5ei</pattern>
 <pattern>port3h</pattern>
 <pattern>por4tin</pattern>
+<pattern>port5is</pattern>
 <pattern>5porto </pattern>
 <pattern>5portos</pattern>
 <pattern>portra4</pattern>
@@ -28851,7 +29697,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>por6t5rau</pattern>
 <pattern>5porträ</pattern>
 <pattern>por6t5räu</pattern>
-<pattern>por4t5re</pattern>
+<pattern>port5ren</pattern>
 <pattern>por6t5ric</pattern>
 <pattern>por4tro</pattern>
 <pattern>po2s</pattern>
@@ -28874,6 +29720,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2posü</pattern>
 <pattern>2pota</pattern>
 <pattern>pot3ar4</pattern>
+<pattern>po3tas</pattern>
 <pattern>po3tä</pattern>
 <pattern>2potb</pattern>
 <pattern>po2te</pattern>
@@ -28908,7 +29755,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pö3ses</pattern>
 <pattern>2pp</pattern>
 <pattern>ppa1</pattern>
-<pattern>pp3a2b</pattern>
+<pattern>pp3ab</pattern>
 <pattern>pp3ac</pattern>
 <pattern>ppal2</pattern>
 <pattern>ppala3</pattern>
@@ -28926,6 +29773,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>p2pe3g</pattern>
 <pattern>p2pei2</pattern>
 <pattern>pp3ein</pattern>
+<pattern>pp3eis</pattern>
+<pattern>ppei6se</pattern>
 <pattern>pp3eit</pattern>
 <pattern>ppel3a4</pattern>
 <pattern>ppen3e</pattern>
@@ -28935,6 +29784,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pper3a</pattern>
 <pattern>ppe2t</pattern>
 <pattern>ppf2</pattern>
+<pattern>pp3fa</pattern>
 <pattern>pp3fr</pattern>
 <pattern>p2p1h</pattern>
 <pattern>pphe2</pattern>
@@ -28951,13 +29801,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pp3lic</pattern>
 <pattern>pp3lis</pattern>
 <pattern>pp3lo</pattern>
-<pattern>p2poc</pattern>
 <pattern>p2pod</pattern>
 <pattern>pp3oh</pattern>
 <pattern>p2po3l</pattern>
 <pattern>ppo2n</pattern>
 <pattern>pp3op</pattern>
-<pattern>pporter6</pattern>
 <pattern>p2pot</pattern>
 <pattern>p2p1ö</pattern>
 <pattern>pp1p</pattern>
@@ -29058,10 +29906,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pro5sti</pattern>
 <pattern>pro3te</pattern>
 <pattern>pro3th</pattern>
+<pattern>pro3tr</pattern>
 <pattern>4prott</pattern>
+<pattern>2prö</pattern>
 <pattern>p3rub</pattern>
 <pattern>4pruc</pattern>
 <pattern>pru5chu</pattern>
+<pattern>prung5l</pattern>
 <pattern>prung5sa</pattern>
 <pattern>2prüc</pattern>
 <pattern>2prüh</pattern>
@@ -29078,6 +29929,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pse2g</pattern>
 <pattern>ps3ein</pattern>
 <pattern>psen3g</pattern>
+<pattern>2psf</pattern>
 <pattern>2psg</pattern>
 <pattern>2psh</pattern>
 <pattern>ps2hi</pattern>
@@ -29085,12 +29937,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>psi5den</pattern>
 <pattern>psie3n</pattern>
 <pattern>psie3r</pattern>
-<pattern>p2sin</pattern>
+<pattern>p2sin2</pattern>
 <pattern>2psk</pattern>
 <pattern>ps2la</pattern>
+<pattern>2psm</pattern>
 <pattern>2p1sp</pattern>
 <pattern>ps3pu</pattern>
 <pattern>2pss2</pattern>
+<pattern>pss4a</pattern>
 <pattern>2pst</pattern>
 <pattern>ps3taf</pattern>
 <pattern>pstat4</pattern>
@@ -29105,7 +29959,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ps2ti</pattern>
 <pattern>ps3tin</pattern>
 <pattern>pstor4</pattern>
-<pattern>ps3tüt</pattern>
 <pattern>2psv</pattern>
 <pattern>2psw</pattern>
 <pattern>1p2sy</pattern>
@@ -29119,28 +29972,28 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ptan2</pattern>
 <pattern>p4t3ana</pattern>
 <pattern>ptange5</pattern>
-<pattern>pt3ar2</pattern>
+<pattern>p4t3ar2</pattern>
 <pattern>pt3a2t</pattern>
 <pattern>pt3au2</pattern>
 <pattern>pt3ax</pattern>
-<pattern>pt1ä</pattern>
 <pattern>ptän2</pattern>
+<pattern>pt3äs</pattern>
 <pattern>ptbau6mes</pattern>
 <pattern>p3tea</pattern>
 <pattern>pt3e2b</pattern>
 <pattern>p2t3ec</pattern>
+<pattern>pt3e2d</pattern>
 <pattern>pt3ef</pattern>
 <pattern>p2t3ei2</pattern>
 <pattern>p4tele</pattern>
 <pattern>p3te2m</pattern>
 <pattern>p4t3emi</pattern>
 <pattern>p4t3emp</pattern>
-<pattern>p3ten</pattern>
+<pattern>4p3ten</pattern>
 <pattern>p4t3eng</pattern>
 <pattern>p4t3ent</pattern>
 <pattern>p2t3ep</pattern>
 <pattern>p4t3er4b</pattern>
-<pattern>pt5erei</pattern>
 <pattern>p4terg</pattern>
 <pattern>pt5ernt</pattern>
 <pattern>pte3ro</pattern>
@@ -29177,15 +30030,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2pt1r</pattern>
 <pattern>ptra2</pattern>
 <pattern>ptri2</pattern>
-<pattern>pt1s2</pattern>
+<pattern>pt1s</pattern>
+<pattern>pts2p</pattern>
+<pattern>pts2t</pattern>
 <pattern>pt3uh</pattern>
 <pattern>pt3ums</pattern>
 <pattern>p4t3ur4h</pattern>
 <pattern>p4t3ur4k</pattern>
+<pattern>p4t3ur4l</pattern>
 <pattern>p4t3urs</pattern>
 <pattern>ptursa5</pattern>
 <pattern>1pty</pattern>
 <pattern>ptz2</pattern>
+<pattern>pua3</pattern>
 <pattern>pu3cke</pattern>
 <pattern>1pu2d</pattern>
 <pattern>pu4er2</pattern>
@@ -29207,6 +30064,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pu2m</pattern>
 <pattern>p3um2g</pattern>
 <pattern>pumge3</pattern>
+<pattern>pum4pa</pattern>
 <pattern>pump3f</pattern>
 <pattern>pum4p3h</pattern>
 <pattern>pum4p3l</pattern>
@@ -29244,7 +30102,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>pü4lei</pattern>
 <pattern>pül3l</pattern>
 <pattern>pü2l3ö</pattern>
-<pattern>pül5ste</pattern>
 <pattern>pü3ren</pattern>
 <pattern>pvi2</pattern>
 <pattern>2pw</pattern>
@@ -29277,7 +30134,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ra4b3ar4</pattern>
 <pattern>3ra4bat</pattern>
 <pattern>r4abbe4</pattern>
-<pattern>5rabbin</pattern>
 <pattern>rab4ble</pattern>
 <pattern>ra4b3ei</pattern>
 <pattern>ra3bel</pattern>
@@ -29292,11 +30148,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rab4ko</pattern>
 <pattern>rable5ser</pattern>
 <pattern>rable5su</pattern>
-<pattern>ra4b3lo</pattern>
 <pattern>rablö5s</pattern>
 <pattern>r2abm</pattern>
 <pattern>rabo5li</pattern>
-<pattern>2ra2br</pattern>
+<pattern>2rabr</pattern>
 <pattern>ra3bra</pattern>
 <pattern>rabre5g</pattern>
 <pattern>ra3bro</pattern>
@@ -29324,6 +30179,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ra5che </pattern>
 <pattern>ra5chen</pattern>
 <pattern>racher4</pattern>
+<pattern>rach5erf</pattern>
 <pattern>rach5erh</pattern>
 <pattern>ra5chest</pattern>
 <pattern>rach5in4</pattern>
@@ -29331,6 +30187,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4rachs</pattern>
 <pattern>rach5sk</pattern>
 <pattern>rachtra6t</pattern>
+<pattern>rachts4</pattern>
 <pattern>rach3u</pattern>
 <pattern>ra3cku</pattern>
 <pattern>r2acr</pattern>
@@ -29340,7 +30197,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rad3an</pattern>
 <pattern>3radar</pattern>
 <pattern>ra3dat</pattern>
-<pattern>r2ade</pattern>
 <pattern>rad5ein</pattern>
 <pattern>rad5ende</pattern>
 <pattern>rad5enz</pattern>
@@ -29369,16 +30225,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>raf3er</pattern>
 <pattern>raf3la</pattern>
 <pattern>raf3lü</pattern>
-<pattern>rafor4m</pattern>
 <pattern>rafter4</pattern>
 <pattern>raft5erz</pattern>
 <pattern>raft3s4</pattern>
+<pattern>ra2fu</pattern>
 <pattern>ra3gan</pattern>
 <pattern>3ragd</pattern>
 <pattern>ra4geg</pattern>
-<pattern>ra4ge3i</pattern>
-<pattern>ragein4</pattern>
-<pattern>rage3l</pattern>
 <pattern>ra4geo</pattern>
 <pattern>ra4geru</pattern>
 <pattern>rage3s</pattern>
@@ -29403,14 +30256,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rah4t3r</pattern>
 <pattern>ra3ims</pattern>
 <pattern>ra3ind</pattern>
-<pattern>ra3i4sc</pattern>
+<pattern>rain3s</pattern>
 <pattern>ra3kel</pattern>
 <pattern>ra3ken</pattern>
 <pattern>ra3ker</pattern>
 <pattern>ra3kes</pattern>
 <pattern>ra3ki</pattern>
 <pattern>rak4ku3</pattern>
-<pattern>ra3k2l</pattern>
+<pattern>ra3kl</pattern>
 <pattern>ra3kno</pattern>
 <pattern>2ra3ko</pattern>
 <pattern>ra3kra</pattern>
@@ -29422,6 +30275,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ral3ak</pattern>
 <pattern>ra5lamp</pattern>
 <pattern>ral3as4</pattern>
+<pattern>ra5late</pattern>
 <pattern>ra5lau </pattern>
 <pattern>ralb4</pattern>
 <pattern>ral4ben</pattern>
@@ -29438,7 +30292,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ral3id</pattern>
 <pattern>rali5ers</pattern>
 <pattern>ra4l5ind</pattern>
-<pattern>ra4l5in4g</pattern>
+<pattern>ralin4g</pattern>
+<pattern>ral5inge</pattern>
 <pattern>ral5insp</pattern>
 <pattern>ra6l5inst</pattern>
 <pattern>ra4linv</pattern>
@@ -29459,19 +30314,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ral5s6tern</pattern>
 <pattern>ral6s5turm</pattern>
 <pattern>ral6s5tür</pattern>
-<pattern>ralt5ak</pattern>
+<pattern>ral4t5ak</pattern>
+<pattern>ral4tem</pattern>
 <pattern>ral4ter</pattern>
+<pattern>ral4tes</pattern>
 <pattern>ral3th</pattern>
 <pattern>ra2lu</pattern>
 <pattern>ral3un</pattern>
 <pattern>3ralü</pattern>
 <pattern>3ralz</pattern>
 <pattern>r3amal</pattern>
-<pattern>ra4masc</pattern>
+<pattern>ra4ma5sc</pattern>
 <pattern>ra3mee</pattern>
 <pattern>ra5mer </pattern>
-<pattern>ra3mil</pattern>
-<pattern>ra3mis</pattern>
+<pattern>ra3mi</pattern>
 <pattern>ram4med</pattern>
 <pattern>ram6mens</pattern>
 <pattern>ram6m5ere</pattern>
@@ -29485,10 +30341,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3ramsc</pattern>
 <pattern>ram5ste</pattern>
 <pattern>2r3amt</pattern>
+<pattern>ram3ta</pattern>
 <pattern>ramt4s</pattern>
 <pattern>r2an </pattern>
 <pattern>ran5ade</pattern>
 <pattern>r3anal</pattern>
+<pattern>ra3na4m</pattern>
 <pattern>r4an3a4r</pattern>
 <pattern>ra3nas</pattern>
 <pattern>ra3nat</pattern>
@@ -29499,21 +30357,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ran4bie</pattern>
 <pattern>ran4bli</pattern>
 <pattern>r2and</pattern>
-<pattern>r4and </pattern>
 <pattern>ran6d5ala</pattern>
 <pattern>ran4d5as</pattern>
+<pattern>ran4dat</pattern>
 <pattern>ran6dau </pattern>
 <pattern>ran5den</pattern>
 <pattern>ran4der</pattern>
 <pattern>ran5der </pattern>
 <pattern>rand5ere</pattern>
+<pattern>rand5erh</pattern>
 <pattern>rand5erke</pattern>
 <pattern>rand5er6m</pattern>
 <pattern>rand5er6r</pattern>
 <pattern>rand5er6s</pattern>
 <pattern>ran4dra</pattern>
 <pattern>ran4dre</pattern>
-<pattern>ran4d5rü</pattern>
 <pattern>rand3s</pattern>
 <pattern>rands4t</pattern>
 <pattern>r2ane</pattern>
@@ -29522,6 +30380,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ra3ner4</pattern>
 <pattern>ra4n5erz</pattern>
 <pattern>ra3nes</pattern>
+<pattern>ra4neu3</pattern>
 <pattern>ran4fal</pattern>
 <pattern>ran4fan</pattern>
 <pattern>ran4fe</pattern>
@@ -29576,6 +30435,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5anzah</pattern>
 <pattern>ran4zei</pattern>
 <pattern>ran4z5er</pattern>
+<pattern>ran4zin</pattern>
 <pattern>ranzu5h</pattern>
 <pattern>ranzu5m</pattern>
 <pattern>ranzu5r</pattern>
@@ -29605,7 +30465,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ra3rä</pattern>
 <pattern>rar2b</pattern>
 <pattern>r2ard</pattern>
-<pattern>r2are</pattern>
+<pattern>ra3rec</pattern>
 <pattern>ra3rei</pattern>
 <pattern>rar3e4v</pattern>
 <pattern>rar3in4</pattern>
@@ -29652,12 +30512,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ra3tak</pattern>
 <pattern>ra3tal</pattern>
 <pattern>ratan4</pattern>
+<pattern>rat3ar</pattern>
+<pattern>ra3tas</pattern>
 <pattern>4rateb</pattern>
 <pattern>4rateg</pattern>
 <pattern>rat3ei4</pattern>
 <pattern>4ratel</pattern>
 <pattern>rat5ente</pattern>
-<pattern>ra4terd</pattern>
 <pattern>ra4terg</pattern>
 <pattern>r4atg</pattern>
 <pattern>rathe4r</pattern>
@@ -29675,12 +30536,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3raton</pattern>
 <pattern>rat4or</pattern>
 <pattern>5ratort</pattern>
-<pattern>ra4t3ra</pattern>
 <pattern>ra3tre</pattern>
 <pattern>r4ats</pattern>
 <pattern>ratsche6f</pattern>
 <pattern>rat4se</pattern>
 <pattern>rat4stä</pattern>
+<pattern>r3at4ti</pattern>
 <pattern>4r3attr</pattern>
 <pattern>3ratu </pattern>
 <pattern>4ra3tum</pattern>
@@ -29709,6 +30570,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5raumab</pattern>
 <pattern>rau4m5ag</pattern>
 <pattern>rau6ment</pattern>
+<pattern>5raumer</pattern>
 <pattern>rau5mes</pattern>
 <pattern>rau4m3i</pattern>
 <pattern>3raumv</pattern>
@@ -29728,12 +30590,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rau6t5ent</pattern>
 <pattern>4rauto</pattern>
 <pattern>rauto6ri</pattern>
-<pattern>raut5s</pattern>
 <pattern>2ra1x</pattern>
 <pattern>ra3xa</pattern>
 <pattern>r3axt</pattern>
 <pattern>2ray</pattern>
-<pattern>ra3zu</pattern>
 <pattern>3razz</pattern>
 <pattern>rä3che</pattern>
 <pattern>räch4s3</pattern>
@@ -29750,6 +30610,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rä3li</pattern>
 <pattern>räl2t</pattern>
 <pattern>2räm</pattern>
+<pattern>rä3me</pattern>
 <pattern>3rän </pattern>
 <pattern>3rä3ni</pattern>
 <pattern>2ränk</pattern>
@@ -29769,7 +30630,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3rätl</pattern>
 <pattern>rät4zu</pattern>
 <pattern>4räue</pattern>
-<pattern>4räu3l</pattern>
+<pattern>2räu3l</pattern>
+<pattern>räu6scher</pattern>
 <pattern>2rb</pattern>
 <pattern>rbab2</pattern>
 <pattern>rb3abb</pattern>
@@ -29797,6 +30659,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4beei</pattern>
 <pattern>rbe5erf</pattern>
 <pattern>rbe5eri</pattern>
+<pattern>rbe5erl</pattern>
 <pattern>rbe5ert</pattern>
 <pattern>r4befa</pattern>
 <pattern>rbefä5h</pattern>
@@ -29817,7 +30680,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4be5hil</pattern>
 <pattern>r4beho</pattern>
 <pattern>rbei3d4</pattern>
-<pattern>rbe5inf</pattern>
 <pattern>rb5einh</pattern>
 <pattern>rbeizu5</pattern>
 <pattern>r3bek</pattern>
@@ -29850,7 +30712,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4beris</pattern>
 <pattern>rb5erke</pattern>
 <pattern>r5bern</pattern>
-<pattern>rbe3ro</pattern>
+<pattern>rbe5ros</pattern>
 <pattern>rberu5h</pattern>
 <pattern>rbe5rum</pattern>
 <pattern>r3bes</pattern>
@@ -29860,6 +30722,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rbese5h</pattern>
 <pattern>rbe4si</pattern>
 <pattern>r4be3sl</pattern>
+<pattern>rbe4so</pattern>
 <pattern>rbe5steu</pattern>
 <pattern>r4be5sto</pattern>
 <pattern>r4bestu</pattern>
@@ -29887,10 +30750,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2b3im</pattern>
 <pattern>rb3inf</pattern>
 <pattern>rbi3tr</pattern>
-<pattern>rb4lad</pattern>
 <pattern>r4b3lan</pattern>
 <pattern>r6b5lasser</pattern>
 <pattern>r4b5last</pattern>
+<pattern>rble2</pattern>
 <pattern>r4ble </pattern>
 <pattern>rble5ck</pattern>
 <pattern>r4bleg</pattern>
@@ -29912,10 +30775,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rb5rechts</pattern>
 <pattern>rb4sam</pattern>
 <pattern>rb4s3an</pattern>
-<pattern>rb4sei</pattern>
 <pattern>rb4send</pattern>
-<pattern>rb4sor</pattern>
-<pattern>rbs5ten</pattern>
 <pattern>rbs4teu</pattern>
 <pattern>rbs4tra</pattern>
 <pattern>rb4sum</pattern>
@@ -29953,6 +30813,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rch3s2</pattern>
 <pattern>rch3t4a</pattern>
 <pattern>rchtak5</pattern>
+<pattern>rcht5erf</pattern>
 <pattern>rcht5erg</pattern>
 <pattern>rch6t5err</pattern>
 <pattern>rch6t5erw</pattern>
@@ -29971,7 +30832,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rd3ak2</pattern>
 <pattern>r2d3al2</pattern>
 <pattern>rda2m</pattern>
-<pattern>r4d3ann</pattern>
+<pattern>rd4anf</pattern>
 <pattern>rd5anti</pattern>
 <pattern>rd5anza</pattern>
 <pattern>rd3ap</pattern>
@@ -30004,12 +30865,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4d3elf</pattern>
 <pattern>r4de3lo</pattern>
 <pattern>rdem2</pattern>
+<pattern>r4dema</pattern>
 <pattern>r4demi</pattern>
 <pattern>rde4mo</pattern>
 <pattern>rd3emp</pattern>
 <pattern>r4denbü</pattern>
-<pattern>rden4es</pattern>
-<pattern>rd5engl</pattern>
 <pattern>r3denh</pattern>
 <pattern>rden4s5a</pattern>
 <pattern>rd5enth</pattern>
@@ -30019,9 +30879,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r3denz</pattern>
 <pattern>rde3ob</pattern>
 <pattern>rde2p</pattern>
-<pattern>rde4rei</pattern>
+<pattern>rde4rei4</pattern>
 <pattern>r5derel</pattern>
-<pattern>rde5rer</pattern>
+<pattern>rde6rerg</pattern>
 <pattern>rder6folg</pattern>
 <pattern>r5derne</pattern>
 <pattern>rd5ernt</pattern>
@@ -30030,6 +30890,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5des </pattern>
 <pattern>r4desc</pattern>
 <pattern>r4de3se</pattern>
+<pattern>rdes4k</pattern>
 <pattern>r4deso</pattern>
 <pattern>r3desp</pattern>
 <pattern>rde5stel</pattern>
@@ -30041,7 +30902,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rdien4s</pattern>
 <pattern>rdienst5ad</pattern>
 <pattern>rdi2m</pattern>
-<pattern>r4d3in4f</pattern>
+<pattern>r4d3inf</pattern>
 <pattern>r4d3ins</pattern>
 <pattern>r3dip</pattern>
 <pattern>rd3ira</pattern>
@@ -30095,8 +30956,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rebe4r</pattern>
 <pattern>re3be4s</pattern>
 <pattern>rebe4z</pattern>
-<pattern>re3bil</pattern>
-<pattern>re3blo3</pattern>
+<pattern>re3bi</pattern>
+<pattern>reblo3</pattern>
 <pattern>re3br</pattern>
 <pattern>re4bus</pattern>
 <pattern>rech5ar4</pattern>
@@ -30112,9 +30973,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3re2co</pattern>
 <pattern>4recô</pattern>
 <pattern>3recy</pattern>
-<pattern>3reda</pattern>
 <pattern>4redd</pattern>
 <pattern>4r3e4del</pattern>
+<pattern>re4dem</pattern>
 <pattern>re4den </pattern>
 <pattern>re3der</pattern>
 <pattern>rede5re</pattern>
@@ -30167,7 +31028,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>re4h5ene</pattern>
 <pattern>reh5ent</pattern>
 <pattern>re3her</pattern>
-<pattern>re3hin</pattern>
 <pattern>reh3l</pattern>
 <pattern>reh3n</pattern>
 <pattern>reh3or4</pattern>
@@ -30175,6 +31035,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>reh3ra</pattern>
 <pattern>reh3ro</pattern>
 <pattern>reh4th</pattern>
+<pattern>re4h3ur</pattern>
 <pattern>re2hü</pattern>
 <pattern>r4ei </pattern>
 <pattern>3reiä</pattern>
@@ -30187,6 +31048,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4reide</pattern>
 <pattern>rei4dep</pattern>
 <pattern>rei4der</pattern>
+<pattern>4r3eidg</pattern>
 <pattern>r4eie</pattern>
 <pattern>4reier </pattern>
 <pattern>4reiern</pattern>
@@ -30199,6 +31061,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3reigä</pattern>
 <pattern>r5ei6gene</pattern>
 <pattern>5reigeno</pattern>
+<pattern>r5eigensc</pattern>
 <pattern>5reige4r</pattern>
 <pattern>5reigew</pattern>
 <pattern>3reigi</pattern>
@@ -30225,7 +31088,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4reinb</pattern>
 <pattern>reinbe5t</pattern>
 <pattern>rei5ne5cke </pattern>
-<pattern>4reing</pattern>
 <pattern>reinge5ni</pattern>
 <pattern>reingere5</pattern>
 <pattern>reini4t</pattern>
@@ -30246,7 +31108,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rei4sal</pattern>
 <pattern>4reisar</pattern>
 <pattern>rei5sen</pattern>
-<pattern>rei6senb</pattern>
+<pattern>r5ei6senb</pattern>
+<pattern>reis5ent</pattern>
 <pattern>reis5erk</pattern>
 <pattern>reises4</pattern>
 <pattern>4reisf</pattern>
@@ -30316,7 +31179,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>re4m3ei</pattern>
 <pattern>re5men</pattern>
 <pattern>2remi</pattern>
-<pattern>re4mitt</pattern>
 <pattern>2remo</pattern>
 <pattern>remo3l</pattern>
 <pattern>re3mor</pattern>
@@ -30324,7 +31186,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2remp</pattern>
 <pattern>r3empf</pattern>
 <pattern>rem4por</pattern>
-<pattern>rems5tel</pattern>
 <pattern>re4mul</pattern>
 <pattern>r4en </pattern>
 <pattern>re3nad</pattern>
@@ -30337,31 +31198,28 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4renbas</pattern>
 <pattern>renbesu5</pattern>
 <pattern>4renbo</pattern>
+<pattern>4r5endab</pattern>
 <pattern>rend5an</pattern>
 <pattern>ren6d5er6k</pattern>
 <pattern>ren6derm</pattern>
 <pattern>4rendg</pattern>
+<pattern>ren3eb</pattern>
 <pattern>ren3ec</pattern>
-<pattern>re4neh</pattern>
 <pattern>renei4</pattern>
 <pattern>ren5ende</pattern>
 <pattern>4r5ener5g</pattern>
 <pattern>ren5erk</pattern>
 <pattern>ren5erm</pattern>
 <pattern>4renexe</pattern>
-<pattern>4renfil</pattern>
 <pattern>re4ng</pattern>
 <pattern>4rengag</pattern>
 <pattern>4rengp</pattern>
 <pattern>4rengs</pattern>
 <pattern>4renhis</pattern>
 <pattern>4renhon</pattern>
-<pattern>re2ni</pattern>
-<pattern>re3nic</pattern>
-<pattern>re3nie</pattern>
-<pattern>re3nik</pattern>
 <pattern>ren3im</pattern>
-<pattern>ren3in4</pattern>
+<pattern>renin4</pattern>
+<pattern>re5nina</pattern>
 <pattern>4renju</pattern>
 <pattern>3renkä</pattern>
 <pattern>renke5li</pattern>
@@ -30375,11 +31233,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4renno</pattern>
 <pattern>renn5sta</pattern>
 <pattern>ren5orc</pattern>
-<pattern>4renpaa</pattern>
 <pattern>4renrec</pattern>
 <pattern>ren6serg</pattern>
 <pattern>ren6s5ing</pattern>
-<pattern>ren5skl</pattern>
 <pattern>ren5sta</pattern>
 <pattern>6renstip</pattern>
 <pattern>rens5tri</pattern>
@@ -30394,11 +31250,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4rentw</pattern>
 <pattern>4rentz</pattern>
 <pattern>4renumg</pattern>
+<pattern>2renü</pattern>
 <pattern>r2enz</pattern>
 <pattern>ren4z5ar</pattern>
 <pattern>ren6zerg</pattern>
 <pattern>ren6zerl</pattern>
-<pattern>ren6z5er6s</pattern>
+<pattern>ren6zerm</pattern>
 <pattern>renz5ertr</pattern>
 <pattern>ren6zerw</pattern>
 <pattern>ren4z5in4</pattern>
@@ -30406,7 +31263,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4renzq</pattern>
 <pattern>4renzr</pattern>
 <pattern>4renzt</pattern>
-<pattern>4ren4zw</pattern>
+<pattern>ren4zut</pattern>
+<pattern>ren4zw</pattern>
 <pattern>renzy5klo</pattern>
 <pattern>4renzym</pattern>
 <pattern>4renzz</pattern>
@@ -30433,38 +31291,37 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5er4bie</pattern>
 <pattern>6rerbreg</pattern>
 <pattern>4r3erbs</pattern>
-<pattern>r3erdb</pattern>
 <pattern>rerde4</pattern>
 <pattern>4r3er4dr</pattern>
 <pattern>rere2</pattern>
 <pattern>4rered</pattern>
 <pattern>rer5eid</pattern>
-<pattern>4r5ereig</pattern>
+<pattern>r5ereig</pattern>
 <pattern>r3erek</pattern>
 <pattern>rer5ent</pattern>
 <pattern>re4r3ep</pattern>
 <pattern>rerer4</pattern>
+<pattern>re4rerl</pattern>
 <pattern>re4r5ers</pattern>
 <pattern>rer5erw</pattern>
 <pattern>re5res</pattern>
 <pattern>4reresi</pattern>
-<pattern>rer4fa</pattern>
-<pattern>4r5erfah</pattern>
+<pattern>r3er4fa</pattern>
+<pattern>4rerfah</pattern>
 <pattern>rer4fin</pattern>
 <pattern>4r3er4fo</pattern>
 <pattern>3rerfr</pattern>
 <pattern>rer4fü</pattern>
 <pattern>r3er4gä</pattern>
-<pattern>4r5ergeb</pattern>
 <pattern>rerge5be</pattern>
+<pattern>6rergebn</pattern>
 <pattern>5rerges</pattern>
-<pattern>rer4gre</pattern>
 <pattern>rer4gri</pattern>
 <pattern>rer4heb</pattern>
 <pattern>rer4ho5l</pattern>
 <pattern>4r3erhö</pattern>
 <pattern>r2eri</pattern>
-<pattern>rer3id</pattern>
+<pattern>re4r3id</pattern>
 <pattern>rer4kan</pattern>
 <pattern>rer4ke</pattern>
 <pattern>4rerken</pattern>
@@ -30473,15 +31330,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4erko</pattern>
 <pattern>4rer4kra</pattern>
 <pattern>rer4la</pattern>
+<pattern>4rerlas</pattern>
 <pattern>4r5erlau</pattern>
-<pattern>rer4lä</pattern>
-<pattern>rer6lebn</pattern>
-<pattern>5rerli</pattern>
+<pattern>4rer4läs</pattern>
+<pattern>rer4leb</pattern>
 <pattern>4r3er4lö</pattern>
 <pattern>rerlö5sen</pattern>
 <pattern>4r3er4mä</pattern>
 <pattern>rermä5ß</pattern>
-<pattern>4rermi</pattern>
 <pattern>rer4mit</pattern>
 <pattern>rermo4</pattern>
 <pattern>rer4mü5d</pattern>
@@ -30494,10 +31350,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4r3erod</pattern>
 <pattern>4reros</pattern>
 <pattern>re5ros </pattern>
-<pattern>r5erosi</pattern>
 <pattern>2r3er2ö</pattern>
-<pattern>r3erre</pattern>
-<pattern>rer4re5g</pattern>
+<pattern>rerre5gu</pattern>
 <pattern>rer4rei</pattern>
 <pattern>rer6satz</pattern>
 <pattern>rer6sätz</pattern>
@@ -30508,6 +31362,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rer4tr</pattern>
 <pattern>rer5tre</pattern>
 <pattern>rer4tüc</pattern>
+<pattern>2r3e2ru</pattern>
 <pattern>rer5vo</pattern>
 <pattern>rer4wac</pattern>
 <pattern>rerwa5che</pattern>
@@ -30516,9 +31371,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6r5erwerb</pattern>
 <pattern>4rer4zä</pattern>
 <pattern>rer4zes</pattern>
-<pattern>4rer4zi</pattern>
-<pattern>r5erzie</pattern>
-<pattern>5rerzim</pattern>
+<pattern>rer6zieh</pattern>
 <pattern>r2es</pattern>
 <pattern>r4es </pattern>
 <pattern>re4s3an</pattern>
@@ -30532,38 +31385,36 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>reses4</pattern>
 <pattern>3reset</pattern>
 <pattern>re4s3in4</pattern>
-<pattern>res3of</pattern>
+<pattern>re4s3of</pattern>
 <pattern>3resol</pattern>
 <pattern>3reson</pattern>
-<pattern>re3sor</pattern>
 <pattern>re3spe</pattern>
 <pattern>4respi</pattern>
-<pattern>res4po</pattern>
 <pattern>re5spru</pattern>
 <pattern>re4ss</pattern>
 <pattern>res4san</pattern>
+<pattern>5ressä</pattern>
 <pattern>res5sch</pattern>
 <pattern>res4sek</pattern>
 <pattern>res4sel</pattern>
 <pattern>res4sem</pattern>
 <pattern>res6sera</pattern>
 <pattern>res6s5er6f</pattern>
+<pattern>res6serm</pattern>
 <pattern>res6s5er6p</pattern>
 <pattern>res6seru</pattern>
 <pattern>res6s5er6w</pattern>
 <pattern>res4spa</pattern>
-<pattern>resta4</pattern>
 <pattern>re5stan</pattern>
 <pattern>re5start</pattern>
-<pattern>res4tas</pattern>
 <pattern>re3stä</pattern>
 <pattern>4re5steh</pattern>
 <pattern>rest5ein</pattern>
+<pattern>re5stel</pattern>
 <pattern>resten4</pattern>
 <pattern>res4tex</pattern>
 <pattern>re4stö</pattern>
 <pattern>rest5rau</pattern>
-<pattern>rest5rei</pattern>
 <pattern>rest5ric</pattern>
 <pattern>re5stru</pattern>
 <pattern>4res4tu</pattern>
@@ -30574,11 +31425,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>re3tal</pattern>
 <pattern>r3etap</pattern>
 <pattern>2reth</pattern>
-<pattern>re3ti</pattern>
 <pattern>re3ton</pattern>
 <pattern>reto5nen</pattern>
-<pattern>retra4</pattern>
-<pattern>ret5rad</pattern>
+<pattern>2retr</pattern>
 <pattern>re3tre</pattern>
 <pattern>ret5rol</pattern>
 <pattern>ret4t3a</pattern>
@@ -30593,7 +31442,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2reur</pattern>
 <pattern>reu3ra4</pattern>
 <pattern>reu4z5ei</pattern>
-<pattern>r3eva</pattern>
+<pattern>2r3eva</pattern>
 <pattern>4revid</pattern>
 <pattern>re3vir</pattern>
 <pattern>2rew</pattern>
@@ -30624,9 +31473,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rf3lic</pattern>
 <pattern>rflo5ck</pattern>
 <pattern>rf2lö</pattern>
-<pattern>r3f2lu</pattern>
-<pattern>rfo2</pattern>
-<pattern>rf3ob</pattern>
+<pattern>rf2lu</pattern>
 <pattern>rf3of</pattern>
 <pattern>rfolg4s</pattern>
 <pattern>r5form</pattern>
@@ -30694,7 +31541,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rge5neren</pattern>
 <pattern>rge5nerer</pattern>
 <pattern>rge5neres</pattern>
-<pattern>rgene6ri</pattern>
 <pattern>rge5nes </pattern>
 <pattern>rgeni3</pattern>
 <pattern>rgent4</pattern>
@@ -30702,6 +31548,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rgen4zw</pattern>
 <pattern>rgeran4</pattern>
 <pattern>rgere5g</pattern>
+<pattern>rger4fa</pattern>
 <pattern>rge5rinn</pattern>
 <pattern>rge5rit</pattern>
 <pattern>r3ges</pattern>
@@ -30736,6 +31583,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2g3ni</pattern>
 <pattern>r2gno</pattern>
 <pattern>rg3nom</pattern>
+<pattern>r2gny</pattern>
 <pattern>r4go </pattern>
 <pattern>r2g3oa</pattern>
 <pattern>rgo2b</pattern>
@@ -30762,8 +31610,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rgs4pi</pattern>
 <pattern>rg3spr</pattern>
 <pattern>rg3sti</pattern>
-<pattern>rg3su</pattern>
 <pattern>rgu2l</pattern>
+<pattern>r3gut</pattern>
 <pattern>r1h2</pattern>
 <pattern>2rh </pattern>
 <pattern>rha2</pattern>
@@ -30774,14 +31622,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rhal4b3</pattern>
 <pattern>2rhan</pattern>
 <pattern>2rhar</pattern>
-<pattern>2rh4au</pattern>
+<pattern>2rhau</pattern>
 <pattern>2rhä</pattern>
 <pattern>rhä2f</pattern>
 <pattern>2rheb</pattern>
 <pattern>rhe4be</pattern>
 <pattern>2rhef</pattern>
 <pattern>4rheit</pattern>
-<pattern>rhe2p</pattern>
+<pattern>r3he2p</pattern>
 <pattern>2rhe2r</pattern>
 <pattern>rher3e</pattern>
 <pattern>2rhi</pattern>
@@ -30804,10 +31652,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2rhü</pattern>
 <pattern>3rhyt</pattern>
 <pattern>2ri </pattern>
+<pattern>rialer4</pattern>
+<pattern>ria6l5erw</pattern>
 <pattern>ria4lin</pattern>
 <pattern>ri3ams</pattern>
+<pattern>ri5and</pattern>
 <pattern>ri3an4g</pattern>
-<pattern>ria3s2</pattern>
+<pattern>ria3s4t</pattern>
 <pattern>2riat</pattern>
 <pattern>ria5tro</pattern>
 <pattern>2riä</pattern>
@@ -30818,20 +31669,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ri3che</pattern>
 <pattern>ri3chi</pattern>
 <pattern>ri5chlo</pattern>
-<pattern>rich5s4k</pattern>
+<pattern>rich5ska</pattern>
 <pattern>rich4sp</pattern>
 <pattern>richt6s5e</pattern>
-<pattern>richts5o</pattern>
+<pattern>richt6s5o</pattern>
 <pattern>richtsor6</pattern>
 <pattern>ri3cke</pattern>
 <pattern>2rico</pattern>
 <pattern>ri4con</pattern>
 <pattern>ri4dau</pattern>
-<pattern>r3idee</pattern>
+<pattern>r3idea</pattern>
+<pattern>4r3idee</pattern>
 <pattern>ri4d3el</pattern>
 <pattern>ri4dent</pattern>
 <pattern>rider4</pattern>
+<pattern>4ridol</pattern>
 <pattern>3ridoo</pattern>
+<pattern>2ridy</pattern>
 <pattern>r2i2e</pattern>
 <pattern>rie4bac</pattern>
 <pattern>riebe6re</pattern>
@@ -30845,7 +31699,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rie3li</pattern>
 <pattern>ri3ell</pattern>
 <pattern>ri3els</pattern>
-<pattern>rie5nad</pattern>
+<pattern>rie5nade</pattern>
 <pattern>riene4</pattern>
 <pattern>riener4</pattern>
 <pattern>rien3s</pattern>
@@ -30855,8 +31709,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>riere4n</pattern>
 <pattern>rie4res</pattern>
 <pattern>ri5ern </pattern>
-<pattern>rie3ro</pattern>
 <pattern>rier5z</pattern>
+<pattern>rie3sa</pattern>
 <pattern>rie5sta</pattern>
 <pattern>rie3ta</pattern>
 <pattern>rie3to</pattern>
@@ -30889,7 +31743,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rig2o</pattern>
 <pattern>rig5sta</pattern>
 <pattern>2rih</pattern>
-<pattern>2ri1i</pattern>
+<pattern>2ri1i2</pattern>
 <pattern>3rii </pattern>
 <pattern>ri4kam</pattern>
 <pattern>rika3s4</pattern>
@@ -30927,7 +31781,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ri3nas</pattern>
 <pattern>ri3nat</pattern>
 <pattern>ri3nä</pattern>
-<pattern>4r3in4be3</pattern>
+<pattern>4rinbe</pattern>
+<pattern>rin4be5t</pattern>
 <pattern>3rinde</pattern>
 <pattern>rin5den</pattern>
 <pattern>rinde5xen</pattern>
@@ -30961,6 +31816,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2r3in2j</pattern>
 <pattern>2rink</pattern>
 <pattern>rin4ka</pattern>
+<pattern>rin6kent</pattern>
 <pattern>rin4kl</pattern>
 <pattern>rin4kn</pattern>
 <pattern>rin4k3o</pattern>
@@ -30987,6 +31843,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4r3insp</pattern>
 <pattern>5r4inspi</pattern>
 <pattern>r5insti</pattern>
+<pattern>rin5sto</pattern>
 <pattern>3rinsy</pattern>
 <pattern>rin4ta</pattern>
 <pattern>rint5an</pattern>
@@ -30997,13 +31854,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2r3in2v</pattern>
 <pattern>rinva3</pattern>
 <pattern>2rinz</pattern>
-<pattern>rinzi5d</pattern>
 <pattern>2rio</pattern>
 <pattern>rio2d</pattern>
 <pattern>3riog</pattern>
 <pattern>rio4ni</pattern>
 <pattern>3riop</pattern>
-<pattern>r4ior</pattern>
+<pattern>r4ior2</pattern>
+<pattern>ri3orb</pattern>
 <pattern>3riosk</pattern>
 <pattern>ri3ox</pattern>
 <pattern>2rip </pattern>
@@ -31038,7 +31895,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ri4st</pattern>
 <pattern>rista4</pattern>
 <pattern>rist5ab</pattern>
-<pattern>ris5tan</pattern>
 <pattern>ris5ten</pattern>
 <pattern>rister4</pattern>
 <pattern>ris6t5erf</pattern>
@@ -31058,9 +31914,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rit4t3h</pattern>
 <pattern>rit4to</pattern>
 <pattern>rit4tr</pattern>
-<pattern>ritts5o</pattern>
+<pattern>ritt4s5o</pattern>
 <pattern>ritts5p</pattern>
-<pattern>3ritu</pattern>
+<pattern>3ritua</pattern>
 <pattern>r3itum</pattern>
 <pattern>ri4ty</pattern>
 <pattern>ri4val</pattern>
@@ -31072,15 +31928,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2r1k</pattern>
 <pattern>rka4b</pattern>
 <pattern>r2kad2</pattern>
-<pattern>rk3adr</pattern>
 <pattern>rk3a2g</pattern>
-<pattern>rk3aka</pattern>
 <pattern>rka2l</pattern>
 <pattern>rk3all</pattern>
 <pattern>rka2m</pattern>
 <pattern>r4kans</pattern>
 <pattern>rk3are</pattern>
-<pattern>r3kas</pattern>
+<pattern>r3ka2s</pattern>
 <pattern>rk5assi</pattern>
 <pattern>r4ka3tr</pattern>
 <pattern>r4k3att</pattern>
@@ -31089,11 +31943,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5kell</pattern>
 <pattern>rke2n</pattern>
 <pattern>rken5s4t</pattern>
-<pattern>rker4he</pattern>
-<pattern>rker4le</pattern>
-<pattern>rker4sa</pattern>
-<pattern>rk5ersta</pattern>
-<pattern>r4k3er4w</pattern>
 <pattern>r4kest</pattern>
 <pattern>rk3ide</pattern>
 <pattern>r2k3im</pattern>
@@ -31103,14 +31952,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rk2l</pattern>
 <pattern>rk3leu</pattern>
 <pattern>rk2n</pattern>
+<pattern>r4k3ne4b</pattern>
 <pattern>r4k3nut</pattern>
 <pattern>rko2a</pattern>
+<pattern>rko2b</pattern>
+<pattern>rk3obe</pattern>
 <pattern>rko2e</pattern>
 <pattern>rko2g</pattern>
 <pattern>r3kom</pattern>
 <pattern>rkonzi4</pattern>
 <pattern>rko2o</pattern>
-<pattern>rk3ord</pattern>
+<pattern>r4k3ord</pattern>
 <pattern>rk3o4ri</pattern>
 <pattern>rko5sen</pattern>
 <pattern>rk3ou</pattern>
@@ -31118,17 +31970,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rk3rom</pattern>
 <pattern>rkrü3c</pattern>
 <pattern>rks3al</pattern>
-<pattern>rk4scho</pattern>
+<pattern>rk4s5cho</pattern>
 <pattern>rk4sein</pattern>
 <pattern>rk4sel</pattern>
 <pattern>rks5ern</pattern>
 <pattern>rk4s3in</pattern>
 <pattern>rksin4t</pattern>
-<pattern>rks3or4</pattern>
+<pattern>rk4s3or4</pattern>
 <pattern>rks3pa</pattern>
 <pattern>rkspa4t</pattern>
 <pattern>rk3sta</pattern>
 <pattern>rk4s5toc</pattern>
+<pattern>rk4stor</pattern>
 <pattern>rk3str</pattern>
 <pattern>rkta2</pattern>
 <pattern>rk4t3ak</pattern>
@@ -31147,6 +32000,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rk4t3in</pattern>
 <pattern>rkto2</pattern>
 <pattern>rkt3ob</pattern>
+<pattern>rk5tor </pattern>
 <pattern>rk4t5rad</pattern>
 <pattern>rk4t5rat</pattern>
 <pattern>rkt5rei</pattern>
@@ -31173,6 +32027,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4langv</pattern>
 <pattern>r2l3ar2</pattern>
 <pattern>rla4s</pattern>
+<pattern>rlast5r</pattern>
 <pattern>rla2t</pattern>
 <pattern>rla3ta</pattern>
 <pattern>rla2v</pattern>
@@ -31200,6 +32055,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rlon3</pattern>
 <pattern>r3lor</pattern>
 <pattern>rlös3s</pattern>
+<pattern>rl3skr</pattern>
 <pattern>rls3pr</pattern>
 <pattern>rls2t</pattern>
 <pattern>rl3ste</pattern>
@@ -31214,11 +32070,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2maf</pattern>
 <pattern>rmage4</pattern>
 <pattern>rma5get</pattern>
+<pattern>rma3kl</pattern>
+<pattern>rma5lec</pattern>
 <pattern>rma5los</pattern>
 <pattern>rm3ami</pattern>
 <pattern>rma4n4e</pattern>
 <pattern>rma5nen </pattern>
+<pattern>rman4gr</pattern>
 <pattern>r4m3an4k</pattern>
+<pattern>rm3anp</pattern>
 <pattern>rman4sa</pattern>
 <pattern>r4m5antr</pattern>
 <pattern>rman4z</pattern>
@@ -31229,6 +32089,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4mare</pattern>
 <pattern>r4ma3ri</pattern>
 <pattern>r4marz</pattern>
+<pattern>r3mass</pattern>
 <pattern>rmassa5</pattern>
 <pattern>r3maß</pattern>
 <pattern>r4matu</pattern>
@@ -31237,11 +32098,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rm3d2</pattern>
 <pattern>rmd4e</pattern>
 <pattern>rmdrü3</pattern>
+<pattern>rm3eck</pattern>
 <pattern>rme5dic</pattern>
 <pattern>rmeer4</pattern>
 <pattern>r4m3ei </pattern>
 <pattern>rm5einb</pattern>
 <pattern>r4meinh</pattern>
+<pattern>rmein6to</pattern>
 <pattern>r4m5einw</pattern>
 <pattern>rmel5au</pattern>
 <pattern>rme3li</pattern>
@@ -31273,7 +32136,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rmet5as</pattern>
 <pattern>r2mex</pattern>
 <pattern>rmi2d2</pattern>
-<pattern>r4m3ide</pattern>
+<pattern>r3mida</pattern>
+<pattern>rm3ide</pattern>
 <pattern>rmi2l</pattern>
 <pattern>rmi4nar</pattern>
 <pattern>rmi4ner</pattern>
@@ -31289,6 +32153,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2mom</pattern>
 <pattern>rmon3s4</pattern>
 <pattern>rmo2r</pattern>
+<pattern>rmoren4</pattern>
 <pattern>rmor3t</pattern>
 <pattern>r4mo3st</pattern>
 <pattern>rmo4ti</pattern>
@@ -31305,6 +32170,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2muh</pattern>
 <pattern>rm3umg</pattern>
 <pattern>rm3ums</pattern>
+<pattern>rm3umt</pattern>
 <pattern>r4m3una</pattern>
 <pattern>r4munf</pattern>
 <pattern>r3mus</pattern>
@@ -31345,10 +32211,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2n3äs</pattern>
 <pattern>rnbeob5</pattern>
 <pattern>rnd2</pattern>
+<pattern>rn3da</pattern>
 <pattern>r4ne </pattern>
 <pattern>r3nee</pattern>
 <pattern>rn3eff</pattern>
 <pattern>rne3g</pattern>
+<pattern>rn3ehr</pattern>
 <pattern>r3n4eid</pattern>
 <pattern>rnei4f</pattern>
 <pattern>r2nek</pattern>
@@ -31357,18 +32225,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rn3emp</pattern>
 <pattern>rn3emu</pattern>
 <pattern>rne2n</pattern>
+<pattern>rn5ends</pattern>
 <pattern>r4n5ener</pattern>
 <pattern>rnen3g4</pattern>
 <pattern>r4neni</pattern>
 <pattern>rn3e2p</pattern>
 <pattern>r3ner</pattern>
-<pattern>rner4fa</pattern>
+<pattern>rn3er4f</pattern>
 <pattern>r4n3erg</pattern>
 <pattern>r4n5erhe</pattern>
 <pattern>rner4ke</pattern>
 <pattern>rner4ku</pattern>
 <pattern>rner4le</pattern>
-<pattern>r4n5er4st</pattern>
 <pattern>r4n3er4t</pattern>
 <pattern>r4n3er4w</pattern>
 <pattern>r4n3er4z</pattern>
@@ -31376,7 +32244,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rne4t3a</pattern>
 <pattern>rne4ter</pattern>
 <pattern>rne4t3r</pattern>
-<pattern>rnet3s</pattern>
 <pattern>rne3uf</pattern>
 <pattern>rn1f2</pattern>
 <pattern>rn1g</pattern>
@@ -31394,6 +32261,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rnn2</pattern>
 <pattern>rn3oly</pattern>
 <pattern>r3nom</pattern>
+<pattern>rn3ome</pattern>
 <pattern>r3non</pattern>
 <pattern>rnop2</pattern>
 <pattern>rn3ope</pattern>
@@ -31402,6 +32270,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rn5orde</pattern>
 <pattern>rn5ost </pattern>
 <pattern>rn5osti</pattern>
+<pattern>rno2t</pattern>
 <pattern>rn3ot4t</pattern>
 <pattern>r3nou</pattern>
 <pattern>rn1ö2</pattern>
@@ -31409,6 +32278,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rn3sä</pattern>
 <pattern>rnsch4</pattern>
 <pattern>rnse2</pattern>
+<pattern>rnseh5a</pattern>
 <pattern>rn3s4l</pattern>
 <pattern>rn3s2p</pattern>
 <pattern>rn3sta</pattern>
@@ -31451,7 +32321,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rob2j</pattern>
 <pattern>ro2bo</pattern>
 <pattern>rob3o4r</pattern>
-<pattern>ro4bre</pattern>
 <pattern>2robs</pattern>
 <pattern>rob5sta</pattern>
 <pattern>rob5str</pattern>
@@ -31465,9 +32334,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>roef2</pattern>
 <pattern>roe2n</pattern>
 <pattern>roener4</pattern>
+<pattern>ro4enz</pattern>
 <pattern>ro3fa</pattern>
 <pattern>ro4fib</pattern>
 <pattern>ro4fie</pattern>
+<pattern>ro4fig</pattern>
 <pattern>r4ofl</pattern>
 <pattern>r4ofr</pattern>
 <pattern>ro3gan</pattern>
@@ -31488,7 +32359,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ro3ke</pattern>
 <pattern>ro3ki</pattern>
 <pattern>r3okt</pattern>
-<pattern>ro3ku</pattern>
 <pattern>ro3lab</pattern>
 <pattern>ro3las</pattern>
 <pattern>2rold</pattern>
@@ -31515,6 +32385,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4romat</pattern>
 <pattern>ro3med</pattern>
 <pattern>rom3ei</pattern>
+<pattern>rom5ent</pattern>
 <pattern>ro5mer </pattern>
 <pattern>rom5erk</pattern>
 <pattern>rom5ers</pattern>
@@ -31530,8 +32401,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ro4niki</pattern>
 <pattern>ro4niku</pattern>
 <pattern>ro3nit</pattern>
-<pattern>4rono</pattern>
 <pattern>ro3nos</pattern>
+<pattern>ro3not</pattern>
 <pattern>rons4</pattern>
 <pattern>ron3sh</pattern>
 <pattern>ron3sp</pattern>
@@ -31555,7 +32426,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3room</pattern>
 <pattern>ro3or</pattern>
 <pattern>2rop</pattern>
-<pattern>ro3pan</pattern>
 <pattern>ro5pas </pattern>
 <pattern>ro3pei</pattern>
 <pattern>ro3pem</pattern>
@@ -31564,6 +32434,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ro3pn</pattern>
 <pattern>ro3pr</pattern>
 <pattern>rops3t</pattern>
+<pattern>ror3ab</pattern>
 <pattern>ro3rad</pattern>
 <pattern>ror3al</pattern>
 <pattern>ror3an4</pattern>
@@ -31586,18 +32457,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ro5sche</pattern>
 <pattern>ro3ser</pattern>
 <pattern>ro3ses</pattern>
-<pattern>3roset</pattern>
 <pattern>ros4i</pattern>
 <pattern>ros4mo</pattern>
 <pattern>ro3sp</pattern>
 <pattern>ros4sa</pattern>
-<pattern>ross5al</pattern>
 <pattern>ross5ei</pattern>
 <pattern>ross5enke</pattern>
 <pattern>ros6sess</pattern>
 <pattern>ros4spa</pattern>
 <pattern>ro3sta</pattern>
 <pattern>3rostb</pattern>
+<pattern>rost5e4c</pattern>
+<pattern>ros4t5er</pattern>
 <pattern>rost5re</pattern>
 <pattern>ro3su</pattern>
 <pattern>2rosz</pattern>
@@ -31609,14 +32480,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ro3tap</pattern>
 <pattern>rotar4</pattern>
 <pattern>rot5art</pattern>
-<pattern>rot3as</pattern>
 <pattern>3rotem</pattern>
 <pattern>ro4t5en4d</pattern>
 <pattern>3ro4ter4</pattern>
 <pattern>rot5erl</pattern>
 <pattern>rot5ers</pattern>
 <pattern>ro3tik</pattern>
-<pattern>rot3s</pattern>
+<pattern>rot3sa</pattern>
 <pattern>rots4te</pattern>
 <pattern>rot4tau</pattern>
 <pattern>rot6terk</pattern>
@@ -31640,6 +32510,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rö3ges</pattern>
 <pattern>1röh</pattern>
 <pattern>2r3ök</pattern>
+<pattern>r3ölf</pattern>
 <pattern>röl4l3a</pattern>
 <pattern>3römi</pattern>
 <pattern>r1ör2</pattern>
@@ -31664,12 +32535,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rper5in4</pattern>
 <pattern>rpe3ru</pattern>
 <pattern>rpes5th</pattern>
+<pattern>rp2fä</pattern>
 <pattern>rp2fo</pattern>
 <pattern>rpho5sen</pattern>
 <pattern>r2pli</pattern>
 <pattern>r3po2</pattern>
 <pattern>rp2r</pattern>
 <pattern>rpro3s</pattern>
+<pattern>rps3a</pattern>
+<pattern>rp2s3i</pattern>
 <pattern>rps3t</pattern>
 <pattern>r2pt</pattern>
 <pattern>rpu2b</pattern>
@@ -31715,6 +32589,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rre4no</pattern>
 <pattern>rren3s</pattern>
 <pattern>rren4za</pattern>
+<pattern>rren6z5er6</pattern>
 <pattern>rrepa3</pattern>
 <pattern>rre4po</pattern>
 <pattern>rre4pr</pattern>
@@ -31724,8 +32599,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5rese</pattern>
 <pattern>rre4si3</pattern>
 <pattern>r4r3esk</pattern>
+<pattern>rre4so</pattern>
 <pattern>rre2v</pattern>
-<pattern>rrevi3</pattern>
 <pattern>r5re4ze</pattern>
 <pattern>r4rezi</pattern>
 <pattern>rr4hen</pattern>
@@ -31776,7 +32651,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4s3am4t</pattern>
 <pattern>rs3ana</pattern>
 <pattern>r4s3an4b</pattern>
-<pattern>r3sand</pattern>
 <pattern>r4sanf</pattern>
 <pattern>r4sanga</pattern>
 <pattern>rs3anh</pattern>
@@ -31784,6 +32658,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rs3anz</pattern>
 <pattern>rsa3re</pattern>
 <pattern>r5sate</pattern>
+<pattern>r5satt</pattern>
 <pattern>rs4au </pattern>
 <pattern>rsau4g</pattern>
 <pattern>rsau4m</pattern>
@@ -31797,7 +32672,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5schem</pattern>
 <pattern>r5scher</pattern>
 <pattern>rscher5ei</pattern>
-<pattern>rsch5erle</pattern>
 <pattern>r3schi</pattern>
 <pattern>r5schif</pattern>
 <pattern>r3scho</pattern>
@@ -31851,7 +32725,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r2so </pattern>
 <pattern>rso2b</pattern>
 <pattern>rs2om</pattern>
-<pattern>r4sord</pattern>
 <pattern>rsor6ge5s</pattern>
 <pattern>r4s5ort </pattern>
 <pattern>r4s5orts</pattern>
@@ -31876,10 +32749,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rsta4l</pattern>
 <pattern>rst5ala</pattern>
 <pattern>rs5tale</pattern>
-<pattern>r4stans</pattern>
+<pattern>r4st5ans</pattern>
 <pattern>r4stant</pattern>
 <pattern>rst3as</pattern>
+<pattern>rs4tat</pattern>
 <pattern>rs4tau</pattern>
+<pattern>rstauto6</pattern>
 <pattern>rs5täti</pattern>
 <pattern>r4steil</pattern>
 <pattern>rst5eindr</pattern>
@@ -31920,8 +32795,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4s3to4t</pattern>
 <pattern>rst5rät</pattern>
 <pattern>r4strea</pattern>
-<pattern>rs5tren</pattern>
+<pattern>r4s5tren</pattern>
 <pattern>rst5ret</pattern>
+<pattern>rst5rin</pattern>
 <pattern>r4strun</pattern>
 <pattern>rs2tu</pattern>
 <pattern>rst5ums</pattern>
@@ -31934,7 +32810,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4s3umf</pattern>
 <pattern>rs3uml</pattern>
 <pattern>rs3um4w</pattern>
-<pattern>rs3una</pattern>
 <pattern>rs4win</pattern>
 <pattern>rs4zin</pattern>
 <pattern>rszu2</pattern>
@@ -31953,6 +32828,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r3taf</pattern>
 <pattern>rt3aff</pattern>
 <pattern>r3tag</pattern>
+<pattern>rt5agent</pattern>
 <pattern>r3tai</pattern>
 <pattern>rt3aka</pattern>
 <pattern>rt3akk</pattern>
@@ -31963,6 +32839,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4talle</pattern>
 <pattern>rt5allt</pattern>
 <pattern>rt3alp</pattern>
+<pattern>r4t3alu</pattern>
 <pattern>rt3ama</pattern>
 <pattern>r3tame</pattern>
 <pattern>rt3ana</pattern>
@@ -31972,7 +32849,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rt3ans</pattern>
 <pattern>r5tant </pattern>
 <pattern>rtan4w</pattern>
-<pattern>rt5an4za</pattern>
+<pattern>rt5anza</pattern>
 <pattern>r5tanzg</pattern>
 <pattern>rt5anzu</pattern>
 <pattern>r3tap</pattern>
@@ -32016,7 +32893,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rtei5na</pattern>
 <pattern>rt4e5ind</pattern>
 <pattern>rtei3s</pattern>
-<pattern>r3teiw</pattern>
 <pattern>r2tek</pattern>
 <pattern>rte5lang</pattern>
 <pattern>rte4le</pattern>
@@ -32043,7 +32919,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rter4be</pattern>
 <pattern>r4terec</pattern>
 <pattern>rt5ereig</pattern>
-<pattern>rter6fas</pattern>
+<pattern>rter4fa</pattern>
 <pattern>r4t5er4fo</pattern>
 <pattern>rt5ergü</pattern>
 <pattern>rter6hal</pattern>
@@ -32055,9 +32931,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rter4n</pattern>
 <pattern>r4t5ernä</pattern>
 <pattern>r4t5ernt</pattern>
-<pattern>r4t3er4ö</pattern>
+<pattern>rter6öff</pattern>
 <pattern>rter6sat</pattern>
 <pattern>r5tersc</pattern>
+<pattern>rter4wa</pattern>
 <pattern>rter4zä</pattern>
 <pattern>rter4zi</pattern>
 <pattern>r4tesa</pattern>
@@ -32067,6 +32944,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4te3sp</pattern>
 <pattern>r4te5sta</pattern>
 <pattern>r4testä</pattern>
+<pattern>rt5etab</pattern>
+<pattern>rt3e4ti</pattern>
 <pattern>r4teuro</pattern>
 <pattern>rtgene5r</pattern>
 <pattern>rtgezo4</pattern>
@@ -32099,6 +32978,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r1to</pattern>
 <pattern>rto2l</pattern>
 <pattern>r3tom</pattern>
+<pattern>rto4nam</pattern>
 <pattern>rto4ne</pattern>
 <pattern>rtop2</pattern>
 <pattern>rt3ope</pattern>
@@ -32116,6 +32996,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r1t2ö</pattern>
 <pattern>r1tr</pattern>
 <pattern>r5trac</pattern>
+<pattern>r4t3ral</pattern>
 <pattern>rt5ram </pattern>
 <pattern>rt5rams</pattern>
 <pattern>rt5rand</pattern>
@@ -32136,12 +33017,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4trou</pattern>
 <pattern>rt3sal</pattern>
 <pattern>rt5sand</pattern>
-<pattern>rt4s3eh</pattern>
 <pattern>rtsei4l</pattern>
 <pattern>rts5in4g</pattern>
 <pattern>rtska4</pattern>
 <pattern>rt3sop</pattern>
-<pattern>rts3or4</pattern>
+<pattern>rt4s3or4</pattern>
 <pattern>rts5par</pattern>
 <pattern>rt5spre</pattern>
 <pattern>rts5treu</pattern>
@@ -32155,7 +33035,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r4t3ur4l</pattern>
 <pattern>rt3ur4s</pattern>
 <pattern>rtursa5</pattern>
-<pattern>r4t3ur4t</pattern>
 <pattern>rtu2t</pattern>
 <pattern>r4t3ute</pattern>
 <pattern>r1tü</pattern>
@@ -32175,9 +33054,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ru3che</pattern>
 <pattern>ru4ch5er4</pattern>
 <pattern>rucht5s</pattern>
-<pattern>ru4ck3a</pattern>
+<pattern>ruck3a</pattern>
 <pattern>ru3cke</pattern>
-<pattern>ruck5er6kr</pattern>
+<pattern>ruck5erkr</pattern>
+<pattern>rudel5i</pattern>
 <pattern>ru1e</pattern>
 <pattern>ru2et</pattern>
 <pattern>1r2uf</pattern>
@@ -32207,16 +33087,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2rum</pattern>
 <pattern>ru2ma</pattern>
 <pattern>ru3man</pattern>
+<pattern>rum4ga</pattern>
 <pattern>rumge5bu</pattern>
 <pattern>rum4mei</pattern>
-<pattern>3rumo</pattern>
 <pattern>rum4ple</pattern>
+<pattern>rum3r</pattern>
 <pattern>rum4ri</pattern>
 <pattern>rum4sat</pattern>
+<pattern>rum4stu</pattern>
 <pattern>rum4stü</pattern>
 <pattern>rum3t</pattern>
 <pattern>rum4wel</pattern>
-<pattern>rumzu3</pattern>
+<pattern>rumzu5s</pattern>
 <pattern>ru2n</pattern>
 <pattern>2r3una</pattern>
 <pattern>2r3un2b</pattern>
@@ -32235,10 +33117,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rund5erw</pattern>
 <pattern>rund5erz</pattern>
 <pattern>4rundi</pattern>
-<pattern>4rundn</pattern>
 <pattern>run4do</pattern>
 <pattern>rund3r</pattern>
-<pattern>rund3s</pattern>
+<pattern>rund3s4</pattern>
 <pattern>run4dur</pattern>
 <pattern>4rundv</pattern>
 <pattern>4rundz</pattern>
@@ -32253,7 +33134,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>run6ge5na</pattern>
 <pattern>run4ger</pattern>
 <pattern>4run4gl</pattern>
-<pattern>rung5le</pattern>
 <pattern>run4gr</pattern>
 <pattern>run4he</pattern>
 <pattern>2r3uni</pattern>
@@ -32269,7 +33149,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>run2s</pattern>
 <pattern>run3sc</pattern>
 <pattern>4runse</pattern>
-<pattern>4runt</pattern>
+<pattern>4runsi</pattern>
+<pattern>2runt</pattern>
 <pattern>runte4</pattern>
 <pattern>2runw</pattern>
 <pattern>run4we3</pattern>
@@ -32285,6 +33166,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ru3sel</pattern>
 <pattern>ru3sem</pattern>
 <pattern>ruser4</pattern>
+<pattern>ru4so </pattern>
 <pattern>ru5spi</pattern>
 <pattern>rus4s5er</pattern>
 <pattern>3russl</pattern>
@@ -32299,12 +33181,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ru3tal</pattern>
 <pattern>rut3an4</pattern>
 <pattern>rut3ap</pattern>
+<pattern>ru3tas</pattern>
 <pattern>rute2</pattern>
 <pattern>ru4tei</pattern>
 <pattern>ru4t3el4</pattern>
 <pattern>ruter4</pattern>
 <pattern>rut5erf</pattern>
-<pattern>rut3o</pattern>
+<pattern>2ruto</pattern>
+<pattern>rut3of</pattern>
 <pattern>rut3r</pattern>
 <pattern>rut6scha</pattern>
 <pattern>2ruw</pattern>
@@ -32376,20 +33260,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rz3al</pattern>
 <pattern>rz3am</pattern>
 <pattern>rz3and</pattern>
+<pattern>rz3ano</pattern>
 <pattern>rz3ant</pattern>
+<pattern>rz3anz</pattern>
 <pattern>rz3app</pattern>
 <pattern>r2z3ar</pattern>
 <pattern>rzar4r</pattern>
 <pattern>rz3as</pattern>
+<pattern>rz3aud</pattern>
 <pattern>r5zähn</pattern>
-<pattern>rz2än3</pattern>
+<pattern>rz3ega</pattern>
 <pattern>r5zeit</pattern>
+<pattern>r3zel</pattern>
 <pattern>rzel5l4a</pattern>
 <pattern>rze2m</pattern>
 <pattern>rze2n</pattern>
 <pattern>rzen3e</pattern>
 <pattern>rzen6gen</pattern>
-<pattern>r3zent</pattern>
+<pattern>r5zentr</pattern>
 <pattern>r4z5ents</pattern>
 <pattern>r4zentw</pattern>
 <pattern>r4zentz</pattern>
@@ -32397,7 +33285,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>rz3epe</pattern>
 <pattern>r4z3erd</pattern>
 <pattern>r4z5er4fr</pattern>
-<pattern>rz5erfü</pattern>
+<pattern>r4z5erfü</pattern>
 <pattern>r4z3er4g</pattern>
 <pattern>rzer4kr</pattern>
 <pattern>rzer4q</pattern>
@@ -32419,11 +33307,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r5zink</pattern>
 <pattern>r4z3int</pattern>
 <pattern>rz3in4v</pattern>
+<pattern>rzkop4</pattern>
 <pattern>rzle2</pattern>
 <pattern>r3z2of</pattern>
 <pattern>r2z3ot2</pattern>
-<pattern>rz4t3au</pattern>
 <pattern>rz4tea</pattern>
+<pattern>rzten4g</pattern>
 <pattern>rzt5ric</pattern>
 <pattern>r2zu </pattern>
 <pattern>rzu4beh</pattern>
@@ -32465,19 +33354,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>r3züc</pattern>
 <pattern>r3zwec</pattern>
 <pattern>rzwe5cke</pattern>
-<pattern>r4z5weis</pattern>
-<pattern>r4z3wir</pattern>
+<pattern>r4zweis</pattern>
+<pattern>r4z5wir</pattern>
+<pattern>rz4wis</pattern>
 <pattern>2sa </pattern>
 <pattern>1s2aa</pattern>
 <pattern>2s1a2b2</pattern>
 <pattern>sa3bä</pattern>
+<pattern>5sabbat</pattern>
 <pattern>sabbe5s</pattern>
 <pattern>sabe2</pattern>
 <pattern>3sa3bel</pattern>
 <pattern>sa3bet</pattern>
 <pattern>sabge3</pattern>
 <pattern>sabma3</pattern>
-<pattern>3sabot</pattern>
 <pattern>sa3brü</pattern>
 <pattern>sabwä5g</pattern>
 <pattern>sabwe5s</pattern>
@@ -32500,6 +33390,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3safe</pattern>
 <pattern>2s3af2f</pattern>
 <pattern>3s2aft</pattern>
+<pattern>saf4to</pattern>
 <pattern>saf4tr</pattern>
 <pattern>saft3s</pattern>
 <pattern>sa2g</pattern>
@@ -32521,23 +33412,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s1ak2</pattern>
 <pattern>2sa2ka</pattern>
 <pattern>sa3kar</pattern>
-<pattern>s2a3ke</pattern>
+<pattern>s2ake</pattern>
+<pattern>sa3ken</pattern>
+<pattern>sa3ker</pattern>
 <pattern>3s4aki</pattern>
 <pattern>2sakk</pattern>
 <pattern>sakku3</pattern>
-<pattern>s2akr</pattern>
 <pattern>2sakt</pattern>
 <pattern>2saku</pattern>
 <pattern>2sakz</pattern>
+<pattern>sal3ag</pattern>
 <pattern>sal3an</pattern>
 <pattern>sa3las</pattern>
 <pattern>sal4at</pattern>
 <pattern>sa3läm</pattern>
-<pattern>s2alb</pattern>
 <pattern>3sald</pattern>
 <pattern>saler4</pattern>
 <pattern>sal5erb</pattern>
+<pattern>sal5erf</pattern>
 <pattern>sal5erk</pattern>
+<pattern>sa3leu</pattern>
 <pattern>s2ali</pattern>
 <pattern>sal3id</pattern>
 <pattern>sal5ins</pattern>
@@ -32549,7 +33443,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4salom</pattern>
 <pattern>s2alp</pattern>
 <pattern>sal4s3o</pattern>
-<pattern>s3altä</pattern>
+<pattern>4s3altä</pattern>
 <pattern>4sal4te</pattern>
 <pattern>sa3lus</pattern>
 <pattern>3salv</pattern>
@@ -32559,6 +33453,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sa3mah</pattern>
 <pattern>sama5ri</pattern>
 <pattern>4s3amat</pattern>
+<pattern>sam4bo</pattern>
 <pattern>4s3ambu</pattern>
 <pattern>s2ame</pattern>
 <pattern>4s3amei</pattern>
@@ -32583,15 +33478,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>san4ba</pattern>
 <pattern>sanbe5t</pattern>
 <pattern>4s3an4br</pattern>
-<pattern>san2c</pattern>
-<pattern>s5and4ac</pattern>
+<pattern>sand4ac</pattern>
 <pattern>san4dan</pattern>
 <pattern>sand5ar4</pattern>
+<pattern>san6d5er6s</pattern>
 <pattern>san5din</pattern>
 <pattern>sando4</pattern>
 <pattern>san4dre</pattern>
 <pattern>san4d5ri</pattern>
-<pattern>3sand5s4</pattern>
+<pattern>3s4and5s4</pattern>
 <pattern>san2e</pattern>
 <pattern>sa3nen</pattern>
 <pattern>4saner</pattern>
@@ -32631,7 +33526,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2san2w</pattern>
 <pattern>2san2z</pattern>
 <pattern>2s1a2p2</pattern>
-<pattern>sapi3</pattern>
 <pattern>s2a3pr</pattern>
 <pattern>2s1a2q</pattern>
 <pattern>s1a2r2</pattern>
@@ -32660,6 +33554,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2sarz</pattern>
 <pattern>2sasi</pattern>
 <pattern>2s3a2s2p</pattern>
+<pattern>sas4sis</pattern>
+<pattern>s3asso</pattern>
 <pattern>2sast</pattern>
 <pattern>sa3stu</pattern>
 <pattern>2s3a2sy</pattern>
@@ -32676,6 +33572,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sat4th</pattern>
 <pattern>4s3attr</pattern>
 <pattern>s4atz</pattern>
+<pattern>sat4zei</pattern>
 <pattern>sat4zel</pattern>
 <pattern>sat4z5en4</pattern>
 <pattern>sat4zer</pattern>
@@ -32684,17 +33581,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3s4auc</pattern>
 <pattern>saudi5e</pattern>
 <pattern>3saue</pattern>
+<pattern>s5auerh</pattern>
 <pattern>sau5erwit</pattern>
+<pattern>4sauf </pattern>
 <pattern>sau4fa</pattern>
 <pattern>4s3aufb</pattern>
+<pattern>4saufn</pattern>
 <pattern>sau5fra</pattern>
-<pattern>s3aufs</pattern>
+<pattern>4s3aufs</pattern>
 <pattern>s3aufz</pattern>
 <pattern>s2aug</pattern>
 <pattern>s5auges</pattern>
 <pattern>saug5la</pattern>
 <pattern>saug5le</pattern>
 <pattern>3sau4gr</pattern>
+<pattern>2s3auk</pattern>
 <pattern>3saum</pattern>
 <pattern>sauna3</pattern>
 <pattern>3s2aur</pattern>
@@ -32702,11 +33603,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4s3ausb</pattern>
 <pattern>4sausd</pattern>
 <pattern>4s3ausf</pattern>
-<pattern>4sausg</pattern>
+<pattern>4s3ausg</pattern>
 <pattern>4s3ausl</pattern>
 <pattern>4s3ausm</pattern>
+<pattern>4sausn</pattern>
 <pattern>s3ausp</pattern>
-<pattern>s3ausr</pattern>
+<pattern>4s3ausr</pattern>
 <pattern>4s3auss</pattern>
 <pattern>4s5austr</pattern>
 <pattern>s3ausü</pattern>
@@ -32731,7 +33633,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2s3ält</pattern>
 <pattern>2s1äm2</pattern>
 <pattern>3sä3ma</pattern>
-<pattern>sä4me</pattern>
 <pattern>3säml</pattern>
 <pattern>2s3än2d</pattern>
 <pattern>4s3ängs</pattern>
@@ -32747,13 +33648,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2ät</pattern>
 <pattern>s4äuge</pattern>
 <pattern>4säugi</pattern>
-<pattern>4säugl</pattern>
+<pattern>3säul</pattern>
 <pattern>3s4äur</pattern>
 <pattern>4s3äuss</pattern>
 <pattern>2säuß</pattern>
 <pattern>2sb2</pattern>
 <pattern>sb4au</pattern>
-<pattern>sbau4c</pattern>
 <pattern>sbau6m5en</pattern>
 <pattern>sbe2</pattern>
 <pattern>sbeda5c</pattern>
@@ -32820,15 +33720,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2schd</pattern>
 <pattern>sche5cken </pattern>
 <pattern>4schef </pattern>
-<pattern>4schefi</pattern>
 <pattern>4schefs</pattern>
 <pattern>4sch5ei </pattern>
 <pattern>6scheinm</pattern>
 <pattern>4schemi</pattern>
+<pattern>4schemp</pattern>
 <pattern>6scheng </pattern>
 <pattern>6schentk</pattern>
-<pattern>scher4e</pattern>
-<pattern>scher6kran</pattern>
 <pattern>6schernt</pattern>
 <pattern>6schertr</pattern>
 <pattern>4schess</pattern>
@@ -32837,7 +33735,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2schg</pattern>
 <pattern>schgene5</pattern>
 <pattern>2schh</pattern>
-<pattern>sch3id</pattern>
+<pattern>sch3i4d</pattern>
 <pattern>4schine</pattern>
 <pattern>4schinf</pattern>
 <pattern>4schins</pattern>
@@ -32853,6 +33751,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6schlein</pattern>
 <pattern>schle4r</pattern>
 <pattern>4schloc</pattern>
+<pattern>4schlog</pattern>
 <pattern>4schlöc</pattern>
 <pattern>4schluf</pattern>
 <pattern>4schmas</pattern>
@@ -32898,25 +33797,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4schrep</pattern>
 <pattern>4schres</pattern>
 <pattern>4schrin</pattern>
-<pattern>4schrip</pattern>
 <pattern>4schris</pattern>
 <pattern>4schrol</pattern>
 <pattern>4schron</pattern>
 <pattern>6schrote</pattern>
 <pattern>4schrou</pattern>
 <pattern>4schrus</pattern>
+<pattern>4schrut</pattern>
 <pattern>2schs</pattern>
 <pattern>sch3s4k</pattern>
-<pattern>sch3so</pattern>
 <pattern>schsor5ten</pattern>
 <pattern>sch5sta</pattern>
 <pattern>sch5s4ti</pattern>
 <pattern>sch5str</pattern>
+<pattern>sch5stu</pattern>
 <pattern>2scht</pattern>
 <pattern>sch3t4a</pattern>
 <pattern>sch3to</pattern>
 <pattern>scht5sp</pattern>
 <pattern>s4chu</pattern>
+<pattern>4schunf</pattern>
 <pattern>4schunt</pattern>
 <pattern>sch2ü</pattern>
 <pattern>2schv</pattern>
@@ -32959,12 +33859,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>seauto4</pattern>
 <pattern>2seä</pattern>
 <pattern>2seb</pattern>
+<pattern>se3bac</pattern>
 <pattern>sebe4k</pattern>
 <pattern>sebe4r</pattern>
 <pattern>sebe4s</pattern>
 <pattern>sebe4t</pattern>
 <pattern>se3bi</pattern>
-<pattern>se3bl</pattern>
 <pattern>se3che</pattern>
 <pattern>4s3echo</pattern>
 <pattern>sechst5r</pattern>
@@ -32975,12 +33875,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3seea</pattern>
 <pattern>see3b</pattern>
 <pattern>se3eck</pattern>
-<pattern>see3h</pattern>
 <pattern>see3ig</pattern>
 <pattern>see3na</pattern>
 <pattern>se3end</pattern>
 <pattern>see5ne</pattern>
 <pattern>se3enz</pattern>
+<pattern>see3p</pattern>
 <pattern>seer4</pattern>
 <pattern>see3ra</pattern>
 <pattern>se3erb</pattern>
@@ -32992,18 +33892,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3ers</pattern>
 <pattern>se3ert</pattern>
 <pattern>4se3erz</pattern>
+<pattern>see3t</pattern>
 <pattern>2sef2</pattern>
 <pattern>se3fä</pattern>
 <pattern>s3eff</pattern>
 <pattern>se3fl</pattern>
 <pattern>sefla3</pattern>
 <pattern>seflo3</pattern>
-<pattern>s2eg</pattern>
 <pattern>2sega</pattern>
 <pattern>s3egal</pattern>
 <pattern>se3gan</pattern>
 <pattern>2segä</pattern>
-<pattern>sege2</pattern>
+<pattern>s2ege2</pattern>
 <pattern>4segeb</pattern>
 <pattern>4seges</pattern>
 <pattern>se3gla</pattern>
@@ -33017,10 +33917,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3hal</pattern>
 <pattern>sehan4</pattern>
 <pattern>seh5ang</pattern>
+<pattern>seh3ar</pattern>
 <pattern>se2hä</pattern>
 <pattern>se3häu</pattern>
 <pattern>4se3hef</pattern>
 <pattern>seh5ein</pattern>
+<pattern>seh5erf</pattern>
 <pattern>seh5erk</pattern>
 <pattern>sehgene5r</pattern>
 <pattern>seh5in4g</pattern>
@@ -33064,7 +33966,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s5einhe</pattern>
 <pattern>4s3eini</pattern>
 <pattern>4s3eink</pattern>
-<pattern>4s3einl</pattern>
+<pattern>4seinl</pattern>
 <pattern>s3einm</pattern>
 <pattern>4s3einn</pattern>
 <pattern>4s3einr</pattern>
@@ -33107,17 +34009,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3läu</pattern>
 <pattern>s2elb</pattern>
 <pattern>3selbe</pattern>
+<pattern>selbst5r</pattern>
 <pattern>sel3d4</pattern>
 <pattern>se3leb</pattern>
 <pattern>sel3ec</pattern>
+<pattern>4s3elef</pattern>
 <pattern>s3ele3g</pattern>
 <pattern>sel5eig</pattern>
 <pattern>4se5leit</pattern>
 <pattern>6selektr</pattern>
+<pattern>4seleme</pattern>
 <pattern>se4lend</pattern>
 <pattern>sel5erd</pattern>
 <pattern>se4l5ere</pattern>
-<pattern>se4l5erf</pattern>
+<pattern>se6l5erfi</pattern>
 <pattern>se4lerk</pattern>
 <pattern>se4l5er4l</pattern>
 <pattern>4selern</pattern>
@@ -33143,11 +34048,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sel3ob</pattern>
 <pattern>4se3loc</pattern>
 <pattern>4se3lot</pattern>
+<pattern>3selp</pattern>
 <pattern>s2els</pattern>
 <pattern>sel5skl</pattern>
 <pattern>sel5sko</pattern>
+<pattern>sel5stem</pattern>
 <pattern>sel3sz</pattern>
 <pattern>sel6tern</pattern>
+<pattern>3selv</pattern>
 <pattern>3sely</pattern>
 <pattern>selz2</pattern>
 <pattern>4se3mac</pattern>
@@ -33157,6 +34065,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4semat</pattern>
 <pattern>2semä</pattern>
 <pattern>4semb</pattern>
+<pattern>sem3bl</pattern>
 <pattern>4semei</pattern>
 <pattern>4semel</pattern>
 <pattern>3se4mes</pattern>
@@ -33188,17 +34097,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se4n5erk</pattern>
 <pattern>se4n5ers</pattern>
 <pattern>se4n5er4w</pattern>
-<pattern>sene4s</pattern>
-<pattern>sen5esc</pattern>
-<pattern>se4ness</pattern>
+<pattern>se4n5ess</pattern>
 <pattern>4senet</pattern>
 <pattern>sen3e4v</pattern>
 <pattern>3senfo</pattern>
 <pattern>sengebü5s</pattern>
 <pattern>sen6gel </pattern>
 <pattern>sengene5</pattern>
-<pattern>seni3e</pattern>
-<pattern>se4n3im</pattern>
+<pattern>senhaus6</pattern>
+<pattern>se2ni</pattern>
+<pattern>se3ni3e</pattern>
+<pattern>sen3im</pattern>
 <pattern>sen3in</pattern>
 <pattern>seninde5</pattern>
 <pattern>se3nit</pattern>
@@ -33216,7 +34125,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3nov</pattern>
 <pattern>3sensä</pattern>
 <pattern>sen4s5eh</pattern>
-<pattern>s5ensem</pattern>
+<pattern>4s5ensem</pattern>
 <pattern>sen5sep</pattern>
 <pattern>senser4</pattern>
 <pattern>sen6s5ers</pattern>
@@ -33225,7 +34134,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3senso</pattern>
 <pattern>sen5spre</pattern>
 <pattern>senst4</pattern>
-<pattern>sen5stal</pattern>
+<pattern>sen5sta</pattern>
 <pattern>sen5s6temp</pattern>
 <pattern>sen5sti</pattern>
 <pattern>sen5sto</pattern>
@@ -33234,6 +34143,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3sensy</pattern>
 <pattern>senta4l</pattern>
 <pattern>4s3entd</pattern>
+<pattern>sen6tenr</pattern>
 <pattern>4s3entf</pattern>
 <pattern>4s3entg</pattern>
 <pattern>sen3ti</pattern>
@@ -33241,6 +34151,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4sentla</pattern>
 <pattern>4s3entn</pattern>
 <pattern>sento4</pattern>
+<pattern>sen6t5ric</pattern>
 <pattern>4s3ents</pattern>
 <pattern>4sentw</pattern>
 <pattern>4s3entz</pattern>
@@ -33251,8 +34162,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3senü</pattern>
 <pattern>3senwi</pattern>
 <pattern>senzu4</pattern>
-<pattern>4senzy</pattern>
-<pattern>sen4zy5k</pattern>
+<pattern>sen4zun</pattern>
 <pattern>2se1o</pattern>
 <pattern>seo2b</pattern>
 <pattern>se3om</pattern>
@@ -33264,15 +34174,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3pf</pattern>
 <pattern>2sepi</pattern>
 <pattern>se3pin</pattern>
+<pattern>s3epis</pattern>
 <pattern>2sepo</pattern>
 <pattern>3sept</pattern>
 <pattern>se3pu2</pattern>
-<pattern>3s2e2q</pattern>
+<pattern>1se2q</pattern>
 <pattern>serab4</pattern>
+<pattern>4seraba</pattern>
 <pattern>se5rabe</pattern>
 <pattern>sera4d4</pattern>
 <pattern>ser5adl</pattern>
 <pattern>ser3af</pattern>
+<pattern>sera4g</pattern>
 <pattern>ser3al</pattern>
 <pattern>ser3am</pattern>
 <pattern>ser3an4</pattern>
@@ -33283,7 +34196,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ser4bär</pattern>
 <pattern>serbe4</pattern>
 <pattern>s5erbe </pattern>
-<pattern>s3erdb</pattern>
 <pattern>sere2</pattern>
 <pattern>ser3eb</pattern>
 <pattern>ser5eck</pattern>
@@ -33297,6 +34209,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6serelev</pattern>
 <pattern>ser5eli</pattern>
 <pattern>ser5emi</pattern>
+<pattern>ser5end</pattern>
 <pattern>ser5ene</pattern>
 <pattern>se4r5enk</pattern>
 <pattern>ser5ens</pattern>
@@ -33315,14 +34228,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3serhä</pattern>
 <pattern>ser4heb</pattern>
 <pattern>s3erhö</pattern>
-<pattern>ser3id</pattern>
+<pattern>se4r3id</pattern>
 <pattern>se5rig</pattern>
 <pattern>se5rin </pattern>
 <pattern>se4riö</pattern>
 <pattern>serk4</pattern>
 <pattern>ser4kä</pattern>
 <pattern>ser4ken</pattern>
-<pattern>ser6kern</pattern>
 <pattern>ser4klä</pattern>
 <pattern>serko4</pattern>
 <pattern>3serl </pattern>
@@ -33337,7 +34249,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ser4mäc</pattern>
 <pattern>ser4mäs</pattern>
 <pattern>ser4mä5ß</pattern>
-<pattern>4s5er4mit</pattern>
 <pattern>4sernt</pattern>
 <pattern>s5ernte</pattern>
 <pattern>ser3ob</pattern>
@@ -33351,6 +34262,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s3eröf</pattern>
 <pattern>se3röl</pattern>
 <pattern>s4ers </pattern>
+<pattern>6s5erschü</pattern>
 <pattern>4s5er4seh</pattern>
 <pattern>4sersg</pattern>
 <pattern>sers4k</pattern>
@@ -33384,6 +34296,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ses2k</pattern>
 <pattern>se5skan</pattern>
 <pattern>s5eskap</pattern>
+<pattern>3sesm</pattern>
 <pattern>2se3so</pattern>
 <pattern>2se3s2p</pattern>
 <pattern>4s3essa</pattern>
@@ -33427,7 +34340,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>se3ufe</pattern>
 <pattern>se3uh</pattern>
 <pattern>s3eul</pattern>
-<pattern>2se3un</pattern>
+<pattern>2seun</pattern>
 <pattern>s3eu2p</pattern>
 <pattern>3seur</pattern>
 <pattern>seu2t</pattern>
@@ -33440,15 +34353,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3sewit</pattern>
 <pattern>s1ex</pattern>
 <pattern>3sex </pattern>
+<pattern>4sexam</pattern>
 <pattern>sex3en</pattern>
+<pattern>2sexi</pattern>
 <pattern>sex2k</pattern>
 <pattern>sexma5t</pattern>
 <pattern>s2exo</pattern>
 <pattern>2sexp</pattern>
 <pattern>sex4pl</pattern>
 <pattern>sext4an</pattern>
-<pattern>sext4r</pattern>
-<pattern>sex5tra</pattern>
+<pattern>4sext4r</pattern>
 <pattern>3sexu</pattern>
 <pattern>2sex2z</pattern>
 <pattern>2sez</pattern>
@@ -33483,24 +34397,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sgla3s</pattern>
 <pattern>sgli5che</pattern>
 <pattern>s3gm</pattern>
-<pattern>s3gu</pattern>
 <pattern>s1h</pattern>
 <pattern>sha2</pattern>
 <pattern>3sha </pattern>
+<pattern>2shaf</pattern>
+<pattern>2shag</pattern>
 <pattern>s4hake </pattern>
 <pattern>4shalb</pattern>
 <pattern>shal4li</pattern>
-<pattern>shalt4s5</pattern>
+<pattern>shalt4</pattern>
+<pattern>shalts5</pattern>
 <pattern>3s4hamp</pattern>
 <pattern>2shan</pattern>
 <pattern>s4has </pattern>
-<pattern>2sh4au</pattern>
+<pattern>2shau</pattern>
 <pattern>shave3</pattern>
 <pattern>2shä2</pattern>
 <pattern>2she2</pattern>
 <pattern>sh4ia</pattern>
 <pattern>s2hib</pattern>
-<pattern>3s2hig</pattern>
 <pattern>2shil</pattern>
 <pattern>2shin</pattern>
 <pattern>3s4hip</pattern>
@@ -33537,7 +34452,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sich3a</pattern>
 <pattern>si5che </pattern>
 <pattern>sich5to</pattern>
-<pattern>sicht5r</pattern>
+<pattern>sich4t5r</pattern>
 <pattern>sicht6se</pattern>
 <pattern>sichts5te</pattern>
 <pattern>sicker5e</pattern>
@@ -33631,7 +34546,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sin4fl</pattern>
 <pattern>4s5in4for</pattern>
 <pattern>4s3in4fr</pattern>
-<pattern>sing5an</pattern>
 <pattern>sin6geni</pattern>
 <pattern>sin5gle </pattern>
 <pattern>sin4g3r</pattern>
@@ -33644,7 +34558,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sin4ko</pattern>
 <pattern>3sinn </pattern>
 <pattern>s5in6nenm</pattern>
-<pattern>s5in4ner</pattern>
+<pattern>s5in4ner4</pattern>
+<pattern>sinn5erf</pattern>
 <pattern>4s3in4no</pattern>
 <pattern>3sinns</pattern>
 <pattern>si3nos</pattern>
@@ -33656,6 +34571,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sin4ten</pattern>
 <pattern>2s3in2v</pattern>
 <pattern>sinva3</pattern>
+<pattern>2s3inz</pattern>
 <pattern>s2ir</pattern>
 <pattern>2siri</pattern>
 <pattern>2s3irr</pattern>
@@ -33695,11 +34611,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2sk </pattern>
 <pattern>2skab</pattern>
 <pattern>ska5lar</pattern>
+<pattern>4skalk</pattern>
 <pattern>2ska2m</pattern>
 <pattern>5skanda</pattern>
 <pattern>2skap</pattern>
 <pattern>2skar</pattern>
-<pattern>2skas</pattern>
+<pattern>2ska2s</pattern>
 <pattern>4skata</pattern>
 <pattern>4skateg</pattern>
 <pattern>s4kater</pattern>
@@ -33709,7 +34626,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2s3kä</pattern>
 <pattern>2skb</pattern>
 <pattern>skel3i</pattern>
-<pattern>skel3s</pattern>
 <pattern>2s3ke2n</pattern>
 <pattern>sken3e</pattern>
 <pattern>3skep</pattern>
@@ -33739,12 +34655,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2kof</pattern>
 <pattern>s2kog</pattern>
 <pattern>2s3koh</pattern>
-<pattern>2s3kol</pattern>
+<pattern>2skol</pattern>
+<pattern>3s4koli</pattern>
 <pattern>4s3kom</pattern>
 <pattern>4s3kon</pattern>
 <pattern>sko5pen</pattern>
 <pattern>s3kopp</pattern>
 <pattern>s4kort</pattern>
+<pattern>s3kos</pattern>
 <pattern>sko5sen</pattern>
 <pattern>sko5ses</pattern>
 <pattern>s2kov</pattern>
@@ -33753,7 +34671,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2skra</pattern>
 <pattern>skraf4</pattern>
 <pattern>2skre</pattern>
-<pattern>3skrib</pattern>
+<pattern>3s4krib</pattern>
 <pattern>s4krip</pattern>
 <pattern>skrü3c</pattern>
 <pattern>2sks</pattern>
@@ -33793,7 +34711,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2lip</pattern>
 <pattern>sli2t</pattern>
 <pattern>sl4o2b</pattern>
-<pattern>s3loc</pattern>
 <pattern>slo2g</pattern>
 <pattern>s4lo3ga</pattern>
 <pattern>slo2t</pattern>
@@ -33802,6 +34719,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>slu2</pattern>
 <pattern>slü2</pattern>
 <pattern>2s1m2</pattern>
+<pattern>sma3b</pattern>
 <pattern>s2maf</pattern>
 <pattern>sma2l</pattern>
 <pattern>s4ma3la</pattern>
@@ -33815,6 +34733,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>smi5sche</pattern>
 <pattern>smit3i</pattern>
 <pattern>smo5die</pattern>
+<pattern>3smok</pattern>
 <pattern>smo2m</pattern>
 <pattern>smu4s</pattern>
 <pattern>s3mü</pattern>
@@ -33835,6 +34754,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>snu2</pattern>
 <pattern>snus2</pattern>
 <pattern>s2ny</pattern>
+<pattern>1so</pattern>
 <pattern>2soa</pattern>
 <pattern>s3oas</pattern>
 <pattern>2s1ob2</pattern>
@@ -33842,12 +34762,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>so4ber</pattern>
 <pattern>so2bl</pattern>
 <pattern>sobli3</pattern>
-<pattern>1s2oc</pattern>
-<pattern>so4ck</pattern>
+<pattern>so2br</pattern>
+<pattern>s2oc</pattern>
+<pattern>3so4ck</pattern>
 <pattern>s4oda</pattern>
 <pattern>so4das </pattern>
 <pattern>so2do3</pattern>
-<pattern>3so2fa</pattern>
+<pattern>so2fa</pattern>
 <pattern>2sofä</pattern>
 <pattern>s4off </pattern>
 <pattern>4s3offi</pattern>
@@ -33857,14 +34778,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>so4gen </pattern>
 <pattern>so4ges</pattern>
 <pattern>so3gl</pattern>
-<pattern>1s2oh</pattern>
+<pattern>s2oh</pattern>
 <pattern>s3ohe</pattern>
 <pattern>3sohl</pattern>
 <pattern>sohle4</pattern>
 <pattern>4s3ohng</pattern>
 <pattern>so2ho</pattern>
 <pattern>2s3oh2r</pattern>
-<pattern>1soi</pattern>
 <pattern>3soid </pattern>
 <pattern>so3ida</pattern>
 <pattern>so2j</pattern>
@@ -33879,30 +34799,29 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sol4d5er</pattern>
 <pattern>so3lee</pattern>
 <pattern>sol3ei</pattern>
-<pattern>so3leu</pattern>
-<pattern>3soll</pattern>
 <pattern>sol4l3a</pattern>
 <pattern>sol4l5er4</pattern>
 <pattern>3so4lm</pattern>
 <pattern>so4lo</pattern>
 <pattern>solo3s</pattern>
 <pattern>3so4ls</pattern>
-<pattern>s3oly</pattern>
-<pattern>1som</pattern>
+<pattern>2s3oly</pattern>
 <pattern>so2ma</pattern>
 <pattern>so3mas</pattern>
 <pattern>2s3omb</pattern>
 <pattern>somen3</pattern>
 <pattern>so3mer</pattern>
+<pattern>3somm</pattern>
 <pattern>s2on</pattern>
 <pattern>so4nar</pattern>
-<pattern>3so4nat</pattern>
+<pattern>so4nat</pattern>
 <pattern>so4nau</pattern>
 <pattern>son3eh</pattern>
 <pattern>so4ner</pattern>
 <pattern>son5ori</pattern>
 <pattern>son4s3o</pattern>
 <pattern>sonsor4</pattern>
+<pattern>son5sta</pattern>
 <pattern>so1o</pattern>
 <pattern>so2p2</pattern>
 <pattern>s3ope</pattern>
@@ -33913,10 +34832,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>so3pro</pattern>
 <pattern>sop3s</pattern>
 <pattern>soran4s</pattern>
-<pattern>s3orat</pattern>
-<pattern>3sorb</pattern>
-<pattern>s3ord</pattern>
-<pattern>4sordn</pattern>
+<pattern>4s3orat</pattern>
+<pattern>2s3ord</pattern>
+<pattern>3sorda</pattern>
 <pattern>sore2</pattern>
 <pattern>so4rei</pattern>
 <pattern>so4r3el</pattern>
@@ -33928,37 +34846,33 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sor6ge5re</pattern>
 <pattern>sor4gie</pattern>
 <pattern>4s3o4rie</pattern>
-<pattern>3sork</pattern>
 <pattern>sor4na</pattern>
 <pattern>sor3o</pattern>
-<pattern>3sorr</pattern>
 <pattern>sor5tak</pattern>
 <pattern>4s5or4tes</pattern>
 <pattern>4s3orth</pattern>
 <pattern>sort4s5t</pattern>
 <pattern>sor3u</pattern>
-<pattern>1sos</pattern>
+<pattern>sorum4</pattern>
 <pattern>so3se</pattern>
-<pattern>2sos2k</pattern>
+<pattern>sos2k</pattern>
 <pattern>2sos2m</pattern>
 <pattern>2so3sp</pattern>
-<pattern>s2oss</pattern>
-<pattern>2sost</pattern>
+<pattern>3s2oss</pattern>
+<pattern>2sos2t</pattern>
 <pattern>s3osth</pattern>
 <pattern>s3osz</pattern>
 <pattern>3so2ß</pattern>
-<pattern>so1t</pattern>
-<pattern>3sota</pattern>
+<pattern>2so1t</pattern>
 <pattern>so3tho</pattern>
 <pattern>soun2</pattern>
 <pattern>sound3</pattern>
-<pattern>s3out</pattern>
+<pattern>2s3out</pattern>
 <pattern>sou3ta</pattern>
 <pattern>sova3</pattern>
-<pattern>1sow</pattern>
 <pattern>sowe2</pattern>
 <pattern>2s1ox</pattern>
-<pattern>1s2oz</pattern>
+<pattern>s2oz</pattern>
 <pattern>2s3oze</pattern>
 <pattern>sö2</pattern>
 <pattern>2s1öd</pattern>
@@ -33974,6 +34888,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2pac</pattern>
 <pattern>4s3pack</pattern>
 <pattern>s4pa3ga</pattern>
+<pattern>4spago</pattern>
 <pattern>2spak</pattern>
 <pattern>4spala</pattern>
 <pattern>4spalä</pattern>
@@ -34001,10 +34916,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s6parten</pattern>
 <pattern>4spartn</pattern>
 <pattern>3sparu</pattern>
+<pattern>s5passi</pattern>
 <pattern>3s4paß</pattern>
 <pattern>3spat </pattern>
 <pattern>5spatel</pattern>
 <pattern>s3pati</pattern>
+<pattern>3spats</pattern>
 <pattern>2spau</pattern>
 <pattern>s3pa2v</pattern>
 <pattern>3spaz</pattern>
@@ -34023,12 +34940,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s3pein</pattern>
 <pattern>s4pek</pattern>
 <pattern>3speku</pattern>
+<pattern>s3pen </pattern>
+<pattern>s3pena</pattern>
+<pattern>s3penn</pattern>
 <pattern>4spensi</pattern>
+<pattern>s3pent</pattern>
 <pattern>3spera</pattern>
 <pattern>s3perf</pattern>
 <pattern>3sperg</pattern>
 <pattern>4s5perle</pattern>
-<pattern>s4perr</pattern>
 <pattern>sper6r5ei</pattern>
 <pattern>4spers</pattern>
 <pattern>4sperü</pattern>
@@ -34042,6 +34962,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4sphän</pattern>
 <pattern>3sphär</pattern>
 <pattern>s4phin</pattern>
+<pattern>2sphy</pattern>
 <pattern>1spi</pattern>
 <pattern>2spia</pattern>
 <pattern>s2pi4e</pattern>
@@ -34049,7 +34970,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4s3pier</pattern>
 <pattern>spier4r</pattern>
 <pattern>2s3pil</pattern>
-<pattern>4sping</pattern>
+<pattern>4s3ping</pattern>
 <pattern>s4pinn</pattern>
 <pattern>2spip</pattern>
 <pattern>s2pir</pattern>
@@ -34059,19 +34980,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2spla</pattern>
 <pattern>spla3c</pattern>
 <pattern>2s3plä</pattern>
+<pattern>4sple</pattern>
 <pattern>s2pli</pattern>
 <pattern>2s3plu</pattern>
-<pattern>s1pn</pattern>
+<pattern>2s1pn</pattern>
 <pattern>s3pod</pattern>
 <pattern>4spoe</pattern>
 <pattern>2s3po2g</pattern>
+<pattern>3spoh</pattern>
 <pattern>3spoi</pattern>
 <pattern>2s3po2k</pattern>
 <pattern>4s3pol</pattern>
 <pattern>3s2pom</pattern>
 <pattern>3s4pons</pattern>
 <pattern>2spoo</pattern>
-<pattern>4spop</pattern>
 <pattern>3s4pore</pattern>
 <pattern>s4porn</pattern>
 <pattern>spor6tag</pattern>
@@ -34087,6 +35009,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4sprax</pattern>
 <pattern>3spray</pattern>
 <pattern>s3präd</pattern>
+<pattern>4s3präg</pattern>
 <pattern>4spräl</pattern>
 <pattern>s4prän</pattern>
 <pattern>4spräs</pattern>
@@ -34117,7 +35040,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s3prüg</pattern>
 <pattern>2s1ps</pattern>
 <pattern>sp3t</pattern>
-<pattern>2s3pu2b</pattern>
+<pattern>4s3pu2b</pattern>
 <pattern>2spuf</pattern>
 <pattern>3spuk</pattern>
 <pattern>4spulv</pattern>
@@ -34126,7 +35049,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2spup</pattern>
 <pattern>3s2pur</pattern>
 <pattern>s3pu2t</pattern>
-<pattern>s4putt</pattern>
 <pattern>s2pür</pattern>
 <pattern>2s1py</pattern>
 <pattern>2sq</pattern>
@@ -34135,7 +35057,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>srat4st</pattern>
 <pattern>srä2</pattern>
 <pattern>sre2</pattern>
-<pattern>sredu5z</pattern>
 <pattern>srefe3</pattern>
 <pattern>srei5sest </pattern>
 <pattern>srela3</pattern>
@@ -34144,7 +35065,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>srepa3</pattern>
 <pattern>sreso3</pattern>
 <pattern>s3re4t</pattern>
-<pattern>srevi3</pattern>
 <pattern>srevo5lu</pattern>
 <pattern>sri3l</pattern>
 <pattern>sri2t</pattern>
@@ -34166,8 +35086,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ss3aj</pattern>
 <pattern>ss3all</pattern>
 <pattern>ssa3ma</pattern>
+<pattern>s4s3amb</pattern>
 <pattern>ssa5men</pattern>
+<pattern>s5samm</pattern>
 <pattern>ss3an4b</pattern>
+<pattern>ssan4c</pattern>
 <pattern>s4sanf</pattern>
 <pattern>s4s3ang</pattern>
 <pattern>s4s3anh</pattern>
@@ -34184,7 +35107,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ssa3st</pattern>
 <pattern>ss3att</pattern>
 <pattern>ss3aud</pattern>
-<pattern>s4s3auf</pattern>
+<pattern>ss3au4f</pattern>
 <pattern>s5saur</pattern>
 <pattern>ss2äu</pattern>
 <pattern>s2sce</pattern>
@@ -34202,11 +35125,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4sein</pattern>
 <pattern>sse5ind</pattern>
 <pattern>sse5inha</pattern>
+<pattern>ss5einl</pattern>
 <pattern>sse5inte</pattern>
 <pattern>s4selem</pattern>
 <pattern>ssel5end</pattern>
 <pattern>sse5mit</pattern>
 <pattern>s4s5endl</pattern>
+<pattern>sse4n5eb</pattern>
 <pattern>sse6nend</pattern>
 <pattern>ssen5ent</pattern>
 <pattern>ssen5eri</pattern>
@@ -34217,7 +35142,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ssen6kels</pattern>
 <pattern>s4senot</pattern>
 <pattern>ssen6s5au</pattern>
-<pattern>s6sensem</pattern>
 <pattern>s2sep</pattern>
 <pattern>sse3pa</pattern>
 <pattern>sser3a4</pattern>
@@ -34265,6 +35189,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2sop</pattern>
 <pattern>sso5ral</pattern>
 <pattern>ssor3c</pattern>
+<pattern>s5sorde</pattern>
 <pattern>s4s5orgi</pattern>
 <pattern>s2sov</pattern>
 <pattern>s4sowe</pattern>
@@ -34286,8 +35211,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s3stab</pattern>
 <pattern>s5stad</pattern>
 <pattern>s4s3tak</pattern>
+<pattern>ss5tank</pattern>
 <pattern>ss5tann</pattern>
+<pattern>s3s4tap</pattern>
 <pattern>ss3tas</pattern>
+<pattern>ssta4te</pattern>
 <pattern>ss5tauc</pattern>
 <pattern>s3stä</pattern>
 <pattern>ss5täti</pattern>
@@ -34316,7 +35244,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4s5trie</pattern>
 <pattern>ss5trit</pattern>
 <pattern>s5strö</pattern>
-<pattern>s5stun</pattern>
+<pattern>s3stuf</pattern>
 <pattern>s2sty</pattern>
 <pattern>s4s3umf</pattern>
 <pattern>s4s3um4g</pattern>
@@ -34324,7 +35252,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ss3uml</pattern>
 <pattern>s4s3umr</pattern>
 <pattern>ss5umsc</pattern>
-<pattern>ss3una</pattern>
+<pattern>s4s5umse</pattern>
 <pattern>ssunge5</pattern>
 <pattern>s4suns</pattern>
 <pattern>s4sun4w</pattern>
@@ -34345,15 +35273,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4tabi</pattern>
 <pattern>4stabit</pattern>
 <pattern>4sta4bl</pattern>
-<pattern>s5table</pattern>
 <pattern>st3abo</pattern>
 <pattern>5stabs </pattern>
+<pattern>4stabst</pattern>
 <pattern>4stabz</pattern>
 <pattern>st2ac</pattern>
 <pattern>s2tad</pattern>
 <pattern>3stadi</pattern>
 <pattern>3stadt</pattern>
 <pattern>4stafel</pattern>
+<pattern>5stafet</pattern>
 <pattern>st3afr</pattern>
 <pattern>2stag</pattern>
 <pattern>s4tagg</pattern>
@@ -34397,6 +35326,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>st5ansa</pattern>
 <pattern>st5ansä</pattern>
 <pattern>st5ansp</pattern>
+<pattern>stan4tr</pattern>
 <pattern>4stan4w</pattern>
 <pattern>stan4za</pattern>
 <pattern>st5anzu</pattern>
@@ -34418,7 +35348,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2stas</pattern>
 <pattern>4statb</pattern>
 <pattern>3stati</pattern>
-<pattern>5staub </pattern>
 <pattern>stau5chu</pattern>
 <pattern>4staufa</pattern>
 <pattern>4st5aufb</pattern>
@@ -34437,6 +35366,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>stau6scha</pattern>
 <pattern>4stausf</pattern>
 <pattern>4stausg</pattern>
+<pattern>4stausl</pattern>
 <pattern>4stausr</pattern>
 <pattern>4stauss</pattern>
 <pattern>staussen6</pattern>
@@ -34446,7 +35376,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4stausw</pattern>
 <pattern>4stausz</pattern>
 <pattern>4stauto</pattern>
-<pattern>stauto6r</pattern>
 <pattern>3stauu</pattern>
 <pattern>2stav</pattern>
 <pattern>s3tav </pattern>
@@ -34477,13 +35406,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4steam</pattern>
 <pattern>4stean</pattern>
 <pattern>ste3b</pattern>
+<pattern>5stechk</pattern>
 <pattern>4stechn</pattern>
 <pattern>ste2d</pattern>
 <pattern>st3edi</pattern>
 <pattern>3stedt</pattern>
 <pattern>2stee</pattern>
 <pattern>3s2teg</pattern>
-<pattern>ste4g3r</pattern>
+<pattern>ste4gra</pattern>
+<pattern>ste4g5re</pattern>
 <pattern>4stehr</pattern>
 <pattern>4s3teic</pattern>
 <pattern>s4t3eid</pattern>
@@ -34497,13 +35428,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4steils</pattern>
 <pattern>6steindr</pattern>
 <pattern>s4teir</pattern>
-<pattern>stei4s</pattern>
+<pattern>s4tei4s</pattern>
 <pattern>ste5isc</pattern>
+<pattern>st5eise</pattern>
+<pattern>s5teist</pattern>
 <pattern>st3eiw</pattern>
 <pattern>s2tek</pattern>
 <pattern>s2tel</pattern>
 <pattern>4s3tel </pattern>
 <pattern>4stela</pattern>
+<pattern>4stelb</pattern>
 <pattern>s3telc</pattern>
 <pattern>s3teld</pattern>
 <pattern>4stelef</pattern>
@@ -34526,7 +35460,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4stema</pattern>
 <pattern>stem5ac</pattern>
 <pattern>ste6m5ent</pattern>
-<pattern>ste4mer</pattern>
 <pattern>4stemi</pattern>
 <pattern>ste4min</pattern>
 <pattern>6stemper</pattern>
@@ -34536,13 +35469,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4sten </pattern>
 <pattern>s4t5ends</pattern>
 <pattern>stener4</pattern>
-<pattern>4sten3s</pattern>
+<pattern>4stens</pattern>
+<pattern>sten5st</pattern>
 <pattern>st5entf</pattern>
 <pattern>st5entg</pattern>
 <pattern>st5entl</pattern>
+<pattern>sten6zerf</pattern>
 <pattern>s2tep</pattern>
 <pattern>4stepr</pattern>
 <pattern>4ster </pattern>
+<pattern>ste4ra</pattern>
 <pattern>4sterba</pattern>
 <pattern>s6terben</pattern>
 <pattern>ster6biet</pattern>
@@ -34588,7 +35524,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4testn</pattern>
 <pattern>stes5tr</pattern>
 <pattern>ste4tag</pattern>
-<pattern>3ste3th</pattern>
 <pattern>ste3tr</pattern>
 <pattern>3s4tett</pattern>
 <pattern>s2teu</pattern>
@@ -34609,7 +35544,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>st5herd</pattern>
 <pattern>st3hex</pattern>
 <pattern>st3hi</pattern>
-<pattern>st3ho2</pattern>
+<pattern>st3ho</pattern>
 <pattern>s3thr</pattern>
 <pattern>s2thy</pattern>
 <pattern>2stia</pattern>
@@ -34624,7 +35559,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4tieh</pattern>
 <pattern>s4tiel</pattern>
 <pattern>4stien</pattern>
-<pattern>3s4ties</pattern>
 <pattern>3stieß</pattern>
 <pattern>3s2tif</pattern>
 <pattern>4stig </pattern>
@@ -34641,7 +35575,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3stils</pattern>
 <pattern>s3timo</pattern>
 <pattern>4stimp</pattern>
-<pattern>stimpe4</pattern>
+<pattern>stimpe6r</pattern>
 <pattern>sti5nas </pattern>
 <pattern>st3inb</pattern>
 <pattern>s4t3ind</pattern>
@@ -34678,8 +35612,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>st3mo</pattern>
 <pattern>2stn</pattern>
 <pattern>st3ne</pattern>
-<pattern>4s4to </pattern>
-<pattern>4st3o4bl</pattern>
+<pattern>4sto </pattern>
+<pattern>st3o4bl</pattern>
 <pattern>4s5tocht</pattern>
 <pattern>4stod </pattern>
 <pattern>3s2tof</pattern>
@@ -34698,6 +35632,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s3ton </pattern>
 <pattern>4stonn</pattern>
 <pattern>s3tons</pattern>
+<pattern>4stoo</pattern>
 <pattern>st3ope</pattern>
 <pattern>4stopf </pattern>
 <pattern>sto4pi</pattern>
@@ -34706,14 +35641,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5stopp </pattern>
 <pattern>4s3tor </pattern>
 <pattern>st3ord</pattern>
-<pattern>4s3tore</pattern>
-<pattern>sto4res</pattern>
+<pattern>s3tore</pattern>
+<pattern>4sto4res</pattern>
 <pattern>4storf</pattern>
 <pattern>4storg</pattern>
 <pattern>4stori</pattern>
 <pattern>4storp</pattern>
 <pattern>4s3tors</pattern>
 <pattern>4stort</pattern>
+<pattern>4s3torw</pattern>
 <pattern>3story</pattern>
 <pattern>s3tos </pattern>
 <pattern>sto5sen</pattern>
@@ -34785,12 +35721,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5strikto</pattern>
 <pattern>5strikts</pattern>
 <pattern>s3tril</pattern>
+<pattern>4s3trim</pattern>
+<pattern>4strink</pattern>
 <pattern>s3trio</pattern>
 <pattern>s4tripp</pattern>
 <pattern>4stript</pattern>
 <pattern>4stris</pattern>
 <pattern>4s3triu</pattern>
 <pattern>s3tro </pattern>
+<pattern>4stroc</pattern>
 <pattern>s3troe</pattern>
 <pattern>3stroh</pattern>
 <pattern>s4trom</pattern>
@@ -34798,14 +35737,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5stromk</pattern>
 <pattern>5stroms</pattern>
 <pattern>4s5tropf</pattern>
-<pattern>4stros</pattern>
 <pattern>s4t5rose</pattern>
 <pattern>s3troy</pattern>
 <pattern>s2trö</pattern>
 <pattern>strö5mer</pattern>
 <pattern>4ströp</pattern>
+<pattern>4strös</pattern>
 <pattern>s3tröt</pattern>
-<pattern>s3trub</pattern>
 <pattern>s3truc</pattern>
 <pattern>3strud</pattern>
 <pattern>s3trug</pattern>
@@ -34818,8 +35756,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>stsas3</pattern>
 <pattern>st4sb</pattern>
 <pattern>2st3t2</pattern>
-<pattern>3s2tub</pattern>
-<pattern>4stubu</pattern>
+<pattern>s2tub</pattern>
+<pattern>5stuben</pattern>
 <pattern>4s3tuch</pattern>
 <pattern>3stud</pattern>
 <pattern>2stue</pattern>
@@ -34886,6 +35824,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>such6s5pe</pattern>
 <pattern>such5stra</pattern>
 <pattern>such6ters</pattern>
+<pattern>sucht4s</pattern>
 <pattern>1su2d</pattern>
 <pattern>2sue</pattern>
 <pattern>su3el</pattern>
@@ -34913,7 +35852,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sum2f</pattern>
 <pattern>4s3umfa</pattern>
 <pattern>4sumfe</pattern>
-<pattern>sumge5b</pattern>
+<pattern>sum4ge5b</pattern>
 <pattern>sumge5h</pattern>
 <pattern>sumgene5</pattern>
 <pattern>sumge5t</pattern>
@@ -34922,21 +35861,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>sum4kä</pattern>
 <pattern>sum4ke</pattern>
 <pattern>sum2l</pattern>
+<pattern>4s3umla</pattern>
 <pattern>sumla5gen</pattern>
-<pattern>3summ</pattern>
-<pattern>sum3o4r</pattern>
+<pattern>3s2umm</pattern>
 <pattern>s2ump</pattern>
 <pattern>sum4re</pattern>
 <pattern>sum2s</pattern>
-<pattern>4s3umsa</pattern>
-<pattern>4s3umse</pattern>
+<pattern>4sumsa</pattern>
 <pattern>4s3umst</pattern>
 <pattern>sum4wan</pattern>
 <pattern>sum4wu3</pattern>
 <pattern>sum4zug</pattern>
 <pattern>sum4zü</pattern>
 <pattern>su2n</pattern>
-<pattern>2suna</pattern>
+<pattern>2s3una</pattern>
 <pattern>sunder4</pattern>
 <pattern>sun6d5erh</pattern>
 <pattern>sun6d5ess</pattern>
@@ -34963,15 +35901,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s4unwa</pattern>
 <pattern>4sun4we</pattern>
 <pattern>sunzu3</pattern>
-<pattern>1s2up</pattern>
-<pattern>2s3up2d</pattern>
+<pattern>1sup</pattern>
+<pattern>2sup2d</pattern>
 <pattern>sup3pl</pattern>
 <pattern>sup3pr</pattern>
 <pattern>su3rab</pattern>
 <pattern>sur4dis</pattern>
 <pattern>su3ren</pattern>
 <pattern>sur3er</pattern>
-<pattern>3surf</pattern>
+<pattern>3s4urf</pattern>
 <pattern>sur5ins</pattern>
 <pattern>2sur2k</pattern>
 <pattern>sur2l</pattern>
@@ -34983,7 +35921,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>susen4</pattern>
 <pattern>sus3i</pattern>
 <pattern>3susr</pattern>
-<pattern>2su2t</pattern>
+<pattern>2s1u2t</pattern>
 <pattern>3sutr</pattern>
 <pattern>su2z</pattern>
 <pattern>1sü</pattern>
@@ -34995,7 +35933,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>s2üs</pattern>
 <pattern>2sv2</pattern>
 <pattern>sva2</pattern>
-<pattern>svi2</pattern>
+<pattern>s3vi2</pattern>
 <pattern>svieh3</pattern>
 <pattern>s3vo</pattern>
 <pattern>svoran6s</pattern>
@@ -35010,13 +35948,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>swo3he</pattern>
 <pattern>1sy</pattern>
 <pattern>2sy </pattern>
-<pattern>2sya</pattern>
+<pattern>2sya2</pattern>
+<pattern>sy3ab</pattern>
 <pattern>2syf</pattern>
 <pattern>sy2l1</pattern>
 <pattern>sy3li</pattern>
 <pattern>3symp</pattern>
 <pattern>sy2n1</pattern>
 <pattern>3synd</pattern>
+<pattern>2syo</pattern>
 <pattern>2syp</pattern>
 <pattern>3sys</pattern>
 <pattern>sy3sto</pattern>
@@ -35119,8 +36059,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3ßenj</pattern>
 <pattern>ßenke5li</pattern>
 <pattern>3ßen3o2</pattern>
+<pattern>ßen3s4k</pattern>
 <pattern>ßen3s4p</pattern>
-<pattern>ßen3st</pattern>
+<pattern>ßen3s4t</pattern>
 <pattern>ßen3sz</pattern>
 <pattern>4ß3entl</pattern>
 <pattern>4ß3ents</pattern>
@@ -35133,6 +36074,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ßerb</pattern>
 <pattern>ßerei5s4</pattern>
 <pattern>4ß5ergeb</pattern>
+<pattern>ßer4ke</pattern>
 <pattern>2ßerl</pattern>
 <pattern>ßer4la</pattern>
 <pattern>ßer4lä</pattern>
@@ -35218,6 +36160,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1ßu</pattern>
 <pattern>2ß1um2</pattern>
 <pattern>2ß3un2f</pattern>
+<pattern>ßunge3</pattern>
 <pattern>2ßunt</pattern>
 <pattern>2ß3un2v</pattern>
 <pattern>2ß1ü</pattern>
@@ -35257,14 +36200,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tabk</pattern>
 <pattern>4t3abla</pattern>
 <pattern>t3a4blä</pattern>
+<pattern>table5g</pattern>
 <pattern>table5su</pattern>
+<pattern>5tablet</pattern>
 <pattern>t3ablö3</pattern>
 <pattern>2tabm</pattern>
 <pattern>2tabn</pattern>
-<pattern>2ta2br</pattern>
+<pattern>2tabr</pattern>
 <pattern>2tabs</pattern>
 <pattern>t3abse</pattern>
 <pattern>tab5ste</pattern>
+<pattern>t5absto</pattern>
 <pattern>2t3abt</pattern>
 <pattern>3ta2bu</pattern>
 <pattern>tabu3s</pattern>
@@ -35319,8 +36265,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ta5gena</pattern>
 <pattern>ta5genb</pattern>
 <pattern>ta5geng</pattern>
+<pattern>6tagent </pattern>
 <pattern>tage3r</pattern>
 <pattern>tage4si</pattern>
+<pattern>t3agg</pattern>
+<pattern>tag4gl</pattern>
 <pattern>tag4gr</pattern>
 <pattern>ta3gie</pattern>
 <pattern>2tagl</pattern>
@@ -35345,7 +36294,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tailän4</pattern>
 <pattern>tail3e</pattern>
 <pattern>tail3i</pattern>
-<pattern>ta3in4s</pattern>
+<pattern>ta3ins</pattern>
 <pattern>2tais</pattern>
 <pattern>2taka</pattern>
 <pattern>taka4l</pattern>
@@ -35356,7 +36305,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4tak2k</pattern>
 <pattern>4takl</pattern>
 <pattern>ta3kla</pattern>
-<pattern>tak4le</pattern>
 <pattern>2t3ak2q</pattern>
 <pattern>2takr</pattern>
 <pattern>ta3kri</pattern>
@@ -35373,12 +36321,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3taktm</pattern>
 <pattern>3tak4t3o4</pattern>
 <pattern>3taktö</pattern>
+<pattern>takt3r</pattern>
 <pattern>tak4tum</pattern>
 <pattern>5taktun</pattern>
 <pattern>3taktw</pattern>
 <pattern>3taku</pattern>
 <pattern>tak2z</pattern>
-<pattern>tal3a4b</pattern>
+<pattern>tal3ab</pattern>
 <pattern>tal3ac</pattern>
 <pattern>ta3lad</pattern>
 <pattern>ta3lag</pattern>
@@ -35394,11 +36343,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ta4l5end</pattern>
 <pattern>tal5en4g</pattern>
 <pattern>ta4l5ens</pattern>
+<pattern>talent6n</pattern>
 <pattern>ta3leo</pattern>
 <pattern>tal5erf</pattern>
 <pattern>tal5erg</pattern>
 <pattern>tal5erha</pattern>
-<pattern>tal5erm</pattern>
 <pattern>ta4lern</pattern>
 <pattern>ta4lers</pattern>
 <pattern>tal5ersa</pattern>
@@ -35420,10 +36369,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ta3lö</pattern>
 <pattern>tal4pe</pattern>
 <pattern>t2als</pattern>
+<pattern>4talter</pattern>
 <pattern>talt4s</pattern>
 <pattern>ta2lu</pattern>
 <pattern>ta3lus</pattern>
 <pattern>3t4am </pattern>
+<pattern>t3amat</pattern>
+<pattern>t3amei</pattern>
 <pattern>3tamen</pattern>
 <pattern>t3amer</pattern>
 <pattern>ta3mir</pattern>
@@ -35443,20 +36395,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tan4ar3</pattern>
 <pattern>ta3nas</pattern>
 <pattern>tanäs3</pattern>
-<pattern>tan4bau</pattern>
+<pattern>tan4ba</pattern>
 <pattern>t3an4bi</pattern>
 <pattern>tand4ac</pattern>
 <pattern>tan5dar</pattern>
-<pattern>tan5dem</pattern>
 <pattern>tander4</pattern>
 <pattern>tan6d5erk</pattern>
 <pattern>tan4dr</pattern>
 <pattern>t5andra</pattern>
 <pattern>tand5ri</pattern>
 <pattern>tand4s5a</pattern>
+<pattern>tand6sen</pattern>
 <pattern>tand4sk</pattern>
 <pattern>tand4st</pattern>
 <pattern>tan4eig</pattern>
+<pattern>tan5erfa</pattern>
 <pattern>tan2f</pattern>
 <pattern>4tanfa</pattern>
 <pattern>tan4geb</pattern>
@@ -35469,12 +36422,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5tango </pattern>
 <pattern>5tangos</pattern>
 <pattern>t3an4gr</pattern>
+<pattern>4tanha</pattern>
 <pattern>t3an4hä</pattern>
 <pattern>tan4he</pattern>
 <pattern>tan4hö</pattern>
 <pattern>t4ani</pattern>
 <pattern>ta3nit</pattern>
 <pattern>tan4kan</pattern>
+<pattern>tank5er6k</pattern>
 <pattern>tan4kl</pattern>
 <pattern>3tanks</pattern>
 <pattern>4t3an4kü</pattern>
@@ -35484,7 +36439,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4tanme</pattern>
 <pattern>tan4mel</pattern>
 <pattern>tan4mie</pattern>
-<pattern>4t3an4na</pattern>
+<pattern>4tan4na</pattern>
 <pattern>t4anne</pattern>
 <pattern>tan2o</pattern>
 <pattern>3tano </pattern>
@@ -35495,6 +36450,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tan4pa</pattern>
 <pattern>tanre5ge</pattern>
 <pattern>4tansa</pattern>
+<pattern>tan4sam</pattern>
 <pattern>tan4sat</pattern>
 <pattern>tan4säs</pattern>
 <pattern>t3an4sc</pattern>
@@ -35512,7 +36468,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tan6tige</pattern>
 <pattern>5tantis</pattern>
 <pattern>t3antr</pattern>
-<pattern>tan4trä</pattern>
 <pattern>tan4tri</pattern>
 <pattern>4tan4wal</pattern>
 <pattern>4tan4wä</pattern>
@@ -35525,6 +36480,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tanzer4</pattern>
 <pattern>tan6z5erf</pattern>
 <pattern>tan6z5erh</pattern>
+<pattern>tan6z5erm</pattern>
+<pattern>tan6z5erz</pattern>
 <pattern>4tanzu</pattern>
 <pattern>tan4zug</pattern>
 <pattern>4t3an4zü</pattern>
@@ -35599,7 +36556,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tar3za</pattern>
 <pattern>3tas </pattern>
 <pattern>ta3sa</pattern>
-<pattern>3t2a2sc</pattern>
+<pattern>t2a2sc</pattern>
 <pattern>ta5schn</pattern>
 <pattern>ta5schr</pattern>
 <pattern>3tasd</pattern>
@@ -35657,12 +36614,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tauchs4</pattern>
 <pattern>2taud</pattern>
 <pattern>t3au4di</pattern>
-<pattern>tauer4</pattern>
-<pattern>tau5erl</pattern>
+<pattern>tau5er4l</pattern>
 <pattern>tau4fak</pattern>
 <pattern>t5au4far</pattern>
 <pattern>4t5aufba</pattern>
 <pattern>t3aufd</pattern>
+<pattern>taufe4</pattern>
 <pattern>5t6aufe </pattern>
 <pattern>tau4f5eu</pattern>
 <pattern>t3auff</pattern>
@@ -35691,9 +36648,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tau6sch5w</pattern>
 <pattern>4tausd</pattern>
 <pattern>3tause</pattern>
-<pattern>4tausee</pattern>
+<pattern>6tausee</pattern>
 <pattern>4t5ausei</pattern>
 <pattern>4t3ausf</pattern>
+<pattern>t3ausg</pattern>
+<pattern>4t3aush</pattern>
 <pattern>t3ausk</pattern>
 <pattern>4t3ausl</pattern>
 <pattern>t3ausn</pattern>
@@ -35725,6 +36684,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1täg</pattern>
 <pattern>2täh</pattern>
 <pattern>t3ähn</pattern>
+<pattern>3täle</pattern>
 <pattern>2täll</pattern>
 <pattern>2t3äl2t</pattern>
 <pattern>2tä2m</pattern>
@@ -35817,7 +36777,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tebe4r</pattern>
 <pattern>t5e4ber </pattern>
 <pattern>tebe4w</pattern>
-<pattern>te3bl</pattern>
+<pattern>t2ec</pattern>
 <pattern>4techa</pattern>
 <pattern>4techd</pattern>
 <pattern>4te3che</pattern>
@@ -35864,6 +36824,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2t3egg</pattern>
 <pattern>2tegl</pattern>
 <pattern>2tego</pattern>
+<pattern>teg5ran</pattern>
 <pattern>5tegris</pattern>
 <pattern>2te1h</pattern>
 <pattern>te4hac</pattern>
@@ -35882,15 +36843,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>teig5le</pattern>
 <pattern>tei5gli</pattern>
 <pattern>t3eign</pattern>
-<pattern>tei3k</pattern>
+<pattern>3teigw</pattern>
+<pattern>tei3k2</pattern>
 <pattern>t2eil</pattern>
 <pattern>tei5land</pattern>
 <pattern>teilän4</pattern>
 <pattern>3teilc</pattern>
-<pattern>tei6lent</pattern>
+<pattern>tei6l5ent</pattern>
 <pattern>tei6l5erh</pattern>
 <pattern>3teiln</pattern>
-<pattern>tei3m</pattern>
+<pattern>teim2</pattern>
+<pattern>tei3mo</pattern>
 <pattern>2tein</pattern>
 <pattern>tein5al4</pattern>
 <pattern>teinde4</pattern>
@@ -35903,12 +36866,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t3eisb</pattern>
 <pattern>t3eish</pattern>
 <pattern>t3eisk</pattern>
-<pattern>tei3sp</pattern>
-<pattern>4teiss</pattern>
 <pattern>2teiß</pattern>
 <pattern>tei3t</pattern>
 <pattern>2teiw</pattern>
-<pattern>teiz2</pattern>
+<pattern>tei3z2</pattern>
 <pattern>teizu4</pattern>
 <pattern>2tej</pattern>
 <pattern>2tekä</pattern>
@@ -35920,6 +36881,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3tela </pattern>
 <pattern>3tel3ab4</pattern>
 <pattern>tel3ac</pattern>
+<pattern>tel5ane</pattern>
 <pattern>4telang</pattern>
 <pattern>telange5</pattern>
 <pattern>te5lass</pattern>
@@ -35945,7 +36907,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3teleo</pattern>
 <pattern>3telep</pattern>
 <pattern>teler4</pattern>
-<pattern>tel5erb</pattern>
+<pattern>te4l5erb</pattern>
 <pattern>te4l5erd</pattern>
 <pattern>te4l5erf</pattern>
 <pattern>te4l5erg</pattern>
@@ -35974,8 +36936,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4tellu</pattern>
 <pattern>3telno</pattern>
 <pattern>telog3</pattern>
-<pattern>4telose</pattern>
-<pattern>tel5ost</pattern>
 <pattern>3telq</pattern>
 <pattern>tel3s4k</pattern>
 <pattern>telt2</pattern>
@@ -35991,13 +36951,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2te3mä</pattern>
 <pattern>4t3em4bl</pattern>
 <pattern>tem4bol</pattern>
+<pattern>teme2</pattern>
+<pattern>tem3eb</pattern>
 <pattern>te4m3ei</pattern>
 <pattern>te4mel</pattern>
-<pattern>temer4</pattern>
+<pattern>te4mer4</pattern>
 <pattern>tem5ere</pattern>
 <pattern>tem5erg</pattern>
 <pattern>tem5erh</pattern>
 <pattern>tem5ern</pattern>
+<pattern>tem5ers</pattern>
 <pattern>tem3i4d</pattern>
 <pattern>tem3im</pattern>
 <pattern>tem5ing</pattern>
@@ -36006,6 +36969,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2temm</pattern>
 <pattern>te4mol</pattern>
 <pattern>tem3o4r</pattern>
+<pattern>2temö</pattern>
+<pattern>6tempelt</pattern>
 <pattern>4t3empf</pattern>
 <pattern>4tem4ph</pattern>
 <pattern>tem3s</pattern>
@@ -36038,6 +37003,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4teneg</pattern>
 <pattern>tenei4</pattern>
 <pattern>te5n4ei </pattern>
+<pattern>tenein5</pattern>
 <pattern>te5nen </pattern>
 <pattern>te4n5end</pattern>
 <pattern>ten5ene</pattern>
@@ -36048,16 +37014,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>te4nerf</pattern>
 <pattern>4t5ener5g</pattern>
 <pattern>te4n5erk</pattern>
+<pattern>tenerlö5</pattern>
 <pattern>ten5erm</pattern>
 <pattern>te4n5ern</pattern>
-<pattern>ten5ero</pattern>
+<pattern>ten5erö</pattern>
 <pattern>te4n5ers</pattern>
 <pattern>ten5ert</pattern>
-<pattern>tene4s</pattern>
+<pattern>tene4s4</pattern>
 <pattern>ten5esc</pattern>
-<pattern>te4ness</pattern>
+<pattern>te4n5ess</pattern>
 <pattern>tene4t</pattern>
 <pattern>ten5eta</pattern>
+<pattern>ten5eti</pattern>
 <pattern>ten3ev</pattern>
 <pattern>4t3eng </pattern>
 <pattern>4tengag</pattern>
@@ -36068,14 +37036,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ten3in4</pattern>
 <pattern>te3nit</pattern>
 <pattern>4teniv</pattern>
-<pattern>t2en3k</pattern>
+<pattern>t2en3k4</pattern>
 <pattern>3tenke</pattern>
 <pattern>tenn2</pattern>
+<pattern>te2no</pattern>
 <pattern>4tenog</pattern>
 <pattern>ten3op</pattern>
 <pattern>ten5orc</pattern>
 <pattern>tenot4</pattern>
 <pattern>ten5ott</pattern>
+<pattern>ten3o4v</pattern>
 <pattern>t4ens </pattern>
 <pattern>tensch4</pattern>
 <pattern>ten6serg</pattern>
@@ -36085,14 +37055,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tens5th</pattern>
 <pattern>ten5sto</pattern>
 <pattern>ten5str</pattern>
+<pattern>ten5stu</pattern>
 <pattern>ten4sur</pattern>
-<pattern>ten6t5an6k</pattern>
 <pattern>tentar4</pattern>
 <pattern>tent5art</pattern>
 <pattern>4tentat</pattern>
 <pattern>4tentb</pattern>
 <pattern>4tentd</pattern>
 <pattern>ten6t5er6t</pattern>
+<pattern>ten6t5erw</pattern>
 <pattern>4tentf</pattern>
 <pattern>4tentg</pattern>
 <pattern>6tentheb</pattern>
@@ -36113,10 +37084,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t2enz</pattern>
 <pattern>ten6zerh</pattern>
 <pattern>ten6z5erw</pattern>
+<pattern>tenz6wei</pattern>
 <pattern>ten4zy5k</pattern>
 <pattern>2teo</pattern>
 <pattern>te3o2b</pattern>
 <pattern>te3of</pattern>
+<pattern>teo4rei</pattern>
 <pattern>t2ep</pattern>
 <pattern>2te3pa</pattern>
 <pattern>2tepe</pattern>
@@ -36138,8 +37111,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ter5ade</pattern>
 <pattern>teraf4</pattern>
 <pattern>ter5aff</pattern>
-<pattern>4terag</pattern>
-<pattern>4te3rah</pattern>
+<pattern>4ter3a4g</pattern>
 <pattern>ter3ak</pattern>
 <pattern>ter5ala</pattern>
 <pattern>ter5alb</pattern>
@@ -36200,12 +37172,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>te4r5ent</pattern>
 <pattern>4tereo</pattern>
 <pattern>terer4</pattern>
-<pattern>ter5erb</pattern>
+<pattern>te4r5erb</pattern>
 <pattern>ter5erd</pattern>
 <pattern>ter5erh</pattern>
 <pattern>te4rerk</pattern>
+<pattern>te4rerl</pattern>
 <pattern>te4r5erp</pattern>
-<pattern>te4rerr</pattern>
+<pattern>te4r5err</pattern>
 <pattern>ter5ers</pattern>
 <pattern>ter5erw</pattern>
 <pattern>4teress</pattern>
@@ -36226,7 +37199,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>6terhiel</pattern>
 <pattern>terho5lu</pattern>
 <pattern>6t5erhöhu</pattern>
-<pattern>ter3id</pattern>
+<pattern>te4r3id</pattern>
 <pattern>4terii</pattern>
 <pattern>ter5iko</pattern>
 <pattern>4teril</pattern>
@@ -36249,6 +37222,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4ternbi</pattern>
 <pattern>4ternc</pattern>
 <pattern>ter6neue</pattern>
+<pattern>4ternwa</pattern>
 <pattern>ter5obr</pattern>
 <pattern>ter5ode</pattern>
 <pattern>4teroi</pattern>
@@ -36281,7 +37255,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>te3rüc</pattern>
 <pattern>terva4</pattern>
 <pattern>terwä5g</pattern>
-<pattern>t5er4wäh</pattern>
 <pattern>ter4wär</pattern>
 <pattern>ter6we5ck</pattern>
 <pattern>ter3z4a</pattern>
@@ -36293,13 +37266,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>terzu5r</pattern>
 <pattern>terzu5z</pattern>
 <pattern>t4es </pattern>
-<pattern>te4s3ak</pattern>
-<pattern>te4s3an4</pattern>
+<pattern>te4sak</pattern>
+<pattern>tesan4</pattern>
+<pattern>te4s5anb</pattern>
 <pattern>te4s3au</pattern>
 <pattern>4tesc</pattern>
 <pattern>tese2</pattern>
 <pattern>4te3seg</pattern>
 <pattern>te3sei</pattern>
+<pattern>te3sek</pattern>
 <pattern>tes5eli</pattern>
 <pattern>te3sen</pattern>
 <pattern>tes3ep</pattern>
@@ -36312,10 +37287,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tes4ka</pattern>
 <pattern>tes4ko</pattern>
 <pattern>tesof4</pattern>
-<pattern>te3sol</pattern>
 <pattern>te5spen</pattern>
 <pattern>tes5per</pattern>
 <pattern>4tespi</pattern>
+<pattern>4te3s4po</pattern>
 <pattern>tesse4</pattern>
 <pattern>tes4ser</pattern>
 <pattern>tes3si</pattern>
@@ -36362,6 +37337,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tetl</pattern>
 <pattern>2te3to</pattern>
 <pattern>te3tre</pattern>
+<pattern>tet2s</pattern>
 <pattern>2tetu</pattern>
 <pattern>2tetü</pattern>
 <pattern>2tety</pattern>
@@ -36379,6 +37355,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2t3eu2p</pattern>
 <pattern>teu5rem</pattern>
 <pattern>teu5res</pattern>
+<pattern>teur5ob</pattern>
 <pattern>teu3ru</pattern>
 <pattern>3teus</pattern>
 <pattern>2tev</pattern>
@@ -36397,12 +37374,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1tés</pattern>
 <pattern>2t1f2</pattern>
 <pattern>tfahr6ta</pattern>
+<pattern>tfall5i</pattern>
 <pattern>tf4äh</pattern>
 <pattern>tfe2</pattern>
 <pattern>tfi2</pattern>
 <pattern>2t1g2</pattern>
 <pattern>tga2</pattern>
-<pattern>tgas5er4</pattern>
+<pattern>tgas5er</pattern>
 <pattern>tgas5te</pattern>
 <pattern>tgas6tr</pattern>
 <pattern>tge2</pattern>
@@ -36424,12 +37402,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tgeüb3</pattern>
 <pattern>tg4lo</pattern>
 <pattern>tgol6der</pattern>
-<pattern>t3gu</pattern>
 <pattern>2th </pattern>
 <pattern>2t1ha</pattern>
 <pattern>t4ha </pattern>
 <pattern>tha2b</pattern>
 <pattern>t2had</pattern>
+<pattern>thage4</pattern>
 <pattern>3thal </pattern>
 <pattern>tha3la</pattern>
 <pattern>3thalh</pattern>
@@ -36437,7 +37415,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4thand</pattern>
 <pattern>than5sc</pattern>
 <pattern>tha3sa</pattern>
-<pattern>t3h4au</pattern>
+<pattern>t3hau</pattern>
 <pattern>2t1hä</pattern>
 <pattern>3thäi</pattern>
 <pattern>3t2hea</pattern>
@@ -36447,13 +37425,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>thei3l</pattern>
 <pattern>3t4hein</pattern>
 <pattern>the5ins</pattern>
-<pattern>3t2hek</pattern>
+<pattern>3t4hek</pattern>
 <pattern>2thel</pattern>
-<pattern>t3helm</pattern>
 <pattern>3theme</pattern>
 <pattern>t3hemi</pattern>
 <pattern>t3hemm</pattern>
-<pattern>t3hend</pattern>
 <pattern>t3heng</pattern>
 <pattern>t3henn</pattern>
 <pattern>then3s</pattern>
@@ -36495,14 +37471,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tho5chr</pattern>
 <pattern>t3hoh</pattern>
 <pattern>t3hole</pattern>
-<pattern>thol3s</pattern>
 <pattern>t3holt</pattern>
 <pattern>t3holz</pattern>
 <pattern>thon3s</pattern>
 <pattern>th3ops</pattern>
 <pattern>t3horn</pattern>
 <pattern>t3hose</pattern>
+<pattern>3thosk</pattern>
 <pattern>tho3st</pattern>
+<pattern>tho2t</pattern>
 <pattern>t3hote</pattern>
 <pattern>t3hou</pattern>
 <pattern>t3hov</pattern>
@@ -36511,6 +37488,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>th3rau</pattern>
 <pattern>thr4i</pattern>
 <pattern>th3rin</pattern>
+<pattern>3throm</pattern>
 <pattern>2ths</pattern>
 <pattern>2th1t</pattern>
 <pattern>t1hu</pattern>
@@ -36560,8 +37538,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tien3s</pattern>
 <pattern>ti3ent</pattern>
 <pattern>tie4r5ei6</pattern>
+<pattern>tierein5</pattern>
 <pattern>tiere4p</pattern>
 <pattern>ti5ern </pattern>
+<pattern>4tiess</pattern>
 <pattern>tie3s4t</pattern>
 <pattern>2tieß</pattern>
 <pattern>tie3tr</pattern>
@@ -36585,7 +37565,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ti4gef</pattern>
 <pattern>ti4geg</pattern>
 <pattern>ti4gek</pattern>
-<pattern>4tigel</pattern>
 <pattern>ti3ge4n</pattern>
 <pattern>4tigene</pattern>
 <pattern>ti4gep</pattern>
@@ -36612,6 +37591,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tiir</pattern>
 <pattern>2tiis</pattern>
 <pattern>tika5be</pattern>
+<pattern>tik5age</pattern>
 <pattern>ti4kam</pattern>
 <pattern>tik5amt</pattern>
 <pattern>ti4kanw</pattern>
@@ -36623,7 +37603,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ti4k5ent</pattern>
 <pattern>ti4kerf</pattern>
 <pattern>tik5erfa</pattern>
-<pattern>tik5erha</pattern>
 <pattern>tik3in</pattern>
 <pattern>tik3n</pattern>
 <pattern>ti4k3op</pattern>
@@ -36634,7 +37613,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tik5rei</pattern>
 <pattern>ti3lab</pattern>
 <pattern>ti5land</pattern>
-<pattern>til5ant</pattern>
 <pattern>ti3las</pattern>
 <pattern>ti3lat</pattern>
 <pattern>ti4l3eb</pattern>
@@ -36648,6 +37626,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ti3lo</pattern>
 <pattern>ti2l3ö</pattern>
 <pattern>2tim</pattern>
+<pattern>ti3maf</pattern>
 <pattern>3timk</pattern>
 <pattern>tim4man</pattern>
 <pattern>t5im4ma5t</pattern>
@@ -36663,6 +37642,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tin2a</pattern>
 <pattern>tinab4</pattern>
 <pattern>ti3nag</pattern>
+<pattern>tinak5t</pattern>
 <pattern>tinal4</pattern>
 <pattern>tin5alb</pattern>
 <pattern>ti5nale</pattern>
@@ -36674,14 +37654,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tin4be3</pattern>
 <pattern>tin4di</pattern>
 <pattern>tindi5z</pattern>
+<pattern>tin4du</pattern>
 <pattern>tin2e</pattern>
-<pattern>tine3a</pattern>
+<pattern>ti4ne3a</pattern>
 <pattern>tinear4</pattern>
 <pattern>tine3i</pattern>
-<pattern>tinein4</pattern>
 <pattern>tinen4z5</pattern>
 <pattern>ti4n5erf</pattern>
-<pattern>ti4net</pattern>
+<pattern>ti4ne3t</pattern>
 <pattern>ti4neu</pattern>
 <pattern>2tin2f</pattern>
 <pattern>t3infe</pattern>
@@ -36700,15 +37680,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tin4kom</pattern>
 <pattern>t3in4ku</pattern>
 <pattern>tin4ner</pattern>
-<pattern>tin4no</pattern>
+<pattern>4t3in4no</pattern>
 <pattern>4tinom</pattern>
 <pattern>ti3nop</pattern>
 <pattern>ti3nos</pattern>
 <pattern>ti2n3ö</pattern>
 <pattern>t4ins </pattern>
-<pattern>t3in4sa</pattern>
+<pattern>4t3in4sa</pattern>
 <pattern>tin4se</pattern>
 <pattern>tin5sei</pattern>
+<pattern>4t5insel</pattern>
 <pattern>tins5es4</pattern>
 <pattern>tin5ste</pattern>
 <pattern>5tinte </pattern>
@@ -36747,6 +37728,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ti3r2h</pattern>
 <pattern>tirn3a</pattern>
 <pattern>tir2r</pattern>
+<pattern>tisch5ec</pattern>
 <pattern>tischla6</pattern>
 <pattern>tisch5lam</pattern>
 <pattern>tisch5wa</pattern>
@@ -36812,7 +37794,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tlä2</pattern>
 <pattern>tle2</pattern>
 <pattern>tlei4bl</pattern>
-<pattern>tlei6d5er</pattern>
+<pattern>tlei6d5er6</pattern>
 <pattern>tle3mi</pattern>
 <pattern>t2lep</pattern>
 <pattern>tl4er</pattern>
@@ -36886,8 +37868,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3tof </pattern>
 <pattern>toff3a</pattern>
 <pattern>tof4f5ei</pattern>
+<pattern>t5offens</pattern>
 <pattern>toff5ent</pattern>
-<pattern>tof4f5er4</pattern>
+<pattern>tof4fer4</pattern>
+<pattern>toff5ertr</pattern>
+<pattern>tof4fo</pattern>
 <pattern>toff3s4</pattern>
 <pattern>tof4f3u</pattern>
 <pattern>to3fi</pattern>
@@ -36905,7 +37890,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tok</pattern>
 <pattern>3tok </pattern>
 <pattern>t3okt</pattern>
-<pattern>to3ku</pattern>
 <pattern>3tol </pattern>
 <pattern>2tola</pattern>
 <pattern>to3las</pattern>
@@ -36925,6 +37909,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tome4</pattern>
 <pattern>to4m5ene</pattern>
 <pattern>to3mer</pattern>
+<pattern>3tomis</pattern>
 <pattern>to5misi</pattern>
 <pattern>to5mism</pattern>
 <pattern>to5mist</pattern>
@@ -36949,6 +37934,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3tonl</pattern>
 <pattern>3tonn</pattern>
 <pattern>tono2</pattern>
+<pattern>ton3op</pattern>
 <pattern>ton4sin</pattern>
 <pattern>ton5spe</pattern>
 <pattern>ton5sta</pattern>
@@ -36962,11 +37948,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>top5ang</pattern>
 <pattern>3topas</pattern>
 <pattern>to3ped</pattern>
+<pattern>top3el</pattern>
 <pattern>to3pem</pattern>
 <pattern>3topf </pattern>
 <pattern>4to3pfä</pattern>
 <pattern>top4fer</pattern>
 <pattern>topf5er6d</pattern>
+<pattern>top5flu</pattern>
 <pattern>top3fo</pattern>
 <pattern>top3hi</pattern>
 <pattern>3to2po</pattern>
@@ -36974,6 +37962,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>to2pt</pattern>
 <pattern>top3te</pattern>
 <pattern>2toq</pattern>
+<pattern>t4or </pattern>
 <pattern>torab4</pattern>
 <pattern>to3rag</pattern>
 <pattern>to3ral</pattern>
@@ -36988,9 +37977,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tor4den</pattern>
 <pattern>4t3ordn</pattern>
 <pattern>4tordr</pattern>
+<pattern>tor5ei4c</pattern>
 <pattern>to4r3el</pattern>
 <pattern>tor4fan</pattern>
 <pattern>t3orga</pattern>
+<pattern>torin4g</pattern>
 <pattern>tor5int</pattern>
 <pattern>to3riz</pattern>
 <pattern>tor5nos</pattern>
@@ -36999,13 +37990,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tor3r</pattern>
 <pattern>t3ort </pattern>
 <pattern>torta4</pattern>
-<pattern>tor5t6au</pattern>
 <pattern>t3orth</pattern>
 <pattern>t3ortn</pattern>
 <pattern>4t3orts</pattern>
 <pattern>tort4s5t</pattern>
 <pattern>4torty</pattern>
-<pattern>tor3um</pattern>
+<pattern>tor3u</pattern>
+<pattern>torum4</pattern>
 <pattern>4torun</pattern>
 <pattern>to3rys</pattern>
 <pattern>torz2</pattern>
@@ -37017,15 +38008,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tos2h</pattern>
 <pattern>to3sm</pattern>
 <pattern>2to3s2p</pattern>
+<pattern>tosser4</pattern>
 <pattern>to3stä</pattern>
 <pattern>to3sth</pattern>
 <pattern>tos2z</pattern>
 <pattern>2tota</pattern>
 <pattern>tote2</pattern>
+<pattern>toten3</pattern>
 <pattern>2toth</pattern>
 <pattern>to3to4m</pattern>
 <pattern>totoma5</pattern>
 <pattern>tot3ri</pattern>
+<pattern>to3tro</pattern>
 <pattern>tot3s4</pattern>
 <pattern>1t2ou</pattern>
 <pattern>tou5che</pattern>
@@ -37063,6 +38057,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tr2</pattern>
 <pattern>2tr </pattern>
 <pattern>tra3a</pattern>
+<pattern>tr4ab</pattern>
 <pattern>trabe4</pattern>
 <pattern>tra5cha</pattern>
 <pattern>tra5chl</pattern>
@@ -37090,20 +38085,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4t3rake</pattern>
 <pattern>tra6lins</pattern>
 <pattern>tra3me</pattern>
-<pattern>tra3mi</pattern>
 <pattern>5t4ran </pattern>
 <pattern>trana4</pattern>
 <pattern>4trand</pattern>
+<pattern>trand5r</pattern>
 <pattern>t5rangi</pattern>
 <pattern>trang5s</pattern>
 <pattern>t5ranki</pattern>
 <pattern>trank5o</pattern>
 <pattern>t3rann</pattern>
+<pattern>t4rans</pattern>
 <pattern>t4rap</pattern>
 <pattern>trar5chi</pattern>
+<pattern>tra3re</pattern>
+<pattern>traster6</pattern>
+<pattern>tras6terf</pattern>
 <pattern>trast5re</pattern>
 <pattern>4traß</pattern>
 <pattern>tra3ta</pattern>
+<pattern>t5ra4tin</pattern>
 <pattern>3tratt</pattern>
 <pattern>3trau </pattern>
 <pattern>4traub </pattern>
@@ -37111,10 +38111,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4trauc</pattern>
 <pattern>traue4</pattern>
 <pattern>trau5ens</pattern>
+<pattern>trau6mer</pattern>
 <pattern>traun3</pattern>
 <pattern>4t3raup</pattern>
 <pattern>4trauß</pattern>
 <pattern>trau5ßen</pattern>
+<pattern>tra3z</pattern>
 <pattern>trä4c</pattern>
 <pattern>2t3räd</pattern>
 <pattern>4tränd</pattern>
@@ -37131,6 +38133,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t3real</pattern>
 <pattern>2treb</pattern>
 <pattern>tre4bel</pattern>
+<pattern>tre4bl</pattern>
 <pattern>tre4b3r</pattern>
 <pattern>2trec</pattern>
 <pattern>t3rech</pattern>
@@ -37164,6 +38167,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2t3re4k</pattern>
 <pattern>2t3rel</pattern>
 <pattern>trela5t</pattern>
+<pattern>t4rem</pattern>
+<pattern>trem5stel</pattern>
 <pattern>5trend </pattern>
 <pattern>t5rendi</pattern>
 <pattern>5trends</pattern>
@@ -37177,12 +38182,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4trepr</pattern>
 <pattern>tre4prä</pattern>
 <pattern>3trer</pattern>
-<pattern>tre2s</pattern>
-<pattern>tre5sen</pattern>
-<pattern>4t3resi</pattern>
+<pattern>5tre5sen</pattern>
+<pattern>4t3re4si</pattern>
 <pattern>tresi5d</pattern>
-<pattern>treso5l</pattern>
-<pattern>4tress</pattern>
+<pattern>tre4so5l</pattern>
+<pattern>tre4son</pattern>
 <pattern>t5resso</pattern>
 <pattern>tres4st</pattern>
 <pattern>4t5rest </pattern>
@@ -37194,6 +38198,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4trett</pattern>
 <pattern>tre2u</pattern>
 <pattern>treu3c</pattern>
+<pattern>3treuh</pattern>
 <pattern>2t3re2v</pattern>
 <pattern>trevo5lu</pattern>
 <pattern>tre3x</pattern>
@@ -37203,12 +38208,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2t1rh</pattern>
 <pattern>4trich </pattern>
 <pattern>4triche</pattern>
+<pattern>trichs4</pattern>
 <pattern>trid2</pattern>
 <pattern>trie5fr</pattern>
 <pattern>tri5enn</pattern>
 <pattern>triere4</pattern>
 <pattern>3triev</pattern>
 <pattern>tri3gl</pattern>
+<pattern>3trigo</pattern>
 <pattern>t2rik</pattern>
 <pattern>tri4kes</pattern>
 <pattern>3triko</pattern>
@@ -37220,9 +38227,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>5tripty</pattern>
 <pattern>t3riss</pattern>
 <pattern>3trist</pattern>
+<pattern>tris5ta</pattern>
 <pattern>3triti</pattern>
-<pattern>4tri4tu</pattern>
-<pattern>tro5be4</pattern>
+<pattern>4t3ri4tu</pattern>
+<pattern>trobe4</pattern>
 <pattern>4t5rock </pattern>
 <pattern>tro5cke</pattern>
 <pattern>tro5den</pattern>
@@ -37236,6 +38244,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>troli4</pattern>
 <pattern>trol4l5a</pattern>
 <pattern>tro4men</pattern>
+<pattern>tro4min</pattern>
 <pattern>5trompe</pattern>
 <pattern>tro6niks</pattern>
 <pattern>t3ronn</pattern>
@@ -37250,13 +38259,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tro5seno</pattern>
 <pattern>tro3sm</pattern>
 <pattern>3tross</pattern>
-<pattern>t3rot </pattern>
+<pattern>4t3rot </pattern>
 <pattern>tro4ten</pattern>
+<pattern>tro3tr</pattern>
 <pattern>4trout</pattern>
 <pattern>2t3rö2c</pattern>
 <pattern>3trög</pattern>
 <pattern>2t3röh</pattern>
 <pattern>2tröm</pattern>
+<pattern>t3rön</pattern>
 <pattern>3tröp</pattern>
 <pattern>3trös</pattern>
 <pattern>4t3röss</pattern>
@@ -37274,6 +38285,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4t3rund</pattern>
 <pattern>t3rung</pattern>
 <pattern>3trup</pattern>
+<pattern>2trus</pattern>
 <pattern>tru5ser</pattern>
 <pattern>2tru2t</pattern>
 <pattern>trü5bend</pattern>
@@ -37285,16 +38297,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3try1</pattern>
 <pattern>2ts</pattern>
 <pattern>tsa2</pattern>
+<pattern>ts4aa</pattern>
 <pattern>ts3ad</pattern>
 <pattern>tsah2</pattern>
 <pattern>t3sai</pattern>
 <pattern>t3s4akk</pattern>
 <pattern>t3sakr</pattern>
 <pattern>t3sala</pattern>
+<pattern>ts4albe</pattern>
 <pattern>ts3all</pattern>
 <pattern>tsal4m</pattern>
 <pattern>ts3alt</pattern>
 <pattern>t4s3amb</pattern>
+<pattern>t5samm</pattern>
 <pattern>ts3amp</pattern>
 <pattern>t4s3am4t</pattern>
 <pattern>tsan2</pattern>
@@ -37304,6 +38319,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t4s3ant</pattern>
 <pattern>ts3anz</pattern>
 <pattern>t2sa4r</pattern>
+<pattern>t3sard</pattern>
 <pattern>t3sark</pattern>
 <pattern>ts3as2</pattern>
 <pattern>tsau2</pattern>
@@ -37320,32 +38336,34 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t2sce</pattern>
 <pattern>tscha5che</pattern>
 <pattern>t6schart</pattern>
-<pattern>t4schef</pattern>
+<pattern>t4s5chef</pattern>
 <pattern>ts5chine</pattern>
 <pattern>t3schl</pattern>
 <pattern>t6schmun</pattern>
 <pattern>t4schmü</pattern>
-<pattern>t6schor </pattern>
+<pattern>t6s5chor </pattern>
 <pattern>t6schors</pattern>
 <pattern>t4schro</pattern>
 <pattern>t4sch5wö</pattern>
 <pattern>t1se2</pattern>
 <pattern>ts3eb</pattern>
-<pattern>t2sed</pattern>
+<pattern>t2s3ed</pattern>
 <pattern>tsee3i</pattern>
 <pattern>tsei4f</pattern>
 <pattern>t5s6ein </pattern>
 <pattern>ts5eind</pattern>
 <pattern>ts5einf</pattern>
 <pattern>ts5einh</pattern>
+<pattern>ts5einl</pattern>
 <pattern>ts5einsa</pattern>
 <pattern>t6s5einsc</pattern>
 <pattern>ts5eint</pattern>
 <pattern>ts3ekl</pattern>
-<pattern>ts3ela</pattern>
+<pattern>t4s3ela</pattern>
 <pattern>t4selbi</pattern>
 <pattern>ts5emis</pattern>
 <pattern>t4sen4q</pattern>
+<pattern>t4sense</pattern>
 <pattern>t4s3ent</pattern>
 <pattern>ts3epi</pattern>
 <pattern>ts3epo</pattern>
@@ -37400,20 +38418,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tsmo2</pattern>
 <pattern>t3smog</pattern>
 <pattern>tso2</pattern>
+<pattern>t3soc</pattern>
 <pattern>tsof2</pattern>
 <pattern>ts3off</pattern>
-<pattern>t3sold</pattern>
-<pattern>t3son</pattern>
-<pattern>ts3op</pattern>
-<pattern>ts3ora</pattern>
+<pattern>t2s3op</pattern>
+<pattern>t4s3ora</pattern>
 <pattern>ts3orc</pattern>
-<pattern>ts3ori</pattern>
-<pattern>ts3orn</pattern>
-<pattern>ts5ort </pattern>
-<pattern>ts5orts</pattern>
+<pattern>t4s3ori</pattern>
+<pattern>t4s3orn</pattern>
+<pattern>t4s5ort </pattern>
+<pattern>t4s5orts</pattern>
 <pattern>t3sos</pattern>
-<pattern>t3souv</pattern>
-<pattern>ts3ov</pattern>
+<pattern>t2s3ov</pattern>
+<pattern>t2sö</pattern>
 <pattern>tsöf2</pattern>
 <pattern>ts2öl</pattern>
 <pattern>ts3pac</pattern>
@@ -37422,7 +38439,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t5spare</pattern>
 <pattern>t3spek</pattern>
 <pattern>tspen6det</pattern>
-<pattern>ts5peri</pattern>
+<pattern>t4s5peri</pattern>
 <pattern>t5sperr</pattern>
 <pattern>t4s3pic</pattern>
 <pattern>t4s5pins</pattern>
@@ -37446,14 +38463,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ts5tant</pattern>
 <pattern>t4s5tanz</pattern>
 <pattern>t4s5tat </pattern>
-<pattern>t4s5ta4te</pattern>
+<pattern>tsta4te</pattern>
+<pattern>t4s5tauc</pattern>
 <pattern>ts3tav</pattern>
 <pattern>tstä2</pattern>
 <pattern>t4s5täti</pattern>
 <pattern>tst4e</pattern>
 <pattern>t4steil</pattern>
 <pattern>t5stein</pattern>
-<pattern>ts3tep</pattern>
+<pattern>ts5telb</pattern>
+<pattern>t4s3tep</pattern>
 <pattern>ts4terb</pattern>
 <pattern>ts4tern</pattern>
 <pattern>ts3th</pattern>
@@ -37463,9 +38482,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t4s5toch</pattern>
 <pattern>tsto4l</pattern>
 <pattern>ts3ton</pattern>
-<pattern>t3stop</pattern>
 <pattern>tsto4r</pattern>
-<pattern>t3stö</pattern>
 <pattern>t4s5trac</pattern>
 <pattern>ts5trad</pattern>
 <pattern>ts4tras</pattern>
@@ -37474,23 +38491,26 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>t4s5tren</pattern>
 <pattern>t6s5treu </pattern>
 <pattern>t4s5trie</pattern>
-<pattern>t4strin</pattern>
 <pattern>t4strun</pattern>
 <pattern>t5s4tub</pattern>
 <pattern>ts4tüm</pattern>
 <pattern>t2sty</pattern>
-<pattern>ts1u</pattern>
 <pattern>t3suc</pattern>
 <pattern>t3sui</pattern>
+<pattern>ts3ul</pattern>
 <pattern>ts3um </pattern>
-<pattern>tsum4g</pattern>
-<pattern>tsum4r</pattern>
-<pattern>tsum4v</pattern>
-<pattern>tsum4w</pattern>
-<pattern>t4sum4z</pattern>
-<pattern>tsun2</pattern>
-<pattern>ts3unk</pattern>
-<pattern>t2sur</pattern>
+<pattern>ts3umb</pattern>
+<pattern>ts3umd</pattern>
+<pattern>ts3umf</pattern>
+<pattern>ts3um4g</pattern>
+<pattern>ts3uml</pattern>
+<pattern>ts3um4r</pattern>
+<pattern>ts3ums</pattern>
+<pattern>ts3um4v</pattern>
+<pattern>ts3um4w</pattern>
+<pattern>t4s3um4z</pattern>
+<pattern>ts3un2</pattern>
+<pattern>t2s3ur</pattern>
 <pattern>tsur4t</pattern>
 <pattern>ts3ut</pattern>
 <pattern>tszu2</pattern>
@@ -37504,12 +38524,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tt5achs</pattern>
 <pattern>ttag5ess</pattern>
 <pattern>ttah2</pattern>
-<pattern>tt3aho</pattern>
 <pattern>tta2l</pattern>
-<pattern>t4t3ana3</pattern>
+<pattern>tt3alb</pattern>
+<pattern>tt3ana3</pattern>
 <pattern>t4t3anb</pattern>
 <pattern>t4t3and</pattern>
-<pattern>t4t3anf</pattern>
+<pattern>tt3anf</pattern>
 <pattern>ttange5h</pattern>
 <pattern>tt5an4ka</pattern>
 <pattern>tt5an4kä</pattern>
@@ -37517,7 +38537,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tt3anl</pattern>
 <pattern>ttan4s</pattern>
 <pattern>tt3an4w</pattern>
-<pattern>t4t3app</pattern>
+<pattern>tt3app</pattern>
 <pattern>tt3arb</pattern>
 <pattern>t5tari</pattern>
 <pattern>tt3ar4m</pattern>
@@ -37542,21 +38562,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ttel5eb</pattern>
 <pattern>tte4l5en</pattern>
 <pattern>ttel5in</pattern>
+<pattern>ttel3o</pattern>
 <pattern>ttels4t</pattern>
 <pattern>ttel5ste</pattern>
-<pattern>tte2m</pattern>
 <pattern>t4t3emu</pattern>
 <pattern>t3ten </pattern>
 <pattern>ttener4</pattern>
 <pattern>tten5erw</pattern>
+<pattern>tte4net</pattern>
 <pattern>tten3g</pattern>
 <pattern>t6tensem</pattern>
+<pattern>ttens4p</pattern>
 <pattern>tt5entb</pattern>
 <pattern>tten5te</pattern>
 <pattern>tt5entf</pattern>
 <pattern>tteran4</pattern>
 <pattern>tter5anb</pattern>
 <pattern>tte4r5ec</pattern>
+<pattern>tterei6</pattern>
 <pattern>tte6r5eis</pattern>
 <pattern>tterge5be</pattern>
 <pattern>t5teri</pattern>
@@ -37565,14 +38588,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tte4r5oh</pattern>
 <pattern>tter7reg</pattern>
 <pattern>tter6tra</pattern>
-<pattern>tte4s3a</pattern>
+<pattern>tte4s5ac</pattern>
 <pattern>tte4s3ä</pattern>
-<pattern>ttes3o</pattern>
+<pattern>tte4s3o</pattern>
 <pattern>tte5stä</pattern>
 <pattern>tte5stri</pattern>
 <pattern>tteu3e</pattern>
 <pattern>tt5extr</pattern>
 <pattern>tt4häus</pattern>
+<pattern>t4t3he4b</pattern>
 <pattern>t4thei</pattern>
 <pattern>tt3hel</pattern>
 <pattern>tt3het</pattern>
@@ -37590,7 +38614,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tt3inf</pattern>
 <pattern>t4t3ins</pattern>
 <pattern>t2tip</pattern>
-<pattern>tt3iso</pattern>
+<pattern>tt5isol</pattern>
 <pattern>t2ti3z</pattern>
 <pattern>tt4lem</pattern>
 <pattern>tt5nan</pattern>
@@ -37601,13 +38625,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tto3m</pattern>
 <pattern>ttona4</pattern>
 <pattern>t4tope</pattern>
-<pattern>tto3ra</pattern>
 <pattern>tt3or4d</pattern>
 <pattern>t4t3or4g</pattern>
 <pattern>t4t3or4n</pattern>
 <pattern>tto3s</pattern>
 <pattern>t4tost</pattern>
+<pattern>tto2t</pattern>
 <pattern>tto3ta</pattern>
+<pattern>tto3tr</pattern>
 <pattern>tt5rand</pattern>
 <pattern>ttra4s</pattern>
 <pattern>t3träg</pattern>
@@ -37619,7 +38644,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tt5ro4ch</pattern>
 <pattern>t5trog</pattern>
 <pattern>tt5rose</pattern>
-<pattern>tt3rot</pattern>
 <pattern>ttru2</pattern>
 <pattern>tt3rud</pattern>
 <pattern>tts5and</pattern>
@@ -37652,6 +38676,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3tu4ber</pattern>
 <pattern>3tu2bu</pattern>
 <pattern>tuch3s</pattern>
+<pattern>tu3cka</pattern>
 <pattern>2tud</pattern>
 <pattern>tudie4n5</pattern>
 <pattern>3tudo</pattern>
@@ -37680,6 +38705,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tuk</pattern>
 <pattern>4tulin</pattern>
 <pattern>t3ul2m</pattern>
+<pattern>tul4pf</pattern>
 <pattern>tul4ph</pattern>
 <pattern>tum4b3l</pattern>
 <pattern>2t3um2f</pattern>
@@ -37711,7 +38737,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tun4fal</pattern>
 <pattern>t3unga</pattern>
 <pattern>tunge5</pattern>
-<pattern>t5un4geh</pattern>
+<pattern>4t5un4geh</pattern>
 <pattern>4t5un4ger</pattern>
 <pattern>4tun4get</pattern>
 <pattern>tun4gl</pattern>
@@ -37719,8 +38745,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4tunif</pattern>
 <pattern>4t3unio</pattern>
 <pattern>tu3nit</pattern>
-<pattern>4tuniv</pattern>
-<pattern>2t3unl</pattern>
+<pattern>4t3u4niv</pattern>
+<pattern>2tunl</pattern>
 <pattern>tun4lö</pattern>
 <pattern>2t3un2m</pattern>
 <pattern>3tunn</pattern>
@@ -37734,7 +38760,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2t3un2v</pattern>
 <pattern>tun2w</pattern>
 <pattern>2t3up </pattern>
-<pattern>tup2d</pattern>
+<pattern>2tup2d</pattern>
 <pattern>tu3pen</pattern>
 <pattern>2t3up2g</pattern>
 <pattern>2tups</pattern>
@@ -37758,7 +38784,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tu3ren</pattern>
 <pattern>turer4</pattern>
 <pattern>tur5erb</pattern>
-<pattern>tur5erf</pattern>
 <pattern>tur5erg</pattern>
 <pattern>tur5erh</pattern>
 <pattern>tur5erk</pattern>
@@ -37772,6 +38797,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tur3e4v</pattern>
 <pattern>turhe5b</pattern>
 <pattern>tu4rin4</pattern>
+<pattern>tur5ini</pattern>
 <pattern>tur5ins</pattern>
 <pattern>tur5int</pattern>
 <pattern>tur3o</pattern>
@@ -37844,12 +38870,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>twe2n</pattern>
 <pattern>twen3e</pattern>
 <pattern>twi2</pattern>
-<pattern>t4wist</pattern>
+<pattern>3t4wist</pattern>
 <pattern>two2</pattern>
 <pattern>t1x</pattern>
 <pattern>1ty</pattern>
 <pattern>2ty </pattern>
-<pattern>2tya</pattern>
+<pattern>2ty1a2</pattern>
 <pattern>2tyb</pattern>
 <pattern>2tyc</pattern>
 <pattern>2ty3d</pattern>
@@ -37879,12 +38905,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2tz</pattern>
 <pattern>tz1a2</pattern>
 <pattern>t2zag</pattern>
-<pattern>tz3aho</pattern>
 <pattern>tzan2</pattern>
 <pattern>t2zap2</pattern>
 <pattern>t2za4r2</pattern>
 <pattern>t3zar </pattern>
-<pattern>t2zän</pattern>
+<pattern>t2z3än</pattern>
 <pattern>t2zäp</pattern>
 <pattern>t2z3är</pattern>
 <pattern>tze2d</pattern>
@@ -37901,6 +38926,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tze2n</pattern>
 <pattern>tzen5ga</pattern>
 <pattern>t6zensem</pattern>
+<pattern>tzen5st</pattern>
 <pattern>t4z5entg</pattern>
 <pattern>t4zentl</pattern>
 <pattern>t4z5ents</pattern>
@@ -37910,12 +38936,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>tzere4</pattern>
 <pattern>tzerei4</pattern>
 <pattern>tze4rer</pattern>
+<pattern>tz6erfe</pattern>
+<pattern>tz6erfr</pattern>
 <pattern>t4z5erhö</pattern>
 <pattern>t5zern</pattern>
 <pattern>tzer3o</pattern>
 <pattern>tz3erö</pattern>
 <pattern>tzer5ta</pattern>
 <pattern>t6z5er6tra</pattern>
+<pattern>t6z5er6trä</pattern>
 <pattern>tz5er4zi</pattern>
 <pattern>tze4sa</pattern>
 <pattern>t2z3id</pattern>
@@ -37960,7 +38989,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2ua</pattern>
 <pattern>u1a2b2</pattern>
 <pattern>uabde3</pattern>
-<pattern>u1ac</pattern>
 <pattern>uad3a</pattern>
 <pattern>uah2</pattern>
 <pattern>ua3he</pattern>
@@ -38006,6 +39034,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uara2</pattern>
 <pattern>ua3ran</pattern>
 <pattern>uar2b</pattern>
+<pattern>uar3de</pattern>
 <pattern>ua3ri</pattern>
 <pattern>uar4k3a</pattern>
 <pattern>uar4k3e</pattern>
@@ -38015,7 +39044,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ua3s2a</pattern>
 <pattern>ua3se</pattern>
 <pattern>uasi3</pattern>
+<pattern>uas2p</pattern>
 <pattern>uate3m</pattern>
+<pattern>uator5t</pattern>
 <pattern>uat3t</pattern>
 <pattern>u3au</pattern>
 <pattern>uauf3</pattern>
@@ -38041,6 +39072,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ubbe2</pattern>
 <pattern>ube2b</pattern>
 <pattern>ube2d</pattern>
+<pattern>ubeer5d</pattern>
+<pattern>ub3ef</pattern>
 <pattern>ube2g</pattern>
 <pattern>u4beha</pattern>
 <pattern>u4b3ehe</pattern>
@@ -38062,7 +39095,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4bess</pattern>
 <pattern>ube2t</pattern>
 <pattern>u2beu</pattern>
-<pattern>ub3eul</pattern>
 <pattern>ubeur5t</pattern>
 <pattern>ube2v</pattern>
 <pattern>ube2w</pattern>
@@ -38090,15 +39122,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ub4s5ang</pattern>
 <pattern>ubsau4</pattern>
 <pattern>ub4s5auf</pattern>
+<pattern>ub4sin</pattern>
 <pattern>ub4s3or4</pattern>
-<pattern>ub4s3pa</pattern>
+<pattern>ub4spar</pattern>
+<pattern>ub4s3pe</pattern>
 <pattern>ubs5ten</pattern>
 <pattern>ubs5ter</pattern>
 <pattern>ubs5trau</pattern>
+<pattern>ub2sz</pattern>
 <pattern>ubt2h</pattern>
 <pattern>ubtro3</pattern>
-<pattern>u2bum</pattern>
-<pattern>ub3ums</pattern>
 <pattern>u2büb</pattern>
 <pattern>2uc</pattern>
 <pattern>uc1c</pattern>
@@ -38107,6 +39140,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uch3ad</pattern>
 <pattern>uch3al</pattern>
 <pattern>uch3am4</pattern>
+<pattern>uch5ank</pattern>
 <pattern>uch5ans</pattern>
 <pattern>uch5ant</pattern>
 <pattern>uch5anz</pattern>
@@ -38119,7 +39153,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4chec</pattern>
 <pattern>uch3ed</pattern>
 <pattern>uch3ei</pattern>
-<pattern>uch5elf</pattern>
+<pattern>u4ch5elf</pattern>
 <pattern>uchen5s4</pattern>
 <pattern>u4chent</pattern>
 <pattern>uch3ep</pattern>
@@ -38147,6 +39181,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uch3op4</pattern>
 <pattern>uchor4</pattern>
 <pattern>uch5org</pattern>
+<pattern>uch5ort</pattern>
 <pattern>u3chos</pattern>
 <pattern>uch3öf</pattern>
 <pattern>u2chr</pattern>
@@ -38154,8 +39189,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uch6s5ein</pattern>
 <pattern>uch4s5el</pattern>
 <pattern>uch4s5in4</pattern>
-<pattern>uchs5or</pattern>
+<pattern>uch4s5or</pattern>
 <pattern>uchs5tan</pattern>
+<pattern>uch5stub</pattern>
 <pattern>ucht5eig</pattern>
 <pattern>uchter4</pattern>
 <pattern>uch6t5erf</pattern>
@@ -38165,7 +39201,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uch6t5erz</pattern>
 <pattern>uch4t5in4</pattern>
 <pattern>uchtor4</pattern>
-<pattern>ucht5sh</pattern>
 <pattern>ucht5sk</pattern>
 <pattern>uch3uh</pattern>
 <pattern>uch3ut</pattern>
@@ -38179,14 +39214,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4ck5ene</pattern>
 <pattern>u4ckent</pattern>
 <pattern>u5ckerem </pattern>
-<pattern>u5ckeren</pattern>
 <pattern>u5ckeres</pattern>
-<pattern>uck5erke</pattern>
 <pattern>u3ckes</pattern>
 <pattern>uck3in</pattern>
 <pattern>uck5spr</pattern>
 <pattern>u3cky</pattern>
 <pattern>u1cl</pattern>
+<pattern>u2cr</pattern>
 <pattern>u2cy</pattern>
 <pattern>2ud</pattern>
 <pattern>ud2a</pattern>
@@ -38200,12 +39234,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2de3i</pattern>
 <pattern>udein4</pattern>
 <pattern>u2dek</pattern>
-<pattern>udel5in</pattern>
 <pattern>ude3m</pattern>
 <pattern>ude2n</pattern>
 <pattern>uden3e</pattern>
 <pattern>uden3s4</pattern>
 <pattern>u4denu</pattern>
+<pattern>uderer4</pattern>
 <pattern>uder3ö</pattern>
 <pattern>u4desa</pattern>
 <pattern>u4desc</pattern>
@@ -38218,7 +39252,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>udget5a</pattern>
 <pattern>u4diar</pattern>
 <pattern>u3dir</pattern>
-<pattern>udium4</pattern>
 <pattern>u2do</pattern>
 <pattern>ud2ob</pattern>
 <pattern>udo3si</pattern>
@@ -38233,6 +39266,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ueb2</pattern>
 <pattern>ue3b4l</pattern>
 <pattern>ue3ch</pattern>
+<pattern>ue2de</pattern>
 <pattern>ue2di</pattern>
 <pattern>ue3do</pattern>
 <pattern>ue3er2</pattern>
@@ -38268,15 +39302,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u5ensar</pattern>
 <pattern>u3ensb</pattern>
 <pattern>u3ensd</pattern>
+<pattern>u5enseb</pattern>
 <pattern>u5en4s5er</pattern>
 <pattern>u3ensf</pattern>
 <pattern>u3ensg</pattern>
 <pattern>u5ensin</pattern>
-<pattern>u3ensk</pattern>
+<pattern>u5enskr</pattern>
 <pattern>u3ensl</pattern>
 <pattern>u3ensm</pattern>
 <pattern>u3ensn</pattern>
-<pattern>uen5spor</pattern>
+<pattern>uen5s6por</pattern>
 <pattern>uen5spr</pattern>
 <pattern>u3enss</pattern>
 <pattern>uen3st</pattern>
@@ -38290,8 +39325,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uenzer4</pattern>
 <pattern>uen6zerh</pattern>
 <pattern>uen4zin</pattern>
-<pattern>uen4zu</pattern>
+<pattern>uen4zun</pattern>
 <pattern>uen4zw</pattern>
+<pattern>ue1o</pattern>
 <pattern>ue1p</pattern>
 <pattern>uer3a</pattern>
 <pattern>uerab4</pattern>
@@ -38316,8 +39352,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ue4r5erg</pattern>
 <pattern>ue4r5erh</pattern>
 <pattern>ue4rerk</pattern>
-<pattern>uer5erm</pattern>
-<pattern>ue4rerr</pattern>
+<pattern>ue4rerl</pattern>
+<pattern>ue4r5erm</pattern>
+<pattern>ue4r5err</pattern>
 <pattern>uer5ers</pattern>
 <pattern>ue6rersa</pattern>
 <pattern>ue6rersc</pattern>
@@ -38326,7 +39363,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ue4rerz</pattern>
 <pattern>uer5esk</pattern>
 <pattern>ue4r3et</pattern>
-<pattern>uer3i4d</pattern>
+<pattern>uer6fahru</pattern>
+<pattern>ue4r3i4d</pattern>
 <pattern>ue4r3i4m</pattern>
 <pattern>uerin6nu</pattern>
 <pattern>uerk4</pattern>
@@ -38335,8 +39373,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uermi4</pattern>
 <pattern>u3ern</pattern>
 <pattern>uer4nan</pattern>
+<pattern>uer4nen</pattern>
 <pattern>uer4neu</pattern>
 <pattern>uerni4</pattern>
+<pattern>uer4no</pattern>
 <pattern>uern5s4t</pattern>
 <pattern>uero2</pattern>
 <pattern>uer3oc</pattern>
@@ -38362,6 +39402,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ue4ruh</pattern>
 <pattern>uer3um4</pattern>
 <pattern>uerwe5ck</pattern>
+<pattern>uerz2</pattern>
 <pattern>uerzu4</pattern>
 <pattern>ue3se</pattern>
 <pattern>ue2s3i</pattern>
@@ -38379,6 +39420,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uf3ane</pattern>
 <pattern>ufa4r</pattern>
 <pattern>uf3are</pattern>
+<pattern>uf3arm</pattern>
 <pattern>u2fat</pattern>
 <pattern>u2f3au</pattern>
 <pattern>u1fä</pattern>
@@ -38391,7 +39433,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uf3ei4g</pattern>
 <pattern>uf3ein</pattern>
 <pattern>ufe3la</pattern>
-<pattern>ufe3li</pattern>
 <pattern>ufel4s5a</pattern>
 <pattern>ufel4s5i</pattern>
 <pattern>u2f3em</pattern>
@@ -38402,6 +39443,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4f5erne</pattern>
 <pattern>ufersu5c</pattern>
 <pattern>ufes2</pattern>
+<pattern>uf3eta</pattern>
 <pattern>u4f3eur</pattern>
 <pattern>u2fex</pattern>
 <pattern>uffer5e</pattern>
@@ -38431,9 +39473,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u3frän</pattern>
 <pattern>ufre6ch</pattern>
 <pattern>ufs3an</pattern>
-<pattern>uf4s3en4</pattern>
 <pattern>ufs5eta</pattern>
 <pattern>uf4s3in4</pattern>
+<pattern>uf2so</pattern>
 <pattern>ufs4por</pattern>
 <pattern>uf4spre</pattern>
 <pattern>uf5stra</pattern>
@@ -38451,6 +39493,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u3fuc</pattern>
 <pattern>uf3um4g</pattern>
 <pattern>uf3uml</pattern>
+<pattern>uf3ums</pattern>
 <pattern>ufün2</pattern>
 <pattern>2ug</pattern>
 <pattern>ugab2</pattern>
@@ -38468,9 +39511,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2gar</pattern>
 <pattern>uga2s</pattern>
 <pattern>ug3asc</pattern>
-<pattern>ug3at4t</pattern>
 <pattern>ug3aus</pattern>
 <pattern>ug3d2</pattern>
+<pattern>ugd4e</pattern>
 <pattern>uge2</pattern>
 <pattern>ugear4</pattern>
 <pattern>u5gebt</pattern>
@@ -38483,6 +39526,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uge5mit</pattern>
 <pattern>ugen6d5re</pattern>
 <pattern>ugenei4</pattern>
+<pattern>ugen5en</pattern>
 <pattern>u4geng</pattern>
 <pattern>uge5nie</pattern>
 <pattern>uge5nis</pattern>
@@ -38495,10 +39539,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uge5rin</pattern>
 <pattern>u4g3er4k</pattern>
 <pattern>uger6prob</pattern>
+<pattern>uger4s</pattern>
+<pattern>u4g5ersa</pattern>
+<pattern>u4g5ersc</pattern>
 <pattern>uger5w</pattern>
 <pattern>uges2</pattern>
 <pattern>ug3esk</pattern>
 <pattern>u4g3ess</pattern>
+<pattern>uggel5a</pattern>
 <pattern>ugi2d</pattern>
 <pattern>ug3ide</pattern>
 <pattern>u2gig</pattern>
@@ -38509,11 +39557,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ug3lad</pattern>
 <pattern>ugla5se</pattern>
 <pattern>ug3län</pattern>
-<pattern>ug3läu</pattern>
+<pattern>u4g3läu</pattern>
 <pattern>ugle2</pattern>
 <pattern>ug3lea</pattern>
 <pattern>ug3lee</pattern>
-<pattern>ug5leis</pattern>
 <pattern>ug5leitb</pattern>
 <pattern>ug5leitu</pattern>
 <pattern>ug3liz</pattern>
@@ -38538,6 +39585,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ug3rol</pattern>
 <pattern>ug3rum</pattern>
 <pattern>ug3rüs</pattern>
+<pattern>ugs4alb</pattern>
 <pattern>ugsal5ben</pattern>
 <pattern>ug3sek</pattern>
 <pattern>ug3set</pattern>
@@ -38549,10 +39597,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ugs4por</pattern>
 <pattern>ug5s4tan</pattern>
 <pattern>ug3stä</pattern>
-<pattern>ugs4tie</pattern>
+<pattern>ug5s4tie</pattern>
 <pattern>ug3s4tr</pattern>
 <pattern>ug4stür</pattern>
-<pattern>ugui3</pattern>
 <pattern>u2gur</pattern>
 <pattern>u2gus</pattern>
 <pattern>u1ha2</pattern>
@@ -38562,12 +39609,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2uhe</pattern>
 <pattern>uhe3a2</pattern>
 <pattern>uhe2b</pattern>
+<pattern>uhe3d</pattern>
 <pattern>uhe3e</pattern>
-<pattern>u3heis</pattern>
 <pattern>u3heiß</pattern>
 <pattern>uhe3la</pattern>
 <pattern>uhe3o</pattern>
 <pattern>uhe3s</pattern>
+<pattern>uheu2</pattern>
 <pattern>uhgene5</pattern>
 <pattern>2uhi</pattern>
 <pattern>uhis3</pattern>
@@ -38579,7 +39627,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uhl5erb</pattern>
 <pattern>uh3les</pattern>
 <pattern>uhle3t</pattern>
-<pattern>uhl3i</pattern>
 <pattern>uhl3o</pattern>
 <pattern>uh3lö</pattern>
 <pattern>uhls2</pattern>
@@ -38604,7 +39651,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ui2a</pattern>
 <pattern>ui3cho</pattern>
 <pattern>ui3cke</pattern>
-<pattern>ui4cker</pattern>
 <pattern>ui3cki</pattern>
 <pattern>ui3cku</pattern>
 <pattern>u1ie</pattern>
@@ -38612,6 +39658,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ui2g</pattern>
 <pattern>u3ige</pattern>
 <pattern>ui3gis</pattern>
+<pattern>ui1k2</pattern>
 <pattern>ui3las</pattern>
 <pattern>uil4les</pattern>
 <pattern>uim2</pattern>
@@ -38640,7 +39687,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4kaly</pattern>
 <pattern>uka2m</pattern>
 <pattern>uka3su</pattern>
-<pattern>uk3äh</pattern>
 <pattern>u1ke</pattern>
 <pattern>u3keh</pattern>
 <pattern>uke2n</pattern>
@@ -38659,8 +39705,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2kot</pattern>
 <pattern>uk2r</pattern>
 <pattern>ukrei3</pattern>
-<pattern>uk3so</pattern>
-<pattern>uk2t3a</pattern>
+<pattern>uk4tan</pattern>
+<pattern>uk4tau</pattern>
 <pattern>uk2t3ä</pattern>
 <pattern>ukt3eb</pattern>
 <pattern>uk4t3el</pattern>
@@ -38678,12 +39724,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u1la</pattern>
 <pattern>ul3a2b2</pattern>
 <pattern>ul3af2</pattern>
-<pattern>u2lag</pattern>
+<pattern>u2l4ag</pattern>
 <pattern>ula4ger</pattern>
 <pattern>ulan4di</pattern>
 <pattern>u4lan4f</pattern>
 <pattern>ulap3</pattern>
-<pattern>ul2ar</pattern>
 <pattern>ula4ra</pattern>
 <pattern>u4larr</pattern>
 <pattern>ularz4</pattern>
@@ -38734,16 +39779,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uli4kel</pattern>
 <pattern>uli3m</pattern>
 <pattern>ulin5ga</pattern>
+<pattern>ul3inh</pattern>
 <pattern>uli4ni</pattern>
 <pattern>u2li3p</pattern>
 <pattern>uli2z</pattern>
-<pattern>ulkor4</pattern>
 <pattern>ullau4</pattern>
 <pattern>ull5ei4c</pattern>
 <pattern>ull5ein</pattern>
 <pattern>ul5len </pattern>
 <pattern>ul5lende</pattern>
 <pattern>ull5endu</pattern>
+<pattern>ull5erkl</pattern>
 <pattern>ull3od</pattern>
 <pattern>ul3lö</pattern>
 <pattern>ull3s2</pattern>
@@ -38755,12 +39801,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2l3or</pattern>
 <pattern>ulo4s</pattern>
 <pattern>ulo2t</pattern>
+<pattern>ul4sal</pattern>
 <pattern>ul4sam</pattern>
 <pattern>ul4s3ec</pattern>
 <pattern>ul4ser</pattern>
 <pattern>ulsgene5</pattern>
 <pattern>ul4s3in</pattern>
-<pattern>ulster4</pattern>
 <pattern>uls6t5erk</pattern>
 <pattern>ulst3h</pattern>
 <pattern>ul4sum</pattern>
@@ -38784,7 +39830,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2um </pattern>
 <pattern>2uma</pattern>
 <pattern>um5a4ben</pattern>
-<pattern>umak2</pattern>
 <pattern>um3aku</pattern>
 <pattern>uma2l2</pattern>
 <pattern>um3alb</pattern>
@@ -38832,7 +39877,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>umei5sen</pattern>
 <pattern>ume4ne</pattern>
 <pattern>umen3s</pattern>
+<pattern>um3e2p</pattern>
 <pattern>ume3ra</pattern>
+<pattern>u4merd</pattern>
 <pattern>u4m3er4f</pattern>
 <pattern>u4m3erg</pattern>
 <pattern>u4m3er4h</pattern>
@@ -38847,7 +39894,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ume2t</pattern>
 <pattern>3umfe</pattern>
 <pattern>2umi</pattern>
-<pattern>u2mid</pattern>
 <pattern>umi2l</pattern>
 <pattern>um3ill</pattern>
 <pattern>um3in4h</pattern>
@@ -38859,7 +39905,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>umi2t</pattern>
 <pattern>um3ite</pattern>
 <pattern>3umke</pattern>
-<pattern>2umm</pattern>
+<pattern>umm5ein</pattern>
 <pattern>umme5lan</pattern>
 <pattern>um3men</pattern>
 <pattern>ummen5s</pattern>
@@ -38879,12 +39925,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ump4fa</pattern>
 <pattern>ump4fin</pattern>
 <pattern>4umpho</pattern>
+<pattern>2umpl</pattern>
 <pattern>um3po</pattern>
-<pattern>um3rum</pattern>
 <pattern>4umsal</pattern>
 <pattern>umsch4</pattern>
 <pattern>umsche4</pattern>
-<pattern>ums3ed</pattern>
 <pattern>ums5ein</pattern>
 <pattern>ums5ens</pattern>
 <pattern>ums5erw</pattern>
@@ -38898,6 +39943,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2umu</pattern>
 <pattern>umum2</pattern>
 <pattern>um3umg</pattern>
+<pattern>u2m1y</pattern>
 <pattern>3umzü</pattern>
 <pattern>4una </pattern>
 <pattern>4unabr</pattern>
@@ -38905,6 +39951,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u3nac</pattern>
 <pattern>un5ader</pattern>
 <pattern>una3ga</pattern>
+<pattern>una3ha</pattern>
 <pattern>una3he</pattern>
 <pattern>una2m</pattern>
 <pattern>un3an2</pattern>
@@ -38950,6 +39997,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4undi</pattern>
 <pattern>un4d3id</pattern>
 <pattern>un4dine</pattern>
+<pattern>und5ini</pattern>
 <pattern>undle4</pattern>
 <pattern>3undn</pattern>
 <pattern>undo2</pattern>
@@ -38979,6 +40027,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uner4a</pattern>
 <pattern>un5erz </pattern>
 <pattern>un2es</pattern>
+<pattern>unes3t</pattern>
 <pattern>u4n3eul</pattern>
 <pattern>unf2</pattern>
 <pattern>3unfal</pattern>
@@ -38987,12 +40036,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>unfi5sche</pattern>
 <pattern>3unfr</pattern>
 <pattern>un3fu</pattern>
+<pattern>unga2</pattern>
 <pattern>ung3ab</pattern>
-<pattern>3ungar</pattern>
+<pattern>ung3ag</pattern>
 <pattern>un4gar </pattern>
 <pattern>un4garn</pattern>
+<pattern>ung5art</pattern>
 <pattern>ungas4</pattern>
 <pattern>ung5ass</pattern>
+<pattern>ung3au</pattern>
 <pattern>ungebe4</pattern>
 <pattern>ungei4</pattern>
 <pattern>ung5eig</pattern>
@@ -39012,6 +40064,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>un4g3ig</pattern>
 <pattern>un4g3in</pattern>
 <pattern>ung5lat</pattern>
+<pattern>ung3lu</pattern>
 <pattern>3unglü</pattern>
 <pattern>ungra4d</pattern>
 <pattern>un4g3rä</pattern>
@@ -39032,11 +40085,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uni3l</pattern>
 <pattern>u2nin</pattern>
 <pattern>un4it</pattern>
-<pattern>3u2niv</pattern>
 <pattern>2unk</pattern>
 <pattern>un4k3ak</pattern>
 <pattern>un4k3an4</pattern>
-<pattern>un4k3au</pattern>
+<pattern>un4kau</pattern>
 <pattern>unker6ke</pattern>
 <pattern>un4ket</pattern>
 <pattern>unk5lin</pattern>
@@ -39045,12 +40097,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>un4knu</pattern>
 <pattern>unkra4</pattern>
 <pattern>un4k3ro</pattern>
-<pattern>unks2</pattern>
+<pattern>unk3s2</pattern>
 <pattern>unktra4</pattern>
 <pattern>unk4t5ri</pattern>
 <pattern>unk4tro</pattern>
 <pattern>un4kum</pattern>
 <pattern>un4küb</pattern>
+<pattern>3unlö</pattern>
 <pattern>unmen4</pattern>
 <pattern>unna2</pattern>
 <pattern>un4n3ad</pattern>
@@ -39098,6 +40151,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>un3trü</pattern>
 <pattern>2untu</pattern>
 <pattern>un3tum</pattern>
+<pattern>un3tun</pattern>
 <pattern>3unty</pattern>
 <pattern>un1u</pattern>
 <pattern>unüb3l</pattern>
@@ -39131,10 +40185,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>upe2</pattern>
 <pattern>upen3s</pattern>
 <pattern>uper3</pattern>
-<pattern>upe4ra</pattern>
+<pattern>upe4ra4</pattern>
 <pattern>upe5rio</pattern>
 <pattern>u3pet</pattern>
-<pattern>up2f3a</pattern>
+<pattern>upf3au</pattern>
+<pattern>upf5lau</pattern>
 <pattern>upf3lo</pattern>
 <pattern>upflü3</pattern>
 <pattern>up2fo</pattern>
@@ -39143,11 +40198,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u1pi</pattern>
 <pattern>up2lu</pattern>
 <pattern>2upo2</pattern>
+<pattern>2upp</pattern>
 <pattern>up2pl</pattern>
 <pattern>uppor4</pattern>
 <pattern>upport5</pattern>
 <pattern>up3sl</pattern>
-<pattern>up3so</pattern>
 <pattern>u2pt</pattern>
 <pattern>up2t3a2</pattern>
 <pattern>up4t5ene</pattern>
@@ -39169,22 +40224,23 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ur3abb</pattern>
 <pattern>ura4ben</pattern>
 <pattern>ur3abh</pattern>
-<pattern>ur3abl</pattern>
 <pattern>ur3abs</pattern>
 <pattern>ur3abt</pattern>
 <pattern>u2rac</pattern>
 <pattern>ura5che</pattern>
 <pattern>ura2d</pattern>
-<pattern>ura3fr</pattern>
+<pattern>ur3adr</pattern>
 <pattern>ura2g</pattern>
 <pattern>ura3gi</pattern>
 <pattern>u3rai</pattern>
-<pattern>u4rak2</pattern>
+<pattern>urak2</pattern>
 <pattern>ur3akk</pattern>
 <pattern>ur3akt</pattern>
 <pattern>u3ral</pattern>
-<pattern>u4r3alg</pattern>
+<pattern>u4ralg</pattern>
 <pattern>ur3alt</pattern>
+<pattern>ural4te</pattern>
+<pattern>ur3alu</pattern>
 <pattern>ur3amp</pattern>
 <pattern>uram4t</pattern>
 <pattern>3ur4an </pattern>
@@ -39197,14 +40253,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uranga5</pattern>
 <pattern>urange5s</pattern>
 <pattern>ur5angs</pattern>
-<pattern>ur3an4n</pattern>
+<pattern>uran4na</pattern>
 <pattern>uran4s</pattern>
 <pattern>uran5sp</pattern>
 <pattern>u5rant </pattern>
 <pattern>u5r4anti</pattern>
 <pattern>uran4tr</pattern>
 <pattern>ur3a4po</pattern>
-<pattern>ur5aren</pattern>
 <pattern>ura4ri</pattern>
 <pattern>ur3att</pattern>
 <pattern>ur3auf</pattern>
@@ -39222,6 +40277,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ur4bog</pattern>
 <pattern>ur4bol</pattern>
 <pattern>urchas4</pattern>
+<pattern>urchi4</pattern>
 <pattern>urde4t</pattern>
 <pattern>ur4dist</pattern>
 <pattern>u4re </pattern>
@@ -39240,6 +40296,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>urein5s</pattern>
 <pattern>u3reit</pattern>
 <pattern>ure2k</pattern>
+<pattern>ure3la</pattern>
 <pattern>u4rele</pattern>
 <pattern>ure3li</pattern>
 <pattern>ure2n</pattern>
@@ -39247,7 +40304,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4re3ni</pattern>
 <pattern>urens4</pattern>
 <pattern>uren5st</pattern>
-<pattern>u4rentn</pattern>
+<pattern>u4r5entn</pattern>
 <pattern>u4rents</pattern>
 <pattern>urepa3</pattern>
 <pattern>ur3epo</pattern>
@@ -39255,7 +40312,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ure2t</pattern>
 <pattern>ureu2</pattern>
 <pattern>ure3un</pattern>
-<pattern>2urf</pattern>
+<pattern>urfar4m5</pattern>
 <pattern>urfei4</pattern>
 <pattern>urf5eig</pattern>
 <pattern>urfer4</pattern>
@@ -39299,9 +40356,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ur3li2</pattern>
 <pattern>urma2</pattern>
 <pattern>urm3ab</pattern>
+<pattern>urm5ang</pattern>
 <pattern>urm5ar4t</pattern>
 <pattern>ur4matt</pattern>
 <pattern>ur4mäh</pattern>
+<pattern>ur4mec</pattern>
 <pattern>urm5eie</pattern>
 <pattern>urm5einh</pattern>
 <pattern>urmer4</pattern>
@@ -39314,22 +40373,27 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>urn2a</pattern>
 <pattern>urna4m</pattern>
 <pattern>urna4t</pattern>
-<pattern>urno2</pattern>
+<pattern>ur4n5ere</pattern>
 <pattern>ur3nob</pattern>
+<pattern>ur3nor3</pattern>
 <pattern>ur3not</pattern>
 <pattern>urob2</pattern>
-<pattern>ur5ober</pattern>
+<pattern>urobe4</pattern>
 <pattern>uro3d</pattern>
 <pattern>ur3off</pattern>
 <pattern>uro3h</pattern>
 <pattern>uro3la</pattern>
-<pattern>u3ron</pattern>
+<pattern>u3ron </pattern>
+<pattern>u3rona</pattern>
+<pattern>u3rone</pattern>
 <pattern>uror2</pattern>
 <pattern>ur3orc</pattern>
+<pattern>ur3org</pattern>
 <pattern>u3rose</pattern>
 <pattern>uro5sen</pattern>
 <pattern>uro5str</pattern>
 <pattern>u3roti</pattern>
+<pattern>uro3tr</pattern>
 <pattern>u1rö1</pattern>
 <pattern>urö2c</pattern>
 <pattern>urp2</pattern>
@@ -39337,10 +40401,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>urrevo5</pattern>
 <pattern>ur2sa</pattern>
 <pattern>3ursac</pattern>
+<pattern>ursan4</pattern>
 <pattern>urs5ang</pattern>
 <pattern>ur3sat</pattern>
 <pattern>ursau4</pattern>
 <pattern>urs5auf</pattern>
+<pattern>ursau5r</pattern>
 <pattern>urse2</pattern>
 <pattern>urs5ein</pattern>
 <pattern>urs5ere</pattern>
@@ -39357,7 +40423,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>urs5tak</pattern>
 <pattern>urs5tel</pattern>
 <pattern>ur4sum</pattern>
-<pattern>ur4sun</pattern>
+<pattern>ur4s3un</pattern>
 <pattern>urta2</pattern>
 <pattern>ur4tai</pattern>
 <pattern>urt5er4z</pattern>
@@ -39412,6 +40478,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2säh</pattern>
 <pattern>u2sär</pattern>
 <pattern>u2s3äs</pattern>
+<pattern>us5bli</pattern>
 <pattern>usby2</pattern>
 <pattern>u2sca</pattern>
 <pattern>u2sce</pattern>
@@ -39423,15 +40490,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u4schär</pattern>
 <pattern>u4schef</pattern>
 <pattern>usch5ei6c</pattern>
-<pattern>u6scheind</pattern>
+<pattern>u6sch5eind</pattern>
 <pattern>u6schene</pattern>
 <pattern>u6schent</pattern>
-<pattern>u6sch5erz</pattern>
 <pattern>usch5eul</pattern>
 <pattern>us4chi</pattern>
 <pattern>u5schil</pattern>
 <pattern>u6schimp</pattern>
 <pattern>u6schlan</pattern>
+<pattern>usch5lap</pattern>
+<pattern>u6schlauf</pattern>
 <pattern>u6schlem</pattern>
 <pattern>usch5ma4</pattern>
 <pattern>usch5mis</pattern>
@@ -39449,7 +40517,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2see</pattern>
 <pattern>us3ei</pattern>
 <pattern>u3seid</pattern>
-<pattern>usein3</pattern>
 <pattern>u2sek</pattern>
 <pattern>us5ekel</pattern>
 <pattern>us2el</pattern>
@@ -39457,8 +40524,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u3sen</pattern>
 <pattern>usen6dac</pattern>
 <pattern>usen6dere</pattern>
-<pattern>u4sense</pattern>
-<pattern>usen5st</pattern>
 <pattern>u4sentl</pattern>
 <pattern>u2sep</pattern>
 <pattern>user3a</pattern>
@@ -39488,15 +40553,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uska4l</pattern>
 <pattern>u3soa</pattern>
 <pattern>us3oc</pattern>
-<pattern>u3sog</pattern>
 <pattern>u2soh</pattern>
-<pattern>u3sol</pattern>
-<pattern>us3op</pattern>
+<pattern>u2s3op</pattern>
 <pattern>us3orb</pattern>
 <pattern>us3orc</pattern>
 <pattern>us3ost</pattern>
 <pattern>us3ou</pattern>
-<pattern>u3sov</pattern>
 <pattern>us3pac</pattern>
 <pattern>us3pas</pattern>
 <pattern>us4pate</pattern>
@@ -39519,9 +40581,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uss5einf</pattern>
 <pattern>uss5eins</pattern>
 <pattern>usse5li</pattern>
-<pattern>us4sem</pattern>
 <pattern>usse4n</pattern>
-<pattern>uss3ep</pattern>
+<pattern>ussen5s</pattern>
 <pattern>us5s6er </pattern>
 <pattern>us6s5erla</pattern>
 <pattern>uss5erle</pattern>
@@ -39530,13 +40591,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ussgene5</pattern>
 <pattern>us3shu</pattern>
 <pattern>uss3l</pattern>
+<pattern>us4stor</pattern>
 <pattern>us4s3um</pattern>
-<pattern>us4s3ur4</pattern>
+<pattern>ussur4</pattern>
+<pattern>uss5urt</pattern>
 <pattern>u4st </pattern>
 <pattern>u3stad</pattern>
 <pattern>usta5de</pattern>
 <pattern>ust5arm</pattern>
-<pattern>us6taub</pattern>
 <pattern>ust5ave</pattern>
 <pattern>u6stele</pattern>
 <pattern>ustel6l5a</pattern>
@@ -39579,25 +40641,25 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u2ß1u</pattern>
 <pattern>2ut</pattern>
 <pattern>utab4</pattern>
+<pattern>ut3abr</pattern>
 <pattern>ut3abs</pattern>
 <pattern>utad2</pattern>
 <pattern>ut3adl</pattern>
-<pattern>u3taf</pattern>
+<pattern>u3tafe</pattern>
+<pattern>ut3aff</pattern>
 <pattern>utage4</pattern>
-<pattern>ut3aho</pattern>
 <pattern>utak2</pattern>
 <pattern>ut3akt</pattern>
 <pattern>u3tal </pattern>
 <pattern>u3tale</pattern>
 <pattern>ut3alg</pattern>
 <pattern>ut3alk</pattern>
+<pattern>ut3al4l</pattern>
 <pattern>ut3al4t</pattern>
-<pattern>ut3am</pattern>
-<pattern>uta3mi</pattern>
+<pattern>ut3ame</pattern>
+<pattern>ut3a3mi</pattern>
 <pattern>ut3and</pattern>
 <pattern>ut3ar2</pattern>
-<pattern>u4tas</pattern>
-<pattern>ut3asc</pattern>
 <pattern>ut3ass</pattern>
 <pattern>ut3auf</pattern>
 <pattern>utä2</pattern>
@@ -39613,16 +40675,19 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ut3eiw</pattern>
 <pattern>u2tek</pattern>
 <pattern>ute2l</pattern>
+<pattern>utel6ei</pattern>
 <pattern>u4telü</pattern>
 <pattern>u4temi</pattern>
 <pattern>ute5n4ac</pattern>
-<pattern>uten3e</pattern>
+<pattern>ute4n3e</pattern>
 <pattern>uten3s</pattern>
 <pattern>ut5entf</pattern>
 <pattern>u2tep</pattern>
 <pattern>uter3a4</pattern>
 <pattern>uteras5t</pattern>
+<pattern>utergene6</pattern>
 <pattern>u4t5erhö</pattern>
+<pattern>uterie5</pattern>
 <pattern>ute6r5ing</pattern>
 <pattern>u4t5erwä</pattern>
 <pattern>u4te5stu</pattern>
@@ -39632,7 +40697,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ut3hi</pattern>
 <pattern>ut3ho</pattern>
 <pattern>u2t3i2d</pattern>
-<pattern>ut5i4gel</pattern>
+<pattern>u4t5i4gel</pattern>
+<pattern>3utili</pattern>
+<pattern>ut3ind</pattern>
 <pattern>utine3</pattern>
 <pattern>uti6nena</pattern>
 <pattern>uti4ner</pattern>
@@ -39659,6 +40726,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uto6renv</pattern>
 <pattern>uto6renw</pattern>
 <pattern>uto6renz</pattern>
+<pattern>ut3ort</pattern>
 <pattern>utos2</pattern>
 <pattern>utra6ch</pattern>
 <pattern>u3trap</pattern>
@@ -39669,17 +40737,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>u3trom</pattern>
 <pattern>utro4t</pattern>
 <pattern>ut3rou</pattern>
+<pattern>ut3röt</pattern>
 <pattern>ut3rü</pattern>
 <pattern>utrü3b</pattern>
 <pattern>ut3sal</pattern>
-<pattern>ut4schl</pattern>
 <pattern>ut4schö</pattern>
 <pattern>ut4sin</pattern>
 <pattern>u4tsk</pattern>
 <pattern>ut3sky</pattern>
-<pattern>ut3so</pattern>
-<pattern>ut3spe</pattern>
-<pattern>ut3spr</pattern>
+<pattern>ut3sp</pattern>
 <pattern>uts2t</pattern>
 <pattern>utte2</pattern>
 <pattern>ut4til</pattern>
@@ -39699,10 +40765,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>utzei4</pattern>
 <pattern>utz5eig</pattern>
 <pattern>ut4z5ene</pattern>
-<pattern>utz4er</pattern>
 <pattern>utz3e4t</pattern>
-<pattern>ut4z3in4</pattern>
+<pattern>ut4z3in</pattern>
 <pattern>ut2zö</pattern>
+<pattern>utzu3h</pattern>
 <pattern>ut2zw</pattern>
 <pattern>2u1u2</pattern>
 <pattern>uum1</pattern>
@@ -39735,14 +40801,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>uz3ar2</pattern>
 <pattern>uz3as</pattern>
 <pattern>uze2</pattern>
-<pattern>u2z3ec</pattern>
+<pattern>uze4c</pattern>
+<pattern>uz3eck</pattern>
 <pattern>uzei4c</pattern>
 <pattern>u4z3ela</pattern>
 <pattern>u4z3ene</pattern>
 <pattern>u4z5erhö</pattern>
 <pattern>uzer4l</pattern>
 <pattern>u4z5erla</pattern>
-<pattern>u5zieru</pattern>
 <pattern>u2z3ik</pattern>
 <pattern>u4z3inf</pattern>
 <pattern>uzo2</pattern>
@@ -39790,11 +40856,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ücken5s</pattern>
 <pattern>ücker4</pattern>
 <pattern>ück5erb</pattern>
+<pattern>ü4ck5erf</pattern>
 <pattern>ück5erh</pattern>
 <pattern>ück5erke</pattern>
 <pattern>ück5erla</pattern>
 <pattern>ü4ck5ers</pattern>
 <pattern>ück5erw</pattern>
+<pattern>ück5erz</pattern>
 <pattern>ü3ckes</pattern>
 <pattern>ück3n</pattern>
 <pattern>ü4cks</pattern>
@@ -39807,10 +40875,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ü2d</pattern>
 <pattern>üd1a2</pattern>
 <pattern>üdal2</pattern>
+<pattern>üdan2</pattern>
 <pattern>ü4de </pattern>
 <pattern>üdel2</pattern>
 <pattern>üder4w</pattern>
-<pattern>üd1o</pattern>
+<pattern>üd1o2</pattern>
+<pattern>üdo4s</pattern>
 <pattern>üdost3</pattern>
 <pattern>üd1ö</pattern>
 <pattern>üdös2</pattern>
@@ -39828,6 +40898,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üf1ä</pattern>
 <pattern>ü2f3ei</pattern>
 <pattern>ü4f3ent</pattern>
+<pattern>ü6fergeb</pattern>
 <pattern>ü2fe2t</pattern>
 <pattern>üf3eti</pattern>
 <pattern>ü2f1i</pattern>
@@ -39843,6 +40914,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üge3g</pattern>
 <pattern>ügel3a</pattern>
 <pattern>ügel3ä</pattern>
+<pattern>ügel3d4</pattern>
 <pattern>ügen3s</pattern>
 <pattern>ü3gern</pattern>
 <pattern>üg4gew</pattern>
@@ -39852,6 +40924,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üg1s2</pattern>
 <pattern>üg2st</pattern>
 <pattern>üh1a2</pattern>
+<pattern>ühand4</pattern>
 <pattern>ü4he </pattern>
 <pattern>üh3ei</pattern>
 <pattern>ü4hel</pattern>
@@ -39883,7 +40956,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üh3les</pattern>
 <pattern>üh3li</pattern>
 <pattern>ühl3ö</pattern>
-<pattern>ühl4s3i</pattern>
+<pattern>ühl4sin</pattern>
 <pattern>üh3ma</pattern>
 <pattern>üh3mes</pattern>
 <pattern>üh3mi</pattern>
@@ -39901,6 +40974,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ühren5s4</pattern>
 <pattern>üh3ro</pattern>
 <pattern>ühr3ta</pattern>
+<pattern>ühr5tei</pattern>
 <pattern>ührzwe5</pattern>
 <pattern>üh1s</pattern>
 <pattern>ühse2</pattern>
@@ -39911,8 +40985,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üh3tei</pattern>
 <pattern>ü1hu</pattern>
 <pattern>üh3w</pattern>
+<pattern>üken3</pattern>
 <pattern>2ül</pattern>
 <pattern>ül1a</pattern>
+<pattern>ül2ad</pattern>
 <pattern>ü1le</pattern>
 <pattern>ü4le </pattern>
 <pattern>ü2l3ef</pattern>
@@ -39926,6 +41002,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ül2la</pattern>
 <pattern>üll3ad</pattern>
 <pattern>üll3au</pattern>
+<pattern>ül4l3ec</pattern>
 <pattern>ül4l3ei4</pattern>
 <pattern>üller4s</pattern>
 <pattern>ül4les</pattern>
@@ -39946,6 +41023,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ümer3a</pattern>
 <pattern>ü4m3id</pattern>
 <pattern>üm3in</pattern>
+<pattern>ümp4fes</pattern>
 <pattern>üm1s</pattern>
 <pattern>üm1u</pattern>
 <pattern>2ün</pattern>
@@ -39979,11 +41057,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ün1t</pattern>
 <pattern>ü1nu</pattern>
 <pattern>ün2za</pattern>
-<pattern>ün4zei</pattern>
 <pattern>ünze4n</pattern>
 <pattern>ün2z3i</pattern>
 <pattern>ün4z3un</pattern>
 <pattern>ün2zw</pattern>
+<pattern>ü1o</pattern>
 <pattern>2üp</pattern>
 <pattern>ü2pe</pattern>
 <pattern>üpf3l</pattern>
@@ -40001,7 +41079,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ü3res</pattern>
 <pattern>ür4f3er</pattern>
 <pattern>ür4fle</pattern>
-<pattern>ür2fr</pattern>
 <pattern>ür4gee</pattern>
 <pattern>ür4ge3g</pattern>
 <pattern>ür4gem</pattern>
@@ -40024,7 +41101,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ür3the</pattern>
 <pattern>ü1ru</pattern>
 <pattern>ür4z5ess</pattern>
-<pattern>ür4z3in4</pattern>
+<pattern>ür4z3in</pattern>
+<pattern>ür2zo</pattern>
 <pattern>ür2zö</pattern>
 <pattern>ür2zw</pattern>
 <pattern>ü1sa</pattern>
@@ -40055,12 +41133,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>üs2st</pattern>
 <pattern>üst3a</pattern>
 <pattern>üste4n</pattern>
+<pattern>üst3h</pattern>
 <pattern>üs4tl</pattern>
 <pattern>ü1su</pattern>
 <pattern>2üß</pattern>
 <pattern>üt3al</pattern>
 <pattern>ü3tan</pattern>
 <pattern>üt3au</pattern>
+<pattern>üte5me</pattern>
 <pattern>üte2n</pattern>
 <pattern>üten3s</pattern>
 <pattern>üter3a</pattern>
@@ -40082,12 +41162,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>1v</pattern>
 <pattern>2va </pattern>
 <pattern>2vaä</pattern>
-<pattern>2v1ab2</pattern>
-<pattern>v2abr</pattern>
+<pattern>2v1a2b2</pattern>
+<pattern>v2a3br</pattern>
 <pattern>vabro3</pattern>
 <pattern>vad2</pattern>
 <pattern>va3das</pattern>
-<pattern>2vae2</pattern>
+<pattern>2va1e2</pattern>
 <pattern>2vaf2</pattern>
 <pattern>va3fl</pattern>
 <pattern>va2g</pattern>
@@ -40117,18 +41197,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4vanze</pattern>
 <pattern>2vap</pattern>
 <pattern>2v3ar2b</pattern>
+<pattern>var4d3r</pattern>
 <pattern>va3rin</pattern>
 <pattern>va3riu</pattern>
 <pattern>v3ar2m</pattern>
 <pattern>2v3ar2t</pattern>
 <pattern>vas2</pattern>
 <pattern>vas3ek</pattern>
+<pattern>va2so</pattern>
 <pattern>v3ass</pattern>
 <pattern>vas3ta</pattern>
 <pattern>vas3to</pattern>
 <pattern>va2t3a2</pattern>
 <pattern>vatak4</pattern>
-<pattern>vat3ei</pattern>
+<pattern>vat3ei4</pattern>
 <pattern>vatem4</pattern>
 <pattern>va4t5emp</pattern>
 <pattern>va4teng</pattern>
@@ -40138,7 +41220,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>vat3h</pattern>
 <pattern>va4t3id</pattern>
 <pattern>va4t3in</pattern>
-<pattern>vat3m</pattern>
+<pattern>vat3me</pattern>
+<pattern>4v3atmo</pattern>
 <pattern>va4t3op</pattern>
 <pattern>va4t5ora</pattern>
 <pattern>va4t5ord</pattern>
@@ -40210,7 +41293,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ven3st</pattern>
 <pattern>ven4t5ag</pattern>
 <pattern>4v3entd</pattern>
-<pattern>venu4</pattern>
 <pattern>ven6z5ere</pattern>
 <pattern>2veo</pattern>
 <pattern>ve3of</pattern>
@@ -40246,11 +41328,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ve5reif</pattern>
 <pattern>ve5reig</pattern>
 <pattern>vere6in</pattern>
+<pattern>vereins5tr</pattern>
 <pattern>verei6s</pattern>
 <pattern>ve3rem</pattern>
 <pattern>veren4</pattern>
 <pattern>verer4</pattern>
 <pattern>ve3res</pattern>
+<pattern>ver5est</pattern>
 <pattern>verf4</pattern>
 <pattern>verg2</pattern>
 <pattern>3vergi</pattern>
@@ -40267,6 +41351,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4vertü</pattern>
 <pattern>vertü5ren</pattern>
 <pattern>ve3rus</pattern>
+<pattern>verz2</pattern>
 <pattern>verzo4</pattern>
 <pattern>verzu4</pattern>
 <pattern>ve3sa</pattern>
@@ -40295,6 +41380,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>vi3als</pattern>
 <pattern>vi4an</pattern>
 <pattern>vi5ans</pattern>
+<pattern>via3s</pattern>
 <pattern>via3t</pattern>
 <pattern>vi2b</pattern>
 <pattern>vi2c</pattern>
@@ -40430,7 +41516,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2vs</pattern>
 <pattern>v1sa</pattern>
 <pattern>v1se2</pattern>
-<pattern>v1so2</pattern>
+<pattern>vso2</pattern>
 <pattern>vson2</pattern>
 <pattern>v1s2p</pattern>
 <pattern>v3sta</pattern>
@@ -40466,7 +41552,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wa3bes</pattern>
 <pattern>wa3bi</pattern>
 <pattern>wa3bo</pattern>
-<pattern>wach6stub</pattern>
 <pattern>wach6tra</pattern>
 <pattern>wach6trä</pattern>
 <pattern>wachzu5h</pattern>
@@ -40504,10 +41589,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wal4t3h</pattern>
 <pattern>wal4t5in4</pattern>
 <pattern>wal4t3o</pattern>
+<pattern>wal4tri</pattern>
 <pattern>wal4tur</pattern>
 <pattern>walze4</pattern>
 <pattern>wal4zw</pattern>
 <pattern>wa3me</pattern>
+<pattern>wam4mei</pattern>
 <pattern>wana3</pattern>
 <pattern>wa3nas</pattern>
 <pattern>wan4dan</pattern>
@@ -40528,6 +41615,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wan4z3a</pattern>
 <pattern>wan6z5en6d</pattern>
 <pattern>wan4z5er</pattern>
+<pattern>war3de</pattern>
 <pattern>3ware</pattern>
 <pattern>ware3i</pattern>
 <pattern>warein4</pattern>
@@ -40538,6 +41626,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3warnu</pattern>
 <pattern>wart4st</pattern>
 <pattern>war3u</pattern>
+<pattern>war4za</pattern>
 <pattern>war6zent</pattern>
 <pattern>was2a</pattern>
 <pattern>wasch5ei</pattern>
@@ -40561,8 +41650,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wä3nen</pattern>
 <pattern>2wäng</pattern>
 <pattern>wär4me5d</pattern>
+<pattern>wärme5i</pattern>
 <pattern>wär4mes</pattern>
-<pattern>wäs4c</pattern>
 <pattern>2w1äu</pattern>
 <pattern>2wb</pattern>
 <pattern>w3bi</pattern>
@@ -40573,7 +41662,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>web3a</pattern>
 <pattern>we4be3a</pattern>
 <pattern>we4be3d</pattern>
-<pattern>we4bee</pattern>
+<pattern>we4be3e</pattern>
 <pattern>we4bei</pattern>
 <pattern>we4bel</pattern>
 <pattern>webe5la</pattern>
@@ -40591,6 +41680,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>we3cha</pattern>
 <pattern>we5cke </pattern>
 <pattern>we5ckes</pattern>
+<pattern>wecks4</pattern>
 <pattern>wee2</pattern>
 <pattern>weed3</pattern>
 <pattern>2wef</pattern>
@@ -40624,12 +41714,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2weif</pattern>
 <pattern>weifel6d</pattern>
 <pattern>weifs4</pattern>
+<pattern>weig3a</pattern>
 <pattern>wei4gem</pattern>
 <pattern>wei4geo</pattern>
 <pattern>wei4ge5p</pattern>
 <pattern>wei4gra</pattern>
 <pattern>3weihr</pattern>
-<pattern>wei3k2</pattern>
+<pattern>2wei3k2</pattern>
 <pattern>3weil</pattern>
 <pattern>wei3la</pattern>
 <pattern>wein5d</pattern>
@@ -40646,6 +41737,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>weis6sel</pattern>
 <pattern>weis6spi</pattern>
 <pattern>wei5str</pattern>
+<pattern>weit5erkr</pattern>
 <pattern>weit5ra</pattern>
 <pattern>wei5tri</pattern>
 <pattern>weit3s</pattern>
@@ -40702,6 +41794,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3werdu</pattern>
 <pattern>we4ref</pattern>
 <pattern>we4reg</pattern>
+<pattern>werer4</pattern>
+<pattern>we4rerz</pattern>
 <pattern>wer4fli</pattern>
 <pattern>wer4g3a</pattern>
 <pattern>wergel6</pattern>
@@ -40714,14 +41808,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>we3rin</pattern>
 <pattern>3werk </pattern>
 <pattern>wer4k3a</pattern>
+<pattern>wer4kä</pattern>
 <pattern>3werke</pattern>
 <pattern>wer4k3i</pattern>
 <pattern>wer4kl</pattern>
 <pattern>werk5lo</pattern>
-<pattern>wer4k3o</pattern>
+<pattern>wer4kop</pattern>
+<pattern>wer4k5or</pattern>
 <pattern>wer4k5re</pattern>
 <pattern>wer4ku</pattern>
 <pattern>wer4kü</pattern>
+<pattern>wer3ö</pattern>
 <pattern>wer3s4h</pattern>
 <pattern>wer6star</pattern>
 <pattern>wert3a</pattern>
@@ -40730,7 +41827,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wer4tel</pattern>
 <pattern>wer6terg</pattern>
 <pattern>wer6t5erm</pattern>
+<pattern>wer6t5erö</pattern>
 <pattern>wert3h</pattern>
+<pattern>3werti</pattern>
 <pattern>wer4t5in</pattern>
 <pattern>wer4t3o4</pattern>
 <pattern>3wertp</pattern>
@@ -40738,8 +41837,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wer4t5ri</pattern>
 <pattern>werts4t</pattern>
 <pattern>wer4t5um</pattern>
+<pattern>wer4t5ur4</pattern>
 <pattern>we2s</pattern>
-<pattern>wes3p</pattern>
+<pattern>wes5pen</pattern>
 <pattern>we4st</pattern>
 <pattern>west3a</pattern>
 <pattern>weste4</pattern>
@@ -40777,12 +41877,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wi2d</pattern>
 <pattern>wie1</pattern>
 <pattern>2wieb</pattern>
-<pattern>3wied</pattern>
 <pattern>wie5n4e</pattern>
 <pattern>wie4st</pattern>
 <pattern>wi4ga</pattern>
 <pattern>wi3ger</pattern>
-<pattern>wil4da</pattern>
+<pattern>wil4d3a</pattern>
 <pattern>wil4dr</pattern>
 <pattern>wim4ma</pattern>
 <pattern>wim6m5ent</pattern>
@@ -40800,12 +41899,15 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>3winer</pattern>
 <pattern>win4gl</pattern>
 <pattern>win4g3r</pattern>
+<pattern>wings4</pattern>
+<pattern>wing5se</pattern>
 <pattern>wi3ni</pattern>
 <pattern>win4kl</pattern>
 <pattern>winn5er6sc</pattern>
 <pattern>win4no</pattern>
 <pattern>winn5str</pattern>
 <pattern>wins2</pattern>
+<pattern>win5se</pattern>
 <pattern>win3sk</pattern>
 <pattern>win5te</pattern>
 <pattern>wire3</pattern>
@@ -40819,6 +41921,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wiss4z</pattern>
 <pattern>wist3r</pattern>
 <pattern>wi3th</pattern>
+<pattern>3witzi</pattern>
 <pattern>3witzl</pattern>
 <pattern>wi2z</pattern>
 <pattern>w2j</pattern>
@@ -40858,6 +41961,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wor6t5erh</pattern>
 <pattern>wor5tes</pattern>
 <pattern>wort3h</pattern>
+<pattern>wor4ti</pattern>
 <pattern>wor4t3r</pattern>
 <pattern>3wort3s</pattern>
 <pattern>wor3u</pattern>
@@ -40869,6 +41973,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wöl6best</pattern>
 <pattern>wöl4fa</pattern>
 <pattern>wöl4fo</pattern>
+<pattern>4wölft</pattern>
 <pattern>wö3re</pattern>
 <pattern>wör2g</pattern>
 <pattern>wör5the</pattern>
@@ -40879,12 +41984,14 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2w1ro</pattern>
 <pattern>2w1s</pattern>
 <pattern>wse2</pattern>
-<pattern>wser3</pattern>
+<pattern>wser3e</pattern>
 <pattern>wser4s</pattern>
 <pattern>ws2h</pattern>
 <pattern>w2ska</pattern>
+<pattern>ws2ki</pattern>
+<pattern>ws2ky</pattern>
 <pattern>ws2t</pattern>
-<pattern>w2s3u</pattern>
+<pattern>w2s1u</pattern>
 <pattern>2w1t2</pattern>
 <pattern>wta2</pattern>
 <pattern>w3ti</pattern>
@@ -40898,6 +42005,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>wun4da</pattern>
 <pattern>wun4dä</pattern>
 <pattern>wun4di</pattern>
+<pattern>2wung</pattern>
 <pattern>wun4g3r</pattern>
 <pattern>wun2s</pattern>
 <pattern>wunsch5ei</pattern>
@@ -40947,6 +42055,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>x3ami</pattern>
 <pattern>x1an</pattern>
 <pattern>x2an </pattern>
+<pattern>x3an2b</pattern>
 <pattern>x2ane</pattern>
 <pattern>xan2n</pattern>
 <pattern>xansa3</pattern>
@@ -41001,6 +42110,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>xhave3</pattern>
 <pattern>xhä2</pattern>
 <pattern>xhi2</pattern>
+<pattern>2xia</pattern>
 <pattern>1xib</pattern>
 <pattern>xi1c</pattern>
 <pattern>xi3dan</pattern>
@@ -41011,7 +42121,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>xie3l</pattern>
 <pattern>xi1g</pattern>
 <pattern>xi1k2</pattern>
-<pattern>xi3lan</pattern>
+<pattern>xi3l4an</pattern>
 <pattern>xil3au</pattern>
 <pattern>xi4l3er4</pattern>
 <pattern>xilli4</pattern>
@@ -41046,6 +42156,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>xmi2</pattern>
 <pattern>x1n</pattern>
 <pattern>xna2</pattern>
+<pattern>xoe2</pattern>
 <pattern>xoge2</pattern>
 <pattern>x1ol</pattern>
 <pattern>x2on</pattern>
@@ -41054,13 +42165,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>x3org</pattern>
 <pattern>xori3</pattern>
 <pattern>xos2</pattern>
-<pattern>x1ö</pattern>
+<pattern>x1ö2</pattern>
 <pattern>2xp</pattern>
 <pattern>x1pa</pattern>
 <pattern>x3par</pattern>
 <pattern>x4po </pattern>
 <pattern>xpo4ni</pattern>
-<pattern>xpor6t5er6</pattern>
+<pattern>xpor6t5er</pattern>
 <pattern>xpor4t5r</pattern>
 <pattern>x1pr</pattern>
 <pattern>x1pu</pattern>
@@ -41093,8 +42204,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>x4t3er4w</pattern>
 <pattern>xt3e2v</pattern>
 <pattern>x2t3ex2</pattern>
-<pattern>x3the</pattern>
-<pattern>xt3hi</pattern>
+<pattern>xt1h</pattern>
 <pattern>x2t3id</pattern>
 <pattern>xti4lin</pattern>
 <pattern>xt5illu</pattern>
@@ -41110,9 +42220,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>xtra3c</pattern>
 <pattern>x3trah</pattern>
 <pattern>xtra3l</pattern>
-<pattern>xt3ran</pattern>
+<pattern>xt5rand</pattern>
 <pattern>xt3rau</pattern>
 <pattern>xt3rec</pattern>
+<pattern>xt3rep</pattern>
 <pattern>xt3res</pattern>
 <pattern>x3tri</pattern>
 <pattern>x3tros</pattern>
@@ -41149,12 +42260,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ya2k2</pattern>
 <pattern>ya3la</pattern>
 <pattern>yal2t</pattern>
-<pattern>ya2m</pattern>
 <pattern>y3an2z</pattern>
 <pattern>1yaq</pattern>
 <pattern>ya3ra</pattern>
 <pattern>yar2b</pattern>
-<pattern>ya3re</pattern>
 <pattern>yar2t</pattern>
 <pattern>yase3</pattern>
 <pattern>y1au</pattern>
@@ -41178,7 +42287,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>y3do</pattern>
 <pattern>ydri2</pattern>
 <pattern>ydrid3</pattern>
-<pattern>yd4ro</pattern>
 <pattern>y1e2d</pattern>
 <pattern>y1ei</pattern>
 <pattern>y2e1l</pattern>
@@ -41224,7 +42332,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>y5lant </pattern>
 <pattern>y5l4ante</pattern>
 <pattern>y5l4anti</pattern>
-<pattern>ylar2</pattern>
+<pattern>yl3ar2</pattern>
 <pattern>y3las</pattern>
 <pattern>y3lat</pattern>
 <pattern>ylau2</pattern>
@@ -41235,7 +42343,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ylde2</pattern>
 <pattern>yle2</pattern>
 <pattern>y3leb</pattern>
-<pattern>yl3est</pattern>
+<pattern>yl3es</pattern>
 <pattern>yl3et</pattern>
 <pattern>ylge2</pattern>
 <pattern>yli2</pattern>
@@ -41284,10 +42392,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2yo </pattern>
 <pattern>yo3d</pattern>
 <pattern>yof2</pattern>
+<pattern>yoff3</pattern>
 <pattern>1yo2g</pattern>
 <pattern>yog4a3</pattern>
 <pattern>yo1m</pattern>
 <pattern>y2on</pattern>
+<pattern>yonal5s4</pattern>
 <pattern>y3ont</pattern>
 <pattern>yor2g</pattern>
 <pattern>yo1s</pattern>
@@ -41307,9 +42417,11 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>y2po1</pattern>
 <pattern>ypo3t2</pattern>
 <pattern>yp1p</pattern>
+<pattern>yp2so</pattern>
 <pattern>yp3th</pattern>
 <pattern>yp3um</pattern>
 <pattern>y2q</pattern>
+<pattern>yra3s</pattern>
 <pattern>y3rau</pattern>
 <pattern>y1rä</pattern>
 <pattern>y3räe</pattern>
@@ -41340,7 +42452,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ysma5len</pattern>
 <pattern>ysma5ler</pattern>
 <pattern>y3s2n</pattern>
-<pattern>y1so</pattern>
 <pattern>ys2po</pattern>
 <pattern>yspra3</pattern>
 <pattern>yst4e</pattern>
@@ -41412,6 +42523,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>z5an4ge5l</pattern>
 <pattern>zan5gen</pattern>
 <pattern>zange5s</pattern>
+<pattern>z3angl</pattern>
 <pattern>zan4gr</pattern>
 <pattern>4z3angs</pattern>
 <pattern>2z3an2h</pattern>
@@ -41430,7 +42542,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2zan2w</pattern>
 <pattern>zanwei5</pattern>
 <pattern>2zan2z</pattern>
-<pattern>2za1o2</pattern>
+<pattern>2zao2</pattern>
 <pattern>za2p</pattern>
 <pattern>zapf3l</pattern>
 <pattern>2z3apo</pattern>
@@ -41463,19 +42575,24 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2z3au2f3</pattern>
 <pattern>2z3au2g</pattern>
 <pattern>2z3auk</pattern>
+<pattern>3zaun</pattern>
 <pattern>z3aur</pattern>
 <pattern>z3ausb</pattern>
 <pattern>z3ausf</pattern>
 <pattern>z3ausl</pattern>
 <pattern>4z3auss</pattern>
 <pattern>z3ausw</pattern>
+<pattern>2z3auß</pattern>
 <pattern>2z3aut</pattern>
 <pattern>2zav</pattern>
 <pattern>2z1äc</pattern>
+<pattern>zäh4lin</pattern>
 <pattern>4zähnl</pattern>
 <pattern>zäh3r</pattern>
 <pattern>2z1äm2</pattern>
-<pattern>z1än2</pattern>
+<pattern>zän2</pattern>
+<pattern>2z3änd</pattern>
+<pattern>z3ängs</pattern>
 <pattern>z1äp</pattern>
 <pattern>z3är2g</pattern>
 <pattern>2z3är2m</pattern>
@@ -41485,6 +42602,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2zäuß</pattern>
 <pattern>2zäx</pattern>
 <pattern>2zb2</pattern>
+<pattern>zbach3</pattern>
 <pattern>z3be2</pattern>
 <pattern>zbele3</pattern>
 <pattern>zber4e</pattern>
@@ -41514,13 +42632,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4z3echo</pattern>
 <pattern>zech3s</pattern>
 <pattern>ze2de</pattern>
-<pattern>ze4dik</pattern>
 <pattern>2zedü</pattern>
 <pattern>2ze1e2</pattern>
 <pattern>2zef2</pattern>
 <pattern>z3eff</pattern>
 <pattern>ze3fl</pattern>
 <pattern>ze1g</pattern>
+<pattern>2zega</pattern>
 <pattern>ze3ha</pattern>
 <pattern>zehe2</pattern>
 <pattern>zehen3</pattern>
@@ -41530,6 +42648,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>ze3ho</pattern>
 <pattern>zeibe4</pattern>
 <pattern>zei6che </pattern>
+<pattern>zei5cho</pattern>
 <pattern>zei3de</pattern>
 <pattern>zei3f</pattern>
 <pattern>zei4ge5g</pattern>
@@ -41548,7 +42667,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zein3e</pattern>
 <pattern>z4eino</pattern>
 <pattern>zein3s</pattern>
-<pattern>ze5in4se</pattern>
+<pattern>ze5inse</pattern>
 <pattern>zeis2</pattern>
 <pattern>zei3sk</pattern>
 <pattern>zei3so</pattern>
@@ -41562,11 +42681,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zei5ter </pattern>
 <pattern>zei4t3o</pattern>
 <pattern>zeit5ri</pattern>
-<pattern>zeit5so</pattern>
 <pattern>2ze1k</pattern>
 <pattern>zel5abr</pattern>
 <pattern>zel3ad</pattern>
-<pattern>4ze3la4g</pattern>
+<pattern>zela4g</pattern>
 <pattern>zel3am</pattern>
 <pattern>zela4n</pattern>
 <pattern>zel5ane</pattern>
@@ -41612,6 +42730,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zen5ene</pattern>
 <pattern>zen5erke</pattern>
 <pattern>zen5erw</pattern>
+<pattern>zenes4</pattern>
+<pattern>zen5ess</pattern>
 <pattern>ze4neu</pattern>
 <pattern>zenfla5</pattern>
 <pattern>4z5enge </pattern>
@@ -41621,16 +42741,18 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zen3n</pattern>
 <pattern>zen3o</pattern>
 <pattern>zenot4</pattern>
+<pattern>zen4san</pattern>
 <pattern>zen4ser</pattern>
-<pattern>zen5spo</pattern>
-<pattern>zen3st</pattern>
+<pattern>zen5s4po</pattern>
+<pattern>zen5sta</pattern>
 <pattern>zen5tei</pattern>
 <pattern>zen5the</pattern>
 <pattern>zenti4s</pattern>
-<pattern>4zentna</pattern>
+<pattern>4z5entna</pattern>
 <pattern>4z5en4tro</pattern>
 <pattern>zent3s</pattern>
 <pattern>zen4z5ar</pattern>
+<pattern>zen6z5er6s</pattern>
 <pattern>zen6zert</pattern>
 <pattern>zen6zerw</pattern>
 <pattern>zen4zin</pattern>
@@ -41645,40 +42767,43 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zeppe3</pattern>
 <pattern>zer3ab4</pattern>
 <pattern>zer3ad4</pattern>
+<pattern>zer3a4g</pattern>
 <pattern>zeral4</pattern>
 <pattern>zer3an4</pattern>
 <pattern>zer3at</pattern>
 <pattern>4z3erbi</pattern>
-<pattern>zer3ed</pattern>
 <pattern>6z5ereign</pattern>
 <pattern>ze4rein</pattern>
 <pattern>4zerek</pattern>
 <pattern>zer5end</pattern>
+<pattern>zer5ent</pattern>
 <pattern>zerer4</pattern>
 <pattern>zer5erw</pattern>
+<pattern>ze4r3e4t</pattern>
 <pattern>zer6fahru</pattern>
 <pattern>zer6fass</pattern>
-<pattern>z3erfo</pattern>
+<pattern>zer6ford</pattern>
 <pattern>4z5er4fül</pattern>
 <pattern>4z3er4gä</pattern>
 <pattern>zer6grei</pattern>
 <pattern>4z3er4gu</pattern>
 <pattern>zer6halt</pattern>
+<pattern>4z5er4hel</pattern>
 <pattern>4z5erhöh</pattern>
-<pattern>zer3i4d</pattern>
+<pattern>ze4r3i4d</pattern>
 <pattern>zerindi5</pattern>
-<pattern>z5erkra</pattern>
 <pattern>5zerl </pattern>
 <pattern>zer6lang</pattern>
 <pattern>4z5er4leb</pattern>
 <pattern>zer5lebe</pattern>
 <pattern>zerlö5sen</pattern>
 <pattern>4z5er4mäc</pattern>
+<pattern>5zerme</pattern>
 <pattern>zermi4</pattern>
-<pattern>4z5er4mit</pattern>
 <pattern>zer4nan</pattern>
 <pattern>zer4n5eb</pattern>
 <pattern>zernei4</pattern>
+<pattern>zern3o</pattern>
 <pattern>4zeroh</pattern>
 <pattern>2zer2ö</pattern>
 <pattern>zerör3</pattern>
@@ -41690,6 +42815,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4z3ersä</pattern>
 <pattern>zer4sät</pattern>
 <pattern>4zersd</pattern>
+<pattern>6z5er6strec</pattern>
 <pattern>zer4t5ag</pattern>
 <pattern>zert5ak6te</pattern>
 <pattern>zer5tant</pattern>
@@ -41702,11 +42828,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zer6trag </pattern>
 <pattern>zer6trags</pattern>
 <pattern>zer6t5rau</pattern>
-<pattern>4z5erträ</pattern>
-<pattern>zer6träg</pattern>
 <pattern>zer6wart</pattern>
 <pattern>zer6weit</pattern>
-<pattern>zer6werb</pattern>
+<pattern>6z5er6werb</pattern>
+<pattern>z4es </pattern>
 <pattern>ze4s3au</pattern>
 <pattern>4zesch</pattern>
 <pattern>zes3er4</pattern>
@@ -41727,8 +42852,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zes6s5orte </pattern>
 <pattern>zes6s5or6ten</pattern>
 <pattern>zes6s5orts</pattern>
-<pattern>zes4s3p</pattern>
-<pattern>zes4ste</pattern>
+<pattern>zes4spa</pattern>
 <pattern>zes4sum</pattern>
 <pattern>zes4s5ur4</pattern>
 <pattern>ze5stau</pattern>
@@ -41779,13 +42903,16 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zhau4t3</pattern>
 <pattern>2zi </pattern>
 <pattern>zi2a</pattern>
+<pattern>zia4lin</pattern>
 <pattern>4zian </pattern>
 <pattern>4zians</pattern>
 <pattern>3ziat</pattern>
 <pattern>2zib</pattern>
 <pattern>zich6ter</pattern>
 <pattern>zi2da</pattern>
+<pattern>zid3ak</pattern>
 <pattern>zid3ei</pattern>
+<pattern>zideut4</pattern>
 <pattern>zie4hei</pattern>
 <pattern>ziel3a</pattern>
 <pattern>ziele4</pattern>
@@ -41797,6 +42924,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zien3s</pattern>
 <pattern>zi3ent</pattern>
 <pattern>zi3enz</pattern>
+<pattern>zie4r5ei</pattern>
 <pattern>4zierk</pattern>
 <pattern>zif4fr</pattern>
 <pattern>zi3fl</pattern>
@@ -41823,8 +42951,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zi3nat</pattern>
 <pattern>4z3inde</pattern>
 <pattern>zindi5v</pattern>
-<pattern>4z3in4du</pattern>
-<pattern>3z4ine</pattern>
+<pattern>zin4duk</pattern>
+<pattern>3zine</pattern>
 <pattern>zi3ner</pattern>
 <pattern>zi4net</pattern>
 <pattern>zin4fe</pattern>
@@ -41834,11 +42962,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4z3init</pattern>
 <pattern>zin4je</pattern>
 <pattern>zinkan4</pattern>
+<pattern>zin6k5erz</pattern>
 <pattern>zin4k3l</pattern>
 <pattern>zin4na</pattern>
 <pattern>zi3nol</pattern>
 <pattern>zi3nom</pattern>
-<pattern>zin4sa</pattern>
+<pattern>4z3in4sa</pattern>
 <pattern>zin4ser</pattern>
 <pattern>4zinsuf</pattern>
 <pattern>zin2t</pattern>
@@ -41877,6 +43006,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>z3kys</pattern>
 <pattern>2z1l</pattern>
 <pattern>zla2</pattern>
+<pattern>zland5er</pattern>
 <pattern>zla3r</pattern>
 <pattern>zle2d</pattern>
 <pattern>zle2g</pattern>
@@ -41916,19 +43046,21 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zo3ke</pattern>
 <pattern>zo2l</pattern>
 <pattern>zol5ant</pattern>
-<pattern>4zoli</pattern>
+<pattern>4zoli2</pattern>
 <pattern>zo3lin</pattern>
 <pattern>zol4l3a</pattern>
 <pattern>zol4l5ei4</pattern>
 <pattern>zol6l5en6t5</pattern>
 <pattern>zoller4</pattern>
 <pattern>zol6lerf</pattern>
+<pattern>zol6l5erk</pattern>
 <pattern>zol6l5erl</pattern>
 <pattern>zol6lert</pattern>
 <pattern>zol4lin</pattern>
 <pattern>zol4lo</pattern>
 <pattern>zolls4</pattern>
 <pattern>zoll5ste</pattern>
+<pattern>z3oly</pattern>
 <pattern>2zom</pattern>
 <pattern>zoma2</pattern>
 <pattern>3z2o2n</pattern>
@@ -41944,8 +43076,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zo3pi</pattern>
 <pattern>2zopt</pattern>
 <pattern>z1or</pattern>
-<pattern>zor2d</pattern>
-<pattern>zor2g</pattern>
+<pattern>2zorc</pattern>
+<pattern>2zor2d</pattern>
+<pattern>2zor2g</pattern>
 <pattern>zo2ri3</pattern>
 <pattern>zor4n3a</pattern>
 <pattern>zor4ne</pattern>
@@ -41957,8 +43090,10 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2z3osz</pattern>
 <pattern>2z1ou2</pattern>
 <pattern>zo2w</pattern>
+<pattern>2z1ox</pattern>
 <pattern>2zoz</pattern>
 <pattern>zö2b</pattern>
+<pattern>2z1ö2d</pattern>
 <pattern>2z1öf2</pattern>
 <pattern>2z1ök</pattern>
 <pattern>z1öl</pattern>
@@ -41986,14 +43121,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>z3ru</pattern>
 <pattern>zrück3</pattern>
 <pattern>2z1s2</pattern>
+<pattern>z3sa</pattern>
 <pattern>zsau2</pattern>
 <pattern>zseu3</pattern>
 <pattern>zsi2</pattern>
 <pattern>z3sl</pattern>
+<pattern>z3sp</pattern>
 <pattern>zspra3</pattern>
 <pattern>zspre3</pattern>
 <pattern>zspu3</pattern>
 <pattern>z3st</pattern>
+<pattern>zstart5</pattern>
 <pattern>2z1t</pattern>
 <pattern>zta2b</pattern>
 <pattern>zt3abr</pattern>
@@ -42011,7 +43149,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zt5eins</pattern>
 <pattern>z2te3k</pattern>
 <pattern>z4te3ma</pattern>
-<pattern>zt3en4g</pattern>
 <pattern>z4t3ent</pattern>
 <pattern>zte3o</pattern>
 <pattern>z4tero</pattern>
@@ -42031,8 +43168,9 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zt3inf</pattern>
 <pattern>zt3ins</pattern>
 <pattern>z3to2</pattern>
+<pattern>zt4or</pattern>
 <pattern>zt3rec</pattern>
-<pattern>zt1s2</pattern>
+<pattern>zts2</pattern>
 <pattern>ztu2</pattern>
 <pattern>z4t3urs</pattern>
 <pattern>ztursa5</pattern>
@@ -42082,7 +43220,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4zufügu</pattern>
 <pattern>zu4g5ans</pattern>
 <pattern>zug3ar</pattern>
-<pattern>zu4gat</pattern>
+<pattern>zu4g3at4</pattern>
 <pattern>4zugebt</pattern>
 <pattern>4zuged</pattern>
 <pattern>4zugef</pattern>
@@ -42102,13 +43240,13 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zu4grä</pattern>
 <pattern>zu4gren</pattern>
 <pattern>zu4gs</pattern>
-<pattern>zug5sti</pattern>
 <pattern>zug5sto</pattern>
 <pattern>zuh2</pattern>
 <pattern>zu4han</pattern>
 <pattern>zu4har</pattern>
 <pattern>zu4höh</pattern>
 <pattern>2z3uhr</pattern>
+<pattern>zui2</pattern>
 <pattern>zuin2</pattern>
 <pattern>zu2ja</pattern>
 <pattern>zu4kal</pattern>
@@ -42132,7 +43270,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zum2</pattern>
 <pattern>2z3um </pattern>
 <pattern>2z3umb</pattern>
-<pattern>zumen4</pattern>
+<pattern>zumen4s</pattern>
 <pattern>2z3umf</pattern>
 <pattern>2z3umg</pattern>
 <pattern>zumge3</pattern>
@@ -42159,7 +43297,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>4z3un4gl</pattern>
 <pattern>zungs3</pattern>
 <pattern>z3unio</pattern>
-<pattern>4zuniv</pattern>
+<pattern>zu4niv</pattern>
 <pattern>2zun2r</pattern>
 <pattern>2z3un2s</pattern>
 <pattern>zunsi3</pattern>
@@ -42167,8 +43305,8 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zuo2</pattern>
 <pattern>zu2pe</pattern>
 <pattern>zu2pf</pattern>
-<pattern>zu4pfe</pattern>
 <pattern>zup4fi</pattern>
+<pattern>zu5pflas</pattern>
 <pattern>zu3pfr</pattern>
 <pattern>zu2pl</pattern>
 <pattern>zu2po</pattern>
@@ -42190,6 +43328,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zu4schö</pattern>
 <pattern>3zus4e2</pattern>
 <pattern>zu4sin</pattern>
+<pattern>zu2so</pattern>
 <pattern>zus4p</pattern>
 <pattern>zuspi5c</pattern>
 <pattern>zus4t</pattern>
@@ -42198,8 +43337,6 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zu4stu</pattern>
 <pattern>zut4a2</pattern>
 <pattern>zu3tap</pattern>
-<pattern>zu2ti</pattern>
-<pattern>zu3tie</pattern>
 <pattern>zuti4s</pattern>
 <pattern>zuto2</pattern>
 <pattern>zu3tor</pattern>
@@ -42224,18 +43361,20 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zvi2</pattern>
 <pattern>z3vo</pattern>
 <pattern>zwa5cke</pattern>
-<pattern>2z3wag</pattern>
+<pattern>2zwaf</pattern>
+<pattern>2zwag</pattern>
 <pattern>2z3wah</pattern>
 <pattern>2zwal</pattern>
-<pattern>4z3wand</pattern>
+<pattern>4zwand</pattern>
 <pattern>zwander6</pattern>
 <pattern>z4wang</pattern>
 <pattern>2z3wap</pattern>
-<pattern>2z3was</pattern>
+<pattern>2zwas</pattern>
 <pattern>2zwäc</pattern>
 <pattern>2zwär2</pattern>
-<pattern>2z3wäs</pattern>
+<pattern>2zwäs</pattern>
 <pattern>zwe2</pattern>
+<pattern>2zweb</pattern>
 <pattern>z2wec</pattern>
 <pattern>4z3wech</pattern>
 <pattern>zwe5cken </pattern>
@@ -42245,17 +43384,17 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>2zweh</pattern>
 <pattern>z4weig</pattern>
 <pattern>4zweil</pattern>
-<pattern>zwei5sp</pattern>
-<pattern>2z3wel</pattern>
+<pattern>zwei6terk</pattern>
+<pattern>2zwel</pattern>
 <pattern>2zwen</pattern>
 <pattern>z4werg</pattern>
-<pattern>4z3werk</pattern>
+<pattern>4zwerk</pattern>
 <pattern>4zwert</pattern>
 <pattern>2zwes</pattern>
 <pattern>z2wic</pattern>
 <pattern>zwi5cke</pattern>
 <pattern>2zwid</pattern>
-<pattern>4zwied</pattern>
+<pattern>4z5wied</pattern>
 <pattern>4zwild</pattern>
 <pattern>z4wing</pattern>
 <pattern>4zwirr</pattern>
@@ -42263,13 +43402,12 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>z4wisc</pattern>
 <pattern>4zwiss</pattern>
 <pattern>z4wist</pattern>
-<pattern>2z3wo</pattern>
-<pattern>2z3wur</pattern>
+<pattern>2zwo</pattern>
+<pattern>2zwur</pattern>
 <pattern>zwur4m3</pattern>
 <pattern>2zwü</pattern>
 <pattern>2zy </pattern>
 <pattern>3zyk</pattern>
-<pattern>zyl3e</pattern>
 <pattern>2zym</pattern>
 <pattern>3zymb</pattern>
 <pattern>3zy2m3i</pattern>
@@ -42281,6 +43419,7 @@ preamble of de-1996_hyphenmin3-2021-01-08.pat
 <pattern>zza3d</pattern>
 <pattern>z3zas </pattern>
 <pattern>zza3t</pattern>
+<pattern>zz3ens</pattern>
 <pattern>z3zer</pattern>
 <pattern>zze3s</pattern>
 <pattern>z3zia</pattern>


### PR DESCRIPTION
After 23 months a new version of the dehypn-exptl patterns were released: https://ctan.org/pkg/dehyph-exptl?lang=de

The new patterns in this PR are based on dehypn-expt 0.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/431)
<!-- Reviewable:end -->
