### PR TITLE
CSS: revamp 'inherit' handling, now fully per CSS specs, and other fixes

### DIFF
--- a/cr3gui/data/epub.css
+++ b/cr3gui/data/epub.css
@@ -113,6 +113,8 @@ dd:dir(rtl) {
 table {
     font-size: 80%;
     margin: 3px 0;
+    border-collapse: separate;
+    border-spacing: 1px; /* needed for separate border to not look uneven */
 }
 table table { /* stop imbricated tables from getting smaller */
     font-size: 100%;

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -378,12 +378,17 @@ enum css_caption_side_t {
 enum css_generic_value_t {
     css_generic_auto = -1,         // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,       // (css_val_unspecified, css_generic_normal), for "line-height: normal"
-    css_generic_transparent = -3,  // (css_val_unspecified, css_generic_transparent), for "color: transparent"
+    // css_generic_transparent = -3, // replaced by (css_val_color, CSS_COLOR_TRANSPARENT)
     css_generic_currentcolor = -4, // (css_val_unspecified, css_generic_currentcolor), for "color: currentcolor"
     css_generic_contain = -5,      // (css_val_unspecified, css_generic_contain), for "background-size: contain"
     css_generic_cover = -6,        // (css_val_unspecified, css_generic_cover), for "background-size: cover"
     css_generic_none = -7          // (css_val_unspecified, css_generic_none), for "max-width: none"
 };
+
+// color 'transparent' is transparent black rgba(0,0,0,0) per specs
+#define CSS_COLOR_TRANSPARENT     0xFF000000
+#define IS_COLOR_FULLY_TRANSPARENT(color_value)  ( (bool)((color_value & 0xFF000000) == 0xFF000000) )
+#define IS_COLOR_FULLY_OPAQUE(color_value)       ( (bool)((color_value & 0xFF000000) == 0x00000000) )
 
 // -cr-hint is a non standard property for providing hints to crengine via style tweaks
 // Handled as a bitmap, with a flag for each hint, as we might set multiple on a same node (max 31 bits)

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -257,6 +257,8 @@ enum css_value_type_t {
 
 /// css border style values
 enum css_border_style_type_t {
+    css_border_inherit,
+    css_border_none,
     css_border_solid,
     css_border_dotted,
     css_border_dashed,
@@ -264,8 +266,7 @@ enum css_border_style_type_t {
     css_border_groove,
     css_border_ridge,
     css_border_inset,
-    css_border_outset,
-    css_border_none
+    css_border_outset
 };
 /// css background property values
 enum css_background_repeat_value_t {
@@ -273,12 +274,10 @@ enum css_background_repeat_value_t {
     css_background_repeat_x,
     css_background_repeat_y,
     css_background_no_repeat,
-    css_background_r_initial,
-    css_background_r_inherit,
-    css_background_r_none
+    css_background_r_inherit
 };
 enum css_background_position_value_t {
-    css_background_left_top,
+    css_background_left_top = 0,
     css_background_left_center,
     css_background_left_bottom,
     css_background_right_top,
@@ -286,18 +285,14 @@ enum css_background_position_value_t {
     css_background_right_bottom,
     css_background_center_top,
     css_background_center_center,
-    css_background_center_bottom,
-    css_background_p_initial,
-    css_background_p_inherit,
-    css_background_p_none
+    css_background_center_bottom = 8,
+    css_background_p_inherit = 9
 };
 
 enum css_border_collapse_value_t {
-    css_border_seperate,
-    css_border_collapse,
-    css_border_c_initial,
     css_border_c_inherit,
-    css_border_c_none
+    css_border_c_separate,
+    css_border_c_collapse
 };
 
 enum css_orphans_widows_value_t { // supported only if in range 1-9

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -65,7 +65,7 @@ XS_TAG2( xml_stylesheet, "?xml-stylesheet" )
 XS_TAG1( html )
 XS_TAG1( head )
 XS_TAG1D( title, true, css_d_block, css_ws_inherit )
-XS_TAG1D( style, true, css_d_none, css_ws_inherit )
+XS_TAG1D( style, true, css_d_none, css_ws_pre ) // pre needed to preserve content:'s content
 XS_TAG1D( script, true, css_d_none, css_ws_inherit )
 XS_TAG1D( base, false, css_d_none, css_ws_inherit ) // among crengine autoclose elements
 XS_TAG1D( basefont, false, css_d_none, css_ws_inherit )

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -427,6 +427,9 @@ inline lUInt16 rgb888to565( lUInt32 cl ) {
     return (lUInt16)(((cl>>8)& 0xF800) | ((cl>>5 )& 0x07E0) | ((cl>>3 )& 0x001F));
 }
 
+// Combine two colors
+lUInt32 combineColors( lUInt32 foreColor, lUInt32 backColor );
+
 #define DIV255(V)                                                                                        \
 ({                                                                                                       \
 	auto _v = (V) + 128;                                                                             \

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -217,7 +217,7 @@ struct css_style_rec_tag {
     , max_width(css_val_unspecified, css_generic_none)
     , max_height(css_val_unspecified, css_generic_none)
     , color(css_val_inherited, 0)
-    , background_color(css_val_unspecified, 0)
+    , background_color(css_val_color, CSS_COLOR_TRANSPARENT)
     , letter_spacing(css_val_inherited, 0)
     , page_break_before(css_pb_auto)
     , page_break_after(css_pb_auto)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -210,12 +210,12 @@ struct css_style_rec_tag {
     , font_features(css_val_inherited, 0)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
-    , width(css_val_unspecified, 0)
-    , height(css_val_unspecified, 0)
-    , min_width(css_val_unspecified, 0)
-    , min_height(css_val_unspecified, 0)
-    , max_width(css_val_unspecified, 0)
-    , max_height(css_val_unspecified, 0)
+    , width(css_val_unspecified, css_generic_auto)
+    , height(css_val_unspecified, css_generic_auto)
+    , min_width(css_val_unspecified, css_generic_auto)
+    , min_height(css_val_unspecified, css_generic_auto)
+    , max_width(css_val_unspecified, css_generic_none)
+    , max_height(css_val_unspecified, css_generic_none)
     , color(css_val_inherited, 0)
     , background_color(css_val_unspecified, 0)
     , letter_spacing(css_val_inherited, 0)
@@ -229,9 +229,9 @@ struct css_style_rec_tag {
     , border_style_bottom(css_border_none)
     , border_style_right(css_border_none)
     , border_style_left(css_border_none)
-    , background_repeat(css_background_r_none)
-    , background_position(css_background_p_none)
-    , border_collapse(css_border_seperate)
+    , background_repeat(css_background_repeat)
+    , background_position(css_background_left_top)
+    , border_collapse(css_border_c_inherit)
     , orphans(css_orphans_widows_inherit)
     , widows(css_orphans_widows_inherit)
     , float_(css_f_none)
@@ -249,19 +249,29 @@ struct css_style_rec_tag {
     {
         // css_length_t fields are initialized by css_length_tag()
         // to (css_val_screen_px, 0)
-        // These should not: a not specified border width will
-        // use DEFAULT_BORDER_WIDTH (=2)
-        border_width[0] = css_length_t(css_val_unspecified, 0);
-        border_width[1] = css_length_t(css_val_unspecified, 0);
-        border_width[2] = css_length_t(css_val_unspecified, 0);
-        border_width[3] = css_length_t(css_val_unspecified, 0);
-        background_size[0] = css_length_t(css_val_unspecified, 0);
-        background_size[1] = css_length_t(css_val_unspecified, 0);
+        // The following ones  should not.
+        // Previously, a not specified border width would use DEFAULT_BORDER_WIDTH (=2)
+        // border_width[0] = css_length_t(css_val_unspecified, 0);
+        // border_width[1] = css_length_t(css_val_unspecified, 0);
+        // border_width[2] = css_length_t(css_val_unspecified, 0);
+        // border_width[3] = css_length_t(css_val_unspecified, 0);
+        // But we now use the real CSS initial value of "medium", which
+        // we have set (in lvstsheet.cpp) to 3px.
+        border_width[0] = css_length_t(css_val_px, 3*256);
+        border_width[1] = css_length_t(css_val_px, 3*256);
+        border_width[2] = css_length_t(css_val_px, 3*256);
+        border_width[3] = css_length_t(css_val_px, 3*256);
         // Also initialize border colors
         border_color[0] = css_length_t(css_val_unspecified, css_generic_currentcolor);
         border_color[1] = css_length_t(css_val_unspecified, css_generic_currentcolor);
         border_color[2] = css_length_t(css_val_unspecified, css_generic_currentcolor);
         border_color[3] = css_length_t(css_val_unspecified, css_generic_currentcolor);
+        // border-spacing are inherited
+        border_spacing[0] = css_length_t(css_val_inherited, 0);
+        border_spacing[1] = css_length_t(css_val_inherited, 0);
+        // background-size defaults to "auto auto"
+        background_size[0] = css_length_t(css_val_unspecified, css_generic_auto);
+        background_size[1] = css_length_t(css_val_unspecified, css_generic_auto);
     }
     void AddRef() { refCount++; }
     int Release() { return --refCount; }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -6020,7 +6020,8 @@ public:
             // then breaking here is not allowed"
             // As it is the target node that will get the margin, if avoid_pb_inside
             // was set for that node, we should avoid a split in that margin.
-            if ( vm_target_avoid_pb_inside )
+            // But any 'always" seen and not yet emited wins.
+            if ( vm_target_avoid_pb_inside && vm_active_pb_flag != RN_SPLIT_ALWAYS )
                 vm_active_pb_flag = RN_SPLIT_AVOID;
         }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10309,13 +10309,23 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
 
     // Handle <epub:switch> <epub:case required-namespace="..."> <epub:default>
     if ( nodeElementId == el_case ) {
-        // We only support MathML (but not inline SVG).
+        // We only support MathML and SVG.
         ldomNode * parent = enode->getParentNode();
         if ( parent && parent->getNodeId() == el_switch ) {
             lString32 required_namespace = enode->getAttributeValue(attr_required_namespace);
-            if ( required_namespace == U"http://www.w3.org/1998/Math/MathML" ) {
+            if ( false ) {
+                // dummy if
+            }
+            #if MATHML_SUPPORT==1
+            else if ( required_namespace == U"http://www.w3.org/1998/Math/MathML" ) {
                 // Supported
             }
+            #endif
+            #if USE_LUNASVG==1
+            else if ( required_namespace == U"http://www.w3.org/2000/svg" ) {
+                // Supported
+            }
+            #endif
             else {
                 // Unsupported namespace: hide this <epub:case>.
                 // We can't here check parent's other children for the presence of one
@@ -10335,10 +10345,18 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 ldomNode * child = parent->getChildNode(i);
                 if ( child->isElement() && child->getNodeId() == el_case ) {
                     lString32 required_namespace = child->getAttributeValue(attr_required_namespace);
+                    #if MATHML_SUPPORT==1
                     if ( required_namespace == U"http://www.w3.org/1998/Math/MathML" ) {
                         has_supported_namespace = true;
                         break;
                     }
+                    #endif
+                    #if USE_LUNASVG==1
+                    if ( required_namespace == U"http://www.w3.org/2000/svg" ) {
+                        has_supported_namespace = true;
+                        break;
+                    }
+                    #endif
                 }
             }
             if ( has_supported_namespace ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5094,7 +5094,14 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     // render props don't change.
     //   _renderedBlockCache.clear();
     changed = _imgScalingOptions.update(props, def_font->getSize()) || changed;
+
+    // We define here the style of the root node.
     css_style_ref_t s( new css_style_rec_t );
+    // We have now all the default initial values of the properties for any style.
+    // Tweak some (mostly all those inherited by default) for the root node, so
+    // these values will be inherited by all children node styles if not specified
+    // in a stylesheet.
+    // All those not updated here keep their default initial value (from lvstyles.h).
     s->display = css_d_block;
     s->white_space = css_ws_normal;
     s->text_align = css_ta_start;
@@ -5102,45 +5109,31 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->text_decoration = css_td_none;
     s->text_transform = css_tt_none;
     s->hyphenate = css_hyph_auto;
-    s->color.type = css_val_unspecified;
-    s->color.value = props->getColorDef(PROP_FONT_COLOR, 0x000000);
-    s->background_color.type = css_val_unspecified;
-    s->background_color.value = props->getColorDef(PROP_BACKGROUND_COLOR, 0xFFFFFF);
-    //_def_style->background_color.type = color;
-    //_def_style->background_color.value = 0xFFFFFF;
-    s->page_break_before = css_pb_auto;
-    s->page_break_after = css_pb_auto;
-    s->page_break_inside = css_pb_auto;
+    s->color = css_length_t(css_val_unspecified, props->getColorDef(PROP_FONT_COLOR, 0x000000));
+    s->background_color = css_length_t(css_val_unspecified, props->getColorDef(PROP_BACKGROUND_COLOR, 0xFFFFFF));
     s->list_style_type = css_lst_disc;
     s->list_style_position = css_lsp_outside;
-    s->vertical_align.type = css_val_unspecified;
-    s->vertical_align.value = css_va_baseline;
     s->font_family = def_font->getFontFamily();
-    s->font_size.type = css_val_screen_px; // we use this type, as we got the real font size from FontManager
-    s->font_size.value = def_font->getSize();
+    s->font_size = css_length_t(css_val_screen_px, def_font->getSize()); // we use screen_px, as we got the real font size from FontManager
     s->font_name = def_font->getTypeFace();
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
-    s->font_features.type = css_val_unspecified;
-    s->font_features.value = 0;
-    s->text_indent.type = css_val_px;
-    s->text_indent.value = 0;
-    // s->line_height.type = css_val_percent;
-    // s->line_height.value = def_interline_space << 8;
-    s->line_height.type = css_val_unspecified;
-    s->line_height.value = css_generic_normal; // line-height: normal
-    s->orphans = css_orphans_widows_1; // default to allow orphans and widows
+    s->font_features = css_length_t(css_val_unspecified, 0);
+    s->text_indent = css_length_t(css_val_screen_px, 0);
+    s->line_height = css_length_t(css_val_unspecified, css_generic_normal); // line-height: normal
+    s->letter_spacing = css_length_t(css_val_unspecified, css_generic_normal); // letter-spacing: normal
+    s->border_collapse = css_border_c_separate;
+    s->border_spacing[0] = css_length_t(css_val_screen_px, 0);
+    s->border_spacing[1] = css_length_t(css_val_screen_px, 0);
+    s->orphans = css_orphans_widows_1; // default to allow orphans and widows (CSS per-specs defaults to 2)
     s->widows = css_orphans_widows_1;
-    s->float_ = css_f_none;
-    s->clear = css_c_none;
-    s->direction = css_dir_inherit;
+    s->direction = css_dir_inherit; // dir= attributes have precedence: we don't set any via styles
     s->visibility = css_v_visible;
     s->line_break = css_lb_auto;
     s->word_break = css_wb_normal;
     s->caption_side = css_cs_top;
-    s->box_sizing = css_bs_content_box;
-    s->cr_hint.type = css_val_unspecified;
-    s->cr_hint.value = CSS_CR_HINT_NONE;
+    s->cr_hint = css_length_t(css_val_unspecified, CSS_CR_HINT_NONE);
+
     //lUInt32 defStyleHash = (((_stylesheet.getHash() * 31) + calcHash(_def_style))*31 + calcHash(_def_font));
     //defStyleHash = defStyleHash * 31 + getDocFlags();
     if ( _last_docflags != getDocFlags() ) {

--- a/crengine/src/mathml_css_h.css
+++ b/crengine/src/mathml_css_h.css
@@ -12,13 +12,18 @@ math {
      * "math" _fontFamilyFonts if set, or to a hardcoded list of known fonts with
      * good OpenType Math support when no font (Math or not) has been specified
      * by any stylesheet or if the inherited font has no OT Math support. */
+    /* We reset a few inherited properties (but not all, some seem to be kept
+     * inherited by Firefox: text-transform, visibility, white-space). */
     font-style: normal;
     font-weight: normal;
     letter-spacing: normal;
     line-height: normal;
+    text-decoration: none;
     text-indent: 0;
     direction: ltr;
     hyphens: none;
+    border-collapse: separate;
+    border-spacing: 0;
 }
 math[display="block"] {
     display: block;
@@ -85,6 +90,7 @@ msup,
 msubsup,
 mmultiscripts {
     display: inline-table; /* the code will wrap each child in a mathBox */
+    border-collapse: separate;
 }
 msub > mathBox,
 msup > mathBox,
@@ -117,6 +123,7 @@ munder,
 mover,
 munderover {
     display: inline-table; /* the code will wrap each child in a mathBox */
+    border-collapse: separate;
 }
 munder > mathBox,
 mover > mathBox,
@@ -145,6 +152,7 @@ munderover[Msubsup] > mathBox + mathBox {
 msqrt,
 mroot {
     display: inline-table; /* the code will wrap each child in a mathBox */
+    border-collapse: separate;
 }
 msqrt > mathBox,
 mroot > mathBox {
@@ -339,6 +347,7 @@ annotation-xml {
 mstack,
 mlongdiv {
     display: inline-table;
+    border-collapse: separate;
     font-family: monospace;
 }
 mstack {


### PR DESCRIPTION
#### `SVG: <epub:switch/case/default>: accept SVG`

As we support SVG better now since #489.

#### `Text: don't adjust spacing of leading no-break-space`

At the start of a paragraph, and after a `<br/>`, don't have the width of leading `nbsp` shrunk or expanded if the line is going to be justified, to ensure alignment of the first word on following similar paragraphs.
See https://github.com/koreader/koreader/issues/7366#issuecomment-1657179477.

#### `Block rendering: fix "break-before: always" sometimes not ensured`

See https://github.com/koreader/koreader/issues/10770#issuecomment-1662071876.

#### `Styles: parse <style> as white-space: pre`

Also helps getting nicer `<head><style>` CSS with "View HTML" instead of all of it on a single line.

#### `CSS: revamp 'inherit' handling, now fully per CSS specs`

We used to support '`inherit`' only for properties that are inherited by default; not supporting 'inherit' set by publishers for others could lead to various issues.

Support '`inherit/initial/unset`' on all the properties we support (and make these invalid if not standalone: `'margin: 0 1em inherit 2px'` is invalid).

Make the initial value for all properties fully per-specs, as well as for all the properties of the root node.  (In the code, always use `css_generic_xyz` values instead of the obscure `(css_unspecified, 0)`.)

Make `border-collapse` and `border-spacing` now inherited by default, as per CSS specs.

Cleanup `border-style/width `parsing.
MathML CSS: reset more inherited properties on `<math>`.

(The color properties handling is being properly dealt with in the next commit.)

#### `CSS/colors: handle 'transparent' as a real color`

Use `(css_val_color, CSS_COLOR_TRANSPARENT)` for '`transparent`' instead of `(css_val_unspecified, css_generic_transparent)`, which avoids special cases when handling its inheritance.
This makes '`currentcolor`' the only value with `css_val_unspecified`, and make fixing the following issues simpler:
- when inheriting '`currentcolor`', it must not be resolved to a color, but inherited as 'currentcolor'.
- other parsed transparent colors like `rgba(12,34,56,0)` or `#88888800` are now handled as '`transparent`'.

(Adventure to get to the formula for combining colors at https://github.com/koreader/crengine/pull/474#issuecomment-1675245205 and previous posts.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/525)
<!-- Reviewable:end -->
