### PR TITLE
CSS/Fonts: add support for font-family to font name mapping

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -188,7 +188,10 @@ enum css_font_family_t {
     css_ff_sans_serif,
     css_ff_cursive,
     css_ff_fantasy,
-    css_ff_monospace
+    css_ff_monospace,
+    css_ff_math,
+    css_ff_emoji,
+    css_ff_fangsong
 };
 
 /// page split property values

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -20,6 +20,7 @@
 #define PROP_FONT_SIZE               "crengine.font.size"
 #define PROP_FALLBACK_FONT_FACES     "crengine.font.fallback.faces"
 #define PROP_FALLBACK_FONT_SIZES_ADJUSTED "crengine.font.fallback.sizes.adjusted"
+#define PROP_FONT_FAMILY_FACES       "crengine.font.family.faces"
     // multiple fallback font faces are to be separated by '|'
 #define PROP_STATUS_FONT_COLOR       "crengine.page.header.font.color"
 #define PROP_STATUS_FONT_FACE        "crengine.page.header.font.face"

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -670,7 +670,7 @@ public:
     /// returns available font files
     virtual void getFontFileNameList( lString32Collection & ) { }
     /// returns font filename and face index for font name
-    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type, bool & has_ot_math ) { return false; }
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type, bool & has_ot_math, bool & has_emojis ) { return false; }
     /// returns registered or instantiated document embedded font list
     virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list ) { }
     virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list ) { }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -670,7 +670,7 @@ public:
     /// returns available font files
     virtual void getFontFileNameList( lString32Collection & ) { }
     /// returns font filename and face index for font name
-    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type ) { return false; }
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type, bool & has_ot_math ) { return false; }
     /// returns registered or instantiated document embedded font list
     virtual void getRegisteredDocumentFontList( int document_id, lString32Collection & list ) { }
     virtual void getInstantiatedDocumentFontList( int document_id, lString32Collection & list ) { }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2478,6 +2478,8 @@ private:
 
     LVEmbeddedFontList _fontList;
 
+    lString8Collection _fontFamilyFonts;
+
 
 #if BUILD_LITE!=1
     /// load document cache file content
@@ -2579,6 +2581,25 @@ public:
     void clear();
     lString32 getDocStylesheetFileName() { return _docStylesheetFileName; }
     void setDocStylesheetFileName(lString32 fileName) { _docStylesheetFileName = fileName; }
+
+    // font-family to font name mapping
+    void setFontFamilyFonts(lString8 fontNames) {
+        _fontFamilyFonts = lString8Collection(fontNames, lString8("|"));
+    }
+    lUInt32 getFontFamilyFontsHash() {
+        lUInt32 hash = 0;
+        for ( int i=_fontFamilyFonts.length()-1; i>=0; i-- )
+            hash = hash * 31 + _fontFamilyFonts[i].getHash() + i*15324;
+        return hash;
+    }
+    lString8 getFontForFamily(css_font_family_t family, bool & ignore_font_names) {
+        int idx = (int)family;
+        if ( idx > 0 && idx < _fontFamilyFonts.length() ) {
+            ignore_font_names = !_fontFamilyFonts[0].empty(); // [0] holds this boolean option (false if empty, true if not)
+            return _fontFamilyFonts[idx];
+        }
+        return lString8::empty_str;
+    }
 
     ldomDocument();
     /// creates empty document which is ready to be copy target of doc partial contents

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4818,6 +4818,7 @@ void LVDocView::createEmptyDocument() {
     else
         m_doc->setInterlineScaleFactor(INTERLINE_SCALE_FACTOR_NO_SCALE * m_def_interline_space / 100);
     m_doc->setScreenSize(m_dx, m_dy); // only used for CSS @media queries
+    m_doc->setFontFamilyFonts(UnicodeToUtf8(m_props->getStringDef(PROP_FONT_FAMILY_FACES, "")));
 
     m_doc->setContainer(m_container);
     // This sets the element names default style (display, whitespace)
@@ -6801,6 +6802,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 fontMan->SetFallbackFontSizesAdjusted(adjusted);
                 REQUEST_RENDER("propsApply - adjusted fallback font sizes")
             }
+        } else if (name == PROP_FONT_FAMILY_FACES) {
+            if (m_doc) // not when noDefaultDocument=true
+                getDocument()->setFontFamilyFonts(UnicodeToUtf8(value));
+            REQUEST_RENDER("propsApply font family faces")
         } else if (name == PROP_STATUS_FONT_FACE) {
             setStatusFontFace(UnicodeToUtf8(value));
         } else if (name == PROP_STATUS_LINE || name == PROP_SHOW_TIME

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17037,7 +17037,7 @@ void ldomDocument::updateRenderContext()
     int dy = _page_height;
     _nodeStyleHash = 0; // force recalculation by calcStyleHash()
     lUInt32 styleHash = calcStyleHash(_rendered);
-    lUInt32 stylesheetHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
+    lUInt32 stylesheetHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font))*31 + getFontFamilyFontsHash();
     //calcStyleHash( getRootNode(), styleHash );
     _hdr.render_style_hash = styleHash;
     _hdr.stylesheet_hash = stylesheetHash;
@@ -17072,7 +17072,7 @@ bool ldomDocument::checkRenderContext()
     int dx = _page_width;
     int dy = _page_height;
     lUInt32 styleHash = calcStyleHash(_rendered);
-    lUInt32 stylesheetHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
+    lUInt32 stylesheetHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font))*31 + getFontFamilyFontsHash();
     //calcStyleHash( getRootNode(), styleHash );
     if ( styleHash != _hdr.render_style_hash ) {
         CRLog::info("checkRenderContext: Style hash doesn't match %x!=%x", styleHash, _hdr.render_style_hash);

--- a/crengine/src/mathml_css_h.css
+++ b/crengine/src/mathml_css_h.css
@@ -5,9 +5,13 @@ R"===( /* " */
  * syntax highlight still work in various text editors */
 
 math {
-    /* font-family: is set by the code to a hardcoded list of known fonts with
-     * good OpenType Math support, when no font (Math or not) has been specified
-     * by previous stylesheets, and if the inherited font has no OT Math support */
+    /* We don't specify "font-family: math", as it would be substituted now with
+     * the font set in _fontFamilyFonts for "math", and we want this stylesheet
+     * to be stable/constant even when this "math" _fontFamilyFonts changes.
+     * Font name(s) will be set by setMathMLElementNodeStyle(), to either this
+     * "math" _fontFamilyFonts if set, or to a hardcoded list of known fonts with
+     * good OpenType Math support when no font (Math or not) has been specified
+     * by any stylesheet or if the inherited font has no OT Math support. */
     font-style: normal;
     font-weight: normal;
     letter-spacing: normal;


### PR DESCRIPTION
#### CSS parsing: accept (and ignore) namesspaces

Properly parse (instead of dropping/skipping):
```css
  m|math { display:block; }
  [m|foo] { background-color: yellow ; }
  [m|foo|="bar"] { font-weight: bold; }
```
so these are matched (namespaces are ignored when matching selectors):
```html
  <math foo="bar-baz">
  <m:math m:foo="bar-baz">
```

#### `isImage()`: more checks for `<object>` as it can have inner content

#### `getFontFileNameAndFaceIndex()`: returns if font has math support

Check for math support at font registration time.

#### `getFontFileNameAndFaceIndex()`: returns if font has emojis

#### CSS/Fonts: add support for `font-family` to font name mapping

Allow frontends to provided a list of font to use with each of the generic font-family names.
Also let `font-family: math/emoji/fangsong` be supported.  Have the font set for "`font-family: math`" font be used with MathML `<math>`.

This will allow implementing support for font-family in KOReader, see https://github.com/koreader/koreader/issues/7426#issuecomment-1258335839 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/490)
<!-- Reviewable:end -->
