### PR TITLE
Improved typography for Chinese and Japanese

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -394,6 +394,10 @@ enum css_generic_value_t {
 // Glyphs should not overflow line edges, and across text nodes or over images
 // (it can also be used to disable hanging punctuation on the targeted nodes).
 #define CSS_CR_HINT_FIT_GLYPHS              0x00000004 // -cr-hint: fit-glyphs (inheritable)
+// Paragraphs ("final" blocks') width and text-indent is to be ajusted to an
+// integer multiple of their font size (so text justification of lines made of
+// only squared CJK glyphs get less chance to need to spread the glyphs).
+#define CSS_CR_HINT_CJK_TAILORED            0x00000008 // -cr-hint: cjk-tailored (inheritable)
 
 // A node with these should be considered as TOC item of level N when building alternate TOC
 #define CSS_CR_HINT_TOC_LEVEL1              0x00000100 // -cr-hint: toc-level1
@@ -432,7 +436,7 @@ enum css_generic_value_t {
                                                        //                           everything else indicates it is)
 
 // A few of them are inheritable, most are not.
-#define CSS_CR_HINT_INHERITABLE_MASK        0x00000006
+#define CSS_CR_HINT_INHERITABLE_MASK        0x0000000E
 
 // Macro for easier checking
 #define STYLE_HAS_CR_HINT(s, h)     ( (bool)(s->cr_hint.value & CSS_CR_HINT_##h) )

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -78,6 +78,8 @@
 #define PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT   "crengine.style.unused.space.threshold.percent"
 // Max allowed added letter spacing (% of font size)
 #define PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT "crengine.style.max.added.letter.spacing.percent"
+// CJK char width expansion (% of nominal width)
+#define PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT          "crengine.style.cjk.width.scale.percent"
 
 #define PROP_FILE_PROPS_FONT_SIZE    "cr3.file.props.font.size"
 

--- a/crengine/include/lvfnt.h
+++ b/crengine/include/lvfnt.h
@@ -247,21 +247,11 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
 #define LCHAR_IS_COLLAPSED_SPACE     0x0200 ///< flag: this char is a space that should not be rendered
 #define LCHAR_IS_TO_IGNORE           0x0400 ///< flag: this char is to be ignored/skipped in text measurement and drawing
 #define LCHAR_IS_RTL                 0x0800 ///< flag: this char is part of a RTL segment
-
-#define LCHAR__AVAILABLE_BIT_13__    0x1000
-#define LCHAR__AVAILABLE_BIT_14__    0x2000
+#define LCHAR_IS_CJK                 0x1000 ///< flag: this char is CJK
+#define LCHAR_IS_FLEXIBLE_WIDTH_CJK  0x2000 ///< flag: this char is a CJK fullwidth char that can have its
+                                            ///        nominal width modified (mostly small punctuation)
 #define LCHAR__AVAILABLE_BIT_15__    0x4000
 #define LCHAR__AVAILABLE_BIT_16__    0x8000
-
-// Some idea, if needed:
-// #define LCHAR_IS_CJK_NOT_PUNCT       0x1000 ///< flag: this char is part a CJK char but not a punctuation
-// #define LCHAR_IS_CJK_LEFT_PUNCT      0x2000 ///< flag: this char is part a CJK left punctuation
-// #define LCHAR_IS_CJK_RIGHT_PUNCT     0x4000 ///< flag: this char is part a CJK right punctuation
-// #define LCHAR_IS_CJK_PUNCT           0x6000 ///< flag: (for checking) this char is a CJK punctuation (neutral if set)
-// #define LCHAR_IS_CJK                 0x7000 ///< flag: (for checking) this char is a CJK char
-
-// LCHAR_IS_EOL was not used by any code, and has been replaced by LCHAR_IS_CLUSTER_TAIL
-// #define LCHAR_IS_EOL              0x0010 ///< flag: this char is CR or LF
 
 
 /** \brief returns true if character is unicode space

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -224,6 +224,7 @@ enum kerning_mode_t {
 
 #define LFNT_HINT_TRANSFORM_STRETCH      0x0100 /// Glyph(s) are to be stretched so their bounding box fits the provided w/h
 #define LFNT_HINT_CJK_ALTERED_WIDTH      0x0200 /// CJK full width glyph is to be shifted to look correct in a non-nominal width
+#define LFNT_HINT_CJK_SCALED_WIDTH       0x0400 /// CJK full width glyph has been scaled by cjk_width_scale_percent
 
 // These 4 translate from LTEXT_TD_* equivalents (see lvtextfm.h). Keep them in sync.
 #define LFNT_DRAW_UNDERLINE              0x1000 /// underlined text

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -223,6 +223,7 @@ enum kerning_mode_t {
 #define LFNT_HINT_IS_FALLBACK_FONT       0x0010 /// set on recursive Harfbuzz rendering/drawing with a fallback font
 
 #define LFNT_HINT_TRANSFORM_STRETCH      0x0100 /// Glyph(s) are to be stretched so their bounding box fits the provided w/h
+#define LFNT_HINT_CJK_ALTERED_WIDTH      0x0200 /// CJK full width glyph is to be shifted to look correct in a non-nominal width
 
 // These 4 translate from LTEXT_TD_* equivalents (see lvtextfm.h). Keep them in sync.
 #define LFNT_DRAW_UNDERLINE              0x1000 /// underlined text

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -180,8 +180,9 @@ typedef struct
 // formatted_word_t flags
 #define LTEXT_WORD_CAN_ADD_SPACE_AFTER       0x0001 /// can add space after this word
 #define LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER 0x0002 /// can break with hyphenation after this word
-#define LTEXT_WORD__AVAILABLE_BIT_03__       0x0004
-#define LTEXT_WORD__AVAILABLE_BIT_04__       0x0008
+#define LTEXT_WORD_IS_CJK                    0x0004 /// word is a single CJK char
+#define LTEXT_WORD_IS_FLEXIBLE_WIDTH_CJK     0x0008 /// word is also a CJK char that may get its nominal width modified (CJK punctuation)
+                                                    /// (we could share 0x0002 if we need to regain a bit)
 
 #define LTEXT_WORD_IS_LINK_START             0x0010 /// first word of link flag
 #define LTEXT_WORD_IS_IMAGE                  0x0020 /// word is an image

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -311,6 +311,8 @@ typedef struct
    lInt32                unused_space_threshold_percent; /**< % (of line width) of unused space on a line to trigger hyphenation,
                                                               or addition of letter spacing for justification  */
    lInt32                max_added_letter_spacing_percent; /**< Max allowed added letter spacing (% of font size) */
+   // CJK char width
+   lInt32                cjk_width_scale_percent; /**< scale the normal width of all CJK chars in all fonts by this percent */
 
    // Highlighting
    text_highlight_options_t highlight_options; /**< options for selection/bookmark highlighting */
@@ -420,6 +422,10 @@ public:
 
     /// set max allowed added letter spacing (0..20% of font size)
     void setMaxAddedLetterSpacingPercent(int maxAddedLetterSpacingPercent);
+
+    /// set CJK glyph width scaling percent option (100..150%)
+    // (scale the nominal width of all CJK chars in all fonts by this percent)
+    void setCJKWidthScalePercent(int cjkWidthScalePercent);
 
     /// set colors for selection and bookmarks
     void setHighlightOptions(text_highlight_options_t * options);

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -113,6 +113,7 @@ extern const int gDOMVersionCurrent;
 #define DEF_MIN_SPACE_CONDENSING_PERCENT 50
 #define DEF_UNUSED_SPACE_THRESHOLD_PERCENT 5
 #define DEF_MAX_ADDED_LETTER_SPACING_PERCENT 0
+#define DEF_CJK_WIDTH_SCALE_PERCENT 100
 
 #define NODE_DISPLAY_STYLE_HASH_UNINITIALIZED 0xFFFFFFFF
 
@@ -492,6 +493,7 @@ protected:
     int  _minSpaceCondensingPercent;
     int  _unusedSpaceThresholdPercent;
     int  _maxAddedLetterSpacingPercent;
+    int  _cjkWidthScalePercent;
 
     lUInt32 _nodeStyleHash;
     lUInt32 _nodeDisplayStyleHash;
@@ -592,6 +594,17 @@ public:
         // This does not need to trigger a re-rendering, just
         // a re-formatting of the final blocks
         _renderedBlockCache.clear();
+        return true;
+    }
+
+    int getCJKWidthScalePercent() {
+        return _cjkWidthScalePercent;
+    }
+
+    bool setCJKWidthScalePercent(int cjkWidthScalePercent) {
+        if (cjkWidthScalePercent == _cjkWidthScalePercent)
+            return false;
+        _cjkWidthScalePercent = cjkWidthScalePercent;
         return true;
     }
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4733,6 +4733,7 @@ void LVDocView::createEmptyDocument() {
     m_doc->setMinSpaceCondensingPercent(m_props->getIntDef(PROP_FORMAT_MIN_SPACE_CONDENSING_PERCENT, DEF_MIN_SPACE_CONDENSING_PERCENT));
     m_doc->setUnusedSpaceThresholdPercent(m_props->getIntDef(PROP_FORMAT_UNUSED_SPACE_THRESHOLD_PERCENT, DEF_UNUSED_SPACE_THRESHOLD_PERCENT));
     m_doc->setMaxAddedLetterSpacingPercent(m_props->getIntDef(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, DEF_MAX_ADDED_LETTER_SPACING_PERCENT));
+    m_doc->setCJKWidthScalePercent(m_props->getIntDef(PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT, DEF_CJK_WIDTH_SCALE_PERCENT));
     m_doc->setHangingPunctiationEnabled(m_props->getBoolDef(PROP_FLOATING_PUNCTUATION, false));
     m_doc->setRenderBlockRenderingFlags(m_props->getIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS));
     m_doc->setDOMVersionRequested(m_props->getIntDef(PROP_REQUESTED_DOM_VERSION, gDOMVersionCurrent));
@@ -6503,6 +6504,13 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
         p = 20;
     props->setInt(PROP_FORMAT_MAX_ADDED_LETTER_SPACING_PERCENT, p);
 
+    p = props->getIntDef(PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT, DEF_CJK_WIDTH_SCALE_PERCENT);
+    if (p<100)
+        p = 100;
+    if (p>150)
+        p = 150;
+    props->setInt(PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT, p);
+
     props->setIntDef(PROP_RENDER_DPI, DEF_RENDER_DPI); // 96 dpi
     props->setIntDef(PROP_RENDER_SCALE_FONT_WITH_DPI, DEF_RENDER_SCALE_FONT_WITH_DPI); // no scale
     props->setIntDef(PROP_RENDER_BLOCK_RENDERING_FLAGS, DEF_RENDER_BLOCK_RENDERING_FLAGS);
@@ -6868,6 +6876,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             if (m_doc) // not when noDefaultDocument=true
                 if (getDocument()->setMaxAddedLetterSpacingPercent(value))
                     REQUEST_RENDER("propsApply max added letter spacing percent")
+        } else if (name == PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT) {
+            int value = props->getIntDef(PROP_FORMAT_CJK_WIDTH_SCALE_PERCENT, DEF_CJK_WIDTH_SCALE_PERCENT);
+            if (m_doc) // not when noDefaultDocument=true
+                if (getDocument()->setCJKWidthScalePercent(value))
+                    REQUEST_RENDER("propsApply CJK width scale percent")
         } else if (name == PROP_HIGHLIGHT_COMMENT_BOOKMARKS) {
             int value = props->getIntDef(PROP_HIGHLIGHT_COMMENT_BOOKMARKS, highlight_mode_underline);
             if (m_highlightBookmarks != value) {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -3696,6 +3696,16 @@ public:
             }
             // Let HB guess what's not been set (script, direction, language)
             hb_buffer_guess_segment_properties(_hb_buffer);
+            // In case HB couldn't guess a script from the unicode chars we added to its buffer,
+            // (which can happen when we give it a single CJK punctuation which would be considered
+            // as script COMMON, or a sequence of digits and punctuations), make sure we have HB aware
+            // of some valid script, so that at least the 'locl' feature works and is able to provide
+            // glyphs for the requested hb_language.
+            if ( hb_buffer_get_script(_hb_buffer) == HB_SCRIPT_INVALID ) {
+                // Provide "latn", which has the best chance to be known by the font and have
+                // its OpenType features working.
+                hb_buffer_set_script(_hb_buffer, HB_SCRIPT_LATIN);
+            }
 
             // See measureText() for details
             if ( letter_spacing > 0 ) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -11474,6 +11474,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         // white-space (nowrap provided by parent with sub-call)
         bool pre = parent_style->white_space >= css_ws_pre;
         int space_width_scale_percent = pre ? 100 : parent->getDocument()->getSpaceWidthScalePercent();
+        int cjk_width_scale_percent = parent->getDocument()->getCJKWidthScalePercent();
 
         // If fit_glyphs, we'll adjust below each word width with calls to
         // getLeftSideBearing() and getRightSideBearing(). These should be
@@ -11535,8 +11536,11 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     w = w * space_width_scale_percent / 100;
                 }
                 lChar32 c = *(txt + start + i);
-                lChar32 next_c = *(txt + start + i + 1); // might be 0 at end of string
+                if ( cjk_width_scale_percent != 100 && lStr_isCJK(c) ) {
+                    w = w * cjk_width_scale_percent / 100;
+                }
                 bool is_collapsable_space = (c == ' '); // We only collapse the classic ASCII spaces in lvtextfm.cpp
+                lChar32 next_c = *(txt + start + i + 1); // might be 0 at end of string
                 if ( lang_cfg->hasLBCharSubFunc() ) {
                     next_c = lang_cfg->getLBCharSubFunc()(&lbCtx, txt+start, i+1, len-1 - (i+1));
                 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3089,6 +3089,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         else if ( substr_icompare("non-linear", decl) )             hints |= CSS_CR_HINT_NON_LINEAR;
                         else if ( substr_icompare("non-linear-combining", decl) )   hints |= CSS_CR_HINT_NON_LINEAR_COMBINING;
                         else if ( substr_icompare("strut-confined", decl) )         hints |= CSS_CR_HINT_STRUT_CONFINED;
+                        else if ( substr_icompare("cjk-tailored", decl) )           hints |= CSS_CR_HINT_CJK_TAILORED;
                         else if ( substr_icompare("fit-glyphs", decl) )             hints |= CSS_CR_HINT_FIT_GLYPHS;
                         else if ( substr_icompare("text-selection-skip", decl) )    hints |= CSS_CR_HINT_TEXT_SELECTION_SKIP;
                         else if ( substr_icompare("text-selection-inline", decl) )  hints |= CSS_CR_HINT_TEXT_SELECTION_INLINE;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -403,6 +403,7 @@ public:
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
+    bool m_kerning_mode;
     bool m_allow_strut_confining;
     bool m_has_multiple_scripts;
     int  m_usable_left_overflow;
@@ -1003,6 +1004,9 @@ public:
     /// copy text of current paragraph to buffers
     void copyText( int start, int end )
     {
+        // We might disable/tweak some kerning-like behaviour depending on this setting
+        m_kerning_mode = fontMan->GetKerningMode();
+
         #if (USE_LIBUNIBREAK==1)
         struct LineBreakContext lbCtx;
         // Let's init it before the first char, by adding a leading Zero-Width Joiner
@@ -1764,7 +1768,7 @@ public:
                 #if (USE_HARFBUZZ==1)
                     // Check if we are using Harfbuzz kerning with the first font met
                     if ( checkIfHarfbuzz && newFont ) {
-                        if ( newFont->getKerningMode() == KERNING_MODE_HARFBUZZ ) {
+                        if ( m_kerning_mode == KERNING_MODE_HARFBUZZ ) {
                             usingHarfbuzz = true;
                         }
                         checkIfHarfbuzz = false;
@@ -2352,7 +2356,7 @@ public:
             }
             LVFont * prev_font = (LVFont *) prev_src->t.font;
             LVFont * font = (LVFont *) src->t.font;
-            if ( font->getKerningMode() == KERNING_MODE_DISABLED ) {
+            if ( m_kerning_mode == KERNING_MODE_DISABLED ) {
                 break; // Don't do any correction at all
             }
 
@@ -3496,7 +3500,7 @@ public:
                         // If not using Harfbuzz, procede to mirror parens & al (don't
                         // do that if Harfbuzz is used, as it does that by itself, and
                         // would mirror back our mirrored chars!)
-                        if ( font->getKerningMode() != KERNING_MODE_HARFBUZZ) {
+                        if ( m_kerning_mode != KERNING_MODE_HARFBUZZ ) {
                             lChar32 * str = (lChar32*)(srcline->t.text + word->t.start);
                             FriBidiChar mirror;
                             for (int i=0; i < word->t.len; i++) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6243,6 +6243,9 @@ int initTableRendMethods( ldomNode * enode, int state )
                 printf("initTableRendMethods(%d): wrapping unproper %d>%d\n",
                             state, first_unproper, last_unproper);
             #endif
+            if ( is_last && last_unproper < 0 ) { // (may happen with old gDOMVersionRequested)
+                last_unproper = cnt-1;
+            }
             int elems_removed = last_unproper - first_unproper + 1;
             ldomNode * tbox = enode->boxWrapChildren(first_unproper, last_unproper, el_tabularBox);
             if ( tbox && !tbox->isNull() ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2370,6 +2370,7 @@ tinyNodeCollection::tinyNodeCollection()
 , _minSpaceCondensingPercent(DEF_MIN_SPACE_CONDENSING_PERCENT)
 , _unusedSpaceThresholdPercent(DEF_UNUSED_SPACE_THRESHOLD_PERCENT)
 , _maxAddedLetterSpacingPercent(DEF_MAX_ADDED_LETTER_SPACING_PERCENT)
+, _cjkWidthScalePercent(DEF_CJK_WIDTH_SCALE_PERCENT)
 , _nodeStyleHash(0)
 , _nodeDisplayStyleHash(NODE_DISPLAY_STYLE_HASH_UNINITIALIZED)
 , _nodeDisplayStyleHashInitial(NODE_DISPLAY_STYLE_HASH_UNINITIALIZED)
@@ -2414,6 +2415,7 @@ tinyNodeCollection::tinyNodeCollection( tinyNodeCollection & v )
 , _minSpaceCondensingPercent(DEF_MIN_SPACE_CONDENSING_PERCENT)
 , _unusedSpaceThresholdPercent(DEF_UNUSED_SPACE_THRESHOLD_PERCENT)
 , _maxAddedLetterSpacingPercent(DEF_MAX_ADDED_LETTER_SPACING_PERCENT)
+, _cjkWidthScalePercent(DEF_CJK_WIDTH_SCALE_PERCENT)
 , _nodeStyleHash(0)
 , _nodeDisplayStyleHash(NODE_DISPLAY_STYLE_HASH_UNINITIALIZED)
 , _nodeDisplayStyleHashInitial(NODE_DISPLAY_STYLE_HASH_UNINITIALIZED)
@@ -3871,6 +3873,7 @@ LFormattedText * lxmlDocBase::createFormattedText()
     p->setMinSpaceCondensingPercent(_minSpaceCondensingPercent);
     p->setUnusedSpaceThresholdPercent(_unusedSpaceThresholdPercent);
     p->setMaxAddedLetterSpacingPercent(_maxAddedLetterSpacingPercent);
+    p->setCJKWidthScalePercent(_cjkWidthScalePercent);
     p->setHighlightOptions(&_highlightOptions);
     return p;
 }
@@ -16043,6 +16046,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered)
     res = res * 31 + _spaceWidthScalePercent;
     res = res * 31 + _minSpaceCondensingPercent;
     res = res * 31 + _unusedSpaceThresholdPercent;
+    res = res * 31 + _cjkWidthScalePercent;
 
     // _maxAddedLetterSpacingPercent does not need to be accounted, as, working
     // only on a laid out line, it does not need a re-rendering, but just

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9324,6 +9324,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
             bool line_is_bidi = frmline->flags & LTEXT_LINE_IS_BIDI;
             for ( int w=0; w<(int)frmline->word_count; w++ ) {
                 const formatted_word_t * word = &frmline->words[w];
+                if (word->flags & LTEXT_WORD_IS_PAD ) {
+                    // Skip these as they are virtual and don't map to real nodes
+                    // text indices: they won't be part of any rect
+                    continue;
+                }
                 bool word_is_rtl = word->flags & LTEXT_WORD_DIRECTION_IS_RTL;
                 bool lastWord = (l == txtform->GetLineCount() - 1
                                  && w == frmline->word_count - 1);
@@ -9354,7 +9359,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                             else {
                                 bestBidiRect.left = word->x + rc.left + frmline->x;
                                 if (extended) {
-                                    // (No specific handling of LTEXT_WORD_IS_PAD seems needed here and below)
                                     if (word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) && word->width > 0)
                                         bestBidiRect.right = bestBidiRect.left + word->width; // width of image
                                     else
@@ -9567,7 +9571,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted) const
                 // Generic code when visual order = logical order
                 if ( word->src_text_index>=srcIndex || lastWord ) {
                     // found word from same src line
-                    // (No specific handling of LTEXT_WORD_IS_PAD seems needed here and below)
                     if ( word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX)
                             || word->src_text_index > srcIndex
                             || (!extended && offset <= word->t.start)


### PR DESCRIPTION
Improve CJK typography (mostly Chinese and Japanese, Korean didn't really need and doesn't get anything), as discussed over the last 2 years in https://github.com/koreader/koreader/issues/6162.
Should allow closing https://github.com/koreader/koreader/issues/6162 and https://github.com/koreader/koreader/issues/6078.

#### `initTableRendMethods()`: fix possible crash

#### `ldomXPointer::getRect()`: skip inline pads

Skip them early (not sure if it's really the best thing to do) to avoid a possible crash later when `font->measureText()` an empty string. Closes #481.

#### Ruby: keep any last text wrapped in internal table elements

Some publishers include 〘 and 〙 around a `<rt>` so that, when ruby is not supported, these are displayed inline and wrap the annotation.
We'd rather have them not shown by having them wrapped and swallowed/hidden among table-like elements.
![image](https://user-images.githubusercontent.com/24273478/171990429-7f8554a1-5723-4db7-a61c-60bea383e5da.png) ![image](https://user-images.githubusercontent.com/24273478/171990542-1661ef59-7c35-40a8-aa69-12af6b82b16d.png) => ![image](https://user-images.githubusercontent.com/24273478/171990572-40725b2b-c080-4b20-aef9-34d631eb9062.png)

#### Font: fix HarfBuzz localized glyphs with CJK punctuation

This is a quick simple solution to get Traditional Chinese punctuation back, and should work fine in practice.
(A more proper fix would be to gather and remember the detected script of all chars, and so use the script detected from the neighbour chars, but this is a lot more costly as it would need another array like `m_text`, `m_flags`: `m_script`.)
See details and discussion starting at https://github.com/koreader/crengine/pull/472#issuecomment-1122647571.

#### lvtext: store kerning mode as a Formatter property

It's a global setting, so applied to all fonts. No need to pick it from each font. Will allow more tweaking depending on this setting.

#### CJK: improved typography by tweaking punctuations

Add support in textlang for flagging CJK punctuations, and ensuring width adjustment (forced or allowed reduction) depending on a punctuation context (neighbout, start or end of line), and differently depending if the language is Japanese, Simplified Chinese or Traditional Chinese.
This allows, for example, to make consecutive opening or closing punctuations halfwidth in SC, and some punctuations at end of line halfwidth, respecting the recommended typography rules for each language (clreq, jlreq).
For reference, some screenshots with copy&paste of the rules I made out at:
https://github.com/koreader/koreader/issues/6162#issuecomment-1146572495

In lvtextfm, detect and flag punctuation chars as "flexible" CJK chars, and use the typography rules when breaking lines and making words.
When line-breaking, when a CJK char would not fit, and a break would not be allowed (which would cause a hole the size of a glyph at end of line, that text justification would solve by spreading out the glyphs), try to steal some width from any previous "flexible" punctuation that stayed full width.
Disable all this when kerning mode is "off", to allow getting the old behaviour.

In lvfntman, when a CJK glyph got its width reduced, try to shift the drawing so this CJK glyph appears in this reduced width as it would naturally (left, right or centered).

#### CJK: allow scaling CJK glyphs' widths

This may allow "Word Spacing" to have some effect on CJK text (where each glyphs is a word).
Scaling glyphs (or letter spacing) is considered bad practice by many typography sites, but it might be helpful with very "solid" CJK fonts and to users learning Chinese.
I've seen this requested twice: at https://github.com/koreader/koreader/issues/6162#issuecomment-650469410 and in some comments at https://www.thetype.com/kongque/.
See https://github.com/koreader/koreader/pull/6134#issuecomment-1140219185 for some screenshots, and next comments saying anything above 105% is ugly though :)

#### CSS/lvrend: adds `-cr-hint: cjk-tailored`

To get paragraphs ("final" blocks) width and text-indent ajusted to an integer multiple of their font size (so text justification of lines made of only squared CJK glyphs get less chance to need to spread the glyphs).
See https://github.com/koreader/koreader/issues/6162#issuecomment-1120416923 why this can't really be done automatically, and why it is best left to a style tweak and a user decision.

#### CJK: expand last line as previous justified line

The last line of a justified paragraph is left aligned and wouldn't get any added spacing, which would make it look more condensed that the justified line above it.
So, when both previous to last and last line starts with 2 CJK chars, add to the last line the same spacing added to the above line so CJK chars looks vertically aligned.
See https://github.com/koreader/koreader/issues/6162#issuecomment-1120416923.
Should allow closing https://github.com/koreader/koreader/issues/8929.

#### CJK: add 1/4 em of spacing between CJK and western words

At the boundary between a CJK segment and a segment of non-CJK chars, we want to add a bit of spacing, 1/4em as advised by clreq and jlreq.
Before:
![image](https://user-images.githubusercontent.com/24273478/171991395-bd6dce61-de37-4c7b-95b8-d1d97232d3ac.png)
After, this spacing giving it a nicer touch:
![image](https://user-images.githubusercontent.com/24273478/171991367-b8231136-aa96-48bd-9ccf-9d229c4140c9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/482)
<!-- Reviewable:end -->
