### PR TITLE
Regex search: fix potential pattern cache bug

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10850,9 +10850,11 @@ static int findRegex( const lString32 & str, int & pos, int & endpos, lString32 
     static lString32 oldPattern;
     static srell::u32regex regexp;
     // poor mans cache of regexp and str_wo_hyphens across calls
-    if (oldPattern != searchPattern) {
-        if (generateRegex( searchPattern, regexp) != 0)
+    if (oldPattern != searchPattern || oldPattern == "") {
+        if (generateRegex( searchPattern, regexp) != 0) {
+            oldPattern = ""; // invalidate cache
             return REGEX_NOT_FOUND;
+        }
         oldPattern = searchPattern;
     }
 


### PR DESCRIPTION
First of all: We are not hit by this bug, because we check for a valid pattern before doing the search.

The bug would be triggered:
pattern1 correct -> regex cached
pattern2 incorrect -> regex gets destroyed, but cache key is not invalidated
pattern1 cached regex (which was destroyed) would be used :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/445)
<!-- Reviewable:end -->
