### PR TITLE
CSS: cache parse results

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -200,6 +200,18 @@ public:
     LVCssSelector * getNext() { return _next; }
     void setNext(LVCssSelector * next) { _next = next; }
     lUInt32 getHash();
+    LVCssSelector * getCopy() {
+        // Return a copy (with everything except _next) that can
+        // be delete()'d without impacting this LVCssSelector
+        LVCssSelector *s = new LVCssSelector();
+        s->_id = _id;
+        s->_decl = _decl; // (this is a LVRef)
+        s->_specificity = _specificity;
+        s->_pseudo_elem = _pseudo_elem;
+        if ( _rules ) // (deep copy of each rule)
+            s->_rules = new LVCssSelectorRule(*_rules);
+        return s;
+    }
 };
 
 
@@ -286,6 +298,7 @@ public:
     void apply( const ldomNode * node, css_style_rec_t * style );
     /// calculate hash
     lUInt32 getHash();
+    void merge(const LVStyleSheet &other);
 };
 
 /// parse number/length value like "120px" or "90%"

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2446,6 +2446,35 @@ public:
 };
 typedef LVRef<ListNumberingProps> ListNumberingPropsRef;
 
+class StyleSheetCache {
+    LVHashTable<lString32, LVStyleSheet *> files;
+
+public:
+    StyleSheetCache() : files(LVHashTable<lString32, LVStyleSheet *>(8)) {}
+
+    ~StyleSheetCache() {
+        clear();
+    }
+
+    void clear() {
+        auto it = files.forwardIterator();
+        for (auto *pair = it.next(); pair; pair = it.next()) {
+            delete pair->value;
+        }
+        files.clear();
+    }
+
+    LVStyleSheet * get(lString32 file) {
+        LVStyleSheet *cached = nullptr;
+        files.get(file, cached);
+        return cached;
+    }
+
+    void set(lString32 file, LVStyleSheet *styleSheet) {
+        files.set(file, styleSheet);
+    }
+};
+
 class ldomDocument : public lxmlDocBase
 {
     friend class ldomDocumentWriter;
@@ -2480,6 +2509,7 @@ private:
 
     lString8Collection _fontFamilyFonts;
 
+    StyleSheetCache _styleSheetCache;
 
 #if BUILD_LITE!=1
     /// load document cache file content
@@ -2637,6 +2667,10 @@ public:
 
     inline bool parseStyleSheet(lString32 codeBase, lString32 css);
     inline bool parseStyleSheet(lString32 cssFile);
+
+    StyleSheetCache & getStyleSheetCache() {
+        return _styleSheetCache;
+    }
 #endif
     /// destructor
     virtual ~ldomDocument();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4922,12 +4922,20 @@ public:
         _inProgress.clear();
     }
 
-    bool Parse(lString32 cssFile)
+    bool Parse(lString32 cssFile, LVStyleSheet &dest)
     {
         bool ret = false;
         if ( cssFile.empty() )
             return ret;
 
+        StyleSheetCache &cache = _document->getStyleSheetCache();
+        LVStyleSheet *cached = cache.get(cssFile);
+        if (cached) {
+            dest.merge(*cached);
+            return true;
+        }
+
+        LVStyleSheet *styleSheet = new LVStyleSheet(_document);
         lString32 codeBase = cssFile;
         LVExtractLastPathElement(codeBase);
         LVContainerRef container = _document->getContainer();
@@ -4937,14 +4945,17 @@ public:
                 lString32 css;
                 css << LVReadTextFile(cssStream);
                 int offset = _inProgress.add(cssFile);
-                ret = Parse(codeBase, css) || ret;
+                ret = Parse(codeBase, css, *styleSheet) || ret;
                 _inProgress.erase(offset, 1);
             }
         }
+
+        dest.merge(*styleSheet);
+        cache.set(cssFile, styleSheet);
         return ret;
     }
 
-    bool Parse(lString32 codeBase, lString32 css)
+    bool Parse(lString32 codeBase, lString32 css, LVStyleSheet &dest)
     {
         bool ret = false;
         if ( css.empty() )
@@ -4959,14 +4970,14 @@ public:
             if ( LVProcessStyleSheetImport( s, import_file, _document ) ) {
                 lString32 importFilename = LVCombinePaths( codeBase, Utf8ToUnicode(import_file) );
                 if ( !importFilename.empty() && !_inProgress.contains(importFilename) ) {
-                    ret = Parse(importFilename) || ret;
+                    ret = Parse(importFilename, dest) || ret;
                 }
             } else {
                 break;
             }
         }
         _nestingLevel -= 1;
-        return (_document->getStyleSheet()->parse(s, false, codeBase) || ret);
+        return (dest.parse(s, false, codeBase) || ret);
     }
 private:
     ldomDocument  *_document;
@@ -5151,13 +5162,13 @@ void ldomDocument::applyDocumentStyleSheet()
 bool ldomDocument::parseStyleSheet(lString32 codeBase, lString32 css)
 {
     LVImportStylesheetParser parser(this);
-    return parser.Parse(codeBase, css);
+    return parser.Parse(codeBase, css, _stylesheet);
 }
 
 bool ldomDocument::parseStyleSheet(lString32 cssFile)
 {
     LVImportStylesheetParser parser(this);
-    return parser.Parse(cssFile);
+    return parser.Parse(cssFile, _stylesheet);
 }
 
 bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback, int width, int dy,
@@ -5232,6 +5243,7 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
         CRLog::trace("Init node styles...");
         applyDocumentStyleSheet();
         getRootNode()->initNodeStyleRecursive( callback );
+        _styleSheetCache.clear();
         CRLog::trace("Restoring stylesheet...");
         _stylesheet.pop();
 


### PR DESCRIPTION
Stylesheets included in each DocFragment are parsed individually, even if they point to the same file. Depending on the number of CSS files, their size, and number of DocFragments, CSS parsing accounts for several percentage of a full LVDocView::Render() time, or even more in extreme cases. By introducing a parsing cache, the time spent in LVImportStylesheetParser::Parse is now negligible.

Closes #491.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/493)
<!-- Reviewable:end -->
