### PR TITLE
Use the right hyphen glyph, fix table THEAD with multiple TRs

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -36,6 +36,7 @@
 #define UNICODE_ZERO_WIDTH_SPACE 0x200b // (as written in antiword/wordconst.h)
 
 /// Unicode hyphens
+#define UNICODE_HYPHEN_MINUS     0x002D
 #define UNICODE_SOFT_HYPHEN_CODE 0x00AD
 #define UNICODE_ARMENIAN_HYPHEN  0x058A
 // All chars from U+2010 to U+2014 allow deprecated wrap after, except U+2011

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -632,8 +632,8 @@ public:
                         if ( j != dest_idx ) {
                             rows.move(dest_idx, j); // move(indexTo, indexFrom)
                             rows_rendering_reordered = true;
-                            dest_idx++;
                         }
+                        dest_idx++;
                         group_met = true;
                     }
                     else if ( group_met ) {


### PR DESCRIPTION
#### Font: use U+002D instead of U+00AD for the hyphen char

Use ASCII minus char instead of Soft-Hyphen char as the latter may be unavailable/blank/bad in some fonts, while the former is usually perfect.
See https://github.com/koreader/koreader/issues/9074#issuecomment-1120099697 and followup posts.
Should allow closing https://github.com/koreader/koreader/issues/9074.

#### Tables: fix FixRowGroupsOrder()

A 2nd `<tr>` in a `<thead>` was moved above the first `<tr>` (the fix is just how it is done for `<tfoot>`).
See https://github.com/koreader/crengine/pull/379#issuecomment-1120263579.
Should fix https://www.mobileread.com/forums/showthread.php?t=346684

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/479)
<!-- Reviewable:end -->
