### PR TITLE
PageMap: allow building synthetic pages numbers

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2306,10 +2306,13 @@ public:
 /// PageMapItems container
 class LVPageMap
 {
-    friend class LVDocView;
+    friend class ldomDocument;
 private:
     ldomDocument *  _doc;
     int             _valid_for_visible_page_numbers;
+    int             _chars_per_synthetic_page; // non-0 means this pagemap has synthetic pages
+    bool            _is_document_provided;
+    bool            _has_document_provided;
     lString32       _source;
     LVPtrVector<LVPageMapItem> _children;
     void addPage( LVPageMapItem * item ) {
@@ -2341,12 +2344,21 @@ public:
         _valid_for_visible_page_numbers = visible_page_numbers;
     }
     void invalidatePageInfo() { _valid_for_visible_page_numbers = 0; }
+    // Whether this page map comes from the document itself
+    void setIsDocumentProvided( bool is_document_provided ) {
+        _is_document_provided = is_document_provided;
+        if ( _is_document_provided ) // If this was called once with true, the document provides some pagemap
+            _has_document_provided = true;
+    }
+    bool isDocumentProvided() const { return _is_document_provided; }
+    bool hasDocumentProvided() const { return _has_document_provided; }
+    int isSynthetic() const { return _chars_per_synthetic_page; }
     // Page source (info about the book paper version the page labels reference)
     void setSource( lString32 source ) { _source = source; }
     lString32 getSource() const { return _source; }
     // root node constructor
     LVPageMap( ldomDocument * doc )
-        : _doc(doc), _valid_for_visible_page_numbers(0) { }
+        : _doc(doc), _valid_for_visible_page_numbers(0), _chars_per_synthetic_page(0), _is_document_provided(false), _has_document_provided(false) { }
     ~LVPageMap() { clear(); }
 };
 
@@ -2513,6 +2525,8 @@ public:
 
     /// returns pointer to PageMapItems container
     LVPageMap * getPageMap() { return &m_pagemap; }
+    /// generate synthetic page map
+    void buildSyntheticPageMap( int chars_per_synthetic_page );
 
 #if BUILD_LITE!=1
     bool isTocFromCacheValid() { return _toc_from_cache_valid; }

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1551,8 +1551,11 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         }
     }
 
-    if ( m_doc->getPageMap()->getChildCount() > 0 && !pageMapSource.empty() )
-        m_doc->getPageMap()->setSource(pageMapSource);
+    if ( m_doc->getPageMap()->getChildCount() > 0 ) {
+        m_doc->getPageMap()->setIsDocumentProvided(true);
+        if ( !pageMapSource.empty() )
+            m_doc->getPageMap()->setSource(pageMapSource);
+    }
 
     writer.OnTagClose(U"", U"body");
     writer.OnStop();


### PR DESCRIPTION
Add a method (available to frontends) to build a synthetic page map, with a new page number every N chars.
This could allow a frontend to show stable page numbers, that do not change with the rendering.
Initial idea described at https://github.com/koreader/koreader/issues/9020#issuecomment-1104374155.

This reuses what was added in https://github.com/koreader/crengine/pull/336  and https://github.com/koreader/koreader/pull/6004.
The function to build it is just there, it works, takes a little bit of time to navigate all the text nodes (too complicated to do it as XML parsing time, and most people won't need it, so no need to force doing it here and waste space and memory - people who want it can bear the additional time it takes).

I'm still not sure how/if this could go into KOReader's menu and settings - but well, let's have this code available so the interested people can experiment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/478)
<!-- Reviewable:end -->
