### PR TITLE
Toggleable support for partial rerenderings of individual DocFragments

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -949,7 +949,8 @@ public:
     /// A changed hash let frontends know their cached values of some document
     /// properties (full height, TOC pages...) may have changed and that they
     /// need to fetch them again
-    lUInt32 getDocumentRenderingHash();
+    /// With extended=true, accounts for a few more view-related state.
+    lUInt32 getDocumentRenderingHash(bool extended=false);
 
     /// Constructor
     LVDocView( int bitsPerPixel=-1, bool noDefaultDocument=false );

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -54,8 +54,8 @@
 
 #define RN_LINE_IS_RTL 0x1000
 
-#define RN_GET_SPLIT_BEFORE(flags) (flags & 0x7)
-#define RN_GET_SPLIT_AFTER(flags) (flags >> 3)
+#define RN_GET_SPLIT_BEFORE(flags) ((flags >> RN_SPLIT_BEFORE) & 0x7)
+#define RN_GET_SPLIT_AFTER(flags)  ((flags >> RN_SPLIT_AFTER)  & 0x7)
 
 #define RN_PAGE_TYPE_NORMAL           0x01
 #define RN_PAGE_TYPE_COVER            0x02

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -240,6 +240,7 @@ public:
     bool hasNonLinearFlows() { return has_nonlinear_flows; }
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
+    void replacePages( int old_y, int old_h, LVRendPageList * pages, int next_pages_shift_y );
 };
 
 class LVFootNote;

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -689,6 +689,8 @@ public:
     void setProps( CRPropRef props ) { _docProps = props; }
 
 #if BUILD_LITE!=1
+    /// is cache file stale
+    bool isCacheFileStale() { return _cacheFileStale; }
     /// set cache file stale flag
     void setCacheFileStale( bool stale ) { _cacheFileStale = stale; }
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1396,6 +1396,15 @@ protected:
         lUInt32 node_displaystyle_hash;
         bool serialize( SerialBuf & buf );
         bool deserialize( SerialBuf & buf );
+        lUInt32 getRenderingHash() {
+            return ((((((
+                 + (lUInt32)render_dx) * 31
+                 + (lUInt32)render_dy) * 31
+                 + (lUInt32)render_docflags) * 31
+                 + (lUInt32)node_displaystyle_hash) * 31
+                 + (lUInt32)stylesheet_hash) * 31
+                 + (lUInt32)render_style_hash);
+        };
         DocFileHeader()
             : render_dx(0), render_dy(0), render_docflags(0), render_style_hash(0), stylesheet_hash(0),
                 node_displaystyle_hash(NODE_DISPLAY_STYLE_HASH_UNINITIALIZED)

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -3078,14 +3078,16 @@ void LVDocView::Render(int dx, int dy, LVRendPageList * pages) {
 /// A changed hash let frontends know their cached values of some document
 /// properties (full height, TOC pages...) may have changed and that they
 /// need to fetch them again
-lUInt32 LVDocView::getDocumentRenderingHash() {
+lUInt32 LVDocView::getDocumentRenderingHash(bool extended) {
     if (m_doc) {
-        // Also account for the number of pages, as toggling m_twoVisiblePagesAsOnePageNumber
-        // does not change the document rendering hash, but it does change page numbers
-        // Also account for the document height, just to be sure
-        return ((( (lUInt32)m_doc->getDocumentRenderingHash()) * 31
-                 + (lUInt32)m_doc->getFullHeight()) * 31
-                 + (lUInt32)getPageCount());
+        lUInt32 hash = (lUInt32)m_doc->getDocumentRenderingHash();
+        if (extended) {
+            // Also account for the number of pages, as toggling m_twoVisiblePagesAsOnePageNumber
+            // does not change the document rendering hash, but it does change page numbers
+            // Also account for the document height, just to be sure
+            hash = (hash*31 + (lUInt32)m_doc->getFullHeight())*31 + (lUInt32)getPageCount();
+        }
+        return hash;
     }
     return 0;
 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9625,6 +9625,18 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
             }
         }
 
+        if ( enode->getNodeId()==el_DocFragment && enode->getDocument()->isPartialRerenderingEnabled() ) {
+            // Check if rerendering needed, and do it if it is
+            if ( enode->getDocument()->partialRender(enode) ) {
+                // Re-rendered, recheck if it is part of the viewport
+                fmt = RenderRectAccessor( enode );
+                height = fmt.getHeight();
+                if ( (doc_y + height + bottom_overflow <= 0 || doc_y - top_overflow >= 0 + dy) ) {
+                    return; // out of range
+                }
+            }
+        }
+
         int direction = RENDER_RECT_GET_DIRECTION(fmt);
         bool is_rtl = direction == REND_DIRECTION_RTL; // shortcut for followup tests
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -15733,6 +15733,7 @@ bool ldomDocument::openFromCache( CacheLoadingCallback * formatCallback, LVDocVi
     _rendered = true;
     _just_rendered_from_cache = true;
     _toc_from_cache_valid = true;
+    _doc_rendering_hash = _hdr.getRenderingHash();
     // Use cached node_displaystyle_hash as _nodeDisplayStyleHashInitial, as it
     // should be in sync with the DOM stored in the cache
     _nodeDisplayStyleHashInitial = _hdr.node_displaystyle_hash;
@@ -17018,13 +17019,7 @@ void ldomDocument::updateRenderContext()
     _hdr.node_displaystyle_hash = _nodeDisplayStyleHashInitial; // we keep using the initial one
     CRLog::info("Updating render properties: styleHash=%x, stylesheetHash=%x, docflags=%x, width=%x, height=%x, nodeDisplayStyleHash=%x",
                 _hdr.render_style_hash, _hdr.stylesheet_hash, _hdr.render_docflags, _hdr.render_dx, _hdr.render_dy, _hdr.node_displaystyle_hash);
-    _doc_rendering_hash = ((((((
-         + (lUInt32)dx) * 31
-         + (lUInt32)dy) * 31
-         + (lUInt32)_docFlags) * 31
-         + (lUInt32)_nodeDisplayStyleHashInitial) * 31
-         + (lUInt32)stylesheetHash) * 31
-         + (lUInt32)styleHash);
+    _doc_rendering_hash = _hdr.getRenderingHash();
 }
 
 /// check document formatting parameters before render - whether we need to reformat; returns false if render is necessary


### PR DESCRIPTION
#### CSS: optimize `:nth-child/of-type()` and `:nth-last-child/of-type()`

This could be painfully slow if used to highlight any other paragraph in a document made of thousands of such paragraphs (ie. to highlight character names in a dumb theater play EPUB
where all character names and speeches are in a same kind of `<P>`).

#### Page splitting: fix oversight in flags handling

Could cause some flags to leak to next elements, and unexpected page splitting and collapsing margin issues.
Should allow closing https://github.com/koreader/koreader/issues/10073. See https://github.com/koreader/koreader/issues/10073#issuecomment-1416036120.

#### Update `_doc_rendering_hash` also when loading from cache


#### `getDocumentRenderingHash(extended)`: add parameter

Allows getting the real `doc_rendering_hash`, use `extended=true` to get this hash augmented with
some view-related state.

#### Toggable support for partial rerenderings of individual DocFragments

Only available with EPUBs containing 2 or more fragments, and a file size large enough to ensure a cache file is used.
The idea is simply, on any rendering setting change, to skip the rerendering of the full book and to defer any rerendering to the moment we draw a DocFragment, and render only it.
Not much care has been made to keep crengine fully coherent, but enough for it to draw and allow turning pages. So, it is expected that we can soon provoke a full rerendering (in the main process when the user decides it when done tweaking settings, or in the background, building a cache that we can quickly reload from) to get back in a sane state. This would have to be ensured by the frontend.
Fortunately, the changes could be made quite localized, and shouldn't have any impact on the current behaviour when partial rendering is not enabled.

Discussed and details all along https://github.com/koreader/koreader/issues/9087#issuecomment-1407432928.
Should allow closing https://github.com/koreader/koreader/issues/9087.
Will use the new icons proposed in https://github.com/koreader/koreader/pull/10086 (see screenshots there for the upcoming KOReader behaviour).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/508)
<!-- Reviewable:end -->
