### PR TITLE
only calculate a document's CRC32 if needed

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1204,7 +1204,6 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc_props->setString(DOC_PROP_TITLE, title);
         m_doc_props->setString(DOC_PROP_LANGUAGE, language);
         m_doc_props->setString(DOC_PROP_DESCRIPTION, description);
-        m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
         // Return possibly multiple <dc:creator> (authors) and <dc:subject> (keywords)
         // as a single doc_props string with values separated by \n.

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4117,7 +4117,8 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
 		m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa(
 				(int) stream->GetSize()));
 		m_doc_props->setString(DOC_PROP_FILE_NAME, arcItemPathName);
-        m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
+		if (!metadataOnly)
+			m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 		// loading document
 		if (LoadDocument(stream, metadataOnly)) {
 			m_filename = lString32(fname);
@@ -4163,7 +4164,8 @@ bool LVDocView::LoadDocument(const lChar32 * fname, bool metadataOnly) {
     m_doc_props->setString(DOC_PROP_FILE_NAME, fn);
 	m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa(
 			(int) stream->GetSize()));
-    m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
+	if (!metadataOnly)
+		m_doc_props->setHex(DOC_PROP_FILE_CRC32, stream->getcrc32());
 
 	if (LoadDocument(stream, metadataOnly)) {
 		m_filename = lString32(fname);
@@ -4657,7 +4659,8 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 					m_doc_props->setString(DOC_PROP_FILE_NAME, fn);
 					m_doc_props->setString(DOC_PROP_CODE_BASE, LVExtractPath(fn) );
 					m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa((int)m_stream->GetSize()));
-                    m_doc_props->setHex(DOC_PROP_FILE_CRC32, m_stream->getcrc32());
+					if (!metadataOnly)
+						m_doc_props->setHex(DOC_PROP_FILE_CRC32, m_stream->getcrc32());
 					found = true;
 				}
 			}


### PR DESCRIPTION
It's only used by the caching, so only calculate it on full document load (i.e. not metadata only).

Resulting speedup during metadata extraction:
- simulator on my laptop (1068 files): ~9% speedup, average ~12 → ~10 ms, minimum 5 → 5 ms, maximum 486 → 319 ms
- on my Kindle Paperwhite (6th generation, 956 files): ×2 speedup: average 225 → 107 ms, minimum 84 → 84 ms, maximum 4862 → 400 ms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/498)
<!-- Reviewable:end -->
