### PR TITLE
fix fribidi include

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -32,7 +32,7 @@
 #endif
 
 #if (USE_FRIBIDI==1)
-#include <fribidi/fribidi.h>
+#include <fribidi.h>
 #endif
 
 #define SPACE_WIDTH_SCALE_PERCENT 100


### PR DESCRIPTION
```bash
▸ pkg-config --cflags fribidi
-I/usr/include/fribidi
```

Otherwise, using `fribidi/fribidi.h` may result in the wrong (system) include being picked up when building the emulator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/519)
<!-- Reviewable:end -->
