### PR TITLE
Monospace and fallback fonts tweaks

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -137,7 +137,7 @@ table caption {
  * approximation than no pre */
 pre, xmp {
     white-space: pre; /* has to be set in fb2def.h to work */
-    font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", monospace;
+    font-family: monospace;
     text-align: left;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
@@ -145,7 +145,7 @@ pre, xmp {
 }
 
 /* Inline elements (all unknown elements default now to display: inline) */
-code, kbd, samp, tt     { font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", monospace; }
+code, kbd, samp, tt     { font-family: monospace; }
 sup                     { font-size: 70%; vertical-align: super; }
 sub                     { font-size: 70%; vertical-align: sub; }
 small                   { font-size: 80%; }

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -83,11 +83,11 @@ th {  font-weight: bold; text-align: center; background-color: #DDD  }
 table caption { text-indent: 0px; padding: 4px; background-color: #EEE }
 table, th, td { border-width: 1px; border-style: solid; border-color: black; border-collapse: collapse; }
 
-tt, samp, kbd { font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", "Courier New", "Courier", monospace; }
+tt, samp, kbd { font-family: monospace; }
 code, pre {
    white-space: pre;
    text-align: left;
-   font-family: "Droid Sans Mono", "Liberation Mono", "DeJaVu Sans Mono", "Courier New", "Courier", monospace;
+   font-family: monospace;
    }
 code {
    display: inline;

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -19,6 +19,7 @@
 #define PROP_LOG_AUTOFLUSH           "crengine.log.autoflush"
 #define PROP_FONT_SIZE               "crengine.font.size"
 #define PROP_FALLBACK_FONT_FACES     "crengine.font.fallback.faces"
+#define PROP_FALLBACK_FONT_SIZES_ADJUSTED "crengine.font.fallback.sizes.adjusted"
     // multiple fallback font faces are to be separated by '|'
 #define PROP_STATUS_FONT_COLOR       "crengine.page.header.font.color"
 #define PROP_STATUS_FONT_FACE        "crengine.page.header.font.face"

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -10,6 +10,7 @@
 #define PROP_FONT_COLOR              "font.color.default"
 #define PROP_FONT_FACE               "font.face.default"
 #define PROP_FONT_BASE_WEIGHT        "font.face.base.weight"        // replaces PROP_FONT_WEIGHT_EMBOLDEN ("font.face.weight.embolden")
+#define PROP_FONT_MONOSPACE_SCALE    "font.monospace.size.scale.percent"
 #define PROP_BACKGROUND_COLOR        "background.color.default"
 #define PROP_BACKGROUND_IMAGE        "background.image.filename"
 #define PROP_TXT_OPTION_PREFORMATTED "crengine.file.txt.preformatted"

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -596,6 +596,7 @@ protected:
     kerning_mode_t _kerningMode;
     hinting_mode_t _hintingMode;
     int _monospaceSizeScale;
+    bool _fallbackFontSizesAdjusted;
 public:
     /// garbage collector frees unused fonts
     virtual void gc() = 0;
@@ -649,9 +650,14 @@ public:
     /// set monospace size scale percent
     virtual void SetMonospaceSizeScale( int scale ) { _monospaceSizeScale = scale; gc(); clearGlyphCache(); }
 
+    /// get adjusted fallback font sizes state
+    virtual int GetFallbackFontSizesAdjusted() { return _fallbackFontSizesAdjusted; }
+    /// set adjusted fallback font sizes state
+    virtual void SetFallbackFontSizesAdjusted( bool adjusted ) { _fallbackFontSizesAdjusted = adjusted; gc(); }
+
     /// constructor
     LVFontManager() : _antialiasMode(font_aa_all), _kerningMode(KERNING_MODE_DISABLED), _hintingMode(HINTING_MODE_AUTOHINT)
-                     , _monospaceSizeScale(100) { }
+                     , _monospaceSizeScale(100), _fallbackFontSizesAdjusted(false) { }
     /// destructor
     virtual ~LVFontManager() { }
     /// returns available typefaces

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -652,7 +652,7 @@ public:
     /// returns available font files
     virtual void getFontFileNameList( lString32Collection & ) { }
     /// returns font filename and face index for font name
-    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index ) { return false; }
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type ) { return false; }
     /// returns registered or instantiated document embedded font list
     virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list ) { }
     virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list ) { }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -595,6 +595,7 @@ protected:
     int _antialiasMode;
     kerning_mode_t _kerningMode;
     hinting_mode_t _hintingMode;
+    int _monospaceSizeScale;
 public:
     /// garbage collector frees unused fonts
     virtual void gc() = 0;
@@ -643,8 +644,14 @@ public:
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
 
+    /// get monospace size scale percent
+    virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }
+    /// set monospace size scale percent
+    virtual void SetMonospaceSizeScale( int scale ) { _monospaceSizeScale = scale; gc(); clearGlyphCache(); }
+
     /// constructor
-    LVFontManager() : _antialiasMode(font_aa_all), _kerningMode(KERNING_MODE_DISABLED), _hintingMode(HINTING_MODE_AUTOHINT) { }
+    LVFontManager() : _antialiasMode(font_aa_all), _kerningMode(KERNING_MODE_DISABLED), _hintingMode(HINTING_MODE_AUTOHINT)
+                     , _monospaceSizeScale(100) { }
     /// destructor
     virtual ~LVFontManager() { }
     /// returns available typefaces

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6765,6 +6765,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             if ( UnicodeToUtf8(value) != oldFaces ) {
                 REQUEST_RENDER("propsApply  fallback font faces")
             }
+        } else if (name == PROP_FALLBACK_FONT_SIZES_ADJUSTED) {
+            bool adjusted = props->getIntDef(PROP_FALLBACK_FONT_SIZES_ADJUSTED, false);
+            if (fontMan->GetFallbackFontSizesAdjusted() != adjusted) {
+                fontMan->SetFallbackFontSizesAdjusted(adjusted);
+                REQUEST_RENDER("propsApply - adjusted fallback font sizes")
+            }
         } else if (name == PROP_STATUS_FONT_FACE) {
             setStatusFontFace(UnicodeToUtf8(value));
         } else if (name == PROP_STATUS_LINE || name == PROP_SHOW_TIME

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6800,6 +6800,12 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 fontSize = MAX_STATUS_FONT_SIZE;
             setStatusFontSize(fontSize);//cr_font_sizes
             value = lString32::itoa(fontSize);
+        } else if (name == PROP_FONT_MONOSPACE_SCALE) {
+            int scale = props->getIntDef(PROP_FONT_MONOSPACE_SCALE, 100);
+            if (fontMan->GetMonospaceSizeScale() != scale) {
+                fontMan->SetMonospaceSizeScale(scale);
+                REQUEST_RENDER("propsApply - font monospace size scale")
+            }
         } else if (name == PROP_HYPHENATION_DICT) {
             // hyphenation dictionary
             lString32 id = props->getStringDef(PROP_HYPHENATION_DICT,

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -620,7 +620,7 @@ public:
         }
         list.sort();
     }
-    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index )
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type )
     {
         int base_weight = bold ? 700 : 400;
         LVFontDef * best_def = NULL;
@@ -646,6 +646,7 @@ public:
         if ( best_def ) {
             filename = best_def->getName();
             index = best_def->getIndex();
+            family_type = best_def->getFamily();
             return true;
         }
         return false;
@@ -5416,10 +5417,10 @@ public:
         _cache.regularizeRegisteredFontsWeights(print_updates);
     }
 
-    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index )
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type )
     {
         FONT_MAN_GUARD
-        return _cache.getFontFileNameAndFaceIndex(name, bold, italic, filename, index);
+        return _cache.getFontFileNameAndFaceIndex(name, bold, italic, filename, index, family_type);
     }
 
     virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list )

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -504,7 +504,15 @@ public:
     }
 
     lUInt32 getHash() {
-        return (((((_size * 31) + _weight)*31  + _italic)*31 + _features)*31+ _family)*31 + _name.getHash();
+        lUInt32 h =  (((((_size * 31) + _weight)*31  + _italic)*31 + _features)*31+ _family)*31 + _name.getHash();
+        // _bias is not a static property, and can be set/unset on these definitions.
+        // If a same _bias value is moved from one font to another, *adding* _bias
+        // to this hash may result in a final identical GetFontListHash() value
+        // (as GetFontListHash() does add all these hashes).
+        // We need to use it a multiplicator to be sure it changes GetFontListHash().
+        if ( _bias > 0 )
+            h *= _bias + 1;
+        return h;
     }
 
     /// returns font file name
@@ -594,7 +602,7 @@ public:
             if (doc == -1 || doc == documentId) // skip document fonts
                 hash = hash + _registered_list[i]->getDef()->getHash();
         }
-        return 0;
+        return hash;
     }
     virtual void getFaceList( lString32Collection & list )
     {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4845,7 +4845,7 @@ public:
                 if ( !grabbedExceedingSpace &&
                         m_pbuffer->min_space_condensing_percent != 100 &&
                         i < m_length-1 &&
-                        ( m_flags[i] & LCHAR_IS_SPACE ) &&
+                        ( m_flags[i] & LCHAR_IS_SPACE ) && !( m_flags[i] & LCHAR_LOCKED_SPACING ) &&
                         !(m_flags[i+1] & LCHAR_IS_SPACE) ) {
                     // Each space not followed by a space is candidate for space condensing
                     int dw = getMaxCondensedSpaceTruncation(i);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -388,6 +388,7 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     // if ( fontMan->getKerning() )
     //     hash += 127365;
     hash = hash * 31 + (int)fontMan->GetKerningMode();
+    hash = hash * 31 + fontMan->GetMonospaceSizeScale();
     hash = hash * 31 + fontMan->GetFontListHash(documentId);
     // Hinting mode change does not need to trigger a re-render, as since
     // we use FT_LOAD_TARGET_LIGHT, hinting has no effect on the x-axis

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -389,6 +389,7 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     //     hash += 127365;
     hash = hash * 31 + (int)fontMan->GetKerningMode();
     hash = hash * 31 + fontMan->GetMonospaceSizeScale();
+    hash = hash * 31 + (int)fontMan->GetFallbackFontSizesAdjusted();
     hash = hash * 31 + fontMan->GetFontListHash(documentId);
     // Hinting mode change does not need to trigger a re-render, as since
     // we use FT_LOAD_TARGET_LIGHT, hinting has no effect on the x-axis


### PR DESCRIPTION
#### Text: fix possible overflow with "white-space: pre"

Since #454, text in PRE could overflow the PRE width. Fix that.
![image](https://user-images.githubusercontent.com/24273478/179368941-31c6f87d-8ec3-4ee2-bb58-a704194b37e8.png)

#### Fonts: getFontFileNameAndFaceIndex(): return family type

As crengine/FreeType can't distinguish sans serif from serif, this is only useful to detect if a font is monospace or not. Might be useful for frontends.
See https://github.com/koreader/koreader/issues/9211#issuecomment-1160556267.

#### Fonts: account for _bias in Font hash

Should trigger a rerendering when we change the bias of some fonts.
Also fix `GetFontListHash()` which was always returning 0 since ages...

#### epub.css, fb2.css: remove hardcoded monospace font names

This should allow another monospace font, set with a bias, to be used for `<pre>` and `<code>` (as with anything having `font-family: monospace`).

#### Fonts: allow scaling monospace fonts

So that when using a main font with a small x-height, one can avoid having tall inline `<code>` bits, and adjust them (manually) to fit the size of the main font or to be a bit smaller to help distinguishing them.
![image](https://user-images.githubusercontent.com/24273478/179369021-4f21737f-bd8d-4363-8624-3e095a9b3626.png)

See https://github.com/koreader/koreader/issues/9211.

#### Fonts: allow adjusting fallback font sizes to x-height

Having all fallback font size having the same x-height should make lowercase letters picked from them less noticable (this can be noticable with greek words, as latin fonts often have only a subset of greek letters, related to maths).
See https://github.com/koreader/koreader/issues/9211#issuecomment-1161788316.

#### HTML parser: trust xml encoding before html charset

EPUBs can have both, and it seems that doing it per XHTML specs is the right thing to do.
See https://github.com/koreader/koreader/issues/8306#issuecomment-938821644 , https://www.w3.org/TR/xhtml1/#C_9

----

With all this, KOReader will get 2 new menu items in `Font settings>`:
![image](https://user-images.githubusercontent.com/24273478/179369078-bfc40541-79b3-4887-97c3-aef9b719289f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/486)
<!-- Reviewable:end -->
