### PR TITLE
MInor NCX ToC and createXPointer(pt) fixes

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9835,6 +9835,12 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             }
         }
     }
+    if ( !strictBounds ) {
+        // We had a final node, but didn't find any xpointer in its content. This might be
+        // because the final node has no text nor image, ie. with just <p><span></span></p>.
+        // So, return the final node itself.
+        return ldomXPointer( finalNode, 0 );
+    }
     return ptr;
 }
 


### PR DESCRIPTION
#### EPUB NCX ToC: don't ignore items with invalid targets

EPUBs may have occasionally buggy NCX entries with invalid targets. Don't ignore them, it's best to get a title and not ignore any subentries, even if tapping on them will lead us nowhere.

#### ldomDocument::createXPointer(pt): handle some edge case

`<p></p>` and `<p><span> </span></p>` are handled correctly.  This handles `<p><span></span></p>`, which was resolving to a null xpointer.
See https://github.com/koreader/koreader/pull/10506#issuecomment-1570167960
Should allow closing https://github.com/koreader/koreader/issues/10505

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/518)
<!-- Reviewable:end -->
