### PR TITLE
Allow hyphens after Russian "не" prefix

### DIFF
--- a/cr3gui/data/hyph/Russian.pattern
+++ b/cr3gui/data/hyph/Russian.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не8</pattern>
+<pattern> не1</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>

--- a/cr3gui/data/hyph/Russian_EnGB.pattern
+++ b/cr3gui/data/hyph/Russian_EnGB.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не8</pattern>
+<pattern> не1</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>

--- a/cr3gui/data/hyph/Russian_EnUS.pattern
+++ b/cr3gui/data/hyph/Russian_EnUS.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не8</pattern>
+<pattern> не1</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>


### PR DESCRIPTION
I'm not sure why it was prohibited before. Looking at [the modern Russian hyphenation rules](https://gramota.ru/biblioteka/spravochniki/pravila-russkoj-orfografii-i-punktuacii/pravila-perenosov), it's perfectly allowed, even recommended to add hyphens after prefixes.

I've tested on my device, and it looks better with this change. You can see how the word spacing has improved:

| Before | After |
|--------|--------|
| <img src="https://github.com/koreader/crengine/assets/483357/520dc84c-2af7-4711-a56a-0f6784c9e8a2" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/2fe310db-d7d7-4762-9759-9cf35c66caf1" width="400"> |
| <img src="https://github.com/koreader/crengine/assets/483357/78edece2-c3a3-4564-8457-76c27d0bb1df" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/5163917f-4a6e-4efd-913e-f6a56b9848f1" width="400"> |
| | Bonus image! <img src="https://github.com/koreader/crengine/assets/483357/28b52abc-59b5-4435-a7ec-2e6833b1222b" width="400"> |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/561)
<!-- Reviewable:end -->
