### PR TITLE
Optimize encoding detection

### DIFF
--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -2006,9 +2006,6 @@ bool detectXmlHtmlEncoding(const unsigned char * buf, int buf_len, char * html_e
 
 int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, char * lang_name, bool skipHtml)
 {
-    int res = AutodetectCodePageUtf( buf, buf_size, cp_name, lang_name );
-    if ( res )
-        return res;
     // use character statistics
    short char_stat[256];
    dbl_char_stat_t dbl_char_stat[DBL_CHAR_STAT_SIZE];


### PR DESCRIPTION
The buffer for encoding detection is 128KiB. For epub files, this overwhelms LVZipDecodeStream's internal buffer (10KB), effectively causes it to be unzipped twice during LoadDocument().

With the assumption that nowadays most ebooks are in Unicode (mandatory for epub), we can use a much smaller buffer for Unicode detection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/497)
<!-- Reviewable:end -->
