### PR TITLE
no unnecessary string modifications

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -564,8 +564,6 @@ public:
     value_type & at( size_type pos ) { if (pos > (size_type)pchunk->len) crFatalError(); return modify()[pos]; }
     /// get character at specified position without range check
     value_type operator [] ( size_type pos ) const { return pchunk->buf8[pos]; }
-    /// get reference to character at specified position
-    value_type & operator [] ( size_type pos ) { return modify()[pos]; }
 
     /// ensures that reference count is 1
     void  lock( size_type newsize );
@@ -825,8 +823,6 @@ public:
     value_type & at( size_type pos ) { if ((unsigned)pos > (unsigned)pchunk->len) crFatalError(); return modify()[pos]; }
     /// returns character at specified position, without index bounds checking
     value_type operator [] ( size_type pos ) const { return pchunk->buf32[pos]; }
-    /// returns reference to specified character position (lvalue)
-    value_type & operator [] ( size_type pos ) { return modify()[pos]; }
     /// resizes string, copies if several references exist
     void  lock( size_type newsize );
     /// returns writable pointer to string buffer

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -553,9 +553,9 @@ public:
     bool startsWith ( const char * substring ) const;
 
     /// returns last character
-    value_type lastChar() { return empty() ? 0 : at(length()-1); }
+    value_type lastChar() const { return empty() ? 0 : pchunk->buf8[length()-1]; }
     /// returns first character
-    value_type firstChar() { return empty() ? 0 : at(0); }
+    value_type firstChar() const { return empty() ? 0 : pchunk->buf8[0]; }
 
     /// calculate hash
     lUInt32 getHash() const;
@@ -813,9 +813,9 @@ public:
     bool startsWithNoCase (const lString32 & substring) const;
 
     /// returns last character
-    value_type lastChar() { return empty() ? 0 : at(length()-1); }
+    value_type lastChar() const { return empty() ? 0 : pchunk->buf32[length()-1]; }
     /// returns first character
-    value_type firstChar() { return empty() ? 0 : at(0); }
+    value_type firstChar() const { return empty() ? 0 : pchunk->buf32[0]; }
 
     /// calculates hash for string
     lUInt32 getHash() const;

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -560,8 +560,6 @@ public:
     /// calculate hash
     lUInt32 getHash() const;
 
-    /// get character at specified position with range check
-    value_type & at( size_type pos ) { if (pos > (size_type)pchunk->len) crFatalError(); return modify()[pos]; }
     /// get character at specified position without range check
     value_type operator [] ( size_type pos ) const { return pchunk->buf8[pos]; }
 
@@ -819,8 +817,6 @@ public:
 
     /// calculates hash for string
     lUInt32 getHash() const;
-    /// returns character at specified position, with index bounds checking, fatal error if fails
-    value_type & at( size_type pos ) { if ((unsigned)pos > (unsigned)pchunk->len) crFatalError(); return modify()[pos]; }
     /// returns character at specified position, without index bounds checking
     value_type operator [] ( size_type pos ) const { return pchunk->buf32[pos]; }
     /// resizes string, copies if several references exist

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1755,7 +1755,7 @@ public:
                                                 parent = parent->getParentNode();
                                             if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
                                                 lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
-                                                if ( href.length()>0 && href.at(0)=='#' ) {
+                                                if ( href.firstChar()=='#' ) {
                                                     href.erase(0,1);
                                                     if ( is_single_column )
                                                         row->single_col_context->addLink( href, link_insert_pos );
@@ -5281,7 +5281,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                             // specifying a -cr-hint: to the footnote target, with no need
                                             // to set one to the link itself
                                         lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
-                                        if ( href.length()>0 && href.at(0)=='#' ) {
+                                        if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
                                         }
@@ -5316,7 +5316,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                         parent = parent->getParentNode();
                                     if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
                                         lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
-                                        if ( href.length()>0 && href.at(0)=='#' ) {
+                                        if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
                                         }
@@ -8722,7 +8722,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                             // specifying a -cr-hint: to the footnote target, with no need
                                             // to set one to the link itself
                                         lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
-                                        if ( href.length()>0 && href.at(0)=='#' ) {
+                                        if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             flow->getPageContext()->addLink( href, link_insert_pos );
                                         }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -14790,7 +14790,7 @@ void ldomDocumentWriterFilter::appendStyle( const lChar32 * style )
     //     return; // disabled
 
     lString32 oldStyle = node->getAttributeValue(attr_style);
-    if ( !oldStyle.empty() && oldStyle.at(oldStyle.length()-1)!=';' )
+    if ( !oldStyle.empty() && oldStyle.lastChar()!=';' )
         oldStyle << "; ";
     oldStyle << style;
     node->setAttributeValue(LXML_NS_NONE, attr_style, oldStyle.c_str());

--- a/crengine/src/mathml.cpp
+++ b/crengine/src/mathml.cpp
@@ -617,12 +617,13 @@ lString32 MathMLHelper::getMathMLAdjustedText(ldomNode * node, const lChar32 * t
     // (no substitution for "normal")
     if ( mathvariant != mathml_mathvariant_normal ) {
         len = mtext.length();
+        lChar32 *ptr = mtext.modify();
         for ( int i=0; i<len; i++ ) {
             lChar32 c = substitute_codepoint(mtext[i], mathvariant);
             // If c==0, no available substitution : we avoid modifying
             // the lString32 when not needed (as it may malloc/free)
             if (c != 0) {
-                mtext[i] = c;
+                ptr[i] = c;
             }
         }
     }
@@ -648,24 +649,25 @@ lString32 MathMLHelper::getMathMLAdjustedText(ldomNode * node, const lChar32 * t
     // as we meet them.
     // Some small list at https://trac.webkit.org/changeset/203714/webkit
     // More at https://lists.w3.org/Archives/Public/www-math/2018Nov/0005.html
-    switch (mtext[0]) {
-        case 0x0302:            // COMBINING CIRCUMFLEX ACCENT
-            mtext[0] = 0x02C6;  // => MODIFIER LETTER CIRCUMFLEX ACCENT
+    lChar32 *ptr = mtext.modify();
+    switch (ptr[0]) {
+        case 0x0302:          // COMBINING CIRCUMFLEX ACCENT
+            ptr[0] = 0x02C6;  // => MODIFIER LETTER CIRCUMFLEX ACCENT
             break;
-        case 0x0303:            // COMBINING TILDE
-            mtext[0] = 0x007E;  // => TILDE
+        case 0x0303:          // COMBINING TILDE
+            ptr[0] = 0x007E;  // => TILDE
             break;
-        case 0x0304:            // COMBINING MACRON
-            mtext[0] = 0x00AF;  // => MACRON
+        case 0x0304:          // COMBINING MACRON
+            ptr[0] = 0x00AF;  // => MACRON
             break;
-        case 0x0305:            // COMBINING OVERLINE
-            mtext[0] = 0x00AF;  // => MACRON
+        case 0x0305:          // COMBINING OVERLINE
+            ptr[0] = 0x00AF;  // => MACRON
             break;
-        case 0x030C:            // COMBINING CARON
-            mtext[0] = 0x02C7;  // => CARON
+        case 0x030C:          // COMBINING CARON
+            ptr[0] = 0x02C7;  // => CARON
             break;
-        case 0x0332:            // COMBINING LOW LINE
-            mtext[0] = 0x005F;  // => LOW LINE
+        case 0x0332:          // COMBINING LOW LINE
+            ptr[0] = 0x005F;  // => LOW LINE
             break;
         default:
             break;


### PR DESCRIPTION
The extra `value_type & operator []` accessors would get picked-up over the normal readonly one: `value_type operator []`, resulting in unnecessary calls to `modify()` (triggering an allocation+copy if the reference count is not 1). Get rid of the former, and fix `lastChar` and `firstChar` method to also be read-only. Additionally, avoid using the `at()` method (prefer an explicit `modify()[…]` when needed), and remove it.

Note: depends on https://github.com/koreader/koreader-base/pull/1675.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/543)
<!-- Reviewable:end -->
