### PR TITLE
Fonts: more granular weights (real and synthetic)

### DIFF
--- a/crengine/include/lvarray.h
+++ b/crengine/include/lvarray.h
@@ -225,6 +225,16 @@ public:
         _array[pos] = item;
         _count++;
     }
+
+    /// returns index of specified value, -1 if not found
+    int indexOf(int value) const {
+        for ( int i=0; i<_count; i++ ) {
+            if ( _array[i] == value )
+                return i;
+        }
+        return -1;
+    }
+
     /// returns array pointer
     T * ptr() const { return _array; }
     /// destructor

--- a/crengine/include/lvdocviewcmd.h
+++ b/crengine/include/lvdocviewcmd.h
@@ -31,7 +31,7 @@ enum LVDocCmd
     DCMD_ROTATE_SET, // rotate viewm param = 0..3 (0=normal, 1=90`, ...)
     DCMD_SAVE_HISTORY, // save history and bookmarks
     DCMD_SAVE_TO_CACHE, // save document to cache for fast opening
-    DCMD_TOGGLE_BOLD, // togle font bolder attribute
+    DCMD_SET_BASE_FONT_WEIGHT, // set base font weight globally, replaces DCMD_TOGGLE_BOLD
     DCMD_SCROLL_BY, // scroll by N pixels, for Scroll view mode only
     DCMD_REQUEST_RENDER, // invalidate rendered data
     DCMD_GO_PAGE_DONT_SAVE_HISTORY,

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -9,7 +9,7 @@
 #define PROP_FONT_KERNING            "font.kerning.mode"
 #define PROP_FONT_COLOR              "font.color.default"
 #define PROP_FONT_FACE               "font.face.default"
-#define PROP_FONT_WEIGHT_EMBOLDEN    "font.face.weight.embolden"
+#define PROP_FONT_BASE_WEIGHT        "font.face.base.weight"        // replaces PROP_FONT_WEIGHT_EMBOLDEN ("font.face.weight.embolden")
 #define PROP_BACKGROUND_COLOR        "background.color.default"
 #define PROP_BACKGROUND_IMAGE        "background.image.filename"
 #define PROP_TXT_OPTION_PREFORMATTED "crengine.file.txt.preformatted"

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -599,7 +599,7 @@ public:
     /// registers font by name
     virtual bool RegisterFont( lString8 name ) = 0;
     /// registers font by name and face
-    virtual bool RegisterExternalFont(lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
+    virtual bool RegisterExternalFont(int /*documentId*/, lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// registers document font
     virtual bool RegisterDocumentFont(int /*documentId*/, LVContainerRef /*container*/, lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// unregisters all document fonts

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -608,6 +608,9 @@ public:
     virtual bool RegisterDocumentFont(int /*documentId*/, LVContainerRef /*container*/, lString32 /*name*/, lString8 /*face*/, bool /*bold*/, bool /*italic*/) { return false; }
     /// unregisters all document fonts
     virtual void UnregisterDocumentFonts(int /*documentId*/) { }
+    /// makes sure registered fonts have a proper entry at weight 400 and 700 when possible,
+    /// to avoid having synthesized fonts for these normal and bold weights
+    virtual void RegularizeRegisteredFontsWeights(bool print_changes=false) { }
     /// initializes font manager
     virtual bool Init( lString8 path ) = 0;
     /// get count of registered fonts

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -588,6 +588,10 @@ public:
     /// returns most similar font
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features=0, int documentId = -1, bool useBias=false) = 0;
+
+    /// return available font weight values
+    virtual void GetAvailableFontWeights(LVArray<int>& weights, lString8 typeface) = 0;
+
     /// set fallback font faces (separated by '|')
     virtual bool SetFallbackFontFaces( lString8 facesString ) { CR_UNUSED(facesString); return false; }
     /// get fallback font faces string (returns empty string if no fallback font is set)

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -161,13 +161,9 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
 // simpler function for first call:
 void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direction=REND_DIRECTION_UNSET, bool ignorePadding=false, int rendFlags=0);
 
-#define STYLE_FONT_EMBOLD_MODE_NORMAL 0
-#define STYLE_FONT_EMBOLD_MODE_EMBOLD 300
-
-/// set global document font style embolden mode (0=off, 300=on)
-void LVRendSetFontEmbolden( int addWidth=STYLE_FONT_EMBOLD_MODE_EMBOLD );
-/// get global document font style embolden mode
-int LVRendGetFontEmbolden();
+// Set/get global document base font weight.
+void LVRendSetBaseFontWeight(int weight);
+int LVRendGetBaseFontWeight();
 
 int measureBorder(ldomNode *enode,int border);
 int lengthToPx( ldomNode *node, css_length_t val, int base_px, int base_em = -1, bool unspecified_as_em=false );

--- a/crengine/include/props.h
+++ b/crengine/include/props.h
@@ -67,6 +67,8 @@ public:
     virtual void limitValueList( const char * propName, const char * values[] );
     /// do validation and corrections
     virtual void limitValueList( const char * propName, int values[], int value_count );
+    /// do validation and corrections
+    virtual void limitValueList( const char * propName, int values[], int value_count, int defValueIndex );
 
     /// get int property by name, returns false if not found
     virtual bool getInt( const char * propName, int &result ) const;

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -2081,7 +2081,10 @@ void MakeStatsForFile( const char * fname, const char * cp_name, const char * la
    int buf_size = ftell(in);
    fseek( in, 0, SEEK_SET );
    unsigned char * buf = new unsigned char[buf_size];
-   (void) fread(buf, 1, buf_size, in);
+   if ( fread(buf, 1, buf_size, in) != buf_size ) {
+       fclose(in);
+       return;
+   }
    short char_stat[256] = { 0 };
    dbl_char_stat_t dbl_char_stat[DBL_CHAR_STAT_SIZE];
    bool skipHtml = hasXmlTags(buf, buf_size);

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -822,7 +822,8 @@ public:
                     state = 2;
             else if (state == 1) {                // ex. [<secure/_stdio.h> or 5/3]
                     tmp<<('/');
-                    state = 0;
+                    if (c != ('/'))               // stay in state 1 if [//]
+                        state = 0;
             }
             else if (state == 2 && c == ('*'))    // ex. [/*he*]
                     state = 3;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2833,7 +2833,7 @@ void LVDocView::setRenderProps(int dx, int dy) {
 
 	lString8 fontName = lString8(DEFAULT_FONT_NAME);
 	m_font_size = scaleFontSizeForDPI(m_requested_font_size);
-	m_font = fontMan->GetFont(m_font_size, 400 + LVRendGetFontEmbolden(),
+	m_font = fontMan->GetFont(m_font_size, LVRendGetBaseFontWeight(),
 			false, DEFAULT_FONT_FAMILY, m_defaultFontFace);
 	//m_font = LVCreateFontTransform( m_font, LVFONT_TRANSFORM_EMBOLDEN );
 	m_infoFont = fontMan->GetFont(m_status_font_size, 400, false,
@@ -5837,14 +5837,13 @@ int LVDocView::doCommand(LVDocCmd cmd, int param) {
     case DCMD_REQUEST_RENDER:
         REQUEST_RENDER("doCommand-request render")
 		break;
-	case DCMD_TOGGLE_BOLD: {
-		int b = m_props->getIntDef(PROP_FONT_WEIGHT_EMBOLDEN, 0) ? 0 : 1;
-		m_props->setInt(PROP_FONT_WEIGHT_EMBOLDEN, b);
-		LVRendSetFontEmbolden(b ? STYLE_FONT_EMBOLD_MODE_EMBOLD
-				: STYLE_FONT_EMBOLD_MODE_NORMAL);
-        REQUEST_RENDER("doCommand-toggle bold")
-	}
-		break;
+    case DCMD_SET_BASE_FONT_WEIGHT: {
+        // replaces DCMD_TOGGLE_BOLD
+        m_props->setInt(PROP_FONT_BASE_WEIGHT, param);
+        LVRendSetBaseFontWeight(param);
+        REQUEST_RENDER("doCommand-set font weight")
+        break;
+    }
 	case DCMD_TOGGLE_PAGE_SCROLL_VIEW: {
 		toggleViewMode();
 	}
@@ -6297,8 +6296,9 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #endif
 	static int bool_options_def_true[] = { 1, 0 };
 	static int bool_options_def_false[] = { 0, 1 };
+	static int int_option_weight[] = { 100, 200, 300, 400, 425, 450, 475, 500, 525, 550, 600, 650, 700, 800, 900, 950 };
 
-	props->limitValueList(PROP_FONT_WEIGHT_EMBOLDEN, bool_options_def_false, 2);
+	props->limitValueList(PROP_FONT_BASE_WEIGHT, int_option_weight, sizeof(int_option_weight) / sizeof(int), 3);
 #ifndef ANDROID
 	props->limitValueList(PROP_EMBEDDED_STYLES, bool_options_def_true, 2);
 	props->limitValueList(PROP_EMBEDDED_FONTS, bool_options_def_true, 2);
@@ -6508,13 +6508,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 REQUEST_RENDER("propsApply - font kerning")
             }
-        } else if (name == PROP_FONT_WEIGHT_EMBOLDEN) {
-            bool embolden = props->getBoolDef(PROP_FONT_WEIGHT_EMBOLDEN, false);
-            int v = embolden ? STYLE_FONT_EMBOLD_MODE_EMBOLD
-                             : STYLE_FONT_EMBOLD_MODE_NORMAL;
-            if (v != LVRendGetFontEmbolden()) {
-                LVRendSetFontEmbolden(v);
-                REQUEST_RENDER("propsApply - embolden")
+        } else if (name == PROP_FONT_BASE_WEIGHT) {
+            // replaces PROP_FONT_WEIGHT_EMBOLDEN
+            int v = props->getIntDef(PROP_FONT_BASE_WEIGHT, 400);
+            if ( LVRendGetBaseFontWeight() != v ) {
+                LVRendSetBaseFontWeight(v);
+                REQUEST_RENDER("propsApply - font weight")
             }
         } else if (name == PROP_TXT_OPTION_PREFORMATTED) {
             bool preformatted = props->getBoolDef(PROP_TXT_OPTION_PREFORMATTED,

--- a/crengine/src/lvfnt.cpp
+++ b/crengine/src/lvfnt.cpp
@@ -71,7 +71,10 @@ int lvfontOpen( const char * fname, lvfont_handle * pfont )
     }
     *pfont = (lvfont_handle) malloc( sz );
     fseek( f, 0, SEEK_SET );
-    (void) fread( *pfont, sz, 1, f );
+    if ( fread( *pfont, sz, 1, f ) != sz ) {
+        fclose(f);
+        return 0;
+    }
     fclose(f);
     tag_lvfont_header * hdr = (tag_lvfont_header *)lvfontGetHeader( *pfont );
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1868,8 +1868,9 @@ public:
         }
         if (_synth_weight > 0 || _italic == 2) { // Don't render yet
             flags &= ~FT_LOAD_RENDER;
-            // Also disable any hinting, as it would be wrong after embolden
-            flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+            // Also disable any hinting, as it would be wrong after embolden.
+            // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+            // flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
         updateTransform(); // no-op
         int error = FT_Load_Glyph(
@@ -2663,8 +2664,9 @@ public:
             }
             if (_synth_weight > 0 || _italic == 2) { // Don't render yet
                 rend_flags &= ~FT_LOAD_RENDER;
-                // Also disable any hinting, as it would be wrong after embolden
-                rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+                // Also disable any hinting, as it would be wrong after embolden.
+                // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+                // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
 
             /* load glyph image into the slot (erase previous one) */
@@ -2723,8 +2725,9 @@ public:
 
             if (_synth_weight > 0 || _italic == 2) { // Don't render yet
                 rend_flags &= ~FT_LOAD_RENDER;
-                // Also disable any hinting, as it would be wrong after embolden
-                rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+                // Also disable any hinting, as it would be wrong after embolden.
+                // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+                // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
 
             /* load glyph image into the slot (erase previous one) */
@@ -3838,8 +3841,9 @@ public:
         }
         if (_synth_weight > 0 || _italic == 2) { // Don't render yet
             rend_flags &= ~FT_LOAD_RENDER;
-            // Also disable any hinting, as it would be wrong after embolden
-            rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+            // Also disable any hinting, as it would be wrong after embolden.
+            // But it feels this is now fine after switching to FT_LOAD_TARGET_LIGHT.
+            // rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
         /* load glyph image into the slot (erase previous one) */
         updateTransform(); // no-op

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5204,12 +5204,16 @@ public:
         _cache.removeDocumentFonts(documentId);
     }
 
-    virtual bool RegisterExternalFont( lString32 name, lString8 family_name, bool bold, bool italic) {
+    virtual bool RegisterExternalFont(int documentId, lString32 name, lString8 family_name, bool bold, bool italic) {
         if (name.startsWithNoCase(lString32("res://")))
             name = name.substr(6);
         else if (name.startsWithNoCase(lString32("file://")))
             name = name.substr(7);
         lString8 fname = UnicodeToUtf8(name);
+        CRLog::debug("RegisterExternalFont(documentId=%d, path=%s)", documentId, fname.c_str());
+        if (_cache.findDocumentFontDuplicate(documentId, fname)) {
+            return false;
+        }
 
         bool res = false;
         int index = 0;
@@ -5263,7 +5267,8 @@ public:
                 -1, // OpenType features = -1 for not yet instantiated fonts
                 fontFamily,
                 family_name,
-                index
+                index,
+                documentId
             );
             #if (DEBUG_FONT_MAN==1)
                 if ( _log ) {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -386,11 +386,11 @@ bool isHBScriptCursive( hb_script_t script ) {
 // LVFontDef carries a font definition, and can be used to identify:
 // - registered fonts, from available font files (size=-1 if scalable)
 // - instantiated fonts from one of the registered fonts, with some
-//   update properties:
+//   updated properties:
 //     - the specific size, > -1
-//     - italic=2 (if font has no real italic, and it is synthetized
+//     - _italic=2 (if font has no real italic, and it is synthesized
 //       thanks to Freetype from the regular font glyphs)
-//     - _weight=601 (if no real bold font, and synthetized from
+//     - _weight=600 (updated weight if synthesized weight made from
 //       the regular font glyphs)
 // It can be used as a key by caches to retrieve a registered font
 // or an instantiated one, and as a query to find in the cache an
@@ -1122,8 +1122,8 @@ protected:
     int           _height; // full line height in pixels
     int           _hyphen_width;
     int           _baseline;
-    int           _weight; // 400: normal, 700: bold, 601: fake/synthetized bold, 100..900 thin..black
-    int           _italic; // 0: regular, 1: italic, 2: fake/synthetized italic
+    int           _weight; // original font weight 400: normal, 700: bold, 100..900 thin..black
+    int           _italic; // 0: regular, 1: italic, 2: fake/synthesized italic
     int *         _extra_metric;
     LVFontGlyphUnsignedMetricCache   _wcache;   // glyph width cache
     LVFontGlyphSignedMetricCache     _lsbcache; // glyph left side bearing cache
@@ -1136,8 +1136,8 @@ protected:
     LVFontRef      _fallbackFont;
     bool           _nextFallbackFontIsSet;
     LVFontRef      _nextFallbackFont;
-    int            _synth_weight; // fake/synthetized weight
-    FT_Pos         _synth_weight_strength; // for emboldening with Harfbuzz
+    int            _synth_weight; // fake/synthesized weight
+    FT_Pos         _synth_weight_strength; // for emboldening with FT_Outline_Embolden()
     FT_Pos         _synth_weight_half_strength;
     int            _features; // requested OpenType features bitmap
 #if USE_HARFBUZZ==1
@@ -1424,33 +1424,42 @@ public:
             return;
         }
         _synth_weight = synth_weight;
-        // We will simply call FT_Outline_Embolden()
-        // to get the glyphinfo and glyph with synthetized bold.
-        // To increase metrics, we add some embolding strength to glyph advance.
+
+        // Previously, when not KERNING_MODE_HARFBUZZ, we were using FT_GlyphSlot_Embolden()
+        // to get the glyphinfo and glyph with synthesized bold (with one FreeType hardcoded
+        // weight strength) and increased metrics, and everything was working naturally:
         //   "Embolden a glyph by a 'reasonable' value (which is highly a matter
         //   of taste) [...] For emboldened outlines the height, width, and
         //   advance metrics are increased by the strength of the emboldening".
-        // We can do as MuPDF does (source/fitz/font.c): keep the HB
-        // positions, offset and advances, embolden the glyph by some value
-        // of 'strength', and shift left/bottom by 1/2 'strength', so the
-        // boldened glyph is centered on its original: the glyph being a
-        // bit larger, it will blend over its neighbour glyphs, but it
-        // looks quite allright.
-        // We need to compute the strength as done in FT_GlyphSlot_Embolden():
-        //   xstr = FT_MulFix( face->units_per_EM, face->size->metrics.y_scale ) / 24;
-        //   ystr = xstr;
-        //   FT_Outline_EmboldenXY( &slot->outline, xstr, ystr );
-        // and will do as MuPDF does (with some private value of 'strength'
-        // but glyph translation is only on the Y axis, since we are using an additional horizontal compensate advance.
-        //   FT_Outline_Embolden(&face->glyph->outline, strength);
-        //   FT_Outline_Translate(&face->glyph->outline, 0, -strength/2);
-        // (with strength (26.6 fixed point): 0=no change; 64=1px embolden; 128=2px embolden and 1px x/y translation)
-        // int strength = (_face->units_per_EM * _face->size->metrics.y_scale) / 24;
-        // Calculations (old) for 400 -> 600 scaling:
-        // FT_Pos embolden_strength = FT_MulFix(_face->units_per_EM, _face->size->metrics.y_scale) / 24;
-        // Make it slightly less bold than Freetype's bold, as we get less spacing
-        // around glyphs with HarfBuzz, by getting the unbolded advances.
-        // embolden_strength = embolden_strength * 3/4; // (*1/2 is fine but a tad too light)
+        //
+        // Previously, when KERNING_MODE_HARFBUZZ, we were using FT_Outline_Embolden(),
+        // but as HarfBuzz uses itself the original font metrics (so, we got all
+        // positionnings based on not-bolded font), we were not increasing advances:
+        // we did as MuPDF does (source/fitz/font.c), we kept the HB positions, offset
+        // and advances, embolden the glyph by some value of 'strength', and shift
+        // left/bottom by 1/2 'strength', so the boldened glyph is centered on its
+        // original: the glyph being a bit larger, but not the advance, it blended
+        // over its neighbour glyphs, but it looked quite allright (even if words in
+        // fake bold were bolder, but not larger than the same word in the regular
+        // font, unlike with a real bold font).
+        //   We used to compute the strength as done in FT_GlyphSlot_Embolden():
+        //     xstr = FT_MulFix( face->units_per_EM, face->size->metrics.y_scale ) / 24;
+        //     ystr = xstr;
+        //     FT_Outline_EmboldenXY( &slot->outline, xstr, ystr );
+        //   and did as MuPDF does (with some private value of 'strength'):
+        //     FT_Outline_Embolden(&face->glyph->outline, strength);
+        //     FT_Outline_Translate(&face->glyph->outline, -strength/2, -strength/2);
+        //   (with strength: 0=no change; 64=1px embolden; 128=2px embolden and 1px x/y translation)
+        //   int strength = (_face->units_per_EM * _face->size->metrics.y_scale) / 24;
+        //   FT_Pos embolden_strength = FT_MulFix(_face->units_per_EM, _face->size->metrics.y_scale) / 24;
+        //   Make it slightly less bold than Freetype's bold, as we get less spacing
+        //   around glyphs with HarfBuzz, by getting the unbolded advances.
+        //   embolden_strength = embolden_strength * 3/4; // (*1/2 is fine but a tad too light)
+
+        // Now, with the wish for more granular weight strengths, in all kerning modes,
+        // we need to use FT_Outline_Embolden(), and we do adjust the advances to make
+        // synthetic bold look less condensed and a bit more like real bold.
+
         // Simplifing...
         // embolden_strength = (_face->units_per_EM*_face->size->metrics.y_scale)/(65536*32)
         // So for any other scaling:
@@ -5970,7 +5979,7 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     // bias
     int bias = useBias ? _bias : 0;
 
-    // Special handling for synthetized fonts:
+    // Special handling for synthesized fonts:
     // The way this function is called:
     // 'this' (or '', properties not prefixed) is either an instance of a
     //     registered font, or a registered font definition,
@@ -5987,7 +5996,7 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     // We want to avoid an instantiated fake bold (resp. fake bold italic) to
     // have a higher score than the registered original when a fake bold italic
     // (resp. fake bold) is requested, so the italic/non italic requested can
-    // be re-synthetized. Otherwise, we'll get some italic when not wanting
+    // be re-synthesized. Otherwise, we'll get some italic when not wanting
     // italic (or vice versa), depending on which has been instantiated first...
     //
     if ( !_real_weight ) {        // 'this' is an instantiated fake weight font

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -3129,6 +3129,9 @@ public:
                     value = 60;
                 break;
 #endif // MATHML_SUPPORT==1
+            default:
+                value = 0;
+                break;
             }
             _extra_metric[metric] = value;
         }
@@ -3762,16 +3765,18 @@ public:
         if ( error ) {
             return;
         }
-        if (_embolden) { // Embolden and render
+        if (_embolden) {
             // See setEmbolden() for details
             if ( _slot->format == FT_GLYPH_FORMAT_OUTLINE ) {
                 FT_Outline_Embolden(&_slot->outline, 2*_embolden_half_strength);
                 FT_Outline_Translate(&_slot->outline, -_embolden_half_strength, -_embolden_half_strength);
             }
-            FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
         }
         if (_italic==2) { // Obliquen and render
             FT_GlyphSlot_Oblique(_slot);
+        }
+        if (_embolden || _italic==2) {
+            // Render now that transformations are applied
             FT_Render_Glyph(_slot, _drawMonochrome?FT_RENDER_MODE_MONO:FT_RENDER_MODE_LIGHT);
         }
         FT_Bitmap * bitmap = &_slot->bitmap;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2438,7 +2438,7 @@ public:
             flags[i] = GET_CHAR_FLAGS(ch); //calcCharFlags( ch );
 
             /* load glyph image into the slot (erase previous one) */
-            int w = _wcache.get(ch);
+            lUInt16 w = _wcache.get(ch);
             if ( w == CACHED_UNSIGNED_METRIC_NOT_SET ) {
                 glyph_info_t glyph;
                 if ( getGlyphInfo( ch, &glyph, def_char ) ) {
@@ -3553,7 +3553,10 @@ public:
                             item->bmp_width,
                             item->bmp_height,
                             palette);
-                        x += posInfo.width + letter_spacing;
+                        // Assume zero advance means it's a diacritic, and we should not apply
+                        // any letter spacing on this char (now, and when justifying)
+                        if ( posInfo.width != 0 )
+                            x += posInfo.width + letter_spacing;
                     }
                 }
             }
@@ -3633,7 +3636,10 @@ public:
                         item->bmp_height,
                         palette);
 
-                    x  += w + letter_spacing;
+                    // Assume zero advance means it's a diacritic, and we should not apply
+                    // any letter spacing on this char (now, and when justifying)
+                    if ( w != 0 )
+                        x += w + letter_spacing;
                 }
                 previous = ch_glyph_index;
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2292,22 +2292,20 @@ bool isSameFontStyle( css_style_rec_t * style1, css_style_rec_t * style2 )
         && (style1->font_weight == style2->font_weight);
 }
 
-//int rend_font_embolden = STYLE_FONT_EMBOLD_MODE_EMBOLD;
-int rend_font_embolden = STYLE_FONT_EMBOLD_MODE_NORMAL;
+static int rend_font_base_weight = 400;
 
-void LVRendSetFontEmbolden( int addWidth )
+void LVRendSetBaseFontWeight( int weight )
 {
-    if ( addWidth < 0 )
-        addWidth = 0;
-    else if ( addWidth>STYLE_FONT_EMBOLD_MODE_EMBOLD )
-        addWidth = STYLE_FONT_EMBOLD_MODE_EMBOLD;
-
-    rend_font_embolden = addWidth;
+    if ( weight < 1 )
+        weight = 1;
+    else if ( weight>999 )
+        weight = 999;
+    rend_font_base_weight = weight;
 }
 
-int LVRendGetFontEmbolden()
+int LVRendGetBaseFontWeight()
 {
-    return rend_font_embolden;
+    return rend_font_base_weight;
 }
 
 LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
@@ -2334,9 +2332,16 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = ((style->font_weight - css_fw_100)+1) * 100;
     else
         fw = 400;
-    fw += rend_font_embolden;
-    if ( fw>900 )
-        fw = 900;
+    fw += (rend_font_base_weight - 400);
+    // Although the css standard does not regulate the use of weight over 900,
+    //   https://www.w3.org/TR/CSS21/fonts.html#propdef-font-weight
+    //   https://developer.mozilla.org/ru/docs/Web/CSS/font-weight
+    // in practice there are fonts with "ExtraBlack" weight (950),
+    // which visually looks more bolder than "Black" (900).
+    if ( fw<1 )
+        fw = 1;
+    else if ( fw>999 )
+        fw = 999;
     // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());
     LVFontRef fnt = fontMan->GetFont(
         sz,
@@ -10090,6 +10095,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
 
     //UPDATE_LEN_FIELD( text_indent );
     spreadParent( pstyle->text_indent, parent_style->text_indent );
+    // acording to https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#meaning_of_relative_weights
+    // With some liberty at ends if 100 is really too thin
     switch( pstyle->font_weight )
     {
     case css_fw_inherit:
@@ -10099,21 +10106,23 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->font_weight = css_fw_400;
         break;
     case css_fw_bold:
-        pstyle->font_weight = css_fw_600;
+        pstyle->font_weight = css_fw_700;
         break;
     case css_fw_bolder:
-        pstyle->font_weight = parent_style->font_weight;
-        if (pstyle->font_weight < css_fw_800)
-        {
-            pstyle->font_weight = (css_font_weight_t)((int)pstyle->font_weight + 2);
-        }
+        if (parent_style->font_weight < css_fw_400)
+            pstyle->font_weight = css_fw_400;
+        else if (parent_style->font_weight < css_fw_600)
+            pstyle->font_weight = css_fw_700;
+        else
+            pstyle->font_weight = css_fw_900;
         break;
     case css_fw_lighter:
-        pstyle->font_weight = parent_style->font_weight;
-        if (pstyle->font_weight > css_fw_200)
-        {
-            pstyle->font_weight = (css_font_weight_t)((int)pstyle->font_weight - 2);
-        }
+        if (parent_style->font_weight < css_fw_400)
+            pstyle->font_weight = css_fw_100;
+        else if (parent_style->font_weight < css_fw_600)
+            pstyle->font_weight = css_fw_300;
+        else
+            pstyle->font_weight = css_fw_700;
         break;
     case css_fw_100:
     case css_fw_200:

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1985,7 +1985,8 @@ public:
                     }
                     */
 
-                    lastWidth += widths[len-1]; //len<m_length ? len : len-1];
+                    if (len > 0)
+                        lastWidth += widths[len-1]; //len<m_length ? len : len-1];
                 }
                 else if ( measuring_object ) {
                     // We have start=i-1 and m_flags[i-1] & LCHAR_IS_OBJECT

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -18664,7 +18664,7 @@ void ldomDocument::registerEmbeddedFonts()
             continue;
         }
         if (url.startsWithNoCase(lString32("res://")) || url.startsWithNoCase(lString32("file://"))) {
-            if (!fontMan->RegisterExternalFont(item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
+            if (!fontMan->RegisterExternalFont(getDocIndex(), item->getUrl(), item->getFace(), item->getBold(), item->getItalic())) {
                 //CRLog::error("Failed to register external font face: %s file: %s", item->getFace().c_str(), LCSTR(item->getUrl()));
             }
             continue;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -388,8 +388,7 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     // layout and paragraphs' heights. We just need to _renderedBlockCache.clear()
     // when hinting mode is changed to reformat paragraphs.
     // hash = hash * 31 + (int)fontMan->GetHintingMode();
-    if ( LVRendGetFontEmbolden() )
-        hash = hash * 75 + 2384761;
+    hash = hash * 31 + LVRendGetBaseFontWeight();
     hash = hash * 31 + gRenderDPI;
     // If not yet rendered (initial loading with XML parsing), we can
     // ignore some global flags that have not yet produced any effect,

--- a/crengine/src/mathml.cpp
+++ b/crengine/src/mathml.cpp
@@ -142,7 +142,7 @@ static lString8 MATHML_DEFAULT_FONTS = lString8(
     "\""    "Libertinus Math"       "\", "
     "\""    "TeX Gyre Termes Math"  "\", "
     "\""    "TeX Gyre Bonum Math"   "\", "
-    "\""    "TeX Gyre Schola"       "\", "
+    "\""    "TeX Gyre Schola Math"  "\", "
     "\""    "TeX Gyre Pagella Math" "\", "
     "\""    "DejaVu Math TeX Gyre"  "\", "
     "\""    "Asana Math"            "\", "

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -254,7 +254,16 @@ void CRPropAccessor::limitValueList( const char * propName, const char * values[
 
 void CRPropAccessor::limitValueList( const char * propName, int values[], int value_count )
 {
-    lString32 defValue = lString32::itoa( values[0] );
+    limitValueList( propName, values, value_count, 0 );
+}
+
+void CRPropAccessor::limitValueList( const char * propName, int values[], int value_count, int defValueIndex )
+{
+    if ( defValueIndex < 0 )
+        defValueIndex = 0;
+    else if ( defValueIndex >= value_count )
+        defValueIndex = value_count - 1;
+    lString32 defValue = lString32::itoa( values[defValueIndex] );
     lString32 value;
     if ( getString( propName, value ) ) {
         for ( int i=0; i < value_count; i++ ) {


### PR DESCRIPTION
From upstream https://github.com/buggins/coolreader/pull/274 by @virxkane, large discussion there.
Includes a few followup fixes and tweaks.

Didn't pick the changes to measureText() and drawTextString() to use 26.6 units, as this could cause some glitches with the normal rendering, as noticed in https://github.com/koreader/koreader/issues/4174#issuecomment-815270310.
@virxkane original 26.6 changes is included as an individual commit below, but reverted.
Then I decided to keep the idea of compensating the emboldening with tweaking letter-spacing, which was OK, but a bit frustrating as then, it didn't happen for small weights increase, so, font-weights adjustments didn't look much different than gamma changes :/ And these constant letter spacing addition make it look a bit ugly like our "Word Expansion: some|more"... Commit added, then reverted.
Then, I thought we could just account for that when computing advances for glyphs before doing the truncation to px - which more reasonably changes the advances, enough to provoke rendering changes in line wrapping (so it feels different than gamma), and small enough and not on all glyphs so in the end, it looks quite alright.
I added a last commit that doesn't do this advance change with our "Font Kerning: good", so we can compare with "best". No-advance change was my initial preference to stay the more conservative, I still quite like this condensed look - but I'll remove it.

Anyway, I'm quite happy with the result and the `Fonts: handle synth_weight tweaks in glyph/glyphinfo slots` solution: it does not change anything in measureText() and drawTextString(), and keep them using pixel units - it only tweaks glyph of synthetic weight fonts, which might be wrong, but the wrongness is kept only on synthetic stuff.
I think this is best:  by always putting the next glyph at a x in pixels, we don't accumulate fuzzy rounding errors: we're at most 0.5px too near or 0.5px too far , which is bearable vs 1 or 2px errors we could get otherwise.

Opening this as Draft - I'll squash and drop a few commits before merging.
(I'll be off soon for 2 weeks, and won't be able to code and test, so I wish this to not be merged before next release.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/435)
<!-- Reviewable:end -->
