### PR TITLE
Fix ruby alignment, fix one possible crash, ignore empty non-linear flows

### DIFF
--- a/cr3gui/data/html5.css
+++ b/cr3gui/data/html5.css
@@ -243,6 +243,7 @@ sup {
 ruby {
   display: ruby;
   text-align: center;
+  text-align-last: initial;
   text-indent: 0;
 }
 rb, rubyBox[T=rb] {

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -367,6 +367,8 @@ private:
     ldomXPointer m_cursorPos;
 
     lString32 m_pageHeaderOverride;
+    /// custom page info (curpage / nbpages %) can be set by frontend
+    lString32 m_pageInfoOverride;
 
     int m_drawBufferBits;
 
@@ -422,6 +424,8 @@ public:
     void setDrawBufferBits( int bits ) { m_drawBufferBits = bits; }
     /// substitute page header with custom text (e.g. to be used while loading)
     void setPageHeaderOverride( lString32 s );
+    /// substitute page info (curpage / nbpages %) with custom text
+    void setPageInfoOverride( lString32 s );
     /// get screen rectangle for current cursor position, returns false if not visible
     bool getCursorRect( lvRect & rc, bool scrollToCursor = false )
     {

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -236,7 +236,7 @@ class LVRendPageList : public LVPtrVector<LVRendPageInfo>
 public:
     LVRendPageList() : has_nonlinear_flows(false) {}
     int FindNearestPage( int y, int direction );
-    void setHasNonLinearFlows() { has_nonlinear_flows=true; }
+    void setHasNonLinearFlows( bool hasnonlinearflows ) { has_nonlinear_flows = hasnonlinearflows; }
     bool hasNonLinearFlows() { return has_nonlinear_flows; }
     bool serialize( SerialBuf & buf );
     bool deserialize( SerialBuf & buf );
@@ -412,6 +412,8 @@ class LVRendPageContext
     int current_flow;
     // maximum flow encountered so far
     int max_flow;
+    // to know if current flow got some lines
+    bool current_flow_empty;
 
     LVHashTable<lString32, LVFootNoteRef> footNotes;
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1721,6 +1721,12 @@ void LVDocView::setPageHeaderOverride(lString32 s) {
 	clearImageCache();
 }
 
+/// substitute page info (curpage / nbpages %) with custom text
+void LVDocView::setPageInfoOverride(lString32 s) {
+	m_pageInfoOverride = s;
+	clearImageCache();
+}
+
 /// draw page header to buffer
 void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 		int pageIndex, int phi, int pageCount) {
@@ -1872,7 +1878,10 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 			}
 		}
 		lString32 pageinfo;
-		if (pageCount > 0) {
+		if (!m_pageInfoOverride.empty()) {
+			pageinfo = m_pageInfoOverride;
+		}
+		else if (pageCount > 0) {
 			if (phi & PGHDR_PAGE_NUMBER)
                 pageinfo += fmt::decimal( getExternalPageNumber(pageIndex) + 1 );
             if (phi & PGHDR_PAGE_COUNT) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -11565,10 +11565,12 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 lastSpaceWidth = 0;
                 int _maxw = 0;
                 int _minw = 0;
-                if ( is_img && img_width > 0) {
-                    // Inline img with a fixed width
-                    _maxw = img_width;
-                    _minw = img_width;
+                if ( is_img ) {
+                    if ( img_width > 0) {
+                        // Inline img with a fixed width
+                        _maxw = img_width;
+                        _minw = img_width;
+                    }
                 }
                 else {
                     // Get the rendered width of the inlineBox


### PR DESCRIPTION
#### html5.css: really ensure ruby centering

Should allow closing https://github.com/koreader/koreader/issues/11771.

#### getRenderedWidths(): fix possible crash with 0-width images

Coding error: images with width=0 in tables/floats would cause an infinite loop and a stack overflow.
Should allow closing https://github.com/koreader/koreader/issues/11680

#### Page splitting: ignore empty non-linear flows

If a non-linear flow was created, but we never got any "line" associated to it, just ignore it and reset the counter.
(Otherwise, frontend would get holes/nil in the array of flows, and would get confused.)
Fix issue noticed at https://github.com/koreader/koreader/issues/8623#issuecomment-2068168592.

#### LvDocView header: allow overriding "page/total %"

So frontend can build this bit of text and propagate it to crengine for it to display in place of its own computed text.
Will allow KOReader (via ReaderCoptListener) to display something similar to what it displays in the footer (which is different from crengine's own text when using hidden flow or reference page numbers).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/565)
<!-- Reviewable:end -->
