### PR TITLE
(Upstream) Various minor picks to keep some bits in sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 
 jobs:
   linux:

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -993,6 +993,6 @@ public:
 
 
 /// draw book cover, either from image, or generated from title/authors
-void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber);
+void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, bool respectAspectRatio, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber);
 
 #endif

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -389,14 +389,6 @@ private:
     void updateDocStyleSheet();
 
 protected:
-
-
-    virtual void drawNavigationBar( LVDrawBuf * drawbuf, int pageIndex, int percent );
-
-    virtual void getNavigationBarRectangle( lvRect & rc );
-
-    virtual void getNavigationBarRectangle( int pageIndex, lvRect & rc );
-
     /// returns document offset for next page
     int getNextPageOffset();
     /// returns document offset for previous page

--- a/crengine/include/lvhashtable.h
+++ b/crengine/include/lvhashtable.h
@@ -217,6 +217,11 @@ public:
         }
         return false;
     }
+    void compact()
+    {
+        if (_count > 0 && _count < _size)
+            resize(_count);
+    }
 private:
     int _size;
     int _count;

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -329,6 +329,8 @@ public:
     lString8 & replace(size_type p0, size_type n0, const lString8 & str, size_type offset, size_type count);
     /// replace fragment with repeated character
     lString8 & replace(size_type p0, size_type n0, size_type count, value_type ch);
+    /// replaces every occurrence of the character before with the character after and returns a reference to this string
+    lString8 & replace(value_type before, value_type after);
     /// make string uppercase
     lString8 & uppercase();
     /// make string lowercase

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -702,6 +702,10 @@ public:
     bool atoi( int &n ) const;
     /// converts to 64 bit integer, returns true if success
     bool atoi( lInt64 &n ) const;
+    /// convert to double
+    double atod() const;
+    /// convert to double, returns true if success
+    bool atod( double &d, char dp = '.' ) const;
     /// returns constant c-string pointer
     const value_type * c_str() const { return pchunk->buf32; }
     /// returns constant c-string pointer, same as c_str()

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1781,15 +1781,15 @@ public:
     bool nextVisibleWordEnd( bool thisBlockOnly = false );
 
     /// move to previous visible word beginning (in sentence)
-    bool prevVisibleWordStartInSentence();
+    bool prevVisibleWordStartInSentence(bool thisBlockOnly);
     /// move to previous visible word end (in sentence)
-    bool prevVisibleWordEndInSentence();
+    bool prevVisibleWordEndInSentence(bool thisBlockOnly);
     /// move to next visible word beginning (in sentence)
-    bool nextVisibleWordStartInSentence();
+    bool nextVisibleWordStartInSentence(bool thisBlockOnly);
     /// move to end of current word (in sentence)
     bool thisVisibleWordEndInSentence();
     /// move to next visible word end (in sentence)
-    bool nextVisibleWordEndInSentence();
+    bool nextVisibleWordEndInSentence(bool thisBlockOnly);
 
     /// move to beginning of current visible text sentence
     bool thisSentenceStart();

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -5,6 +5,10 @@
 #include "../include/chmfmt.h"
 #include <chm_lib.h>
 
+#include "../include/fb2def.h"
+#define XS_IMPLEMENT_SCHEME 1
+#include "../include/fb2def.h"
+
 #define DUMP_CHM_DOC 0
 
 struct crChmExternalFileStream : public chmExternalFileStream {
@@ -819,7 +823,7 @@ public:
     }
 
     lString32 getContentsFileName() {
-        if ( _binaryTOCURLTableId!=0 ) {
+        if ( _binaryTOCURLTableId!=0 && _urlTable != NULL ) {
             lString8 url = _urlTable->urlById(_binaryTOCURLTableId);
             if ( !url.empty() )
                 return decodeString(url);
@@ -860,10 +864,10 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingNa
     if ( stream.isNull() )
         return NULL;
 
+#if 0
     // detect encondig
     stream->SetPos(0);
 
-#if 0
     ldomDocument * encDetectionDoc = LVParseHTMLStream( stream );
     int encoding = 0;
     if ( encDetectionDoc!=NULL ) {
@@ -899,11 +903,14 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingNa
     ldomDocument * doc;
     doc = new ldomDocument();
     doc->setDocFlags( 0 );
+    doc->setNodeTypes(fb2_elem_table);
+    doc->setAttributeTypes(fb2_attr_table);
+    doc->setNameSpaceTypes(fb2_ns_table);
 
     ldomDocumentWriterFilter writerFilter(doc, false, HTML_AUTOCLOSE_TABLE);
     writerFilter.setFlags(writerFilter.getFlags() | TXTFLG_CONVERT_8BIT_ENTITY_ENCODING);
 
-    /// FB2 format
+    /// HTML format
     LVFileFormatParser * parser = new LVHTMLParser(stream, &writerFilter);
     if ( !defEncodingName.empty() )
         parser->SetCharset(defEncodingName.c_str());
@@ -1103,11 +1110,11 @@ public:
                 return false;
             }
 
-    #if DUMP_CHM_DOC==1
-        LVStreamRef out = LVOpenFileStream(U"/tmp/chm-toc.html", LVOM_WRITE);
-        if ( !out.isNull() )
-            doc->saveToStream( out, NULL, true );
-    #endif
+#if DUMP_CHM_DOC==1
+            LVStreamRef out = LVOpenFileStream(U"chm-toc.xml", LVOM_WRITE);
+            if ( !out.isNull() )
+                doc->saveToStream( out, NULL, true );
+#endif
 
             ldomNode * body = doc->getRootNode(); //doc->createXPointer(cs32("/html[1]/body[1]"));
             bool res = false;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6475,10 +6475,14 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_FONT_GAMMA) {
             double gamma = 1.0;
             lString32 s = props->getStringDef(PROP_FONT_GAMMA, "1.0");
-            lString8 s8 = UnicodeToUtf8(s);
-            if ( sscanf(s8.c_str(), "%lf", &gamma)==1 ) {
+            // When parsing a gamma value string, the decimal point is always '.' char.
+            // So if a different decimal point character is used in the current locale,
+            // and if we use some library function to convert the string to floating point number, then it may fail.
+            if (s.atod(gamma, '.')) {
                 fontMan->SetGamma(gamma);
                 clearImageCache();
+            } else {
+                CRLog::error("Invalid gamma value (%s)", LCSTR(s));
             }
         } else if (name == PROP_FONT_HINTING) {
             int mode = props->getIntDef(PROP_FONT_HINTING, (int)HINTING_MODE_AUTOHINT);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -7042,7 +7042,7 @@ static cover_palette_t series_palette[8] = {
     {0x00C0D0C0, 0x20E8E8D8, 0xC0FFC040, 0xD0F0E0E0, 0x00400040, 0x00000080, 0x00402040, 0x80FFFFFF},
 };
 
-void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber) {
+void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, bool respectAspectRatio, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber) {
     CR_UNUSED(seriesNumber);
     bool isGray = buf.GetBitsPerPixel() <= 8;
     cover_palette_t * palette = NULL;
@@ -7057,8 +7057,24 @@ void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, lString8 fontFace,
     int dx = buf.GetWidth();
     int dy = buf.GetHeight();
     if (!image.isNull() && image->GetWidth() > 0 && image->GetHeight() > 0) {
+        int xoff = 0;
+        int yoff = 0;
+        if (respectAspectRatio) {
+            // recalc dx, dy for respectAspectRatio
+            int dst_aspect = 100*dx/dy;
+            int src_aspect = 100*image->GetWidth()/image->GetHeight();
+            if (dst_aspect > src_aspect) {
+                int new_dx = src_aspect*dy/100;
+                xoff = (dx - new_dx + 1)/2;
+                dx = new_dx;
+            } else if (dst_aspect < src_aspect) {
+                int new_dy = 100*dx/src_aspect;
+                yoff = (dy - new_dy + 1)/2;
+                dy = new_dy;
+            }
+        }
         CRLog::trace("drawing image cover page %d x %d", dx, dy);
-        buf.Draw(image, 0, 0, dx, dy);
+        buf.Draw(image, xoff, yoff, dx, dy);
 		return;
 	}
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1648,31 +1648,6 @@ void LVDocView::getPageRectangle(int pageIndex, lvRect & pageRect, bool mergeTwo
     }
 }
 
-void LVDocView::getNavigationBarRectangle(lvRect & navRect) {
-	getNavigationBarRectangle(getVisiblePageCount() == 2 ? 1 : 2, navRect);
-}
-
-void LVDocView::getNavigationBarRectangle(int pageIndex, lvRect & navRect) {
-	lvRect headerRect;
-	getPageHeaderRectangle(pageIndex, headerRect);
-	navRect = headerRect;
-	if (headerRect.bottom <= headerRect.top)
-		return;
-	navRect.top = navRect.bottom - 6;
-}
-
-void LVDocView::drawNavigationBar(LVDrawBuf * drawbuf, int pageIndex,
-		int percent) {
-    CR_UNUSED2(drawbuf, percent);
-	//LVArray<int> & sbounds = getSectionBounds();
-	lvRect navBar;
-	getNavigationBarRectangle(pageIndex, navBar);
-	//bool leftPage = (getVisiblePageCount()==2 && !(pageIndex&1) );
-
-	//lUInt32 cl1 = 0xA0A0A0;
-	//lUInt32 cl2 = getBackgroundColor();
-}
-
 /// sets battery state
 bool LVDocView::setBatteryState(int newState) {
 	if (m_battery_state == newState)
@@ -1736,9 +1711,6 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
         int percent_pos = /*info.left + */percent * info.width() / 10000;
 	//    int gh = 3; //drawGauge ? 3 : 1;
 	LVArray<int> & sbounds = getSectionBounds();
-	// NavBar no longer used:
-	// lvRect navBar;
-	// getNavigationBarRectangle(pageIndex, navBar);
 	int gpos = info.bottom;
 //	if (drawbuf->GetBitsPerPixel() <= 2) {
 //		// gray

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -354,6 +354,11 @@ static lChar32 getReplacementChar(lUInt32 code, bool * can_be_ignored = NULL) {
     case 0x25AA: // css_lst_square:
     case 0x25FE: // css_lst_square:
         return '-';
+    case 0x21AF: // DOWNWARDS ZIGZAG ARROW
+    case 0x26A1: // HIGH VOLTAGE SIGN
+    case 0x2B4D: // DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW
+    case 0x1F5F2:// LIGHTNING MOOD
+        return '+';
     default:
         break;
     }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -5199,6 +5199,16 @@ lString8 & lString8::replace(size_type p0, size_type n0, const lString8 & str) {
     return *this;
 }
 
+lString8 & lString8::replace(value_type before, value_type after) {
+    value_type* ptr = modify();
+    while (*ptr) {
+        if (*ptr == before)
+            *ptr = after;
+        ++ptr;
+    }
+    return *this;
+}
+
 lString32 & lString32::replace(size_type p0, size_type n0, const lString32 & str)
 {
     lString32 s1 = substr( 0, p0 );

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1241,6 +1241,88 @@ bool lString32::atoi( lInt64 &n ) const
     return *s=='\0' || *s==' ' || *s=='\t';
 }
 
+double lString32::atod() const {
+    double d = 0.0;
+    bool res = atod(d, '.');
+    return res ? d : 0.0;
+}
+
+bool lString32::atod( double &d, char dp ) const {
+    // Simplified implementation without overflow checking
+    int sign = 1;
+    unsigned long intg = 0;
+    unsigned long frac = 0;
+    unsigned long frac_div = 1;
+    unsigned int exp = 0;
+    int exp_sign = 1;
+    bool res = false;
+    const value_type * s = c_str();
+    while (*s == ' ' || *s == '\t')
+        s++;
+    if (*s == '-') {
+        sign = -1;
+        s++;
+    }
+    else if (*s == '+') {
+        s++;
+    }
+    if (*s>='0' && *s<='9') {
+        res = true;
+        while (*s>='0' && *s<='9') {
+            intg = intg * 10 + ( (*s)-'0' );
+            s++;
+        }
+    }
+    if (res && *s == dp) {
+        // decimal point found
+        s++;
+        res = false;
+        if (*s>='0' && *s<='9') {
+            res = true;
+            while (*s>='0' && *s<='9') {
+                frac = frac * 10 + ( (*s)-'0' );
+                s++;
+                frac_div *= 10;
+            }
+        }
+    }
+    if (res && (*s == 'e' || *s == 'E')) {
+        // exponent part
+        s++;
+        if (*s == '-') {
+            exp_sign = -1;
+            s++;
+        }
+        else if (*s == '+') {
+            s++;
+        }
+        res = false;
+        if (*s>='0' && *s<='9') {
+            res = true;
+            while (*s>='0' && *s<='9') {
+                exp = exp * 10 + ( (*s)-'0' );
+                s++;
+            }
+        }
+    }
+    if (res && (*s != '\0' && *s != ' ' && *s != '\t')) {
+        // unprocessed characters left
+        res = false;
+    }
+    d = (double)intg;
+    if (frac_div > 1)
+        d += ((double)frac)/((double)frac_div);
+    if (exp > 1) {
+        double pwr = exp_sign > 0 ? 10.0 : 0.1;
+        for (unsigned int i = 0; i < exp; i++) {
+            d *= pwr;
+        }
+    }
+    if (sign < 0)
+        d = -d;
+    return res;
+}
+
 #define STRING_HASH_MULT 31
 lUInt32 lString32::getHash() const
 {

--- a/thirdparty/chmlib/src/lzx.c
+++ b/thirdparty/chmlib/src/lzx.c
@@ -268,7 +268,7 @@ int LZXreset(struct LZXstate *pState)
 
 #define ENSURE_BITS(n)							\
   while (bitsleft < (n)) {						\
-    bitbuf |= ((inpos[1]<<8)|inpos[0]) << (ULONG_BITS-16 - bitsleft);	\
+    bitbuf |= (ULONG)((inpos[1]<<8)|inpos[0]) << (ULONG_BITS-16 - bitsleft);	\
     bitsleft += 16; inpos+=2;						\
   }
 


### PR DESCRIPTION
Picking what we can easily from https://github.com/buggins/coolreader/pull/304 and https://github.com/buggins/coolreader/pull/307:
- methods added to base objects, that can be helpful with future devs
- stuff that touches things we don't use (LVDrawBookCover, sentence selection fixes) and that git applied without much complain
- some easy cleanup.

Many other things not picked as they touch mostly the UI<->Core interface and we have already diverged too much, so even if I would have liked picking https://github.com/buggins/coolreader/commit/2d693aedd44c93 to keep much of that in sync, I didn't as we have diverged because of previous added things that we didn't need and I didn't picked at the time :/
Also, some top status bar refactoring that couldn't be integrated because we did some changes on our side, and upstream did too (ability to put this status bar at the bottom that we obviously didn't need, etc...)
So, well, that's how it is - with lvdocview.cpp having to be a bit of their version of our cre.cpp.

The LVDrawBookCover will need some fixes to cre.cpp, because we have its call in a method we don't use - so I'll comment out our drawCoverPage() and cursorRight().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/450)
<!-- Reviewable:end -->
