### PR TITLE
Text: fix possible underflow/crash

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4744,7 +4744,7 @@ public:
                 maxWidth = getCurrentLineWidth();
             }
 
-            if ( m_flags[pos] & LCHAR_IS_CLUSTER_TAIL ) {
+            if ( m_flags[pos] & LCHAR_IS_CLUSTER_TAIL && pos > 0 ) {
                 // This line starts with a cluster tail, probably because hyphenation was
                 // allowed inside this cluster. The first char(s) would get a width of 0,
                 // which may allow more text to be brought into this line: later, in AddLine(),


### PR DESCRIPTION
Happens with `<p>&#x2060;abc</p>`, this word joiner char, being 0-width, is considered a diacritic and cluster tail.
Noticed by @benoit-pierre at https://github.com/koreader/crengine/pull/511#discussion_r1342174345

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/530)
<!-- Reviewable:end -->
