### PR TITLE
CSS: add a few style tweaks helpers, and other fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -417,14 +417,16 @@ enum css_generic_value_t {
                                                        //                                  if the node happens to be inline)
 #define CSS_CR_HINT_TEXT_SELECTION_SKIP     0x00040000 // -cr-hint: text-selection-skip    don't include inner text in selection
 
-// To be set on a block element: it is a footnote (must be a full footnote block container),
-// and to be displayed at the bottom of all pages that contain a link to it.
-#define CSS_CR_HINT_FOOTNOTE_INPAGE         0x00080000 // -cr-hint: footnote-inpage
-
 // To be set on a block element: this block makes a non-linear flow that can be hidden from normal flow by frontends.
 // Consecutive siblings all hinted with 'non-linear-combining' combine all into a single flow.
 #define CSS_CR_HINT_NON_LINEAR              0x00100000 // -cr-hint: non-linear
 #define CSS_CR_HINT_NON_LINEAR_COMBINING    0x00300000 // -cr-hint: non-linear-combining  (2 bits flag, includes previous one)
+
+// To be set on a block element: it is a footnote (must be a full footnote block container),
+// and to be displayed at the bottom of all pages that contain a link to it.
+#define CSS_CR_HINT_FOOTNOTE_INPAGE         0x00400000 // -cr-hint: footnote-inpage
+#define CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE  0x00800000 // (internal: set by previous one, and inherited early by children)
+
 
 // For footnote popup detection by koreader-base/cre.cpp
 #define CSS_CR_HINT_NOTEREF                 0x01000000 // -cr-hint: noteref         link is to a footnote
@@ -437,6 +439,7 @@ enum css_generic_value_t {
 
 // A few of them are inheritable, most are not.
 #define CSS_CR_HINT_INHERITABLE_MASK        0x0000000E
+#define CSS_CR_HINT_INHERITABLE_EARLY_MASK  0x00800000 // inherited before stylesheets are applied
 
 // Macro for easier checking
 #define STYLE_HAS_CR_HINT(s, h)     ( (bool)(s->cr_hint.value & CSS_CR_HINT_##h) )

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -80,6 +80,7 @@ class LVCssDeclaration {
 private:
     int * _data;
     bool _check_if_supported;
+    bool  _extra_weighted;
 public:
     void apply( css_style_rec_t * style );
     bool empty() { return _data==NULL; }
@@ -88,8 +89,10 @@ public:
         _check_if_supported = true; // will tweak parse() behaviour and meaning of return value
         return parse(decl, false, doc);
     }
+    void setExtraWeighted( bool weighted ) { _extra_weighted = weighted; }
+    int isExtraWeighted() { return _extra_weighted; }
     lUInt32 getHash();
-    LVCssDeclaration() : _data(NULL), _check_if_supported(false) { }
+    LVCssDeclaration() : _data(NULL), _check_if_supported(false), _extra_weighted(false) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }
 };
 
@@ -162,7 +165,7 @@ private:
 
     lUInt16 _id;
     LVCssDeclRef _decl;
-    int _specificity;
+    lUInt32 _specificity;
     int _pseudo_elem; // from enum LVCssSelectorPseudoElement, or 0
     LVCssSelector * _next;
     LVCssSelectorRule * _rules;
@@ -171,7 +174,7 @@ private:
 public:
     LVCssSelector( LVCssSelector & v );
     LVCssSelector() : _id(0), _specificity(0), _pseudo_elem(0),  _next(NULL), _rules(NULL) { }
-    LVCssSelector(int specificity) : _id(0), _specificity(specificity), _pseudo_elem(0), _next(NULL), _rules(NULL) { }
+    LVCssSelector(lUInt32 specificity) : _id(0), _specificity(specificity), _pseudo_elem(0), _next(NULL), _rules(NULL) { }
     ~LVCssSelector() { if (_next) delete _next; if (_rules) delete _rules; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
     bool parse( const char * &str, lxmlDocBase * doc );
     lUInt16 getElementNameId() { return _id; }
@@ -192,7 +195,8 @@ public:
         }
     }
     void setDeclaration( LVCssDeclRef decl ) { _decl = decl; }
-    int getSpecificity() { return _specificity; }
+    void addSpecificity(lUInt32 specificity) { _specificity += specificity; }
+    lUInt32 getSpecificity() { return _specificity; }
     LVCssSelector * getNext() { return _next; }
     void setNext(LVCssSelector * next) { _next = next; }
     lUInt32 getHash();

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1038,6 +1038,14 @@ public:
     };
 };
 
+// https://www.oreilly.com/library/view/programming-web-graphics/1565924789/ch01s02.html:
+// "If a file does not have a global color table and does not have local color tables,
+// the image will be rendered using the application's default color table, with unpredictable results"
+// "The GIF specification suggests that the first two elements of a color table be black (0) and white (1),
+// but this is not necessarily always the case".
+// Let's get the same values as MuPDF's mupdf/source/fitz/load-gif.c (which does it via a hardcoded table).
+#define GIF_DEFAULT_PALETTE_COLOR_VALUE(b) ( b == 0 ? 0x000000 : ( b == 1 ? 0xFFFFFF : (b<<16|b<<8|b) ) )
+
 class LVGifFrame
 {
 protected:
@@ -1082,7 +1090,7 @@ public:
         int y = 0;
         for ( int i=0; i<h; i++ ) {
             for ( int j=0; j<w; j++ ) {
-                line[j] = pColorTable[background_color];
+                line[j] = pColorTable ? pColorTable[background_color] : GIF_DEFAULT_PALETTE_COLOR_VALUE(background_color);
             }
             if ( i >= m_top  && i < m_top+m_cy ) {
                 unsigned char * __restrict p_line = m_buffer + (i-m_top)*m_cx;
@@ -1091,7 +1099,7 @@ public:
                     if (b!=background_color) {
                         if (defined_transparent && b==transparent_color)
                             line[x + m_left] = 0xFF000000;
-                        else line[x + m_left] = pColorTable[b];
+                        else line[x + m_left] = pColorTable ? pColorTable[b] : GIF_DEFAULT_PALETTE_COLOR_VALUE(b);
                     }
                     else if (defined_transparent && b==transparent_color)  {
                         line[x + m_left] = 0xFF000000;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10167,6 +10167,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
 
+    // Some hint flags need to be inherited early, to have some effect on the stylesheet soon to be applied
+    pstyle->cr_hint.value |= (parent_style->cr_hint.value & CSS_CR_HINT_INHERITABLE_EARLY_MASK);
+
     // display before stylesheet is applied (for fallback below if legacy mode)
     css_display_t orig_elem_display = pstyle->display;
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2631,17 +2631,32 @@ bool getStyledImageSize( ldomNode * enode, int & img_width, int & img_height, in
     // We don't apply values in % when no container width or height is provided
     // which is what's suggested when they are not yet known:
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
-    if ( style->width.type != css_val_unspecified && (container_width >= 0 || style->width.type != css_val_percent) )
+    // Also, when gRenderDPI=0 (old crengine behaviour), lengthToPx() returns 0 for absolute
+    // CSS units (in, cm, mm, pt, pc), which is ok for margins and such, but not for images:
+    // we want non-zero w/h: so do as if no style when the unit is one of these.
+    if ( style->width.type != css_val_unspecified
+                        && (container_width >= 0 || style->width.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->width.type < css_val_in || style->width.type > css_val_pc) )
         width = lengthToPx(enode, style->width, container_width);
-    if ( style->min_width.type != css_val_unspecified && (container_width >= 0 || style->min_width.type != css_val_percent) )
+    if ( style->min_width.type != css_val_unspecified
+                        && (container_width >= 0 || style->min_width.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->min_width.type < css_val_in || style->min_width.type > css_val_pc) )
         min_width = lengthToPx(enode, style->min_width, container_width);
-    if ( style->max_width.type != css_val_unspecified && (container_width >= 0 || style->max_width.type != css_val_percent) )
+    if ( style->max_width.type != css_val_unspecified
+                        && (container_width >= 0 || style->max_width.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->max_width.type < css_val_in || style->max_width.type > css_val_pc) )
         max_width = lengthToPx(enode, style->max_width, container_width);
-    if ( style->height.type != css_val_unspecified && (container_height >= 0 || style->height.type != css_val_percent) )
+    if ( style->height.type != css_val_unspecified
+                        && (container_height >= 0 || style->height.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->height.type < css_val_in || style->height.type > css_val_pc) )
         height = lengthToPx(enode, style->height, container_height);
-    if ( style->min_height.type != css_val_unspecified && (container_height >= 0 || style->min_height.type != css_val_percent) )
+    if ( style->min_height.type != css_val_unspecified
+                        && (container_height >= 0 || style->min_height.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->min_height.type < css_val_in || style->min_height.type > css_val_pc) )
         min_height = lengthToPx(enode, style->min_height, container_height);
-    if ( style->max_height.type != css_val_unspecified && (container_height >= 0 || style->max_height.type != css_val_percent) )
+    if ( style->max_height.type != css_val_unspecified
+                        && (container_height >= 0 || style->max_height.type != css_val_percent)
+                        && (gRenderDPI > 0 || style->max_height.type < css_val_in || style->max_height.type > css_val_pc) )
         max_height = lengthToPx(enode, style->max_height, container_height);
 
     if ( enforce_page_constraints ) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3507,6 +3507,16 @@ public:
                                 // src text
                                 *((lChar32 *) (m_srcs[wstart]->t.text + m_charindex[wstart])) = U' ';
                             }
+                            else if (m_srcs[wstart]->flags & LTEXT_SRC_IS_OBJECT && m_srcs[wstart]->o.objflags & LTEXT_OBJECT_IS_FLOAT) {
+                                // But not if what's on this line is a float (the code below don't expect floats)
+                                // Keep the empty line with the strut height.
+                                continue;
+                                // Note: this check and "continue" could be moved around there, with different
+                                // results. Didn't manage to get resulsts as Firefox in edgy constructs with
+                                // only <br/> and floats (Firefox may have a blank line, while we may give the
+                                // block a 0-height). A bit non-obvious how this should be handled (and possibly
+                                // also above when "nothing but floats")...
+                            }
                         }
                         else { // Last or single para with no word
                             // A line has already been added: just make

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -90,7 +90,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.69k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x002D
+#define FORMATTING_VERSION_ID 0x002E
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
#### CSS: add "`-cr-hint: late`" to increase selectors specificity

Should allow `'* { -cr-hint: late; ... }'` to be checked and applied after other selectors with higher specifity.
This can be useful with style tweaks, and makes tweaks a lot simpler.
See https://github.com/koreader/koreader/pull/5863#issuecomment-1173095462

#### CSS: add a few non-static "`-cr-only-if`:" values

Existing values are static, and depend on the document and rendering options.
Add a few non-static ones, that need to be saved in the declaration and checked on each node.
This allows such combinations:
```css
* { -cr-only-if: inside-inpage-footnote -inpage-footnote -inline;
        margin: 0 !important; display: inline; }
```
See https://github.com/koreader/koreader/pull/5863#issuecomment-1173097714

#### getStyledImageSize(): fix missing images when gRenderDPI=0

When `gRenderDPI`=0 (old crengine behaviour), `lengthToPx()` returns 0 for absolute CSS units (in, cm, mm, pt, pc), which might be ok for margins and such, but not for images: we want non-zero w/h: so do as if no style when the unit is one of these, to avoid missing images.
See https://github.com/koreader/koreader/issues/9281#issuecomment-1172906647

#### Text: fix possible crash with floats and `<br/>`

With:
`<p><span dir="ltr"><img src="..." style="float: right"/><br/></span></p>`
we would crash soon after with:
`  FATAL ERROR #130: Unexpected object type for word`
This just avoids getting this fatal error, but does not really do the proper handling this edgy construction should get.
(Noticed while trying to test/understand why we got blank pages with the book from https://github.com/koreader/koreader/issues/9281 - it looks like we don't really handle correctly paragraphs made only of collapsed spaces, ignorable bidi unicode chars, and floats....)

#### LVImg: fix crash on GIF images without color table

See https://github.com/koreader/koreader/issues/9297#issuecomment-1175148220
Should allow closing https://github.com/koreader/koreader/issues/9297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/485)
<!-- Reviewable:end -->
