### PR TITLE
Use transparent colors on battery-symbol

### DIFF
--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -179,7 +179,7 @@ public:
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette ) = 0;
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither=true, bool use_opaque = false ) = 0;
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither=true, bool use_transparency = false ) = 0;
     /// draws part of source image, possible rescaled
     virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, int srcx, int srcy, int srcwidth, int srcheight, bool dither=true ) { CR_UNUSED10(img, x, y, width, height, srcx, srcy, srcwidth, srcheight, dither); }
     /// for GL buf only - rotated drawing
@@ -394,7 +394,7 @@ public:
     /// sets new size
     virtual void Resize( int dx, int dy );
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false );
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_transparency = false );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
     /// constructor
@@ -519,7 +519,7 @@ public:
     /// sets new size
     virtual void Resize( int dx, int dy );
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false );
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_transparency = false );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
     /// returns scanline pointer
@@ -598,7 +598,7 @@ public:
         FillRect( x0, y0, x1, y1, color0);
     }
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false ) {
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_transparency = false ) {
         // An image (even if empty) sets the ink area
         // printf("  ink Draw image %d %d %d %d\n", x, y, width, height);
         updateInkBounds(x, y, x+width, y+height);

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -179,7 +179,7 @@ public:
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette ) = 0;
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither=true ) = 0;
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither=true, bool use_opaque = false ) = 0;
     /// draws part of source image, possible rescaled
     virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, int srcx, int srcy, int srcwidth, int srcheight, bool dither=true ) { CR_UNUSED10(img, x, y, width, height, srcx, srcy, srcwidth, srcheight, dither); }
     /// for GL buf only - rotated drawing
@@ -394,7 +394,7 @@ public:
     /// sets new size
     virtual void Resize( int dx, int dy );
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither );
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
     /// constructor
@@ -519,7 +519,7 @@ public:
     /// sets new size
     virtual void Resize( int dx, int dy );
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither );
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
     /// returns scanline pointer
@@ -598,7 +598,7 @@ public:
         FillRect( x0, y0, x1, y1, color0);
     }
     /// draws image
-    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither ) {
+    virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque = false ) {
         // An image (even if empty) sets the ink area
         // printf("  ink Draw image %d %d %d %d\n", x, y, width, height);
         updateInkBounds(x, y, x+width, y+height);

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -416,7 +416,7 @@ private:
     bool smoothscale;
     lUInt8 * __restrict decoded;
     bool isNinePatch;
-    bool use_opaque;
+    bool use_transparency;
 public:
     static int * __restrict GenMap( int src_len, int dst_len )
     {
@@ -462,9 +462,9 @@ public:
         }
         return map;
     }
-    LVImageScaledDrawCallback(LVBaseDrawBuf * dstbuf, LVImageSourceRef img, int x, int y, int width, int height, bool dith, bool inv, bool smooth, bool use_opaque=false )
+    LVImageScaledDrawCallback(LVBaseDrawBuf * dstbuf, LVImageSourceRef img, int x, int y, int width, int height, bool dith, bool inv, bool smooth, bool use_transparency=false )
     : src(img), dst(dstbuf), dst_x(x), dst_y(y), dst_dx(width), dst_dy(height), xmap(0), ymap(0), dither(dith), invert(inv), smoothscale(smooth), decoded(0),
-      use_opaque(use_opaque)
+      use_transparency(use_transparency)
     {
         src_dx = img->GetWidth();
         src_dy = img->GetHeight();
@@ -579,7 +579,7 @@ public:
                     //       (i.e., 0 is opaque, 0xFF is transparent)...
                     if ( alpha == 0xFF ) {
                         // Transparent, don't plot it...
-                        if ( invert && !use_opaque ) {
+                        if ( invert && !use_transparency ) {
                             // ...unless we're doing night-mode shenanigans, in which case, we need to fake an inverted background
                             // (i.e., a *black* background, so it gets inverted back to white with NightMode, since white is our expected "standard" background color)
                             // c.f., https://github.com/koreader/koreader/issues/4986
@@ -620,7 +620,7 @@ public:
                     // NOTE: See final branch of the ladder. Not quite sure why some alpha ranges are treated differently...
                     if ( alpha >= 0xF0 ) {
                         // Transparent, don't plot it...
-                        if ( invert && !use_opaque ) {
+                        if ( invert && !use_transparency ) {
                             // ...unless we're doing night-mode shenanigans, in which case, we need to fake an inverted background
                             // (i.e., a *black* background, so it gets inverted back to white with NightMode, since white is our expected "standard" background color)
                             // c.f., https://github.com/koreader/koreader/issues/4986
@@ -654,7 +654,7 @@ public:
                     const lUInt8 alpha = (cl >> 24)&0xFF;
                     if ( alpha == 0xFF ) {
                         // Transparent, don't plot it...
-                        if ( invert && !use_opaque ) {
+                        if ( invert && !use_transparency ) {
                             // ...unless we're doing night-mode shenanigans, in which case, we need to fake a white background.
                             cl = 0x00FFFFFF;
                         } else {
@@ -714,7 +714,7 @@ public:
                     const lUInt8 alpha = (cl >> 24)&0xFF;
                     if ( alpha == 0xFF ) {
                         // Transparent, don't plot it...
-                        if ( invert && !use_opaque ) {
+                        if ( invert && !use_transparency ) {
                             // ...unless we're doing night-mode shenanigans, in which case, we need to fake a white background.
                             cl = 0x00FFFFFF;
                         } else {
@@ -760,7 +760,7 @@ public:
                     const lUInt8 alpha = (cl >> 24)&0xFF;
                     if ( alpha & 0x80 ) {
                         // Transparent, don't plot it...
-                        if ( invert && ! use_opaque ) {
+                        if ( invert && ! use_transparency ) {
                             // ...unless we're doing night-mode shenanigans, in which case, we need to fake a white background.
                             cl = 0x00FFFFFF;
                         } else {
@@ -846,12 +846,12 @@ int  LVGrayDrawBuf::GetBitsPerPixel() const
     return _bpp;
 }
 
-void LVGrayDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque )
+void LVGrayDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_transparency )
 {
     //fprintf( stderr, "LVGrayDrawBuf::Draw( img(%d, %d), %d, %d, %d, %d\n", img->GetWidth(), img->GetHeight(), x, y, width, height );
     if ( width<=0 || height<=0 )
         return;
-    LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, _ditherImages, _invertImages, _smoothImages, use_opaque );
+    LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, _ditherImages, _invertImages, _smoothImages, use_transparency );
     img->Decode( &drawcb );
 
     _drawnImagesCount++;
@@ -1472,10 +1472,10 @@ int  LVColorDrawBuf::GetBitsPerPixel() const
     return _bpp;
 }
 
-void LVColorDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_opaque )
+void LVColorDrawBuf::Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither, bool use_transparency )
 {
     //fprintf( stderr, "LVColorDrawBuf::Draw( img(%d, %d), %d, %d, %d, %d\n", img->GetWidth(), img->GetHeight(), x, y, width, height );
-    LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither, _invertImages, _smoothImages, use_opaque );
+    LVImageScaledDrawCallback drawcb( this, img, x, y, width, height, dither, _invertImages, _smoothImages, use_transparency );
     img->Decode( &drawcb );
     _drawnImagesCount++;
     _drawnImagesSurface += width*height;

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2550,7 +2550,7 @@ void LVDrawBatteryIcon( LVDrawBuf * drawbuf, const lvRect & batteryRc, int perce
         drawbuf->Draw( icon, rc.left,
             rc.top,
             sz.x,
-            sz.y, false );
+            sz.y, false, true );
         if ( charging )
             drawText = false;
         rc.left += 3;


### PR DESCRIPTION
Use transparency on the batter symbol -> nightmode.
This should solve https://github.com/koreader/koreader/issues/7750

Tested on emulator (with/without color rendering) and on a Tolino.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/447)
<!-- Reviewable:end -->
