### PR TITLE
[CI] Run apt-get update before apt-get install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Install prerequisites
-      run: sudo apt-get install clang-tidy cppcheck jq libxml2-utils
+      run: sudo apt-get update && sudo apt-get install clang-tidy cppcheck jq libxml2-utils
 
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Cf. `https://github.com/actions/virtual-environments/issues/1757`. This will likely add about 10 extra seconds to the runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/471)
<!-- Reviewable:end -->
