### PR TITLE
EPUB: add identifiers to doc props

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -768,7 +768,7 @@ public:
     lString32 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
     /// returns book keywords (separated by "; ")
     lString32 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
-    /// returns book identifiers (type:identifier separated by ";")
+    /// returns book identifiers (scheme:identifier separated by ";")
     lString32 getIdentifiers() { return m_doc_props->getStringDef(DOC_PROP_IDENTIFIERS); }
     /// returns book series name and number (series name #1)
     lString32 getSeries()

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -768,6 +768,8 @@ public:
     lString32 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
     /// returns book keywords (separated by "; ")
     lString32 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
+    /// returns book identifiers (type:identifier separated by ";")
+    lString32 getIdentifiers() { return m_doc_props->getStringDef(DOC_PROP_IDENTIFIERS); }
     /// returns book series name and number (series name #1)
     lString32 getSeries()
     {

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -768,7 +768,7 @@ public:
     lString32 getDescription() { return m_doc_props->getStringDef(DOC_PROP_DESCRIPTION); }
     /// returns book keywords (separated by "; ")
     lString32 getKeywords() { return m_doc_props->getStringDef(DOC_PROP_KEYWORDS); }
-    /// returns book identifiers (scheme:identifier separated by ";")
+    /// returns book identifiers (scheme:identifier separated by "\n")
     lString32 getIdentifiers() { return m_doc_props->getStringDef(DOC_PROP_IDENTIFIERS); }
     /// returns book series name and number (series name #1)
     lString32 getSeries()

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -108,6 +108,7 @@ extern const int gDOMVersionCurrent;
 #define DOC_PROP_FILE_CRC32      "doc.file.crc32"
 #define DOC_PROP_CODE_BASE       "doc.file.code.base"
 #define DOC_PROP_COVER_FILE      "doc.cover.file"
+#define DOC_PROP_IDENTIFIERS     "doc.identifiers"
 
 #define DEF_SPACE_WIDTH_SCALE_PERCENT 100
 #define DEF_MIN_SPACE_CONDENSING_PERCENT 50

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -94,6 +94,7 @@ extern const int gDOMVersionCurrent;
 #define DOC_PROP_LANGUAGE        "doc.language"
 #define DOC_PROP_DESCRIPTION     "doc.description"
 #define DOC_PROP_KEYWORDS        "doc.keywords"
+#define DOC_PROP_IDENTIFIERS     "doc.identifiers"
 #define DOC_PROP_SERIES_NAME     "doc.series.name"
 #define DOC_PROP_SERIES_NUMBER   "doc.series.number"
 #define DOC_PROP_ARC_NAME        "doc.archive.name"
@@ -108,7 +109,6 @@ extern const int gDOMVersionCurrent;
 #define DOC_PROP_FILE_CRC32      "doc.file.crc32"
 #define DOC_PROP_CODE_BASE       "doc.file.code.base"
 #define DOC_PROP_COVER_FILE      "doc.cover.file"
-#define DOC_PROP_IDENTIFIERS     "doc.identifiers"
 
 #define DEF_SPACE_WIDTH_SCALE_PERCENT 100
 #define DEF_MIN_SPACE_CONDENSING_PERCENT 50

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1397,7 +1397,7 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             lString32 scheme = item->getAttributeValue(U"scheme");
             lString32 identifier;
             // In version 3, scheme is not set but the type is rather included in the text itself
-            if(scheme.empty_str == scheme) {
+            if(scheme.empty()) {
                 identifier = item->getText().trim().lowercase();
             }else {
                 // In version 2, the scheme is only found as attribute

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1396,15 +1396,17 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 continue;
             lString32 scheme = item->getAttributeValue(U"scheme");
             lString32 identifier;
+
             // In version 3, scheme is not set but the type is rather included in the text itself
-            if(scheme.empty()) {
-                identifier = item->getText().trim().lowercase();
-            }else {
+            if (scheme.empty()) {
+                identifier = item->getText().trim();
+            }
+            else {
                 // In version 2, the scheme is only found as attribute
-                identifier << scheme << ":" << item->getText().trim().lowercase();
+                identifier << scheme << ":" << item->getText().trim();
             }
             if (identifiers_set) {
-                identifiers << ";" << identifier;
+                identifiers << "\n" << identifier;
             }
             else {
                 identifiers << identifier;

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1384,6 +1384,35 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
         m_doc_props->setString(DOC_PROP_KEYWORDS, subjects);
         CRLog::info("Authors: %s Title: %s", LCSTR(authors), LCSTR(title));
 
+        // Return possibly multiple <dc:identifier> (identifiers)
+        // as a single doc_props string with values in a key-value format (scheme:identifier) separated by ;
+        bool identifiers_set = false;
+        lString32 identifiers;
+        // Iterate all package/metadata/identifier
+        lUInt16 identifier_id = doc->getElementNameIndex(U"identifier");
+        for (size_t i=0; i<nb_metadata_items; i++) {
+            ldomNode * item = metadata->getChildNode(i);
+            if ( item->getNodeId() != identifier_id )
+                continue;
+            lString32 scheme = item->getAttributeValue(U"scheme");
+            lString32 identifier;
+            // In version 3, scheme is not set but the type is rather included in the text itself
+            if(scheme.empty_str == scheme) {
+                identifier = item->getText().trim().lowercase();
+            }else {
+                // In version 2, the scheme is only found as attribute
+                identifier << scheme << ":" << item->getText().trim().lowercase();
+            }
+            if (identifiers_set) {
+                identifiers << ";" << identifier;
+            }
+            else {
+                identifiers << identifier;
+                identifiers_set = true;
+            }
+        }
+        m_doc_props->setString(DOC_PROP_IDENTIFIERS, identifiers);
+
         bool hasSeriesMeta = false;
         bool hasSeriesIdMeta = false;
         // Iterate all package/metadata/meta

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1396,7 +1396,6 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
                 continue;
             lString32 scheme = item->getAttributeValue(U"scheme");
             lString32 identifier;
-
             // In version 3, scheme is not set but the type is rather included in the text itself
             if (scheme.empty()) {
                 identifier = item->getText().trim();


### PR DESCRIPTION
I wanted to write a plugin to automatically sync my progress from KOReader to hardcover.app and need the ISBN of the book for that to ensure proper matching.  

This will add the identifiers as `doc_prop` in the format of `scheme:identifier` separated by `;` e.g. `isbn:9783462312317;asin:b0ckwvvv4z`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/560)
<!-- Reviewable:end -->
