### PR TITLE
lvfntman: fix `LVFontGlobalGlyphCache::removeNoLock`

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1270,6 +1270,7 @@ void LVFontGlobalGlyphCache::remove( LVFontGlyphCacheItem * item )
 
 void LVFontGlobalGlyphCache::removeNoLock( LVFontGlyphCacheItem * item )
 {
+    size -= item->getSize();
     if ( item==head )
         head = item->next_global;
     if ( item==tail )
@@ -1282,7 +1283,6 @@ void LVFontGlobalGlyphCache::removeNoLock( LVFontGlyphCacheItem * item )
         item->next_global->prev_global = item->prev_global;
     item->next_global = NULL;
     item->prev_global = NULL;
-    size -= item->getSize();
 }
 
 void LVFontGlobalGlyphCache::clear()


### PR DESCRIPTION
The cache size was not updated when removing the last item.

Potential impact: negligible, between 64 and 316 bytes on each book opening after the first one, resulting in a ~1% reduction in usable cache size after opening 17 books.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/532)
<!-- Reviewable:end -->
