### PR TITLE
LVStyleSheet: optimize `LVStyleSheet::merge`

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -177,7 +177,7 @@ public:
     LVCssSelector(lUInt32 specificity) : _id(0), _specificity(specificity), _pseudo_elem(0), _next(NULL), _rules(NULL) { }
     ~LVCssSelector() { if (_next) delete _next; if (_rules) delete _rules; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
     bool parse( const char * &str, lxmlDocBase * doc );
-    lUInt16 getElementNameId() { return _id; }
+    lUInt16 getElementNameId() const { return _id; }
     bool check( const ldomNode * node ) const;
     void applyToPseudoElement( const ldomNode * node, css_style_rec_t * style ) const;
     void apply( const ldomNode * node, css_style_rec_t * style ) const
@@ -196,11 +196,11 @@ public:
     }
     void setDeclaration( LVCssDeclRef decl ) { _decl = decl; }
     void addSpecificity(lUInt32 specificity) { _specificity += specificity; }
-    lUInt32 getSpecificity() { return _specificity; }
-    LVCssSelector * getNext() { return _next; }
+    lUInt32 getSpecificity() const { return _specificity; }
+    LVCssSelector * getNext() const { return _next; }
     void setNext(LVCssSelector * next) { _next = next; }
-    lUInt32 getHash();
-    LVCssSelector * getCopy() {
+    lUInt32 getHash() const;
+    LVCssSelector * getCopy() const {
         // Return a copy (with everything except _next) that can
         // be delete()'d without impacting this LVCssSelector
         LVCssSelector *s = new LVCssSelector();

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5885,7 +5885,7 @@ lUInt32 LVCssSelectorRule::getHash()
     return hash;
 }
 
-lUInt32 LVCssSelector::getHash()
+lUInt32 LVCssSelector::getHash() const
 {
     lUInt32 hash = 0;
     lUInt32 nextHash = 0;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -6033,10 +6033,23 @@ void LVStyleSheet::merge(const LVStyleSheet &other) {
     if (length > _selectors.length())
         _selectors.set(length - 1, nullptr);
     for (int i = 0; i < length; ++i) {
+        if (!other._selectors[i])
+            continue;
+        LVCssSelector *prev = NULL;
+        LVCssSelector *next = _selectors[i];
         for (LVCssSelector *p = other._selectors[i]; p; p = p->getNext()) {
             LVCssSelector *item = p->getCopy();
             item->addSpecificity(_selector_count);
-            insert_into_selectors(item, _selectors);
+            while (next && next->getSpecificity() <= item->getSpecificity()) {
+                prev = next;
+                next = next->getNext();
+            }
+            item->setNext(next);
+            if (prev)
+                prev->setNext(item);
+            else
+                _selectors[i] = item;
+            prev = item;
         }
     }
     _selector_count += other._selector_count;


### PR DESCRIPTION
Take into account the fact that the selectors are already ordered.

This change improves loading times on a number of my EPUBs (~20 files, including 8 out of the 15 slowest on both Kindle and PC).

Timings (release builds with LTO):

| file                       | master (kindle) | PR (kindle)      | master (laptop) | PR (laptop)      |
| -------------------------  | ------:         |-------:          | ------:         |-------:          |
|  461 (814 KB, ~ 480 pages) | ~27052 ms       | ~18532 ms (-31%) | ~ 3237 ms       | ~ 1550 ms (-52%) |
|  609 (938 KB, ~ 702 pages) | ~26807 ms       | ~23162 ms (-14%) | ~ 2706 ms       | ~ 1926 ms (-29%) |
|  798 (604 KB, ~ 550 pages) | ~14431 ms       | ~12204 ms (-15%) | ~ 1558 ms       | ~ 1044 ms (-33%) |
| 1373 (  1 MB, ~1023 pages) | ~13895 ms       | ~12066 ms (-13%) | ~ 1403 ms       | ~ 1107 ms (-21%) |
|  273 (979 KB, ~ 485 pages) | ~11271 ms       | ~ 9731 ms (-14%) | ~ 1311 ms       | ~  863 ms (-34%) |
|  375 (721 KB, ~ 491 pages) | ~10866 ms       | ~ 9449 ms (-13%) | ~ 1220 ms       | ~  814 ms (-33%) |
|  174 (  1 MB, ~ 659 pages) | ~ 9913 ms       | ~ 5879 ms (-41%) | ~ 1406 ms       | ~  489 ms (-65%) |
|  272 (538 KB, ~ 419 pages) | ~ 8348 ms       | ~ 6549 ms (-22%) | ~  917 ms       | ~  527 ms (-43%) |
|  683 (631 KB, ~ 221 pages) | ~ 4363 ms       | ~ 3846 ms (-12%) | ~  510 ms       | ~  362 ms (-29%) |
|  467 (467 KB, ~ 219 pages) | ~ 4322 ms       | ~ 3797 ms (-12%) | ~  497 ms       | ~  358 ms (-28%) |
|  799 (  2 MB, ~ 224 pages) | ~ 3512 ms       | ~ 3110 ms (-11%) | ~  364 ms       | ~  307 ms (-16%) |
|  852 (  1 MB, ~ 504 pages) | ~ 3330 ms       | ~ 3095 ms ( -7%) | ~  358 ms       | ~  297 ms (-17%) |
|  629 (  3 MB, ~ 191 pages) | ~ 2733 ms       | ~ 2492 ms ( -9%) | ~  296 ms       | ~  250 ms (-16%) |
| 1290 (  1 MB, ~ 651 pages) | ~ 2668 ms       | ~ 2444 ms ( -8%) | ~  310 ms       | ~  249 ms (-20%) |
|  566 (955 KB, ~ 417 pages) | ~ 2257 ms       | ~ 2075 ms ( -8%) | ~  262 ms       | ~  224 ms (-15%) |
| 1665 (  2 MB, ~ 296 pages) | ~ 1722 ms       | ~ 1666 ms ( -3%) | ~  215 ms       | ~  157 ms (-27%) |
| 1969 (323 KB, ~ 270 pages) | ~ 1475 ms       | ~ 1341 ms ( -9%) | ~  163 ms       | ~  126 ms (-23%) |
| 1981 (363 KB, ~ 304 pages) | ~ 1366 ms       | ~ 1313 ms ( -4%) | ~  161 ms       | ~  124 ms (-23%) |
| 1689 (907 KB, ~ 110 pages) | ~ 1244 ms       | ~ 1185 ms ( -5%) | ~  121 ms       | ~   99 ms (-19%) |
| 1652 (253 KB, ~ 335 pages) | ~  967 ms       | ~  933 ms ( -4%) | ~  108 ms       | ~   88 ms (-19%) |
| 1724 (276 KB, ~  18 pages) | ~  271 ms       | ~  249 ms ( -8%) | ~   25 ms       | ~   19 ms (-23%) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/509)
<!-- Reviewable:end -->
