### PR TITLE
TextLang: add TextLangCfg->softHyphenateText(lang, text)

### DIFF
--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -312,6 +312,8 @@ public:
     bool isSimplifiedChinese() const { return _is_zh_SC; }
     bool isTraditionalChinese() const { return _is_zh_TC; }
 
+    lString32 softHyphenateText( lString32 & text, bool use_default_hyph_method=false );
+
     TextLangCfg( lString32 lang_tag );
     ~TextLangCfg();
 };


### PR DESCRIPTION
Can be used by frontends to get any text soft-hyphenated according to crengine hyphenation dicts.
Code and logic taken (and removed) from writeNodeEx().
Will help with https://github.com/koreader/koreader/pull/9630.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/492)
<!-- Reviewable:end -->
