### PR TITLE
Various XML, text and FB2 fixes

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -1,4 +1,4 @@
-body { text-align: left; margin: 0; text-indent: 0px; /* justify */ }
+body { text-align: left; margin: 0; text-indent: 0px; page-break-after: always; }
 
 p { text-align: justify; text-indent: 1.2em; margin-top: 0em; margin-bottom: 0em }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2490,7 +2490,6 @@ public:
             align = m_para_dir_is_rtl ? LTEXT_ALIGN_RIGHT : LTEXT_ALIGN_LEFT;
 
         TR("addLine(%d, %d) y=%d  align=%d", start, end, m_y, align);
-        // printf("addLine(%d, %d) y=%d  align=%d maxWidth=%d\n", start, end, m_y, align, maxWidth);
 
         // Note: parameter needReduceSpace and variable splitBySpaces (which
         // was always true) have been removed, as we always split by space:
@@ -2737,15 +2736,13 @@ public:
         }
         // Ignore space at start of line (this rarely happens, as line
         // splitting discards the space on which a split is made - but it
-        // can happen in other rare wrap cases like lastDeprecatedWrap)
-        if ( (m_flags[start] & LCHAR_IS_SPACE) && !(lastSrc->flags & LTEXT_FLAG_PREFORMATTED) ) {
-            // But do it only if we're going to stay in same text node (if not
-            // the space may have some reason - there's sometimes a no-break-space
-            // before an image)
-            if (start < end-1 && m_srcs[start+1] == m_srcs[start]) {
-                start++;
-                lastSrc = m_srcs[start];
-            }
+        // can happen in other rare wrap cases like lastDeprecatedWrap
+        // or if a wrap happened to be allowed before a no-break-space).
+        // Do it only for the 2nd++ lines of a paragraph, as a leading
+        // no-break-space may be used to add some indentation.
+        if ( !first && (m_flags[start] & LCHAR_IS_SPACE) && !(lastSrc->flags & LTEXT_FLAG_PREFORMATTED) ) {
+            start++;
+            lastSrc = m_srcs[start];
         }
 
         // Some words vertical-align positioning might need to be fixed

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -3143,7 +3143,15 @@ bool LVXMLParser::Parse()
                     // Process &#124; and HTML entities, but don't touch space
                     PreProcessXmlString( attrvalue, TXTFLG_PROCESS_ATTRIBUTE );
                 }
-                attrvalue.trimDoubleSpaces(false,false,false);
+                // attrvalue.trimDoubleSpaces(false,false,false);
+                // According to the XML specs, all spaces (leading, trailing, consecutives)
+                // should be kept as-is in attributes.
+                // Given the few bits of our code that checks for lowercase equality, it feels
+                // safer to trim leading and trailing spaces, which have better chances to be
+                // typos from the author than have a specific meaning.
+                // We should not trim double spaces, which may be found in filenames in
+                // an EPUB's .opf (filenames with leading/trailing spaces ought to be rare).
+                attrvalue.trim();
                 m_callback->OnAttribute(attrns.c_str(), attrname.c_str(), attrvalue.c_str());
 
                 if (inXmlTag && attrname == "encoding")

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5428,13 +5428,13 @@ int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * e
                 state = 2;
             else if (state==1 && ((ch>='a' && ch<='z') || (ch>='A' && ch<='Z')) ) {
                 int k;
-                lChar32 entname[16];
-                for ( k = 0; k < 16; k++ ) {
+                lChar32 entname[32];
+                for ( k = 0; k < 32; k++ ) {
                     entname[k] = str[k + i];
                     if (!entname[k] || entname[k]==';' || entname[k]==' ')
                         break;
                 }
-                if (16 == k)
+                if (32 == k)
                     k--;
                 entname[k] = 0;
                 int n;


### PR DESCRIPTION
#### fb2.css: ensure page break after <body>

In case footnotes' `<body>` don't come with a proper `<title>` that would have ensured this page break.
See https://github.com/koreader/koreader/pull/7625#issuecomment-830662168

#### (Upstream) XML parsing: fix long named character references

Increase the buffer size for recognition of named character references to handle all those expected to be recognised. The longest name in the `def_entity_table[]` appears to be CounterClockwiseContourIntegral" so including a trailing null a buffer size of 32 is needed.
From https://github.com/buggins/coolreader/pull/287

#### XML parsing: don't trim double spaces in attributes

Should allow closing https://github.com/koreader/koreader/issues/7661 and hopefully won't cause much harm.

#### Fix ignore occasional space at start of line

Rework 89b0650e: ignore the space even if followed by another text node; just don't ignore it for the first line where it could have some purpose (eg. to add some indentation).
See https://github.com/koreader/crengine/issues/364#issuecomment-835831394

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/438)
<!-- Reviewable:end -->
