### PR TITLE
Various picks from crengine-ng

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -322,13 +322,13 @@ public:
     /// sets cache file
     void setCache( CacheFile * cache );
     /// checks buffer sizes, compacts most unused chunks
-    void compact( int reservedSpace, const ldomTextStorageChunk *excludedChunk = NULL );
+    void compact( lUInt32 reservedSpace, const ldomTextStorageChunk* excludedChunk = NULL );
     lUInt32 getUncompressedSize() { return _uncompressedSize; }
 #if BUILD_LITE!=1
     /// allocates new text node, return its address inside storage
     lUInt32 allocText( lUInt32 dataIndex, lUInt32 parentIndex, const lString8 & text );
     /// allocates storage for new element, returns address address inside storage
-    lUInt32 allocElem( lUInt32 dataIndex, lUInt32 parentIndex, int childCount, int attrCount );
+    lUInt32 allocElem( lUInt32 dataIndex, lUInt32 parentIndex, lUInt32 childCount, lUInt32 attrCount );
     /// get text by address
     lString8 getText( lUInt32 address );
     /// get pointer to text data
@@ -402,7 +402,7 @@ public:
     /// adds new text item to buffer, returns offset inside chunk of stored data
     int addText( lUInt32 dataIndex, lUInt32 parentIndex, const lString8 & text );
     /// adds new element item to buffer, returns offset inside chunk of stored data
-    int addElem( lUInt32 dataIndex, lUInt32 parentIndex, int childCount, int attrCount );
+    int addElem( lUInt32 dataIndex, lUInt32 parentIndex, lUInt32 childCount, lUInt32 attrCount );
     /// get text item from buffer by offset
     lString8 getText( int offset );
     /// get node parent by offset

--- a/crengine/include/lvtypes.h
+++ b/crengine/include/lvtypes.h
@@ -235,12 +235,12 @@ public:
             ((w&0x00FF)<<8) );
     }
     /// make 64 bit word least-significant-first byte order (Intel)
-    lUInt32 lsf( lUInt64 w )
+    lUInt64 lsf( lUInt64 w )
     {
         return ( _lsf ) ? w : rev(w);
     }
     /// make 64 bit word most-significant-first byte order (PPC)
-    lUInt32 msf( lUInt64 w )
+    lUInt64 msf( lUInt64 w )
     {
         return ( !_lsf ) ? w : rev(w);
     }

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1175,8 +1175,8 @@ bool AlgoHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8
                     // (should we check that earlier, and break after the preceding vowel
                     // instead of not at all?)
                     bool forbidden = false;
-                    const char * dblSequences[] = {
-                        "sh", "th", "ph", "ch", NULL
+                    const lChar32 * dblSequences[] = {
+                        U"sh", U"th", U"ph", U"ch", NULL
                     };
                     next = i+1;
                     while ( next < len && (chprops[next] & (CH_PROP_MODIFIER|CH_PROP_HYPHEN)) ) {

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -671,7 +671,7 @@ protected:
 public:
     HyphPatternReader(lString32Collection & result) : insidePatternTag(false), data(result)
     {
-        result.clear();
+        result.clear(); // NOLINT: 1 uninitialized field at the end of the constructor call (?!)
     }
     /// called on parsing end
     virtual void OnStop() { }
@@ -1339,6 +1339,12 @@ lUInt8 UserHyphDict::init(lString32 filename, bool reload)
             ++words_in_file;
     }
 
+    if (words_in_file == 0) {
+        free(buf);
+        release();
+        return USER_HYPH_DICT_RELOAD;
+    }
+
     // do fast thourogh check if requested dictionary matches the loaded one
     if ( _filename.compare(filename)==0 && _filesize == filesize && _hash_value == hash_value ) {
         free(buf);
@@ -1424,7 +1430,7 @@ bool UserHyphDict::getMask(lChar32 *word, char *mask)
 
     size_t left = 0;
     size_t right = words_in_memory-1;
-    size_t mid = right;
+    size_t mid;
     while ( left <= right )
     {
         mid = left + (right-left)/2;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1360,7 +1360,7 @@ int getFontWeight(FT_Face face) {
 // have since been upgraded to be lUInt16)
 // (LCHAR_DEPRECATED_WRAP_AFTER for '-' and '/', as they may be used to
 // separate words.)
-static lUInt16 char_flags[] = {
+static const lUInt16 char_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, // 0    00
     0, 0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, // 8    08
     0, LCHAR_IS_SPACE | LCHAR_ALLOW_WRAP_AFTER, 0, 0, // 12   0C

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -705,7 +705,6 @@ public:
         // place row cells horizontally
         for (i=0; i<rows.length(); i++) {
             int x=0;
-            int miny=-1;
             CCRTableRow * row = rows[i];
             row->index = i;
             for (j=0; j<rows[i]->cells.length(); j++) {
@@ -765,6 +764,7 @@ public:
              * I can't guess which other case this was supposed to solve...
              * So let's disable it until we find why it was needed.
              *
+            int miny=-1;
             // update min row count
             for (j=0; j<x; j++) {
                 if (miny==-1 || miny>cols[j]->nrows)
@@ -3118,7 +3118,6 @@ lString32 renderListItemMarker( ldomNode * enode, int & marker_width, int * fina
 
 // (Common condition used at multiple occasions, made as as function for clarity)
 bool renderAsListStylePositionInside( const css_style_ref_t style, bool is_rtl=false ) {
-    bool render_as_lsp_inside = false;
     if ( style->list_style_position == css_lsp_inside ) {
         return true;
     }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1274,7 +1274,7 @@ bool lString32::atod( double &d, char dp ) const {
             s++;
         }
     }
-    if (res && *s == dp) {
+    if (res && *s == (value_type)dp) {
         // decimal point found
         s++;
         res = false;
@@ -2441,7 +2441,7 @@ int lString32::pos(const lChar8 * subStr) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf32[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != (value_type)subStr[j])
             {
                 flg = 0;
                 break;
@@ -2465,7 +2465,7 @@ int lString32::pos(const lChar8 * subStr, int start) const
     {
         int flg = 1;
         for (int j=0; j<l; j++)
-            if (pchunk->buf32[i+j] != subStr[j])
+            if (pchunk->buf32[i+j] != (value_type)subStr[j])
             {
                 flg = 0;
                 break;
@@ -5502,7 +5502,7 @@ bool lString32::startsWith(const lChar8 * substring) const
     const lChar32 * s1 = c_str();
     const lChar8 * s2 = substring;
     for ( int i=0; i<len; i++ )
-        if (s1[i] != s2[i])
+        if (s1[i] != (lChar32)s2[i])
             return false;
     return true;
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3061,6 +3061,7 @@ bool ldomDataStorageManager::load()
     if (n > 10000)
         return false; // invalid
     _recentChunk = NULL;
+    _activeChunk = NULL;
     _chunks.clear();
     lUInt32 compsize = 0;
     lUInt32 uncompsize = 0;
@@ -16769,7 +16770,7 @@ public:
     bool clear()
     {
         for ( int i=0; i<_files.length(); i++ )
-            LVDeleteFile( _files[i]->filename );
+            LVDeleteFile( _cacheDir + _files[i]->filename );
         _files.clear();
         return writeIndex();
     }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -236,6 +236,7 @@ enum CacheFileBlockType {
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 #include <lvtextfm.h>
+#include "../include/lvdocviewprops.h"
 
 // define to store new text nodes as persistent text, instead of mutable
 #define USE_PERSISTENT_TEXT 1
@@ -4958,9 +4959,9 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->text_transform = css_tt_none;
     s->hyphenate = css_hyph_auto;
     s->color.type = css_val_unspecified;
-    s->color.value = 0x000000;
+    s->color.value = props->getColorDef(PROP_FONT_COLOR, 0x000000);
     s->background_color.type = css_val_unspecified;
-    s->background_color.value = 0xFFFFFF;
+    s->background_color.value = props->getColorDef(PROP_BACKGROUND_COLOR, 0xFFFFFF);
     //_def_style->background_color.type = color;
     //_def_style->background_color.value = 0xFFFFFF;
     s->page_break_before = css_pb_auto;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -11863,7 +11863,6 @@ bool ldomXRange::getRectEx( lvRect & rect, bool & isSingleLine )
 void ldomXRange::getSegmentRects( LVArray<lvRect> & rects )
 {
     bool go_on = true;
-    int lcount = 1;
     lvRect lineStartRect = lvRect();
     lvRect nodeStartRect = lvRect();
     lvRect curCharRect = lvRect();
@@ -20532,7 +20531,7 @@ bool LVPageMap::deserialize( ldomDocument * doc, SerialBuf & buf )
     _chars_per_synthetic_page = (int)charsPerSyntheticPage;
     _is_document_provided = (bool)isDocumentProvided;
     _has_document_provided = (bool)hasDocumentProvided;
-    for ( int i=0; i<childCount; i++ ) {
+    for ( lUInt32 i=0; i<childCount; i++ ) {
         LVPageMapItem * item = new LVPageMapItem(doc);
         if ( !item->deserialize( doc, buf ) ) {
             delete item;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4897,6 +4897,8 @@ public:
         LVContainerRef container = _document->getContainer();
         if (!container.isNull()) {
             LVStreamRef cssStream = container->OpenStream(cssFile.c_str(), LVOM_READ);
+            if (cssStream.isNull())
+                cssStream = container->OpenStream(DecodeHTMLUrlString(cssFile).c_str(), LVOM_READ);
             if (!cssStream.isNull()) {
                 lString32 css;
                 css << LVReadTextFile(cssStream);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4590,7 +4590,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                             doIndentOneLevelLessAfterNewLineAfterEndTag = true;
                         // But if previous sibling node is a floating or boxing inline node
                         // that have done what we just did, cancel some of what we did
-                        if ( node->getNodeIndex() > 0 ) {
+                        if ( parent && node->getNodeIndex() > 0 ) {
                             ldomNode * prevsibling = parent->getChildNode(node->getNodeIndex()-1);
                             if ( prevsibling->isFloatingBox() || prevsibling->isBoxingInlineBox() ) {
                                 doNewlineBeforeIndentBeforeStartTag = false;
@@ -4611,7 +4611,7 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                         doIndentOneLevelLessAfterNewLineAfterEndTag = true;
                     else if ( containsEnd )
                         doIndentOneLevelLessAfterNewLineAfterEndTag = true;
-                    if ( node->getNodeIndex() > 0 ) {
+                    if ( parent && node->getNodeIndex() > 0 ) {
                         ldomNode * prevsibling = parent->getChildNode(node->getNodeIndex()-1);
                         if ( prevsibling->isFloatingBox() || prevsibling->isBoxingInlineBox() ) {
                             doNewlineBeforeIndentBeforeStartTag = false;
@@ -8268,6 +8268,9 @@ void ldomDocumentWriter::OnStop()
 // But in this, we do some specifics for tags that ARE a <BODY> tag.
 void ldomDocumentWriter::OnTagBody()
 {
+    if ( !_currNode )
+        return;
+
     // Specific if we meet the <BODY> tag and we have styles to apply and
     // store in the DOM
     // (This can't happen with EPUBs: the ldomDocumentFragmentWriter that
@@ -8276,7 +8279,7 @@ void ldomDocumentWriter::OnTagBody()
     // _headStyleText and _stylesheetLinks are then empty. Styles for EPUB
     // are handled in :OnTagOpen() when being a DocFragment and meeting
     // the BODY.)
-    if ( _currNode && _currNode->getElement() && _currNode->getElement()->getNodeId() == el_body &&
+    if ( _currNode->getElement() && _currNode->getElement()->getNodeId() == el_body &&
             ( !_headStyleText.empty() || _stylesheetLinks.length() > 0 ) ) {
         // If we're BODY, and we have meet styles in the previous HEAD
         // (links to css files or <STYLE> content), we need to save them
@@ -8334,7 +8337,7 @@ void ldomDocumentWriter::OnTagBody()
         OnTagClose(U"", U"stylesheet");
         CRLog::trace("added BODY>stylesheet child element with HEAD>STYLE&LINKS content");
     }
-    else if ( _currNode ) { // for all other tags (including BODY when no style)
+    else { // for all other tags (including BODY when no style)
         #if MATHML_SUPPORT==1
             if ( _currNode->_insideMathML ) {
                 // All attributes are set, this may add other attributes depending

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5450,7 +5450,6 @@ int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * e
                 if (32 == k)
                     k--;
                 entname[k] = 0;
-                int n;
                 lChar32 code = 0;
                 lChar32 code2 = 0;
                 if ( str[i+k]==';' || str[i+k]==' ' ) {

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -28,7 +28,7 @@ static bool langStartsWith(const lString32 lang_tag, const char * prefix) {
     const lChar32 * s1 = lang_tag.c_str();
     const lChar8 * s2 = prefix;
     for ( int i=0; i<prefix_len; i++ )
-        if (s1[i] != s2[i])
+        if (s1[i] != (lChar32)s2[i])
             return false;
     if ( lang_len == prefix_len ) // "en" starts with "en"
         return true;


### PR DESCRIPTION
Various picks from @virxkane 's https://gitlab.com/coolreader-ng/crengine-ng .

#### (crengine-ng) Various small picks: unused variables, cast & types

Remove unused variables, fix types, more proper casts.

From crengine-ng commits:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/259e8e7a9951d74fa81b268c7117c24070d8b7cb
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/a90ac8cc26fd1aefa9a33d11edecd6696578cbd5
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/3ed32dd05d1d26c79ec3cc725e8a04f28e7ad984
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/f9095b8aa773c1bcafa5ec0fb3b0cd4587feadbe
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/64ce6c2a8135841374f0f9338c29b753657a25c6
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/146fdd59a46958cda6a1cbce5e14c8f0a1bee845
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/2791906f7b59b9eb897f40b46c0053064f7ec9e1
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/116e5cf5d8e6fcf7233d939c501d009719f630af


#### (crengine-ng) LVStream: minor fixes

- ZIP64 minor fixes: when finding 'End of central directory record' don't try to lseek outside of file size.
- LVPumpStream() function improved: added check result of write operation.
- LVDeleteDirectory(): use rmdir instead of unlink.
- Give a name to typedef struct ZipLocalFileHdr to avoir clang warning

From crengine-ng commits:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/6e6655432e510f1ef7973e4923de974d7916e3d5
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/8e024f68b5ff6a17c4717539b0b7b1d63b831830
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/750751bbe67dc9d61c6d245c4b2fbe50eb92eddc
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/5c7db1c550ffcea9f8f296bac8f678d513202c88

#### (crengine-ng) LVStream: cleanup zip processing

ZIP processing: replaced hardcoded maximum entry name length and maximum extra entry data length with a new defines.
It is allowed to skip extra entry data if it is too long without stopping the processing of the zip archive.

From crengine-ng commit:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/5473ebed8ae8b300ca5f1138a5d6ad41b8155723

#### (crengine-ng) ldomDataStorageManager: fix cast & types

From crengine-ng commit:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/3ed32dd05d1d26c79ec3cc725e8a04f28e7ad984

#### (crengine-ng) ldomDataStorageManager: fix possible segfault

- SIGSEGV fixed in ldomDataStorageManager class, AddressSanitizer: heap-use-after-free.
- Fix cache emptying function.

From crengine-ng commits:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/eaee261107221c46b759a68b527515c39b986c0f
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/1f3dc6b5395b29cc63297a6b5a6191ad0f1102fd

#### (crengine-ng) DOM/MathML: more currNode/parentNode sanity checks

From crengine-ng commit:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/9f1032becb4f6ae765e30c356525227e24fe61a8

#### (crengine-ng) Default style: use cr3.ini fg & bg colors

ldomDocument default style: use text color and background color from document properties instead of black and white.
This fixes incorrect colors for mathml elements (fraction bar, sqrt symbol...) with non-standard color settings.

From crengine-ng commit:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/aed17364d766a92b619e92d9a9da9b84cff2fd29

#### (crengine-ng) Support regular documents inside zip

LVDocView::loadDocumentInt(): allow to open '*.fb3', '*.epub', '*.doc', '*.docx', '*.odt' inside zip-archives.

From crengine-ng commit:
https://gitlab.com/coolreader-ng/crengine-ng/-/commit/d0be59c7a24063c6037e8a3bd25fe9f099553a9b

#### Silence some clang warnings

New warnings on old code that got to be checked by clang-tidy on this PR.

#### Stylesheets: support percent-encoded stylesheet links

Should allow closing https://github.com/koreader/koreader/issues/10021

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/504)
<!-- Reviewable:end -->
