### PR TITLE
fix teardown

### DIFF
--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -134,7 +134,7 @@ class HyphMan
     // static HyphMethod * _method;
     // static HyphDictionary * _selectedDictionary;
     static HyphDictionaryList * _dictList; // available hyph dict files (+ none/algo/softhyphens)
-    static LVHashTable<lString32, HyphMethod*> _loaded_hyph_methods; // methods with loaded dictionaries
+    static LVHashTable<lString32, HyphMethod*, true> _loaded_hyph_methods; // methods with loaded dictionaries
     static HyphDataLoader* _dataLoader;
     static int _LeftHyphenMin;
     static int _RightHyphenMin;

--- a/crengine/include/lvhashtable.h
+++ b/crengine/include/lvhashtable.h
@@ -47,7 +47,7 @@ inline lUInt32 getHash(void * n )
 /**
     Implements hash table map
 */
-template <typename keyT, typename valueT> class LVHashTable
+template <typename keyT, typename valueT, bool own_values = false> class LVHashTable
 {
 	friend class iterator;
 public:
@@ -114,6 +114,8 @@ public:
             pair * p = _table[i];
             while ( p ) {
                 pair * tmp = p;
+                if constexpr (own_values)
+                    delete p->value;
                 p = p->next;
                 delete tmp;
             }
@@ -177,6 +179,8 @@ public:
         {
             if ( (*p)->key == key )
             {
+                if constexpr (own_values)
+                    delete p->value;
                 pair * tmp = *p;
                 *p = (*p)->next;
                 delete tmp;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -54,7 +54,7 @@
 int HyphMan::_LeftHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_RightHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_TrustSoftHyphens = HYPH_DEFAULT_TRUST_SOFT_HYPHENS;
-LVHashTable<lString32, HyphMethod*> HyphMan::_loaded_hyph_methods(16);
+LVHashTable<lString32, HyphMethod*, true> HyphMan::_loaded_hyph_methods(16);
 HyphDataLoader* HyphMan::_dataLoader = NULL;
 
 
@@ -170,13 +170,6 @@ void HyphMan::uninit()
 {
     // Avoid existing frontend code to have to call it:
     TextLangMan::uninit();
-    // Clean up _loaded_hyph_methods
-    LVHashTable<lString32, HyphMethod*>::iterator it = _loaded_hyph_methods.forwardIterator();
-    LVHashTable<lString32, HyphMethod*>::pair* pair;
-    while ((pair = it.next())) {
-        delete pair->value;
-    }
-    _loaded_hyph_methods.clear();
     if ( _dictList )
             delete _dictList;
     _dictList = NULL;

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -152,7 +152,6 @@ lUInt32 TextLangMan::getHash() {
 // No need to explicitely call this in frontend code.
 // Calling HyphMan::uninit() will have this one called.
 void TextLangMan::uninit() {
-    _lang_cfg_list.clear();
 }
 
 // For HyphMan legacy methods


### PR DESCRIPTION
Fix issues with calling koreader base' teardown in `cre.cpp`, including the fact that the destructor for `static LVHashTable<lString32, HyphMethod*, true> _loaded_hyph_methods` gets called before it, so trying to iterate on the hashtable to cleanup memory is triggering uses after free.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/520)
<!-- Reviewable:end -->
