### PR TITLE
CSS: add support for "caption-side: top/bottom", and other SVG, CSS and table fixes

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -201,6 +201,10 @@ table[align=right i] { float: right; }
  * page number is in a title= attribute.) */
 span[type=pagebreak] { display: none; }
 
+/* EPUB3: also hide any <nav hidden=""> made available in the book content,
+ * which could be a huge list of reference page numbers */
+nav[hidden] { display: none; }
+
 /* Old element or className based selectors involving display: that
  * we need to support for older gDOMVersionRequested
  * DO NOT MODIFY BELOW to not break past highlights */

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -373,6 +373,13 @@ enum css_box_sizing_t {
     css_bs_border_box
 };
 
+/// caption-side property values
+enum css_caption_side_t {
+    css_cs_inherit,
+    css_cs_top,
+    css_cs_bottom
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,         // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,       // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -851,7 +851,7 @@ public:
     /// set document stylesheet text
     void setStyleSheet( lString8 css_text, bool use_macros=true );
     /// gather snippets from all stylesheets involved that the provided node would match
-    void gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches );
+    void gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches, bool with_m_stylesheet=true );
 
     /// set default interline space, percent (100..200)
     void setDefaultInterlineSpace( int percent );

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -143,9 +143,9 @@ public:
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }
     /// check condition for node
-    bool check( const ldomNode * & node );
+    bool check( const ldomNode * & node, bool allow_cache=true );
     /// check next rules for node
-    bool checkNextRules( const ldomNode * node );
+    bool checkNextRules( const ldomNode * node, bool allow_cache=true );
     /// Some selector rule types do the full rules chain check themselves
     bool isFullChecking() { return _type == cssrt_ancessor || _type == cssrt_predsibling; }
     lUInt32 getHash();
@@ -179,7 +179,7 @@ public:
     ~LVCssSelector() { if (_next) delete _next; if (_rules) delete _rules; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
     bool parse( const char * &str, lxmlDocBase * doc );
     lUInt16 getElementNameId() const { return _id; }
-    bool check( const ldomNode * node ) const;
+    bool check( const ldomNode * node, bool allow_cache=true ) const;
     void applyToPseudoElement( const ldomNode * node, css_style_rec_t * style ) const;
     void apply( const ldomNode * node, css_style_rec_t * style ) const
     {

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -91,10 +91,11 @@ enum css_style_rec_important_bit {
     imp_bit_line_break,
     imp_bit_word_break,
     imp_bit_box_sizing,
+    imp_bit_caption_side,
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 69 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 70 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -181,6 +182,7 @@ struct css_style_rec_tag {
     css_line_break_t       line_break;
     css_word_break_t       word_break;
     css_box_sizing_t       box_sizing;
+    css_caption_side_t     caption_side;
     lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
@@ -239,6 +241,7 @@ struct css_style_rec_tag {
     , line_break(css_lb_inherit)
     , word_break(css_wb_inherit)
     , box_sizing(css_bs_content_box)
+    , caption_side(css_cs_inherit)
     , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -925,7 +925,7 @@ public:
     void initNodeStyleRecursive( LVDocViewCallback * progressCallback );
 
     /// gather snippets from all stylesheets involved that this node would match
-    void gatherStylesheetMatchingRulesets(lString8 css, bool include_document_stylesheets, lString8Collection & matches);
+    void gatherStylesheetMatchingRulesets(const lString8 & css, bool include_document_stylesheets, lString8Collection & matches);
 #endif
 
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -530,13 +530,15 @@ void LVDocView::updateDocStyleSheet() {
     m_stylesheetNeedsUpdate = false;
 }
 
-void LVDocView::gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches ) {
+void LVDocView::gatherStylesheetsMatchingRulesets( lUInt32 nodeDataIndex, lString8Collection & matches, bool with_m_stylesheet ) {
     matches.clear();
-    matches.add(cs8("/* --- in main stylesheet and tweaks: --- */"));
+    if ( with_m_stylesheet )
+        matches.add(cs8("/* --- in main stylesheet and tweaks: --- */"));
     ldomNode * node = m_doc->getTinyNode( nodeDataIndex );
     if ( node && node->isElement() ) {
         // Provide our useragent stylesheet, that we have (here only) as plain text
-        node->gatherStylesheetMatchingRulesets(m_stylesheet, true, matches);
+        lString8 css = with_m_stylesheet ? m_stylesheet : lString8();
+        node->gatherStylesheetMatchingRulesets(css, true, matches);
     }
 }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -130,8 +130,6 @@ int CssPageBreak2Flags( css_page_break_t prop );
 // Uncomment for debugging table rendering:
 // #define DEBUG_TABLE_RENDERING
 
-#define TABLE_BORDER_WIDTH 1
-
 class CCRTableCol;
 class CCRTableRow;
 
@@ -1305,6 +1303,13 @@ public:
             else if (cols[x]->width_auto && cols[x]->min_width > 0) {
                 dist_nb_cols += 1;      // candidate to get more width
             }
+            else {
+                // Otherwise, not a candidate to get more width:
+                // be sure we don't distribute to it.
+                if ( cols[x]->min_width != 0 ) {
+                    cols[x]->min_width = -1;
+                }
+            }
         }
         #ifdef DEBUG_TABLE_RENDERING
             for (int x=0; x<cols.length(); x++)
@@ -1372,6 +1377,8 @@ public:
                         dist_nb_cols += 1;
                     }
                 }
+                // (Not sure what to do if still dist_nb_cols==0 (all empty cols),
+                // should we distribute to all cols, or let them be, or does it matter?
                 #ifdef DEBUG_TABLE_RENDERING
                     printf("TABLE WIDTHS step5: %d to distribute to all %d non empty cols\n",
                         restw, dist_nb_cols);

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -134,6 +134,7 @@ enum css_decl_code {
     cssd_line_break3,
     cssd_word_break,
     cssd_box_sizing,
+    cssd_caption_side,
     cssd_content,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
@@ -242,6 +243,7 @@ static const char * css_decl_name[] = {
     "-webkit-line-break",
     "word-break",
     "box-sizing",
+    "caption-side",
     "content",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
@@ -2902,6 +2904,15 @@ static const char * css_bs_names[] =
     NULL
 };
 
+// caption-side value names
+static const char * css_cs_names[] =
+{
+    "inherit",
+    "top",
+    "bottom",
+    NULL
+};
+
 static const char * css_cr_only_if_names[]={
         "any",
         "always",
@@ -4215,6 +4226,9 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             case cssd_box_sizing:
                 n = parse_name( decl, css_bs_names, -1 );
                 break;
+            case cssd_caption_side:
+                n = parse_name( decl, css_cs_names, -1 );
+                break;
             case cssd_content:
                 {
                     lString32 parsed_content;
@@ -4603,6 +4617,9 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
             break;
         case cssd_box_sizing:
             style->Apply( (css_box_sizing_t) *p++, &style->box_sizing, imp_bit_box_sizing, is_important );
+            break;
+        case cssd_caption_side:
+            style->Apply( (css_caption_side_t) *p++, &style->caption_side, imp_bit_caption_side, is_important );
             break;
         case cssd_cr_hint:
             {

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -115,6 +115,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.line_break) * 31
          + (lUInt32)rec.word_break) * 31
          + (lUInt32)rec.box_sizing) * 31
+         + (lUInt32)rec.caption_side) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
@@ -195,6 +196,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.line_break == r2.line_break&&
            r1.word_break == r2.word_break&&
            r1.box_sizing == r2.box_sizing&&
+           r1.caption_side == r2.caption_side&&
            r1.content == r2.content&&
            r1.cr_hint==r2.cr_hint;
 }
@@ -396,6 +398,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(line_break);
     ST_PUT_ENUM(word_break);
     ST_PUT_ENUM(box_sizing);
+    ST_PUT_ENUM(caption_side);
     buf << content;
     ST_PUT_LEN(cr_hint);
     lUInt32 hash = calcHash(*this);
@@ -469,6 +472,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_line_break_t, line_break);
     ST_GET_ENUM(css_word_break_t, word_break);
     ST_GET_ENUM(css_box_sizing_t, box_sizing);
+    ST_GET_ENUM(css_caption_side_t, caption_side);
     buf>>content;
     ST_GET_LEN(cr_hint);
     lUInt32 hash = 0;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -90,7 +90,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.71k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x002F
+#define FORMATTING_VERSION_ID 0x0030
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)
@@ -5137,6 +5137,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->visibility = css_v_visible;
     s->line_break = css_lb_auto;
     s->word_break = css_wb_normal;
+    s->caption_side = css_cs_top;
     s->box_sizing = css_bs_content_box;
     s->cr_hint.type = css_val_unspecified;
     s->cr_hint.value = CSS_CR_HINT_NONE;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -8569,7 +8569,7 @@ bool ldomNode::applyNodeStylesheet()
     return false;
 }
 
-void ldomNode::gatherStylesheetMatchingRulesets(lString8 css, bool include_document_stylesheets, lString8Collection & matches) {
+void ldomNode::gatherStylesheetMatchingRulesets(const lString8 & css, bool include_document_stylesheets, lString8Collection & matches) {
     LVStyleSheet styleSheet(getDocument());
     styleSheet.gatherNodeMatchingRulesets(this, css.c_str(), matches);
     if ( include_document_stylesheets ) {


### PR DESCRIPTION
#### `SVG: support embedded base64 images when no doc`

Fix embedded base64 images not supported when used by frontends to render a SVG without having a document loaded.
Issue noticed at https://github.com/koreader/koreader/issues/10711#issuecomment-1641562965.

#### `epub.css: hide <nav hidden="">`

A single nav.xhtml could be in the spine, and host a ToC `<nav>` and a huge page list `<nav hidden="">`, that we should not show as per-specs.
Should allow closing https://github.com/koreader/koreader/issues/10703 (see discussion in there).

#### `Tables: fix possible specified width overflow`

Ie. with the following, the cells would overflow the document width:
```html
<table style="width: 100%;">
  <tr><td style="width: 4em">abc</td><td>def</td></tr>
</table>
```
![image](https://github.com/koreader/crengine/assets/24273478/fe209413-76fb-46c9-a496-8ec65fda3a08)

#### `Tables: fix caption and table width interactions`

Per-specs, a caption computed max width should not be involved in the table width computation (it was not, in the table rendering code, but it was in `getRenderedWidth()`).
On the contrary, its computed min width should be involved (it was in `getRenderedWidth()`, but not in the table rendering code).

#### `CSS/Tables: add support for "caption-side: top/bottom"`

crengine was always putting caption at the top of the table.

These 2 caption commits are needed to support the recently updated HTML we get for Wikipedia articles. See https://github.com/koreader/koreader/pull/5840#issuecomment-1646576070.
It now uses some simpler code:
```html
<figure class="mw-default-size" typeof="mw:File/Thumb">
  <img src="images/img00039.png" style="width: 220px; height: 196px" alt=""/>
  <figcaption>
    Some short ot long text
  </figcaption>
</figure>
```
and sets `figure { display: table }` and `figcaption { display: table-caption }` - which is a nice trick, because of that behaviour of `display: table-caption` that I didn't know about.
Previously, they had to duplicate the `style="width, height"` on the containers. Now, the figure just wraps the sized image, and the caption does not get involved (it will fit and wrap under the image).
Such a wikipedia `<figure>` with float will render as:
![image](https://github.com/koreader/crengine/assets/24273478/6d25915b-49c2-4c04-9504-9a82ff98f5b7)
and look as before (a bit more work for crengine with the needed "complete incomplete tables" work, but easier than having to report the image width and height on all the upper containers via Lua patterns...

#### `gatherNodeMatchingRulesets(): avoid messing document cache`

Checking pseudoclasses like `nth-child()` is using a cache to speed things up; this cache makes use of each node's `RenderRectAccessor`, which is unset at the time of styles checking, and reset after, before it is filled with valuable data and cached into the book cache.
`gatherNodeMatchingRulesets()`, used on user request after the book is fully rendered, should not use this cache trick, as it would then mess with the valuable data and corrupt the book rendering data.
So, pass a allow_cache param all along the `check()` calls.

(`View HTML + Show matched stylesheet rules` on a paragraph targetted by such pseudo class would make that paragraph disappear ! It was actually rendered on the first page of the docfragment, because by checking these pseudoclasses, we were setting its `y` (relative to the the DocFragment start) to a little number (its position in the DocFragment paragraph collection :)

#### `gatherStylesheetsMatchingRulesets(): add with_m_stylesheet param`

Will allow having long-press on:
![image](https://github.com/koreader/crengine/assets/24273478/1393a56d-397d-414f-acd4-1b7341155efa)
to not show the bits from our epub.css and our styletweaks, which can be noise (because many tweaks target `*`) when investigating a book:
![image](https://github.com/koreader/crengine/assets/24273478/5e675e80-f2ee-4f9f-91b2-49f1ba83c8d8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/524)
<!-- Reviewable:end -->
