### PR TITLE
Use empty paragraphs to insert a new line

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -2,7 +2,7 @@ body { text-align: left; margin: 0; text-indent: 0px; page-break-after: always; 
 
 p { text-align: justify; text-indent: 1.2em; margin-top: 0em; margin-bottom: 0em }
 
-empty-line { height: 1em }
+empty-line, p:empty { height: 1em }
 
 hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em; /* 2px */ }
 

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -1,8 +1,8 @@
 body { text-align: left; margin: 0; text-indent: 0px; page-break-after: always; }
 
-p { text-align: justify; text-indent: 1.2em; margin-top: 0em; margin-bottom: 0em }
+p { text-align: justify; text-indent: 1.2em; margin-top: 0em; margin-bottom: 0em; min-height: 1em; }
 
-empty-line, p:empty { height: 1em }
+empty-line { height: 1em }
 
 hr { height: 1px; background-color: #808080; margin-top: 0.5em; margin-bottom: 0.5em; /* 2px */ }
 


### PR DESCRIPTION
Some FB2 books incorrectly use <p /> tags to add an empty new lines. Ideally, they should use <empty-line /> instead, but oh well.

KOReader doesn't display any empty vertical space, so there's no break at all.

I've tested this change on my own device, and it worked.

<details>

<summary>See the images for comparison.</summary>
![After](https://github.com/koreader/crengine/assets/483357/e0a35449-8309-416f-85d9-a69447212c76)
![Before](https://github.com/koreader/crengine/assets/483357/de57bc26-5cb5-475d-8c97-40671f8ece4b)
</details>

Closes koreader/koreader#11173.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/547)
<!-- Reviewable:end -->
