### PR TITLE
lvstring: fix size handling

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -577,12 +577,10 @@ public:
     void  reset( size_type size );
     /// returns character count
     size_type   length() const { return pchunk->len; }
-    /// returns buffer size
-    size_type   size() const { return pchunk->len; }
     /// changes buffer size
     void  resize(size_type count = 0, value_type e = 0);
     /// returns maximum number of chars that can fit into buffer
-    size_type   capacity() const { return pchunk->size-1; }
+    size_type   capacity() const { return pchunk->size; }
     /// reserve space for specified amount of chars
     void  reserve(size_type count = 0);
     /// returns true if string is empty
@@ -839,12 +837,10 @@ public:
     void  reset( size_type size );
     /// returns string length, in characters
     size_type   length() const { return pchunk->len; }
-    /// returns string length, in characters
-    size_type   size() const { return pchunk->len; }
     /// resizes string buffer, appends with specified character if buffer is being extended
     void  resize(size_type count = 0, value_type e = 0);
     /// returns string buffer size
-    size_type   capacity() const { return pchunk->size-1; }
+    size_type   capacity() const { return pchunk->size; }
     /// ensures string buffer can hold at least count characters
     void  reserve(size_type count = 0);
     /// erase all extra characters from end of string after size

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -973,7 +973,7 @@ lString32 lString32::substr(size_type pos, size_type n) const
 
 lString32 & lString32::pack()
 {
-    if (pchunk->len + 4 < pchunk->size )
+    if (pchunk->len < pchunk->size)
     {
         if (pchunk->nref>1)
         {
@@ -2448,7 +2448,7 @@ int lString32::pos(lString32 subStr) const
 
 lString8 & lString8::pack()
 {
-    if (pchunk->len + 4 < pchunk->size )
+    if (pchunk->len < pchunk->size)
     {
         if (pchunk->nref>1)
         {

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -626,11 +626,11 @@ lString32 & lString32::assign(const lChar32 * str)
         size_type len = _lStr_len(str);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -655,11 +655,11 @@ lString32 & lString32::assign(const lChar8 * str)
         size_type len = _lStr_len(str);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -684,11 +684,11 @@ lString32 & lString32::assign(const lChar32 * str, size_type count)
         size_type len = _lStr_nlen(str, count);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -713,11 +713,11 @@ lString32 & lString32::assign(const lChar8 * str, size_type count)
         size_type len = _lStr_nlen(str, count);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -758,11 +758,11 @@ lString32 & lString32::assign(const lString32 & str, size_type offset, size_type
         {
             if (pchunk->nref==1)
             {
-                if (pchunk->size<=count)
+                if (pchunk->size < count)
                 {
                     // resize is necessary
                     pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(count+1) );
-                    pchunk->size = count+1;
+                    pchunk->size = count;
                 }
             }
             else
@@ -1784,11 +1784,11 @@ lString8 & lString8::assign(const lChar8 * str)
         size_type len = _lStr_len(str);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf8 = (lChar8*) ::realloc( pchunk->buf8, sizeof(lChar8)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -1813,11 +1813,11 @@ lString8 & lString8::assign(const lChar8 * str, size_type count)
         size_type len = _lStr_nlen(str, count);
         if (pchunk->nref==1)
         {
-            if (pchunk->size<=len)
+            if (pchunk->size < len)
             {
                 // resize is necessary
                 pchunk->buf8 = (lChar8*) ::realloc( pchunk->buf8, sizeof(lChar8)*(len+1) );
-                pchunk->size = len+1;
+                pchunk->size = len;
             }
         }
         else
@@ -1858,11 +1858,11 @@ lString8 & lString8::assign(const lString8 & str, size_type offset, size_type co
         {
             if (pchunk->nref==1)
             {
-                if (pchunk->size<=count)
+                if (pchunk->size < count)
                 {
                     // resize is necessary
                     pchunk->buf8 = (lChar8*) ::realloc( pchunk->buf8, sizeof(lChar8)*(count+1) );
-                    pchunk->size = count+1;
+                    pchunk->size = count;
                 }
             }
             else

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -858,7 +858,7 @@ void lString32::reset( size_type size )
 void lString32::resize(size_type n, lChar32 e)
 {
     lock( n );
-    if (n>=pchunk->size)
+    if (pchunk->size < n)
     {
         pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(n+1) );
         pchunk->size = n;
@@ -1958,7 +1958,7 @@ void lString8::reset( size_type size )
 void lString8::resize(size_type n, lChar8 e)
 {
     lock( n );
-    if (n>=pchunk->size)
+    if (pchunk->size < n)
     {
         pchunk->buf8 = (lChar8*) ::realloc( pchunk->buf8, sizeof(lChar8)*(n+1) );
         pchunk->size = n;


### PR DESCRIPTION
The chunk `size` is the allocated size minus one (the terminating `\0`). Fix methods that don't have the same definition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/538)
<!-- Reviewable:end -->
