### PR TITLE
Various BiDi, <br/>, floats, table cells and FB2 cover related fixes

### DIFF
--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -140,7 +140,8 @@ int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing 
 lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction=REND_DIRECTION_UNSET );
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
-                       int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL );
+                       int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL,
+                       lString32 running_bidi_ctrlchars=lString32::empty_str );
 /// renders block which contains subblocks (with enode document's rendering flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
         int usable_left_overflow=0, int usable_right_overflow=0, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -2970,6 +2970,8 @@ void LVGrayDrawBuf::DrawRescaled(const LVDrawBuf * __restrict src, int x, int y,
         }
     }
 	CHECK_GUARD_BYTE;
+	_drawnImagesCount += ((LVBaseDrawBuf*)src)->getDrawnImagesCount();
+	_drawnImagesSurface += dx*dy;
 }
 
 
@@ -3025,6 +3027,8 @@ void LVColorDrawBuf::DrawRescaled(const LVDrawBuf * __restrict src, int x, int y
 			}
 		}
 	}
+	_drawnImagesCount += ((LVBaseDrawBuf*)src)->getDrawnImagesCount();
+	_drawnImagesSurface += dx*dy;
 }
 
 /// returns scanline pointer

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7181,6 +7181,13 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool margin_left_auto = css_margin_left.type == css_val_unspecified && css_margin_left.value == css_generic_auto;
     bool margin_right_auto = css_margin_right.type == css_val_unspecified && css_margin_right.value == css_generic_auto;
 
+    if ( style->display == css_d_table_cell ) {
+        // https://www.w3.org/TR/CSS2/tables.html#table-layout:
+        // "Internal table elements do not have margins."
+        margin_left = margin_right = margin_top = margin_bottom = 0;
+        margin_left_auto = margin_right_auto = false;
+    }
+
     // Adjust box size and position
 
     // We may trust width set on our own boxing elements, even if a table


### PR DESCRIPTION
#### DrawBuf::DrawRescaled(): account for _drawnImagesCount/Surface

This is used to draw FB2 covers, so they too will get enhanced image handling from frontend (dithering, color...)
See https://github.com/koreader/koreader-base/pull/1484#issuecomment-1507508646 and around.

#### renderBlockElementEnhanced: ignore margins set on table cells

As per-specs. They were already ignored when sizing tables and cells, but not when rendering the cell content, which could cause unwanted wraps.

#### writeNodeEx: also return `@import`'ed css file names

Should help inspecting books that use `@import` in their main stylesheet (as in the slow-loading Japanese books provided by @NiLuJe in the past).

#### Text: fix interactions of standalone floats and `<br/>`

Handle cases like these:
`  <p><img src="..." style="float: right"/></p>`
which should have a zero-height.
`  <p><img src="..." style="float: right"/><br/></p>`
which should keep the strut height.
This behaves as Firefox, and should do the proper handling mentionned in be304606d.
Also do the proper final work in the other places we `return` early in AddLine().

#### BiDi: fix HTML driven BiDi possibly wrong after `<br/>`

When `dir=rtl` would be provided by some inner inline tag, it would be lost after an inner `<BR/>`, ie.:
```html
<p>
  <span dir="rtl">
    this was properly rendered RTL
    <br/>
    but this wasn't.
  </span>
</p>
```
Also comment out unused closeWithPDFPDI.

#### Text: fix spaces not collapsing when interleaved with ignorables

Also try to handle better leading and trailing spaces in BiDi paragraphs.

#### BiDi: ensure proper ordering when white-space: pre

After meeting a `\n`, Bidi state would be messed up.
Should fix cases like:
```html
<p dir="rtl" style="white-space: pre">this was rendered RTL
but this wasn't.
</p>
```
(Same logic as used in koreader-base/xtext.cpp.)

#### BiDi: ensure proper ordering when white-space: pre (2)

Also forward our bidi ctrl char (a single one, no support if more are nested), similar to the above commit `BiDi: fix HTML driven BiDi possibly wrong after <br/>`, but with `\n` in `white-space: pre` text.
Should fix cases like this:
```html
<p style="white-space: pre"><span dir="rtl">this was rendered RTL
but this wasn't.
</p>
```

Sample test file for all this: [test-space-in-p.html.txt](https://github.com/koreader/crengine/files/11409470/test-space-in-p.html.txt)

Koreader before in the middle (doing wrong), Firefox in the background on the sides (doing right):
![image](https://user-images.githubusercontent.com/24273478/236550408-5fa82197-70d7-4979-9d0f-6ca7cbd35eae.png)

Koreader after in the middle, Firefox in the background on the sides, both agreeing:
![image](https://user-images.githubusercontent.com/24273478/236550553-c6b53f19-16bf-4243-917f-0357b8cfd80f.png)

(I don't really undestand how it happens that KOReader keeps the 2 spaces in the middle between A and BC, and between TEXT and where, as it should, as Firefox does - as I have some code that is supposed to blindly collapse them :) so I guess there is some lucky interaction with BiDi levels and the way the "word" making code handles space at start or end of words...

----

I initially just wanted to fix the float/`<br/>` issue - but my sample case had `dir="rtl"`, and testing, I was meeting more and more RTL/BiDi issues, ): ...universe alternate horrifying this in pulled been ve'I, again once and

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/517)
<!-- Reviewable:end -->
