### PR TITLE
Various text selection, footnotes & misc fixes and tweaks

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -358,6 +358,8 @@ private:
     CRPropRef m_props;
     // document properties
     CRPropRef m_doc_props;
+    // alternative doc properties, set by frontend, used for display, not saved in cache
+    CRPropRef m_alt_doc_props;
 
     bool m_swapDone;
 
@@ -793,6 +795,32 @@ public:
     /// returns book content CRC32
     lUInt32 getFileCRC32() {
         return (lUInt32)m_doc_props->getIntDef(DOC_PROP_FILE_CRC32, 0);
+    }
+
+    /// return alt document properties
+    CRPropRef getAltDocProps() { return m_alt_doc_props; }
+    /// returns alt or original book title
+    lString32 getAltTitleOrTitle() {
+        if ( m_alt_doc_props->hasProperty(DOC_PROP_TITLE) )
+            return m_alt_doc_props->getStringDef(DOC_PROP_TITLE);
+        return m_doc_props->getStringDef(DOC_PROP_TITLE);
+    }
+    /// returns alt or original book authors
+    lString32 getAltAuthorsOrAuthors() {
+        if ( m_alt_doc_props->hasProperty(DOC_PROP_AUTHORS) )
+            return m_alt_doc_props->getStringDef(DOC_PROP_AUTHORS);
+        return m_doc_props->getStringDef(DOC_PROP_AUTHORS);
+    }
+    /// returns alt or original book series
+    lString32 getAltSeriesOrSeries() {
+        if ( m_alt_doc_props->hasProperty(DOC_PROP_SERIES_NAME) ) {
+            lString32 name = m_alt_doc_props->getStringDef(DOC_PROP_SERIES_NAME);
+            lString32 number = m_alt_doc_props->getStringDef(DOC_PROP_SERIES_NUMBER);
+            if ( !name.empty() && !number.empty() )
+                name << " #" << number;
+            return name;
+        }
+        return getSeries();
     }
 
 #if 0 // unused

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -336,7 +336,9 @@ public:
     {
         lines.add( line );
     }
-    CompactArray<LVRendLineInfo*, 2, 4> & getLines() { return lines; }
+    // CompactArray<LVRendLineInfo*, 2, 4> & getLines() { printf("getLines %x\n", lines); return lines; }
+    LVRendLineInfo * getLine(int index) { return lines[index]; }
+    int  length() { return lines.length(); }
     bool empty() { return lines.empty(); }
     void clear() { lines.clear(); }
     lString32 getId() { return id; }

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1698,6 +1698,8 @@ public:
     inline bool isElement() const { return !isNull() && getNode()->isElement(); }
     /// returns true if current node is element
     inline bool isText() const { return !isNull() && getNode()->isText(); }
+    /// returns true if current node is an image
+    inline bool isImage() const { return !isNull() && getNode()->isImage(); }
     /// returns HTML (serialized from the DOM, may be different from the source HTML)
     lString8 getHtml( lString32Collection & cssFiles, lString8 & extra, int wflags=0 );
     lString8 getHtml( int wflags=0 ) {
@@ -1823,6 +1825,8 @@ public:
     bool nextVisibleText( bool thisBlockOnly = false );
     /// move to previous visible text node
     bool prevVisibleText( bool thisBlockOnly = false );
+    /// move to next text node or image
+    bool nextTextOrImage( bool thisBlockOnly = false );
 
     /// move to prev visible char
     bool prevVisibleChar( bool thisBlockOnly = false );
@@ -2061,7 +2065,7 @@ public:
     };
     // returns multiple segments rects (one for each text line)
     // that the ldomXRange spans on the page.
-    void getSegmentRects( LVArray<lvRect> & rects );
+    void getSegmentRects( LVArray<lvRect> & rects, bool includeImages=false );
 #endif
     /// returns nearest common element for start and end points
     ldomNode * getNearestCommonParent();
@@ -2117,6 +2121,7 @@ public:
     //         LTR paragraphs) (2 & 3 might be used for crengine internal bookmarks,
     //         see hist.h for enum bmk_type)
     //  0x11, 0x12, 0x13:  enhanced drawing (segmented mark, spanning a single line)
+    //  0x111, 0x112, 0x113: additionally include images in segments
     lUInt32   flags;
     bool empty()
     {

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2046,7 +2046,7 @@ public:
     /// returns true if this interval intersects specified interval
     bool checkIntersection( ldomXRange & v );
     /// returns text between two XPointer positions
-    lString32 getRangeText( lChar32 blockDelimiter='\n', int maxTextLen=0 );
+    lString32 getRangeText( lChar32 blockDelimiter='\n', int maxTextLen=0, lChar32 imageReplacement=0, LVArray<ldomNode*> * imageNodes=NULL);
     /// get all words from specified range
     void getRangeWords( LVArray<ldomWord> & list );
     /// returns href attribute of <A> element, null string if not found

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1014,6 +1014,11 @@ public:
     /// returns attribute value by attribute name id, looking at children if needed
     const lString32 & getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const;
     const lString32 & getFirstInnerAttributeValue( lUInt16 id ) const { return getFirstInnerAttributeValue( LXML_NS_ANY, id ); }
+    /// returns all attribute values by attribute name id, looking at all children
+    const void getAllInnerAttributeValues( lUInt16 nsid, lUInt16 id, lString32Collection & values ) const;
+    const void getAllInnerAttributeValues( lUInt16 id, lString32Collection & values ) const {
+        return getAllInnerAttributeValues( LXML_NS_ANY, id, values );
+    }
 
     /// returns element type structure pointer if it was set in document for this element name
     const css_elem_def_props_t * getElementTypePtr();

--- a/crengine/include/props.h
+++ b/crengine/include/props.h
@@ -39,6 +39,8 @@ public:
 
     /// returns true if specified property exists
     virtual bool hasProperty( const char * propName ) const = 0;
+    /// delete specified property
+    virtual bool deleteProperty( const char * propName ) = 0;
     /// get string property by name, returns false if not found
     virtual bool getString( const char * propName, lString32 &result ) const = 0;
     /// get string property by name, returns default value if not found

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -208,6 +208,7 @@ LVDocView::LVDocView(int bitsPerPixel, bool noDefaultDocument) :
 	m_props = LVCreatePropsContainer();
 	m_doc_props = LVCreatePropsContainer();
 	propsUpdateDefaults( m_props);
+	m_alt_doc_props = LVCreatePropsContainer();
 
 	//m_drawbuf.Clear(m_backgroundColor);
 
@@ -1112,9 +1113,9 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
             css_ff_serif, cs8("Times New Roman")));
 	LVFontRef series_fnt(fontMan->GetFont(base_font_size - 3, 400, true,
             css_ff_serif, cs8("Times New Roman")));
-	lString32 authors = getAuthors();
-	lString32 title = getTitle();
-	lString32 series = getSeries();
+	lString32 authors = getAltAuthorsOrAuthors();
+	lString32 title = getAltTitleOrTitle();
+	lString32 series = getAltSeriesOrSeries();
 	if (title.empty())
         title = "no title";
 	LFormattedText txform;
@@ -1917,11 +1918,11 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		int authorsw = 0;
 		lString32 authors;
 		if (phi & PGHDR_AUTHOR)
-			authors = getAuthors();
+			authors = getAltAuthorsOrAuthors();
 		int titlew = 0;
 		lString32 title;
 		if (phi & PGHDR_TITLE) {
-			title = getTitle();
+			title = getAltTitleOrTitle();
 			if (title.empty() && authors.empty())
 				title = m_doc_props->getStringDef(DOC_PROP_FILE_NAME);
 			if (!title.empty())

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -644,13 +644,13 @@ public:
     void StartFootNote( LVFootNote * note )
     {
         #ifdef DEBUG_FOOTNOTES
-            CRLog::trace( "StartFootNote(%d)", note->getLines().length() );
+            CRLog::trace( "StartFootNote(%d)", note->length() );
         #endif
-        if ( !note || note->getLines().length()==0 )
+        if ( !note || note->length()==0 )
             return;
         footnote = note;
-        //footstart = footnote->getLines()[0];
-        //footlast = footnote->getLines()[0];
+        //footstart = footnote->getLine(0);
+        //footlast = footnote->getLine(0);
         footend = NULL;
     }
     void AddFootnoteFragmentToList()
@@ -1052,7 +1052,7 @@ public:
             // delayed footnotes, so push them now.
             // But only if the first line of them fits. Otherwise, keep
             // them delayed (our own footnotes will then be delayed too).
-            if ( delayed_footnotes[0]->getLines()[0]->getHeight() <= getAvailableHeightForFootnotes() ) {
+            if ( delayed_footnotes[0]->getLine(0)->getHeight() <= getAvailableHeightForFootnotes() ) {
                 pushDelayedFootnotes();
             }
         }
@@ -1069,12 +1069,12 @@ public:
             return;
         cur_page_seen_footnotes.add(note);
 
-        int note_nb_lines = note->getLines().length();
+        int note_nb_lines = note->length();
         int note_top = -1;
         int note_bottom = -1;
         for ( int i=0; i < note_nb_lines; i++ ) {
             // Note: we don't ensure SPLIT_AVOID/ALWAYS inside footnotes
-            LVRendLineInfo * line = note->getLines()[i];
+            LVRendLineInfo * line = note->getLine(i);
             if ( note_top < 0 )
                 note_top = line->getStart();
             int new_note_bottom = line->getEnd();
@@ -1136,7 +1136,7 @@ public:
                     // See if a first footnote line + its top margin fit on the page.
                     // If they don't, delay all footnotes but don't flush the page,
                     // as some main content line could still fit on this page.
-                    if ( note->getLines()[0]->getHeight() > getAvailableHeightForFootnotes() ) {
+                    if ( note->getLine(0)->getHeight() > getAvailableHeightForFootnotes() ) {
                         if ( delayed_footnotes.indexOf(note) < 0 )
                             delayed_footnotes.add( note );
                         continue;
@@ -1262,14 +1262,14 @@ void LVRendPageContext::split()
            // }
             for ( int j=0; j<line->getLinks()->length(); j++ ) {
                 LVFootNote* note = line->getLinks()->get(j);
-                if ( note->getLines().length() ) {
+                if ( note->length() ) {
                     // Avoid duplicated footnotes in the same page
                     if (s.IsFootNoteInCurrentPage(note))
                         continue;
                     foundFootNote = true;
                     s.StartFootNote( note );
-                    for ( int k=0; k<note->getLines().length(); k++ ) {
-                        s.AddFootnoteLine( note->getLines()[k] );
+                    for ( int k=0; k<note->length(); k++ ) {
+                        s.AddFootnoteLine( note->getLine(k) );
                     }
                     s.EndFootNote();
                 }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3876,10 +3876,18 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             #ifdef DEBUG_DUMP_ENABLED
                 logfile << "+OBJECT ";
             #endif
+            lUInt32 linkflags = 0;
+            if (is_link_start && *is_link_start) { // was propagated from some outer <A>
+                linkflags = LTEXT_IS_LINK; // used to gather in-page footnotes
+                *is_link_start = false;
+                    // reset to false, so next text nodes or other images in that link are not
+                    // flagged, and don't make out duplicate in-page footnotes
+            }
             bool isBlock = style->display == css_d_block;
             if ( isBlock ) {
                 // If block image, forget any current flags and start from baseflags (?)
                 lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
+                flags |= linkflags;
                 //txform->AddSourceLine(U"title", 5, 0x000000, 0xffffff, font, baseflags, interval, margin, NULL, 0, 0);
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
@@ -3912,6 +3920,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             } else { // inline image
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
+                flags |= linkflags;
                 txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9192,12 +9192,12 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
                                       rightpoint2.y-i+1, shadecolor);}
                     break;
                 case css_border_inset:
-                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    for(int i=0;i<leftpoint1.y-leftpoint3.y;i++)
                     {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate+1,
                                       rightpoint1.y-i+1, lightcolor,dot,interval,0);}
                     break;
                 case css_border_outset:
-                    for(int i=0;i<=leftpoint1.y-leftpoint3.y;i++)
+                    for(int i=0;i<leftpoint1.y-leftpoint3.y;i++)
                     {drawbuf.DrawLine(leftpoint1.x+i*leftrate, leftpoint1.y-i, rightpoint1.x-i*rightrate+1,
                                       rightpoint1.y-i+1, shadecolor,dot,interval,0);}
                     break;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -3774,6 +3774,10 @@ public:
                         // Per specs, the baseline is the bottom of the image
                         top_to_baseline = word->o.height;
                         baseline_to_bottom = 0;
+                        // Flag word if that image is at the start of a link (for in-page footnotes)
+                        if ( srcline->flags & LTEXT_IS_LINK ) {
+                            word->flags |= LTEXT_WORD_IS_LINK_START;
+                        }
                     }
                     else if ( srcline->o.objflags & LTEXT_OBJECT_IS_PAD ) {
                         word->flags = LTEXT_WORD_IS_PAD;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -18897,9 +18897,17 @@ ldomNode * ldomNode::elementFromPoint( lvPoint pt, int direction, bool strict_bo
             }
             if ( pt.y >= fmt.getY() + fmt.getHeight() ) { // pt.y is inside the box bottom overflow
                 // Get back absolute coordinates of pt
-                lvRect rc;
-                getParentNode()->getAbsRect( rc );
-                lvPoint pt0 = lvPoint(rc.left+pt.x, rc.top+pt.y );
+                lvPoint pt0;
+                ldomNode * parentNode = getParentNode();
+                if ( parentNode ) {
+                    lvRect rc;
+                    parentNode->getAbsRect( rc );
+                    pt0 = lvPoint(rc.left+pt.x, rc.top+pt.y );
+                }
+                else {
+                    // No parent node: we are the root node (and the origin of absolute coordinates)
+                    pt0 = pt;
+                }
                 // Check each of this element's children if pt is inside it (so, we'll
                 // go by here for each of them that has some overflow too, and that
                 // contributed to making this element's overflow.)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -95,7 +95,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.72k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0031
+#define FORMATTING_VERSION_ID 0x0032
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5473,7 +5473,6 @@ bool ldomDocument::partialRender( ldomNode * node ) {
     if ( _doc_pages ) {
         _doc_pages->replacePages(base_y, orig_h, &newpages, next_fragments_shift_y);
     }
-    _pagesData.setPos(0); // so a next render() won't go deserializing them from _pageData
 
     _partial_rerenderings_count++;
     return true;
@@ -5684,7 +5683,7 @@ bool ldomDocument::render( LVRendPageList * pages, LVDocViewCallback * callback,
 
     } else {
         CRLog::info("rendering context is not changed - no render!");
-        if ( _pagesData.pos() ) {
+        if ( was_just_rendered_from_cache && _pagesData.pos() ) {
             _pagesData.setPos(0);
             pages->deserialize( _pagesData );
         }

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -200,6 +200,16 @@ public:
         int pos;
         return findItem( propName, pos );
     }
+    /// delete specified property
+    virtual bool deleteProperty( const char * propName )
+    {
+        int pos;
+        if ( findItem( propName, pos ) ) {
+            clear(pos, pos+1);
+            return true;
+        }
+        return false;
+    }
     /// clear all items
     virtual void clear();
     /// returns property path in root container
@@ -781,6 +791,12 @@ public:
     {
         lString32 str;
         return getString( propName, str );
+    }
+    /// delete specified property
+    virtual bool deleteProperty( const char * propName )
+    {
+        // not implemented
+        return false;
     }
     CRPropSubContainer(CRPropContainer * root, lString8 path)
     : _root(root), _path(path), _start(0), _end(0), _revision(0)


### PR DESCRIPTION
#### LvDocView: allow setting custom title/authors/series

Frontend can set custom title/authors/series to be displayed in the top status bar (and in the rarely seen FB2 synthesized front text cover).
Will help https://github.com/koreader/koreader/pull/11463 to do it stuff more properly. See https://github.com/koreader/koreader/pull/11463#issuecomment-1939067151

#### elementFromPoint(): fix possible crash when float at end of document

A float at the end of the document could add some overflow to the root node "rect", and we would segfault when looking for its parent.
See https://github.com/koreader/koreader/issues/11409#issuecomment-1913089844 .
Should allow closing https://github.com/koreader/koreader/issues/11409 .

#### Non-linear fragments: fix generic handling on erm_final

Followup to 03e0f372, where we added the closing of a non-linear sequence for erm_block elements, but totally forgot to do the same for erm_final elements!
Noticed around https://github.com/koreader/koreader/issues/10193#issuecomment-1915204376.

#### DrawBorder: fix bottom border inset/outset drawing

The bottom border could be thicker than the others.
Now similar to the top/left/right border drawing branches.

#### `getSegmentRects()`: allow segments to include images

This will allow including images at start or end of line in text selection & highlights, avoiding holes.
It is also necessary with popup footnotes it we want to have them detected and highlight the link when the footnote link is solely an image (which seems popular in Chinese EPUBs).
Should allow closing the popup footnotes issue in https://github.com/koreader/koreader/issues/11451
Will allow to go on with including images in text selection and highlights: https://github.com/koreader/koreader/issues/11460.

#### `getRangeText()`: allow gathering images

Allow getting in the text one unicode codepoint in place of each image (which may make the highlight text more readable).
Can optionally return the list of associated image nodes.
Will allow to go on with including images in text selection and highlights: https://github.com/koreader/koreader/issues/11460.

#### Allow standalone image in link to trigger in-page footnotes

We were only considering links with text as candidates to get in-page footnotes.
(Image links seem popular in some Chinese books.)
Should allow closing the in-page footnotes issue in https://github.com/koreader/koreader/issues/11451

#### ldomDocument::render(): avoid uneeded deserialization on each page turn

`_pagesData` is the serialized pages data, loaded from cache, and to be saved to cache.
`pos() > 0` means it has some content, that can be saved to cache. There were some interference with using it as meaning there has been some content read, that should be deserialized.  Only deserialize when we know we should, when just loaded from cache.

#### lvtinydom: add ldomNode::getAllInnerAttributeValues()

Will be useful to get all the `id=` values in a footnote section.

#### LVFootNote: avoid retrieving internal CompactArray object

Add methods to get what we want, without the need to get a reference to the internal object itself (which could cause it to be freed when going out of scope and could cause some crashes if accessed again).

#### In-page footnotes: allows for multiple id= inside them

Previously, when entering a block element tagged with `-cr-hint: footnote-inpage`, we were associating it with the first `id=` attribute found inside it.
It was then added to the page containing links with `href=` this id.
But it may happen that some `href=` points to some inner `id=` inside the footnote section (ie. the container has an `id=` but the `href=` points to a `<span id=>` inside the container, with another id), in which case no footnote was found for that `href`.
We now reference the same `LVFootNote` to all the ids met.
The `LVFootNote` stubs created when meeting the href need to be kept, so we associate them with the "actual footnote" we create, so it can act as a proxy to it.
Problem met in a few koreader issues, latest one at https://github.com/koreader/koreader/issues/11411#issuecomment-1925925214.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/554)
<!-- Reviewable:end -->
