### PR TITLE
LVTextFileBase: fix parsing of variable width encodings

### DIFF
--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -193,7 +193,7 @@ protected:
     int m_read_buffer_pos;
     bool m_eof;
 
-    void checkEof(lvsize_t bytes_needed);
+    void checkEof(int bytes_needed);
 
     inline lChar32 ReadCharFromBuffer()
     {

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -193,7 +193,7 @@ protected:
     int m_read_buffer_pos;
     bool m_eof;
 
-    void checkEof();
+    void checkEof(lvsize_t bytes_needed);
 
     inline lChar32 ReadCharFromBuffer()
     {

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -219,8 +219,11 @@ lChar32 LVTextFileBase::ReadRtfChar( int, const lChar32 * conv_table )
     return ' ';
 }
 
-void LVTextFileBase::checkEof(lvsize_t bytes_needed)
+void LVTextFileBase::checkEof(int bytes_needed)
 {
+    int bytes_remaining = m_buf_len - m_buf_pos;
+    bytes_needed -= bytes_remaining;
+
     // If we would need bytes_needed more bytes to correctly complete a multibyte
     // char, and we would meet EOF before getting that many, this multibyte char
     // is truncated and invalid: do as if EOF was reached.

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -227,7 +227,7 @@ void LVTextFileBase::checkEof(int bytes_needed)
     // If we would need bytes_needed more bytes to correctly complete a multibyte
     // char, and we would meet EOF before getting that many, this multibyte char
     // is truncated and invalid: do as if EOF was reached.
-    if ( m_buf_fpos+m_buf_len >= this->m_stream_size - bytes_needed)
+    if ( m_buf_fpos + m_buf_len + bytes_needed > this->m_stream_size )
         m_buf_pos = m_buf_len = m_stream_size - m_buf_fpos; //force eof
         //m_buf_pos = m_buf_len = m_stream_size - (m_buf_fpos+m_buf_len);
 }


### PR DESCRIPTION
Some bytes/chars could be lost if, while reading, our buffer would end inside a multibyte character, possibly losing sync and causing garbled data.
See issue and discussion in https://github.com/koreader/koreader/issues/10218.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/515)
<!-- Reviewable:end -->
