### PR TITLE
Page splitting: revamp, fix some issues

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -348,7 +348,8 @@ enum css_line_break_t {
     css_lb_normal,
     css_lb_loose,
     css_lb_strict,
-    css_lb_anywhere
+    css_lb_anywhere,
+    css_lb_cr_loose // private value "line-break: -cr-loose" to ignore &nbsp;
 };
 
 /// word-break property values

--- a/crengine/include/lvarray.h
+++ b/crengine/include/lvarray.h
@@ -226,10 +226,10 @@ public:
         _count++;
     }
 
-    /// returns index of specified value, -1 if not found
-    int indexOf(int value) const {
+    /// returns index of specified item, -1 if not found
+    int indexOf(T item) const {
         for ( int i=0; i<_count; i++ ) {
-            if ( _array[i] == value )
+            if ( _array[i] == item )
                 return i;
         }
         return -1;

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -266,6 +266,7 @@ typedef struct
    lUInt32               height;        /**< height of text fragment */
    lUInt16               width;         /**< width of text fragment */
    lUInt16               page_height;   /**< max page height */
+   LVHashTable<lUInt32, lString32Collection*> * inlineboxes_links;
 
     // Each line box starts with a zero-width inline box (called "strut") with
     // the element's font and line height properties:
@@ -481,6 +482,8 @@ public:
     {
         return m_pbuffer->floats[index];
     }
+
+    lString32Collection * GetInlineBoxLinks( ldomNode * node );
 
     void Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * marks = NULL,  ldomMarkedRangeList *bookmarks = NULL );
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -173,7 +173,7 @@ LVDocView::LVDocView(int bitsPerPixel, bool noDefaultDocument) :
 			m_pageMargins(DEFAULT_PAGE_MARGIN,
 					DEFAULT_PAGE_MARGIN / 2 /*+ INFO_FONT_SIZE + 4 */,
 					DEFAULT_PAGE_MARGIN, DEFAULT_PAGE_MARGIN / 2),
-			m_pagesVisible(2), m_pagesVisible_onlyIfSane(true),
+			m_pagesVisible(2), m_pagesVisible_onlyIfSane(true), m_twoVisiblePagesAsOnePageNumber(false),
 			m_pageHeaderInfo(PGHDR_PAGE_NUMBER
 #ifndef LBOOK
 					| PGHDR_CLOCK

--- a/crengine/src/lvopc.cpp
+++ b/crengine/src/lvopc.cpp
@@ -5,7 +5,13 @@ static const lChar32 * const OPC_PropertiesContentType = U"application/vnd.openx
 
 OpcPart::~OpcPart()
 {
-    m_relations.clear();
+    LVHashTable<lString32, LVHashTable<lString32, lString32> *>::iterator it = m_relations.forwardIterator();
+    LVHashTable<lString32, LVHashTable<lString32, lString32> *>::pair* p;
+    while ((p = it.next()) != NULL) {
+        LVHashTable<lString32, lString32>* relationsTable = p->value;
+        if (relationsTable)
+            delete relationsTable;
+    }
 }
 
 LVStreamRef OpcPart::open()

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10078,8 +10078,14 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // it's better or not: we'll see.
     // (Note that we can use * { font-variant: normal !important; } to
     // stop any font-variant without !important from being applied.)
-    pstyle->font_features.value |= parent_style->font_features.value;
-    pstyle->font_features.type = css_val_unspecified;
+    // There is one case where we don't inherit: when styles had this
+    // node ending up being (css_val_unspecified, 0), which can only
+    // happen with "font-variant(-*): normal/none", that might be
+    // used to prevent some upper font-variant to be inherited.
+    if ( pstyle->font_features.type == css_val_inherited || pstyle->font_features.value != 0 ) {
+        pstyle->font_features.value |= parent_style->font_features.value;
+        pstyle->font_features.type = css_val_unspecified;
+    }
 
     // cr_hint is also a bitmap, and only some bits are inherited.
     // A node starts with (css_val_inherited, 0), but if some

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -8289,6 +8289,17 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                             // check link start flag for every word
                             if ( line->words[w].flags & LTEXT_WORD_IS_LINK_START ) {
                                 const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
+                                if ( line->words[w].flags & LTEXT_WORD_IS_INLINE_BOX ) {
+                                    // With an inline box, links were already parsed when it was rendered,
+                                    // and have been stored in the txform buffer
+                                    lString32Collection * links = txform->GetInlineBoxLinks( (ldomNode*)src->object );
+                                    if ( links ) {
+                                        for ( int n=0; n<links->length(); n++ ) {
+                                            flow->getPageContext()->addLink( links->at(n), link_insert_pos );
+                                        }
+                                    }
+                                    continue;
+                                }
                                 if ( src && src->object ) {
                                     ldomNode * node = (ldomNode*)src->object;
                                     ldomNode * parent = node->getParentNode();

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -64,7 +64,7 @@ static int size_8 = 0;
 
 /// get reference to atomic constant string for string literal e.g. cs8("abc") -- fast and memory effective
 const lString8 & cs8(const char * str) {
-    int index =  (int)(((ptrdiff_t)str * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK);
+    unsigned int index =  (unsigned int)(((ptrdiff_t)str * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK);
     for (;;) {
         const void * p = const_ptrs_8[index];
         if (p == str) {
@@ -93,7 +93,7 @@ static int size_32 = 0;
 
 /// get reference to atomic constant wide string for string literal e.g. cs32("abc") -- fast and memory effective
 const lString32 & cs32(const char * str) {
-    int index =  (int)(((ptrdiff_t)str * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK);
+    unsigned int index =  (unsigned int)(((ptrdiff_t)str * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK);
     for (;;) {
         const void * p = const_ptrs_32[index];
         if (p == str) {
@@ -118,7 +118,7 @@ const lString32 & cs32(const char * str) {
 
 /// get reference to atomic constant wide string for string literal e.g. cs32(U"abc") -- fast and memory effective
 const lString32 & cs32(const lChar32 * str) {
-    int index = (((int)((ptrdiff_t)str)) * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK;
+    unsigned int index = (((unsigned int)((ptrdiff_t)str)) * CONST_STRING_BUFFER_HASH_MULT) & CONST_STRING_BUFFER_MASK;
     for (;;) {
         const void * p = const_ptrs_32[index];
         if (p == str) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1864,6 +1864,7 @@ static const char * css_lb_names[] =
     "loose",
     "strict",
     "anywhere",
+    "-cr-loose",
     NULL
 };
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3186,7 +3186,16 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
         case cssd_font_features:
             // We want to 'OR' the bitmap from any declaration that is to be applied to this node
             // (while still ensuring !important).
-            style->ApplyAsBitmapOr( read_length(p), &style->font_features, imp_bit_font_features, is_important );
+            {
+                css_length_t font_features = read_length(p);
+                if ( font_features.value == 0 && font_features.type == css_val_unspecified ) {
+                    // except if "font-variant: normal/none", which resets all previously set bits
+                    style->Apply( font_features, &style->font_features, imp_bit_font_features, is_important );
+                }
+                else {
+                    style->ApplyAsBitmapOr( font_features, &style->font_features, imp_bit_font_features, is_important );
+                }
+            }
             break;
         case cssd_text_indent:
             style->Apply( read_length(p), &style->text_indent, imp_bit_text_indent, is_important );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6170,6 +6170,7 @@ int initTableRendMethods( ldomNode * enode, int state )
             first_unproper = -1;
             last_unproper = -1;
         }
+        child->persist();
     }
     // if ( state==0 ) {
     //     dumpRendMethods( enode, cs32("   ") );
@@ -7617,6 +7618,8 @@ void ldomNode::initNodeRendMethod()
             }
         }
     #endif
+
+    persist();
 }
 #endif
 
@@ -18623,6 +18626,7 @@ void ldomNode::moveItemsTo( ldomNode * destination, int startChildIndex, int end
         item->setParentNode(destination);
         destination->addChild( item->getDataIndex() );
     }
+    destination->persist();
     // TODO: renumber rest of children in necessary
 /*#ifdef _DEBUG
     if ( !_document->checkConsistency( false ) )

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -87,7 +87,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.62k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0027
+#define FORMATTING_VERSION_ID 0x0028
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3896,14 +3896,8 @@ ldomDocument::ldomDocument()
 , lists(100)
 {
     _docIndex = ldomNode::registerDocument(this);
-    allocTinyElement(NULL, 0, 0);
-    // Note: valgrind reports (sometimes, when some document is opened or closed,
-    // with metadataOnly or not) a memory leak (64 bytes in 1 blocks are definitely
-    // lost), about this, created in allocTinyElement():
-    //    tinyElement * elem = new tinyElement(...)
-    // possibly because it's not anchored anywhere.
-    // Attempt at anchoring into a _nullNode, and calling ->detroy()
-    // in ~ldomDocument(), did not prevent this report, and caused other ones...
+    ldomNode* node = allocTinyElement(NULL, 0, 0);
+    node->persist();
 
     //new ldomElement( this, NULL, 0, 0, 0 );
     //assert( _instanceMapCount==2 );

--- a/crengine/src/mathml.cpp
+++ b/crengine/src/mathml.cpp
@@ -1733,6 +1733,7 @@ static void fixupMathMLRecursive( ldomNode * node, bool is_in_script ) {
         }
     }
     fixupMathML( node, is_in_script );
+    node->persist();
     return;
         // If we would be inseting nodes in the upper tree, we might
         // want to use a non-recursive subtree walker

--- a/crengine/src/mathml_table_ext.h
+++ b/crengine/src/mathml_table_ext.h
@@ -75,7 +75,7 @@ void CCRTable::MathML_checkAndTweakTableElement() {
                     i++; // keep it in row1 as a filler for the missing cell at top right
                 }
                 else {
-                    row1->cells.remove(i); // remove it
+                    delete row1->cells.remove(i); // remove it
                 }
                 insert_at = 0; // next cells will be moved at start of rows
                 next_is_sup = false; // next is a sub

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -771,6 +771,14 @@ lChar32 TextLangCfg::getCssLbCharSub(css_line_break_t css_linebreak, css_word_br
             }
             #endif
         }
+
+        // Private keyword: "line-break: -cr-loose", to ignore no-break-space (some books
+        // may abuse &nbsp; between words like article and noun, possibly to make it easier
+        // for people with reading difficulties)
+        if ( css_linebreak == css_lb_cr_loose ) {
+            if ( ch==0x00A0 ) return ' ';    // non-breaking space => space
+            if ( ch==0x2011 ) return 0x2010; // non-breaking hyphen => hyphen
+        }
     }
     return ch;
 }


### PR DESCRIPTION
**(Upstream) lvstring: fix signed integer overflow
(Upstream) lvopc: fix memory leak
(Upstream) ldomDocument(): fix memory leak
(Upstream) lvtinydom: fix memory leaks**
From https://github.com/buggins/coolreader/pull/299

#### LVArray: fix indexOf() to work with any type

Fix oversight in our decb46c75db253ac52639029085fc7ea821e6b40 / https://github.com/buggins/coolreader/commit/a11201401e1bba63039140c0ae5d807948a51f63#diff-f37b0ebc86a9c3391b92d47a8dce2d3cdb5cc270e2dcf07b4ef73af5e1d4af6f  I guess,
(Pinging @virxkane  for info).

#### LVDocView: fix m_twoVisiblePagesAsOnePageNumber uninitialised

#### CSS: line-break: accept "-cr-loose" to ignore no-break-spaces

Can be handy to counteract https://github.com/koreader/crengine/pull/423#issuecomment-856147122.

#### CSS: font-variant: extend effect of "normal" and "none"

See, and should allow closing https://github.com/koreader/koreader/issues/7913.

#### lvrend: fix BlockFloat footnotes context line associations

Footnote links inside floats were previously associated to the line before the float, which could make them shown on the previous page if the float needs a page break to be shown without break.
We now delay these links associations, and associate them only when the float is fully passed by, so the footnote is never before the float.

#### In-page footnotes: support links inside inline-block

Was too lazy to handle it at the time, turned out it wasn't that complicated :)

#### Page splitting: revamp, fix some issues

Rewritten page splitter, which should be easier to understand and tweak.
The old code was quite tedious, trying to do everything in one single pass.
This new code first finds out group of consecutive lines that should be kept together (break avoid), and process each group when they end, and only then the footnotes they contain (with delay if they don't fit).
This fixes 2 small issues (see https://github.com/koreader/koreader/pull/5031#issuecomment-783658619):
- footnotes could slice a paragraph with floats on the line the footnotes happen; now, they are delayed till the end of the block, and the full block can go to the next page (with its footnotes) if it is taller than the current page.
- if a first footnote and its separator didn't fit on a page, a new page was made so it can be added, leaving some blank at bottom of previous page ; now, we delay footnotes in this case, allowing an additional line of the main text to be added if it fits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/443)
<!-- Reviewable:end -->
