### PR TITLE
Optimize LVCssSelectorRule::check()

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5137,7 +5137,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache )
         break;
     case cssrt_id:            // E#id
         {
-            const lString32 val = node->getAttributeValue(attr_id);
+            const lString32 &val = node->getAttributeValue(attr_id);
             if ( val.empty() )
                 return false;
             // With EPUBs and CHMs, using ldomDocumentFragmentWriter,
@@ -5161,7 +5161,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache )
         break;
     case cssrt_class:         // E.class
         {
-            const lString32 val = node->getAttributeValue(attr_class);
+            const lString32 &val = node->getAttributeValue(attr_class);
             if ( val.empty() )
                 return false;
             // val.lowercase(); // className should be case sensitive
@@ -5169,12 +5169,13 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache )
             // this class attribute contains multiple class names, which needs
             // more complex checks
             if ( val[val.length()-1] == ' ' ) {
-                lString32 value_w_space_after = _value + " ";
-                if (val.pos(value_w_space_after) == 0)
-                    return true; // at start
-                lString32 value_w_spaces_before_after = " " + _value + " ";
-                if (val.pos(value_w_spaces_before_after) != -1)
-                    return true; // in between or at end
+                int start = 0;
+                int pos;
+                while ((pos = val.pos(_value, start)) >= 0) {
+                    if ((pos == 0 || val[pos - 1] == ' ') && val[pos + _value.length()] == ' ')
+                        return true;
+                    start += _value.length();
+                }
                 return false;
             }
             return val == _value;


### PR DESCRIPTION
1. isRoot() is not free. Move it up the hierarchy.
2. avoid unnecessary string copy
3. don't allocate new strings when matching class name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/528)
<!-- Reviewable:end -->
