### PR TITLE
CJK: fix bad ruby drawing on last paragraph line

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2907,7 +2907,6 @@ public:
             }
         }
 
-        bool boxes_positions_possibly_invalid = false;
         if ( extra_width < 0 ) {
             // line is too wide
             // reduce spaces to fit line
@@ -2948,30 +2947,11 @@ public:
         else if ( alignment==LTEXT_ALIGN_LEFT ) {
             // no additional alignment necessary
             // Except may be with CJK lines (the last line of a justified paragraph being left aligned)
-            if ( m_has_cjk ) {
-                if ( m_pbuffer->light_formatting ) {
-                    // If we are here, it's because we have inline boxes (probably ruby).
-                    // But the previous line may not, and may not have gone thru alignLine(), and
-                    // so m_cjk_prev_line_added_space_div/_mod may not be from the previous line
-                    // and may not be accurate.
-                    // The x position of the inlineBoxes we'll have computed below will be invalid,
-                    // and we'll need to recompute it when drawing that line (that we alas won't
-                    // get saved in the cache).
-                    // We'll set a flag in this case, but only if we know we'll need to do that work:
-                    if ( frmline->word_count >= 2 && frmline->words[0].flags & LTEXT_WORD_IS_CJK
-                                                  && frmline->words[1].flags & LTEXT_WORD_IS_CJK ) {
-                        boxes_positions_possibly_invalid = true;
-                    }
-                }
-                else if ( (m_cjk_prev_line_added_space_div > 0 || m_cjk_prev_line_added_space_mod > 0)
-                          && frmline->word_count >= 2 && frmline->words[0].flags & LTEXT_WORD_IS_CJK
-                                                      && frmline->words[1].flags & LTEXT_WORD_IS_CJK ) {
-                    // Non-light-formatting:
-                    // The previous line did get some spacing added to ensure text justification (see below), so it is justified.
-                    // This is the last line, it is left-aligned, and it starts with at least 2 CJK chars.
-                    // We can apply that same spacing between the leading CJK chars of this last line, so they look vertically
-                    // aligned with the ones in the line above.
-                    // 2 steps: first, check if we won't exceed the available width; if not, apply changes
+            if ( m_has_cjk && ( m_cjk_prev_line_added_space_div > 0 || m_cjk_prev_line_added_space_mod > 0 ) ) {
+                // We did add spacing to the previous line to ensure text justification (see below)
+                if ( frmline->word_count >= 2 && frmline->words[0].flags & LTEXT_WORD_IS_CJK
+                                              && frmline->words[1].flags & LTEXT_WORD_IS_CJK ) {
+                    // 2 steps: first, check if we don't exceed the available width; if not, apply changes
                     for ( int apply=0; apply<=1; apply++ ) {
                         if ( !apply ) {
                             // Don't do it if addSpaceDiv is larger than 1/4 em (probably some excessive
@@ -3088,8 +3068,7 @@ public:
                     RenderRectAccessor fmt( node );
                     if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_POSITIONNED) )
                         continue;
-                    if ( !boxes_positions_possibly_invalid )
-                        RENDER_RECT_SET_FLAG(fmt, BOX_IS_POSITIONNED);
+                    RENDER_RECT_SET_FLAG(fmt, BOX_IS_POSITIONNED);
                     fmt.setX( frmline->x + word->x );
                     fmt.setY( frmline->y + frmline->baseline - word->o.baseline + word->y );
                     fmt.push();


### PR DESCRIPTION
Actually, all inline boxes on the last line of a justified paragraph.
Follow up to c7c6bef9, where I didn't think about light formatting and not all lines going thru alignLine() on the initial opening of a book: these wrong positions would be saved in the cache, and never corrected.

See https://github.com/koreader/koreader/issues/11021#issuecomment-1771537372

~~I'm not super confident with this though: modifying stuff fetched from the cache (we never do that), and not explictely updating an existing cache (we also never do that, when this is needed, we fully reload and rebuild the DOM+cache).~~
~~All the cache memory <=> disk handling/flushing/trashing is still pretty obscure to me, and I'm not sure if implicit cache update can happen (and what happens when it happens :). There is [code that can do that](https://github.com/koreader/crengine/blob/f6abee69d5ea10660e0e76f76c3cb41ce1fa1fbe/crengine/src/lvtinydom.cpp#L3287-L3322), that could be triggered under memory limit pressure, that has caused issues in the past and that I made do a `printf("CRE WARNING")`, that I think I have never seen printed...~~
~~I'm also not sure if this code was ever really meant to be used and has been tested, or if it was just remnants of ideas that were never fully implemented.~~
(The same reason that makes me lukewarm with https://github.com/koreader/koreader/pull/10940.)

~~But all other solutions I could think of would be to have CJK paragraphs not rendered "light formatting", so making CJK book slowers to open.~~
(Or, thinking again while writing this - although I may have thought about it, but ruled it out, not sure if and why :/...: we may know it has CJK **and** inline boxes early, so we could do non-light formatting only in this case - which could still make some book opening unncessarily slow.)
~~We'll see.~~
I think I'll go with that sissy safest road.

Should allow closing https://github.com/koreader/koreader/issues/11021.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/548)
<!-- Reviewable:end -->
