### PR TITLE
lvtinydom: fix memory leaks

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6919,6 +6919,7 @@ int initTableRendMethods( ldomNode * enode, int state )
                         }
                     }
                 }
+                tbox->persist();
             }
             // If tbox is NULL, all unproper have been removed, and no element added
             if (is_last)
@@ -7218,6 +7219,7 @@ void ldomNode::initNodeRendMethod()
                             ibox->setAttributeValue(LXML_NS_NONE, attr_T, U"EmbeddedBlock");
                             setNodeStyle( ibox, getStyle(), getFont() );
                             ibox->setRendMethod( erm_inline );
+                            ibox->persist();
                         }
                     }
                 }
@@ -7727,6 +7729,7 @@ void ldomNode::initNodeRendMethod()
                         tbox->initNodeStyle();
                         tbox->setRendMethod( erm_table );
                         initTableRendMethods( tbox, 0 );
+                        tbox->persist();
                     }
                     did_wrap = true;
                 }
@@ -8149,9 +8152,12 @@ void ldomNode::initNodeRendMethod()
                                     }
                                     // We let <rp> be invisible like other unexpected elements
                                 }
+                                rbox3->persist();
                             }
                         }
+                        rbox2->persist();
                     }
+                    rbox1->persist();
                 }
             }
         }


### PR DESCRIPTION
Between 128 and ~2M when doing a full load on 23 (out of ~1K) of the files I tested.

Examples:

- [epub30-spec.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/epub30-spec.epub): 17152 byte(s) leaked in 402 allocation(s).
- [hefty-water.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/hefty-water.epub): 2048 byte(s) leaked in 48 allocation(s).
- [kusamakura-japanese-vertical-writing.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/kusamakura-japanese-vertical-writing.epub): 2356736 byte(s) leaked in 55236 allocation(s).
- [kusamakura-preview-embedded.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/kusamakura-preview-embedded.epub): 2356736 byte(s) leaked in 55236 allocation(s).
- [kusamakura-preview.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/kusamakura-preview.epub): 201728 byte(s) leaked in 4728 
- [mymedia_lite.epub](https://github.com/IDPF/epub3-samples/releases/download/20170606/mymedia_lite.epub): 512 byte(s) leaked in 12 allocation(s).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/533)
<!-- Reviewable:end -->
