### PR TITLE
Various text drawing fixes, add overlap/italic correction

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -4092,6 +4092,8 @@ public:
                 // to not be too high (should probably be computed from other metrics)
                 int liney = y + _underline_thickness;
                 buf->FillRect( x0, liney, x, liney+_underline_thickness, cl );
+                // If we want to use this flag while developping for visually marking the start of words, use this instead:
+                // buf->FillRect( x0-_baseline/4, y, x0+_baseline/4, y+1, cl );
             }
             if ( flags & LFNT_DRAW_LINE_THROUGH ) {
                 // int liney = y + _baseline - _size/4 - h/2;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3378,7 +3378,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // processing for images (their current font is the parent font, and
         // of no use for vertical-alignement).
         css_length_t vertical_align = style->vertical_align;
-        if ( (vertical_align.type == css_val_unspecified && vertical_align.value == css_va_baseline) ||
+        if ( rm == erm_final ) {
+            // vertical-align only applies on inline elements
+            // Any vertical-align set on a DIV or P has no effect with Firefox, and
+            // don't change the line height or baseline.
+        }
+        else if ( (vertical_align.type == css_val_unspecified && vertical_align.value == css_va_baseline) ||
               vertical_align.value == 0 ) {
             // "Align the baseline of the box with the baseline of the parent box.
             //  If the box does not have a baseline, align the bottom margin edge with


### PR DESCRIPTION
### Fonts: fix hinting with synthesized weight inconsistencies

Toggling hinting mode with synthesized weights font could give unsteady glyphs/words widths, which fails the expectation that hinting changes does not need a re-rendering.
This could result in paragraphs overlapping each others.
(Noticable with kerning off/fast only, as harfbuzz use its own metrics.)

### Drawing: fix glyphs at top/bottom possibly truncated

This was somehow prevented by using `setHidePartialGlyphs()`, which was removed by 7e6e7c65c as it felt a bit odd.
Fix this issue in a hopefully better way by using more generically the alternative larger clip (previously added in 6546ef99c for inline-block elements).
Details and screenshots in https://github.com/koreader/crengine/pull/467#issuecomment-1082081477 and follow up posts.
(Some old related discussion at https://github.com/koreader/crengine/pull/327#issuecomment-584146847).

### CSS vertical-align set on final blocks should not apply

It should only apply on inner inline elements (`<P><SPAN>`), and has no effect when set on the `<P>` itself.
(It was causing paragraph line height to go bigger, which may have gone unnoticed as it was consistent on all lines and could masquerade as CSS `line-height`, but it was causing odd issues when using `-cr-hint: strut-confined`.)

### Text: correct glyph overlap at text node boundaries

This is usually known as "italic correction", but we can do it more generically for all text nodes, as it can help too with regular fonts with different line-height or vertical-align.
We don't use font and glyph metrics like side bearings, as this is quite limited: we do it visually by drawing both left and right words in a new `LVHorizontalOverlapMeasurementDrawBuf`, and getting the collision distance from the real glyphs used by the final drawing.

It's a generic issue with text rendering, and not easy to solve - some discussions:
`https://github.com/harfbuzz/harfbuzz/issues/3346#issuecomment-1000911273`
https://typedrawers.com/discussion/3023/shouldnt-italic-be-an-opentype-feature
I went initially at playing with right/left side bearings to do the correction, but it was mostly bad.
But, with our DrawBuf infrastructure, we can easily do it better and more visually than anything we could do with font metrics.
It was quite a bit annoying tuning (min distance, vertical spreading, min opacity) to get just the right amount of triggering/correction.

Some non-real-word radical sample for testing, showing how the overlap and correction are different with various fonts:
Before (explicitely not using harfbuzz and getting bad positionning of combined diacritics with some fonts):
![MoreFontsWithout](https://user-images.githubusercontent.com/24273478/161532630-88f9eec2-9ac0-4541-91b6-fdb23be2d10a.png)

After (added some small overline at the start of the "word" being moved right to not overlap):
![MoreFontsWithCorrection](https://user-images.githubusercontent.com/24273478/161532653-ea79033a-d297-45ff-ae4b-7e444c4bc8e4.png)

Some more real world samples with extracts from books where I noticed these overlaps, using FreeSerif here (which is quite easy to exhibit overlaps, it's less radical with other fonts):
Before:
![FreeSerifWithout](https://user-images.githubusercontent.com/24273478/161533445-2077d689-e92c-4b8b-84e4-0c9cea942608.png)

After (some of the overline on some `a` are in the books, mine showing where corrections were added are the ones higher):
![FreeSerifWithCorrection](https://user-images.githubusercontent.com/24273478/161533462-585e9161-2597-45db-a21c-0b57e63dfb58.png)

It looks better on our high DPI devices where the adjustments are smaller/smoother.