### PR TITLE
Add support for inline margin/border/padding

### DIFF
--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -68,11 +68,10 @@ extern "C" {
 #define LTEXT_LOCKED_SPACING         0x00040000  // regular spaces should not change width with text justification
 #define LTEXT_HYPHENATE              0x00080000  // allow hyphenation
 
-// Source object type (when source is not a text node)
-#define LTEXT_SRC_IS_OBJECT          0x00100000  // object (image)
-#define LTEXT_SRC_IS_INLINE_BOX      0x00200000  // inlineBox wrapping node
-#define LTEXT_SRC_IS_FLOAT           0x00400000  // float:'ing node
-#define LTEXT_SRC_IS_FLOAT_DONE      0x00800000  // float:'ing node (already dealt with)
+#define LTEXT_SRC_IS_OBJECT          0x00100000  // Source is not a text node
+#define LTEXT__AVAILABLE_BIT_22__    0x00200000
+#define LTEXT__AVAILABLE_BIT_23__    0x00400000
+#define LTEXT__AVAILABLE_BIT_24__    0x00800000
 // "clear" handling
 #define LTEXT_SRC_IS_CLEAR_RIGHT     0x01000000  // text follows <BR style="clear: right">
 #define LTEXT_SRC_IS_CLEAR_LEFT      0x02000000  // text follows <BR style="clear: left">
@@ -86,6 +85,11 @@ extern "C" {
 #define LTEXT__AVAILABLE_BIT_31__    0x40000000
 #define LTEXT_LEGACY_RENDERING       0x80000000  // Legacy text rendering tweaks
 
+// Object flags (used when LTEXT_SRC_IS_OBJECT is set)
+#define LTEXT_OBJECT_IS_IMAGE             0x0001  // image
+#define LTEXT_OBJECT_IS_INLINE_BOX        0x0002  // inlineBox wrapping node
+#define LTEXT_OBJECT_IS_FLOAT             0x0004  // float:'ing node
+#define LTEXT_OBJECT_IS_FLOAT_DONE        0x0008  // float:'ing node (already dealt with)
 
 // Extra LTEXT properties we can request (via these values) and fetch from the node style,
 // mostly used for rare inherited CSS properties that don't need us to waste a bit for
@@ -129,6 +133,7 @@ typedef struct
         } t;
         struct {
             // (Note: width & height will be stored negative when they are in % unit)
+            lUInt16        objflags; /**< \brief object flags */
             lInt16         width;    /**< \brief width of image or inline-block-box */
             lInt16         height;   /**< \brief height of image or inline-block box */
             lUInt16        baseline; /**< \brief baseline of inline-block box */
@@ -361,6 +366,7 @@ void lvtextAddSourceObject(
    lInt16         width,
    lInt16         height,
    lUInt32         flags,     /* flags */
+   lUInt16         objflags,  /* object flags */
    lInt16          interval,  /* line height in screen pixels */
    lInt16          valign_dy, /* drift y from baseline */
    lInt16          indent,    /* first line indent (or all but first, when negative) */
@@ -421,6 +427,7 @@ public:
 
     void AddSourceObject(
                 lUInt32         flags,     /* flags */
+                lUInt16         objflags,  /* object flags */
                 lInt16          interval,  /* line height in screen pixels */
                 lInt16          valign_dy, /* drift y from baseline */
                 lInt16          indent,    /* first line indent (or all but first, when negative) */

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -88,8 +88,10 @@ extern "C" {
 // Object flags (used when LTEXT_SRC_IS_OBJECT is set)
 #define LTEXT_OBJECT_IS_IMAGE             0x0001  // image
 #define LTEXT_OBJECT_IS_INLINE_BOX        0x0002  // inlineBox wrapping node
-#define LTEXT_OBJECT_IS_FLOAT             0x0004  // float:'ing node
-#define LTEXT_OBJECT_IS_FLOAT_DONE        0x0008  // float:'ing node (already dealt with)
+#define LTEXT_OBJECT_IS_EMBEDDED_BLOCK    0x0004  // block element among inlines (should also have previous bit LTEXT_OBJECT_IS_INLINE_BOX
+                                                  //                              as it is also an inlineBox wrapping node)
+#define LTEXT_OBJECT_IS_FLOAT             0x0010  // float:'ing node
+#define LTEXT_OBJECT_IS_FLOAT_DONE        0x0020  // float:'ing node (already dealt with)
 
 // Extra LTEXT properties we can request (via these values) and fetch from the node style,
 // mostly used for rare inherited CSS properties that don't need us to waste a bit for

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -174,12 +174,12 @@ typedef struct
 
 // formatted_word_t flags
 #define LTEXT_WORD_CAN_ADD_SPACE_AFTER       0x0001 /// can add space after this word
-#define LTEXT_WORD_CAN_BREAK_LINE_AFTER      0x0002 /// can break line after this word (not used anywhere)
-#define LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER 0x0004 /// can break with hyphenation after this word
-#define LTEXT_WORD_MUST_BREAK_LINE_AFTER     0x0008 /// must break line after this word (not used anywhere)
+#define LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER 0x0002 /// can break with hyphenation after this word
+#define LTEXT_WORD__AVAILABLE_BIT_03__       0x0004
+#define LTEXT_WORD__AVAILABLE_BIT_04__       0x0008
 
 #define LTEXT_WORD_IS_LINK_START             0x0010 /// first word of link flag
-#define LTEXT_WORD_IS_OBJECT                 0x0020 /// word is an image
+#define LTEXT_WORD_IS_IMAGE                  0x0020 /// word is an image
 #define LTEXT_WORD_IS_INLINE_BOX             0x0040 /// word is a inline-block or inline-table wrapping box
 #define LTEXT_WORD__AVAILABLE_BIT_08__       0x0080
 

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -69,7 +69,7 @@ extern "C" {
 #define LTEXT_HYPHENATE              0x00080000  // allow hyphenation
 
 #define LTEXT_SRC_IS_OBJECT          0x00100000  // Source is not a text node
-#define LTEXT__AVAILABLE_BIT_22__    0x00200000
+#define LTEXT_HAS_TOP_BOTTOM_BORDER  0x00200000  // text should have top or bottom border (possibly from upper inline container nodes)
 #define LTEXT__AVAILABLE_BIT_23__    0x00400000
 #define LTEXT__AVAILABLE_BIT_24__    0x00800000
 // "clear" handling
@@ -92,6 +92,9 @@ extern "C" {
                                                   //                              as it is also an inlineBox wrapping node)
 #define LTEXT_OBJECT_IS_FLOAT             0x0010  // float:'ing node
 #define LTEXT_OBJECT_IS_FLOAT_DONE        0x0020  // float:'ing node (already dealt with)
+
+#define LTEXT_OBJECT_IS_PAD               0x0100  // inline pad (accounting for margin/border/padding of inline element)
+#define LTEXT_OBJECT_IS_PAD_RIGHT         0x0200  // inline pad is right pad (otherwise, left pad)
 
 // Extra LTEXT properties we can request (via these values) and fetch from the node style,
 // mostly used for rare inherited CSS properties that don't need us to waste a bit for
@@ -183,7 +186,7 @@ typedef struct
 #define LTEXT_WORD_IS_LINK_START             0x0010 /// first word of link flag
 #define LTEXT_WORD_IS_IMAGE                  0x0020 /// word is an image
 #define LTEXT_WORD_IS_INLINE_BOX             0x0040 /// word is a inline-block or inline-table wrapping box
-#define LTEXT_WORD__AVAILABLE_BIT_08__       0x0080
+#define LTEXT_WORD_IS_PAD                    0x0080 /// word is just filler for node's left/right padding/margin/border
 
 #define LTEXT_WORD_DIRECTION_KNOWN           0x0100 /// word has been thru bidi: if next flag is unset, it is LTR.
 #define LTEXT_WORD_DIRECTION_IS_RTL          0x0200 /// word is RTL

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3118,7 +3118,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // be guessed and renderBlockElement() called to render it
             // and get is height, so LFormattedText knows how to render
             // this erm_final text around it.
-            txform->AddSourceObject(baseflags|LTEXT_SRC_IS_FLOAT, line_h, valign_dy, indent, enode, lang_cfg );
+            txform->AddSourceObject(baseflags, LTEXT_OBJECT_IS_FLOAT, line_h, valign_dy, indent, enode, lang_cfg );
             baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             return;
         }
@@ -3684,7 +3684,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     for ( int i=0; i<lines.length(); i++ )
                         txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                 }
-                txform->AddSourceObject(flags, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
                 title = enode->getAttributeValue(attr_subtitle);
                 if ( !title.empty() ) {
                     lString32Collection lines;
@@ -3702,7 +3702,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else { // inline image
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
-                txform->AddSourceObject(flags, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
@@ -3751,12 +3751,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // in this final block (except it that space is included in some
                 // other inline element (<span> </span>) in which case, it is
                 // explicitely expected to generate an empty line.
-                // We also use LTEXT_SRC_IS_INLINE_BOX (no need to waste a bit in
-                // the lUInt32 for LTEXT_SRC_IS_EMBEDDED_BLOCK).
+                // We also use LTEXT_OBJECT_IS_INLINE_BOX (no need to waste a bit in
+                // the lUInt16 for LTEXT_OBJECT_IS_EMBEDDED_BLOCK).
             }
             // We use the flags computed previously (and not baseflags) as they
             // carry vertical alignment
-            txform->AddSourceObject(flags|LTEXT_SRC_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
+            txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
             if ( is_embedded_block ) {
                 // Let flags unchanged, with their newline/alignment flag as if it
                 // hadn't been consumed, so it is reported back into baseflags below

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3710,8 +3710,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             #ifdef DEBUG_DUMP_ENABLED
                 logfile << "+INLINEBOX ";
             #endif
-            bool is_embedded_block = enode->isEmbeddedBlockBoxingInlineBox();
-            if ( is_embedded_block ) {
+            if ( enode->isEmbeddedBlockBoxingInlineBox() ) {
                 // If embedded-block wrapper: it should not be part of the lines
                 // made by the surrounding text/elements: we should ensure a new
                 // line before and after it.
@@ -3745,25 +3744,22 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // These might have no effect, but let's explicitely drop them.
                 valign_dy = 0;
                 indent = 0;
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX|LTEXT_OBJECT_IS_EMBEDDED_BLOCK, line_h, valign_dy, indent, enode, lang_cfg );
+                // Let flags unchanged, with their newline/alignment flag as if it
+                // hadn't been consumed, so it is reported back into baseflags below
+                // so that the next sibling (or upper followup inline node) starts
+                // on a new line.
                 // Note: a space just before or just after (because of a newline in
                 // the HTML source) should have been removed or included in the
                 // boxing element - so we shouldn't have any spurious empty line
                 // in this final block (except it that space is included in some
                 // other inline element (<span> </span>) in which case, it is
                 // explicitely expected to generate an empty line.
-                // We also use LTEXT_OBJECT_IS_INLINE_BOX (no need to waste a bit in
-                // the lUInt16 for LTEXT_OBJECT_IS_EMBEDDED_BLOCK).
-            }
-            // We use the flags computed previously (and not baseflags) as they
-            // carry vertical alignment
-            txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
-            if ( is_embedded_block ) {
-                // Let flags unchanged, with their newline/alignment flag as if it
-                // hadn't been consumed, so it is reported back into baseflags below
-                // so that the next sibling (or upper followup inline node) starts
-                // on a new line.
             }
             else {
+                // We use the flags computed previously (and not baseflags) as they
+                // carry vertical alignment
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4627,26 +4627,15 @@ public:
                 // We do not need to go thru processParagraph() to handle an embedded block
                 // (bogus block element children of an inline element): we have a dedicated
                 // handler for it.
-                bool isEmbeddedBlock = false;
-                if ( i == start + 1 ) {
+                if ( i == start + 1 && m_pbuffer->srctext[start].flags & LTEXT_SRC_IS_OBJECT
+                                    && m_pbuffer->srctext[start].o.objflags & LTEXT_OBJECT_IS_EMBEDDED_BLOCK ) {
                     // Embedded block among inlines had been surrounded by LTEXT_FLAG_NEWLINE,
                     // so we'll get one standalone here.
-                    if ( m_pbuffer->srctext[start].flags & LTEXT_SRC_IS_OBJECT
-                                && m_pbuffer->srctext[start].o.objflags & LTEXT_OBJECT_IS_INLINE_BOX ) {
-                        // We used LTEXT_OBJECT_IS_INLINE_BOX for embedded blocks too (to not
-                        // waste a bit in the lUInt16 for LTEXT_OBJECT_IS_EMBEDDED_BLOCK that
-                        // we would only be using here), so do this check to see if it
-                        // really is an embedded block.
-                        ldomNode * node = (ldomNode *) m_pbuffer->srctext[start].object;
-                        if ( node->isEmbeddedBlockBoxingInlineBox() ) {
-                            isEmbeddedBlock = true;
-                        }
-                    }
-                }
-                if ( isEmbeddedBlock )
                     processEmbeddedBlock( start );
-                else
+                }
+                else {
                     processParagraph( start, i, isLastPara );
+                }
                 start = i;
             }
         }
@@ -5173,7 +5162,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         getAbsMarksFromMarks(marks, absmarks, node);
                         absmarks_update_needed = false;
                     }
-                    if ( node->isEmbeddedBlockBoxingInlineBox() ) {
+                    if ( srcline->o.objflags & LTEXT_OBJECT_IS_EMBEDDED_BLOCK ) {
                         // With embedded blocks, we shouldn't drop the clip (as we do next
                         // for regular inline-block boxes)
                         DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -239,7 +239,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
 //        CRLog::trace("c font = %08x  txt = %08x", (lUInt32)font, (lUInt32)text);
 //        ((LVFont*)font)->getVisualAligmentWidth();
 //    }
-//    if (font == NULL && ((flags & LTEXT_WORD_IS_OBJECT) == 0)) {
+//    if (font == NULL && ((flags & LTEXT_WORD_IS_IMAGE) == 0)) {
 //        CRLog::fatal("No font specified for text");
 //    }
     if ( !lang_cfg )
@@ -429,7 +429,7 @@ public:
 // So, when checking for these, also checks for m_flags[i] & LCHAR_IS_OBJECT.
 // Note that m_charindex, being lUInt16, assume text nodes are not longer
 // than 65535 chars. Things will get messy with longer text nodes...
-#define OBJECT_CHAR_INDEX     ((lUInt16)0xFFFF)
+#define IMAGE_CHAR_INDEX      ((lUInt16)0xFFFF)
 #define FLOAT_CHAR_INDEX      ((lUInt16)0xFFFE)
 #define INLINEBOX_CHAR_INDEX  ((lUInt16)0xFFFD)
 
@@ -1181,7 +1181,7 @@ public:
                 else if ( src->o.objflags & LTEXT_OBJECT_IS_IMAGE ) {
                     m_text[pos] = 0;
                     m_srcs[pos] = src;
-                    m_charindex[pos] = OBJECT_CHAR_INDEX; //0xFFFF;
+                    m_charindex[pos] = IMAGE_CHAR_INDEX; //0xFFFF;
                     m_flags[pos] = LCHAR_IS_OBJECT;
                     #if (USE_LIBUNIBREAK==1)
                         // Let libunibreak know there was an object
@@ -2073,7 +2073,7 @@ public:
                         lastWidth += width;
                         m_widths[start] = lastWidth;
                     }
-                    else {
+                    else if ( m_charindex[start] == IMAGE_CHAR_INDEX ) {
                         // measure image
                         // assume i==start+1
                         src_text_fragment_t * src = m_srcs[start];
@@ -2108,6 +2108,10 @@ public:
                             width, height, m_pbuffer->width, m_max_img_height, m_length>1,
                             UnicodeToLocal(ldomXPointer((ldomNode*)m_srcs[start]->object, 0).toString()).c_str());
                         */
+                    }
+                    else {
+                        // Should not happen
+                        crFatalError(129, "Attempting to measure unexpected object type");
                     }
                 }
                 else {
@@ -3187,7 +3191,7 @@ public:
                         }
                     }
                     else if ( srcline->o.objflags & LTEXT_OBJECT_IS_IMAGE ) {
-                        word->flags = LTEXT_WORD_IS_OBJECT;
+                        word->flags = LTEXT_WORD_IS_IMAGE;
                         // The image dimensions have already been resized to fit
                         // into m_pbuffer->width (and strut confining if requested.
                         // Note: it can happen when there is some text-indent than
@@ -3592,8 +3596,6 @@ public:
                         // between previous word and this one if needed
                         frmline->words[frmline->word_count-2].flags |= LTEXT_WORD_CAN_ADD_SPACE_AFTER;
                     }
-                    // if ( m_flags[i-1] & LCHAR_ALLOW_WRAP_AFTER )
-                    //     word->flags |= LTEXT_WORD_CAN_BREAK_LINE_AFTER; // not used anywhere
 
                     if ( lastWord && (align == LTEXT_ALIGN_RIGHT || align == LTEXT_ALIGN_WIDTH) ) {
                         // Adjust line end if needed.
@@ -5057,7 +5059,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 srcline = &m_pbuffer->srctext[word->src_text_index];
                 if ( (srcline->flags & LTEXT_HAS_EXTRA) && getLTextExtraProperty(srcline, LTEXT_EXTRA_CSS_HIDDEN) && !buf->WantsHiddenContent() )
                     continue;
-                if (word->flags & LTEXT_WORD_IS_OBJECT)
+                if (word->flags & LTEXT_WORD_IS_IMAGE)
                 {
                     // no background, TODO
                 }
@@ -5134,7 +5136,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                 srcline = &m_pbuffer->srctext[word->src_text_index];
                 if ( (srcline->flags & LTEXT_HAS_EXTRA) && getLTextExtraProperty(srcline, LTEXT_EXTRA_CSS_HIDDEN) && !buf->WantsHiddenContent() )
                     continue;
-                if (word->flags & LTEXT_WORD_IS_OBJECT)
+                if (word->flags & LTEXT_WORD_IS_IMAGE)
                 {
                     ldomNode * node = (ldomNode *) srcline->object;
                     if (node) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9016,7 +9016,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 // Otherwise, return xpointer to the inlineBox itself
                 return ldomXPointer(node, 0);
             }
-            if ( word->flags & LTEXT_WORD_IS_OBJECT ) {
+            if ( word->flags & LTEXT_WORD_IS_IMAGE ) {
                 return ldomXPointer(node, 0);
             }
             // It is a word
@@ -9058,7 +9058,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                     // Otherwise, return xpointer to the inlineBox itself
                     return ldomXPointer(node, 0);
                 }
-                if ( word->flags & LTEXT_WORD_IS_OBJECT ) {
+                if ( word->flags & LTEXT_WORD_IS_IMAGE ) {
                     // Object (image)
                     #if 1
                     // return image object itself
@@ -9345,7 +9345,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             else {
                                 bestBidiRect.left = word->x + rc.left + frmline->x;
                                 if (extended) {
-                                    if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
+                                    if (word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                         bestBidiRect.right = bestBidiRect.left + word->width; // width of image
                                     else
                                         bestBidiRect.right = bestBidiRect.left + 1;
@@ -9353,14 +9353,14 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             }
                             hasBestBidiRect = true;
                             nearestForwardSrcIndex = word->src_text_index;
-                            if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX))
+                            if (word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX))
                                 nearestForwardSrcOffset = 0;
                             else
                                 nearestForwardSrcOffset = word->t.start;
                         }
                         else if (word->src_text_index == srcIndex) {
                             // Found word in that exact source text node
-                            if ( word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) ) {
+                            if ( word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) ) {
                                 // An image is the single thing in its srcIndex
                                 rect.top = rc.top + frmline->y;
                                 rect.bottom = rect.top + frmline->height;
@@ -9557,7 +9557,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                 // Generic code when visual order = logical order
                 if ( word->src_text_index>=srcIndex || lastWord ) {
                     // found word from same src line
-                    if ( word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX)
+                    if ( word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX)
                             || word->src_text_index > srcIndex
                             || (!extended && offset <= word->t.start)
                             || (extended && offset < word->t.start)
@@ -9569,7 +9569,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                         //rect.top = word->y + rc.top + frmline->y + frmline->baseline;
                         rect.top = rc.top + frmline->y;
                         if (extended) {
-                            if (word->flags & (LTEXT_WORD_IS_OBJECT|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
+                            if (word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                 rect.right = rect.left + word->width; // width of image
                             else
                                 rect.right = rect.left + 1; // not the right word: no char width

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -90,7 +90,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.67k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x002C
+#define FORMATTING_VERSION_ID 0x002D
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -8973,6 +8973,9 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 ldomNode * node = (ldomNode *)src->object;
                 if ( !node ) // ignore crengine added text (spacing, list item bullets...)
                     continue;
+                if ( tmpword->flags & LTEXT_WORD_IS_PAD ) { // ignore inline padding
+                    continue;
+                }
                 if ( !line_is_bidi ) {
                     word = tmpword;
                     if ( find_first )
@@ -9049,6 +9052,9 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 if ( !node ) // Ignore crengine added text (spacing, list item bullets...)
                     continue;
 
+                if ( word->flags & LTEXT_WORD_IS_PAD ) {
+                    continue;
+                }
                 if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
                     // pt is inside this inline-block inlineBox node
                     ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
@@ -9345,6 +9351,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             else {
                                 bestBidiRect.left = word->x + rc.left + frmline->x;
                                 if (extended) {
+                                    // (No specific handling of LTEXT_WORD_IS_PAD seems needed here and below)
                                     if (word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                         bestBidiRect.right = bestBidiRect.left + word->width; // width of image
                                     else
@@ -9557,6 +9564,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                 // Generic code when visual order = logical order
                 if ( word->src_text_index>=srcIndex || lastWord ) {
                     // found word from same src line
+                    // (No specific handling of LTEXT_WORD_IS_PAD seems needed here and below)
                     if ( word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX)
                             || word->src_text_index > srcIndex
                             || (!extended && offset <= word->t.start)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9277,9 +9277,9 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
         ldomXPointerEx xp(node, offset);
         for ( int i=0; i<txtform->GetSrcCount(); i++ ) {
             const src_text_fragment_t * src = txtform->GetSrcInfo(i);
-            if ( src->flags & LTEXT_SRC_IS_FLOAT ) // skip floats
-                continue;
             bool isObject = (src->flags&LTEXT_SRC_IS_OBJECT)!=0;
+            if ( isObject && src->o.objflags & LTEXT_OBJECT_IS_FLOAT ) // skip floats
+                continue;
             if ( src->object == node ) {
                 srcIndex = i;
                 srcLen = isObject ? 0 : src->t.len;


### PR DESCRIPTION
First 3 commits are just cleanups to allow for the main 4th commit.

### lvtext: tweak object flags implementation

We have room in `src_text_fragment_t` in the union struct used for objects, so put object-only flags in there, leaving more bits available in the 'flags' field shared by object (image, inline-block, floats) and text fragments.
(This is just reorganisation, no rendering change.)

### lvtext: rename `LTEXT_WORD_IS_OBJECT` to `LTEXT_WORD_IS_IMAGE`

Also rename `OBJECT_CHAR_INDEX` to `IMAGE_CHAR_INDEX`.
Also remove `LTEXT_WORD_` unused flags.

### lvtext: add `LTEXT_OBJECT_IS_EMBEDDED_BLOCK`

To keep things clearer and avoid some function calls.

### Text: support for inline margin/border/padding

Handle left/right margin/border/padding on inline elements.
Also add limited support for top/bottom borders (drawn at line height edges, no support for vertical padding).
Only dotted/dashed/solid border styles are handled (any other style is drawn as solid).
Should allow closing https://github.com/koreader/koreader/issues/8156 : 
![image](https://user-images.githubusercontent.com/24273478/164467692-100f4461-1ac6-40db-b45a-5346164f27c3.png)

Firefox | KOReader:
![image](https://user-images.githubusercontent.com/24273478/164468696-1f4c2309-ed89-4c0a-b90c-ff76e4354220.png)

![image](https://user-images.githubusercontent.com/24273478/164468888-5aab9015-7d09-4892-b73f-4c50e7a0453a.png)

Showing our limitations, when there is padding or imbricated borders, and we don't adjust to each fragment text box:
![image](https://user-images.githubusercontent.com/24273478/164469267-ce5f697a-53b0-4b8d-abbd-f3743b086715.png)

I added this mostly to handle padding, as I've met books that use it to do some alignment, for example:
Before:
![image](https://user-images.githubusercontent.com/24273478/164470132-d3ffba82-fe92-409f-a8b1-27dc0320c556.png)

After:
![image](https://user-images.githubusercontent.com/24273478/164470319-b05e7544-73ca-47ea-9a6f-434874380705.png)

So, it's not just cosmetics, but sometimes about readability :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/477)
<!-- Reviewable:end -->
