### PR TITLE
Improve css class matching

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -816,6 +816,7 @@ public:
     value_type firstChar() const { return empty() ? 0 : pchunk->buf32[0]; }
 
     /// calculates hash for string
+    static lUInt32 getHash(const lChar32 *begin, const lChar32 *end);
     lUInt32 getHash() const;
     /// returns character at specified position, without index bounds checking
     value_type operator [] ( size_type pos ) const { return pchunk->buf32[pos]; }

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -83,16 +83,16 @@ private:
     bool _check_if_supported;
     bool  _extra_weighted;
 public:
-    void apply( css_style_rec_t * style );
-    bool empty() { return _data==NULL; }
+    void apply( css_style_rec_t * style ) const;
+    bool empty() const { return _data==NULL; }
     bool parse( const char * & decl, bool higher_importance=false, lxmlDocBase * doc=NULL, lString32 codeBase=lString32::empty_str );
     bool parseAndCheckIfSupported( const char * & decl, lxmlDocBase * doc=NULL ) {
         _check_if_supported = true; // will tweak parse() behaviour and meaning of return value
         return parse(decl, false, doc);
     }
     void setExtraWeighted( bool weighted ) { _extra_weighted = weighted; }
-    int isExtraWeighted() { return _extra_weighted; }
-    lUInt32 getHash();
+    int isExtraWeighted() const { return _extra_weighted; }
+    lUInt32 getHash() const;
     LVCssDeclaration() : _data(NULL), _datalen(0), _check_if_supported(false), _extra_weighted(false) { }
     ~LVCssDeclaration() { if (_data) delete[] _data; }
 };
@@ -139,17 +139,17 @@ public:
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
     void setAttr( lUInt16 id, const lString32 value ) { _attrid = id; _value = value; }
-    LVCssSelectorRule * getNext() { return _next; }
+    LVCssSelectorRule * getNext() const { return _next; }
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }
     /// check condition for node
-    bool check( const ldomNode * & node, bool allow_cache=true );
+    bool check( const ldomNode * & node, bool allow_cache=true ) const;
     /// check next rules for node
-    bool checkNextRules( const ldomNode * node, bool allow_cache=true );
+    bool checkNextRules( const ldomNode * node, bool allow_cache=true ) const;
     /// Some selector rule types do the full rules chain check themselves
-    bool isFullChecking() { return _type == cssrt_ancessor || _type == cssrt_predsibling; }
-    lUInt32 getHash();
-    lUInt32 getWeight();
+    bool isFullChecking() const { return _type == cssrt_ancessor || _type == cssrt_predsibling; }
+    lUInt32 getHash() const;
+    lUInt32 getWeight() const;
 };
 
 /** \brief simple CSS selector
@@ -296,12 +296,12 @@ public:
         return parseAndAdvance(s, higher_importance, codeBase);
     }
     /// apply stylesheet to node style
-    void apply( const ldomNode * node, css_style_rec_t * style );
+    void apply( const ldomNode * node, css_style_rec_t * style ) const;
     /// calculate hash
-    lUInt32 getHash();
+    lUInt32 getHash() const;
     void merge(const LVStyleSheet &other);
     /// gather snippets in the provided CSS that the provided node would match
-    bool gatherNodeMatchingRulesets(ldomNode * node, const char * str, lString8Collection & matches);
+    bool gatherNodeMatchingRulesets(ldomNode * node, const char * str, lString8Collection & matches) const;
 };
 
 /// parse number/length value like "120px" or "90%"

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -132,16 +132,24 @@ class LVCssSelectorRule
     lUInt16 _attrid;
     LVCssSelectorRule * _next;
     lString32 _value;
+    lUInt32 _valueHash = 0;
 public:
-    LVCssSelectorRule(LVCssSelectorRuleType type)
+    explicit LVCssSelectorRule(LVCssSelectorRuleType type)
     : _type(type), _id(0), _attrid(0), _next(NULL)
     { }
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
-    void setAttr( lUInt16 id, const lString32 value ) { _attrid = id; _value = value; }
+    void setAttr( lUInt16 id, const lString32 value ) {
+        _attrid = id;
+        _value = value;
+        if (_type == cssrt_class)
+            _valueHash = _value.getHash();
+    }
     const LVCssSelectorRule * getNext() const { return _next; }
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }
+    // A fail-fast check, returning false to rule out a match.
+    bool quickClassCheck(const lUInt32 *classHashes, size_t size) const;
     /// check condition for node
     bool check( const ldomNode * & node, bool allow_cache=true ) const;
     /// check next rules for node
@@ -178,6 +186,7 @@ public:
     bool parse( const char * &str, lxmlDocBase * doc );
     lUInt16 getElementNameId() const { return _id; }
     bool check( const ldomNode * node, bool allow_cache=true ) const;
+    bool quickClassCheck(const lUInt32 *classHashes, size_t size) const;
     void applyToPseudoElement( const ldomNode * node, css_style_rec_t * style ) const;
     void apply( const ldomNode * node, css_style_rec_t * style ) const
     {

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -139,7 +139,7 @@ public:
     LVCssSelectorRule( LVCssSelectorRule & v );
     void setId( lUInt16 id ) { _id = id; }
     void setAttr( lUInt16 id, const lString32 value ) { _attrid = id; _value = value; }
-    LVCssSelectorRule * getNext() const { return _next; }
+    const LVCssSelectorRule * getNext() const { return _next; }
     void setNext(LVCssSelectorRule * next) { _next = next; }
     ~LVCssSelectorRule() { if (_next) delete _next; }
     /// check condition for node
@@ -169,14 +169,12 @@ private:
     lUInt32 _specificity;
     int _pseudo_elem; // from enum LVCssSelectorPseudoElement, or 0
     LVCssSelector * _next;
-    LVCssSelectorRule * _rules;
-    void insertRuleStart( LVCssSelectorRule * rule );
-    void insertRuleAfterStart( LVCssSelectorRule * rule );
+    LVRef<LVCssSelectorRule> _rules;
 public:
     LVCssSelector( LVCssSelector & v );
     LVCssSelector() : _id(0), _specificity(0), _pseudo_elem(0),  _next(NULL), _rules(NULL) { }
-    LVCssSelector(lUInt32 specificity) : _id(0), _specificity(specificity), _pseudo_elem(0), _next(NULL), _rules(NULL) { }
-    ~LVCssSelector() { if (_next) delete _next; if (_rules) delete _rules; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
+    explicit LVCssSelector(lUInt32 specificity) : _id(0), _specificity(specificity), _pseudo_elem(0), _next(NULL), _rules(NULL) { }
+    ~LVCssSelector() { if (_next) delete _next; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
     bool parse( const char * &str, lxmlDocBase * doc );
     lUInt16 getElementNameId() const { return _id; }
     bool check( const ldomNode * node, bool allow_cache=true ) const;
@@ -209,8 +207,7 @@ public:
         s->_decl = _decl; // (this is a LVRef)
         s->_specificity = _specificity;
         s->_pseudo_elem = _pseudo_elem;
-        if ( _rules ) // (deep copy of each rule)
-            s->_rules = new LVCssSelectorRule(*_rules);
+        s->_rules = _rules;
         return s;
     }
 };

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -1274,6 +1274,14 @@ bool lString32::atod( double &d, char dp ) const {
 }
 
 #define STRING_HASH_MULT 31
+
+lUInt32 lString32::getHash(const lChar32 *begin, const lChar32 *end) {
+    lUInt32 res = 0;
+    for (; begin < end; ++begin)
+        res = res * STRING_HASH_MULT + *begin;
+    return res;
+}
+
 lUInt32 lString32::getHash() const
 {
     lUInt32 res = 0;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -4459,7 +4459,7 @@ static css_length_t read_length( int * &data )
     return len;
 }
 
-void LVCssDeclaration::apply( css_style_rec_t * style )
+void LVCssDeclaration::apply( css_style_rec_t * style ) const
 {
     if (!_data)
         return;
@@ -4832,7 +4832,7 @@ void LVCssDeclaration::apply( css_style_rec_t * style )
     }
 }
 
-lUInt32 LVCssDeclaration::getHash() {
+lUInt32 LVCssDeclaration::getHash() const {
     if (!_data)
         return 0;
     int * p = _data;
@@ -4857,7 +4857,7 @@ lUInt32 LVCssDeclaration::getHash() {
 #define WEIGHT_SPECIFICITY_ELEMENT  1<<19 // allow for 32 element names div > p span (d)
 #define WEIGHT_SELECTOR_ORDER       1     // allow for counting 524288 selectors
 
-lUInt32 LVCssSelectorRule::getWeight() {
+lUInt32 LVCssSelectorRule::getWeight() const {
     /* Each LVCssSelectorRule will add its own weight to
        its LVCssSelector container specifity.
 
@@ -4922,7 +4922,7 @@ lUInt32 LVCssSelectorRule::getWeight() {
     return 0;
 }
 
-bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache )
+bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
 {
     if (!node || node->isNull() || node->isRoot())
         return false;
@@ -5388,7 +5388,7 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache )
     return true;
 }
 
-bool LVCssSelectorRule::checkNextRules( const ldomNode * node, bool allow_cache )
+bool LVCssSelectorRule::checkNextRules( const ldomNode * node, bool allow_cache ) const
 {
     // Similar to LVCssSelector::check() just below, but
     // invoked from a rule
@@ -5991,7 +5991,7 @@ LVStyleSheet::LVStyleSheet( LVStyleSheet & sheet )
     _selector_count = sheet._selector_count;
 }
 
-void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style )
+void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
 {
     if (!_selectors.length())
         return; // no rules!
@@ -6052,7 +6052,7 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style )
     }
 }
 
-lUInt32 LVCssSelectorRule::getHash()
+lUInt32 LVCssSelectorRule::getHash() const
 {
     lUInt32 hash = 0;
     hash = ( ( ( (lUInt32)_type * 31
@@ -6082,7 +6082,7 @@ lUInt32 LVCssSelector::getHash() const
 }
 
 /// calculate hash
-lUInt32 LVStyleSheet::getHash()
+lUInt32 LVStyleSheet::getHash() const
 {
     lUInt32 hash = 0;
     for ( int i=0; i<_selectors.length(); i++ ) {
@@ -6206,7 +6206,7 @@ bool LVStyleSheet::parseAndAdvance( const char * &str, bool higher_importance, l
 }
 
 /// Gather snippets in the provided CSS that the provided node would match
-bool LVStyleSheet::gatherNodeMatchingRulesets(ldomNode * node, const char * str, lString8Collection & matches) {
+bool LVStyleSheet::gatherNodeMatchingRulesets(ldomNode * node, const char * str, lString8Collection & matches) const {
     // Parsing as in parseAndAdvance() but simplified as we don't need to build anything
     bool ret = false;
     if ( !_doc ) {


### PR DESCRIPTION
This is my first PR on https://github.com/koreader/crengine/issues/529

I've tested with load and render, but I've no knowledge of cache mechanism yet so not sure it works there. I publish them  for review now because I want to avoid conflicts to subsequent commit(s) :)

Tested with two sets of books from Project Gutenburg, and cycle estimations of `LoadDocument()` reported by callgrind are as follows (fewer is better):

| Percentile | Largest Books | Median Books |
| --|--|--|
| Best 10% | -39.2% | -11.3% |
| Median | -6.0% | -3.3% |
| Worst 10% | -1.6% | -0.2% |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/545)
<!-- Reviewable:end -->
