### PR TITLE
Optimize `LVHTMLParser::CheckFormat()`

### DIFF
--- a/crengine/include/crtxtenc.h
+++ b/crengine/include/crtxtenc.h
@@ -109,6 +109,8 @@ int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, 
 */
 int AutodetectCodePageUtf( const unsigned char * buf, int buf_size, char * cp_name );
 
+const char *SniffBOM(const unsigned char * buf, int buf_size);
+
 bool hasXmlTags(const lUInt8 * buf, int size);
 
 /**

--- a/crengine/include/crtxtenc.h
+++ b/crengine/include/crtxtenc.h
@@ -93,23 +93,21 @@ const char* langToLanguage( int lang );
     \param buf is buffer with text data to autodetect
     \param buf_size is size of data in buffer, bytes
     \param cp_name is buffer to store autodetected name of encoding, i.e. "utf-8", "windows-1251"
-    \param lang_name is buffer to store autodetected name of language, i.e. "en", "ru"
+    \param skipHtml if true, skip HTML/XML tags
 
     \return non-zero on success
 */
-int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, char * lang_name, bool skipHtml);
+int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, bool skipHtml);
 /**
     \brief Autodetects encoding of text data in buffer, only using ByteOrderMark or Utf-8 validity detection.
 
     \param buf is buffer with text data to autodetect
     \param buf_size is size of data in buffer, bytes
     \param cp_name is buffer to store autodetected name of encoding, i.e. "utf-8", "windows-1251"
-    \param lang_name is buffer to store autodetected name of language, i.e. "en", "ru"
-    \param skipHtml if true, skip HTML/XML tags
 
     \return non-zero on success
 */
-int AutodetectCodePageUtf( const unsigned char * buf, int buf_size, char * cp_name, char * lang_name );
+int AutodetectCodePageUtf( const unsigned char * buf, int buf_size, char * cp_name );
 
 bool hasXmlTags(const lUInt8 * buf, int size);
 

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -191,6 +191,7 @@ protected:
     int m_read_buffer_len;
     int m_read_buffer_pos;
     bool m_eof;
+    bool m_bom_removed = false;
 
     void checkEof(int bytes_needed);
 

--- a/crengine/include/lvxml.h
+++ b/crengine/include/lvxml.h
@@ -185,7 +185,6 @@ protected:
     char_encoding_type m_enc_type;
     lString32 m_txt_buf;
     lString32 m_encoding_name;
-    lString32 m_lang_name;
     lChar32 * m_conv_table; // charset conversion table for 8-bit encodings
 
     lChar32 m_read_buffer[XML_CHAR_BUFFER_SIZE];
@@ -281,8 +280,6 @@ public:
     //lString32 ReadLine( int maxLineSize, lvpos_t & fpos, lvsize_t & fsize, lUInt32 & flags );
     /// returns name of character encoding
     lString32 GetEncodingName() { return m_encoding_name; }
-    /// returns name of language
-    lString32 GetLangName() { return m_lang_name; }
 
     // overrides
     /// sets charset by name

--- a/crengine/src/crtxtenc.cpp
+++ b/crengine/src/crtxtenc.cpp
@@ -1892,33 +1892,27 @@ double CompareDblCharStats( const dbl_char_stat_t * stat1, const dbl_char_stat_t
 // EXTERNAL DEFINE
 extern cp_stat_t cp_stat_table[];
 
-int AutodetectCodePageUtf( const unsigned char * buf, int buf_size, char * cp_name, char * lang_name )
+int AutodetectCodePageUtf( const unsigned char * buf, int buf_size, char * cp_name )
 {
     // checking byte order signatures
     if ( buf[0]==0xEF && buf[1]==0xBB && buf[2]==0xBF ) {
         strcpy( cp_name, "utf-8" );     // NOLINT: strcpy is fine with hardcoded string with len < 32
-        strcpy( lang_name, "en" );      // NOLINT
         return 1;
     } else if ( buf[0]==0 && buf[1]==0 && buf[2]==0xFE && buf[3]==0xFF ) {
         strcpy( cp_name, "utf-32be" ); // NOLINT
-        strcpy( lang_name, "en" );     // NOLINT
         return 1;
     } else if ( buf[0]==0xFE && buf[1]==0xFF ) {
         strcpy( cp_name, "utf-16be" ); // NOLINT
-        strcpy( lang_name, "en" );     // NOLINT
         return 1;
     } else if ( buf[0]==0xFF && buf[1]==0xFE && buf[2]==0 && buf[3]==0 ) {
         strcpy( cp_name, "utf-32le" ); // NOLINT
-        strcpy( lang_name, "en" );     // NOLINT
         return 1;
     } else if ( buf[0]==0xFF && buf[1]==0xFE ) {
         strcpy( cp_name, "utf-16le" ); // NOLINT
-        strcpy( lang_name, "en" );     // NOLINT
         return 1;
     }
     if ( isValidUtf8Data( buf, buf_size ) ) {
         strcpy( cp_name, "utf-8" );    // NOLINT
-        strcpy( lang_name, "en" );     // NOLINT
         return 1;
     }
    return 0;
@@ -2004,9 +1998,9 @@ bool detectXmlHtmlEncoding(const unsigned char * buf, int buf_len, char * html_e
     return false;
 }
 
-int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, char * lang_name, bool skipHtml)
+int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, bool skipHtml)
 {
-    int res = AutodetectCodePageUtf( buf, buf_size, cp_name, lang_name );
+    int res = AutodetectCodePageUtf( buf, buf_size, cp_name );
     if ( res )
         return res;
     // use character statistics
@@ -2037,8 +2031,7 @@ int AutodetectCodePage(const unsigned char * buf, int buf_size, char * cp_name, 
 	   }
    }
    strcpy(cp_name, cp_stat_table[bestn].cp_name);     // NOLINT: strcpy is fine, all strings are len < 32
-   strcpy(lang_name, cp_stat_table[bestn].lang_name); // NOLINT
-   CRLog::debug("Detected codepage:%s lang:%s index:%d %s", cp_name, lang_name, bestn, skipHtml ? "(skipHtml)" : "");
+   CRLog::debug("Detected codepage:%s index:%d %s", cp_name, bestn, skipHtml ? "(skipHtml)" : "");
    if (skipHtml) {
        if (detectXmlHtmlEncoding(buf, buf_size, cp_name)) {
            CRLog::debug("Encoding parsed from XML/HTML: %s", cp_name);

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -993,9 +993,7 @@ void LVTextFileBase::Reset()
 {
     LVFileParserBase::Reset();
     clearCharBuffer();
-    // Remove Byte Order Mark from beginning of file
-    if ( PeekCharFromBuffer()==0xFEFF )
-        ReadCharFromBuffer();
+    m_bom_removed = false;
 }
 
 void LVTextFileBase::SetCharset( const lChar32 * name )
@@ -5678,6 +5676,12 @@ int LVTextFileBase::fillCharBuffer()
 //    CRLog::trace("buf: %s\n", UnicodeToUtf8(lString32(m_read_buffer, m_read_buffer_len)).c_str() );
 //#endif
     //CRLog::trace("Buf:'%s'", LCSTR(lString32(m_read_buffer, m_read_buffer_len)) );
+    if (!m_bom_removed) {
+        m_bom_removed = true;
+        if (charsRead > 0 && m_read_buffer[m_read_buffer_pos] == 0xfeff) {
+            ++m_read_buffer_pos;
+        }
+    }
     return m_read_buffer_len - m_read_buffer_pos;
 }
 

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -831,7 +831,6 @@ int LVTextFileBase::ReadChars( lChar32 * buf, int maxsize )
 bool LVTextFileBase::AutodetectEncoding( bool utfOnly )
 {
     char enc_name[32];
-    char lang_name[32];
     lvpos_t oldpos = m_stream->GetPos();
     unsigned sz = CP_AUTODETECT_BUF_SIZE;
     m_stream->SetPos( 0 );
@@ -850,14 +849,13 @@ bool LVTextFileBase::AutodetectEncoding( bool utfOnly )
     int res = 0;
     bool hasTags = hasXmlTags(buf, sz);
     if ( utfOnly )
-        res = AutodetectCodePageUtf(buf, sz, enc_name, lang_name);
+        res = AutodetectCodePageUtf(buf, sz, enc_name);
     else
-        res = AutodetectCodePage(buf, sz, enc_name, lang_name, hasTags);
+        res = AutodetectCodePage(buf, sz, enc_name, hasTags);
     delete[] buf;
     m_stream->SetPos( oldpos );
     if ( res) {
-        //CRLog::debug("Code page decoding results: encoding=%s, lang=%s", enc_name, lang_name);
-        m_lang_name = lString32( lang_name );
+        //CRLog::debug("Code page decoding results: encoding=%s", enc_name);
         SetCharset( lString32( enc_name ).c_str() );
     }
 
@@ -2498,7 +2496,6 @@ bool LVTextBookmarkParser::CheckFormat()
 {
     Reset();
     // encoding test
-    m_lang_name = cs32("en");
     SetCharset( U"utf8" );
 
     #define TEXT_PARSER_DETECT_SIZE 16384
@@ -2755,7 +2752,6 @@ LVTextRobustParser::~LVTextRobustParser()
 /// returns true if format is recognized by parser
 bool LVTextRobustParser::CheckFormat()
 {
-    m_lang_name = lString32( "en" );
     SetCharset( lString32( "utf-8" ).c_str() );
     return true;
 }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -1166,7 +1166,6 @@ bool DetectPDBFormat( LVStreamRef stream, doc_format_t & contentFormat )
 
 bool isCorrectUtf8Text(LVStreamRef & stream) {
     char enc_name[32];
-    char lang_name[32];
     lvpos_t oldpos = stream->GetPos();
     unsigned sz = 16384;
     stream->SetPos( 0 );
@@ -1183,7 +1182,7 @@ bool isCorrectUtf8Text(LVStreamRef & stream) {
     }
 
     int res = 0;
-    res = AutodetectCodePageUtf(buf, sz, enc_name, lang_name);
+    res = AutodetectCodePageUtf(buf, sz, enc_name);
     delete[] buf;
     return res != 0;
 }


### PR DESCRIPTION
This is a series of commits superseding https://github.com/koreader/crengine/pull/497

Current implementation works as follows:
1. run `AutodetectEncoding()`. It detects BOM, runs heuristics on 128K bytes if not found.
2. use the previous result to convert input bytes to char32_t
3. scan for tags. if it's (x)html then look further for encoding information. If charset/encoding is found in html, it prevails.

The problem with this approach is:
- slow
- if the heuristics used in step2 is wrong, step 3 is likely to fail.

The new implementation is (very) loosely based on the HTML standard.

Tests:
- I tested on some mid-sized epubs from Project Gutenburg, and `LoadDocument()` consumes (median) ~11% less cycles as reported by callgrind.
- I haven't tested other formats nor malformed inputs, due to availability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/537)
<!-- Reviewable:end -->
