### PR TITLE
Add typography rules for Russian

### DIFF
--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -639,20 +639,20 @@ lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 
     // https://www.artlebedev.ru/kovodstvo/sections/62/
     if ( pos >= 1 && text[pos-1] == ' ' ) {
         switch ( text[pos] ) {
-            case 'А':
-            case 'В':
-            case 'И':
-            case 'К':
-            case 'О':
-            case 'С':
-            case 'У': // Meaning in English:
-            case 'а': // but
-            case 'в': // in
-            case 'и': // and
-            case 'к': // towards
-            case 'о': // about
-            case 'с': // with
-            case 'у': // at
+            case U"\x0410": // "А"
+            case U"\x0412": // "В"
+            case U"\x0418": // "И"
+            case U"\x041a": // "К"
+            case U"\x041e": // "О" 
+            case U"\x0421": // "С"
+            case U"\x0423": // "У". Meaning in English:
+            case U"\x0430": // but ("а")
+            case U"\x0432": // in ("в")
+            case U"\x0438": // and ("и")
+            case U"\x043a": // towards ("к")
+            case U"\x043e": // about ("о")
+            case U"\x0441": // with ("с")
+            case U"\x0443": // at ("у")
                 return '(';
                 break;
             default:

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -639,20 +639,20 @@ lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 
     // https://www.artlebedev.ru/kovodstvo/sections/62/
     if ( pos >= 1 && text[pos-1] == ' ' ) {
         switch ( text[pos] ) {
-            case U"\x0410": // "А"
-            case U"\x0412": // "В"
-            case U"\x0418": // "И"
-            case U"\x041a": // "К"
-            case U"\x041e": // "О" 
-            case U"\x0421": // "С"
-            case U"\x0423": // "У". Meaning in English:
-            case U"\x0430": // but ("а")
-            case U"\x0432": // in ("в")
-            case U"\x0438": // and ("и")
-            case U"\x043a": // towards ("к")
-            case U"\x043e": // about ("о")
-            case U"\x0441": // with ("с")
-            case U"\x0443": // at ("у")
+            case 0x0410: // "А"
+            case 0x0412: // "В"
+            case 0x0418: // "И"
+            case 0x041a: // "К"
+            case 0x041e: // "О" 
+            case 0x0421: // "С"
+            case 0x0423: // "У". Meaning in English:
+            case 0x0430: // but ("а")
+            case 0x0432: // in ("в")
+            case 0x0438: // and ("и")
+            case 0x043a: // towards ("к")
+            case 0x043e: // about ("о")
+            case 0x0441: // with ("с")
+            case 0x0443: // at ("у")
                 return '(';
                 break;
             default:

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -635,11 +635,29 @@ lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
 }
 
 lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
-    // Russian typography prohibits one letter words at the end of the line.
+    // Russian typography prohibits one letter prepositions and conjunctions at the end of the line.
     // https://www.artlebedev.ru/kovodstvo/sections/62/
     if ( pos >= 1 && text[pos-1] == ' ' ) {
-        return '(';
-    }
+        switch ( text[pos] ) {
+            case 'А':
+            case 'В':
+            case 'И':
+	        case 'К':
+            case 'О':
+            case 'С':
+            case 'У':
+            case 'а':
+            case 'в':
+            case 'и':
+	        case 'к':
+            case 'о':
+            case 'с':
+            case 'у':
+                return '(';
+                break;
+            default:
+                break;
+        }
     return text[pos];
 }
 

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -640,7 +640,7 @@ lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 
     if ( pos >= 1 && text[pos-1] == ' ' ) {
         return '(';
     }
-	  if ( pos >= 2 && text[pos-2] == ' ' ) {
+    if ( pos >= 2 && text[pos-2] == ' ' ) {
         return '(';
     }
     return text[pos];
@@ -1193,7 +1193,7 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     else if ( LANG_STARTS_WITH(("pt") ("sr")) ) { // Portuguese, Serbian
         _duplicate_real_hyphen_on_next_line = true;
     }
-	  else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
+	else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
         _lb_char_sub_func = &lb_char_sub_func_russian;
     }
 #endif

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -635,12 +635,9 @@ lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
 }
 
 lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
-    // Russian typography prohibits one and two letter words at the end of the line.
+    // Russian typography prohibits one letter words at the end of the line.
     // https://www.artlebedev.ru/kovodstvo/sections/62/
     if ( pos >= 1 && text[pos-1] == ' ' ) {
-        return '(';
-    }
-    if ( pos >= 2 && text[pos-2] == ' ' ) {
         return '(';
     }
     return text[pos];
@@ -1193,7 +1190,7 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     else if ( LANG_STARTS_WITH(("pt") ("sr")) ) { // Portuguese, Serbian
         _duplicate_real_hyphen_on_next_line = true;
     }
-	else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
+    else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
         _lb_char_sub_func = &lb_char_sub_func_russian;
     }
 #endif

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -635,24 +635,24 @@ lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
 }
 
 lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
-    // Russian typography prohibits one letter prepositions and conjunctions at the end of the line.
+    // Russian typography doesn't recommend one letter prepositions and conjunctions at the end of the line.
     // https://www.artlebedev.ru/kovodstvo/sections/62/
     if ( pos >= 1 && text[pos-1] == ' ' ) {
         switch ( text[pos] ) {
             case 'А':
             case 'В':
             case 'И':
-	        case 'К':
+            case 'К':
             case 'О':
             case 'С':
-            case 'У':
-            case 'а':
-            case 'в':
-            case 'и':
-	        case 'к':
-            case 'о':
-            case 'с':
-            case 'у':
+            case 'У': // Meaning in English:
+            case 'а': // but
+            case 'в': // in
+            case 'и': // and
+            case 'к': // towards
+            case 'о': // about
+            case 'с': // with
+            case 'у': // at
                 return '(';
                 break;
             default:

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -634,6 +634,18 @@ lChar32 lb_char_sub_func_czech_slovak(struct LineBreakContext *lbpCtx, const lCh
     return text[pos];
 }
 
+lChar32 lb_char_sub_func_russian(struct LineBreakContext *lbpCtx, const lChar32 * text, int pos, int next_usable) {
+    // Russian typography prohibits one and two letter words at the end of the line.
+    // https://www.artlebedev.ru/kovodstvo/sections/62/
+    if ( pos >= 1 && text[pos-1] == ' ' ) {
+        return '(';
+    }
+	  if ( pos >= 2 && text[pos-2] == ' ' ) {
+        return '(';
+    }
+    return text[pos];
+}
+
 // (Mostly) non-language specific char substitution to ensure CSS line-break and word-break properties
 //
 // Note: the (hardcoded in many places) default behaviour (without these tweaks) in crengine
@@ -1180,6 +1192,9 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
     }
     else if ( LANG_STARTS_WITH(("pt") ("sr")) ) { // Portuguese, Serbian
         _duplicate_real_hyphen_on_next_line = true;
+    }
+	  else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
+        _lb_char_sub_func = &lb_char_sub_func_russian;
     }
 #endif
 


### PR DESCRIPTION
Russian typography frowns upon having one letter prepositions and conjunctions hanging at the end of the line.

There are many Russian resources discussing this, I've linked some of the better known ones:
https://www.artlebedev.ru/kovodstvo/sections/62/
https://gramota.ru/spravka/vopros/294020
https://gramota.ru/spravka/vopros/219773

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/557)
<!-- Reviewable:end -->
