### PR TITLE
fix fonts leaks

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -140,7 +140,7 @@ struct LVFontGlyphCacheItem
     //       We just use 16 everywhere, as this turned out to be mildly helpful on armv7 (c.f., https://github.com/koreader/crengine/pull/441).
     alignas(16) lUInt8 bmp[1];
     //=======================================================================
-    int getSize()
+    int getSize() const
     {
         // NOTE: Again, we stash the data *in place of* the bmp array, so, the effective size of our object is:
         //       LVFontGlyphCacheItem-up-to-bmp + the glyph storage size.
@@ -570,10 +570,10 @@ public:
     LVEmbeddedFontDef() : _bold(false), _italic(false) {
     }
 
-    const lString32 & getUrl() { return _url; }
-    const lString8 & getFace() { return _face; }
-    bool getBold() { return _bold; }
-    bool getItalic() { return _italic; }
+    const lString32 & getUrl() const { return _url; }
+    const lString8 & getFace() const { return _face; }
+    bool getBold() const { return _bold; }
+    bool getItalic() const { return _italic; }
     void setFace(const lString8 &  face) { _face = face; }
     void setBold(bool bold) { _bold = bold; }
     void setItalic(bool italic) { _italic = italic; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -538,17 +538,17 @@ public:
     /// set fallback font for this font
     virtual void setFallbackFont( LVFontRef font ) { CR_UNUSED(font); }
     /// get fallback font for this font
-    LVFont * getFallbackFont() { return NULL; }
+    LVFontRef getFallbackFont() { return LVFontRef(); }
 
     /// set next fallback font for this font (for when used as a fallback font)
     virtual void setNextFallbackFont( LVFontRef font ) { CR_UNUSED(font); }
     /// get next fallback font for this font (when already used as a fallback font)
-    LVFont * getNextFallbackFont() { return NULL; }
+    LVFontRef getNextFallbackFont() { return LVFontRef(); }
 
     /// get alternative font for drawing decimal list item numbers (could return same font with OTF tabular-nums)
-    virtual LVFont * getDecimalListItemFont() { return this; }
+    virtual LVFontRef getDecimalListItemFont() { return LVFontRef(this); }
     /// get alternative font for drawing disc/circle/square list item markers (could return an other font with better bullet glyphs)
-    virtual LVFont * getBulletListItemFont() { return this; }
+    virtual LVFontRef getBulletListItemFont() { return LVFontRef(this); }
 };
 
 enum font_antialiasing_t

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -375,6 +375,9 @@ enum glyph_extra_metric_t
 
 class LVDrawBuf;
 class SVGGlyphsCollector;
+class LVFont;
+
+typedef LVProtectedFastRef<LVFont> LVFontRef;
 
 /** \brief base class for fonts
 
@@ -533,12 +536,12 @@ public:
     // virtual int getKerningOffset(lChar32 ch1, lChar32 ch2, lChar32 def_char) { CR_UNUSED3(ch1,ch2,def_char); return 0; }
 
     /// set fallback font for this font
-    virtual void setFallbackFont( LVProtectedFastRef<LVFont> font ) { CR_UNUSED(font); }
+    virtual void setFallbackFont( LVFontRef font ) { CR_UNUSED(font); }
     /// get fallback font for this font
     LVFont * getFallbackFont() { return NULL; }
 
     /// set next fallback font for this font (for when used as a fallback font)
-    virtual void setNextFallbackFont( LVProtectedFastRef<LVFont> font ) { CR_UNUSED(font); }
+    virtual void setNextFallbackFont( LVFontRef font ) { CR_UNUSED(font); }
     /// get next fallback font for this font (when already used as a fallback font)
     LVFont * getNextFallbackFont() { return NULL; }
 
@@ -547,8 +550,6 @@ public:
     /// get alternative font for drawing disc/circle/square list item markers (could return an other font with better bullet glyphs)
     virtual LVFont * getBulletListItemFont() { return this; }
 };
-
-typedef LVProtectedFastRef<LVFont> LVFontRef;
 
 enum font_antialiasing_t
 {

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -535,6 +535,11 @@ public:
     // Obsolete:
     // virtual int getKerningOffset(lChar32 ch1, lChar32 ch2, lChar32 def_char) { CR_UNUSED3(ch1,ch2,def_char); return 0; }
 
+    /// clear internal references to this font pointer
+    virtual void clearFontRefs( const LVFont *ptr ) { }
+    /// clear all internal font references
+    virtual void clearFontRefs() { }
+
     /// set fallback font for this font
     virtual void setFallbackFont( LVFontRef font ) { CR_UNUSED(font); }
     /// get fallback font for this font

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -572,7 +572,6 @@ void LVDocView::Clear() {
 	// Also drop font instances from previous document (see
 	// lvtinydom.cpp ldomDocument::render() for the reason)
 	fontMan->gc();
-	fontMan->gc();
 }
 
 /// invalidate image cache, request redraw

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -634,7 +634,7 @@ public:
             ;
     }
 
-    lUInt32 getHash() {
+    lUInt32 getHash() const {
         lUInt32 h =  (((((_size * 31) + _weight)*31  + _italic)*31 + _features)*31+ _family)*31 + _name.getHash();
         // _bias is not a static property, and can be set/unset on these definitions.
         // If a same _bias value is moved from one font to another, *adding* _bias
@@ -669,9 +669,9 @@ public:
     void setHasOTMath(bool has_ot_math) { _has_ot_math = has_ot_math; }
     bool hasEmojis() const { return _has_emojis; }
     void setHasEmojis(bool has_emojis) { _has_emojis = has_emojis; }
-    int getDocumentId() { return _documentId; }
+    int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
-    LVByteArrayRef getBuf() { return _buf; }
+    LVByteArrayRef getBuf() const { return _buf; }
     void setBuf(LVByteArrayRef buf) { _buf = buf; }
     ~LVFontDef() {}
     /// calculates difference between two fonts
@@ -719,7 +719,7 @@ public:
     void update( const LVFontDef * def, LVFontRef ref );
     void removeDocumentFonts(int documentId);
     void getAvailableFontWeights(LVArray<int>& weights, lString8 faceName);
-    int  length() { return _registered_list.length(); }
+    int  length() const { return _registered_list.length(); }
     void addInstance( const LVFontDef * def, LVFontRef ref );
     bool setAsPreferredFontWithBias( lString8 face, int bias, bool clearOthersBias );
     LVPtrVector< LVFontCacheItem > * getInstances() { return &_instance_list; }
@@ -1402,7 +1402,7 @@ struct LVCharTriplet
     lChar32 prevChar;
     lChar32 Char;
     lChar32 nextChar;
-    bool operator == (const struct LVCharTriplet& other) {
+    bool operator == (const struct LVCharTriplet& other) const {
         return prevChar == other.prevChar && Char == other.Char && nextChar == other.nextChar;
     }
 };

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1485,15 +1485,15 @@ public:
     }
 
     /// get fallback font for this font (when it is used as the main font)
-    LVFont * getFallbackFont() {
+    LVFontRef getFallbackFont() {
         if ( _fallbackFontIsSet )
-            return _fallbackFont.get();
+            return _fallbackFont;
         _fallbackFont = fontMan->GetFallbackFont(_size, getWeight(), _italic!=0);
         if ( fontMan->GetFallbackFontSizesAdjusted() ) {
             _fallbackFont = getVisuallyAdjustedOtherFont( _fallbackFont );
         }
         _fallbackFontIsSet = true;
-        return _fallbackFont.get();
+        return _fallbackFont;
     }
 
     /// set next fallback font for this font (for when used as a fallback font)
@@ -1504,15 +1504,15 @@ public:
     }
 
     /// get next fallback font for this font (when it is already used as a fallback font)
-    LVFont * getNextFallbackFont() {
+    LVFontRef getNextFallbackFont() {
         if ( _nextFallbackFontIsSet )
-            return _nextFallbackFont.get();
+            return _nextFallbackFont;
         _nextFallbackFont = fontMan->GetFallbackFont(_size, getWeight(), _italic!=0, _faceName);
         if ( fontMan->GetFallbackFontSizesAdjusted() ) {
             _nextFallbackFont = getVisuallyAdjustedOtherFont( _nextFallbackFont );
         }
         _nextFallbackFontIsSet = true;
-        return _nextFallbackFont.get();
+        return _nextFallbackFont;
     }
 
     LVFontRef getVisuallyAdjustedOtherFont( LVFontRef other_font ) {
@@ -1551,9 +1551,9 @@ public:
         return x_height;
     }
 
-    virtual LVFont * getDecimalListItemFont() {
+    virtual LVFontRef getDecimalListItemFont() {
         if ( !_DecimalListItemFont.isNull() )
-            return _DecimalListItemFont.get();
+            return _DecimalListItemFont;
         if ( _kerningMode == KERNING_MODE_HARFBUZZ && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
             // We can request the same font with OpenType feature "tabular nums", for fixed width
             // digits and better alignment of decimal list items (no need to do it if this feature
@@ -1574,12 +1574,12 @@ public:
             // LFNT_OT_FEATURES_P_TNUM won't be used with other kerning modes, so use this same font
             _DecimalListItemFont = LVFontRef(this);
         }
-        return _DecimalListItemFont.get();
+        return _DecimalListItemFont;
     }
 
-    virtual LVFont * getBulletListItemFont() {
+    virtual LVFontRef getBulletListItemFont() {
         if ( !_BulletListItemFont.isNull() )
-            return _BulletListItemFont.get();
+            return _BulletListItemFont;
         lString8 preferred_bullet_fonts(PREFERRED_BULLET_FONTS);
         _BulletListItemFont = fontMan->GetFont(
             getSize(),
@@ -1606,7 +1606,7 @@ public:
             if ( !found ) // None found: use this same font
                 _BulletListItemFont = LVFontRef(this);
         }
-        return _BulletListItemFont.get();
+        return _BulletListItemFont;
     }
 
     /// returns font weight
@@ -2344,7 +2344,7 @@ public:
         else {
             glyph_index = getCharIndex( code, 0 );
             if ( glyph_index==0 ) {
-                LVFont * fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
+                LVFontRef fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
                 if ( !fallback ) {
                     // No fallback
                     glyph_index = getCharIndex( code, def_char );
@@ -2546,7 +2546,7 @@ public:
         else {
             glyph_index = getCharIndex( code, 0 );
             if ( glyph_index==0 ) {
-                LVFont * fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
+                LVFontRef fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
                 if ( !fallback ) {
                     // No fallback
                     glyph_index = getCharIndex( code, '?' );
@@ -2691,7 +2691,7 @@ public:
     virtual bool getGlyphExtraMetric( glyph_extra_metric_t metric, lUInt32 code, int & value, bool scaled_to_px, lChar32 def_char=0, bool is_fallback=false ) {
         int glyph_index = getCharIndex( code, 0 );
         if ( glyph_index==0 ) {
-            LVFont * fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
+            LVFontRef fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
             if ( !fallback ) {
                 // No fallback
                 glyph_index = getCharIndex( code, def_char );
@@ -2830,8 +2830,8 @@ public:
             // full shaping without filterChar(), and if any .notdef
             // codepoint, re-shape with filterChar()...
             bool is_fallback_font = hints & LFNT_HINT_IS_FALLBACK_FONT;
-            LVFont * fallback = is_fallback_font ? getNextFallbackFont() : getFallbackFont();
-            bool has_fallback_font = (bool) fallback;
+            LVFontRef fallback = is_fallback_font ? getNextFallbackFont() : getFallbackFont();
+            bool has_fallback_font = !fallback.isNull();
             if ( has_fallback_font ) { // It has a fallback font, add chars as-is
                 for (i = 0; i < len; i++) {
                     hb_buffer_add(_hb_buffer, (hb_codepoint_t)(text[i]), i);
@@ -3348,7 +3348,7 @@ public:
         //FONT_GUARD
         FT_UInt ch_glyph_index = getCharIndex( ch, 0 );
         if ( ch_glyph_index==0 ) {
-            LVFont * fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
+            LVFontRef fallback = is_fallback ? getNextFallbackFont() : getFallbackFont();
             if ( !fallback ) {
                 // No fallback
                 ch_glyph_index = getCharIndex( ch, def_char );
@@ -4049,8 +4049,8 @@ public:
             hb_buffer_clear_contents(_hb_buffer);
             // Fill HarfBuzz buffer
             bool is_fallback_font = flags & LFNT_HINT_IS_FALLBACK_FONT;
-            LVFont * fallback = is_fallback_font ? getNextFallbackFont() : getFallbackFont();
-            bool has_fallback_font = (bool) fallback;
+            LVFontRef fallback = is_fallback_font ? getNextFallbackFont() : getFallbackFont();
+            bool has_fallback_font = !fallback.isNull();
             if ( has_fallback_font ) { // It has a fallback font, add chars as-is
                 for (i = 0; i < len; i++) {
                     hb_buffer_add(_hb_buffer, (hb_codepoint_t)(text[i]), i);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1459,9 +1459,7 @@ protected:
     LVFontRef      _fallbackFont;
     bool           _nextFallbackFontIsSet;
     LVFontRef      _nextFallbackFont;
-    bool           _DecimalListItemFontIsSet;
     LVFontRef      _DecimalListItemFont;
-    bool           _BulletListItemFontIsSet;
     LVFontRef      _BulletListItemFont;
     int            _synth_weight; // fake/synthesized weight
     FT_Pos         _synth_weight_strength; // for emboldening with FT_Outline_Embolden()
@@ -1554,7 +1552,7 @@ public:
     }
 
     virtual LVFont * getDecimalListItemFont() {
-        if ( _DecimalListItemFontIsSet )
+        if ( !_DecimalListItemFont.isNull() )
             return _DecimalListItemFont.get();
         if ( _kerningMode == KERNING_MODE_HARFBUZZ && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
             // We can request the same font with OpenType feature "tabular nums", for fixed width
@@ -1576,12 +1574,11 @@ public:
             // LFNT_OT_FEATURES_P_TNUM won't be used with other kerning modes, so use this same font
             _DecimalListItemFont = LVFontRef(this);
         }
-        _DecimalListItemFontIsSet = true;
         return _DecimalListItemFont.get();
     }
 
     virtual LVFont * getBulletListItemFont() {
-        if ( _BulletListItemFontIsSet )
+        if ( !_BulletListItemFont.isNull() )
             return _BulletListItemFont.get();
         lString8 preferred_bullet_fonts(PREFERRED_BULLET_FONTS);
         _BulletListItemFont = fontMan->GetFont(
@@ -1609,7 +1606,6 @@ public:
             if ( !found ) // None found: use this same font
                 _BulletListItemFont = LVFontRef(this);
         }
-        _BulletListItemFontIsSet = true;
         return _BulletListItemFont.get();
     }
 
@@ -1631,7 +1627,6 @@ public:
         , _glyph_cache(globalCache), _drawMonochrome(false)
         , _hintingMode(HINTING_MODE_AUTOHINT), _kerningMode(KERNING_MODE_DISABLED)
         , _fallbackFontIsSet(false), _nextFallbackFontIsSet(false)
-        , _DecimalListItemFontIsSet(false), _BulletListItemFontIsSet(false)
         , _synth_weight(0), _synth_weight_strength(0), _synth_weight_half_strength(0)
         , _features(0)
         #if USE_HARFBUZZ==1
@@ -1852,7 +1847,7 @@ public:
 
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
         _kerningMode = kerningMode;
-        _DecimalListItemFontIsSet = false; // depends on kerning mode
+        _DecimalListItemFont.Clear(); // depends on kerning mode
         _hash = 0; // Force lvstyles.cpp calcHash(font_ref_t) to recompute the hash
         #if USE_HARFBUZZ==1
         setupHBFeatures();

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7478,6 +7478,13 @@ void LVFontCache::gc()
     }
     if ( CRLog::isDebugEnabled() )
         CRLog::debug("LVFontCache::gc() : %d fonts still used, %d fonts dropped", usedCount, droppedCount );
+    if (droppedCount) {
+        // We need more than 1 gc() for a complete cleanup: to drop font
+        // instances that were only referenced by dropped fonts (fallbacks,
+        // bullet, decimal, …).  The performance impact of reinstantiating
+        // fonts is minimal.
+        gc();
+    }
 }
 
 #if !defined(__SYMBIAN32__) && defined(_WIN32) && USE_FREETYPE!=1

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5577,10 +5577,7 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
         // We don't want such instances to be used for styles as it could cause some
         // cache check issues (perpetual "style hash mismatch", as these synthetised
         // fonts would not yet be there when loading from cache).
-        // We need 2 gc() for a complete cleanup. The performance impact of
-        // reinstantiating the fonts is minimal.
-        gc(); // drop font instances that were only referenced by dropped styles
-        gc(); // drop fallback font instances that were only referenced by dropped fonts
+        gc();
 
         //ldomNode * root = getRootNode();
         //css_style_ref_t roots = root->getStyle();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4951,6 +4951,8 @@ ldomDocument::~ldomDocument()
 #if BUILD_LITE!=1
     updateMap(); // NOLINT: Call to virtual function during destruction
 #endif
+    _def_font.Clear();
+    _fonts.clear();
     fontMan->UnregisterDocumentFonts(_docIndex);
     ldomNode::unregisterDocument(this);
 }


### PR DESCRIPTION
Main 2 changes:
- ensure a self-referencing font can still possibly be garbage collected.
- check and ensure we don't remove the last reference (from the font manager internal list of instances / registrations) to a font with a reference count >1 (leak).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/536)
<!-- Reviewable:end -->
