### PR TITLE
CSS: minor parsing fixes

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -301,6 +301,7 @@ private:
     LVImageSourceRef m_backgroundImage;
     LVRef<LVColorDrawBuf> m_backgroundImageScaled;
     bool m_backgroundTiled;
+    bool m_stylesheetUseMacros;
     bool m_stylesheetNeedsUpdate;
     int m_highlightBookmarks;
     LVPtrVector<LVBookMarkPercentInfo> m_bookmarksPercents;
@@ -848,7 +849,7 @@ public:
     int doCommand( LVDocCmd cmd, int param=0 );
 
     /// set document stylesheet text
-    void setStyleSheet( lString8 css_text );
+    void setStyleSheet( lString8 css_text, bool use_macros=true );
 
     /// set default interline space, percent (100..200)
     void setDefaultInterlineSpace( int percent );

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -831,6 +831,8 @@ public:
                     state = 2;
             else if (state == 3 && c == ('/'))    // ex. [/*heh*/]
                     state = 0;
+            else if (state == 3 && c == ('*'))    // ex. [/*heh**]
+                    state = 3;
             else if (state == 3)                // ex. [/*heh*e]
                     state = 2;
             /* Moved up for faster normal path:

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -168,6 +168,7 @@ LVDocView::LVDocView(int bitsPerPixel, bool noDefaultDocument) :
 			 */
 			, m_stream(NULL), m_doc(NULL), m_stylesheet(def_stylesheet),
             m_backgroundTiled(true),
+            m_stylesheetUseMacros(true),
             m_stylesheetNeedsUpdate(true),
             m_highlightBookmarks(1),
 			m_pageMargins(DEFAULT_PAGE_MARGIN,
@@ -508,11 +509,12 @@ lString8 substituteCssMacros(lString8 src, CRPropRef props) {
 }
 
 /// set document stylesheet text
-void LVDocView::setStyleSheet(lString8 css_text) {
+void LVDocView::setStyleSheet(lString8 css_text, bool use_macros) {
 	LVLock lock(getMutex());
     REQUEST_RENDER("setStyleSheet")
 
     m_stylesheet = css_text;
+    m_stylesheetUseMacros = use_macros;
     m_stylesheetNeedsUpdate = true;
 }
 
@@ -521,7 +523,10 @@ void LVDocView::updateDocStyleSheet() {
     if (m_is_rendered && !m_stylesheetNeedsUpdate)
         return;
     CRPropRef p = m_props->getSubProps("styles.");
-    m_doc->setStyleSheet(substituteCssMacros(m_stylesheet, p).c_str(), true);
+    if ( m_stylesheetUseMacros )
+        m_doc->setStyleSheet(substituteCssMacros(m_stylesheet, p).c_str(), true);
+    else
+        m_doc->setStyleSheet(m_stylesheet.c_str(), true);
     m_stylesheetNeedsUpdate = false;
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -88,7 +88,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.66k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.67k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0029
 


### PR DESCRIPTION
#### setStyleSheet(): allow disabling CoolReader macro processing

CoolReader CSS macro processing of user-agent stylesheets prevents using `p[id$="foo"]` (to match "foo" at the end of the "id" attribute value, as anything starting with a `$` is handled as a macro and replaced, which may corrupt normal stylesheets (and style tweaks).
We will use this on our side:
```diff
--- a/cre.cpp
+++ b/cre.cpp
@@ -1580 +1580 @@ static int setStyleSheet(lua_State *L) {
-       doc->text_view->setStyleSheet(css);
+       doc->text_view->setStyleSheet(css, false); // Skip crengine substituteCssMacros()

```
#### epubfmt.cpp: fix initial parsing of CSS files

Fix initial parsing of CSS files (used to see if any embedded fonts), that would stumble on `txt ******/` depending if odd or even number of `*`.
This fixes issue 1 reported at https://github.com/koreader/koreader/issues/8715#issuecomment-1019537155

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/463)
<!-- Reviewable:end -->
