### PR TITLE
[CI] Add stylelint to prevent typos in CSS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,17 @@ jobs:
 
     - name: Lint
       run: .ci/script.sh
+
+    # NPM tests
+
+    - name: Uses Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'latest'
+        # No cache, there are complaints about lockfiles that we don't want otherwise. See <https://github.com/actions/setup-node/issues/928>.
+        # cache: 'npm'
+
+    - run: npm init --yes && npm install stylelint stylelint-config-standard
+
+    - name: Check CSS syntax
+      run: npx stylelint "**/*.css"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
     - run: npm init --yes && npm install stylelint stylelint-config-standard
 
     - name: Check CSS syntax (only epub.css, html5.css and fb2.css)
-      run: npx stylelint cr3gui/data/epub.css cr3gui/data/html5.css fb2.css
+      run: npx stylelint cr3gui/data/epub.css cr3gui/data/html5.css cr3gui/data/fb2.css

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,5 @@ jobs:
 
     - run: npm init --yes && npm install stylelint stylelint-config-standard
 
-    - name: Check CSS syntax
-      run: npx stylelint "**/*.css"
+    - name: Check CSS syntax (only epub.css, html5.css and fb2.css)
+      run: npx stylelint cr3gui/data/epub.css cr3gui/data/html5.css fb2.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,2 @@
-crengine/src/**/*.css
+# This contains CSS embedded in a raw string literal, which confuses stylelint.
+crengine/src/mathml_css_h.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+crengine/src/**/*.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,0 @@
-# This contains CSS embedded in a raw string literal, which confuses stylelint.
-crengine/src/mathml_css_h.css

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,7 +6,11 @@
     "declaration-block-single-line-max-declarations": null,
     "length-zero-no-unit": null,
     "property-no-unknown": [true, {
-      "ignoreProperties": ["hyphenate"]
+      "ignoreProperties": [
+        "binding",
+
+        "hyphenate"
+      ]
     }],
     "rule-empty-line-before": null,
     "selector-attribute-quotes": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+ "extends": "stylelint-config-standard",
+ "rules": {
+    "declaration-block-no-redundant-longhand-properties": null,
+    "length-zero-no-unit": null
+ }
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,9 @@
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
     "length-zero-no-unit": null,
+    "property-no-unknown": [true, {
+      "ignoreProperties": ["hyphenate"]
+    }],
     "rule-empty-line-before": null,
     "selector-attribute-quotes": null,
     "selector-type-case": ["lower", {
@@ -23,6 +26,14 @@
         "description",
         "genre",
 
+        "epigraph",
+        "v",
+        "stanza",
+        "poem",
+        "text-author",
+        "epigraph",
+
+        "book-title",
         "subtitle",
         "title-info",
         "keywords",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,6 +16,8 @@
 
     "selector-type-no-unknown": [true, {
       "ignoreTypes": [
+        "noframes",
+
         "DocFragment",
         "rubyBox",
 

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,9 @@
     "comment-empty-line-before": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
-    "length-zero-no-unit": null,
+    "length-zero-no-unit": [true, { "severity": "warning" }],
+    "no-descending-specificity": [true, { "severity": "warning" }],
+    "no-duplicate-selectors": [true, { "severity": "warning" }],
     "property-no-unknown": [true, {
       "ignoreProperties": [
         "binding",
@@ -18,7 +20,6 @@
     "selector-type-case": ["lower", {
       "ignoreTypes": ["DocFragment", "rubyBox"]
     }],
-
     "selector-type-no-unknown": [true, {
       "ignoreTypes": [
         "noframes",
@@ -59,6 +60,7 @@
         "strikethrough",
         "spacing"
       ]
-    }]
+    }],
+    "shorthand-property-no-redundant-values": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,6 +10,7 @@
     }],
     "rule-empty-line-before": null,
     "selector-attribute-quotes": null,
+    "selector-class-pattern": "(^([a-z][a-z0-9]*)(-[a-z0-9]+)*$|^fb2_info$)",
     "selector-type-case": ["lower", {
       "ignoreTypes": ["DocFragment", "rubyBox"]
     }],
@@ -17,6 +18,7 @@
     "selector-type-no-unknown": [true, {
       "ignoreTypes": [
         "noframes",
+        "rbc",
 
         "DocFragment",
         "rubyBox",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
  "extends": "stylelint-config-standard",
  "rules": {
     "declaration-block-no-redundant-longhand-properties": null,
+    "declaration-block-single-line-max-declarations": null,
     "length-zero-no-unit": null
  }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,15 @@
  "rules": {
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
-    "length-zero-no-unit": null
+    "length-zero-no-unit": null,
+
+    "selector-type-no-unknown": [true, {
+      "ignoreTypes": [
+        "author",
+        "date",
+        "description",
+        "genre"
+      ]
+}]
  }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,17 +1,45 @@
 {
- "extends": "stylelint-config-standard",
- "rules": {
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "comment-empty-line-before": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
     "length-zero-no-unit": null,
+    "rule-empty-line-before": null,
+    "selector-attribute-quotes": null,
+    "selector-type-case": ["lower", {
+      "ignoreTypes": ["DocFragment", "rubyBox"]
+    }],
 
     "selector-type-no-unknown": [true, {
       "ignoreTypes": [
+        "DocFragment",
+        "rubyBox",
+
+        "empty-line",
+
         "author",
         "date",
         "description",
-        "genre"
+        "genre",
+
+        "subtitle",
+        "title-info",
+        "keywords",
+        "lang",
+        "src-lang",
+        "translator",
+        "document-info",
+        "publish-info",
+        "custom-info",
+        "coverpage",
+        "underline",
+        "spacing",
+        "emphasis",
+        "underline",
+        "strikethrough",
+        "spacing"
       ]
-}]
- }
+    }]
+  }
 }

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -43,10 +43,8 @@ title, h1, h2, h3, h4, h5, h6, subtitle {
 h1, h2, h3, h4, h5, h6 {
 	display: block;
 	margin-top: 0.5em;
-	margin-bottom: 0.3em;
-	padding: 10px ;
-	margin-top: 0.5em;
 	margin-bottom: 0.5em;
+	padding: 10px ;
 }
 title, h1, h2 {
 	page-break-before: always;


### PR DESCRIPTION
In reply to https://github.com/koreader/crengine/pull/555#issuecomment-1970053271

This is an initial poc. Some of the rules like `length-zero-no-unit` definitely make sense to me, but the existing code is full of things like `0px` and I dislike changing things for the sake of changing them.

For `-cr-etc` I think we should be able to define a `custom-property-pattern` (as a regex).

For `selector-type-no-unknown` we should do something like `"ignoreTypes": ["genre", "author", "etc"]`. Disabling it completely would probably defeat the purpose.

And so on.

I don't know if I'll continue on this tonight, but this way the (rather excessive) list of complaints is already available to see.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/556)
<!-- Reviewable:end -->
