### PR TITLE
set thirdparty libraries symbol visibility

### DIFF
--- a/thirdparty/antiword/CMakeLists.txt
+++ b/thirdparty/antiword/CMakeLists.txt
@@ -47,3 +47,4 @@ endif(WIN32)
 
 ADD_LIBRARY(antiword STATIC ${ANTIWORD_SOURCES})
 
+set_target_properties(antiword PROPERTIES C_VISIBILITY_PRESET hidden)

--- a/thirdparty/chmlib/CMakeLists.txt
+++ b/thirdparty/chmlib/CMakeLists.txt
@@ -19,3 +19,4 @@ SET (CHMLIB_SOURCES
 
 ADD_LIBRARY(chmlib STATIC ${CHMLIB_SOURCES})
 
+set_target_properties(chmlib PROPERTIES C_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Hide everything since antiword and chmlib are compiled and linked statically and none of their symbols are exported by the main library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/544)
<!-- Reviewable:end -->
