### PR TITLE
Various in-page footnotes, tables and covers fixes and tweaks

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -456,6 +456,7 @@ enum css_generic_value_t {
 
 
 // For footnote popup detection by koreader-base/cre.cpp
+// 'noteref-ignore' also prevents in-page footnotes from being added to the pages of links with that hint
 #define CSS_CR_HINT_NOTEREF                 0x01000000 // -cr-hint: noteref         link is to a footnote
 #define CSS_CR_HINT_NOTEREF_IGNORE          0x02000000 // -cr-hint: noteref-ignore  link is not to a footnote (even if
                                                        //                           everything else indicates it is)

--- a/crengine/include/epubfmt.h
+++ b/crengine/include/epubfmt.h
@@ -5,7 +5,9 @@
 #include "../include/lvtinydom.h"
 
 bool DetectEpubFormat( LVStreamRef stream );
-bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback, CacheLoadingCallback * formatCallback, bool metadataOnly = false );
+bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback,
+    CacheLoadingCallback * formatCallback, bool metadataOnly = false,
+    const elem_def_t * node_scheme=NULL, const attr_def_t * attr_scheme=NULL, const ns_def_t * ns_scheme=NULL);
 lString32 EpubGetRootFilePath( LVContainerRef m_arc );
 LVStreamRef GetEpubCoverpage(LVContainerRef arc);
 

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -105,6 +105,7 @@ public:
     virtual void setHidePartialGlyphs( bool hide ) = 0;
     /// set to true to invert images only (so they get inverted back to normal by nightmode)
     virtual void setInvertImages( bool invert ) = 0;
+    virtual bool getInvertImages() const = 0;
     /// set to true to enforce dithering (only relevant for 8bpp Gray drawBuf)
     virtual void setDitherImages( bool dither ) = 0;
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor
@@ -251,6 +252,7 @@ public:
     virtual void setHidePartialGlyphs( bool hide ) { _hidePartialGlyphs = hide; }
     /// set to true to invert images only (so they get inverted back to normal by nightmode)
     virtual void setInvertImages( bool invert ) { _invertImages = invert; }
+    virtual bool getInvertImages() const { return _invertImages; }
     /// set to true to enforce dithering (only relevant for 8bpp Gray drawBuf)
     virtual void setDitherImages( bool dither ) { _ditherImages = dither; }
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4439,7 +4439,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 			if ( m_callback )
                 m_callback->OnLoadFileFormatDetected(doc_format_epub);
             updateDocStyleSheet();
-            bool res = ImportEpubDocument( m_stream, m_doc, m_callback, this, metadataOnly );
+            // See epubfmt.cpp's ExtractCoverFilenameFromCoverPageFragment()
+            // for why we need to pass fb2_elem_table and such.
+            bool res = ImportEpubDocument( m_stream, m_doc, m_callback, this, metadataOnly, fb2_elem_table, fb2_attr_table, fb2_ns_table );
 			if ( !res ) {
 				setDocFormat( doc_format_none );
                 createDefaultDocument( cs32("ERROR: Error reading EPUB format"), cs32("Cannot open document") );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1161,6 +1161,7 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
 			dst_dy = imgrc.height();
 		//CRLog::trace("drawCoverTo() - drawing image");
         LVColorDrawBuf buf2(src_dx, src_dy, 32);
+        buf2.setInvertImages(drawBuf->getInvertImages());
         buf2.Draw(imgsrc, 0, 0, src_dx, src_dy, true);
         drawBuf->DrawRescaled(&buf2, imgrc.left + (imgrc.width() - dst_dx) / 2,
                 imgrc.top + (imgrc.height() - dst_dy) / 2, dst_dx, dst_dy, 0);

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1543,8 +1543,9 @@ public:
                                 ldomNode * parent = node->getParentNode();
                                 while (parent && parent->getNodeId() != el_a)
                                     parent = parent->getParentNode();
-                                if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                    lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
+                                            && !STYLE_HAS_CR_HINT(parent->getStyle(), NOTEREF_IGNORE) ) {
+                                    lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href);
                                     if ( href.firstChar()=='#' ) {
                                         href.erase(0,1);
                                         caption_links.add( href );
@@ -1745,8 +1746,9 @@ public:
                                             ldomNode * parent = node->getParentNode();
                                             while (parent && parent->getNodeId() != el_a)
                                                 parent = parent->getParentNode();
-                                            if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                                lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                            if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
+                                                        && !STYLE_HAS_CR_HINT(parent->getStyle(), NOTEREF_IGNORE) ) {
+                                                lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href);
                                                 if ( href.firstChar()=='#' ) {
                                                     href.erase(0,1);
                                                     if ( is_single_column )
@@ -5321,12 +5323,9 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                     ldomNode * parent = node->getParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
-                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                            // was: && parent->getAttributeValue(LXML_NS_ANY, attr_type ) == "note")
-                                            // but we want to be able to gather in-page footnotes by only
-                                            // specifying a -cr-hint: to the footnote target, with no need
-                                            // to set one to the link itself
-                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
+                                                && !STYLE_HAS_CR_HINT(parent->getStyle(), NOTEREF_IGNORE) ) {
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href);
                                         if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
@@ -5360,8 +5359,9 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                     ldomNode * parent = node->getParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
-                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
+                                                && !STYLE_HAS_CR_HINT(parent->getStyle(), NOTEREF_IGNORE) ) {
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href);
                                         if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             context.addLink( href, link_insert_pos );
@@ -8906,12 +8906,9 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                     ldomNode * parent = node->getParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
-                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href ) ) {
-                                            // was: && parent->getAttributeValue(LXML_NS_ANY, attr_type ) == "note")
-                                            // but we want to be able to gather in-page footnotes by only
-                                            // specifying a -cr-hint: to the footnote target, with no need
-                                            // to set one to the link itself
-                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href );
+                                    if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
+                                                && !STYLE_HAS_CR_HINT(parent->getStyle(), NOTEREF_IGNORE) ) {
+                                        lString32 href = parent->getAttributeValue(LXML_NS_ANY, attr_href);
                                         if ( href.firstChar()=='#' ) {
                                             href.erase(0,1);
                                             flow->getPageContext()->addLink( href, link_insert_pos );

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -93,7 +93,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.73k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.74k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0032
 


### PR DESCRIPTION
#### In-page footnotes: avoid with `-cr-hint: noteref-ignore`

This hint was initially added to prevent footnote popups by frontend, and is rarely useful and used. Have it also prevent in-page footnotes from being added to the pages of links with that hint.

Already documented at https://github.com/koreader/koreader/blob/67cd647d1a6a36c95d512b1ee461b7a7faf484c4/frontend/apps/reader/modules/readerstyletweak.lua#L882-L885 :
> Can be set on links (`<a href='#..'>`) to have them NOT trigger footnote popups and in-page footnote.
If some DocFragment presents an index of names with cross references, resulting in in-page footnotes taking half of these pages, you can avoid this with:
`DocFragment[id$=_16] a { -cr-hint: noteref-ignore }`

#### In-page footnotes: ensure they don't cross "flows"

When footnotes are pushed on a next page, make sure this page ends up in the same "flow": if the next content is part of another "flow", emit a page with only these footnotes, and create a new page for the coming content.
See https://github.com/koreader/crengine/pull/443#issuecomment-2001964918 for details and screenshots of the issue.

#### Tables: fix rendering when negative text-indent

Tweak for table cells similar to how we do with negative text-indent in normal paragraphs.
In `getRenderedWidths()`, try to properly size them when overflow are not allowed ("book" render mode), although this won't handle all cases.

#### FB2 cover drawing: ensure `_invertImages` flag

FB2 cover drawing uses a specific codepath: update it so it behaves as all other images drawing in regards to the invertImage setting set on the main DrawBuf.
Should allow closing https://github.com/koreader/koreader/issues/11574.

#### EPUB: fallback to look for a cover in the first fragment

If no EPUB3 or EPUB2 cover found, look at the first XHTML fragment from the spine: if it contains a single image and no text, assume that image can be used as a cover. Also accept an image with `<img alt"=cover">` in this first fragment if it comes before any text or other images.
See https://github.com/koreader/koreader/issues/11571#issuecomment-2008099189.
It uses the idea (and early patch, adapted) described at https://github.com/koreader/koreader/pull/11491#issuecomment-1962733691 and followups, that ended up not making it into crengine, as just fixing support for EPUB3 covers was enough (done in #555).
Should allow closing https://github.com/koreader/koreader/issues/11571.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/558)
<!-- Reviewable:end -->
