### PR TITLE
Minor CSS fixes, add support for .docm

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -79,6 +79,7 @@ struct ldomNode;
 class LVCssDeclaration {
 private:
     int * _data;
+    lUInt32 _datalen;
     bool _check_if_supported;
     bool  _extra_weighted;
 public:
@@ -92,7 +93,7 @@ public:
     void setExtraWeighted( bool weighted ) { _extra_weighted = weighted; }
     int isExtraWeighted() { return _extra_weighted; }
     lUInt32 getHash();
-    LVCssDeclaration() : _data(NULL), _check_if_supported(false), _extra_weighted(false) { }
+    LVCssDeclaration() : _data(NULL), _datalen(0), _check_if_supported(false), _extra_weighted(false) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }
 };
 

--- a/crengine/src/bookformats.cpp
+++ b/crengine/src/bookformats.cpp
@@ -4,6 +4,7 @@
 lString32 LVDocFormatName(int fmt) {
     switch (fmt) {
     case doc_format_fb2: return lString32("FB2");
+    case doc_format_fb3: return lString32("FB3");
     case doc_format_txt: return lString32("TXT");
     case doc_format_rtf: return lString32("RTF");
     case doc_format_epub: return lString32("EPUB");
@@ -11,7 +12,9 @@ lString32 LVDocFormatName(int fmt) {
     case doc_format_txt_bookmark: return lString32("BMK");
     case doc_format_chm: return lString32("CHM");
     case doc_format_doc: return lString32("DOC");
+    case doc_format_docx: return lString32("DOCX");
     case doc_format_pdb: return lString32("PDB");
+    case doc_format_odt: return lString32("ODT");
     default: return lString32("?");
     }
 }
@@ -19,6 +22,7 @@ lString32 LVDocFormatName(int fmt) {
 lString8 LVDocFormatCssFileName(int fmt) {
     switch (fmt) {
     case doc_format_fb2: return lString8("fb2.css");
+    case doc_format_fb3: return lString8("fb3.css");
     case doc_format_txt: return lString8("txt.css");
     case doc_format_rtf: return lString8("rtf.css");
     case doc_format_epub: return lString8("epub.css");
@@ -26,7 +30,9 @@ lString8 LVDocFormatCssFileName(int fmt) {
     case doc_format_txt_bookmark: return lString8("txt.css");
     case doc_format_chm: return lString8("chm.css");
     case doc_format_doc: return lString8("doc.css");
+    case doc_format_docx: return lString8("docx.css");
     case doc_format_pdb: return lString8("htm.css");
+    case doc_format_odt: return lString8("odt.css");
     default: return lString8("txt.css");
     }
 }
@@ -34,6 +40,8 @@ lString8 LVDocFormatCssFileName(int fmt) {
 int LVDocFormatFromExtension(lString32 &pathName) {
     if (pathName.endsWith(".fb2"))
         return doc_format_fb2;
+    if (pathName.endsWith(".fb3"))
+        return doc_format_fb3;
     if (pathName.endsWith(".txt") || pathName.endsWith(".tcr") || pathName.endsWith(".pml"))
         return doc_format_txt;
     if (pathName.endsWith(".rtf"))
@@ -48,8 +56,12 @@ int LVDocFormatFromExtension(lString32 &pathName) {
         return doc_format_chm;
     if (pathName.endsWith(".doc"))
         return doc_format_doc;
+    if (pathName.endsWith(".docx") || pathName.endsWith(".docm"))
+        return doc_format_docx;
     if (pathName.endsWith(".pdb") || pathName.endsWith(".prc") || pathName.endsWith(".mobi") || pathName.endsWith(".azw"))
         return doc_format_pdb;
+    if (pathName.endsWith(".odt"))
+        return doc_format_odt;
     return doc_format_none;
 }
 

--- a/crengine/src/docxfmt.cpp
+++ b/crengine/src/docxfmt.cpp
@@ -10,6 +10,7 @@
 #define DOCX_LAST_ITEM { -1, NULL }
 
 static const lChar32* const docx_DocumentContentType   = U"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+static const lChar32* const docm_DocumentContentType   = U"application/vnd.ms-word.document.macroEnabled.main+xml";
 static const lChar32* const docx_NumberingContentType  = U"application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml";
 static const lChar32* const docx_StylesContentType     = U"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml";
 static const lChar32* const docx_ImageRelationship     = U"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
@@ -279,7 +280,8 @@ bool DetectDocXFormat( LVStreamRef stream )
 
     OpcPackage package(m_arc);
 
-    return package.partExist(package.getContentPartName(docx_DocumentContentType));
+    return (   package.partExist(package.getContentPartName(docx_DocumentContentType))
+            || package.partExist(package.getContentPartName(docm_DocumentContentType)) );
 }
 
 class docxImportContext;
@@ -1569,8 +1571,11 @@ bool ImportDocXDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallba
         return false;
 
     LVStreamRef m_stream = importContext.openContentPart(docx_DocumentContentType);
-    if ( m_stream.isNull() )
-        return false;
+    if ( m_stream.isNull() ) {
+        m_stream = importContext.openContentPart(docm_DocumentContentType);
+        if ( m_stream.isNull() )
+            return false;
+    }
 
     ldomDocumentWriter writer(doc);
     docXMLreader docReader(&writer);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -167,7 +167,7 @@ static void SVGGlyphsCollector_svg_continue_to(hb_draw_funcs_t *, SVGGlyphsColle
 }
 
 #if USE_HARFBUZZ==1
-// For use with hb_font_get_glyph_shape()
+// For use with hb_font_draw_glyph()
 static hb_draw_funcs_t *SVGGlyphsCollector_svg_funcs = NULL;
 void setup_SVGGlyphsCollector_svg_funcs() {
     SVGGlyphsCollector_svg_funcs = hb_draw_funcs_create();
@@ -2516,7 +2516,7 @@ public:
             if (_kerningMode == KERNING_MODE_HARFBUZZ && code_is_glyph_index ) {
                 // With kerning mode harfbuzz, we get called with the fallback font and the glyph
                 // index in that font. No need to check if it is present or iterate fallback fonts.
-                // We can use hb_font_get_glyph_shape() which will make a smoother shape than
+                // We can use hb_font_draw_glyph() which will make a smoother shape than
                 // what we can get with FreeType outline contours below.
                 // But Harfbuzz doesn't know about any fake italic or synth weight, and has
                 // no way to do itself these transforms.
@@ -2526,7 +2526,7 @@ public:
                     if ( SVGGlyphsCollector_svg_funcs == NULL ) {
                         setup_SVGGlyphsCollector_svg_funcs();
                     }
-                    hb_font_get_glyph_shape(_hb_font, code, SVGGlyphsCollector_svg_funcs, svg_collector);
+                    hb_font_draw_glyph(_hb_font, code, SVGGlyphsCollector_svg_funcs, svg_collector);
                     return true;
                 }
             }

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2259,7 +2259,7 @@ bool LVSvgImageSource::Decode( LVImageDecoderCallback * callback ) {
                 lUInt8 b = (((*src)     & 0xFF)*255) / alpha;
                 *dst++ = ((alpha^0xFF)<<24) | (r<<16) | (g<<8) | b;
             }
-            *src++;
+            src++;
         }
         callback->OnLineDecoded( this, y, row );
     }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4258,8 +4258,8 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
     // store parsed result
     if (buf.pos()) {
         buf<<(lUInt32) cssd_stop; // add end marker
-        int sz = buf.pos()/4;
-        _data = new int[sz];
+        _datalen = buf.pos()/4;
+        _data = new int[_datalen];
         // Could that cause problem with different endianess?
         buf.copyTo( (lUInt8*)_data, buf.pos() );
         // Alternative:
@@ -4661,7 +4661,7 @@ lUInt32 LVCssDeclaration::getHash() {
         return 0;
     int * p = _data;
     lUInt32 hash = 0;
-    for (;*p != cssd_stop;p++)
+    for (lUInt32 i=0; i<_datalen; i++, p++)
         hash = hash * 31 + *p;
     return hash;
 }


### PR DESCRIPTION
#### DocX: add support for similar DocM format

https://github.com/koreader/koreader/issues/10599#issuecomment-1627678171. Thanks @pkb.
Should allow closing https://github.com/koreader/koreader/issues/10599.

#### LVStyleSheet: fix LVCssDeclaration::getHash()

Computations could stop too early (when meeting the ASCII char `cssd_stop`, currently `h`, ie. in a `'url(aha.png)'`), which would have any change after that `h` goes unnoticed.
Noticed at https://github.com/koreader/crengine/issues/514#issuecomment-1616584156.

#### CSS parsing: accept Unicode values for ID and classnames

(We still expect ASCII for element and attribute names.)
Got a French EPUB that has in its CSS (as utf8, shown here read as latin1):
```css
section{
visibility: hidden;
}
section#mentions,
section#prÃ©face,
section#lever-de-rideau-avant-propos,
section#actepremier-en-scÃ¨ne-histoire,
section#remerciements { visibility: visible !important; }
```
which was mostly blank :)
We'll now support `#id` and `.classname` made with other chars than ASCII ones.
I hope it won't cause issues with other fancy CSS with other encodings.

#### update for Harfbuzz 8, fix some compiler warning

`hb_font_get_glyph_shape()` is deprecated and has been replaced with `hb_font_draw_glyph()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/523)
<!-- Reviewable:end -->
