### PR TITLE
lvdocview: remove (unused) `crskin` and `wolutil` related code

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -16,7 +16,6 @@
 #include "crsetup.h"
 #include "lvtypes.h"
 #include "lvplatform.h"
-#include "crskin.h"
 #include "lvtinydom.h"
 #include "lvpagesplitter.h"
 #include "lvdrawbuf.h"
@@ -368,8 +367,6 @@ private:
     lString32 m_pageHeaderOverride;
 
     int m_drawBufferBits;
-
-    CRPageSkinRef _pageSkin;
 
     /// sets current document format
     void setDocFormat( doc_format_t fmt );
@@ -743,9 +740,6 @@ public:
         m_statusColor = cl;
         clearImageCache();
     }
-
-    CRPageSkinRef getPageSkin();
-    void setPageSkin( CRPageSkinRef skin );
 
     /// returns xpointer for specified window point
     ldomXPointer getNodeByPoint( lvPoint pt, bool strictBounds=false, bool forTextSelection=false );

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -795,12 +795,14 @@ public:
         return (lUInt32)m_doc_props->getIntDef(DOC_PROP_FILE_CRC32, 0);
     }
 
+#if 0 // unused
     /// export to WOL format
     bool exportWolFile( const char * fname, bool flgGray, int levels );
     /// export to WOL format
     bool exportWolFile( const lChar32 * fname, bool flgGray, int levels );
     /// export to WOL format
     bool exportWolFile( LVStream * stream, bool flgGray, int levels );
+#endif
 
     /// get a stream for reading to document internal file (path inside the ZIP for EPUBs,
     /// path relative to document directory for non-container documents like HTML)

--- a/crengine/include/lvimg.h
+++ b/crengine/include/lvimg.h
@@ -122,7 +122,7 @@ LVImageSourceRef LVCreateFileCopyImageSource( lString32 fname );
 /// creates image source as memory copy of stream contents
 LVImageSourceRef LVCreateStreamCopyImageSource( LVStreamRef stream );
 /// creates decoded memory copy of image, if it's unpacked size is less than maxSize (8 bit gray or 32 bit color)
-LVImageSourceRef LVCreateUnpackedImageSource( LVImageSourceRef srcImage, int maxSize = MAX_SKIN_IMAGE_CACHE_ITEM_UNPACKED_SIZE, bool gray=false );
+LVImageSourceRef LVCreateUnpackedImageSource( LVImageSourceRef srcImage, int maxSize = 80*80*4, bool gray=false );
 /// creates decoded memory copy of image, if it's unpacked size is less than maxSize; bpp: 8,16,32 supported
 LVImageSourceRef LVCreateUnpackedImageSource( LVImageSourceRef srcImage, int maxSize, int bpp );
 /// creates image source based on draw buffer

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -21,7 +21,7 @@
 #include "../include/lvstsheet.h"
 #include "../include/textlang.h"
 
-#include "../include/wolutil.h"
+// #include "../include/wolutil.h"
 #include "../include/crtxtenc.h"
 #include "../include/crtrace.h"
 #include "../include/epubfmt.h"
@@ -798,6 +798,8 @@ void LVDocView::cachePageImage( int delta )
 }
 #endif
 
+#if 0 // unused
+
 bool LVDocView::exportWolFile(const char * fname, bool flgGray, int levels) {
 	LVStreamRef stream = LVOpenFileStream(fname, LVOM_WRITE);
 	if (!stream)
@@ -811,6 +813,8 @@ bool LVDocView::exportWolFile(const lChar32 * fname, bool flgGray, int levels) {
 		return false;
 	return exportWolFile(stream.get(), flgGray, levels);
 }
+
+#endif
 
 void dumpSection(ldomNode * elem) {
 	lvRect rc;
@@ -1196,6 +1200,8 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
 	//CRLog::trace("drawCoverTo() - done");
 }
 
+#if 0 // unused
+
 /// export to WOL format
 bool LVDocView::exportWolFile(LVStream * stream, bool flgGray, int levels) {
 	checkRender();
@@ -1332,6 +1338,8 @@ bool LVDocView::exportWolFile(LVStream * stream, bool flgGray, int levels) {
 
 	return true;
 }
+
+#endif
 
 int LVDocView::GetFullHeight() {
 	LVLock lock(getMutex());

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -231,14 +231,6 @@ LVDocView::~LVDocView() {
 	Clear();
 }
 
-CRPageSkinRef LVDocView::getPageSkin() {
-	return _pageSkin;
-}
-
-void LVDocView::setPageSkin(CRPageSkinRef skin) {
-	_pageSkin = skin;
-}
-
 /// get text format options
 txt_format_t LVDocView::getTextFormatOptions() {
     return m_doc && m_doc->getDocFlag(DOC_FLAG_PREFORMATTED_TEXT) ? txt_format_pre


### PR DESCRIPTION
Will allow https://github.com/koreader/koreader-base/pull/1675.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/542)
<!-- Reviewable:end -->
