### PR TITLE
Tweaks to allow text selection in margins

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -748,13 +748,13 @@ public:
     void setPageSkin( CRPageSkinRef skin );
 
     /// returns xpointer for specified window point
-    ldomXPointer getNodeByPoint( lvPoint pt, bool strictBounds=false );
+    ldomXPointer getNodeByPoint( lvPoint pt, bool strictBounds=false, bool forTextSelection=false );
     /// returns image source for specified window point, if point is inside image
     LVImageSourceRef getImageByPoint(lvPoint pt);
     /// draws scaled image into buffer, clear background according to current settings
     bool drawImage(LVDrawBuf * buf, LVImageSourceRef img, int x, int y, int dx, int dy);
     /// converts point from window to document coordinates, returns true if success
-    bool windowToDocPoint( lvPoint & pt );
+    bool windowToDocPoint( lvPoint & pt, bool pullInPageArea=false );
     /// converts point from document to window coordinates, returns true if success
     bool docToWindowPoint( lvPoint & pt, bool isRectBottom=false, bool fitToPage=false );
 

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -653,6 +653,9 @@ public:
     virtual void getFontFileNameList( lString32Collection & ) { }
     /// returns font filename and face index for font name
     virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index ) { return false; }
+    /// returns registered or instantiated document embedded font list
+    virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list ) { }
+    virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list ) { }
 
     /// returns first found face from passed list, or return face for font found by family only
     virtual lString8 findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily);

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1642,6 +1642,8 @@ public:
             return lString32::empty_str;
         return node->getText( blockDelimiter );
     }
+    /// returns char (0 if node a text node, or end of text node)
+    lChar32 getChar();
     /// returns href attribute of <A> element, null string if not found
     lString32 getHRef();
     /// returns href attribute of <A> element, plus xpointer of <A> element itself

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -1165,7 +1165,6 @@ public:
             } else {
                 CRLog::error("Document type is not HTML for fragment %s", LCSTR(fname));
             }
-            appendedFragments++;
         }
         return appendedFragments;
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -650,6 +650,30 @@ public:
         }
         return false;
     }
+    virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list )
+    {
+        list.clear();
+        for ( int i=0; i<_registered_list.length(); i++ ) {
+            if (_registered_list[i]->getDef()->getDocumentId() != document_id)
+                continue;
+            lString32 name = Utf8ToUnicode( _registered_list[i]->getDef()->getTypeFace() );
+            if ( !list.contains(name) )
+                list.add( name );
+        }
+        list.sort();
+    }
+    virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list )
+    {
+        list.clear();
+        for ( int i=0; i<_instance_list.length(); i++ ) {
+            if (_instance_list[i]->getDef()->getDocumentId() != document_id)
+                continue;
+            lString32 name = Utf8ToUnicode( _instance_list[i]->getDef()->getTypeFace() );
+            if ( !list.contains(name) )
+                list.add( name );
+        }
+        list.sort();
+    }
     virtual void clearFallbackFonts()
     {
         LVPtrVector< LVFontCacheItem > * fonts = getInstances();
@@ -5396,6 +5420,17 @@ public:
     {
         FONT_MAN_GUARD
         return _cache.getFontFileNameAndFaceIndex(name, bold, italic, filename, index);
+    }
+
+    virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list )
+    {
+        FONT_MAN_GUARD
+        _cache.getRegisteredDocumentFontList(document_id, list);
+    }
+    virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list )
+    {
+        FONT_MAN_GUARD
+        _cache.getInstantiatedDocumentFontList(document_id, list);
     }
 
     bool SetAlias(lString8 alias,lString8 facename,int id,bool bold,bool italic)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -405,7 +405,7 @@ public:
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
-    bool m_kerning_mode;
+    kerning_mode_t m_kerning_mode;
     bool m_allow_strut_confining;
     bool m_has_multiple_scripts;
     int  m_usable_left_overflow;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13587,6 +13587,19 @@ lString32 ldomXRange::getRangeText( lChar32 blockDelimiter, int maxTextLen )
     return removeSoftHyphens( callback.getText() );
 }
 
+lChar32 ldomXPointer::getChar()
+{
+    ldomNode * node = getNode();
+    if ( !node || !node->isText() )
+        return 0;
+    lString32 text = node->getText();
+    int textLen = text.length();
+    int offset = _data->getOffset();
+    if ( offset >= textLen || offset < 0 )
+        return 0;
+    return text[offset];
+}
+
 /// returns href attribute of <A> element, plus xpointer of <A> element itself
 lString32 ldomXPointer::getHRef(ldomXPointer & a_xpointer)
 {

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -965,7 +965,7 @@ void LVTextFileBase::SetCharset( const lChar32 * name )
         m_enc_type = ce_utf16_le;
         SetCharsetTable( NULL );
 #if GBK_ENCODING_SUPPORT == 1
-    } else if ( m_encoding_name == "gbk" || m_encoding_name == "cp936" || m_encoding_name == "cp-936") {
+    } else if ( m_encoding_name == "gbk" || m_encoding_name == "gb2312" || m_encoding_name == "cp936" || m_encoding_name == "cp-936") {
         m_enc_type = ce_gbk;
         SetCharsetTable( NULL );
 #endif


### PR DESCRIPTION
#### lvtext: fix m_kerning_mode type

Messed by a7cea02c #482: it since fails detecting Harfbuzz is used and would handle bracket mirroring, and we end up mirroring them and Harfbuzz unmirroring them, resulting in messed up brackets in Arabic and Hebrew.
Noticed at https://github.com/koreader/crengine/pull/483#discussion_r889719759, thanks @weijiuqiao.

#### XML: let 'gb2312' (Chinese) encoding be known

Met in some CHM files at https://github.com/koreader/koreader/issues/9176#issuecomment-1147386804

#### Add ldomXPointer::getChar()

May be used to extend highlight to include punctuations, some idea at https://github.com/koreader/koreader/issues/8857#issuecomment-1151198923

#### LVDocView::getNodeByPoint(): tweak for text selection

Should allow selecting text by panning from/to/inside the outer margins, and getting something better/nearer when in paragraph left/right margins or in their collapsed top/bottom margins.
See https://github.com/koreader/koreader/issues/9169#issuecomment-1146625083.
Should allow closing https://github.com/koreader/koreader/issues/9169.

#### Fonts: allow fetching the list of embedded fonts

Frontends might want to know if there are some, and show their names.
See some idea at https://github.com/koreader/koreader/issues/9190.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/484)
<!-- Reviewable:end -->
