### PR TITLE
CSS: some fixes and optimisations

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -134,7 +134,7 @@ public:
     { }
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
-    void setAttr( lUInt16 id, lString32 value ) { _attrid = id; _value = value; }
+    void setAttr( lUInt16 id, const lString32 value ) { _attrid = id; _value = value; }
     LVCssSelectorRule * getNext() { return _next; }
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2829,6 +2829,7 @@ private:
     lString32 htmlDir;
     lString32 htmlLang;
     lString32 htmlStyle;
+    lString32 htmlClass;
     bool insideHtmlTag;
 
     bool m_nonlinear = false;

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1406,7 +1406,7 @@ void lString32Collection::erase(int offset, int cnt)
 {
     if (count<=0)
         return;
-    if (offset < 0 || offset + cnt >= count)
+    if (offset < 0 || offset + cnt > count)
         return;
     int i;
     for (i = offset; i < offset + cnt; i++)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4610,26 +4610,20 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         break;
     case cssrt_class:         // E.class
         {
-            lString32 val = node->getAttributeValue(attr_class);
+            const lString32 val = node->getAttributeValue(attr_class);
             if ( val.empty() )
                 return false;
             // val.lowercase(); // className should be case sensitive
-            // if ( val.length() != _value.length() )
-            //     return false;
-            //CRLog::trace("attr_class: %s %s", LCSTR(val), LCSTR(_value) );
-            /*As I have eliminated leading and ending spaces in the attribute value, any space in
-             *val means there are more than one classes */
-            if (val.pos(" ") != -1) {
+            // we have appended a space when there was some inner space, meaning
+            // this class attribute contains multiple class names, which needs
+            // more complex checks
+            if ( val[val.length()-1] == ' ' ) {
                 lString32 value_w_space_after = _value + " ";
                 if (val.pos(value_w_space_after) == 0)
                     return true; // at start
-                lString32 value_w_space_before = " " + _value;
-                int pos = val.pos(value_w_space_before);
-                if (pos != -1 && pos + value_w_space_before.length() == val.length())
-                    return true; // at end
                 lString32 value_w_spaces_before_after = " " + _value + " ";
                 if (val.pos(value_w_spaces_before_after) != -1)
-                    return true; // in between
+                    return true; // in between or at end
                 return false;
             }
             return val == _value;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8280,6 +8280,23 @@ void ldomDocumentWriter::OnAttribute( const lChar32 * nsname, const lChar32 * at
     //logfile << "ldomDocumentWriter::OnAttribute() [" << nsname << ":" << attrname << "]";
     lUInt16 attr_ns = (nsname && nsname[0]) ? _document->getNsNameIndex( nsname ) : 0;
     lUInt16 attr_id = (attrname && attrname[0]) ? _document->getAttrNameIndex( attrname ) : 0;
+
+    if ( attr_id == attr_class ) { // class="something" in an ldomDocument
+        // To make it less expensive in LVCssSelectorRule::check() when checking classname
+        // selectors for a class attribute with multiple classnames (separated by spaces),
+        // we append a space now if there is any inside attrvalue (we are provided with it
+        // trimmed, so a trailing space will mean there is an inner space)
+        lChar32 * c = (lChar32*)attrvalue;
+        for ( ; *c != 0; c++) {
+            if ( *c == U' ' ) { // There is at least one space
+                lString32 new_value = lString32(attrvalue);
+                new_value.append(U" ");
+                _currNode->addAttribute( attr_ns, attr_id, new_value.c_str() );
+                return;
+            }
+        }
+    }
+
     _currNode->addAttribute( attr_ns, attr_id, attrvalue );
 
     //logfile << " !a!\n";
@@ -14945,6 +14962,22 @@ void ldomDocumentWriterFilter::OnAttribute( const lChar32 * nsname, const lChar3
     // Othewise, add the attribute
     lUInt16 attr_ns = (nsname && nsname[0]) ? _document->getNsNameIndex( nsname ) : 0;
     lUInt16 attr_id = (attrname && attrname[0]) ? _document->getAttrNameIndex( attrname ) : 0;
+
+    if ( attr_id == attr_class ) { // class="something" in an ldomDocument
+        // To make it less expensive in LVCssSelectorRule::check() when checking classname
+        // selectors for a class attribute with multiple classnames (separated by spaces),
+        // we append a space now if there is any inside attrvalue (we are provided with it
+        // trimmed, so a trailing space will mean there is an inner space)
+        lChar32 * c = (lChar32*)attrvalue;
+        for ( ; *c != 0; c++) {
+            if ( *c == U' ' ) { // There is at least one space
+                lString32 new_value = lString32(attrvalue);
+                new_value.append(U" ");
+                _currNode->addAttribute( attr_ns, attr_id, new_value.c_str() );
+                return;
+            }
+        }
+    }
 
     _currNode->addAttribute( attr_ns, attr_id, attrvalue );
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -88,7 +88,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.64k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.65k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0029
 
@@ -13790,6 +13790,8 @@ void ldomDocumentFragmentWriter::OnAttribute( const lChar32 * nsname, const lCha
                 htmlLang = attrvalue;
             else if ( !lStr_cmp(attrname, "style") )
                 htmlStyle = attrvalue;
+            else if ( !lStr_cmp(attrname, "class") )
+                htmlClass = attrvalue;
         }
         else if ( styleDetectionState ) {
             // We won't include this <link/> element in the DOM, but we'll include the
@@ -13837,6 +13839,7 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const 
             htmlDir.clear();
             htmlLang.clear();
             htmlStyle.clear();
+            htmlClass.clear();
         }
     }
 
@@ -13886,6 +13889,8 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const 
                 parent->OnAttribute(U"", U"lang", htmlLang.c_str() );
             if ( !htmlStyle.empty() ) // add attribute <DocFragment style="..." from <html style="..."> tag
                 parent->OnAttribute(U"", U"style", htmlStyle.c_str() );
+            if ( !htmlClass.empty() ) // add attribute <DocFragment class="..." from <html class="..."> tag
+                parent->OnAttribute(U"", U"class", htmlClass.c_str() );
             if (this->m_nonlinear)
                 parent->OnAttribute(U"", U"NonLinear", U"" );
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13913,7 +13913,12 @@ ldomNode * ldomDocumentFragmentWriter::OnTagOpen( const lChar32 * nsname, const 
             // ldomElementWriter for DocFragment is left/destroyed (by onBodyExit(),
             // because this OnTagOpen has set to it _stylesheetIsSet).
             parent->OnTagOpen(U"", baseTag.c_str());
-            parent->OnTagBody();
+            // Calling parent->OnTagBody() here shouldn't be needed, as
+            // it will be done when the parser that called us will call
+            // ldomDocumentFragmentWriter::OnTagBody() below. Doing it
+            // here would have it done twice, and can cause issues with
+            // styles and font set on this BODY element. So don't do it.
+            // parent->OnTagBody();
             return baseElement;
         }
     }


### PR DESCRIPTION
`lString32Collection::erase(): fix bounds checking`

As already done correctly in `lString8Collection::erase()`.
Before this fix, a single stylesheet associated to an EPUB html fragment would have been parsed twice; this may then speed up applying styles to nodes in this case.
Details at https://github.com/koreader/koreader/issues/8384#issuecomment-961294424
Bug since #454, causing x2 / x3 slowdown on EPUBs where fragments reference a single stylesheet.

`ldomDocumentFragmentWriter: fix OnTagBody called twice`

It caused issues with some combinations of styles/fonts are set on a BODY element.
See https://github.com/koreader/koreader/issues/8417#issuecomment-961950942
Should allow closing https://github.com/koreader/koreader/issues/8417.

`CSS: optimize E.class rule check`
`CSS: optimize E#id rule check`

This also prevents `#foo` from wrongly matching `id="not foo"`.
Details at https://github.com/koreader/koreader/issues/8384#issuecomment-962119598.
May cause a 10% loading speedup on some books (on my x64 emulator, but somehow hardly noticable on my ARM Kobo...)

`EPUB: forward class attribute from the html element`

Follow up to d016347a:
In EPUB, the <html> node of each embedded HTML file is not included in the generated single DOM.  Forward its `class=` attribute to be included as an attribute of the followup `<docFragment>`.

With @NiLuJe book from https://github.com/koreader/koreader/issues/8384, on my Kobo:
- The first commit makes the loading time go from 65 to 25 seconds.
- The 3rd + 4th comits may gain 1 or 2 more seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/458)
<!-- Reviewable:end -->
