### PR TITLE
Speedup PreProcessXmlString()

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5428,8 +5428,9 @@ int codeconvert(int code)
     }
 }
 
+template<bool pre>
 static void PreProcessXmlString(const lChar32 *str, const lChar32 *end, const lChar32 *enc_table,
-                           const lChar32 *&src, lChar32 *&dst, bool pre, bool attribute, bool cdata,
+                           const lChar32 *&src, lChar32 *&dst, bool attribute, bool cdata,
                            int &nsp, lChar32 &lch, lChar32 &nch, int &state) {
     for (; src < end; ++src) {
         lChar32 ch = *src;
@@ -5552,7 +5553,8 @@ static void PreProcessXmlString(const lChar32 *str, const lChar32 *end, const lC
             }
         }
 next:
-        lch = ch;
+        if (pre)
+            lch = ch;
     }
 }
 
@@ -5574,7 +5576,10 @@ int PreProcessXmlString(lChar32 * str, int len, lUInt32 flags, const lChar32 * e
     const lChar32 *src = str;
     const lChar32 *end = str + len;
     lChar32 *dst = str;
-    PreProcessXmlString(str, end, enc_table, src, dst, pre, attribute, cdata, nsp, lch, nch, state);
+    if (pre)
+        PreProcessXmlString<true>(str, end, enc_table, src, dst, attribute, cdata, nsp, lch, nch, state);
+    else
+        PreProcessXmlString<false>(str, end, enc_table, src, dst, attribute, cdata, nsp, lch, nch, state);
     return dst - str;
 }
 

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5455,16 +5455,18 @@ static void PreProcessXmlString(const lChar32 *str, const lChar32 *end, const lC
                 nch = 0;
                 goto next;
             }
+            if (state == 0) {
+                if (ch == ' ') {
+                    if ( pre || attribute || !nsp )
+                        *dst++ = ch;
+                    nsp++;
+                    goto next;
+                }
+            }
         }
         if (state == 0) {
-            if (ch == ' ') {
-                if ( pre || attribute || !nsp )
-                    *dst++ = ch;
-                nsp++;
-            } else {
-                *dst++ = ch;
-                nsp = 0;
-            }
+            *dst++ = ch;
+            nsp = 0;
         } else {
             if (state == 2 && ch=='x')
                 state = 22;


### PR DESCRIPTION
There are more than necessary comparions made on every char. By
1. do a quick check before proceeding to more complicated paths
2. use pointers instead of indices
we see ~50% fewer time spent in the function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/526)
<!-- Reviewable:end -->
