### PR TITLE
Remove too generic hyphenation rule for Russian "э" vowel

### DIFF
--- a/cr3gui/data/hyph/Russian.pattern
+++ b/cr3gui/data/hyph/Russian.pattern
@@ -4269,7 +4269,6 @@
 <pattern>ь2я</pattern>
 <pattern>ья1в</pattern>
 <pattern>ь3ягс</pattern>
-<pattern>1э</pattern>
 <pattern>э1в</pattern>
 <pattern>эв1р</pattern>
 <pattern>2эг</pattern>

--- a/cr3gui/data/hyph/Russian_EnGB.pattern
+++ b/cr3gui/data/hyph/Russian_EnGB.pattern
@@ -4269,7 +4269,6 @@
 <pattern>ь2я</pattern>
 <pattern>ья1в</pattern>
 <pattern>ь3ягс</pattern>
-<pattern>1э</pattern>
 <pattern>э1в</pattern>
 <pattern>эв1р</pattern>
 <pattern>2эг</pattern>

--- a/cr3gui/data/hyph/Russian_EnUS.pattern
+++ b/cr3gui/data/hyph/Russian_EnUS.pattern
@@ -4269,7 +4269,6 @@
 <pattern>ь2я</pattern>
 <pattern>ья1в</pattern>
 <pattern>ь3ягс</pattern>
-<pattern>1э</pattern>
 <pattern>э1в</pattern>
 <pattern>эв1р</pattern>
 <pattern>2эг</pattern>


### PR DESCRIPTION
With this rule the engine makes hyphenations in unexpected places:

| With the rule | Without it |
|--------|--------|
| <img src="https://github.com/koreader/crengine/assets/483357/04f38375-d264-4045-b5ae-d8218f0ebb1a" width="400"> | |
| <img src="https://github.com/koreader/crengine/assets/483357/91796935-84e0-434f-b417-3dc0647c7726" width="400"> | <img src="https://github.com/koreader/crengine/assets/483357/3da837c1-809d-4913-92e6-ded113460a8a" width="400"> |

It also makes hyphens in the words like this: "фл-эшка" ("fl-ash drive"), "Бл-эк" ("Bl-ack"), "Гр-эй" ("Gr-ay").

@hius07, can you please take a look or recommend another reviewer?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/564)
<!-- Reviewable:end -->
