### PR TITLE
Various small fixes and tweaks

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -824,7 +824,7 @@ public:
     /// returns bookmark
     ldomXPointer getBookmark( bool precise = true );
     /// returns bookmark for specified page
-    ldomXPointer getPageBookmark( int page );
+    ldomXPointer getPageBookmark( int page_num, bool precise=true, bool internal=false );
     /// sets current bookmark
     void setBookmark( ldomXPointer bm );
     /// moves position to bookmark

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2752,10 +2752,16 @@ ldomXPointer LVDocView::getNodeByPoint(lvPoint pt, bool strictBounds, bool forTe
 			//   returns some text from a paragraph a few pages above that doesn't have that margin...
 			// - pt might be in some inter paragraphs collapsed top/bottom margin, that would resolve
 			//   to none of them.
-			// Consider the ptr obtained with PT_DIR_EXACT valid only if non-null and if its rect contains pt.y
+			// Consider the ptr obtained with PT_DIR_EXACT valid only if non-null and if its rect contains pt.y,
+			// We also want to be sure that it's a xpointer to some text (which it should usually be - when it's
+			// not it may be because we did not find any text because of some left/right margin, and we may have
+			// reached an upper container that contains pt (ie. a DocFragment), and the way createXPointer()
+			// handles this case by returning the first or last child (ie. for a DocFragment, returning
+			// either <styleSheet> or <body>, the former being invalid, the latter being valid) could
+			// lead to inconsistent results when we cross the half of this block element's height...
 			bool valid = false;
 			lvRect rc;
-			if ( !ptr.isNull() && ptr.getRect(rc) ) {
+			if ( !ptr.isNull() && ptr.isText() && ptr.getRect(rc) ) {
 				if ( pt.y >= rc.top && pt.y < rc.bottom )
 					valid = true;
 			}

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5461,6 +5461,10 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
 //        CRLog::trace("reusing existing format data...");
 //    }
 
+    if ( !_rendered ) {
+        // We have loaded the document and applied styles: drop this cache
+        _styleSheetCache.clear();
+    }
     bool was_just_rendered_from_cache = _just_rendered_from_cache; // cleared by checkRenderContext()
     if ( !checkRenderContext() ) {
         // Remember these, in case we later do partial rerenderings

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -20350,6 +20350,10 @@ int ldomNode::getSurroundingAddedHeight(bool account_height_below_strut_baseline
                     if (line_h < 0) { // shouldn't happen
                         line_h = n->getFont()->getHeight(); // line-height: normal
                     }
+                    int interline_scale_factor = getDocument()->getInterlineScaleFactor();
+                    if ( style->line_height.type != css_val_screen_px && interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE ) {
+                        line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+                    }
                     int f_half_leading = (line_h - fh) / 2;
                     int baseline_to_bottom = line_h - fb - f_half_leading;
                     // Account the height below the strut baseline (but not


### PR DESCRIPTION
#### CSS stylesheets cache: also clear it after initial load

Followup to c71001e7 #493, where we already do clear that cache after a re-rendering. We also need to clear it after the initial loading, otherwise these cached stylesheets would be used on the first re-rendering, possible causing media queries changes and font-family font substitutions to have no effect on the first rerendering.
See https://github.com/koreader/crengine/pull/493#issuecomment-1455186966.

#### getSurroundingAddedHeight(): use interline_scale_factor

Forgotten in cc5147cb3 #467.
See https://github.com/koreader/crengine/pull/467#issuecomment-1462649997.

#### LVDocView::getNodeByPoint(): tweak again for text selection

Follow up to 1bfb7103 #484: also check also check if xpointer is text to avoid other strange issues.

#### LVDocView::getPageBookmark(): behave as getBookmark()

This function is only used in some obscure cr3gui/src/cr3jinke.cpp, but can be useful, so make it behave as the function used to get the current page xpointer.
Will help with https://github.com/koreader/koreader/issues/10193.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/513)
<!-- Reviewable:end -->
