### PR TITLE
LVStream: fix and improve `LVZipDecodeStream` implementation

### DIFF
--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -542,11 +542,11 @@ protected:
 public:
     virtual lvsize_t        GetSize() const { return m_size; }
     virtual const lChar32 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
-    virtual lUInt32         GetFlags() const  { return m_flags; }
-    virtual bool            IsContainer() const  { return m_is_container; }
-    lvpos_t GetSrcPos() { return m_srcpos; }
-    lvsize_t GetSrcSize() { return m_srcsize; }
-    lUInt32 GetSrcFlags() { return m_srcflags; }
+    virtual lUInt32         GetFlags() const { return m_flags; }
+    virtual bool            IsContainer() const { return m_is_container; }
+    lvpos_t GetSrcPos() const { return m_srcpos; }
+    lvsize_t GetSrcSize() const { return m_srcsize; }
+    lUInt32 GetSrcFlags() const { return m_srcflags; }
     void SetSrc( lvpos_t pos, lvsize_t size, lUInt32 flags )
     {
         m_srcpos = pos;

--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -535,6 +535,7 @@ protected:
     lvsize_t     m_size;
     lString32    m_name;
     lUInt32      m_flags;
+    lUInt32      m_crc;
     bool         m_is_container;
     lvpos_t      m_srcpos;
     lvsize_t     m_srcsize;
@@ -544,6 +545,7 @@ public:
     virtual const lChar32 * GetName() const { return m_name.empty()?NULL:m_name.c_str(); }
     virtual lUInt32         GetFlags() const { return m_flags; }
     virtual bool            IsContainer() const { return m_is_container; }
+    lUInt32 GetCRC() const { return m_crc; }
     lvpos_t GetSrcPos() const { return m_srcpos; }
     lvsize_t GetSrcSize() const { return m_srcsize; }
     lUInt32 GetSrcFlags() const { return m_srcflags; }
@@ -557,15 +559,16 @@ public:
     {
         m_name = name;
     }
-    void SetItemInfo( lString32 fname, lvsize_t size, lUInt32 flags, bool isContainer = false )
+    void SetItemInfo( lString32 fname, lvsize_t size, lUInt32 flags, lUInt32 crc = 0, bool isContainer = false )
     {
         m_name = fname;
         m_size = size;
         m_flags = flags;
+        m_crc = crc;
         m_is_container = isContainer;
     }
     LVCommonContainerItemInfo() : m_size(0), m_flags(0), m_is_container(false),
-        m_srcpos(0), m_srcsize(0), m_srcflags(0)
+        m_srcpos(0), m_srcsize(0), m_srcflags(0), m_crc(0)
     {
     }
     virtual ~LVCommonContainerItemInfo ()

--- a/crengine/src/chmfmt.cpp
+++ b/crengine/src/chmfmt.cpp
@@ -219,7 +219,7 @@ public:
     void addFileItem( const char * filename, LONGUINT64 len )
     {
         LVCommonContainerItemInfo * item = new LVCommonContainerItemInfo();
-        item->SetItemInfo( lString32(filename), (lvsize_t)len, 0, false );
+        item->SetItemInfo( lString32(filename), (lvsize_t)len, 0 );
         //CRLog::trace("CHM file item: %s [%d]", filename, (int)len);
         Add(item);
     }

--- a/crengine/src/lvstream.cpp
+++ b/crengine/src/lvstream.cpp
@@ -2327,11 +2327,13 @@ private:
             return false;
         }
 
+#if 0
         m_CRC = lStr_crc32(m_CRC, m_outbuf, getAvailBytes());
         if (res == Z_STREAM_END && m_CRC != m_originalCRC) {
             CRLog::error("ZIP stream '%s': CRC doesn't match", LCSTR(lString32(GetName())));
             return false;
         }
+#endif
 
         return true;
     }


### PR DESCRIPTION
# Summary    

The initial goal of this PR was to avoid unnecessary rewinds of ZIP streams
due to the common pattern of first reading an initial chunk (to detect the
encoding/format) before consuming/parsing the whole stream.

Example when loading an EPUB:
```
LVStreamFragment(“mimetype”)
LVZipDecodeStream(“META-INF/container.xml”)
rewind(META-INF/container.xml)
rewind(META-INF/container.xml)
rewind(META-INF/container.xml)
rewind(META-INF/container.xml)
LVZipDecodeStream(“OEBPS/content.opf”)
rewind(OEBPS/content.opf)
rewind(OEBPS/content.opf)
rewind(OEBPS/content.opf)
rewind(OEBPS/content.opf)
rewind(OEBPS/content.opf)
LVZipDecodeStream(“OEBPS/Styles/style0001.css”)
rewind(OEBPS/Styles/style0001.css)
LVZipDecodeStream(“OEBPS/Styles/style0002.css”)
rewind(OEBPS/Styles/style0002.css)
LVZipDecodeStream(“OEBPS/Images/cover00216.jpeg”)
rewind(OEBPS/Images/cover00216.jpeg)
LVZipDecodeStream(“OEBPS/Text/cover_page.xhtml”)
rewind(OEBPS/Text/cover_page.xhtml)
rewind(OEBPS/Text/cover_page.xhtml)
rewind(OEBPS/Text/cover_page.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0000.xhtml”)
rewind(OEBPS/Text/part0000.xhtml)
rewind(OEBPS/Text/part0000.xhtml)
rewind(OEBPS/Text/part0000.xhtml)
LVZipDecodeStream(“OEBPS/Styles/style0001.css”)
rewind(OEBPS/Styles/style0001.css)
LVZipDecodeStream(“OEBPS/Styles/style0002.css”)
rewind(OEBPS/Styles/style0002.css)
LVZipDecodeStream(“OEBPS/Text/part0001.xhtml”)
rewind(OEBPS/Text/part0001.xhtml)
rewind(OEBPS/Text/part0001.xhtml)
rewind(OEBPS/Text/part0001.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0002.xhtml”)
rewind(OEBPS/Text/part0002.xhtml)
rewind(OEBPS/Text/part0002.xhtml)
rewind(OEBPS/Text/part0002.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0003.xhtml”)
rewind(OEBPS/Text/part0003.xhtml)
rewind(OEBPS/Text/part0003.xhtml)
rewind(OEBPS/Text/part0003.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0004.xhtml”)
rewind(OEBPS/Text/part0004.xhtml)
rewind(OEBPS/Text/part0004.xhtml)
rewind(OEBPS/Text/part0004.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0005.xhtml”)
rewind(OEBPS/Text/part0005.xhtml)
rewind(OEBPS/Text/part0005.xhtml)
rewind(OEBPS/Text/part0005.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0006.xhtml”)
rewind(OEBPS/Text/part0006.xhtml)
rewind(OEBPS/Text/part0006.xhtml)
rewind(OEBPS/Text/part0006.xhtml)
rewind(OEBPS/Text/part0006.xhtml)
[…]
LVZipDecodeStream(“OEBPS/Text/part0029.xhtml”)
rewind(OEBPS/Text/part0029.xhtml)
rewind(OEBPS/Text/part0029.xhtml)
rewind(OEBPS/Text/part0029.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0030.xhtml”)
rewind(OEBPS/Text/part0030.xhtml)
rewind(OEBPS/Text/part0030.xhtml)
rewind(OEBPS/Text/part0030.xhtml)
rewind(OEBPS/Text/part0030.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0031.xhtml”)
rewind(OEBPS/Text/part0031.xhtml)
rewind(OEBPS/Text/part0031.xhtml)
rewind(OEBPS/Text/part0031.xhtml)
LVZipDecodeStream(“OEBPS/toc.ncx”)
rewind(OEBPS/toc.ncx)
rewind(OEBPS/toc.ncx)
rewind(OEBPS/toc.ncx)
rewind(OEBPS/toc.ncx)
```

Between 1 and 5 extra rewinds!

The code is now smarter, and will keep track of the bounds of the currently
uncompressed chunk so seeking within those bounds does not trigger a rewind.

Loading the same EPUB:
```
LVStreamFragment(“mimetype”)
LVZipDecodeStream(“META-INF/container.xml”)
LVZipDecodeStream(“OEBPS/content.opf”)
LVZipDecodeStream(“OEBPS/Styles/style0001.css”)
rewind(OEBPS/Styles/style0001.css)
LVZipDecodeStream(“OEBPS/Styles/style0002.css”)
LVZipDecodeStream(“OEBPS/Images/cover00216.jpeg”)
LVZipDecodeStream(“OEBPS/Text/cover_page.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0000.xhtml”)
LVZipDecodeStream(“OEBPS/Styles/style0001.css”)
rewind(OEBPS/Styles/style0001.css)
LVZipDecodeStream(“OEBPS/Styles/style0002.css”)
LVZipDecodeStream(“OEBPS/Text/part0001.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0002.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0003.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0004.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0005.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0006.xhtml”)
rewind(OEBPS/Text/part0006.xhtml)
[…]
LVZipDecodeStream(“OEBPS/Text/part0029.xhtml”)
LVZipDecodeStream(“OEBPS/Text/part0030.xhtml”)
rewind(OEBPS/Text/part0030.xhtml)
LVZipDecodeStream(“OEBPS/Text/part0031.xhtml”)
LVZipDecodeStream(“OEBPS/toc.ncx”)
```

There's still an extra rewind when the encoding detection code is involved (see #497).

In the process of doing that I also fixed the CRC handling:

- it was incorrectly calculated on the packed data (instead of the uncompressed result), but because of another error in the code, the final check was never done, so no CRC error were ever detected/reported.
- the case where a zip local file header CRC is not available was not handled (similarly to how the packed / unpacked sizes can be missing): I fixed and simplified the `LVZipDecodeStream::Create` to always use the information passed by the archive container (which normally comes from the central directory).


# Performance impact

Overall, loading is slightly faster. I tested on 2 different configurations:

- simulator, on my laptop (a Skylake Core i3): release build with LTO enabled (but `-ffast-math` disabled for LuaJIT or the build fails on Arch Linux…)
- my Kindle Paperwhite (6th generation): release build with LTO enabled

Loading times:

- laptop (956 files): 
  * on average: faster (-11.4%)
  * 48 files see no significant impact (less than 2% difference)
  * 0 files are slower
  * 908 files are faster (best: -30.3%)
- kindle (915 files):
  * on average faster: -3.7%
  * 239 files see no significant impact (less than 2% difference)
  * 4 files are slower (worse: +10.1%)
  * 672 files are faster (best: -12.8%)

Rendering times:

- laptop (956 files): 
  * on average: faster (-1.9%)
  * 621 files see no significant impact (less than 2% difference)
  * 0 files are slower
  * 335 files are faster (best: -12.4%)
- kindle (915 files):
  * on average: no impact (-0.2%)
  * 899 files see no significant impact (less than 2% difference)
  * 7 files are slower (worse: +3.7%)
  * 9 files are faster (best: -6.5%)

For reference, if that last extra rewind wast taken care of (by reducing the
encoding detection buffer size to 16K), the resulting loading times become:

- laptop: -16.2% (best: -30.3%, worse: ±2%)
- kindle: -7.1% (best: -23.7%, worse: +10.5%)


## Analysis of slower loading times

Because the CRC is now correctly calculated on the decompressed data, entries with a high compression ratio can be slower to read. 

The 2 slowest loading times (+10.5% and +7.8%) on Kindle are example of
inefficiencies in the font manager: duplicated calls to uncompress the same 4
fonts (`4*81=324` and `4*27=108` times respectively). With an average
compression ratio of ~3.6, calculating the CRC as a noticeable impact on
performance.


## Possible improvements

- fix the encoding detection code to get rid of the remaining rewind on text content.
- the code to handle images sometimes decodes one 2 times (`!assume_valid && !img->Decode( NULL )` in `LVCreateStreamImageSource`).
- IMHO, the benefit of checking the CRC are debatable: because the final check is only done once the full stream has been decompressed and already consumed, it offers no real protection against corrupted content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/507)
<!-- Reviewable:end -->
