### PR TITLE
Avoid some re-renderings, hanging punctuation tweaks

### DIFF
--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -210,6 +210,7 @@ typedef struct
    lUInt16            width;       /**< width */
    lUInt16            height;      /**< height */
    lUInt16            baseline;    /**< baseline y offset */
+   lUInt16            width_overflow; /**< right edge glyph overflow over width (when hanging punctuation) */
    lUInt8             flags;       /**< flags */
    lUInt8             align;       /**< alignment */
 } formatted_line_t;

--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -146,7 +146,7 @@ public:
     lString32 & getClosingQuote( bool update_level=true );
 
     int getHyphenHangingPercent();
-    int getHangingPercent( bool right_hanging, bool & check_font, const lChar32 * text, int pos, int next_usable );
+    int getHangingPercent( bool right_hanging, bool rtl_line, bool & check_font, const lChar32 * text, int pos, int next_usable );
 
     #if USE_HARFBUZZ==1
     hb_language_t getHBLanguage() const { return _hb_language; }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3583,6 +3583,8 @@ void LVDocView::setStatusFontSize(int newSize) {
 	m_status_font_size = newSize;
 	if (oldSize != newSize) {
 		propsGetCurrent()->setInt(PROP_STATUS_FONT_SIZE, m_status_font_size);
+		m_infoFont = fontMan->GetFont(m_status_font_size, 400, false,
+			DEFAULT_FONT_FAMILY, m_statusFontFace);
         REQUEST_RENDER("setStatusFontSize")
 	}
 	//goToBookmark(_posBookmark);
@@ -3623,6 +3625,7 @@ void LVDocView::setFontSize(int newSize) {
         propsGetCurrent()->setInt(PROP_FONT_SIZE, m_requested_font_size);
         m_font_size = scaleFontSizeForDPI(m_requested_font_size);
         CRLog::debug("New requested font size: %d (asked: %d)", m_requested_font_size, newSize);
+        updateLayout(); // when 2 visible pages, the middle margin width depends on this font size
         REQUEST_RENDER("setFontSize")
     }
     //goToBookmark(_posBookmark);
@@ -3635,6 +3638,8 @@ void LVDocView::setDefaultFontFace(const lString8 & newFace) {
 
 void LVDocView::setStatusFontFace(const lString8 & newFace) {
 	m_statusFontFace = newFace;
+	m_infoFont = fontMan->GetFont(m_status_font_size, 400, false,
+			DEFAULT_FONT_FAMILY, m_statusFontFace);
     REQUEST_RENDER("setStatusFontFace")
 }
 

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3319,7 +3319,7 @@ public:
                             int shift_x = 0;
                             if ( allow_hanging ) {
                                 bool check_font;
-                                int percent = srcline->lang_cfg->getHangingPercent(false, check_font, m_text, wstart, end-wstart-1);
+                                int percent = srcline->lang_cfg->getHangingPercent(false, m_para_dir_is_rtl, check_font, m_text, wstart, end-wstart-1);
                                 if ( percent && check_font && left_overflow > 0 ) {
                                     // Some fonts might already have enough negative
                                     // left side bearing for some chars, that would
@@ -3487,7 +3487,7 @@ public:
                                 }
                                 else {
                                     bool check_font;
-                                    int percent = srcline->lang_cfg->getHangingPercent(true, check_font, m_text, lastnonspace, end-lastnonspace-1);
+                                    int percent = srcline->lang_cfg->getHangingPercent(true, m_para_dir_is_rtl, check_font, m_text, lastnonspace, end-lastnonspace-1);
                                     if ( percent && check_font && right_overflow > 0 ) {
                                         // Some fonts might already have enough negative
                                         // right side bearing for some chars, that would

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3434,6 +3434,10 @@ public:
                         // Adjust line end if needed.
                         // If we need to adjust last word's last char, we need to put the delta
                         // in this word->width, which will make it into frmline->width.
+                        // By reducing the last word width and so frmline->width, we'll have
+                        // its drawing (with its real width) overflow the line width. We'll
+                        // store this overflow in frmline->width_overflow so we can include
+                        // it in text highlighting.
 
                         // Find the real last drawn glyph
                         int lastnonspace = i-1;
@@ -3509,6 +3513,9 @@ public:
                                 shift_w = usable_right_overflow + rsb;
                             }
                             word->width -= shift_w;
+                            // This last word will overflow over frmline->width: remember it,
+                            // so we can include it in the drawing of native text selection.
+                            frmline->width_overflow = shift_w;
                         }
                     }
 
@@ -4903,7 +4910,9 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
 #ifndef CR_USE_INVERT_FOR_SELECTION_MARKS
             if ( marks!=NULL && marks->length()>0 ) {
                 // Here is drawn the "native highlighting" of a selection in progress
-                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width, frmline->y + frmline->height );
+                // (We include frmline->width_overflow so any hanging punctuation overflow
+                // over frmline->width is included in the drawing.)
+                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width + frmline->width_overflow, frmline->y + frmline->height );
                 for ( int i=0; i<marks->length(); i++ ) {
                     lvRect mark;
                     ldomMarkedRange * range = marks->get(i);
@@ -4915,7 +4924,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 }
             }
             if (bookmarks!=NULL && bookmarks->length()>0) {
-                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width, frmline->y + frmline->height );
+                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width + frmline->width_overflow, frmline->y + frmline->height );
                 for ( int i=0; i<bookmarks->length(); i++ ) {
                     lvRect mark;
                     ldomMarkedRange * range = bookmarks->get(i);
@@ -4930,7 +4939,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
 #ifdef CR_USE_INVERT_FOR_SELECTION_MARKS
             // process bookmarks
             if ( bookmarks != NULL && bookmarks->length() > 0 ) {
-                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width, frmline->y + frmline->height );
+                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width + frmline->width_overflow, frmline->y + frmline->height );
                 for ( int i=0; i<bookmarks->length(); i++ ) {
                     lvRect bookmark_rc;
                     ldomMarkedRange * range = bookmarks->get(i);
@@ -5116,7 +5125,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
 #ifdef CR_USE_INVERT_FOR_SELECTION_MARKS
             // process marks
             if ( marks!=NULL && marks->length()>0 ) {
-                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width, frmline->y + frmline->height );
+                lvRect lineRect( frmline->x, frmline->y, frmline->x + frmline->width + frmline->width_overflow, frmline->y + frmline->height );
                 for ( int i=0; i<marks->length(); i++ ) {
                     lvRect mark;
                     ldomMarkedRange * range = marks->get(i);


### PR DESCRIPTION
`setStatusFontSize/Face(): avoid spurious re-rendering`

Update the font instance as soon its size or face is updated. Should help fixing https://github.com/koreader/koreader/pull/7312#issuecomment-986180114, see followup comments there.
Also call updateLayout() on main font size change, as in 2-pages mode, the middle margin needs to be recomputed. See https://github.com/koreader/koreader/pull/8501#issuecomment-986271199.
Otherwise, these would be noticed later and cause spurious and uneeded re-renderings.

`Hanging punctuation: include it in native highlighting`

The part of punctuation hanging in the right margin wasn't included in the "native" text selection highlighting because the range segments were cropped to frmline-width.
So, remember by how much we overflow it, and extend the crop region (lineRect) to include it.

This is just a minor aesthetic issue - fortunately, it costs nothing as sizeof(formatted_line_t) does not change with this added field (still 32 bytes on x64, 24 bytes on arm32).
When _doing_ mutliple text selection with long press + pan, the box was rugged on the left side (following the hanging punctuation), but was flat on the right side (with parts of hanging punctuation glyphs not part of the text selection). When releasing, and having KOReader draw the boxes, we get the rugged box on both sides. This little change was just bugging me :)

`Hanging punctuation: tweak hanging ratios again`

Hanging ratio was a bit too heavy for guillemets.  Make it lower, and dependant on the side (instead of the presence of a space alongside).
Discussed at https://github.com/koreader/crengine/pull/355#issuecomment-986280651 and follow ups.
Waiting for additional suggestions from @zwim before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/461)
<!-- Reviewable:end -->
