### PR TITLE
Rework and cleanup char categorization and word selection

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1777,8 +1777,6 @@ public:
     bool prevVisibleWordEnd( bool thisBlockOnly = false );
     /// move to next visible word beginning
     bool nextVisibleWordStart( bool thisBlockOnly = false );
-    /// move to end of current word
-    bool thisVisibleWordEnd( bool thisBlockOnly = false );
     /// move to next visible word end
     bool nextVisibleWordEnd( bool thisBlockOnly = false );
 

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1082,9 +1082,9 @@ bool AlgoHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8
                     continue;
                 if ( widths[i] > maxWidth )
                     break;
-                if ( chprops[i] & CH_PROP_VOWEL ) {
+                if ( CH_PROP_IS_VOWEL(chprops[i]) ) {
                     for ( j=i+1; j<end; ++j ) {
-                        if ( chprops[j] & CH_PROP_VOWEL ) {
+                        if ( CH_PROP_IS_VOWEL(chprops[j]) ) {
                             int next = i+1;
                             while ( (chprops[next] & CH_PROP_HYPHEN) && next<end-MIN_WORD_LEN_TO_HYPHEN) {
                                 // printf("next++\n");
@@ -1095,9 +1095,9 @@ bool AlgoHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8
                                 // printf("next2++\n");
                                 next2++;
                             }
-                            if ( (chprops[next] & CH_PROP_CONSONANT) && (chprops[next2] & CH_PROP_CONSONANT) )
+                            if ( CH_PROP_IS_CONSONANT(chprops[next]) && CH_PROP_IS_CONSONANT(chprops[next2]) )
                                 i = next;
-                            else if ( (chprops[next] & CH_PROP_CONSONANT) && ( chprops[next2] & CH_PROP_ALPHA_SIGN ) )
+                            else if ( CH_PROP_IS_CONSONANT(chprops[next]) && CH_PROP_IS_ALPHA_SIGN(chprops[next2]) )
                                 i = next2;
                             if ( i-start>=1 && end-i>2 ) {
                                 // insert hyphenation mark

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3163,7 +3163,7 @@ bool LVDocView::getCursorRect(ldomXPointer ptr, lvRect & rc,
 
 		lvPoint topLeft = rc.topLeft();
 		lvPoint bottomRight = rc.bottomRight();
-		if (docToWindowPoint(topLeft) && docToWindowPoint(bottomRight)) {
+		if (docToWindowPoint(topLeft) && docToWindowPoint(bottomRight, true)) {
 			rc.setTopLeft(topLeft);
 			rc.setBottomRight(bottomRight);
 			return true;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -11585,16 +11585,6 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 if ( (flags[i] & LCHAR_IS_SPACE) && (space_width_scale_percent != 100) ) {
                     w = w * space_width_scale_percent / 100;
                 }
-                bool is_cjk = (c >= UNICODE_CJK_IDEOGRAPHS_BEGIN && c <= UNICODE_CJK_IDEOGRAPHS_END
-                            && ( c<=UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_BEGIN
-                                || c>=UNICODE_CJK_PUNCTUATION_HALF_AND_FULL_WIDTH_END) );
-                            // Do we need to do something about CJK punctuation?
-                    // Having CJK columns min_width the width of a single CJK char
-                    // may, on some pages, make some table cells have a single
-                    // CJK char per line, which can look uglier than when not
-                    // dealing with them specifically (see with: bool is_cjk=false).
-                    // But Firefox does that too, may be a bit less radically than
-                    // us, so our table algorithm may need some tweaking...
                 if (flags[i] & LCHAR_ALLOW_WRAP_AFTER) { // A space
                     if (is_collapsable_space) { // a collapsable ascii space
                         if (collapseNextSpace) // ignore this space
@@ -11615,7 +11605,14 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                         minWidth = curWordWidth; // longest word found
                     curWordWidth = 0;
                 }
-                else if (is_cjk) { // CJK chars are themselves a word
+                else if ( lStr_isCJK(c) ) { // CJK chars are themselves a word
+                    // Do we need to do something about CJK punctuation?
+                    // Having CJK columns min_width the width of a single CJK char
+                    // may, on some pages, make some table cells have a single
+                    // CJK char per line, which can look uglier than when not
+                    // dealing with them specifically (see with: bool is_cjk=false).
+                    // But Firefox does that too, may be a bit less radically than
+                    // us, so our table algorithm may need some tweaking...
                     collapseNextSpace = false; // next space should not be ignored
                     lastSpaceWidth = 0; // no width to take off if we stop with this char
                     curMaxWidth += w;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -90,7 +90,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.67k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x002A
+#define FORMATTING_VERSION_ID 0x002B
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -13217,7 +13217,7 @@ public:
                 _list.add( ldomWord( node, beginOfWord, i ) );
                 beginOfWord = -1;
             }
-            if (lGetCharProps(text[i]) == CH_PROP_CJK && i < len) { // a CJK char makes its own word
+            if (lStr_isCJK(text[i], true) && i < len) { // a CJK char makes its own word
                 _list.add( ldomWord( node, i, i+1 ) );
                 beginOfWord = -1;
             }


### PR DESCRIPTION
Followup to #468, hoping to get now a more consistent char categorization without duplicated code (that could contradict each other), and trusting Unicode (via utf8proc).

### LVString: fix char props, add lStr_isCJK() and lStr_isRTL()

Reorganize `CH_PROP_*` flags: remove unused ones, combine some of them to possibly get new slots for the future.
Fix some chars' `CH_PROP`, have `getCharProp()` correctly set them for other ranges thanks to utf8proc categories, even if some of these flags are not used yet.
(Added CH_PROP_PUNCT_OPEN/CLOSE even if not used currently, it might be useful with CJK typography https://github.com/koreader/koreader/issues/6162.)

Factorize RTL detection in `lStr_isRTL()`.
Factorize CJK detection in `lStr_isCJK()`.
Remove wrong defines of CJK ranges: they were mostly used in legacy code (where we harcoded these bad ranges, not worth fixing them).

### Rework `is/prev/next-VisibleWord-Start/End()`

Things look more robust and simple when thinking in terms of IsWordChar / IsWordBoundary, than as previously in terms of IsWordSeparator and handling the special case of CJK.
Consider `CH_PROP_SIGN` (symbols, currency, math, emoji...) as single char words, just like CJK.
(So that we are ready for the future when books will be written mostly with emojis, and we'll have emoji dictionaries, and the rare alpha words will have to be looked up in precious old dictionaries because nobody will read alphabetic any longer... 📚 🙈 😰 🧠👻 )

Remove no longer needed `IsWordSeparator()`, and not used `thisVisibleWordEnd()` (which, as it was not used, wasn't obvious what it should do).
Rename badly named and duplicated `canWrapWordBefore()` `-After()` to `IsStandaloneWord()` (used by the otherwise untouched `*Sentence*` functions).

Note: the previous code was a bit convoluted when checking stuff. I had a hunch working with char/boundary would be better and more correct, and my initial rewrite was as convoluted as previously :) and I had a few bugs on edge cases. When going at solving them, I came with some really less convoluted code that began to look quite symmetric/similar in the 4 prev/next-VisibleWord-start/end, and actually going along with that code symmetricity was solving more edge cases ! :) So, I guess my hunch was a good one!

Will need a companion patch to cre.cpp:
```diff
@@ -1916,3 +1916,6 @@ static int getTextFromPositions(lua_State *L) {
                // But it is less OK with an initial long-press on a glyph, where we get a 50% chance of
-               // having the next char selected. Try to handle this case better:
+               // having the next char selected. Try to handle this case better.
+               // It turns out this also happens when some CJK/symbol char is near a multi-alpha word,
+               // so, when grabbing prev or next below, we use prevVisibleWordStart()/ nextVisibleWordEnd()
+               // instead of just moving offset by -1/1.
                if (r.getStart() == r.getEnd()) { // for single CJK character
@@ -1936,11 +1939,6 @@ static int getTextFromPositions(lua_State *L) {
                        if (grab_prev) {
-                               int offset = r.getStart().getOffset();
-                               if (offset > 0)
-                                       r.getStart().setOffset(offset - 1);
+                               r.getStart().prevVisibleWordStart();
                        }
                        else {
-                               int offset = r.getEnd().getOffset();
-                               if (offset < textLen)
-                                       r.getEnd().setOffset(offset + 1);
-                                               // (offset can be 0 .. textlen, textlen means after the last char)
+                               r.getEnd().nextVisibleWordEnd();
                        }
```

This solves the existing issue of long-press on an alpha word among CJK was grabbing the previous CJK char:
![image](https://user-images.githubusercontent.com/24273478/159699281-f2d6d7d7-6984-4831-8caf-ec512a925448.png)

### getCursorRect(): fix bottom point check

Use `docToWindowPoint(... isRectBottom=true)` from 939cfc2d0 when checking bottomRight point.
(This fixes some issues with CJK/Symbol text selection on the bottom line of a page.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/472)
<!-- Reviewable:end -->
