### PR TITLE
CSS: add support for 'box-sizing', and various other fixes

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -155,8 +155,8 @@ rb, rubyBox[T=rb] {
     line-height: 1;
 }
 rt, rubyBox[T=rt] {
-    line-height: 1.2;
-    font-size: 50%;
+    line-height: 1.6;
+    font-size: 42%;
     font-variant-east-asian: ruby;
     -cr-hint: text-selection-skip;
 }

--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -151,8 +151,8 @@ rb, rubyBox[T=rb] {
     line-height: 1;
 }
 rt, rubyBox[T=rt] {
-    line-height: 1.2;
-    font-size: 50%;
+    line-height: 1.6;
+    font-size: 42%;
     font-variant-east-asian: ruby;
     -cr-hint: text-selection-skip;
 }

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -361,6 +361,13 @@ enum css_word_break_t {
     css_wb_keep_all
 };
 
+/// box-sizing property values
+enum css_box_sizing_t {
+    css_bs_inherit,
+    css_bs_content_box,
+    css_bs_border_box
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,         // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,       // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -283,6 +283,7 @@ bool parse_number_value( const char * & str, css_length_t & value,
                                     bool accept_auto=false,
                                     bool accept_none=false,
                                     bool accept_normal=false,
+                                    bool accept_unspecified=false,
                                     bool accept_contain_cover=false,
                                     bool is_font_size=false );
 

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -82,7 +82,7 @@ private:
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
-    bool parse( const char * & decl, lUInt32 domVersionRequested, bool higher_importance=false, lxmlDocBase * doc=NULL, lString32 codeBase=lString32::empty_str );
+    bool parse( const char * & decl, bool higher_importance=false, lxmlDocBase * doc=NULL, lString32 codeBase=lString32::empty_str );
     lUInt32 getHash();
     LVCssDeclaration() : _data(NULL) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -90,13 +90,14 @@ enum css_style_rec_important_bit {
     imp_bit_visibility,
     imp_bit_line_break,
     imp_bit_word_break,
+    imp_bit_box_sizing,
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 68 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 69 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
-// In lvstyles.cpp, we have hardcoded important[0] ... importance[1]
+// In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
 // So once NB_IMP_SLOTS becomes 4 when IMP_BIT_MAX > 96, add in lvstyles.cpp
 // the needed important[3] and importance[3]. Let us know if we forget that:
 #if (NB_IMP_SLOTS != 3)
@@ -172,6 +173,7 @@ struct css_style_rec_tag {
     css_visibility_t       visibility;
     css_line_break_t       line_break;
     css_word_break_t       word_break;
+    css_box_sizing_t       box_sizing;
     lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
@@ -229,6 +231,7 @@ struct css_style_rec_tag {
     , visibility(css_v_inherit)
     , line_break(css_lb_inherit)
     , word_break(css_wb_inherit)
+    , box_sizing(css_bs_content_box)
     , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2809,7 +2809,7 @@ private:
     ldomNode * baseElement;
     ldomNode * lastBaseElement;
 
-    lString8 headStyleText;
+    lString32 headStyleText;
     int headStyleState;
 
     lString32 htmlDir;
@@ -2821,7 +2821,7 @@ private:
 public:
 
     /// return content of html/head/style element
-    lString8 getHeadStyleText() { return headStyleText; }
+    lString8 getHeadStyleText() { return UnicodeToUtf8(headStyleText); }
 
     ldomNode * getBaseElement() { return lastBaseElement; }
 
@@ -2877,7 +2877,7 @@ public:
     virtual void OnText( const lChar32 * text, int len, lUInt32 flags )
     {
         if (headStyleState == 1) {
-            headStyleText << UnicodeToUtf8(lString32(text, len));
+            headStyleText << lString32(text, len);
             return;
         }
         if ( insideTag )

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1298,6 +1298,8 @@ public:
     void setAttributeTypes( const attr_def_t * attr_scheme );
     // set namespace types from table
     void setNameSpaceTypes( const ns_def_t * ns_scheme );
+    // set node/attribute/namespace types by copying them from an other document
+    void setAllTypesFrom( lxmlDocBase * d );
 
     // debug dump
     void dumpUnknownEntities( const char * fname );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2754,8 +2754,6 @@ protected:
     bool _libRuDocumentDetected;
     bool _libRuParagraphStart;
     bool _libRuParseAsPre;
-    lUInt16 _styleAttrId;
-    lUInt16 _classAttrId;
     lUInt16 * _rules[MAX_ELEMENT_TYPE_ID];
     bool _tagBodyCalled;
     // Some states used when gDOMVersionRequested >= 20200824

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2814,6 +2814,7 @@ private:
 
     lString32 htmlDir;
     lString32 htmlLang;
+    lString32 htmlStyle;
     bool insideHtmlTag;
 
     bool m_nonlinear = false;
@@ -2851,6 +2852,7 @@ public:
         insideHtmlTag = false;
         htmlDir.clear();
         htmlLang.clear();
+        htmlStyle.clear();
     }
     /// called on parsing end
     virtual void OnStop()

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -5,10 +5,6 @@
 #include "../include/chmfmt.h"
 #include <chm_lib.h>
 
-#include "../include/fb2def.h"
-#define XS_IMPLEMENT_SCHEME 1
-#include "../include/fb2def.h"
-
 #define DUMP_CHM_DOC 0
 
 struct crChmExternalFileStream : public chmExternalFileStream {
@@ -859,7 +855,7 @@ public:
     }
 };
 
-ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingName )
+ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingName, ldomDocument * parent_doc )
 {
     if ( stream.isNull() )
         return NULL;
@@ -903,9 +899,7 @@ ldomDocument * LVParseCHMHTMLStream( LVStreamRef stream, lString32 defEncodingNa
     ldomDocument * doc;
     doc = new ldomDocument();
     doc->setDocFlags( 0 );
-    doc->setNodeTypes(fb2_elem_table);
-    doc->setAttributeTypes(fb2_attr_table);
-    doc->setNameSpaceTypes(fb2_ns_table);
+    doc->setAllTypesFrom(parent_doc);
 
     ldomDocumentWriterFilter writerFilter(doc, false, HTML_AUTOCLOSE_TABLE);
     writerFilter.setFlags(writerFilter.getFlags() | TXTFLG_CONVERT_8BIT_ENTITY_ENCODING);
@@ -1104,7 +1098,7 @@ public:
                 CRLog::error("CHM: Cannot open .hhc");
                 return false;
             }
-            ldomDocument * doc = LVParseCHMHTMLStream( tocStream, defEncodingName );
+            ldomDocument * doc = LVParseCHMHTMLStream( tocStream, defEncodingName, _doc );
             if ( !doc ) {
                 CRLog::error("CHM: Cannot parse .hhc");
                 return false;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4870,6 +4870,11 @@ bool LVDocView::ParseDocument() {
 					m_doc_props->setString(DOC_PROP_TITLE, s);
 				}
 			}
+			// HTML documents may have gotten a TOC built from ldomElementWriter internal
+			// support for FictionBook (FB2) structure (nested <section><title>), which
+			// would have gather not much info from HTML. So build a new TOC from classic
+			// HTML headings.
+			m_doc->buildTocFromHeadings();
 		}
 
 		//        lString32 docstyle = m_doc->createXPointer(U"/FictionBook/stylesheet").getText();

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4697,6 +4697,7 @@ void LVDocView::insertBookmarkPercentInfo(int start_page, int end_y, int percent
 bool LVDocView::ParseDocument() {
 
 	createEmptyDocument();
+	setRenderProps(0, 0); // to allow apply styles and rend method while loading
 
 	if (m_stream->GetSize() > DOCUMENT_CACHING_MIN_SIZE) {
 		// try loading from cache
@@ -4715,7 +4716,6 @@ bool LVDocView::ParseDocument() {
 		//m_doc->getStyleSheet()->clear();
 		//m_doc->getStyleSheet()->parse(m_stylesheet.c_str());
 
-		setRenderProps(0, 0); // to allow apply styles and rend method while loading
         if (m_doc->openFromCache(this, m_callback)) {
 			CRLog::info("Document is found in cache, will reuse");
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4651,6 +4651,17 @@ void LVDocView::createEmptyDocument() {
     m_doc->setNodeTypes(fb2_elem_table);
     m_doc->setAttributeTypes(fb2_attr_table);
     m_doc->setNameSpaceTypes(fb2_ns_table);
+    // Note:
+    // All book formats parsing start with this, and get these fb2def.h
+    // elements defined and included in the document ids maps. This allows
+    // all our specific XHTML DOM element handling in ldomDocumentWriter
+    // using "==el_body", "==el_head" to match on books.
+    // But secondary XML files (.opf, .ncx...) get parsed with
+    // LVParseXMLStream(), which will not inject these known ids maps
+    // and will start a DOM with empty maps: met elements and attributes
+    // will get IDs starting from 512 (even if named <body> or <head>),
+    // and won't trigger these specific elements handling where we
+    // use these < 512 IDs (el_body, el_head...), which is good!
 }
 
 /// format of document from cache is known

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9770,7 +9770,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // We can't get the codeBase of this node anymore at this point, which
             // would be needed to resolve "background-image: url(...)" relative
             // file path... So these won't work when defined in a style= attribute.
-            if ( decl.parse( s, domVersionRequested, false, doc ) ) {
+            if ( decl.parse( s, false, doc ) ) {
                 decl.apply( pstyle );
             }
         }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -354,15 +354,14 @@ public:
 
                 int item_direction = elem_direction;
                 if ( item->hasAttribute( attr_dir ) ) {
-                    lString32 dir = item->getAttributeValue( attr_dir );
-                    dir = dir.lowercase();
-                    if ( dir.compare("rtl") == 0 ) {
+                    lString32 dir = item->getAttributeValueLC( attr_dir );
+                    if ( dir == U"rtl" ) {
                         item_direction = REND_DIRECTION_RTL;
                     }
-                    else if ( dir.compare("ltr") == 0 ) {
+                    else if ( dir == U"ltr" ) {
                         item_direction = REND_DIRECTION_LTR;
                     }
-                    else if ( dir.compare("auto") == 0 ) {
+                    else if ( dir == U"auto" ) {
                         item_direction = REND_DIRECTION_UNSET;
                     }
                 }
@@ -3722,8 +3721,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // When meeting them, we add the equivalent unicode opening and closing chars so
                 // that fribidi (working on text only) can ensure what's specified with HTML tags.
                 // See http://unicode.org/reports/tr9/#Markup_And_Formatting
-                lString32 dir = enode->getAttributeValue( attr_dir );
-                dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
+                lString32 dir = enode->getAttributeValueLC( attr_dir );
                 if ( nodeElementId == el_bdo ) {
                     // <bdo> (bidirectional override): prevents the bidirectional algorithm from
                     //       rearranging the sequence of characters it encloses
@@ -3735,14 +3733,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  dir=rtl  => FSI RLO
                     //  leaving  => PDF PDI
                     // but it then doesn't have the intended effect (fribidi bug or limitation?)
-                    if ( dir.compare("rtl") == 0 ) {
+                    if ( dir == "rtl" ) {
                         // txform->AddSourceLine( U"\x2068\x202E", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         // closeWithPDFPDI = true;
                         txform->AddSourceLine( U"\x202E", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDF = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
-                    else if ( dir.compare("ltr") == 0 ) {
+                    else if ( dir == "ltr" ) {
                         // txform->AddSourceLine( U"\x2068\x202D", 1, cl, bgcl, font, lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         // closeWithPDFPDI = true;
                         txform->AddSourceLine( U"\x202D", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
@@ -3757,17 +3755,17 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     //  dir=rtl  => RLI     U+2067  RIGHT-TO-LEFT ISOLATE
                     //  dir=auto => FSI     U+2068  FIRST STRONG ISOLATE
                     //  leaving  => PDI     U+2069  POP DIRECTIONAL ISOLATE
-                    if ( dir.compare("rtl") == 0 ) {
+                    if ( dir == "rtl" ) {
                         txform->AddSourceLine( U"\x2067", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
-                    else if ( dir.compare("ltr") == 0 ) {
+                    else if ( dir == "ltr" ) {
                         txform->AddSourceLine( U"\x2066", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
-                    else if ( nodeElementId == el_bdi || dir.compare("auto") == 0 ) {
+                    else if ( nodeElementId == el_bdi || dir == "auto" ) {
                         txform->AddSourceLine( U"\x2068", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
                         closeWithPDI = true;
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
@@ -6816,15 +6814,14 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // See if dir= attribute or CSS specified direction
     int direction = flow->getDirection();
     if ( enode->hasAttribute( attr_dir ) ) {
-        lString32 dir = enode->getAttributeValue( attr_dir );
-        dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
-        if ( dir.compare("rtl") == 0 ) {
+        lString32 dir = enode->getAttributeValueLC( attr_dir );
+        if ( dir == "rtl" ) {
             direction = REND_DIRECTION_RTL;
         }
-        else if ( dir.compare("ltr") == 0 ) {
+        else if ( dir == "ltr" ) {
             direction = REND_DIRECTION_LTR;
         }
-        else if ( dir.compare("auto") == 0 ) {
+        else if ( dir == "auto" ) {
             direction = REND_DIRECTION_UNSET; // let fribidi detect direction
         }
     }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3807,7 +3807,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
                         }
                         lString32 dir = elem->getAttributeValue( attr_dir );
                         dir = dir.lowercase(); // (no need for trim(), it's done by the XMLParser)
-                        if ( dir.compare(_value) == 0 )
+                        if ( dir == _value )
                             return true;
                         // We could ignore invalide values, but for now, just stop looking.
                         return false;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -127,6 +127,7 @@ enum css_decl_code {
     cssd_line_break2,
     cssd_line_break3,
     cssd_word_break,
+    cssd_box_sizing,
     cssd_content,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
@@ -234,6 +235,7 @@ static const char * css_decl_name[] = {
     "-epub-line-break",
     "-webkit-line-break",
     "word-break",
+    "box-sizing",
     "content",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
@@ -1879,6 +1881,15 @@ static const char * css_wb_names[] =
     NULL
 };
 
+// box-sizing value names
+static const char * css_bs_names[] =
+{
+    "inherit",
+    "content-box",
+    "border-box",
+    NULL
+};
+
 static const char * css_cr_only_if_names[]={
         "any",
         "always",
@@ -3040,6 +3051,9 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
             case cssd_word_break:
                 n = parse_name( decl, css_wb_names, -1 );
                 break;
+            case cssd_box_sizing:
+                n = parse_name( decl, css_bs_names, -1 );
+                break;
             case cssd_content:
                 {
                     lString32 parsed_content;
@@ -3371,6 +3385,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_word_break:
             style->Apply( (css_word_break_t) *p++, &style->word_break, imp_bit_word_break, is_important );
+            break;
+        case cssd_box_sizing:
+            style->Apply( (css_box_sizing_t) *p++, &style->box_sizing, imp_bit_box_sizing, is_important );
             break;
         case cssd_cr_hint:
             {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1946,7 +1946,7 @@ enum cr_only_if_t {
     cr_only_if_fb2_document, // fb2 or fb3
 };
 
-bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, bool higher_importance, lxmlDocBase * doc, lString32 codeBase )
+bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDocBase * doc, lString32 codeBase )
 {
     if ( !decl )
         return false;
@@ -1979,7 +1979,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 {
                     int dom_version;
                     if ( parse_integer( decl, dom_version ) ) {
-                        if ( domVersionRequested >= dom_version ) {
+                        if ( !doc || doc->getDOMVersionRequested() >= dom_version ) {
                             return false; // ignore the whole declaration
                         }
                     }
@@ -2114,7 +2114,7 @@ bool LVCssDeclaration::parse( const char * &decl, lUInt32 domVersionRequested, b
                 break;
             case cssd_display:
                 n = parse_name( decl, css_d_names, -1 );
-                if (domVersionRequested < 20180524 && n == css_d_list_item_block) {
+                if (n == css_d_list_item_block && doc && doc->getDOMVersionRequested() < 20180524) {
                     n = css_d_list_item_legacy; // legacy rendering of list-item
                 }
                 break;
@@ -4660,7 +4660,6 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString32 co
     LVCssSelector * prev_selector;
     int err_count = 0;
     int rule_count = 0;
-    lUInt32 domVersionRequested = _doc->getDOMVersionRequested();
     for (;*str;)
     {
         // new rule
@@ -4694,7 +4693,7 @@ bool LVStyleSheet::parse( const char * str, bool higher_importance, lString32 co
             }
             // parse declaration
             LVCssDeclRef decl( new LVCssDeclaration );
-            if ( !decl->parse( str, domVersionRequested, higher_importance, _doc, codeBase ) )
+            if ( !decl->parse( str, higher_importance, _doc, codeBase ) )
             {
                 err = true;
                 err_count++;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4346,6 +4346,20 @@ bool LVCssSelector::parse( const char * &str, lxmlDocBase * doc )
                 // selectors (eg: blah {font-style: italic}) may have different values
                 // returned by getElementNameIndex() across book loadings, and cause:
                 // "cached rendering is invalid (style hash mismatch): doing full rendering"
+            if ( _id == el_html ) {
+                int doc_format = doc->getProps()->getIntDef(DOC_PROP_FILE_FORMAT_ID, doc_format_none);
+                if ( doc_format == doc_format_epub || doc_format == doc_format_chm ) {
+                    // When building DOM from EPUB or CHM files, the <html> element is skipped
+                    // and its <body> child is wrapped in a <DocFragment> element (so, taking
+                    // the place of the skipped <html>).
+                    // So, make a selector for "html" actually match "DocFragment".
+                    _id = el_DocFragment;
+                    // For embedded styles, this will help here with descendants selectors
+                    // like "html div {}". For CSS targetting the HTML element, we'll re-initNodeStyle()
+                    // the parent <DocFragment> when meeting the <body> (as at the time we meet
+                    // this document stylesheet, we've already past/entered the DocFragment.)
+                }
+            }
             _specificity += WEIGHT_SPECIFICITY_ELEMENT; // we have an element: update specificity
             if (*str==' ' || *str=='\t' || *str=='\n' || *str == '\r')
                 check_attribute_rules = false;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -114,6 +114,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.visibility) * 31
          + (lUInt32)rec.line_break) * 31
          + (lUInt32)rec.word_break) * 31
+         + (lUInt32)rec.box_sizing) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
@@ -193,6 +194,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.visibility == r2.visibility&&
            r1.line_break == r2.line_break&&
            r1.word_break == r2.word_break&&
+           r1.box_sizing == r2.box_sizing&&
            r1.content == r2.content&&
            r1.cr_hint==r2.cr_hint;
 }
@@ -393,6 +395,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(visibility);
     ST_PUT_ENUM(line_break);
     ST_PUT_ENUM(word_break);
+    ST_PUT_ENUM(box_sizing);
     buf << content;
     ST_PUT_LEN(cr_hint);
     lUInt32 hash = calcHash(*this);
@@ -465,6 +468,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_visibility_t, visibility);
     ST_GET_ENUM(css_line_break_t, line_break);
     ST_GET_ENUM(css_word_break_t, word_break);
+    ST_GET_ENUM(css_box_sizing_t, box_sizing);
     buf>>content;
     ST_GET_LEN(cr_hint);
     lUInt32 hash = 0;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4774,6 +4774,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->visibility = css_v_visible;
     s->line_break = css_lb_auto;
     s->word_break = css_wb_normal;
+    s->box_sizing = css_bs_content_box;
     s->cr_hint.type = css_val_unspecified;
     s->cr_hint.value = CSS_CR_HINT_NONE;
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7896,7 +7896,7 @@ void ldomDocumentWriter::OnTagBody()
             import << "\");\n";
             imports << import;
         }
-        lString32 styleText = imports + _headStyleText.c_str();
+        lString32 styleText = imports + _headStyleText;
         _stylesheetLinks.clear();
         _headStyleText.clear();
 
@@ -13723,7 +13723,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const 
                     imports << import;
                 }
                 stylesheetLinks.clear();
-                lString32 styleText = imports + headStyleText.c_str();
+                lString32 styleText = imports + headStyleText;
                 // Add it to <DocFragment><stylesheet>, so it becomes:
                 //   <stylesheet href="...">
                 //     @import url(path_to_css_2nd_file)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5116,6 +5116,27 @@ void lxmlDocBase::setNameSpaceTypes( const ns_def_t * ns_scheme )
     }
 }
 
+// set node/attribute/namespace types by copying them from an other document
+void lxmlDocBase::setAllTypesFrom( lxmlDocBase * d )
+{
+    // Simpler to just serialize and deserialize them all
+    SerialBuf buf(0, true);
+    d->_elementNameTable.serialize( buf );
+    buf << d->_nextUnknownElementId;
+    d->_attrNameTable.serialize( buf );
+    buf << d->_nextUnknownAttrId;
+    d->_nsNameTable.serialize( buf );
+    buf << d->_nextUnknownNsId;
+
+    buf.setPos(0);
+    _elementNameTable.deserialize( buf );
+    buf >> _nextUnknownElementId;
+    _attrNameTable.deserialize( buf );
+    buf >> _nextUnknownAttrId;
+    _nsNameTable.deserialize( buf );
+    buf >> _nextUnknownNsId;
+}
+
 void lxmlDocBase::dumpUnknownEntities( const char * fname )
 {
     FILE * f = fopen( fname, "wt" STDIO_CLOEXEC );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -7646,8 +7646,14 @@ void ldomNode::initNodeRendMethod()
 
 void ldomElementWriter::onBodyExit()
 {
-    if ( _isSection )
+    if ( _isSection ) {
+        // Generic handling of FictionBook (FB2) structure (nested <section><title>),
+        // from which we build a TOC at DOM built time. This works also with
+        // other formats that get a <FictionBook> based DOM, but it shouldn't
+        // trigger much with other HTML based formats like HTML and EPUB, that
+        // will get their TOC from some other context/source.
         updateTocItem();
+    }
 
 #if BUILD_LITE!=1
     if ( !_document->isDefStyleSet() )


### PR DESCRIPTION
#### (Upstream) CHM: avoid including fb2def.h

Rework bits from 46ad95e3 to not include declaration of static variables from fb2def.h, saving 20KB of libcrengine.so size.
Discussed around https://github.com/buggins/coolreader/pull/308#discussion_r699276529. Picked from https://github.com/buggins/coolreader/pull/310.

#### lvtinydom/lvrend: compare ids instead of strings

Follow up to 545e609ee.
This also makes sure that our specific XHTML DOM element handling in ldomDocumentWriter only match on real books and not on secondary XML files (like .opf, .ncx...) parsed with LVParseXMLStream().
Also use `getAttributeValueLC()` when appropriate.
Also make `attr_dir` comparisons more readable.

#### ParseDocument(): earlier setRenderProps()

This is already done for some formats like EPUB/DocX...
Be sure it's also done for simpler formats like HTML, before the DOM writers act, so the root node can get its style set.
(This was not really an issue, as the root node style ends up being set at DOM writer destroy time, but it is needed to properly support (soon) `"@media (min-width: 30em)"` while loading the document.)

#### HTML documents: rebuild TOC from headings after load

Should allow closing https://github.com/koreader/koreader/issues/7942.

#### Font: use metrics for underline offset and thickness

Previously, the underline may have felt too near the text with some fonts.
Before / After:
![image](https://user-images.githubusercontent.com/24273478/131525776-11b3c908-a0ef-4a39-aa99-cc105c31235f.png) ![image](https://user-images.githubusercontent.com/24273478/131525883-522f0eed-3b80-452d-a4c9-e93ad802883d.png)
(Strangely, with my preferred font Bitter, underline never felt wrong - but everytime I tested other fonts on a Wikipedia EPUB full of links, it mostly always felt wrong...)

#### epub.css, html5.css: tweak ruby styling

Discussed and screenshots in https://github.com/koreader/koreader/issues/8063

#### CSS: fix EPUB's `head>style` content encoding

Should be handled and stored in the DOM as Unicode and not UTF8.
Should allow closing https://github.com/koreader/koreader/issues/8034.

#### CSS: add support for 'box-sizing: content-box/border-box'

We had code to handle both border-box and content-box via a global rendering flag.
Un-global it by making it a style slot, the flag will just set its default value.
(Mostly everytime you see some small overflow in the right margin, it's because the book has CSS with `box-sizing: border-box`. It could be solved by switching Render Mode to "book", but we'll get them OK now.)

#### CSS: parse_ident(): fix possible buffer overflow

#### CSS: parse_number_value(): add accept_unspecified

So we rightly don't accept numbers without units for most properties except line-height.

#### CSS: remove domVersionRequested from function args

It can be fetched from the passed `lxmlDocBase * doc` when needed.

#### CSS: support for styling the `<html>` element

Support `<html style=>` and CSS targetting the `<html>` element.
See https://github.com/koreader/koreader/issues/7515#issuecomment-815064239.
Should allow closing https://github.com/koreader/koreader/issues/7515.

More risky changes to our CSS parsing to support at-rules (`@media, @supports`) will be in a next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/453)
<!-- Reviewable:end -->
