### PR TITLE
LVHashTable: fix iterator implementation

### DIFF
--- a/crengine/include/lvhashtable.h
+++ b/crengine/include/lvhashtable.h
@@ -80,17 +80,10 @@ public:
 		}
 		pair * next()
 		{
-			if ( index>=_tbl._size )
-				return NULL;
 			if ( ptr )
 				ptr = ptr->next;
-			if ( !ptr ) {
-				for ( ; index < _tbl._size; ) {
-					ptr = _tbl._table[ index++ ];
-					if ( ptr )
-						return ptr;
-				}
-			}
+			while ( !ptr && index < _tbl._size )
+				ptr = _tbl._table[ index++ ];
 			return ptr;
 		}
 	};

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5427,16 +5427,7 @@ void lxmlDocBase::serializeMaps( SerialBuf & buf )
 
     int start = buf.pos();
     buf.putMagic( node_by_id_map_magic );
-    lUInt32 cnt = 0;
-    {
-        LVHashTable<lUInt32,lInt32>::iterator ii = _idNodeMap.forwardIterator();
-        for ( LVHashTable<lUInt32,lInt32>::pair * p = ii.next(); p!=NULL; p = ii.next() ) {
-            cnt++;
-        }
-    }
-    // TODO: investigate why length() doesn't work as count
-    if ( (int)cnt!=_idNodeMap.length() )
-        CRLog::error("_idNodeMap.length=%d doesn't match real item count %d", _idNodeMap.length(), cnt);
+    lUInt32 cnt = _idNodeMap.length();
     buf << cnt;
     if (cnt > 0)
     {


### PR DESCRIPTION
Ensure **all** elements of the last bucket are iterated on (not just the first one).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/499)
<!-- Reviewable:end -->
