### PR TITLE
Allocation & alignment trickeries

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -134,15 +134,11 @@ struct LVFontGlyphCacheItem
     lInt16  origin_x;
     lInt16  origin_y;
     lUInt16 advance;
-    // NOTE: We stash the actual *storage* in there, so, make sure this will be on an address aligned like malloc would.
-    //       This is a bit of a shortcut: __BIGGEST_ALIGNMENT__ will often be higher than the usual malloc alignment,
-    //       which is usually 16 on 64-bits and 8 otherwise (c.f., https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html).
-    //       But it's also 16 on x86 on recent glibcs (c.f., https://sourceware.org/bugzilla/show_bug.cgi?id=21120),
-    //       so we can't really fake it via __SIZEOF_POINTER__ * 2 ;).
-    //       In any case, we only care about the *offset* of bmp here, so, even if we overalign
-    //       (e.g., it's 32 on Skylake), it doesn't matter, because the layout of the struct ensures we get the same offset,
-    //       the only difference being more *trailing* padding, which we don't care about.
-    alignas(__BIGGEST_ALIGNMENT__) lUInt8 bmp[1];
+    // NOTE: We stash the actual *storage* in there, so, make sure this will be on an address aligned like a 64-bit malloc would.
+    //       This is usually 16 on 64-bit and 8 otherwise (c.f., https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html).
+    //       It's also 16 on x86 on recent glibcs (c.f., https://sourceware.org/bugzilla/show_bug.cgi?id=21120).
+    //       We just use 16 everywhere, as this turned out to be mildly helpful on armv7 (c.f., https://github.com/koreader/crengine/pull/441).
+    alignas(16) lUInt8 bmp[1];
     //=======================================================================
     int getSize()
     {

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -142,7 +142,7 @@ struct LVFontGlyphCacheItem
     //       In any case, we only care about the *offset* of bmp here, so, even if we overalign
     //       (e.g., it's 32 on Skylake), it doesn't matter, because the layout of the struct ensures we get the same offset,
     //       the only difference being more *trailing* padding, which we don't care about.
-    lUInt8 bmp[1] __attribute__((aligned(__BIGGEST_ALIGNMENT__)));
+    alignas(__BIGGEST_ALIGNMENT__) lUInt8 bmp[1];
     //=======================================================================
     int getSize()
     {

--- a/crengine/include/lvplatform.h
+++ b/crengine/include/lvplatform.h
@@ -67,4 +67,13 @@
 #  define STDIO_CLOEXEC
 #endif
 
+// In case the compiler doesn't define __BIGGEST_ALIGNMENT__ (MSVC?)
+#ifndef __BIGGEST_ALIGNMENT__
+#  if defined(__SIZEOF_POINTER__)
+#    define __BIGGEST_ALIGNMENT__ (__SIZEOF_POINTER__ * 2)
+#  else
+#    define __BIGGEST_ALIGNMENT__ (16)
+#  endif
+#endif
+
 #endif // LVPLATFORM_H_INCLUDED

--- a/crengine/include/lvplatform.h
+++ b/crengine/include/lvplatform.h
@@ -67,6 +67,21 @@
 #  define STDIO_CLOEXEC
 #endif
 
+// In case the compiler doesn't define __SIZEOF_POINTER__ (MSVC?)
+// c.f., https://github.com/qt/qtbase/blob/dev/src/corelib/global/qprocessordetection.h
+#ifndef __SIZEOF_POINTER__
+#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64) ||                 \
+      defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64) || \
+      defined(__ia64) || defined(__ia64__) || defined(_M_IA64) ||                        \
+      defined(_MIPS_ARCH_MIPS64) || defined(__mips64) ||                                 \
+      defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)                 \
+      defined(__EMSCRIPTEN__)
+#    define __SIZEOF_POINTER__ 8
+#  else
+#    define __SIZEOF_POINTER__ 4
+#  endif
+#endif
+
 // In case the compiler doesn't define __BIGGEST_ALIGNMENT__ (MSVC?)
 #ifndef __BIGGEST_ALIGNMENT__
 #  if defined(__SIZEOF_POINTER__)

--- a/crengine/include/lvplatform.h
+++ b/crengine/include/lvplatform.h
@@ -82,13 +82,4 @@
 #  endif
 #endif
 
-// In case the compiler doesn't define __BIGGEST_ALIGNMENT__ (MSVC?)
-#ifndef __BIGGEST_ALIGNMENT__
-#  if defined(__SIZEOF_POINTER__)
-#    define __BIGGEST_ALIGNMENT__ (__SIZEOF_POINTER__ * 2)
-#  else
-#    define __BIGGEST_ALIGNMENT__ (16)
-#  endif
-#endif
-
 #endif // LVPLATFORM_H_INCLUDED

--- a/crengine/qimagescale/qdrawhelper_p.h
+++ b/crengine/qimagescale/qdrawhelper_p.h
@@ -63,6 +63,20 @@ namespace CRe {
 #  define Q_DECL_VECTORCALL
 #endif
 
+// c.f., https://github.com/qt/qtbase/blob/dev/src/corelib/global/qprocessordetection.h
+#ifndef __SIZEOF_POINTER__
+#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64) ||                 \
+      defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64) || \
+      defined(__ia64) || defined(__ia64__) || defined(_M_IA64) ||                        \
+      defined(_MIPS_ARCH_MIPS64) || defined(__mips64) ||                                 \
+      defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)                 \
+      defined(__EMSCRIPTEN__)
+#    define __SIZEOF_POINTER__ 8
+#  else
+#    define __SIZEOF_POINTER__ 4
+#  endif
+#endif
+
 #if __SIZEOF_POINTER__ == 8 // 64-bit versions
 
 static inline __attribute__((always_inline)) uint INTERPOLATE_PIXEL_256(uint x, uint a, uint y, uint b) {

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1484,45 +1484,25 @@ void LVColorDrawBuf::Clear( lUInt32 color )
 {
     // NOTE: Guard against _dx <= 0?
     if ( _bpp==16 ) {
-        // Shortcut for black & white
-        if (color == 0x00000000) {
-            memset(_data, 0x00, _rowsize * _dy);
-        } else if (color == 0x00FFFFFF) {
-            memset(_data, 0xFF, _rowsize * _dy);
-        } else {
-            const lUInt16 cl16 = rgb888to565(color);
-            for (int y=0; y<_dy; y++)
+        const lUInt16 cl16 = rgb888to565(color);
+        for (int y=0; y<_dy; y++)
+        {
+            lUInt16 * __restrict dst = (lUInt16 *)GetScanLine(y);
+            size_t px_count = _dx;
+            while (px_count--)
             {
-                lUInt16 * __restrict dst = (lUInt16 *)GetScanLine(y);
-                size_t px_count = _dx;
-                while (px_count--)
-                {
-                    *dst++ = cl16;
-                }
+                *dst++ = cl16;
             }
         }
     } else {
         const lUInt32 cl32 = color;
-        // Shortcut for black & white
-        if (cl32 == 0x00000000) {
-            memset(_data, 0x00, _rowsize * _dy);
-        } else if (cl32 == 0x00FFFFFF) {
-            memset(_data, 0xFF, _rowsize * _dy);
-            // We need to take care of the alpha component now...
-            const unsigned char* const end = _data + (_rowsize * _dy);
-            // Start at the first alpha byte, then loop over each subsequent alpha byte, pixel-by-pixel
-            for (unsigned char* p = _data + 3U; p <= end; p += 4U) {
-                *p = 0x00;
-            }
-        } else {
-            for (int y=0; y<_dy; y++)
+        for (int y=0; y<_dy; y++)
+        {
+            lUInt32 * __restrict dst = (lUInt32 *)GetScanLine(y);
+            size_t px_count = _dx;
+            while (px_count--)
             {
-                lUInt32 * __restrict dst = (lUInt32 *)GetScanLine(y);
-                size_t px_count = _dx;
-                while (px_count--)
-                {
-                    *dst++ = cl32;
-                }
+                *dst++ = cl32;
             }
         }
     }

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1484,25 +1484,45 @@ void LVColorDrawBuf::Clear( lUInt32 color )
 {
     // NOTE: Guard against _dx <= 0?
     if ( _bpp==16 ) {
-        const lUInt16 cl16 = rgb888to565(color);
-        for (int y=0; y<_dy; y++)
-        {
-            lUInt16 * __restrict dst = (lUInt16 *)GetScanLine(y);
-            size_t px_count = _dx;
-            while (px_count--)
+        // Shortcut for black & white
+        if (color == 0x00000000) {
+            memset(_data, 0x00, _rowsize * _dy);
+        } else if (color == 0x00FFFFFF) {
+            memset(_data, 0xFF, _rowsize * _dy);
+        } else {
+            const lUInt16 cl16 = rgb888to565(color);
+            for (int y=0; y<_dy; y++)
             {
-                *dst++ = cl16;
+                lUInt16 * __restrict dst = (lUInt16 *)GetScanLine(y);
+                size_t px_count = _dx;
+                while (px_count--)
+                {
+                    *dst++ = cl16;
+                }
             }
         }
     } else {
         const lUInt32 cl32 = color;
-        for (int y=0; y<_dy; y++)
-        {
-            lUInt32 * __restrict dst = (lUInt32 *)GetScanLine(y);
-            size_t px_count = _dx;
-            while (px_count--)
+        // Shortcut for black & white
+        if (cl32 == 0x00000000) {
+            memset(_data, 0x00, _rowsize * _dy);
+        } else if (cl32 == 0x00FFFFFF) {
+            memset(_data, 0xFF, _rowsize * _dy);
+            // We need to take care of the alpha component now...
+            const unsigned char* const end = _data + (_rowsize * _dy);
+            // Start at the first alpha byte, then loop over each subsequent alpha byte, pixel-by-pixel
+            for (unsigned char* p = _data + 3U; p <= end; p += 4U) {
+                *p = 0x00;
+            }
+        } else {
+            for (int y=0; y<_dy; y++)
             {
-                *dst++ = cl32;
+                lUInt32 * __restrict dst = (lUInt32 *)GetScanLine(y);
+                size_t px_count = _dx;
+                while (px_count--)
+                {
+                    *dst++ = cl32;
+                }
             }
         }
     }

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -947,8 +947,8 @@ bool LVPngImageSource::Decode( LVImageDecoderCallback * callback )
         // NOTE: Stash *both* the array of row pointers *and* the image data in a single allocation.
         //       This implies some alignment trickery to ensure both pointers are aligned as malloc would.
         //       c.f., the comments for LVFontGlyphCacheItem in lvfntman.h
-        // To that effect, compute the size of the array of row pointers, and align it to __BIGGEST_ALIGNMENT__
-        size_t image_offset = ALIGN((height * sizeof(*row_pointers)), __BIGGEST_ALIGNMENT__);
+        // To that effect, compute the size of the array of row pointers, and align it on a 16-byte boundary.
+        size_t image_offset = ALIGN((height * sizeof(*row_pointers)), 16);
         // And we can now alloc the whole thing...
         storage = (unsigned char *) malloc(image_offset + image_size);
         // ...and update both pointers to point to the right storage location.

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -831,6 +831,13 @@ public:
 
 #if (USE_LIBPNG==1)
 
+// c.f., <linux/kernel.h>
+#define ALIGN(x, a)                                                                                              \
+({                                                                                                               \
+	auto mask__ = (a) -1U;                                                                                   \
+	(((x) + (mask__)) & ~(mask__));                                                                          \
+})
+
 LVPngImageSource::LVPngImageSource( ldomNode * node, LVStreamRef stream )
         : LVNodeImageSource(node, stream)
 {
@@ -929,14 +936,24 @@ bool LVPngImageSource::Decode( LVImageDecoderCallback * callback )
         png_set_bgr(png_ptr);
 
         png_set_interlace_handling(png_ptr);
-        png_read_update_info(png_ptr, info_ptr);//update after set
+        png_read_update_info(png_ptr, info_ptr);  // update after set
 
         size_t rowbytes = png_get_rowbytes(png_ptr, info_ptr);
         size_t image_size = height * rowbytes;
+        unsigned char * storage = NULL;
         unsigned char * __restrict image = NULL;
         png_bytep * __restrict row_pointers = NULL;
-        image = new unsigned char[image_size];
-        row_pointers = new png_bytep[height];
+
+        // NOTE: Stash *both* the array of row pointers *and* the image data in a single allocation.
+        //       This implies some alignment trickery to ensure both pointers are aligned as malloc would.
+        //       c.f., the comments for LVFontGlyphCacheItem in lvfntman.h
+        // To that effect, compute the size of the array of row pointers, and align it to __BIGGEST_ALIGNMENT__
+        size_t image_offset = ALIGN((height * sizeof(*row_pointers)), __BIGGEST_ALIGNMENT__);
+        // And we can now alloc the whole thing...
+        storage = (unsigned char *) malloc(image_offset + image_size);
+        // ...and update both pointers to point to the right storage location.
+        image = storage + image_offset; // Still aligned properly, thanks to the above trickery.
+        row_pointers = (png_bytep * __restrict) storage;
 
         for (size_t y = 0; y < height; y++) {
             row_pointers[y] = image + y * rowbytes;
@@ -948,8 +965,7 @@ bool LVPngImageSource::Decode( LVImageDecoderCallback * callback )
 
         png_read_end(png_ptr, info_ptr);
         callback->OnEndDecode(this, false);
-        delete [] image;
-        delete [] row_pointers;
+        free(storage);
     }
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 


### PR DESCRIPTION
c.f., the discussion in #426

It's fairly anecdotal for LvImg, but it might yield significantly better performance in LvFntMan, because, arguably, memcpy'ing cached glyph bitmaps around is kinda what CRe does the most ;p.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/441)
<!-- Reviewable:end -->
