### PR TITLE
Fix CSS so the large images in FB2 files don't overflow to second page

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -10,7 +10,7 @@ a { display: inline; text-decoration: underline; }
 a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 a[type="note"]::before { content: "\2060" } /* word joiner, avoid break before */
 
-image { text-align: center; text-indent: 0; display: block }
+image { text-align: center; text-indent: 0; display: block; max-height: 99vh; }
 p image { display: inline }
 li image { display: inline }
 
@@ -64,7 +64,7 @@ h5 { font-size: 110% }
 title, h1, h2 {
 	page-break-before: always;
 	page-break-inside: avoid;
-	page-break-after: avoid;
+	page-break-after: auto;
 }
 ol title, ul title {
 	page-break-before: auto;


### PR DESCRIPTION
This PR fixes 2 issues.

1. First one when the image is downsized correctly but keeps attached to the header due to `page-break-after: avoid`. I'm not sure why this attribute was set originally — I traveled through Git history 16 years back and [it was still there](https://github.com/koreader/crengine/commit/fb6e1596f906072b3e40befa27ea5618ccdf11e8#diff-cdb89964e4e4ec826941dfa84f8d1d74fb887222cb8f1b702160ae646306ce73).

| Rendering with `page-break-after: avoid` | Rendering with `page-break-after: auto` |
|--------|--------|
| <img src="https://github.com/koreader/crengine/assets/483357/5feb0f76-be78-42df-b6d6-83d0e0534a3d" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/d5f75424-eb32-487e-ad8b-ca760ce6b968" width="400"> | 
| <img src="https://github.com/koreader/crengine/assets/483357/a89eea4e-13d7-43e5-bc9a-58ec33701e2b" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/51b129b6-5668-4f6e-97b3-01f0181f625c" width="400"> | 

2. The first fix doesn't help when there's no header before the image (or maybe the image was too large, I'm not sure). In this case, setting `max-height: 99vh` did the trick. When I tried setting `max-height: 100vh`, it had no effect.

| Before | After |
|--------|--------|
| <img src="https://github.com/koreader/crengine/assets/483357/a21563c5-1df3-497d-8857-8fbacdda7cb4" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/af75c66e-b17f-4e53-98e7-ec577b47dcf4" width="400"> |
| <img src="https://github.com/koreader/crengine/assets/483357/99a38c09-6b13-4c53-99ec-401dc0c4a0b0" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/f7034209-8eaf-44c2-84f8-b2c039a627ed" width="400"> | 

Fixes https://github.com/koreader/koreader/issues/9292.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/562)
<!-- Reviewable:end -->
