### PR TITLE
Fix FB2 image sizing & centering, and bottom border on empty block elements

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -10,7 +10,7 @@ a { display: inline; text-decoration: underline; }
 a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 a[type="note"]::before { content: "\2060" } /* word joiner, avoid break before */
 
-image { text-align: center; text-indent: 0; display: block }
+image { text-indent: 0; display: block; margin: 0 auto; }
 p image { display: inline }
 li image { display: inline }
 

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -2068,14 +2068,15 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 
     if ( fontList.length() != fontList_nb_before_head_parsing ) {
         // New fonts met when parsing <head><style> of some DocFragments
+        // Drop styles (before unregistering fonts, as they may reference them)
+        m_doc->forceReinitStyles();
+            // todo: we could avoid forceReinitStyles() when embedded fonts are disabled
+            // (but being here is quite rare - and having embedded font disabled even more)
         m_doc->unregisterEmbeddedFonts();
         // set document font list, and register fonts
         m_doc->getEmbeddedFontList().set(fontList);
         m_doc->registerEmbeddedFonts();
         printf("CRE: document loaded, but styles re-init needed (cause: embedded fonts)\n");
-        m_doc->forceReinitStyles();
-        // todo: we could avoid forceReinitStyles() when embedded fonts are disabled
-        // (but being here is quite rare - and having embedded font disabled even more)
     }
 
     // fragmentCount is not fool proof, best to check if we really made

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -95,7 +95,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.74k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0032
+#define FORMATTING_VERSION_ID 0x0033
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
#### EPUB: avoid crash when `@font-face` in `<head><style>`

Assertions in `LVFontCache::_removeDocumentFonts()` would fail (when DEBUG enabled).
Noticed and investigated at https://github.com/koreader/crengine/pull/536#issuecomment-2002142872.

#### FB2: fix block images sizing and centering

Followup to 1544bcfb, where we made an image self container's width adjust to the image width, so `text-align:center` no longer does what was expected.  Switch to `margin-left/right:auto` to get them centered again. See https://github.com/koreader/koreader/issues/11623#issuecomment-2040436412.
Also, for standalone block images, set the strut and line-height to 0 (as we do for HTML) so they their block is adjusted to the page height when the image itself exceeds it, to avoid such images to be truncated and sliced on two pages. Noticed and investigated in https://github.com/koreader/crengine/pull/562.
Should allow closing https://github.com/koreader/koreader/issues/11623.

#### lvrend: fix positionning of bottom border on empty block elements

Fix some possible issues with empty block elements having some bottom border (included in padding_bottom) when previous vertical margins are collapsing.
(Not 100% certain this is the right fix that won't cause side effects...)
Should allow closing https://github.com/koreader/koreader/issues/11594.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/563)
<!-- Reviewable:end -->
