### PR TITLE
Fix hyphenation on Armenian and Georgian text

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -131,15 +131,16 @@ int decodeDecimal( const lChar32 * str, int len );
 #define CH_PROP_ALPHA_SIGN  0x0200 ///< alpha sign character flag
 #define CH_PROP_DASH        0x0400 ///< minus, emdash, endash, ... (- signs)
 #define CH_PROP_CJK         0x0800 ///< CJK ideographs
-#define CH_PROP_AVOID_WRAP_AFTER   0x1000 ///< avoid wrap on following space
-#define CH_PROP_AVOID_WRAP_BEFORE  0x2000 ///< avoid wrap on preceding space
+#define CH_PROP_RTL         0x1000 ///< RTL character
+#define CH_PROP_AVOID_WRAP_AFTER   0x2000 ///< avoid wrap on following space
+#define CH_PROP_AVOID_WRAP_BEFORE  0x4000 ///< avoid wrap on preceding space
 
 /// retrieve character properties mask array for wide c-string
 void lStr_getCharProps( const lChar32 * str, int sz, lUInt16 * props );
 /// retrieve character properties mask for single wide character
 lUInt16 lGetCharProps( lChar32 ch );
 /// find alpha sequence bounds
-void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end );
+void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end, bool & has_rtl );
 // is char a word separator
 bool lStr_isWordSeparator( lChar32 ch );
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2716,8 +2716,9 @@ public:
                 _hyphen_width = getCharWidth( UNICODE_SOFT_HYPHEN_CODE );
             if ( lastFitChar > 3 ) {
                 int hwStart, hwEnd;
-                lStr_findWordBounds( text, len, lastFitChar-1, hwStart, hwEnd );
-                if ( hwStart < (int)(lastFitChar-1) && hwEnd > hwStart+3 ) {
+                bool hasRtl;
+                lStr_findWordBounds( text, len, lastFitChar-1, hwStart, hwEnd, hasRtl );
+                if ( !hasRtl && hwStart < (int)(lastFitChar-1) && hwEnd > hwStart+3 ) {
                     //int maxw = max_width - (hwStart>0 ? widths[hwStart-1] : 0);
                     if ( lang_cfg )
                         lang_cfg->getHyphMethod()->hyphenate(text+hwStart, hwEnd-hwStart, widths+hwStart, flags+hwStart, _hyphen_width, max_width);

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -4343,7 +4343,45 @@ inline lUInt16 getCharProp(lChar32 ch) {
              (ch>=UNICODE_GENERAL_PUNCTUATION_BEGIN && ch<=UNICODE_GENERAL_PUNCTUATION_END) ||
              (ch>=UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_BEGIN && ch<=UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_END))
         return CH_PROP_PUNCT;
-    return 0;
+
+    // Try to guess a few other things about other chars we don't handle above
+    lUInt16 prop = 0;
+#if (USE_UTF8PROC==1)
+    // For other less known ranges, fallback to detecting letters with utf8proc,
+    // which is enough to be able to ensure hyphenation for Armenian and Georgian.
+    utf8proc_category_t cat = utf8proc_category(ch);
+    switch (cat) {
+        case UTF8PROC_CATEGORY_LU:
+        case UTF8PROC_CATEGORY_LT:
+            prop |= CH_PROP_UPPER;
+            break;
+        case UTF8PROC_CATEGORY_LL:
+        case UTF8PROC_CATEGORY_LM:
+        case UTF8PROC_CATEGORY_LO:
+            prop |= CH_PROP_LOWER;
+            break;
+        default:
+            break;
+    }
+#endif
+    // Detect RTL (details in lvtextfm.cpp)
+    if ( ch >= 0x0590 && ch <= 0x08FF ) // Hebrew, Arabic, Syriac, Thaana, Nko, Samaritan...
+        prop |= CH_PROP_RTL;
+    else if ( ch >= 0xFB1D ) { // Try to balance the searches
+        if ( ch <= 0xFDFF )     // FB1D>FDFF Hebrew and Arabic presentation forms
+            prop |= CH_PROP_RTL;
+        else if ( ch <= 0xFEFF ) {
+            if ( ch >= 0xFE70)   // FE70>FEFF Arabic presentation forms
+                prop |= CH_PROP_RTL;
+        }
+        else if ( ch <= 0x1EEBB ) {
+            if (ch >= 0x1E800)   // 1E800>1EEBB Other rare scripts possibly RTL
+                prop |= CH_PROP_RTL;
+            else if ( ch <= 0x10FFF && ch >= 0x10800 ) // 10800>10FFF Other rare scripts possibly RTL
+                prop |= CH_PROP_RTL;
+        }
+    }
+    return prop;
 }
 
 void lStr_getCharProps( const lChar32 * str, int sz, lUInt16 * props )
@@ -4388,9 +4426,10 @@ bool lStr_isWordSeparator( lChar32 ch )
 }
 
 /// find alpha sequence bounds
-void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end )
+void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int & end, bool & has_rtl )
 {
     int hwStart, hwEnd;
+    has_rtl = false;
 
     // 20180615: don't split anymore on UNICODE_SOFT_HYPHEN_CODE, consider
     // it like an alpha char of zero width not drawn.
@@ -4425,7 +4464,7 @@ void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int
     {
         lChar32 ch = str[hwStart];
         lUInt16 props = getCharProp(ch);
-        if ( props & CH_PROP_ALPHA || props & CH_PROP_HYPHEN )
+        if ( props & (CH_PROP_ALPHA|CH_PROP_HYPHEN) )
             break;
     }
     if ( hwStart<0 ) {
@@ -4439,7 +4478,10 @@ void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int
     {
         lChar32 ch = str[hwStart];
         //int lastAlpha = -1;
-        if ( getCharProp(ch) & CH_PROP_ALPHA || getCharProp(ch) & CH_PROP_HYPHEN ) {
+        lUInt16 props = getCharProp(ch);
+        if ( props & (CH_PROP_ALPHA|CH_PROP_HYPHEN) ) {
+            if ( props & CH_PROP_RTL )
+                has_rtl = true;
             //lastAlpha = hwStart;
         } else {
             hwStart++;
@@ -4454,7 +4496,8 @@ void lStr_findWordBounds( const lChar32 * str, int sz, int pos, int & start, int
     for (hwEnd=hwStart+1; hwEnd<sz; hwEnd++) // 20080404
     {
         lChar32 ch = str[hwEnd];
-        if (!(getCharProp(ch) & CH_PROP_ALPHA) && !(getCharProp(ch) & CH_PROP_HYPHEN))
+        lUInt16 props = getCharProp(ch);
+        if ( !(props & (CH_PROP_ALPHA|CH_PROP_HYPHEN)) )
             break;
         ch = str[hwEnd-1];
         if ( ch==' ' ) // || ch==UNICODE_SOFT_HYPHEN_CODE) )

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4115,14 +4115,17 @@ public:
                     // let's go with it as-is as it might be a safety and might help
                     // us not be stuck in some infinite loop here.
                     int wstart, wend;
-                    lStr_findWordBounds( m_text, m_length, wordpos, wstart, wend );
+                    bool has_rtl;
+                    lStr_findWordBounds( m_text, m_length, wordpos, wstart, wend, has_rtl );
                     if ( wend <= lastNormalWrap ) {
                         // We passed back lastNormalWrap: no need to look for more
                         break;
                     }
                     int len = wend - wstart;
-                    if ( len < MIN_WORD_LEN_TO_HYPHENATE ) {
+                    if ( len < MIN_WORD_LEN_TO_HYPHENATE || has_rtl ) {
                         // Too short word found, skip it
+                        // Also skip words containing RTL chars (so, probably full RTL words),
+                        // as we only handle drawing hyphens on the right
                         wordpos = wstart - 1;
                         continue;
                     }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4238,14 +4238,15 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                 // (or the previous word if wordpos happens to be a space or some
                 // punctuation) by looking only for alpha chars in m_text.
                 int start, end;
-                lStr_findWordBounds( text32, txtlen, wordpos, start, end );
+                bool has_rtl;
+                lStr_findWordBounds( text32, txtlen, wordpos, start, end, has_rtl );
                 if ( end <= HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
                     // Too short word at start, we're done
                     break;
                 }
                 int len = end - start;
-                if ( len < HYPH_MIN_WORD_LEN_TO_HYPHENATE ) {
-                    // Too short word found, skip it
+                if ( len < HYPH_MIN_WORD_LEN_TO_HYPHENATE || has_rtl ) {
+                    // Too short word found, or word containing RTL: skip it
                     wordpos = start - 1;
                     continue;
                 }


### PR DESCRIPTION
`getCharProp()` is nearly no longer used when using libunibreak, but it is still used by `lStr_findWordBounds()` to detect words to try to hyphenate.
It knowing only about latin, greek and cyrillic letters made hyphenation not detect any candidate word in Armenian and Georgian text.
So, fallback to use utf8proc to detect letters in any other alphabet so hyphenation (including soft-hyphens) can work.
Also detect RTL chars, as we don't want to hyphenate on soft-hyphens in Arabic or Hebrew, as the text rendering code currently can't draw hyphens on the left.

Will allow closing https://github.com/koreader/koreader/issues/7539

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/436)
<!-- Reviewable:end -->
