### PR TITLE
Styles: check when inheritable CSS set on boxing elements

### DIFF
--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -105,9 +105,16 @@ enum css_style_rec_important_bit {
 #endif
 
 // Style handling flags
-#define STYLE_REC_FLAG_MATCHED  0x01 // This style has had some stylesheet declaration matched and applied.
-                                     // Currently only used for a pseudo element style,
-                                     // see LVCssSelector::apply() if more generic usage needed.
+
+// This style has had some stylesheet declaration matched and applied.
+// Currently only used for a pseudo element style, see LVCssSelector::apply() if more generic usage needed.
+#define STYLE_REC_FLAG_MATCHED              0x01
+
+// This style has had applied some stylesheet declaration with inheritable CSS properties.
+// Used in the load phase for boxing elements created after their children already had
+// their style set: a re-rendering is needed for these children to inherit properly,
+// so they get the same consistent style they would get after a re-rendering.
+#define STYLE_REC_FLAG_INHERITABLE_APPLIED  0x02
 
 /**
     \brief Element style record.

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -137,6 +137,10 @@ extern const int gDOMVersionCurrent;
 #define PT_DIR_SCAN_FORWARD_LOGICAL_FIRST    2
 #define PT_DIR_SCAN_FORWARD_LOGICAL_LAST     3
 
+// Flags for setNodeStylesInvalidIfLoading(int reason_flag)
+#define NODE_STYLES_INVALID_PECULIAR_CSS_PSEUDOCLASSES                 0x01
+#define NODE_STYLES_INVALID_FOSTER_PARENTING_OF_INVALID_TABLE_ELEMENT  0x02
+#define NODE_STYLES_INVALID_INHERITED_PROPERTY_SET_ON_BOXING_ELEMENT   0x04
 
 //#if BUILD_LITE!=1
 /// final block cache
@@ -498,7 +502,7 @@ protected:
     lUInt32 _nodeStyleHash;
     lUInt32 _nodeDisplayStyleHash;
     lUInt32 _nodeDisplayStyleHashInitial;
-    bool _nodeStylesInvalidIfLoading;
+    int  _nodeStylesInvalidIfLoadingReasons;
     bool _boxingWishedButPreventedByCache;
 
     int calcFinalBlocks();
@@ -693,8 +697,8 @@ public:
         return _nodeDisplayStyleHashInitial != NODE_DISPLAY_STYLE_HASH_UNINITIALIZED &&
                 _nodeDisplayStyleHash != _nodeDisplayStyleHashInitial;
     }
-    void setNodeStylesInvalidIfLoading() {
-        _nodeStylesInvalidIfLoading = true;
+    void setNodeStylesInvalidIfLoading(int reason_flag) {
+        _nodeStylesInvalidIfLoadingReasons |= reason_flag;
     }
     void setBoxingWishedButPreventedByCache() {
         _boxingWishedButPreventedByCache = true;

--- a/crengine/include/textlang.h
+++ b/crengine/include/textlang.h
@@ -212,7 +212,8 @@ public:
     }
 
     static TextLangCfg * getTextLangCfg(); // get LangCfg for _main_lang
-    static TextLangCfg * getTextLangCfg( lString32 lang_tag );
+    static TextLangCfg * getTextLangCfg( lString32 lang_tag, bool force=false );
+        // (frontends can provide force=true to ignore _embedded_langs_enabled=false)
     static TextLangCfg * getTextLangCfg( ldomNode * node );
     static int getLangNodeIndex( ldomNode * node );
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7186,7 +7186,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // We may trust width set on our own boxing elements, even if a table
     // element wheree it is usually ignored
-    bool is_boxing_elem = nodeElementId >= EL_BOXING_START && nodeElementId <= EL_BOXING_END;
+    bool is_boxing_elem = nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START;
     // <HR> gets its style width, height and margin:auto no matter flags
     bool is_hr = nodeElementId == el_hr;
     // <EMPTY-LINE> block element with height added for empty lines in txt document
@@ -10270,7 +10270,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         if ( nodeElementId >= EL_MATHML_START && nodeElementId <= EL_MATHML_END ) {
             setMathMLElementNodeStyle( enode, pstyle );
         }
-        else if (   (nodeElementId >= EL_BOXING_START && nodeElementId <= EL_BOXING_END)
+        else if (   (nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START)
                   || nodeElementId == el_pseudoElem
                   || nodeElementId == el_annotation ) { // <annotation> is also a FB2 element, so we have to check its parent
             ldomNode * unboxedParent = enode->getUnboxedParent();
@@ -10823,6 +10823,10 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         update_style_content_property(pstyle, enode);
     }
 
+    if ( nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START && (pstyle->flags & STYLE_REC_FLAG_INHERITABLE_APPLIED) ) {
+        doc->setNodeStylesInvalidIfLoading(NODE_STYLES_INVALID_INHERITED_PROPERTY_SET_ON_BOXING_ELEMENT);
+    }
+
     pstyle->flags = 0; // cleanup, before setStyle() adds it to cache
 
     // set calculated style
@@ -11054,7 +11058,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         int _maxWidth = 0;
         int _minWidth = 0;
 
-        bool is_boxing_elem = nodeElementId >= EL_BOXING_START && nodeElementId <= EL_BOXING_END;
+        bool is_boxing_elem = nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START;
         bool use_style_width = false;
         css_length_t style_width = style->width;
         if ( BLOCK_RENDERING(rendFlags, ENSURE_STYLE_WIDTH) ) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4303,27 +4303,35 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_white_space:
             style->Apply( (css_white_space_t) *p++, &style->white_space, imp_bit_white_space, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_align:
             style->Apply( (css_text_align_t) *p++, &style->text_align, imp_bit_text_align, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_align_last:
             style->Apply( (css_text_align_t) *p++, &style->text_align_last, imp_bit_text_align_last, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_decoration:
             style->Apply( (css_text_decoration_t) *p++, &style->text_decoration, imp_bit_text_decoration, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_transform:
             style->Apply( (css_text_transform_t) *p++, &style->text_transform, imp_bit_text_transform, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_hyphenate:
             style->Apply( (css_hyphenate_t) *p++, &style->hyphenate, imp_bit_hyphenate, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_list_style_type:
             style->Apply( (css_list_style_type_t) *p++, &style->list_style_type, imp_bit_list_style_type, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_list_style_position:
             style->Apply( (css_list_style_position_t) *p++, &style->list_style_position, imp_bit_list_style_position, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_page_break_before:
             style->Apply( (css_page_break_t) *p++, &style->page_break_before, imp_bit_page_break_before, is_important );
@@ -4339,6 +4347,7 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_font_family:
             style->Apply( (css_font_family_t) *p++, &style->font_family, imp_bit_font_family, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_font_names:
             {
@@ -4349,16 +4358,20 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
                     names << (lChar8)(*p++);
                 names.pack();
                 style->Apply( names, &style->font_name, imp_bit_font_name, is_important );
+                style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             }
             break;
         case cssd_font_style:
             style->Apply( (css_font_style_t) *p++, &style->font_style, imp_bit_font_style, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_font_weight:
             style->Apply( (css_font_weight_t) *p++, &style->font_weight, imp_bit_font_weight, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_font_size:
             style->Apply( read_length(p), &style->font_size, imp_bit_font_size, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_font_features:
             // We want to 'OR' the bitmap from any declaration that is to be applied to this node
@@ -4372,19 +4385,24 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
                 else {
                     style->ApplyAsBitmapOr( font_features, &style->font_features, imp_bit_font_features, is_important );
                 }
+                style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             }
             break;
         case cssd_text_indent:
             style->Apply( read_length(p), &style->text_indent, imp_bit_text_indent, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_line_height:
             style->Apply( read_length(p), &style->line_height, imp_bit_line_height, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_letter_spacing:
             style->Apply( read_length(p), &style->letter_spacing, imp_bit_letter_spacing, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_color:
             style->Apply( read_length(p), &style->color, imp_bit_color, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_background_color:
             style->Apply( read_length(p), &style->background_color, imp_bit_background_color, is_important );
@@ -4527,9 +4545,11 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_orphans:
             style->Apply( (css_orphans_widows_value_t) *p++, &style->orphans, imp_bit_orphans, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_widows:
             style->Apply( (css_orphans_widows_value_t) *p++, &style->widows, imp_bit_widows, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_float:
             style->Apply( (css_float_t) *p++, &style->float_, imp_bit_float, is_important );
@@ -4539,15 +4559,19 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_direction:
             style->Apply( (css_direction_t) *p++, &style->direction, imp_bit_direction, is_important );
+            // inherited in CSS specs, but not needed for us as we handle it at rendering time
             break;
         case cssd_visibility:
             style->Apply( (css_visibility_t) *p++, &style->visibility, imp_bit_visibility, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_line_break:
             style->Apply( (css_line_break_t) *p++, &style->line_break, imp_bit_line_break, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_word_break:
             style->Apply( (css_word_break_t) *p++, &style->word_break, imp_bit_word_break, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_box_sizing:
             style->Apply( (css_box_sizing_t) *p++, &style->box_sizing, imp_bit_box_sizing, is_important );
@@ -4560,9 +4584,13 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
                 css_length_t cr_hint = read_length(p);
                 if ( cr_hint.value & CSS_CR_HINT_NONE_NO_INHERIT ) {
                     style->Apply( cr_hint, &style->cr_hint, imp_bit_cr_hint, is_important );
+                    style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED; // this cancels inheritance, this cancelling is then inherited
                 }
                 else {
                     style->ApplyAsBitmapOr( cr_hint, &style->cr_hint, imp_bit_cr_hint, is_important );
+                    if ( cr_hint.value & (CSS_CR_HINT_INHERITABLE_MASK|CSS_CR_HINT_INHERITABLE_EARLY_MASK) ) {
+                        style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+                    }
                 }
             }
             break;
@@ -4735,7 +4763,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
     // so if one is specified, we should not skip it with getUnboxed*().
     // We expect to find only a single kind of them per selector though.
     lUInt16 exceptBoxingNodeId = 0;
-    if ( _id >= EL_BOXING_START && _id <= EL_BOXING_END ) { // _id from rule
+    if ( _id <= EL_BOXING_END && _id >= EL_BOXING_START ) { // _id from rule
         exceptBoxingNodeId = _id;
     }
     else {
@@ -4743,7 +4771,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node )
         // rule, it's because the previous rule was checking for this
         // boxing element name
         lUInt16 curNodeId = node->getNodeId();
-        if ( curNodeId >= EL_BOXING_START && curNodeId <= EL_BOXING_END )
+        if ( curNodeId <= EL_BOXING_END && curNodeId >= EL_BOXING_START )
             exceptBoxingNodeId = curNodeId;
     }
     switch (_type)
@@ -5189,7 +5217,7 @@ bool LVCssSelector::check( const ldomNode * node ) const
             // Start checking the rules starting from the real parent
             // (except if this selector target a boxing element: we should
             // stop unboxing at that boxing element).
-            if ( _id >= EL_BOXING_START && _id <= EL_BOXING_END )
+            if ( _id <= EL_BOXING_END && _id >= EL_BOXING_START )
                 node = node->getUnboxedParent(_id);
             else
                 node = node->getUnboxedParent();
@@ -5355,7 +5383,7 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc )
         if ( n >= csspc_last_child ) {
             // Pseudoclasses after csspc_last_child can't be accurately checked
             // in the initial loading phase: a re-render will be needed.
-            doc->setNodeStylesInvalidIfLoading();
+            doc->setNodeStylesInvalidIfLoading(NODE_STYLES_INVALID_PECULIAR_CSS_PSEUDOCLASSES);
             // There might still be some issues if CSS would set some display: property
             // as, when re-rendering, a cache might be present and prevent modifying
             // the DOM for some needed autoBoxing - or the invalid styles set now

--- a/crengine/src/mathml.cpp
+++ b/crengine/src/mathml.cpp
@@ -2618,7 +2618,7 @@ static void ensureMathMLInnerMOsHorizontalStretchRecursive( ldomNode * node, ldo
         if ( !child || !child->isElement() )
             continue;
         lUInt16 childElementId = child->getNodeId();
-        if ( childElementId >= EL_BOXING_START && childElementId <= EL_BOXING_END ) {
+        if ( childElementId <= EL_BOXING_END && childElementId >= EL_BOXING_START ) {
             if ( width == -1 && childElementId == el_mathBox ) {
                 // Grab the width of the first mathBox we meet: we know a mathBox
                 // child of munder/mover has been set table-cell and has the width

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -205,8 +205,8 @@ HyphMethod * TextLangMan::getHyphMethodForLang( lString32 lang_tag ) {
 }
 
 // Return the (single and cached) TextLangCfg for the provided lang_tag
-TextLangCfg * TextLangMan::getTextLangCfg( lString32 lang_tag ) {
-    if ( !_embedded_langs_enabled ) {
+TextLangCfg * TextLangMan::getTextLangCfg( lString32 lang_tag, bool force ) {
+    if ( !_embedded_langs_enabled && !force ) {
         // Drop provided lang_tag: always return main lang TextLangCfg
         lang_tag = _main_lang;
     }


### PR DESCRIPTION
#### `getTextLangCfg(lang_tag)`: add `'force'` parameter

So frontend can use it (for hyphenating any text) without being affected by the `_embedded_langs_enabled` crengine setting.
Thsi fixes a small issue noticed at https://github.com/koreader/koreader/pull/9630#issuecomment-1314320371:
> One required thing to have it work (a bug I'll solve later): you need to have opened once a CRE document after the start of KOReader, and have "Respect embedded lang tags" enabled.

#### Styles: check when inheritable CSS set on boxing elements

And, if noticed in the XML loading phase (where boxing elements are inserted in the DOM), force a rerendering so the final rendering is consistent between loading/rendering.
This could have caused hard to understand differences when using style tweaks, ie. with in-page footnotes that target autoBoxing, as they can themselves cause a full reloading of the document.

Also make the output message more precise about the reason for the re-rendering.
Also reorder tests when checking for boxing elements (they have small IDs, so checking END first saves a test).

(Hope this last commit won't cause issues with some problematic books, like: loading, rendering, rerendering, boxing element additions, ask for "a reload might be needed", reloading, rendering, rerendering, boxing element additions... We'll see.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/496)
<!-- Reviewable:end -->
