### PR TITLE
Text: fix mismatched `free` on `new`-allocated memory

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -206,7 +206,7 @@ void lvtextFreeFormatter( formatted_text_fragment_t * pbuffer )
         while ( (pair = it.next()) ) {
             delete pair->value;
         }
-        free( pbuffer->inlineboxes_links );
+        delete pbuffer->inlineboxes_links;
     }
     free(pbuffer);
 }


### PR DESCRIPTION
Allocation is done [here](https://github.com/koreader/crengine/blob/master/crengine/src/lvtextfm.cpp#L2120).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/501)
<!-- Reviewable:end -->
