### PR TITLE
Add some helpers for "View HTML", other small fixes

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -850,6 +850,8 @@ public:
 
     /// set document stylesheet text
     void setStyleSheet( lString8 css_text, bool use_macros=true );
+    /// gather snippets from all stylesheets involved that the provided node would match
+    void gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches );
 
     /// set default interline space, percent (100..200)
     void setDefaultInterlineSpace( int percent );

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -299,6 +299,8 @@ public:
     /// calculate hash
     lUInt32 getHash();
     void merge(const LVStyleSheet &other);
+    /// gather snippets in the provided CSS that the provided node would match
+    bool gatherNodeMatchingRulesets(ldomNode * node, const char * str, lString8Collection & matches);
 };
 
 /// parse number/length value like "120px" or "90%"

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -923,6 +923,9 @@ public:
     void initNodeRendMethodRecursive();
     /// init render method for the whole subtree
     void initNodeStyleRecursive( LVDocViewCallback * progressCallback );
+
+    /// gather snippets from all stylesheets involved that this node would match
+    void gatherStylesheetMatchingRulesets(lString8 css, bool include_document_stylesheets, lString8Collection & matches);
 #endif
 
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1676,9 +1676,11 @@ public:
     /// returns true if current node is element
     inline bool isText() const { return !isNull() && getNode()->isText(); }
     /// returns HTML (serialized from the DOM, may be different from the source HTML)
-    lString8 getHtml( lString32Collection & cssFiles, int wflags=0 );
+    lString8 getHtml( lString32Collection & cssFiles, lString8 & extra, int wflags=0 );
     lString8 getHtml( int wflags=0 ) {
-        lString32Collection cssFiles; return getHtml(cssFiles, wflags);
+        lString32Collection cssFiles;
+        lString8 extra;
+        return getHtml(cssFiles, extra, wflags);
     }
 };
 
@@ -2041,9 +2043,11 @@ public:
     /// returns nearest common element for start and end points
     ldomNode * getNearestCommonParent();
     /// returns HTML (serialized from the DOM, may be different from the source HTML)
-    lString8 getHtml( lString32Collection & cssFiles, int wflags=0, bool fromRootNode=false );
+    lString8 getHtml( lString32Collection & cssFiles, lString8 & extra, int wflags=0, bool fromRootNode=false );
     lString8 getHtml( int wflags=0, bool fromRootNode=false ) {
-        lString32Collection cssFiles; return getHtml(cssFiles, wflags, fromRootNode);
+        lString32Collection cssFiles;
+        lString8 extra;
+        return getHtml(cssFiles, extra, wflags, fromRootNode);
     };
 
     /// searches for specified text inside range

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -530,6 +530,16 @@ void LVDocView::updateDocStyleSheet() {
     m_stylesheetNeedsUpdate = false;
 }
 
+void LVDocView::gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches ) {
+    matches.clear();
+    matches.add(cs8("/* --- in main stylesheet and tweaks: --- */"));
+    ldomNode * node = m_doc->getTinyNode( nodeDataIndex );
+    if ( node && node->isElement() ) {
+        // Provide our useragent stylesheet, that we have (here only) as plain text
+        node->gatherStylesheetMatchingRulesets(m_stylesheet, true, matches);
+    }
+}
+
 void LVDocView::Clear() {
 	{
 		LVLock lock(getMutex());

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1791,6 +1791,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
             drawbuf->FillRect(x, gpos - 2 - sz/2, x + szx, gpos - 2 + sz/2 + 1, cl);
 	}
 
+	TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( getLanguage() );
 	lString32 text;
 	//int iy = info.top; // + (info.height() - m_infoFont->getHeight()) * 2 / 3;
         int iy = info.top + /*m_infoFont->getHeight() +*/ (info.height() - m_infoFont->getHeight()) / 2 - HEADER_MARGIN/2;
@@ -1884,7 +1885,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		if (!pageinfo.empty()) {
 			piw = m_infoFont->getTextWidth(pageinfo.c_str(), pageinfo.length());
 			m_infoFont->DrawTextString(drawbuf, info.right - piw, iy,
-					pageinfo.c_str(), pageinfo.length(), U' ', NULL, false);
+					pageinfo.c_str(), pageinfo.length(), U' ', NULL, false, lang_cfg);
 			info.right -= piw + info.height() / 2;
 		}
 		if (phi & PGHDR_CLOCK) {
@@ -1936,7 +1937,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 	text = fitTextWidthWithEllipsis(text, m_infoFont, newcr.width());
 	if (!text.empty()) {
 		m_infoFont->DrawTextString(drawbuf, info.left, iy, text.c_str(),
-				text.length(), U' ', NULL, false);
+				text.length(), U' ', NULL, false, lang_cfg);
 	}
 	drawbuf->SetClipRect(&oldcr);
 	//--------------

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -988,6 +988,10 @@ LVStreamRef LVDocView::getDocumentFileStream( lString32 filePath ) {
         if ( cont.isNull() ) // no real container
             cont = m_container; // consider document directory as the container
         LVStreamRef stream = cont->OpenStream(filePath.c_str(), LVOM_READ);
+        if (stream.isNull()) {
+            // Try again in case filePath is provided %-encoded
+            stream = cont->OpenStream(DecodeHTMLUrlString(filePath).c_str(), LVOM_READ);
+        }
         // if failure, a NULL stream is returned
         return stream;
     }

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4595,6 +4595,22 @@ public:
                 maxWidth = getCurrentLineWidth();
             }
 
+            if ( m_flags[pos] & LCHAR_IS_CLUSTER_TAIL ) {
+                // This line starts with a cluster tail, probably because hyphenation was
+                // allowed inside this cluster. The first char(s) would get a width of 0,
+                // which may allow more text to be brought into this line: later, in AddLine(),
+                // we may have to handle the excess of text by reducing all spaces' widths
+                // and possibly making them all 0 or negative if needed.
+                // So, account for the whole cluster width into this line (by considering it as a
+                // negative spaceReduceWidth): it might be too much and we could do with a fraction
+                // of it (but which value?), but better too much spacing than not enough.
+                int bpos = pos - 1;
+                while ( bpos > 0 && m_flags[bpos] & LCHAR_IS_CLUSTER_TAIL )
+                    bpos--;
+                int cluster_width = (m_widths[bpos] - (bpos > 0 ? m_widths[bpos-1] : 0));
+                spaceReduceWidth -= cluster_width;
+            }
+
             // Find candidates where end of line is possible
             bool seen_non_collapsed_space = false;
             bool seen_first_rendered_char = false;


### PR DESCRIPTION
#### Header: render title/authors with book language glyphs

Allow getting the in the header the glyphs for the book languages, see https://app.gitter.im/#/room/#koreader_koreader:gitter.im/$pbQZfpmcRQ9kcILx8uWwgnlh7ve6U98x2iAc1M1UI6A
![image](https://user-images.githubusercontent.com/24273478/222898358-e9e3d44b-fa07-4bac-a948-dab44a5b0886.png) when the book language is Japanese.

#### Text: fix issues when hyphenation happened on a ligature

See https://github.com/koreader/crengine/pull/261#issuecomment-1445123070.

#### getDocumentFileStream() support percent-encoded path

As done in 3ff7558e.

#### getHtml(): add flag to get CSS selectors for met elements

Use an additional stream where writeNodeEx can output formatted info about tags met (with offset in the main stream, the tag level, the node dataIndex, and selectors for the classnames and attributes).

#### Add gatherStylesheetsMatchingRulesets(node)

For a node, returns all the rulesets (from all stylesheets involved), as text snippets, that the provided node would match.
Can be used by frontends providing View HTML/CSS features to help understanding what CSS bits cause what.

The last 2 commits will allow supporting long-press in the View HTML widget, to get more info about the long-pressed element about the CSS it matches, and be able to copy its classnames if we want to Find them in the CSS, or Paste them in a book style tweak.

![image](https://user-images.githubusercontent.com/24273478/222898543-31c5bb63-066c-4e19-bd32-79c914d38f71.png)

![image](https://user-images.githubusercontent.com/24273478/222898569-b8648c1a-528b-463d-acd0-9241cb77a91b.png)

![image](https://user-images.githubusercontent.com/24273478/222898591-03f0751f-0e33-4100-82a7-cca0fd94e1c0.png)

![image](https://user-images.githubusercontent.com/24273478/222898598-4255393b-1d16-4ef5-bc10-930f6c3e2a7f.png)

This should help understanding more easily what CSS is the cause of some publisher rendering choice you want to fight - and the Copy/Paste should help with avoiding going back and forth trying to remember some classname like `class=MsoNormalTextIL1SubText` and trying to type it correctly in a book style tweak - and seeing no effect because you made a typo :)

There are 2 hardcoded English wording:
![image](https://user-images.githubusercontent.com/24273478/222898786-4b7c0d87-c5bf-420b-8182-3d03d9080035.png)
I don't think these need translations, as it's just CSS technical bits, and I don't want to pass some kind of tags all along to frontend so it can replace it.

The first one is actually the "user agent stylesheet", our epub.css or html5.css + the enabled style tweaks appended.
"style tweaks" is a KOReader frontend concept, so it feels a bit strong to hardcode that concept in crengine, but well... I guess it's _our_ crengine now :)
Any better idea for these wordings in yellow ?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/511)
<!-- Reviewable:end -->
