### PR TITLE
Combine hyphenation patterns for Serbian Cyrillic and Latin scripts

### DIFF
--- a/cr3gui/data/hyph/Serbian.pattern
+++ b/cr3gui/data/hyph/Serbian.pattern
@@ -1,3500 +1,6779 @@
 <?xml version="1.0" encoding="utf8"?>
 <!--
-  Taken and converted from:
-
-  https://github.com/hyphenation/tex-hyphen/blob/master/hyph-utf8/tex/generic/hyph-utf8/patterns/tex/hyph-sr-cyrl.tex
+20240529
+taken, combined and converted from https://devbase.net/dict-sr/hyphen-sr-20100818.zip
+See https://devbase.net/dict-sr/
 -->
 <HyphenationDescription>
-  <pattern>т2ј</pattern>
-  <pattern>т2л</pattern>
-  <pattern>т2љ</pattern>
-  <pattern>т2р</pattern>
-  <pattern>т2в</pattern>
-  <pattern>д2ј</pattern>
-  <pattern>д2л</pattern>
-  <pattern>д2љ</pattern>
-  <pattern>д2р</pattern>
-  <pattern>д2в</pattern>
-  <pattern>г2ј</pattern>
-  <pattern>г2л</pattern>
-  <pattern>г2љ</pattern>
-  <pattern>г2р</pattern>
-  <pattern>г2в</pattern>
-  <pattern>х2ј</pattern>
-  <pattern>х2л</pattern>
-  <pattern>х2љ</pattern>
-  <pattern>х2р</pattern>
-  <pattern>х2в</pattern>
-  <pattern>к2ј</pattern>
-  <pattern>к2л</pattern>
-  <pattern>к2љ</pattern>
-  <pattern>к2р</pattern>
-  <pattern>к2в</pattern>
-  <pattern>2д1ж</pattern>
-  <pattern>2д1б</pattern>
-  <pattern>2д1ц</pattern>
-  <pattern>2д1д</pattern>
-  <pattern>2д1ф</pattern>
-  <pattern>2д1г</pattern>
-  <pattern>2д1х</pattern>
-  <pattern>2д1к</pattern>
-  <pattern>2д1м</pattern>
-  <pattern>2д1н</pattern>
-  <pattern>2д1п</pattern>
-  <pattern>2д1с</pattern>
-  <pattern>2д1т</pattern>
-  <pattern>2д1њ</pattern>
-  <pattern>2д1џ</pattern>
-  <pattern>2д1з</pattern>
-  <pattern>2д1ш</pattern>
-  <pattern>2д1ђ</pattern>
-  <pattern>2д1ћ</pattern>
-  <pattern>2д1ч</pattern>
-  <pattern>2г1ж</pattern>
-  <pattern>2г1б</pattern>
-  <pattern>2г1ц</pattern>
-  <pattern>2г1д</pattern>
-  <pattern>2г1ф</pattern>
-  <pattern>2г1г</pattern>
-  <pattern>2г1х</pattern>
-  <pattern>2г1к</pattern>
-  <pattern>2г1м</pattern>
-  <pattern>2г1н</pattern>
-  <pattern>2г1п</pattern>
-  <pattern>2г1с</pattern>
-  <pattern>2г1т</pattern>
-  <pattern>2г1њ</pattern>
-  <pattern>2г1џ</pattern>
-  <pattern>2г1з</pattern>
-  <pattern>2г1ш</pattern>
-  <pattern>2г1ђ</pattern>
-  <pattern>2г1ћ</pattern>
-  <pattern>2г1ч</pattern>
-  <pattern>2х1ж</pattern>
-  <pattern>2х1б</pattern>
-  <pattern>2х1ц</pattern>
-  <pattern>2х1д</pattern>
-  <pattern>2х1ф</pattern>
-  <pattern>2х1г</pattern>
-  <pattern>2х1х</pattern>
-  <pattern>2х1к</pattern>
-  <pattern>2х1м</pattern>
-  <pattern>2х1н</pattern>
-  <pattern>2х1п</pattern>
-  <pattern>2х1с</pattern>
-  <pattern>2х1т</pattern>
-  <pattern>2х1њ</pattern>
-  <pattern>2х1џ</pattern>
-  <pattern>2х1з</pattern>
-  <pattern>2х1ш</pattern>
-  <pattern>2х1ђ</pattern>
-  <pattern>2х1ћ</pattern>
-  <pattern>2х1ч</pattern>
-  <pattern>2к1ж</pattern>
-  <pattern>2к1б</pattern>
-  <pattern>2к1ц</pattern>
-  <pattern>2к1д</pattern>
-  <pattern>2к1ф</pattern>
-  <pattern>2к1г</pattern>
-  <pattern>2к1х</pattern>
-  <pattern>2к1к</pattern>
-  <pattern>2к1м</pattern>
-  <pattern>2к1н</pattern>
-  <pattern>2к1п</pattern>
-  <pattern>2к1с</pattern>
-  <pattern>2к1т</pattern>
-  <pattern>2к1њ</pattern>
-  <pattern>2к1џ</pattern>
-  <pattern>2к1з</pattern>
-  <pattern>2к1ш</pattern>
-  <pattern>2к1ђ</pattern>
-  <pattern>2к1ћ</pattern>
-  <pattern>2к1ч</pattern>
-  <pattern>2т1ж</pattern>
-  <pattern>2т1б</pattern>
-  <pattern>2т1ц</pattern>
-  <pattern>2т1д</pattern>
-  <pattern>2т1ф</pattern>
-  <pattern>2т1г</pattern>
-  <pattern>2т1х</pattern>
-  <pattern>2т1к</pattern>
-  <pattern>2т1м</pattern>
-  <pattern>2т1н</pattern>
-  <pattern>2т1п</pattern>
-  <pattern>2т1с</pattern>
-  <pattern>2т1т</pattern>
-  <pattern>2т1њ</pattern>
-  <pattern>2т1џ</pattern>
-  <pattern>2т1з</pattern>
-  <pattern>2т1ш</pattern>
-  <pattern>2т1ђ</pattern>
-  <pattern>2т1ћ</pattern>
-  <pattern>2т1ч</pattern>
-  <pattern>2дј </pattern>
-  <pattern>2дл </pattern>
-  <pattern>2дљ </pattern>
-  <pattern>2др </pattern>
-  <pattern>2дв </pattern>
-  <pattern>2гј </pattern>
-  <pattern>2гл </pattern>
-  <pattern>2гљ </pattern>
-  <pattern>2гр </pattern>
-  <pattern>2гв </pattern>
-  <pattern>2хј </pattern>
-  <pattern>2хл </pattern>
-  <pattern>2хљ </pattern>
-  <pattern>2хр </pattern>
-  <pattern>2хв </pattern>
-  <pattern>2кј </pattern>
-  <pattern>2кл </pattern>
-  <pattern>2кљ </pattern>
-  <pattern>2кр </pattern>
-  <pattern>2кв </pattern>
-  <pattern>2тј </pattern>
-  <pattern>2тл </pattern>
-  <pattern>2тљ </pattern>
-  <pattern>2тр </pattern>
-  <pattern>2тв </pattern>
-  <pattern>п2ј</pattern>
-  <pattern>п2л</pattern>
-  <pattern>п2љ</pattern>
-  <pattern>п2р</pattern>
-  <pattern>в2ј</pattern>
-  <pattern>в2л</pattern>
-  <pattern>в2љ</pattern>
-  <pattern>в2р</pattern>
-  <pattern>б2ј</pattern>
-  <pattern>б2л</pattern>
-  <pattern>б2љ</pattern>
-  <pattern>б2р</pattern>
-  <pattern>ф2ј</pattern>
-  <pattern>ф2л</pattern>
-  <pattern>ф2љ</pattern>
-  <pattern>ф2р</pattern>
-  <pattern>м2ј</pattern>
-  <pattern>м2л</pattern>
-  <pattern>м2љ</pattern>
-  <pattern>м2р</pattern>
-  <pattern>2б1ж</pattern>
-  <pattern>2б1б</pattern>
-  <pattern>2б1ц</pattern>
-  <pattern>2б1д</pattern>
-  <pattern>2б1ф</pattern>
-  <pattern>2б1г</pattern>
-  <pattern>2б1х</pattern>
-  <pattern>2б1к</pattern>
-  <pattern>2б1м</pattern>
-  <pattern>2б1н</pattern>
-  <pattern>2б1п</pattern>
-  <pattern>2б1с</pattern>
-  <pattern>2б1т</pattern>
-  <pattern>2б1в</pattern>
-  <pattern>2б1њ</pattern>
-  <pattern>2б1џ</pattern>
-  <pattern>2б1з</pattern>
-  <pattern>2б1ш</pattern>
-  <pattern>2б1ђ</pattern>
-  <pattern>2б1ћ</pattern>
-  <pattern>2б1ч</pattern>
-  <pattern>2ф1ж</pattern>
-  <pattern>2ф1б</pattern>
-  <pattern>2ф1ц</pattern>
-  <pattern>2ф1д</pattern>
-  <pattern>2ф1ф</pattern>
-  <pattern>2ф1г</pattern>
-  <pattern>2ф1х</pattern>
-  <pattern>2ф1к</pattern>
-  <pattern>2ф1м</pattern>
-  <pattern>2ф1н</pattern>
-  <pattern>2ф1п</pattern>
-  <pattern>2ф1с</pattern>
-  <pattern>2ф1т</pattern>
-  <pattern>2ф1в</pattern>
-  <pattern>2ф1њ</pattern>
-  <pattern>2ф1џ</pattern>
-  <pattern>2ф1з</pattern>
-  <pattern>2ф1ш</pattern>
-  <pattern>2ф1ђ</pattern>
-  <pattern>2ф1ћ</pattern>
-  <pattern>2ф1ч</pattern>
-  <pattern>2м1ж</pattern>
-  <pattern>2м1б</pattern>
-  <pattern>2м1ц</pattern>
-  <pattern>2м1д</pattern>
-  <pattern>2м1ф</pattern>
-  <pattern>2м1г</pattern>
-  <pattern>2м1х</pattern>
-  <pattern>2м1к</pattern>
-  <pattern>2м1м</pattern>
-  <pattern>2м1н</pattern>
-  <pattern>2м1п</pattern>
-  <pattern>2м1с</pattern>
-  <pattern>2м1т</pattern>
-  <pattern>2м1в</pattern>
-  <pattern>2м1њ</pattern>
-  <pattern>2м1џ</pattern>
-  <pattern>2м1з</pattern>
-  <pattern>2м1ш</pattern>
-  <pattern>2м1ђ</pattern>
-  <pattern>2м1ћ</pattern>
-  <pattern>2м1ч</pattern>
-  <pattern>2п1ж</pattern>
-  <pattern>2п1б</pattern>
-  <pattern>2п1ц</pattern>
-  <pattern>2п1д</pattern>
-  <pattern>2п1ф</pattern>
-  <pattern>2п1г</pattern>
-  <pattern>2п1х</pattern>
-  <pattern>2п1к</pattern>
-  <pattern>2п1м</pattern>
-  <pattern>2п1н</pattern>
-  <pattern>2п1п</pattern>
-  <pattern>2п1с</pattern>
-  <pattern>2п1т</pattern>
-  <pattern>2п1в</pattern>
-  <pattern>2п1њ</pattern>
-  <pattern>2п1џ</pattern>
-  <pattern>2п1з</pattern>
-  <pattern>2п1ш</pattern>
-  <pattern>2п1ђ</pattern>
-  <pattern>2п1ћ</pattern>
-  <pattern>2п1ч</pattern>
-  <pattern>2в1ж</pattern>
-  <pattern>2в1б</pattern>
-  <pattern>2в1ц</pattern>
-  <pattern>2в1д</pattern>
-  <pattern>2в1ф</pattern>
-  <pattern>2в1г</pattern>
-  <pattern>2в1х</pattern>
-  <pattern>2в1к</pattern>
-  <pattern>2в1м</pattern>
-  <pattern>2в1н</pattern>
-  <pattern>2в1п</pattern>
-  <pattern>2в1с</pattern>
-  <pattern>2в1т</pattern>
-  <pattern>2в1в</pattern>
-  <pattern>2в1њ</pattern>
-  <pattern>2в1џ</pattern>
-  <pattern>2в1з</pattern>
-  <pattern>2в1ш</pattern>
-  <pattern>2в1ђ</pattern>
-  <pattern>2в1ћ</pattern>
-  <pattern>2в1ч</pattern>
-  <pattern>2бј </pattern>
-  <pattern>2бл </pattern>
-  <pattern>2бљ </pattern>
-  <pattern>2бр </pattern>
-  <pattern>2фј </pattern>
-  <pattern>2фл </pattern>
-  <pattern>2фљ </pattern>
-  <pattern>2фр </pattern>
-  <pattern>2мј </pattern>
-  <pattern>2мл </pattern>
-  <pattern>2мљ </pattern>
-  <pattern>2мр </pattern>
-  <pattern>2пј </pattern>
-  <pattern>2пл </pattern>
-  <pattern>2пљ </pattern>
-  <pattern>2пр </pattern>
-  <pattern>2вј </pattern>
-  <pattern>2вл </pattern>
-  <pattern>2вљ </pattern>
-  <pattern>2вр </pattern>
-  <pattern>с2ц</pattern>
-  <pattern>с2ј</pattern>
-  <pattern>с2к</pattern>
-  <pattern>с2л</pattern>
-  <pattern>с2м</pattern>
-  <pattern>с2н</pattern>
-  <pattern>с2п</pattern>
-  <pattern>с2љ</pattern>
-  <pattern>с2р</pattern>
-  <pattern>с2т</pattern>
-  <pattern>с2в</pattern>
-  <pattern>с2њ</pattern>
-  <pattern>2с1ж</pattern>
-  <pattern>2с1б</pattern>
-  <pattern>2с1д</pattern>
-  <pattern>2с1ф</pattern>
-  <pattern>2с1г</pattern>
-  <pattern>2с1х</pattern>
-  <pattern>2с1с</pattern>
-  <pattern>2с1џ</pattern>
-  <pattern>2с1з</pattern>
-  <pattern>2с1ш</pattern>
-  <pattern>2с1ђ</pattern>
-  <pattern>2с1ћ</pattern>
-  <pattern>2с1ч</pattern>
-  <pattern>2сј </pattern>
-  <pattern>2ск </pattern>
-  <pattern>2сл </pattern>
-  <pattern>2см </pattern>
-  <pattern>2сн </pattern>
-  <pattern>2сп </pattern>
-  <pattern>2сљ </pattern>
-  <pattern>2ср </pattern>
-  <pattern>2ст </pattern>
-  <pattern>2св </pattern>
-  <pattern>2сњ </pattern>
-  <pattern>2сц </pattern>
-  <pattern>з2б</pattern>
-  <pattern>з2д</pattern>
-  <pattern>з2г</pattern>
-  <pattern>з2ј</pattern>
-  <pattern>з2л</pattern>
-  <pattern>з2м</pattern>
-  <pattern>з2н</pattern>
-  <pattern>з2љ</pattern>
-  <pattern>з2р</pattern>
-  <pattern>з2в</pattern>
-  <pattern>з2њ</pattern>
-  <pattern>2з1ж</pattern>
-  <pattern>2з1ц</pattern>
-  <pattern>2з1ф</pattern>
-  <pattern>2з1х</pattern>
-  <pattern>2з1к</pattern>
-  <pattern>2з1п</pattern>
-  <pattern>2з1с</pattern>
-  <pattern>2з1т</pattern>
-  <pattern>2з1џ</pattern>
-  <pattern>2з1з</pattern>
-  <pattern>2з1ш</pattern>
-  <pattern>2з1ђ</pattern>
-  <pattern>2з1ћ</pattern>
-  <pattern>2з1ч</pattern>
-  <pattern>2зј </pattern>
-  <pattern>2зл </pattern>
-  <pattern>2зм </pattern>
-  <pattern>2зн </pattern>
-  <pattern>2зљ </pattern>
-  <pattern>2зр </pattern>
-  <pattern>2зв </pattern>
-  <pattern>2зњ </pattern>
-  <pattern>2зб </pattern>
-  <pattern>2зд </pattern>
-  <pattern>2зг </pattern>
-  <pattern>ш2ц</pattern>
-  <pattern>ш2к</pattern>
-  <pattern>ш2л</pattern>
-  <pattern>ш2м</pattern>
-  <pattern>ш2н</pattern>
-  <pattern>ш2п</pattern>
-  <pattern>ш2љ</pattern>
-  <pattern>ш2т</pattern>
-  <pattern>ш2в</pattern>
-  <pattern>ш2њ</pattern>
-  <pattern>ш2ћ</pattern>
-  <pattern>ш2ч</pattern>
-  <pattern>2ш1ж</pattern>
-  <pattern>2ш1б</pattern>
-  <pattern>2ш1д</pattern>
-  <pattern>2ш1ф</pattern>
-  <pattern>2ш1г</pattern>
-  <pattern>2ш1х</pattern>
-  <pattern>2ш1с</pattern>
-  <pattern>2ш1џ</pattern>
-  <pattern>2ш1з</pattern>
-  <pattern>2ш1ш</pattern>
-  <pattern>2ш1ђ</pattern>
-  <pattern>2ш1ј</pattern>
-  <pattern>2ш1р</pattern>
-  <pattern>2шк </pattern>
-  <pattern>2шл </pattern>
-  <pattern>2шм </pattern>
-  <pattern>2шн </pattern>
-  <pattern>2шп </pattern>
-  <pattern>2шљ </pattern>
-  <pattern>2шт </pattern>
-  <pattern>2шв </pattern>
-  <pattern>2шњ </pattern>
-  <pattern>2шћ </pattern>
-  <pattern>2шч </pattern>
-  <pattern>2шц </pattern>
-  <pattern>ж2б</pattern>
-  <pattern>ж2д</pattern>
-  <pattern>ж2г</pattern>
-  <pattern>ж2л</pattern>
-  <pattern>ж2м</pattern>
-  <pattern>ж2н</pattern>
-  <pattern>ж2љ</pattern>
-  <pattern>ж2в</pattern>
-  <pattern>ж2њ</pattern>
-  <pattern>ж2ђ</pattern>
-  <pattern>2ж1ж</pattern>
-  <pattern>2ж1ц</pattern>
-  <pattern>2ж1ф</pattern>
-  <pattern>2ж1х</pattern>
-  <pattern>2ж1к</pattern>
-  <pattern>2ж1п</pattern>
-  <pattern>2ж1с</pattern>
-  <pattern>2ж1т</pattern>
-  <pattern>2ж1џ</pattern>
-  <pattern>2ж1з</pattern>
-  <pattern>2ж1ш</pattern>
-  <pattern>2ж1ћ</pattern>
-  <pattern>2ж1ч</pattern>
-  <pattern>2ж1ј</pattern>
-  <pattern>2ж1р</pattern>
-  <pattern>2жл </pattern>
-  <pattern>2жм </pattern>
-  <pattern>2жн </pattern>
-  <pattern>2жљ </pattern>
-  <pattern>2жв </pattern>
-  <pattern>2жњ </pattern>
-  <pattern>2жђ </pattern>
-  <pattern>2жб </pattern>
-  <pattern>2жд </pattern>
-  <pattern>2жг </pattern>
-  <pattern>ц2ј</pattern>
-  <pattern>ц2р</pattern>
-  <pattern>ц2в</pattern>
-  <pattern>2ц1ж</pattern>
-  <pattern>2ц1б</pattern>
-  <pattern>2ц1ц</pattern>
-  <pattern>2ц1д</pattern>
-  <pattern>2ц1ф</pattern>
-  <pattern>2ц1г</pattern>
-  <pattern>2ц1х</pattern>
-  <pattern>2ц1к</pattern>
-  <pattern>2ц1л</pattern>
-  <pattern>2ц1м</pattern>
-  <pattern>2ц1н</pattern>
-  <pattern>2ц1п</pattern>
-  <pattern>2ц1љ</pattern>
-  <pattern>2ц1с</pattern>
-  <pattern>2ц1т</pattern>
-  <pattern>2ц1њ</pattern>
-  <pattern>2ц1џ</pattern>
-  <pattern>2ц1з</pattern>
-  <pattern>2ц1ш</pattern>
-  <pattern>2ц1ђ</pattern>
-  <pattern>2ц1ћ</pattern>
-  <pattern>2ц1ч</pattern>
-  <pattern>2цј </pattern>
-  <pattern>2цр </pattern>
-  <pattern>2цв </pattern>
-  <pattern>ч2в</pattern>
-  <pattern>2ч1ж</pattern>
-  <pattern>2ч1б</pattern>
-  <pattern>2ч1ц</pattern>
-  <pattern>2ч1д</pattern>
-  <pattern>2ч1ф</pattern>
-  <pattern>2ч1г</pattern>
-  <pattern>2ч1х</pattern>
-  <pattern>2ч1ј</pattern>
-  <pattern>2ч1к</pattern>
-  <pattern>2ч1л</pattern>
-  <pattern>2ч1м</pattern>
-  <pattern>2ч1н</pattern>
-  <pattern>2ч1п</pattern>
-  <pattern>2ч1љ</pattern>
-  <pattern>2ч1р</pattern>
-  <pattern>2ч1с</pattern>
-  <pattern>2ч1т</pattern>
-  <pattern>2ч1њ</pattern>
-  <pattern>2ч1џ</pattern>
-  <pattern>2ч1з</pattern>
-  <pattern>2ч1ш</pattern>
-  <pattern>2ч1ђ</pattern>
-  <pattern>2ч1ћ</pattern>
-  <pattern>2ч1ч</pattern>
-  <pattern>2чв </pattern>
-  <pattern>2ј1ж</pattern>
-  <pattern>2ј1б</pattern>
-  <pattern>2ј1ц</pattern>
-  <pattern>2ј1д</pattern>
-  <pattern>2ј1ф</pattern>
-  <pattern>2ј1г</pattern>
-  <pattern>2ј1х</pattern>
-  <pattern>2ј1ј</pattern>
-  <pattern>2ј1к</pattern>
-  <pattern>2ј1л</pattern>
-  <pattern>2ј1м</pattern>
-  <pattern>2ј1н</pattern>
-  <pattern>2ј1п</pattern>
-  <pattern>2ј1љ</pattern>
-  <pattern>2ј1р</pattern>
-  <pattern>2ј1с</pattern>
-  <pattern>2ј1т</pattern>
-  <pattern>2ј1в</pattern>
-  <pattern>2ј1њ</pattern>
-  <pattern>2ј1џ</pattern>
-  <pattern>2ј1з</pattern>
-  <pattern>2ј1ш</pattern>
-  <pattern>2ј1ђ</pattern>
-  <pattern>2ј1ћ</pattern>
-  <pattern>2ј1ч</pattern>
-  <pattern>2л1ж</pattern>
-  <pattern>2л1б</pattern>
-  <pattern>2л1ц</pattern>
-  <pattern>2л1д</pattern>
-  <pattern>2л1ф</pattern>
-  <pattern>2л1г</pattern>
-  <pattern>2л1х</pattern>
-  <pattern>2л1ј</pattern>
-  <pattern>2л1к</pattern>
-  <pattern>2л1л</pattern>
-  <pattern>2л1м</pattern>
-  <pattern>2л1н</pattern>
-  <pattern>2л1п</pattern>
-  <pattern>2л1љ</pattern>
-  <pattern>2л1р</pattern>
-  <pattern>2л1с</pattern>
-  <pattern>2л1т</pattern>
-  <pattern>2л1в</pattern>
-  <pattern>2л1њ</pattern>
-  <pattern>2л1џ</pattern>
-  <pattern>2л1з</pattern>
-  <pattern>2л1ш</pattern>
-  <pattern>2л1ђ</pattern>
-  <pattern>2л1ћ</pattern>
-  <pattern>2л1ч</pattern>
-  <pattern>2н1ж</pattern>
-  <pattern>2н1б</pattern>
-  <pattern>2н1ц</pattern>
-  <pattern>2н1д</pattern>
-  <pattern>2н1ф</pattern>
-  <pattern>2н1г</pattern>
-  <pattern>2н1х</pattern>
-  <pattern>2н1ј</pattern>
-  <pattern>2н1к</pattern>
-  <pattern>2н1л</pattern>
-  <pattern>2н1м</pattern>
-  <pattern>2н1н</pattern>
-  <pattern>2н1п</pattern>
-  <pattern>2н1љ</pattern>
-  <pattern>2н1р</pattern>
-  <pattern>2н1с</pattern>
-  <pattern>2н1т</pattern>
-  <pattern>2н1в</pattern>
-  <pattern>2н1њ</pattern>
-  <pattern>2н1џ</pattern>
-  <pattern>2н1з</pattern>
-  <pattern>2н1ш</pattern>
-  <pattern>2н1ђ</pattern>
-  <pattern>2н1ћ</pattern>
-  <pattern>2н1ч</pattern>
-  <pattern>2љ1ж</pattern>
-  <pattern>2љ1б</pattern>
-  <pattern>2љ1ц</pattern>
-  <pattern>2љ1д</pattern>
-  <pattern>2љ1ф</pattern>
-  <pattern>2љ1г</pattern>
-  <pattern>2љ1х</pattern>
-  <pattern>2љ1ј</pattern>
-  <pattern>2љ1к</pattern>
-  <pattern>2љ1л</pattern>
-  <pattern>2љ1м</pattern>
-  <pattern>2љ1н</pattern>
-  <pattern>2љ1п</pattern>
-  <pattern>2љ1љ</pattern>
-  <pattern>2љ1р</pattern>
-  <pattern>2љ1с</pattern>
-  <pattern>2љ1т</pattern>
-  <pattern>2љ1в</pattern>
-  <pattern>2љ1њ</pattern>
-  <pattern>2љ1џ</pattern>
-  <pattern>2љ1з</pattern>
-  <pattern>2љ1ш</pattern>
-  <pattern>2љ1ђ</pattern>
-  <pattern>2љ1ћ</pattern>
-  <pattern>2љ1ч</pattern>
-  <pattern>2р1ж</pattern>
-  <pattern>2р1б</pattern>
-  <pattern>2р1ц</pattern>
-  <pattern>2р1д</pattern>
-  <pattern>2р1ф</pattern>
-  <pattern>2р1г</pattern>
-  <pattern>2р1х</pattern>
-  <pattern>2р1ј</pattern>
-  <pattern>2р1к</pattern>
-  <pattern>2р1л</pattern>
-  <pattern>2р1м</pattern>
-  <pattern>2р1н</pattern>
-  <pattern>2р1п</pattern>
-  <pattern>2р1љ</pattern>
-  <pattern>2р1р</pattern>
-  <pattern>2р1с</pattern>
-  <pattern>2р1т</pattern>
-  <pattern>2р1в</pattern>
-  <pattern>2р1њ</pattern>
-  <pattern>2р1џ</pattern>
-  <pattern>2р1з</pattern>
-  <pattern>2р1ш</pattern>
-  <pattern>2р1ђ</pattern>
-  <pattern>2р1ћ</pattern>
-  <pattern>2р1ч</pattern>
-  <pattern>2њ1ж</pattern>
-  <pattern>2њ1б</pattern>
-  <pattern>2њ1ц</pattern>
-  <pattern>2њ1д</pattern>
-  <pattern>2њ1ф</pattern>
-  <pattern>2њ1г</pattern>
-  <pattern>2њ1х</pattern>
-  <pattern>2њ1ј</pattern>
-  <pattern>2њ1к</pattern>
-  <pattern>2њ1л</pattern>
-  <pattern>2њ1м</pattern>
-  <pattern>2њ1н</pattern>
-  <pattern>2њ1п</pattern>
-  <pattern>2њ1љ</pattern>
-  <pattern>2њ1р</pattern>
-  <pattern>2њ1с</pattern>
-  <pattern>2њ1т</pattern>
-  <pattern>2њ1в</pattern>
-  <pattern>2њ1њ</pattern>
-  <pattern>2њ1џ</pattern>
-  <pattern>2њ1з</pattern>
-  <pattern>2њ1ш</pattern>
-  <pattern>2њ1ђ</pattern>
-  <pattern>2њ1ћ</pattern>
-  <pattern>2њ1ч</pattern>
-  <pattern>2џ1ж</pattern>
-  <pattern>2џ1б</pattern>
-  <pattern>2џ1ц</pattern>
-  <pattern>2џ1д</pattern>
-  <pattern>2џ1ф</pattern>
-  <pattern>2џ1г</pattern>
-  <pattern>2џ1х</pattern>
-  <pattern>2џ1ј</pattern>
-  <pattern>2џ1к</pattern>
-  <pattern>2џ1л</pattern>
-  <pattern>2џ1м</pattern>
-  <pattern>2џ1н</pattern>
-  <pattern>2џ1п</pattern>
-  <pattern>2џ1љ</pattern>
-  <pattern>2џ1р</pattern>
-  <pattern>2џ1с</pattern>
-  <pattern>2џ1т</pattern>
-  <pattern>2џ1в</pattern>
-  <pattern>2џ1њ</pattern>
-  <pattern>2џ1џ</pattern>
-  <pattern>2џ1з</pattern>
-  <pattern>2џ1ш</pattern>
-  <pattern>2џ1ђ</pattern>
-  <pattern>2џ1ћ</pattern>
-  <pattern>2џ1ч</pattern>
-  <pattern>2ђ1ж</pattern>
-  <pattern>2ђ1б</pattern>
-  <pattern>2ђ1ц</pattern>
-  <pattern>2ђ1д</pattern>
-  <pattern>2ђ1ф</pattern>
-  <pattern>2ђ1г</pattern>
-  <pattern>2ђ1х</pattern>
-  <pattern>2ђ1ј</pattern>
-  <pattern>2ђ1к</pattern>
-  <pattern>2ђ1л</pattern>
-  <pattern>2ђ1м</pattern>
-  <pattern>2ђ1н</pattern>
-  <pattern>2ђ1п</pattern>
-  <pattern>2ђ1љ</pattern>
-  <pattern>2ђ1р</pattern>
-  <pattern>2ђ1с</pattern>
-  <pattern>2ђ1т</pattern>
-  <pattern>2ђ1в</pattern>
-  <pattern>2ђ1њ</pattern>
-  <pattern>2ђ1џ</pattern>
-  <pattern>2ђ1з</pattern>
-  <pattern>2ђ1ш</pattern>
-  <pattern>2ђ1ђ</pattern>
-  <pattern>2ђ1ћ</pattern>
-  <pattern>2ђ1ч</pattern>
-  <pattern>2ћ1ж</pattern>
-  <pattern>2ћ1б</pattern>
-  <pattern>2ћ1ц</pattern>
-  <pattern>2ћ1д</pattern>
-  <pattern>2ћ1ф</pattern>
-  <pattern>2ћ1г</pattern>
-  <pattern>2ћ1х</pattern>
-  <pattern>2ћ1ј</pattern>
-  <pattern>2ћ1к</pattern>
-  <pattern>2ћ1л</pattern>
-  <pattern>2ћ1м</pattern>
-  <pattern>2ћ1н</pattern>
-  <pattern>2ћ1п</pattern>
-  <pattern>2ћ1љ</pattern>
-  <pattern>2ћ1р</pattern>
-  <pattern>2ћ1с</pattern>
-  <pattern>2ћ1т</pattern>
-  <pattern>2ћ1в</pattern>
-  <pattern>2ћ1њ</pattern>
-  <pattern>2ћ1џ</pattern>
-  <pattern>2ћ1з</pattern>
-  <pattern>2ћ1ш</pattern>
-  <pattern>2ћ1ђ</pattern>
-  <pattern>2ћ1ћ</pattern>
-  <pattern>2ћ1ч</pattern>
-  <pattern> х2</pattern>
-  <pattern> ј2</pattern>
-  <pattern> к2</pattern>
-  <pattern> л2</pattern>
-  <pattern> м2</pattern>
-  <pattern> н2</pattern>
-  <pattern> п2</pattern>
-  <pattern> љ2</pattern>
-  <pattern> р2</pattern>
-  <pattern> с2</pattern>
-  <pattern> т2</pattern>
-  <pattern> в2</pattern>
-  <pattern> њ2</pattern>
-  <pattern> џ2</pattern>
-  <pattern> з2</pattern>
-  <pattern> ш2</pattern>
-  <pattern> ђ2</pattern>
-  <pattern> ћ2</pattern>
-  <pattern> ч2</pattern>
-  <pattern> ж2</pattern>
-  <pattern> б2</pattern>
-  <pattern> ц2</pattern>
-  <pattern> д2</pattern>
-  <pattern> ф2</pattern>
-  <pattern> г2</pattern>
-  <pattern>2о1</pattern>
-  <pattern>о3а1</pattern>
-  <pattern>о3е1</pattern>
-  <pattern>о3и1</pattern>
-  <pattern>2о3о1</pattern>
-  <pattern>о3у1</pattern>
-  <pattern>2у1</pattern>
-  <pattern>у3а1</pattern>
-  <pattern>у3е1</pattern>
-  <pattern>у3и1</pattern>
-  <pattern>у3о1</pattern>
-  <pattern>2у3у1</pattern>
-  <pattern>2а1</pattern>
-  <pattern>2а3а1</pattern>
-  <pattern>а3е1</pattern>
-  <pattern>а3и1</pattern>
-  <pattern>а3о1</pattern>
-  <pattern>а3у1</pattern>
-  <pattern>2е1</pattern>
-  <pattern>е3а1</pattern>
-  <pattern>2е3е1</pattern>
-  <pattern>е3и1</pattern>
-  <pattern>е3о1</pattern>
-  <pattern>е3у1</pattern>
-  <pattern>2и1</pattern>
-  <pattern>и3а1</pattern>
-  <pattern>и3е1</pattern>
-  <pattern>2и3и1</pattern>
-  <pattern>и3о1</pattern>
-  <pattern>и3у1</pattern>
-  <pattern>2с2к1б</pattern>
-  <pattern>2с2к1ц</pattern>
-  <pattern>2с2к1д</pattern>
-  <pattern>2с2к1ф</pattern>
-  <pattern>2с2к1г</pattern>
-  <pattern>2с2к1х</pattern>
-  <pattern>2с2к1к</pattern>
-  <pattern>2с2к1м</pattern>
-  <pattern>2с2к1н</pattern>
-  <pattern>2с2к1п</pattern>
-  <pattern>2с2к1с</pattern>
-  <pattern>2с2к1т</pattern>
-  <pattern>2с2к1њ</pattern>
-  <pattern>2с2к1џ</pattern>
-  <pattern>2с2к1з</pattern>
-  <pattern>2с2к1ш</pattern>
-  <pattern>2с2к1ђ</pattern>
-  <pattern>2с2к1ћ</pattern>
-  <pattern>2с2к1ч</pattern>
-  <pattern>2с2к1ж</pattern>
-  <pattern>2с2т1б</pattern>
-  <pattern>2с2т1ц</pattern>
-  <pattern>2с2т1д</pattern>
-  <pattern>2с2т1ф</pattern>
-  <pattern>2с2т1г</pattern>
-  <pattern>2с2т1х</pattern>
-  <pattern>2с2т1к</pattern>
-  <pattern>2с2т1м</pattern>
-  <pattern>2с2т1н</pattern>
-  <pattern>2с2т1п</pattern>
-  <pattern>2с2т1с</pattern>
-  <pattern>2с2т1т</pattern>
-  <pattern>2с2т1њ</pattern>
-  <pattern>2с2т1џ</pattern>
-  <pattern>2с2т1з</pattern>
-  <pattern>2с2т1ш</pattern>
-  <pattern>2с2т1ђ</pattern>
-  <pattern>2с2т1ћ</pattern>
-  <pattern>2с2т1ч</pattern>
-  <pattern>2с2т1ж</pattern>
-  <pattern>2ш2к1б</pattern>
-  <pattern>2ш2к1ц</pattern>
-  <pattern>2ш2к1д</pattern>
-  <pattern>2ш2к1ф</pattern>
-  <pattern>2ш2к1г</pattern>
-  <pattern>2ш2к1х</pattern>
-  <pattern>2ш2к1к</pattern>
-  <pattern>2ш2к1м</pattern>
-  <pattern>2ш2к1н</pattern>
-  <pattern>2ш2к1п</pattern>
-  <pattern>2ш2к1с</pattern>
-  <pattern>2ш2к1т</pattern>
-  <pattern>2ш2к1њ</pattern>
-  <pattern>2ш2к1џ</pattern>
-  <pattern>2ш2к1з</pattern>
-  <pattern>2ш2к1ш</pattern>
-  <pattern>2ш2к1ђ</pattern>
-  <pattern>2ш2к1ћ</pattern>
-  <pattern>2ш2к1ч</pattern>
-  <pattern>2ш2к1ж</pattern>
-  <pattern>2ш2т1б</pattern>
-  <pattern>2ш2т1ц</pattern>
-  <pattern>2ш2т1д</pattern>
-  <pattern>2ш2т1ф</pattern>
-  <pattern>2ш2т1г</pattern>
-  <pattern>2ш2т1х</pattern>
-  <pattern>2ш2т1к</pattern>
-  <pattern>2ш2т1м</pattern>
-  <pattern>2ш2т1н</pattern>
-  <pattern>2ш2т1п</pattern>
-  <pattern>2ш2т1с</pattern>
-  <pattern>2ш2т1т</pattern>
-  <pattern>2ш2т1њ</pattern>
-  <pattern>2ш2т1џ</pattern>
-  <pattern>2ш2т1з</pattern>
-  <pattern>2ш2т1ш</pattern>
-  <pattern>2ш2т1ђ</pattern>
-  <pattern>2ш2т1ћ</pattern>
-  <pattern>2ш2т1ч</pattern>
-  <pattern>2ш2т1ж</pattern>
-  <pattern>2с2п1б</pattern>
-  <pattern>2с2п1ц</pattern>
-  <pattern>2с2п1д</pattern>
-  <pattern>2с2п1ф</pattern>
-  <pattern>2с2п1г</pattern>
-  <pattern>2с2п1х</pattern>
-  <pattern>2с2п1к</pattern>
-  <pattern>2с2п1м</pattern>
-  <pattern>2с2п1н</pattern>
-  <pattern>2с2п1п</pattern>
-  <pattern>2с2п1с</pattern>
-  <pattern>2с2п1т</pattern>
-  <pattern>2с2п1в</pattern>
-  <pattern>2с2п1њ</pattern>
-  <pattern>2с2п1џ</pattern>
-  <pattern>2с2п1з</pattern>
-  <pattern>2с2п1ш</pattern>
-  <pattern>2с2п1ђ</pattern>
-  <pattern>2с2п1ћ</pattern>
-  <pattern>2с2п1ч</pattern>
-  <pattern>2с2п1ж</pattern>
-  <pattern>2с2в1б</pattern>
-  <pattern>2с2в1ц</pattern>
-  <pattern>2с2в1д</pattern>
-  <pattern>2с2в1ф</pattern>
-  <pattern>2с2в1г</pattern>
-  <pattern>2с2в1х</pattern>
-  <pattern>2с2в1к</pattern>
-  <pattern>2с2в1м</pattern>
-  <pattern>2с2в1н</pattern>
-  <pattern>2с2в1п</pattern>
-  <pattern>2с2в1с</pattern>
-  <pattern>2с2в1т</pattern>
-  <pattern>2с2в1в</pattern>
-  <pattern>2с2в1њ</pattern>
-  <pattern>2с2в1џ</pattern>
-  <pattern>2с2в1з</pattern>
-  <pattern>2с2в1ш</pattern>
-  <pattern>2с2в1ђ</pattern>
-  <pattern>2с2в1ћ</pattern>
-  <pattern>2с2в1ч</pattern>
-  <pattern>2с2в1ж</pattern>
-  <pattern>2ш2п1б</pattern>
-  <pattern>2ш2п1ц</pattern>
-  <pattern>2ш2п1д</pattern>
-  <pattern>2ш2п1ф</pattern>
-  <pattern>2ш2п1г</pattern>
-  <pattern>2ш2п1х</pattern>
-  <pattern>2ш2п1к</pattern>
-  <pattern>2ш2п1м</pattern>
-  <pattern>2ш2п1н</pattern>
-  <pattern>2ш2п1п</pattern>
-  <pattern>2ш2п1с</pattern>
-  <pattern>2ш2п1т</pattern>
-  <pattern>2ш2п1в</pattern>
-  <pattern>2ш2п1њ</pattern>
-  <pattern>2ш2п1џ</pattern>
-  <pattern>2ш2п1з</pattern>
-  <pattern>2ш2п1ш</pattern>
-  <pattern>2ш2п1ђ</pattern>
-  <pattern>2ш2п1ћ</pattern>
-  <pattern>2ш2п1ч</pattern>
-  <pattern>2ш2п1ж</pattern>
-  <pattern>2ш2в1б</pattern>
-  <pattern>2ш2в1ц</pattern>
-  <pattern>2ш2в1д</pattern>
-  <pattern>2ш2в1ф</pattern>
-  <pattern>2ш2в1г</pattern>
-  <pattern>2ш2в1х</pattern>
-  <pattern>2ш2в1к</pattern>
-  <pattern>2ш2в1м</pattern>
-  <pattern>2ш2в1н</pattern>
-  <pattern>2ш2в1п</pattern>
-  <pattern>2ш2в1с</pattern>
-  <pattern>2ш2в1т</pattern>
-  <pattern>2ш2в1в</pattern>
-  <pattern>2ш2в1њ</pattern>
-  <pattern>2ш2в1џ</pattern>
-  <pattern>2ш2в1з</pattern>
-  <pattern>2ш2в1ш</pattern>
-  <pattern>2ш2в1ђ</pattern>
-  <pattern>2ш2в1ћ</pattern>
-  <pattern>2ш2в1ч</pattern>
-  <pattern>2ш2в1ж</pattern>
-  <pattern>2ж2д1б</pattern>
-  <pattern>2ж2д1ц</pattern>
-  <pattern>2ж2д1д</pattern>
-  <pattern>2ж2д1ф</pattern>
-  <pattern>2ж2д1г</pattern>
-  <pattern>2ж2д1х</pattern>
-  <pattern>2ж2д1к</pattern>
-  <pattern>2ж2д1м</pattern>
-  <pattern>2ж2д1н</pattern>
-  <pattern>2ж2д1п</pattern>
-  <pattern>2ж2д1с</pattern>
-  <pattern>2ж2д1т</pattern>
-  <pattern>2ж2д1њ</pattern>
-  <pattern>2ж2д1џ</pattern>
-  <pattern>2ж2д1з</pattern>
-  <pattern>2ж2д1ш</pattern>
-  <pattern>2ж2д1ђ</pattern>
-  <pattern>2ж2д1ћ</pattern>
-  <pattern>2ж2д1ч</pattern>
-  <pattern>2ж2д1ж</pattern>
-  <pattern>2ж2г1б</pattern>
-  <pattern>2ж2г1ц</pattern>
-  <pattern>2ж2г1д</pattern>
-  <pattern>2ж2г1ф</pattern>
-  <pattern>2ж2г1г</pattern>
-  <pattern>2ж2г1х</pattern>
-  <pattern>2ж2г1к</pattern>
-  <pattern>2ж2г1м</pattern>
-  <pattern>2ж2г1н</pattern>
-  <pattern>2ж2г1п</pattern>
-  <pattern>2ж2г1с</pattern>
-  <pattern>2ж2г1т</pattern>
-  <pattern>2ж2г1њ</pattern>
-  <pattern>2ж2г1џ</pattern>
-  <pattern>2ж2г1з</pattern>
-  <pattern>2ж2г1ш</pattern>
-  <pattern>2ж2г1ђ</pattern>
-  <pattern>2ж2г1ћ</pattern>
-  <pattern>2ж2г1ч</pattern>
-  <pattern>2ж2г1ж</pattern>
-  <pattern>2з2д1б</pattern>
-  <pattern>2з2д1ц</pattern>
-  <pattern>2з2д1д</pattern>
-  <pattern>2з2д1ф</pattern>
-  <pattern>2з2д1г</pattern>
-  <pattern>2з2д1х</pattern>
-  <pattern>2з2д1к</pattern>
-  <pattern>2з2д1м</pattern>
-  <pattern>2з2д1н</pattern>
-  <pattern>2з2д1п</pattern>
-  <pattern>2з2д1с</pattern>
-  <pattern>2з2д1т</pattern>
-  <pattern>2з2д1њ</pattern>
-  <pattern>2з2д1џ</pattern>
-  <pattern>2з2д1з</pattern>
-  <pattern>2з2д1ш</pattern>
-  <pattern>2з2д1ђ</pattern>
-  <pattern>2з2д1ћ</pattern>
-  <pattern>2з2д1ч</pattern>
-  <pattern>2з2д1ж</pattern>
-  <pattern>2з2г1б</pattern>
-  <pattern>2з2г1ц</pattern>
-  <pattern>2з2г1д</pattern>
-  <pattern>2з2г1ф</pattern>
-  <pattern>2з2г1г</pattern>
-  <pattern>2з2г1х</pattern>
-  <pattern>2з2г1к</pattern>
-  <pattern>2з2г1м</pattern>
-  <pattern>2з2г1н</pattern>
-  <pattern>2з2г1п</pattern>
-  <pattern>2з2г1с</pattern>
-  <pattern>2з2г1т</pattern>
-  <pattern>2з2г1њ</pattern>
-  <pattern>2з2г1џ</pattern>
-  <pattern>2з2г1з</pattern>
-  <pattern>2з2г1ш</pattern>
-  <pattern>2з2г1ђ</pattern>
-  <pattern>2з2г1ћ</pattern>
-  <pattern>2з2г1ч</pattern>
-  <pattern>2з2г1ж</pattern>
-  <pattern>2ж2в1б</pattern>
-  <pattern>2ж2в1ц</pattern>
-  <pattern>2ж2в1д</pattern>
-  <pattern>2ж2в1ф</pattern>
-  <pattern>2ж2в1г</pattern>
-  <pattern>2ж2в1х</pattern>
-  <pattern>2ж2в1к</pattern>
-  <pattern>2ж2в1м</pattern>
-  <pattern>2ж2в1н</pattern>
-  <pattern>2ж2в1п</pattern>
-  <pattern>2ж2в1с</pattern>
-  <pattern>2ж2в1т</pattern>
-  <pattern>2ж2в1в</pattern>
-  <pattern>2ж2в1њ</pattern>
-  <pattern>2ж2в1џ</pattern>
-  <pattern>2ж2в1з</pattern>
-  <pattern>2ж2в1ш</pattern>
-  <pattern>2ж2в1ђ</pattern>
-  <pattern>2ж2в1ћ</pattern>
-  <pattern>2ж2в1ч</pattern>
-  <pattern>2ж2в1ж</pattern>
-  <pattern>2ж2б1б</pattern>
-  <pattern>2ж2б1ц</pattern>
-  <pattern>2ж2б1д</pattern>
-  <pattern>2ж2б1ф</pattern>
-  <pattern>2ж2б1г</pattern>
-  <pattern>2ж2б1х</pattern>
-  <pattern>2ж2б1к</pattern>
-  <pattern>2ж2б1м</pattern>
-  <pattern>2ж2б1н</pattern>
-  <pattern>2ж2б1п</pattern>
-  <pattern>2ж2б1с</pattern>
-  <pattern>2ж2б1т</pattern>
-  <pattern>2ж2б1в</pattern>
-  <pattern>2ж2б1њ</pattern>
-  <pattern>2ж2б1џ</pattern>
-  <pattern>2ж2б1з</pattern>
-  <pattern>2ж2б1ш</pattern>
-  <pattern>2ж2б1ђ</pattern>
-  <pattern>2ж2б1ћ</pattern>
-  <pattern>2ж2б1ч</pattern>
-  <pattern>2ж2б1ж</pattern>
-  <pattern>2з2в1б</pattern>
-  <pattern>2з2в1ц</pattern>
-  <pattern>2з2в1д</pattern>
-  <pattern>2з2в1ф</pattern>
-  <pattern>2з2в1г</pattern>
-  <pattern>2з2в1х</pattern>
-  <pattern>2з2в1к</pattern>
-  <pattern>2з2в1м</pattern>
-  <pattern>2з2в1н</pattern>
-  <pattern>2з2в1п</pattern>
-  <pattern>2з2в1с</pattern>
-  <pattern>2з2в1т</pattern>
-  <pattern>2з2в1в</pattern>
-  <pattern>2з2в1њ</pattern>
-  <pattern>2з2в1џ</pattern>
-  <pattern>2з2в1з</pattern>
-  <pattern>2з2в1ш</pattern>
-  <pattern>2з2в1ђ</pattern>
-  <pattern>2з2в1ћ</pattern>
-  <pattern>2з2в1ч</pattern>
-  <pattern>2з2в1ж</pattern>
-  <pattern>2з2б1б</pattern>
-  <pattern>2з2б1ц</pattern>
-  <pattern>2з2б1д</pattern>
-  <pattern>2з2б1ф</pattern>
-  <pattern>2з2б1г</pattern>
-  <pattern>2з2б1х</pattern>
-  <pattern>2з2б1к</pattern>
-  <pattern>2з2б1м</pattern>
-  <pattern>2з2б1н</pattern>
-  <pattern>2з2б1п</pattern>
-  <pattern>2з2б1с</pattern>
-  <pattern>2з2б1т</pattern>
-  <pattern>2з2б1в</pattern>
-  <pattern>2з2б1њ</pattern>
-  <pattern>2з2б1џ</pattern>
-  <pattern>2з2б1з</pattern>
-  <pattern>2з2б1ш</pattern>
-  <pattern>2з2б1ђ</pattern>
-  <pattern>2з2б1ћ</pattern>
-  <pattern>2з2б1ч</pattern>
-  <pattern>2з2б1ж</pattern>
-  <pattern>2ж2м1б</pattern>
-  <pattern>2ж2м1ц</pattern>
-  <pattern>2ж2м1д</pattern>
-  <pattern>2ж2м1ф</pattern>
-  <pattern>2ж2м1г</pattern>
-  <pattern>2ж2м1х</pattern>
-  <pattern>2ж2м1к</pattern>
-  <pattern>2ж2м1м</pattern>
-  <pattern>2ж2м1н</pattern>
-  <pattern>2ж2м1п</pattern>
-  <pattern>2ж2м1с</pattern>
-  <pattern>2ж2м1т</pattern>
-  <pattern>2ж2м1в</pattern>
-  <pattern>2ж2м1њ</pattern>
-  <pattern>2ж2м1џ</pattern>
-  <pattern>2ж2м1з</pattern>
-  <pattern>2ж2м1ш</pattern>
-  <pattern>2ж2м1ђ</pattern>
-  <pattern>2ж2м1ћ</pattern>
-  <pattern>2ж2м1ч</pattern>
-  <pattern>2ж2м1ж</pattern>
-  <pattern>2с2м1б</pattern>
-  <pattern>2с2м1ц</pattern>
-  <pattern>2с2м1д</pattern>
-  <pattern>2с2м1ф</pattern>
-  <pattern>2с2м1г</pattern>
-  <pattern>2с2м1х</pattern>
-  <pattern>2с2м1к</pattern>
-  <pattern>2с2м1м</pattern>
-  <pattern>2с2м1н</pattern>
-  <pattern>2с2м1п</pattern>
-  <pattern>2с2м1с</pattern>
-  <pattern>2с2м1т</pattern>
-  <pattern>2с2м1в</pattern>
-  <pattern>2с2м1њ</pattern>
-  <pattern>2с2м1џ</pattern>
-  <pattern>2с2м1з</pattern>
-  <pattern>2с2м1ш</pattern>
-  <pattern>2с2м1ђ</pattern>
-  <pattern>2с2м1ћ</pattern>
-  <pattern>2с2м1ч</pattern>
-  <pattern>2с2м1ж</pattern>
-  <pattern>2з2м1б</pattern>
-  <pattern>2з2м1ц</pattern>
-  <pattern>2з2м1д</pattern>
-  <pattern>2з2м1ф</pattern>
-  <pattern>2з2м1г</pattern>
-  <pattern>2з2м1х</pattern>
-  <pattern>2з2м1к</pattern>
-  <pattern>2з2м1м</pattern>
-  <pattern>2з2м1н</pattern>
-  <pattern>2з2м1п</pattern>
-  <pattern>2з2м1с</pattern>
-  <pattern>2з2м1т</pattern>
-  <pattern>2з2м1в</pattern>
-  <pattern>2з2м1њ</pattern>
-  <pattern>2з2м1џ</pattern>
-  <pattern>2з2м1з</pattern>
-  <pattern>2з2м1ш</pattern>
-  <pattern>2з2м1ђ</pattern>
-  <pattern>2з2м1ћ</pattern>
-  <pattern>2з2м1ч</pattern>
-  <pattern>2з2м1ж</pattern>
-  <pattern>2ш2м1б</pattern>
-  <pattern>2ш2м1ц</pattern>
-  <pattern>2ш2м1д</pattern>
-  <pattern>2ш2м1ф</pattern>
-  <pattern>2ш2м1г</pattern>
-  <pattern>2ш2м1х</pattern>
-  <pattern>2ш2м1к</pattern>
-  <pattern>2ш2м1м</pattern>
-  <pattern>2ш2м1н</pattern>
-  <pattern>2ш2м1п</pattern>
-  <pattern>2ш2м1с</pattern>
-  <pattern>2ш2м1т</pattern>
-  <pattern>2ш2м1в</pattern>
-  <pattern>2ш2м1њ</pattern>
-  <pattern>2ш2м1џ</pattern>
-  <pattern>2ш2м1з</pattern>
-  <pattern>2ш2м1ш</pattern>
-  <pattern>2ш2м1ђ</pattern>
-  <pattern>2ш2м1ћ</pattern>
-  <pattern>2ш2м1ч</pattern>
-  <pattern>2ш2м1ж</pattern>
-  <pattern>2с2ц1б</pattern>
-  <pattern>2с2ц1ц</pattern>
-  <pattern>2с2ц1д</pattern>
-  <pattern>2с2ц1ф</pattern>
-  <pattern>2с2ц1г</pattern>
-  <pattern>2с2ц1х</pattern>
-  <pattern>2с2ц1к</pattern>
-  <pattern>2с2ц1л</pattern>
-  <pattern>2с2ц1м</pattern>
-  <pattern>2с2ц1н</pattern>
-  <pattern>2с2ц1п</pattern>
-  <pattern>2с2ц1љ</pattern>
-  <pattern>2сц2р</pattern>
-  <pattern>2с2ц1с</pattern>
-  <pattern>2с2ц1т</pattern>
-  <pattern>2с2ц1њ</pattern>
-  <pattern>2с2ц1џ</pattern>
-  <pattern>2с2ц1з</pattern>
-  <pattern>2с2ц1ш</pattern>
-  <pattern>2с2ц1ђ</pattern>
-  <pattern>2с2ц1ћ</pattern>
-  <pattern>2с2ц1ч</pattern>
-  <pattern>2с2ц1ж</pattern>
-  <pattern>2ш2ц1б</pattern>
-  <pattern>2ш2ц1ц</pattern>
-  <pattern>2ш2ц1д</pattern>
-  <pattern>2ш2ц1ф</pattern>
-  <pattern>2ш2ц1г</pattern>
-  <pattern>2ш2ц1х</pattern>
-  <pattern>2ш2ц1к</pattern>
-  <pattern>2ш2ц1л</pattern>
-  <pattern>2ш2ц1м</pattern>
-  <pattern>2ш2ц1н</pattern>
-  <pattern>2ш2ц1п</pattern>
-  <pattern>2ш2ц1љ</pattern>
-  <pattern>2шц2р</pattern>
-  <pattern>2ш2ц1с</pattern>
-  <pattern>2ш2ц1т</pattern>
-  <pattern>2ш2ц1њ</pattern>
-  <pattern>2ш2ц1џ</pattern>
-  <pattern>2ш2ц1з</pattern>
-  <pattern>2ш2ц1ш</pattern>
-  <pattern>2ш2ц1ђ</pattern>
-  <pattern>2ш2ц1ћ</pattern>
-  <pattern>2ш2ц1ч</pattern>
-  <pattern>2ш2ц1ж</pattern>
-  <pattern>2ш2ч1б</pattern>
-  <pattern>2ш2ч1ц</pattern>
-  <pattern>2ш2ч1д</pattern>
-  <pattern>2ш2ч1ф</pattern>
-  <pattern>2ш2ч1г</pattern>
-  <pattern>2ш2ч1х</pattern>
-  <pattern>2ш2ч1ј</pattern>
-  <pattern>2ш2ч1к</pattern>
-  <pattern>2ш2ч1л</pattern>
-  <pattern>2ш2ч1м</pattern>
-  <pattern>2ш2ч1н</pattern>
-  <pattern>2ш2ч1п</pattern>
-  <pattern>2ш2ч1љ</pattern>
-  <pattern>2ш2ч1р</pattern>
-  <pattern>2ш2ч1с</pattern>
-  <pattern>2ш2ч1т</pattern>
-  <pattern>2ш2ч1њ</pattern>
-  <pattern>2ш2ч1џ</pattern>
-  <pattern>2ш2ч1з</pattern>
-  <pattern>2ш2ч1ш</pattern>
-  <pattern>2ш2ч1ђ</pattern>
-  <pattern>2ш2ч1ћ</pattern>
-  <pattern>2ш2ч1ч</pattern>
-  <pattern>2ш2ч1ж</pattern>
-  <pattern>2х2в1б</pattern>
-  <pattern>2х2в1ц</pattern>
-  <pattern>2х2в1д</pattern>
-  <pattern>2х2в1ф</pattern>
-  <pattern>2х2в1г</pattern>
-  <pattern>2х2в1х</pattern>
-  <pattern>2х2в1к</pattern>
-  <pattern>2х2в1м</pattern>
-  <pattern>2х2в1н</pattern>
-  <pattern>2х2в1п</pattern>
-  <pattern>2х2в1с</pattern>
-  <pattern>2х2в1т</pattern>
-  <pattern>2х2в1њ</pattern>
-  <pattern>2х2в1џ</pattern>
-  <pattern>2х2в1з</pattern>
-  <pattern>2х2в1ш</pattern>
-  <pattern>2х2в1ђ</pattern>
-  <pattern>2х2в1ћ</pattern>
-  <pattern>2х2в1ч</pattern>
-  <pattern>2х2в1ж</pattern>
-  <pattern>2ж3в2л</pattern>
-  <pattern>2ж3в2љ</pattern>
-  <pattern>2ц3в2л</pattern>
-  <pattern>2ц3в2љ</pattern>
-  <pattern>2з3в2л</pattern>
-  <pattern>2з3в2љ</pattern>
-  <pattern>2ш3в2л</pattern>
-  <pattern>2ш3в2љ</pattern>
-  <pattern>2ч3в2л</pattern>
-  <pattern>2ч3в2љ</pattern>
-  <pattern>2ч3в2ј</pattern>
-  <pattern>2с3в2љ</pattern>
-  <pattern>2д3в2л</pattern>
-  <pattern>2д3в2љ</pattern>
-  <pattern>2д3в2р</pattern>
-  <pattern>2к3в2ј</pattern>
-  <pattern>2к3в2л</pattern>
-  <pattern>2к3в2љ</pattern>
-  <pattern>2т3в2ј</pattern>
-  <pattern>2т3в2л</pattern>
-  <pattern>2т3в2љ</pattern>
-  <pattern>2г3в2ј</pattern>
-  <pattern>2г3в2л</pattern>
-  <pattern>2г3в2љ</pattern>
-  <pattern>2г3в2р</pattern>
-  <pattern>2х3в2ј</pattern>
-  <pattern>2х3в2л</pattern>
-  <pattern>2х3в2љ</pattern>
-  <pattern>2х3в2р</pattern>
-  <pattern>2ж3м2ј</pattern>
-  <pattern>2ж3м2л</pattern>
-  <pattern>2ж3м2љ</pattern>
-  <pattern>2ж3м2р</pattern>
-  <pattern>2з3м2л</pattern>
-  <pattern>2з3м2р</pattern>
-  <pattern>2ш3м2ј</pattern>
-  <pattern>2ш3м2л</pattern>
-  <pattern>2ш3м2љ</pattern>
-  <pattern>2ш3ц2ј</pattern>
-  <pattern>2ш3ц2в</pattern>
-  <pattern>2ш3ч2в</pattern>
-  <pattern>2ш3т2ј</pattern>
-  <pattern>2ш3т2л</pattern>
-  <pattern>2ш3т2љ</pattern>
-  <pattern>2с3т2л</pattern>
-  <pattern>2с3к2ј</pattern>
-  <pattern>2с3к2љ</pattern>
-  <pattern>2ш3п2ј</pattern>
-  <pattern>2ш3п2л</pattern>
-  <pattern>2ш3п2љ</pattern>
-  <pattern>2ж3д2ј</pattern>
-  <pattern>2ж3д2л</pattern>
-  <pattern>2ж3д2љ</pattern>
-  <pattern>2ж3д2в</pattern>
-  <pattern>2ж3г2ј</pattern>
-  <pattern>2ж3г2л</pattern>
-  <pattern>2ж3г2љ</pattern>
-  <pattern>2ж3г2р</pattern>
-  <pattern>2ж3г2в</pattern>
-  <pattern>2з3д2л</pattern>
-  <pattern>2з3д2љ</pattern>
-  <pattern>2з3д2в</pattern>
-  <pattern>2з3г2ј</pattern>
-  <pattern>2з3г2љ</pattern>
-  <pattern>2ж3б2ј</pattern>
-  <pattern>2ж3б2л</pattern>
-  <pattern>2ж3б2љ</pattern>
-  <pattern>2ж3б2р</pattern>
-  <pattern>2з3б2љ</pattern>
-  <pattern> а4е2р2о1</pattern>
-  <pattern> 2а1</pattern>
-  <pattern> а3е1</pattern>
-  <pattern> бе4о1</pattern>
-  <pattern> б2е1</pattern>
-  <pattern> би4о1</pattern>
-  <pattern> б2и1</pattern>
-  <pattern> ге4о1</pattern>
-  <pattern> г2е1</pattern>
-  <pattern> за3г2н</pattern>
-  <pattern> з2а1</pattern>
-  <pattern> з2а3т2к2а1</pattern>
-  <pattern> за2т1к</pattern>
-  <pattern> иза3г2н</pattern>
-  <pattern> 2и1</pattern>
-  <pattern> из2а1</pattern>
-  <pattern> иза3т2к</pattern>
-  <pattern> и2з3г</pattern>
-  <pattern> и2з3г2н</pattern>
-  <pattern> и2з3д</pattern>
-  <pattern> изд2н2о1</pattern>
-  <pattern> и2з2д1н</pattern>
-  <pattern> изд2н2у1</pattern>
-  <pattern> изд2н2а1</pattern>
-  <pattern> и2з3р</pattern>
-  <pattern> из2р2к</pattern>
-  <pattern> и2с3т</pattern>
-  <pattern> и2с2т2к</pattern>
-  <pattern> на2г2н</pattern>
-  <pattern> н2а1</pattern>
-  <pattern> на2г2њ</pattern>
-  <pattern> на3д2нев</pattern>
-  <pattern> на2д1н</pattern>
-  <pattern> надн2е1</pattern>
-  <pattern> на3д2нич</pattern>
-  <pattern> надн2и1</pattern>
-  <pattern> на3д2ниц</pattern>
-  <pattern> на3т2ках</pattern>
-  <pattern> на2т1к</pattern>
-  <pattern> н2а1тк2а1</pattern>
-  <pattern> на3т2кам</pattern>
-  <pattern> на3т2кас2м</pattern>
-  <pattern> на3т2кас2т</pattern>
-  <pattern> ода3г2н</pattern>
-  <pattern> 2о1</pattern>
-  <pattern> од2а1</pattern>
-  <pattern> ода3д2н</pattern>
-  <pattern> од3г2н</pattern>
-  <pattern> о2д1г</pattern>
-  <pattern> од3м2н</pattern>
-  <pattern> о2д1м</pattern>
-  <pattern> о3т2ках</pattern>
-  <pattern> о2т1к</pattern>
-  <pattern> отк2а1</pattern>
-  <pattern> о3т2кам</pattern>
-  <pattern> о3т2кас2м</pattern>
-  <pattern> о3т2кас2т</pattern>
-  <pattern> по3г2н</pattern>
-  <pattern> п2о1</pattern>
-  <pattern> по3д2нев</pattern>
-  <pattern> по2д1н</pattern>
-  <pattern> подн2е1</pattern>
-  <pattern> по3м2н</pattern>
-  <pattern> по3м2њ</pattern>
-  <pattern> по3р2в</pattern>
-  <pattern> по3р2ђ</pattern>
-  <pattern> по3т2ках</pattern>
-  <pattern> по2т1к</pattern>
-  <pattern> потк2а1</pattern>
-  <pattern> по3т2кам</pattern>
-  <pattern> по3т2кат</pattern>
-  <pattern> по3т2кав</pattern>
-  <pattern> пред3м2н</pattern>
-  <pattern> п2р</pattern>
-  <pattern> пр2е1</pattern>
-  <pattern> пре2д1м</pattern>
-  <pattern> пред3м2њ</pattern>
-  <pattern> пре3т2ках</pattern>
-  <pattern> пре2т1к</pattern>
-  <pattern> претк2а1</pattern>
-  <pattern> пре3т2кам</pattern>
-  <pattern> пре3т2кат</pattern>
-  <pattern> про3г2н</pattern>
-  <pattern> пр2о1</pattern>
-  <pattern> про3т2к2и1</pattern>
-  <pattern> про2т1к</pattern>
-  <pattern> про3т2к2а1</pattern>
-  <pattern> раза3г2н</pattern>
-  <pattern> р2а1</pattern>
-  <pattern> р2а1з2а1</pattern>
-  <pattern> ра2з3г</pattern>
-  <pattern> ра2з3г2н</pattern>
-  <pattern> ра2з3д</pattern>
-  <pattern> раз3д2н2и1</pattern>
-  <pattern> ра2з2д1н</pattern>
-  <pattern> р2а1з2а3т2к2а1</pattern>
-  <pattern> раза2т1к</pattern>
-  <pattern> у3г2м2и1</pattern>
-  <pattern> 2у1</pattern>
-  <pattern> у2г1м</pattern>
-  <pattern> у3г2н</pattern>
-  <pattern> уз2а3т2к2а1</pattern>
-  <pattern> уз2а1</pattern>
-  <pattern> уза2т1к</pattern>
-  <pattern>3х2тет2и1</pattern>
-  <pattern>хт2е1</pattern>
-  <pattern>3х2тјет2и1</pattern>
-  <pattern>хт2ј</pattern>
-  <pattern>хтј2е1</pattern>
-  <pattern>3х2тел</pattern>
-  <pattern>3х2тев</pattern>
-  <pattern>3х2тењ</pattern>
-  <pattern>3х2тјел</pattern>
-  <pattern>3х2тјев</pattern>
-  <pattern>3х2тјењ</pattern>
-  <pattern>3г2дегод </pattern>
-  <pattern>гд2е1</pattern>
-  <pattern>гдег2о1</pattern>
-  <pattern>3г2дјегод </pattern>
-  <pattern>гд2ј</pattern>
-  <pattern>гдј2е1</pattern>
-  <pattern>гдјег2о1</pattern>
-  <pattern>3г2декак</pattern>
-  <pattern>гдек2а1</pattern>
-  <pattern>3г2декад</pattern>
-  <pattern>3г2дјекак</pattern>
-  <pattern>гдјек2а1</pattern>
-  <pattern>3г2дјекад</pattern>
-  <pattern>ни3г2де </pattern>
-  <pattern>н2и1</pattern>
-  <pattern>ни2г1д</pattern>
-  <pattern>нигд2е1</pattern>
-  <pattern>не3г2де </pattern>
-  <pattern>н2е1</pattern>
-  <pattern>не2г1д</pattern>
-  <pattern>негд2е1</pattern>
-  <pattern>ни3г2дје </pattern>
-  <pattern>нигд2ј</pattern>
-  <pattern>нигдј2е1</pattern>
-  <pattern>не3г2дје </pattern>
-  <pattern>негд2ј</pattern>
-  <pattern>негдј2е1</pattern>
-  <pattern>3б2дет</pattern>
-  <pattern>бд2е1</pattern>
-  <pattern>3б2дењ</pattern>
-  <pattern>3б2дјет</pattern>
-  <pattern>бд2ј</pattern>
-  <pattern>бдј2е1</pattern>
-  <pattern>3б2дјењ</pattern>
-  <pattern>3г2мил</pattern>
-  <pattern>гм2и1</pattern>
-  <pattern>3г2миљ</pattern>
-  <pattern>3г2миз</pattern>
-  <pattern>3г2нос</pattern>
-  <pattern>гн2о1</pattern>
-  <pattern>3г2ноз</pattern>
-  <pattern>3г2ној</pattern>
-  <pattern>3г2нај</pattern>
-  <pattern>гн2а1</pattern>
-  <pattern>3г2нез2д</pattern>
-  <pattern>гн2е1</pattern>
-  <pattern>3г2нијез2д</pattern>
-  <pattern>гн2и1</pattern>
-  <pattern>гниј2е1</pattern>
-  <pattern>3г2неж2ђ</pattern>
-  <pattern>3г2нијеж2ђ</pattern>
-  <pattern>3г2нев</pattern>
-  <pattern>3г2њев</pattern>
-  <pattern>гњ2е1</pattern>
-  <pattern>3г2њав</pattern>
-  <pattern>гњ2а1</pattern>
-  <pattern>3г2њес</pattern>
-  <pattern>3г2њет</pattern>
-  <pattern>3г2њеч</pattern>
-  <pattern>3г2њил</pattern>
-  <pattern>гњ2и1</pattern>
-  <pattern>3г2њи3о1</pattern>
-  <pattern>3г2њиљ</pattern>
-  <pattern>3г2њит</pattern>
-  <pattern>3г2њур</pattern>
-  <pattern>гњ2у1</pattern>
-  <pattern>3к2нез</pattern>
-  <pattern>кн2е1</pattern>
-  <pattern>3к2неж</pattern>
-  <pattern>3к2њиж</pattern>
-  <pattern>књ2и1</pattern>
-  <pattern>3к2њиг</pattern>
-  <pattern>3м2нож</pattern>
-  <pattern>мн2о1</pattern>
-  <pattern>3м2ног</pattern>
-  <pattern>3м2наж</pattern>
-  <pattern>мн2а1</pattern>
-  <pattern>3п2сик</pattern>
-  <pattern>пс2и1</pattern>
-  <pattern>3п2сич</pattern>
-  <pattern>3п2сов</pattern>
-  <pattern>пс2о1</pattern>
-  <pattern>3п2суј</pattern>
-  <pattern>пс2у1</pattern>
-  <pattern>3р2ђ2а1</pattern>
-  <pattern>3с2фер</pattern>
-  <pattern>сф2е1</pattern>
-  <pattern>3т2мас2т</pattern>
-  <pattern>тм2а1</pattern>
-  <pattern>3т2мул</pattern>
-  <pattern>тм2у1</pattern>
-  <pattern>3т2му3о1</pattern>
-  <pattern>3т2муљ</pattern>
-  <pattern>3т2мур</pattern>
-  <pattern>3ц2миз</pattern>
-  <pattern>цм2и1</pattern>
-  <pattern>3ц2мак</pattern>
-  <pattern>цм2а1</pattern>
-  <pattern>3ц2мач</pattern>
-  <pattern>3ц2мок</pattern>
-  <pattern>цм2о1</pattern>
-  <pattern>3ч2лан</pattern>
-  <pattern>чл2а1</pattern>
-  <pattern>3ч2лањ</pattern>
-  <pattern>3р2ј2е1</pattern>
-  <pattern>4р3јем</pattern>
-  <pattern>4р3је </pattern>
-  <pattern> бе2з3ј</pattern>
-  <pattern> бе2з3л</pattern>
-  <pattern> бе2з3м</pattern>
-  <pattern> бе2з3н</pattern>
-  <pattern> бе2з3љ</pattern>
-  <pattern> бе2з3р</pattern>
-  <pattern> бе2з3в</pattern>
-  <pattern> бе2з3њ</pattern>
-  <pattern> бе2з3б</pattern>
-  <pattern> бе2з3д</pattern>
-  <pattern> бе2з3г</pattern>
-  <pattern> бе2з3и1</pattern>
-  <pattern> бе2з3о1</pattern>
-  <pattern> бе2з3у1</pattern>
-  <pattern> бе2з3алкохол</pattern>
-  <pattern> без2а1</pattern>
-  <pattern> беза2л1к</pattern>
-  <pattern> безалк2о1</pattern>
-  <pattern> безалкох2о1</pattern>
-  <pattern> бе2з3атомс2к</pattern>
-  <pattern> безат2о1</pattern>
-  <pattern> безато2м1с</pattern>
-  <pattern> бе3з4бе2д1н</pattern>
-  <pattern> б2е1зб2е1</pattern>
-  <pattern> бе3з4бед2а1</pattern>
-  <pattern> бе3з4бје2д1н</pattern>
-  <pattern> безб2ј</pattern>
-  <pattern> б2е1збј2е1</pattern>
-  <pattern> бе3з4бјед2а1</pattern>
-  <pattern> бе3з4бел2и1</pattern>
-  <pattern> бе3з4бол</pattern>
-  <pattern> безб2о1</pattern>
-  <pattern> бе3з4ву2ч1н</pattern>
-  <pattern> безв2у1</pattern>
-  <pattern> бе3з4вуч2а1</pattern>
-  <pattern> бе3з4истан</pattern>
-  <pattern> безис2т</pattern>
-  <pattern> безист2а1</pattern>
-  <pattern> бе3з4истен</pattern>
-  <pattern> безист2е1</pattern>
-  <pattern> бе3з4јак</pattern>
-  <pattern> безј2а1</pattern>
-  <pattern> бе3з4јач</pattern>
-  <pattern> бе3з4ло2б1н</pattern>
-  <pattern> безл2о1</pattern>
-  <pattern> бе3з4лоб2а1</pattern>
-  <pattern> бе3з4начај</pattern>
-  <pattern> безн2а1</pattern>
-  <pattern> безнач2а1</pattern>
-  <pattern> бе3з4ра2ч1н</pattern>
-  <pattern> безр2а1</pattern>
-  <pattern> бе3з4р2а1ч2а1</pattern>
-  <pattern> бе3з4уп</pattern>
-  <pattern> бе3з4уб</pattern>
-  <pattern> бе2с3ц</pattern>
-  <pattern> бе2с3к</pattern>
-  <pattern> бе2с3п</pattern>
-  <pattern> бе2с3т</pattern>
-  <pattern> бе3с4крупул</pattern>
-  <pattern> беск2р</pattern>
-  <pattern> бескр2у1</pattern>
-  <pattern> бескруп2у1</pattern>
-  <pattern> бе3с4поко2ј1н</pattern>
-  <pattern> бесп2о1</pattern>
-  <pattern> бесп2о1к2о1</pattern>
-  <pattern> бе3с4покој2а1</pattern>
-  <pattern> бе3с4по2р1н</pattern>
-  <pattern> бе3с4пор2а1</pattern>
-  <pattern> бе3с4твар</pattern>
-  <pattern> бест2в</pattern>
-  <pattern> беств2а1</pattern>
-  <pattern> бе3с4тид</pattern>
-  <pattern> бест2и1</pattern>
-  <pattern> бе3с4тиј2а1</pattern>
-  <pattern> бе3с4тил2у1</pattern>
-  <pattern> бе3с4тиљ</pattern>
-  <pattern> бе3с4тр2а1н2а1</pattern>
-  <pattern> бест2р</pattern>
-  <pattern> бестр2а1</pattern>
-  <pattern> бе3с4трас</pattern>
-  <pattern> бес4тселер</pattern>
-  <pattern> бе2с2т1с</pattern>
-  <pattern> бестс2е1</pattern>
-  <pattern> бестсел2е1</pattern>
-  <pattern> бе2ш3ћ</pattern>
-  <pattern> бе2ш3ч</pattern>
-  <pattern> ва2н3ев2р</pattern>
-  <pattern> в2а1</pattern>
-  <pattern> ван2е1</pattern>
-  <pattern> ва2н3устав</pattern>
-  <pattern> ван2у1</pattern>
-  <pattern> ванус2т</pattern>
-  <pattern> вануст2а1</pattern>
-  <pattern> и2з3б</pattern>
-  <pattern> и2з3ј</pattern>
-  <pattern> и2з3л</pattern>
-  <pattern> и2з3м</pattern>
-  <pattern> и2з3н</pattern>
-  <pattern> и2з3љ</pattern>
-  <pattern> и2з3в</pattern>
-  <pattern> и2з3њ</pattern>
-  <pattern> 2и2з3и1</pattern>
-  <pattern> и2з3о1</pattern>
-  <pattern> и2з3у1</pattern>
-  <pattern> и2з3биј2а1</pattern>
-  <pattern> 2и1зб2и1</pattern>
-  <pattern> и2з3бив2а1</pattern>
-  <pattern> 2и2з3вед2и1</pattern>
-  <pattern> изв2е1</pattern>
-  <pattern> и2з3ве2д1н</pattern>
-  <pattern> и2з3ве2д1б</pattern>
-  <pattern> и2з3в2е1д2е1</pattern>
-  <pattern> и2з3дај</pattern>
-  <pattern> изд2а1</pattern>
-  <pattern> и2з3а1б2а1</pattern>
-  <pattern> и2з3а1к2а1</pattern>
-  <pattern> и2з3анал</pattern>
-  <pattern> изан2а1</pattern>
-  <pattern> и3з4бав</pattern>
-  <pattern> изб2а1</pattern>
-  <pattern> и3з4бичк2а1в2а1</pattern>
-  <pattern> изби2ч1к</pattern>
-  <pattern> избичк2а1</pattern>
-  <pattern> и3з4блеушан</pattern>
-  <pattern> изб2л</pattern>
-  <pattern> избл2е1</pattern>
-  <pattern> избле3у1</pattern>
-  <pattern> изблеуш2а1</pattern>
-  <pattern> и3з4бојак</pattern>
-  <pattern> изб2о1</pattern>
-  <pattern> избој2а1</pattern>
-  <pattern> и3з4бо2ј1к</pattern>
-  <pattern> 2и3з4вал2и1</pattern>
-  <pattern> изв2а1</pattern>
-  <pattern> и3з4вал2у1</pattern>
-  <pattern> и3з4в2а1л2а1</pattern>
-  <pattern> и3з4вал2е1</pattern>
-  <pattern> 2и3з4ваљ2и1</pattern>
-  <pattern> и3з4виж2д</pattern>
-  <pattern> 2и1зв2и1</pattern>
-  <pattern> и3з4вииск2р</pattern>
-  <pattern> 2и1зв2и3и1</pattern>
-  <pattern> извиис2к</pattern>
-  <pattern> и3з4виј2а1</pattern>
-  <pattern> и3з4вијен</pattern>
-  <pattern> извиј2е1</pattern>
-  <pattern> и3з4вин</pattern>
-  <pattern> и3з4вир</pattern>
-  <pattern> и3з4вињ</pattern>
-  <pattern> и3з4витоп</pattern>
-  <pattern> извит2о1</pattern>
-  <pattern> и3з4вјед</pattern>
-  <pattern> изв2ј</pattern>
-  <pattern> извј2е1</pattern>
-  <pattern> и3з4војац</pattern>
-  <pattern> изв2о1</pattern>
-  <pattern> извој2а1</pattern>
-  <pattern> и3з4во2ј1ц</pattern>
-  <pattern> и3з4вор</pattern>
-  <pattern> и3з4гомет</pattern>
-  <pattern> изг2о1</pattern>
-  <pattern> изгом2е1</pattern>
-  <pattern> и3з4гред</pattern>
-  <pattern> изг2р</pattern>
-  <pattern> изгр2е1</pattern>
-  <pattern> и3з4г2р1н</pattern>
-  <pattern> и3з4г2р1т</pattern>
-  <pattern> и3з4драв</pattern>
-  <pattern> изд2р</pattern>
-  <pattern> издр2а1</pattern>
-  <pattern> и3з4иђ</pattern>
-  <pattern> и3з4ид</pattern>
-  <pattern> 2и3з4и1м2и1</pattern>
-  <pattern> и3з4јеж2љ</pattern>
-  <pattern> изј2е1</pattern>
-  <pattern> и3з4лоз</pattern>
-  <pattern> изл2о1</pattern>
-  <pattern> и3з4лож</pattern>
-  <pattern> и3з4лог</pattern>
-  <pattern> и3з4лопаћ</pattern>
-  <pattern> излоп2а1</pattern>
-  <pattern> и3з4ним</pattern>
-  <pattern> изн2и1</pattern>
-  <pattern> и3з4ној</pattern>
-  <pattern> изн2о1</pattern>
-  <pattern> из4оанем</pattern>
-  <pattern> изо3а1</pattern>
-  <pattern> изоан2е1</pattern>
-  <pattern> из4оаном</pattern>
-  <pattern> изоан2о1</pattern>
-  <pattern> из4обат</pattern>
-  <pattern> изоб2а1</pattern>
-  <pattern> из4оброн</pattern>
-  <pattern> изоб2р</pattern>
-  <pattern> изобр2о1</pattern>
-  <pattern> из4огам</pattern>
-  <pattern> изог2а1</pattern>
-  <pattern> из4о1ге3о1</pattern>
-  <pattern> изог2е1</pattern>
-  <pattern> из4оглос</pattern>
-  <pattern> изог2л</pattern>
-  <pattern> изогл2о1</pattern>
-  <pattern> из4огон</pattern>
-  <pattern> изог2о1</pattern>
-  <pattern> из4ограф</pattern>
-  <pattern> изог2р</pattern>
-  <pattern> изогр2а1</pattern>
-  <pattern> из4одим</pattern>
-  <pattern> 2и1зод2и1</pattern>
-  <pattern> из4один</pattern>
-  <pattern> из4одоз</pattern>
-  <pattern> изод2о1</pattern>
-  <pattern> из4оклин</pattern>
-  <pattern> изок2л</pattern>
-  <pattern> изокл2и1</pattern>
-  <pattern> из4околон</pattern>
-  <pattern> изок2о1</pattern>
-  <pattern> изокол2о1</pattern>
-  <pattern> и3з4олат</pattern>
-  <pattern> изол2а1</pattern>
-  <pattern> и3з4олац</pattern>
-  <pattern> и3з4олир</pattern>
-  <pattern> изол2и1</pattern>
-  <pattern> и3з4олов</pattern>
-  <pattern> изол2о1</pattern>
-  <pattern> из4оле2к1с</pattern>
-  <pattern> изол2е1</pattern>
-  <pattern> из4олу2к1с</pattern>
-  <pattern> изол2у1</pattern>
-  <pattern> из4омер</pattern>
-  <pattern> изом2е1</pattern>
-  <pattern> из4омет2р</pattern>
-  <pattern> из4омо2р1ф</pattern>
-  <pattern> изом2о1</pattern>
-  <pattern> из4онеф</pattern>
-  <pattern> изон2е1</pattern>
-  <pattern> из4оном</pattern>
-  <pattern> изон2о1</pattern>
-  <pattern> из4опат</pattern>
-  <pattern> изоп2а1</pattern>
-  <pattern> из4опер</pattern>
-  <pattern> изоп2е1</pattern>
-  <pattern> из4опл2е1</pattern>
-  <pattern> изоп2л</pattern>
-  <pattern> из4опол</pattern>
-  <pattern> изоп2о1</pattern>
-  <pattern> из4опсеф</pattern>
-  <pattern> изо2п1с</pattern>
-  <pattern> изопс2е1</pattern>
-  <pattern> из4орах</pattern>
-  <pattern> изор2а1</pattern>
-  <pattern> 2и1з4осе3и1</pattern>
-  <pattern> изос2е1</pattern>
-  <pattern> из4оси2н1т</pattern>
-  <pattern> 2и1зос2и1</pattern>
-  <pattern> из4осис2т</pattern>
-  <pattern> из4оскел</pattern>
-  <pattern> изос2к</pattern>
-  <pattern> изоск2е1</pattern>
-  <pattern> из4оскоп</pattern>
-  <pattern> изоск2о1</pattern>
-  <pattern> из4остаз</pattern>
-  <pattern> изос2т</pattern>
-  <pattern> изост2а1</pattern>
-  <pattern> из4ост2е1</pattern>
-  <pattern> из4отах</pattern>
-  <pattern> изот2а1</pattern>
-  <pattern> из4отал</pattern>
-  <pattern> из4отер</pattern>
-  <pattern> изот2е1</pattern>
-  <pattern> из4отон</pattern>
-  <pattern> из2о1т2о1</pattern>
-  <pattern> из4отоп</pattern>
-  <pattern> из4о1тр2о1</pattern>
-  <pattern> изот2р</pattern>
-  <pattern> из4офон</pattern>
-  <pattern> из2о1ф2о1</pattern>
-  <pattern> из4офот</pattern>
-  <pattern> из4охал</pattern>
-  <pattern> изох2а1</pattern>
-  <pattern> из4охаз</pattern>
-  <pattern> из4охел</pattern>
-  <pattern> изох2е1</pattern>
-  <pattern> из4охиј</pattern>
-  <pattern> 2и1зох2и1</pattern>
-  <pattern> из4охим</pattern>
-  <pattern> из4охит</pattern>
-  <pattern> из4охи2п1с</pattern>
-  <pattern> из4охор</pattern>
-  <pattern> изох2о1</pattern>
-  <pattern> из4о1хр2о1</pattern>
-  <pattern> изох2р</pattern>
-  <pattern> и3з4раел</pattern>
-  <pattern> изр2а1</pattern>
-  <pattern> изра3е1</pattern>
-  <pattern> и3з4раиљ</pattern>
-  <pattern> 2и1зра3и1</pattern>
-  <pattern> 2и3з4рач2и1</pattern>
-  <pattern> и3з4ун</pattern>
-  <pattern> и3з4у2п1ч</pattern>
-  <pattern> и2с3ц</pattern>
-  <pattern> и2с3к</pattern>
-  <pattern> и2с3п</pattern>
-  <pattern> и3с4как</pattern>
-  <pattern> иск2а1</pattern>
-  <pattern> и3с4кат</pattern>
-  <pattern> и3с4кањ</pattern>
-  <pattern> и3с4кариот</pattern>
-  <pattern> искар2и1</pattern>
-  <pattern> искари3о1</pattern>
-  <pattern> и3с4квас</pattern>
-  <pattern> иск2в</pattern>
-  <pattern> искв2а1</pattern>
-  <pattern> и3с4кв2р1ч</pattern>
-  <pattern> искв2р</pattern>
-  <pattern> и3с4кин</pattern>
-  <pattern> 2и1ск2и1</pattern>
-  <pattern> и3с4кит2а1</pattern>
-  <pattern> и3с4конс2к</pattern>
-  <pattern> иск2о1</pattern>
-  <pattern> иско2н1с</pattern>
-  <pattern> и3с4коч</pattern>
-  <pattern> и3с4крам</pattern>
-  <pattern> иск2р</pattern>
-  <pattern> искр2а1</pattern>
-  <pattern> и3с4крит</pattern>
-  <pattern> 2и1скр2и1</pattern>
-  <pattern> и3с4криш</pattern>
-  <pattern> и3с4крич</pattern>
-  <pattern> и3с4криц</pattern>
-  <pattern> и3с4крат</pattern>
-  <pattern> и3с4крен</pattern>
-  <pattern> искр2е1</pattern>
-  <pattern> и3с4крењ</pattern>
-  <pattern> и3с4крој</pattern>
-  <pattern> искр2о1</pattern>
-  <pattern> и3с4крс2н</pattern>
-  <pattern> иск2р1с</pattern>
-  <pattern> и3с4крс2а1</pattern>
-  <pattern> и3с4купљ2а1</pattern>
-  <pattern> иск2у1</pattern>
-  <pattern> искуп2љ</pattern>
-  <pattern> и3с4лам</pattern>
-  <pattern> ис2л</pattern>
-  <pattern> исл2а1</pattern>
-  <pattern> и3с4лаб</pattern>
-  <pattern> и3с4леђ</pattern>
-  <pattern> исл2е1</pattern>
-  <pattern> и3с4лед</pattern>
-  <pattern> и3с4лијеђ</pattern>
-  <pattern> 2и1сл2и1</pattern>
-  <pattern> ислиј2е1</pattern>
-  <pattern> и3с4лијед</pattern>
-  <pattern> и3с4љеђ</pattern>
-  <pattern> ис2љ</pattern>
-  <pattern> исљ2е1</pattern>
-  <pattern> и3с4љед</pattern>
-  <pattern> и3с4лик</pattern>
-  <pattern> и3с4лин</pattern>
-  <pattern> и3с4лов</pattern>
-  <pattern> исл2о1</pattern>
-  <pattern> и3с4луш</pattern>
-  <pattern> исл2у1</pattern>
-  <pattern> и3с4луж</pattern>
-  <pattern> и3с4м2е1</pattern>
-  <pattern> ис2м</pattern>
-  <pattern> и3с4миј2е1</pattern>
-  <pattern> исм2и1</pattern>
-  <pattern> и3с4мј2е1</pattern>
-  <pattern> исм2ј</pattern>
-  <pattern> и3с4пав</pattern>
-  <pattern> исп2а1</pattern>
-  <pattern> и3с4паљив</pattern>
-  <pattern> испаљ2и1</pattern>
-  <pattern> и3с4пир2а1</pattern>
-  <pattern> исп2и1</pattern>
-  <pattern> и3с4плит</pattern>
-  <pattern> исп2л</pattern>
-  <pattern> 2и1спл2и1</pattern>
-  <pattern> и3с4плић</pattern>
-  <pattern> и3с4покој</pattern>
-  <pattern> исп2о1</pattern>
-  <pattern> испок2о1</pattern>
-  <pattern> и3с4полин</pattern>
-  <pattern> испол2и1</pattern>
-  <pattern> и3с4пон</pattern>
-  <pattern> и3с4порав</pattern>
-  <pattern> испор2а1</pattern>
-  <pattern> 2и3с4прав2и1</pattern>
-  <pattern> исп2р</pattern>
-  <pattern> испр2а1</pattern>
-  <pattern> и3с4пра2в1к</pattern>
-  <pattern> и3с4пра2в1н</pattern>
-  <pattern> и3с4прав2љ</pattern>
-  <pattern> и3с4пр2а1в2а1</pattern>
-  <pattern> и3с4пу2п1ч</pattern>
-  <pattern> исп2у1</pattern>
-  <pattern> и3с4пур</pattern>
-  <pattern> и3с4ред</pattern>
-  <pattern> ис2р</pattern>
-  <pattern> иср2е1</pattern>
-  <pattern> и3с4р1к</pattern>
-  <pattern> 2и3с4тав2и1</pattern>
-  <pattern> ист2а1</pattern>
-  <pattern> и3с4тав2љ</pattern>
-  <pattern> и3с4та2к1н</pattern>
-  <pattern> и3с4там</pattern>
-  <pattern> и3с4тар</pattern>
-  <pattern> и3с4тас</pattern>
-  <pattern> и3с4таћ</pattern>
-  <pattern> и3с4тин</pattern>
-  <pattern> 2и1ст2и1</pattern>
-  <pattern> и3с4тир</pattern>
-  <pattern> и3с4тиц</pattern>
-  <pattern> и3с4тифан</pattern>
-  <pattern> истиф2а1</pattern>
-  <pattern> и3с4ток</pattern>
-  <pattern> ист2о1</pattern>
-  <pattern> 2и3с4тор2и1</pattern>
-  <pattern> и3с4то2ч1н</pattern>
-  <pattern> и3с4то2ч1њ</pattern>
-  <pattern> и3с4точ2а1</pattern>
-  <pattern> и3с4трав</pattern>
-  <pattern> ист2р</pattern>
-  <pattern> истр2а1</pattern>
-  <pattern> и3с4трад</pattern>
-  <pattern> и3с4тран</pattern>
-  <pattern> и3с4трић</pattern>
-  <pattern> 2и1стр2и1</pattern>
-  <pattern> и3с4триж</pattern>
-  <pattern> и3с4триц</pattern>
-  <pattern> и3с4труг</pattern>
-  <pattern> истр2у1</pattern>
-  <pattern> и3с4туп</pattern>
-  <pattern> ист2у1</pattern>
-  <pattern> и3с4ук</pattern>
-  <pattern> ис2у1</pattern>
-  <pattern> и3с4ус</pattern>
-  <pattern> и3с4ут</pattern>
-  <pattern> и3с4уш</pattern>
-  <pattern> и2ж3ђ</pattern>
-  <pattern> и2ш3ћ</pattern>
-  <pattern> и2ш3ч</pattern>
-  <pattern> из3бе2з3об2р</pattern>
-  <pattern> изб2е1</pattern>
-  <pattern> избез2о1</pattern>
-  <pattern> из3бе2з3ум</pattern>
-  <pattern> избез2у1</pattern>
-  <pattern> из3ва2н3ев2р</pattern>
-  <pattern> изван2е1</pattern>
-  <pattern> на2д3л</pattern>
-  <pattern> на2д3љ</pattern>
-  <pattern> на2д3в</pattern>
-  <pattern> на3д4вал</pattern>
-  <pattern> надв2а1</pattern>
-  <pattern> на3д4вес2и1</pattern>
-  <pattern> надв2е1</pattern>
-  <pattern> на3д4вес2т</pattern>
-  <pattern> на3д4виј</pattern>
-  <pattern> надв2и1</pattern>
-  <pattern> на3д4вит</pattern>
-  <pattern> н2а3д4вл2а1</pattern>
-  <pattern> на2д3в2л</pattern>
-  <pattern> на3д4вој2е1</pattern>
-  <pattern> надв2о1</pattern>
-  <pattern> на3д4вор</pattern>
-  <pattern> на2д3иг2р</pattern>
-  <pattern> над2и1</pattern>
-  <pattern> на2д3и2н1ж</pattern>
-  <pattern> н2а2д3ин2а1</pattern>
-  <pattern> на2д3ис2к</pattern>
-  <pattern> на2д3јах</pattern>
-  <pattern> над2ј</pattern>
-  <pattern> н2а1дј2а1</pattern>
-  <pattern> на2д3јач</pattern>
-  <pattern> на2д3јек</pattern>
-  <pattern> надј2е1</pattern>
-  <pattern> на2д3јез</pattern>
-  <pattern> на2д3јеч</pattern>
-  <pattern> на2д3јун</pattern>
-  <pattern> надј2у1</pattern>
-  <pattern> на3д4лан</pattern>
-  <pattern> надл2а1</pattern>
-  <pattern> на3д4леш</pattern>
-  <pattern> надл2е1</pattern>
-  <pattern> на3д4леж</pattern>
-  <pattern> н2а2д3ор2а1</pattern>
-  <pattern> над2о1</pattern>
-  <pattern> на2д3о1с2о1</pattern>
-  <pattern> на2д3ос2е1</pattern>
-  <pattern> на2д3осј2е1</pattern>
-  <pattern> надос2ј</pattern>
-  <pattern> на2д3оф2и1</pattern>
-  <pattern> на2д3оч</pattern>
-  <pattern> на2д3ран</pattern>
-  <pattern> над2р</pattern>
-  <pattern> н2а1др2а1</pattern>
-  <pattern> на2д3рач</pattern>
-  <pattern> на2д3рас2т</pattern>
-  <pattern> на2д3раш2ћ</pattern>
-  <pattern> на2д3реал</pattern>
-  <pattern> надр2е1</pattern>
-  <pattern> н2а1дре3а1</pattern>
-  <pattern> на2д3реп</pattern>
-  <pattern> на2д3рук</pattern>
-  <pattern> надр2у1</pattern>
-  <pattern> на2д3руч</pattern>
-  <pattern> на2д3руг</pattern>
-  <pattern> на2д3удар</pattern>
-  <pattern> над2у1</pattern>
-  <pattern> надуд2а1</pattern>
-  <pattern> на2д3ум</pattern>
-  <pattern> на2д3уч</pattern>
-  <pattern> н2а2ј3а1</pattern>
-  <pattern> на2ј3е1</pattern>
-  <pattern> на2ј3и1</pattern>
-  <pattern> на2ј3о1</pattern>
-  <pattern> на2ј3у1</pattern>
-  <pattern> на3ј4ав2и1</pattern>
-  <pattern> на3ј4ав2љ</pattern>
-  <pattern> н2а3ј4а1в2а1</pattern>
-  <pattern> на3ј4ав2е1</pattern>
-  <pattern> на3ј4ад2и1</pattern>
-  <pattern> н2а3ј4а1д2а1</pattern>
-  <pattern> на3ј4ад2е1</pattern>
-  <pattern> на3ј4аж2и1</pattern>
-  <pattern> на3ј4аз2и1</pattern>
-  <pattern> на3ј4ак2о1</pattern>
-  <pattern> н2а3ј4а1к2а1</pattern>
-  <pattern> на3ј4ал2о1</pattern>
-  <pattern> на3ј4ам2и1</pattern>
-  <pattern> на3ј4ам2л</pattern>
-  <pattern> на3ј4а2м1н</pattern>
-  <pattern> на3ј4ар2и1</pattern>
-  <pattern> на3ј4а2р1м</pattern>
-  <pattern> на3ј4а2р1ц</pattern>
-  <pattern> на3ј4ат2и1</pattern>
-  <pattern> на3ј4аук</pattern>
-  <pattern> наја3у1</pattern>
-  <pattern> на3ј4ах</pattern>
-  <pattern> на3ј4аш</pattern>
-  <pattern> на3ј4ед2и1</pattern>
-  <pattern> на3ј4е2д1н</pattern>
-  <pattern> на3ј4ед2р</pattern>
-  <pattern> н2а3ј4ед2а1</pattern>
-  <pattern> на3ј4еж2и1</pattern>
-  <pattern> на3ј4еж2у1</pattern>
-  <pattern> на3ј4е1ж2е1</pattern>
-  <pattern> на3ј4ез2н</pattern>
-  <pattern> на3ј4ез2д</pattern>
-  <pattern> на3ј4ест2и1</pattern>
-  <pattern> најес2т</pattern>
-  <pattern> на3ј4е2т1к</pattern>
-  <pattern> на3ј4ец</pattern>
-  <pattern> на3ј4ур2и1</pattern>
-  <pattern> на3ј4урен</pattern>
-  <pattern> најур2е1</pattern>
-  <pattern> о2б3ј</pattern>
-  <pattern> о2б3љ</pattern>
-  <pattern> о2б3р</pattern>
-  <pattern> обе2з3б</pattern>
-  <pattern> об2е1</pattern>
-  <pattern> обе2з3д</pattern>
-  <pattern> обе2з3г</pattern>
-  <pattern> обе2з3ј</pattern>
-  <pattern> обе2з3л</pattern>
-  <pattern> обе2з3м</pattern>
-  <pattern> обе2з3н</pattern>
-  <pattern> 2о1бе2з3о1</pattern>
-  <pattern> обе2з3љ</pattern>
-  <pattern> обе2з3р</pattern>
-  <pattern> обе2з3у1</pattern>
-  <pattern> обе2з3в</pattern>
-  <pattern> обе3з4виј</pattern>
-  <pattern> обезв2и1</pattern>
-  <pattern> обе3з4нан</pattern>
-  <pattern> обезн2а1</pattern>
-  <pattern> обе3з4нањ</pattern>
-  <pattern> обе3з4нач</pattern>
-  <pattern> обе3з4уб</pattern>
-  <pattern> обе2с3ц</pattern>
-  <pattern> обе2с3к</pattern>
-  <pattern> обе2с3п</pattern>
-  <pattern> обе2с3т</pattern>
-  <pattern> обе3с4тан</pattern>
-  <pattern> обест2а1</pattern>
-  <pattern> обе3с4тиј</pattern>
-  <pattern> обест2и1</pattern>
-  <pattern> обе3с4тран</pattern>
-  <pattern> обест2р</pattern>
-  <pattern> обестр2а1</pattern>
-  <pattern> обе2ш3ћ</pattern>
-  <pattern> обе2ш3ч</pattern>
-  <pattern> о2б3иг2р</pattern>
-  <pattern> об2и1</pattern>
-  <pattern> о2б3истин</pattern>
-  <pattern> обис2т</pattern>
-  <pattern> об2и1ст2и1</pattern>
-  <pattern> о2б3истињ</pattern>
-  <pattern> о3б4јек</pattern>
-  <pattern> обј2е1</pattern>
-  <pattern> о3б4јер</pattern>
-  <pattern> о3б4јес2и1</pattern>
-  <pattern> о3б4јет</pattern>
-  <pattern> о3б4јеш</pattern>
-  <pattern> о2б3лај</pattern>
-  <pattern> об2л</pattern>
-  <pattern> обл2а1</pattern>
-  <pattern> о2б3лам</pattern>
-  <pattern> о2б3ла2к1ш</pattern>
-  <pattern> о2б3лас2к</pattern>
-  <pattern> о2б3леп</pattern>
-  <pattern> обл2е1</pattern>
-  <pattern> о2б3лет</pattern>
-  <pattern> о2б3лећ</pattern>
-  <pattern> о2б3леж</pattern>
-  <pattern> о2б3лег</pattern>
-  <pattern> о2б3лијеп</pattern>
-  <pattern> обл2и1</pattern>
-  <pattern> облиј2е1</pattern>
-  <pattern> о2б3лијет</pattern>
-  <pattern> о2б3лијеж</pattern>
-  <pattern> о2б3лијег</pattern>
-  <pattern> о2б3леден</pattern>
-  <pattern> облед2е1</pattern>
-  <pattern> о2б3лив</pattern>
-  <pattern> о2б3лизат</pattern>
-  <pattern> облиз2а1</pattern>
-  <pattern> о2б3лизав</pattern>
-  <pattern> о2б3л2и1з2и1</pattern>
-  <pattern> о2б3лис2т</pattern>
-  <pattern> о2б3лок2а1</pattern>
-  <pattern> обл2о1</pattern>
-  <pattern> о2б3лук</pattern>
-  <pattern> обл2у1</pattern>
-  <pattern> о2б3луч</pattern>
-  <pattern> о3б4љан</pattern>
-  <pattern> обљ2а1</pattern>
-  <pattern> о3б4љут</pattern>
-  <pattern> обљ2у1</pattern>
-  <pattern> о3б4љуз</pattern>
-  <pattern> о2б3ор2у1</pattern>
-  <pattern> об2о1</pattern>
-  <pattern> о3б4раж2е1</pattern>
-  <pattern> обр2а1</pattern>
-  <pattern> о3б4раз2и1</pattern>
-  <pattern> о3б4раз2н</pattern>
-  <pattern> 2о3б4раз2о1</pattern>
-  <pattern> о3б4раз2у1</pattern>
-  <pattern> о3б4р2а1з2а1</pattern>
-  <pattern> о3б4раз2д</pattern>
-  <pattern> о3б4ра2м1б</pattern>
-  <pattern> о3б4ран</pattern>
-  <pattern> о3б4рањ</pattern>
-  <pattern> о3б4рат</pattern>
-  <pattern> о3б4раћ</pattern>
-  <pattern> о3б4раш2н</pattern>
-  <pattern> о3б4раш2ч</pattern>
-  <pattern> о3б4р1в</pattern>
-  <pattern> о3б4р1ђ</pattern>
-  <pattern> о3б4рем</pattern>
-  <pattern> обр2е1</pattern>
-  <pattern> о3б4рес</pattern>
-  <pattern> о3б4ређ</pattern>
-  <pattern> о3б4реч</pattern>
-  <pattern> о3б4реж</pattern>
-  <pattern> о3б4рец</pattern>
-  <pattern> о3б4ред</pattern>
-  <pattern> о3б4рет2и1</pattern>
-  <pattern> о3б4ре2т1н</pattern>
-  <pattern> о3б4риј</pattern>
-  <pattern> обр2и1</pattern>
-  <pattern> о3б4рис</pattern>
-  <pattern> о3б4рит</pattern>
-  <pattern> о3б4рив</pattern>
-  <pattern> о3б4рич</pattern>
-  <pattern> о3б4риц</pattern>
-  <pattern> о3б4р1к</pattern>
-  <pattern> о3б4р1л</pattern>
-  <pattern> о3б4р1н</pattern>
-  <pattern> о3б4р1љ</pattern>
-  <pattern> о3б4р1с</pattern>
-  <pattern> о3б4р1т</pattern>
-  <pattern> о3б4р1ш</pattern>
-  <pattern> о3б4р1ч</pattern>
-  <pattern> о3б4рок</pattern>
-  <pattern> 2о1бр2о1</pattern>
-  <pattern> о3б4рон</pattern>
-  <pattern> о3б4роњ</pattern>
-  <pattern> о3б4роћ</pattern>
-  <pattern> о3б4роч</pattern>
-  <pattern> о3б4ров2а1</pattern>
-  <pattern> о3б4ро2в1ц</pattern>
-  <pattern> о3б4рук</pattern>
-  <pattern> обр2у1</pattern>
-  <pattern> о3б4рун</pattern>
-  <pattern> о3б4рус</pattern>
-  <pattern> о3б4руњ</pattern>
-  <pattern> о3б4руш</pattern>
-  <pattern> о3б4руч</pattern>
-  <pattern> о2б3убож</pattern>
-  <pattern> об2у1</pattern>
-  <pattern> обуб2о1</pattern>
-  <pattern> о2б3уз</pattern>
-  <pattern> о2б3уж</pattern>
-  <pattern> о2б3уд</pattern>
-  <pattern> о2б3ум2и1</pattern>
-  <pattern> о2б3ум2ј</pattern>
-  <pattern> о2б3ум2р</pattern>
-  <pattern> о2б3ум2е1</pattern>
-  <pattern> о2д3ј</pattern>
-  <pattern> о2д3л</pattern>
-  <pattern> о2д3љ</pattern>
-  <pattern> о2д3р</pattern>
-  <pattern> о2д3в</pattern>
-  <pattern> о2д3а2р1г</pattern>
-  <pattern> о3д4вај</pattern>
-  <pattern> одв2а1</pattern>
-  <pattern> о3д4важ</pattern>
-  <pattern> о3д4вес2н</pattern>
-  <pattern> одв2е1</pattern>
-  <pattern> о3д4вес2т</pattern>
-  <pattern> о3д4вес2а1</pattern>
-  <pattern> о3д4викав</pattern>
-  <pattern> одв2и1</pattern>
-  <pattern> одвик2а1</pattern>
-  <pattern> о3д4ви2к1н</pattern>
-  <pattern> о3д4вис</pattern>
-  <pattern> о3д4вић</pattern>
-  <pattern> о3д4вој</pattern>
-  <pattern> одв2о1</pattern>
-  <pattern> о2д3иг2р</pattern>
-  <pattern> од2и1</pattern>
-  <pattern> о2д3и2з3в</pattern>
-  <pattern> о2д3и2з3д</pattern>
-  <pattern> о2д3ис2к</pattern>
-  <pattern> о2д3и1ст2и1</pattern>
-  <pattern> одис2т</pattern>
-  <pattern> о3д4јел</pattern>
-  <pattern> одј2е1</pattern>
-  <pattern> о3д4јен</pattern>
-  <pattern> о3д4јев</pattern>
-  <pattern> о3д4јећ</pattern>
-  <pattern> о3д4лаз</pattern>
-  <pattern> одл2а1</pattern>
-  <pattern> о3д4лаж</pattern>
-  <pattern> о3д4лаг</pattern>
-  <pattern> о3д4л2а1к2а1</pattern>
-  <pattern> о3д4лук</pattern>
-  <pattern> одл2у1</pattern>
-  <pattern> о3д4луч</pattern>
-  <pattern> о2д3оз2д</pattern>
-  <pattern> 2о1д2о1</pattern>
-  <pattern> о2д3оз2г</pattern>
-  <pattern> о2д3ок</pattern>
-  <pattern> о2д3о2н1л</pattern>
-  <pattern> 2о2д3о1н2о1</pattern>
-  <pattern> о2д3он2у1</pattern>
-  <pattern> о2д3о2н1д</pattern>
-  <pattern> о3д4ран2и1</pattern>
-  <pattern> одр2а1</pattern>
-  <pattern> 2о3д4ран2о1</pattern>
-  <pattern> о3д4ран2у1</pattern>
-  <pattern> о3д4р2а1н2а1</pattern>
-  <pattern> о3д4ран2е1</pattern>
-  <pattern> о3д4раз</pattern>
-  <pattern> о3д4раћ</pattern>
-  <pattern> о3д4раж</pattern>
-  <pattern> о3д4рап2и1</pattern>
-  <pattern> о3д4рап2љ</pattern>
-  <pattern> о3д4р2а1п2а1</pattern>
-  <pattern> о3д4рач2и1</pattern>
-  <pattern> о3д4рвен</pattern>
-  <pattern> од2р1в</pattern>
-  <pattern> одрв2е1</pattern>
-  <pattern> о3д4рвењ</pattern>
-  <pattern> о3д4рвеч</pattern>
-  <pattern> о3д4рем</pattern>
-  <pattern> одр2е1</pattern>
-  <pattern> о3д4рен</pattern>
-  <pattern> о3д4рет</pattern>
-  <pattern> о3д4ређ</pattern>
-  <pattern> о3д4ред</pattern>
-  <pattern> о3д4р1л</pattern>
-  <pattern> о3д4р1н</pattern>
-  <pattern> о3д4р1п</pattern>
-  <pattern> о3д4р1љ</pattern>
-  <pattern> о3д4р1т</pattern>
-  <pattern> о3д4р1ж</pattern>
-  <pattern> о3д4рин</pattern>
-  <pattern> одр2и1</pattern>
-  <pattern> о3д4рињ</pattern>
-  <pattern> о3д4риш</pattern>
-  <pattern> о3д4рич</pattern>
-  <pattern> о3д4риб</pattern>
-  <pattern> о3д4риц</pattern>
-  <pattern> о3д4рон</pattern>
-  <pattern> 2о1др2о1</pattern>
-  <pattern> о3д4роњ</pattern>
-  <pattern> о3д4руж</pattern>
-  <pattern> одр2у1</pattern>
-  <pattern> о3д4руг</pattern>
-  <pattern> о2д3ув2и1</pattern>
-  <pattern> од2у1</pattern>
-  <pattern> о2д3ув2е1</pattern>
-  <pattern> о2д3уз2и1</pattern>
-  <pattern> о2д3уз2л</pattern>
-  <pattern> о2д3уз2д</pattern>
-  <pattern> о2д3уз2е1</pattern>
-  <pattern> о2д3ук</pattern>
-  <pattern> о2д3ул</pattern>
-  <pattern> о2д3ум</pattern>
-  <pattern> о2д3уч</pattern>
-  <pattern> по2д3а2д1м</pattern>
-  <pattern> под2а1</pattern>
-  <pattern> по2д3вариј</pattern>
-  <pattern> под2в</pattern>
-  <pattern> подв2а1</pattern>
-  <pattern> подвар2и1</pattern>
-  <pattern> по2д3вез</pattern>
-  <pattern> подв2е1</pattern>
-  <pattern> по2д3веч</pattern>
-  <pattern> по2д3веж</pattern>
-  <pattern> по2д3вик</pattern>
-  <pattern> подв2и1</pattern>
-  <pattern> по2д3вил</pattern>
-  <pattern> по2д3вир</pattern>
-  <pattern> по2д3вињ</pattern>
-  <pattern> по2д3влас</pattern>
-  <pattern> по2д3в2л</pattern>
-  <pattern> подвл2а1</pattern>
-  <pattern> по2д3влаш</pattern>
-  <pattern> по2д3воз</pattern>
-  <pattern> п2о1дв2о1</pattern>
-  <pattern> по2д3вођ</pattern>
-  <pattern> по2д3вож</pattern>
-  <pattern> по2д3вод</pattern>
-  <pattern> по2д3врат</pattern>
-  <pattern> по2д3в2р</pattern>
-  <pattern> подвр2а1</pattern>
-  <pattern> по2д3враћ</pattern>
-  <pattern> по2д3в2р1ћ</pattern>
-  <pattern> по2д3в2р1ж</pattern>
-  <pattern> по2д3в2р1г</pattern>
-  <pattern> по2д3врис</pattern>
-  <pattern> подвр2и1</pattern>
-  <pattern> по2д3в2р1с</pattern>
-  <pattern> по2д3вућ</pattern>
-  <pattern> подв2у1</pattern>
-  <pattern> по2д3иг2р</pattern>
-  <pattern> под2и1</pattern>
-  <pattern> по2д3из2в</pattern>
-  <pattern> по2д3ј</pattern>
-  <pattern> по3д4јен</pattern>
-  <pattern> подј2е1</pattern>
-  <pattern> по3д4јеч</pattern>
-  <pattern> по2д3лакат</pattern>
-  <pattern> под2л</pattern>
-  <pattern> подл2а1</pattern>
-  <pattern> подлак2а1</pattern>
-  <pattern> по2д3ла2к1т</pattern>
-  <pattern> по2д3леп</pattern>
-  <pattern> подл2е1</pattern>
-  <pattern> по2д3лет</pattern>
-  <pattern> по2д3лећ</pattern>
-  <pattern> по2д3леж</pattern>
-  <pattern> по2д3лег</pattern>
-  <pattern> по2д3лиз</pattern>
-  <pattern> подл2и1</pattern>
-  <pattern> по2д3лијеп</pattern>
-  <pattern> подлиј2е1</pattern>
-  <pattern> по2д3лијет</pattern>
-  <pattern> по2д3лијећ</pattern>
-  <pattern> по2д3лијеж</pattern>
-  <pattern> по2д3лијег</pattern>
-  <pattern> по2д3лис2т</pattern>
-  <pattern> по2д3лок</pattern>
-  <pattern> п2о1дл2о1</pattern>
-  <pattern> по2д3лом</pattern>
-  <pattern> по2д3луп</pattern>
-  <pattern> подл2у1</pattern>
-  <pattern> по2д3луч</pattern>
-  <pattern> по2д3луж</pattern>
-  <pattern> по2д3љут</pattern>
-  <pattern> под2љ</pattern>
-  <pattern> подљ2у1</pattern>
-  <pattern> по2д3о2к1н</pattern>
-  <pattern> п2о1д2о1</pattern>
-  <pattern> по2д3ош</pattern>
-  <pattern> по2д3оч</pattern>
-  <pattern> по2д3оф</pattern>
-  <pattern> по2д3ра2в1н</pattern>
-  <pattern> под2р</pattern>
-  <pattern> подр2а1</pattern>
-  <pattern> по2д3ра2в1њ</pattern>
-  <pattern> по2д3рад</pattern>
-  <pattern> по2д3ра2з3д</pattern>
-  <pattern> по2д3раз2р</pattern>
-  <pattern> по2д3раз2у1</pattern>
-  <pattern> по2д3рам</pattern>
-  <pattern> по2д3ран</pattern>
-  <pattern> по2д3рас</pattern>
-  <pattern> по2д3рањ</pattern>
-  <pattern> по2д3реп</pattern>
-  <pattern> подр2е1</pattern>
-  <pattern> по2д3рес</pattern>
-  <pattern> по2д3рез</pattern>
-  <pattern> по2д3рик</pattern>
-  <pattern> подр2и1</pattern>
-  <pattern> по2д3рит</pattern>
-  <pattern> по2д3рон</pattern>
-  <pattern> п2о1др2о1</pattern>
-  <pattern> по2д3ров</pattern>
-  <pattern> по2д3рож</pattern>
-  <pattern> по2д3рук</pattern>
-  <pattern> подр2у1</pattern>
-  <pattern> по2д3руб</pattern>
-  <pattern> по2д3руч2и1</pattern>
-  <pattern> по2д3ру2ч1н</pattern>
-  <pattern> по2д3руч2а1</pattern>
-  <pattern> по2д3упл2а1</pattern>
-  <pattern> под2у1</pattern>
-  <pattern> подуп2л</pattern>
-  <pattern> по2д3ус2м</pattern>
-  <pattern> по2д3ус2н</pattern>
-  <pattern> пре2д3ј</pattern>
-  <pattern> пре2д3в</pattern>
-  <pattern> пре3д4вај</pattern>
-  <pattern> предв2а1</pattern>
-  <pattern> пре3д4вар</pattern>
-  <pattern> пре3д4вес2т</pattern>
-  <pattern> предв2е1</pattern>
-  <pattern> пре3д4вој2и1</pattern>
-  <pattern> предв2о1</pattern>
-  <pattern> пре3д4вој2а1</pattern>
-  <pattern> пр2е3д4вој2е1</pattern>
-  <pattern> пре3д4вор</pattern>
-  <pattern> пре3д4вос</pattern>
-  <pattern> пре3д4јен</pattern>
-  <pattern> предј2е1</pattern>
-  <pattern> пре2д3иг2р</pattern>
-  <pattern> пред2и1</pattern>
-  <pattern> пре2д3ид</pattern>
-  <pattern> пре2д3из2б</pattern>
-  <pattern> пре2д3и1сп2и1</pattern>
-  <pattern> предис2п</pattern>
-  <pattern> пре2д3ист2о1</pattern>
-  <pattern> предис2т</pattern>
-  <pattern> пре2д3ист2р</pattern>
-  <pattern> пре2д3об2ј</pattern>
-  <pattern> пред2о1</pattern>
-  <pattern> пр2е2д3одр2е1</pattern>
-  <pattern> предод2р</pattern>
-  <pattern> пре2д3окус</pattern>
-  <pattern> предок2у1</pattern>
-  <pattern> пре2д3ос2в</pattern>
-  <pattern> пр2е2д3ос2е1</pattern>
-  <pattern> пр2е2д3осј2е1</pattern>
-  <pattern> предос2ј</pattern>
-  <pattern> пре2д3рат</pattern>
-  <pattern> пред2р</pattern>
-  <pattern> предр2а1</pattern>
-  <pattern> пре2д3рач</pattern>
-  <pattern> пре2д3рад</pattern>
-  <pattern> пре2д3руч</pattern>
-  <pattern> предр2у1</pattern>
-  <pattern> пре2д3убеђ</pattern>
-  <pattern> пред2у1</pattern>
-  <pattern> предуб2е1</pattern>
-  <pattern> пре2д3убијеђ</pattern>
-  <pattern> предуб2и1</pattern>
-  <pattern> предубиј2е1</pattern>
-  <pattern> пре2д3убјеђ</pattern>
-  <pattern> предуб2ј</pattern>
-  <pattern> предубј2е1</pattern>
-  <pattern> пре2д3увер</pattern>
-  <pattern> предув2е1</pattern>
-  <pattern> пре2д3увјер</pattern>
-  <pattern> предув2ј</pattern>
-  <pattern> пр2е1дувј2е1</pattern>
-  <pattern> пре2д3увјет</pattern>
-  <pattern> пре2д3угов</pattern>
-  <pattern> предуг2о1</pattern>
-  <pattern> пре2д3удар</pattern>
-  <pattern> предуд2а1</pattern>
-  <pattern> пре2д3упис</pattern>
-  <pattern> предуп2и1</pattern>
-  <pattern> пре2д3усл2о1</pattern>
-  <pattern> предус2л</pattern>
-  <pattern> проти2в3а2к1ц</pattern>
-  <pattern> прот2и1</pattern>
-  <pattern> против2а1</pattern>
-  <pattern> проти2в3от2р</pattern>
-  <pattern> пр2о1тив2о1</pattern>
-  <pattern> проти2в3оф</pattern>
-  <pattern> проти2в3р</pattern>
-  <pattern> проти2в3ус</pattern>
-  <pattern> против2у1</pattern>
-  <pattern> проти2в3уд</pattern>
-  <pattern> ра2ж3ђ</pattern>
-  <pattern> ра2з3б</pattern>
-  <pattern> ра2з3е1</pattern>
-  <pattern> ра2з3и1</pattern>
-  <pattern> ра2з3ј</pattern>
-  <pattern> ра2з3л</pattern>
-  <pattern> ра2з3м</pattern>
-  <pattern> ра2з3н</pattern>
-  <pattern> ра2з3љ</pattern>
-  <pattern> ра2з3р</pattern>
-  <pattern> ра2з3в</pattern>
-  <pattern> ра2з3њ</pattern>
-  <pattern> ра2з3анал</pattern>
-  <pattern> разан2а1</pattern>
-  <pattern> ра3з4бан</pattern>
-  <pattern> р2а1зб2а1</pattern>
-  <pattern> ра3з4бар</pattern>
-  <pattern> ра3з4ба3у1</pattern>
-  <pattern> ра3з4бад</pattern>
-  <pattern> ра3з4башур</pattern>
-  <pattern> разбаш2у1</pattern>
-  <pattern> ра3з4бој</pattern>
-  <pattern> разб2о1</pattern>
-  <pattern> ра3з4бор</pattern>
-  <pattern> ра3з4вал</pattern>
-  <pattern> разв2а1</pattern>
-  <pattern> ра3з4в2е1д2е1</pattern>
-  <pattern> разв2е1</pattern>
-  <pattern> ра3з4вес2т</pattern>
-  <pattern> ра3з4виг2о1</pattern>
-  <pattern> разв2и1</pattern>
-  <pattern> ра3з4виј2у1</pattern>
-  <pattern> р2а3з4виј2а1</pattern>
-  <pattern> ра3з4виј2е1</pattern>
-  <pattern> ра3з4вит</pattern>
-  <pattern> ра3з4вић</pattern>
-  <pattern> ра3з4вој</pattern>
-  <pattern> разв2о1</pattern>
-  <pattern> ра3з4вон</pattern>
-  <pattern> ра3з4врат</pattern>
-  <pattern> разв2р</pattern>
-  <pattern> р2а1звр2а1</pattern>
-  <pattern> ра3з4враћ</pattern>
-  <pattern> ра3з4в2р1т</pattern>
-  <pattern> ра3з4в2р1ћ</pattern>
-  <pattern> ра3з4гађ</pattern>
-  <pattern> разг2а1</pattern>
-  <pattern> ра3з4г2р1т</pattern>
-  <pattern> разг2р</pattern>
-  <pattern> ра3з4ев</pattern>
-  <pattern> ра3з4иј</pattern>
-  <pattern> ра3з4ил</pattern>
-  <pattern> ра3з4ин</pattern>
-  <pattern> ра3з4ир</pattern>
-  <pattern> ра3з4ит</pattern>
-  <pattern> ра3з4из</pattern>
-  <pattern> ра3з4иђ</pattern>
-  <pattern> ра3з4ић</pattern>
-  <pattern> ра3з4ид</pattern>
-  <pattern> ра3з4лаз</pattern>
-  <pattern> р2а1зл2а1</pattern>
-  <pattern> ра3з4лаг</pattern>
-  <pattern> ра3з4лик</pattern>
-  <pattern> разл2и1</pattern>
-  <pattern> ра3з4лич</pattern>
-  <pattern> ра3з4лоз</pattern>
-  <pattern> разл2о1</pattern>
-  <pattern> ра3з4лож</pattern>
-  <pattern> ра3з4лог</pattern>
-  <pattern> ра3з4мет</pattern>
-  <pattern> разм2е1</pattern>
-  <pattern> ра3з4мећ</pattern>
-  <pattern> ра3з4мрс2к</pattern>
-  <pattern> ра2з3м2р</pattern>
-  <pattern> разм2р1с</pattern>
-  <pattern> ра3з4нат</pattern>
-  <pattern> разн2а1</pattern>
-  <pattern> ра2з3об2л</pattern>
-  <pattern> раз2о1</pattern>
-  <pattern> ра2з3об2р</pattern>
-  <pattern> р2а2з3об2а1</pattern>
-  <pattern> ра2з3од</pattern>
-  <pattern> ра2з3орат</pattern>
-  <pattern> р2а1зор2а1</pattern>
-  <pattern> ра2з3орав</pattern>
-  <pattern> ра2з3о2р1т</pattern>
-  <pattern> ра2з3ор2у1</pattern>
-  <pattern> ра2з3от</pattern>
-  <pattern> ра3з4ред</pattern>
-  <pattern> разр2е1</pattern>
-  <pattern> ра3з4рок</pattern>
-  <pattern> разр2о1</pattern>
-  <pattern> ра3з4роч</pattern>
-  <pattern> ра2з3ув2е1</pattern>
-  <pattern> раз2у1</pattern>
-  <pattern> ра2з3уд2и1</pattern>
-  <pattern> р2а2з3уд2а1</pattern>
-  <pattern> ра2з3у2д1б</pattern>
-  <pattern> ра2з3уз2и1</pattern>
-  <pattern> ра2з3уз2д</pattern>
-  <pattern> ра2з3уз2е1</pattern>
-  <pattern> ра2з3улар</pattern>
-  <pattern> разул2а1</pattern>
-  <pattern> ра2з3ум2р</pattern>
-  <pattern> ра2с3ц</pattern>
-  <pattern> ра2с3к</pattern>
-  <pattern> ра2с3п</pattern>
-  <pattern> ра2с3т</pattern>
-  <pattern> ра3с4как</pattern>
-  <pattern> р2а1ск2а1</pattern>
-  <pattern> ра3с4ка2н1д</pattern>
-  <pattern> ра3с4кин</pattern>
-  <pattern> раск2и1</pattern>
-  <pattern> ра3с4клап</pattern>
-  <pattern> раск2л</pattern>
-  <pattern> р2а1скл2а1</pattern>
-  <pattern> ра3с4клањ</pattern>
-  <pattern> ра3с4клад</pattern>
-  <pattern> ра3с4клон</pattern>
-  <pattern> раскл2о1</pattern>
-  <pattern> ра3с4клоп2и1</pattern>
-  <pattern> ра3с4клоп2љ</pattern>
-  <pattern> р2а3с4клоп2а1</pattern>
-  <pattern> ра3с4кош</pattern>
-  <pattern> раск2о1</pattern>
-  <pattern> ра3с4кроп</pattern>
-  <pattern> раск2р</pattern>
-  <pattern> раскр2о1</pattern>
-  <pattern> ра3с4пај</pattern>
-  <pattern> р2а1сп2а1</pattern>
-  <pattern> ра3с4пав</pattern>
-  <pattern> ра3с4пет2и1</pattern>
-  <pattern> расп2е1</pattern>
-  <pattern> ра3с4пет2о1</pattern>
-  <pattern> р2а3с4пет2а1</pattern>
-  <pattern> ра3с4п2е1т2е1</pattern>
-  <pattern> ра3с4пик2у1</pattern>
-  <pattern> расп2и1</pattern>
-  <pattern> ра3с4пињ</pattern>
-  <pattern> ра3с4плин</pattern>
-  <pattern> расп2л</pattern>
-  <pattern> распл2и1</pattern>
-  <pattern> ра3с4плињ</pattern>
-  <pattern> ра3с4п1н</pattern>
-  <pattern> ра3с4полож</pattern>
-  <pattern> расп2о1</pattern>
-  <pattern> распол2о1</pattern>
-  <pattern> ра3с4пон</pattern>
-  <pattern> ра3с4пор</pattern>
-  <pattern> ра3с4прав</pattern>
-  <pattern> расп2р</pattern>
-  <pattern> распр2а1</pattern>
-  <pattern> ра3с4прем</pattern>
-  <pattern> распр2е1</pattern>
-  <pattern> ра3с4р1ђ</pattern>
-  <pattern> рас2р</pattern>
-  <pattern> ра3с4р1д</pattern>
-  <pattern> ра3с4р2е1</pattern>
-  <pattern> ра3с4тај</pattern>
-  <pattern> р2а1ст2а1</pattern>
-  <pattern> ра3с4тан</pattern>
-  <pattern> ра3с4тат</pattern>
-  <pattern> ра3с4тав</pattern>
-  <pattern> ра3с4тењ</pattern>
-  <pattern> раст2е1</pattern>
-  <pattern> ра3с4тил</pattern>
-  <pattern> раст2и1</pattern>
-  <pattern> ра3с4тир</pattern>
-  <pattern> ра3с4тис</pattern>
-  <pattern> ра3с4тит</pattern>
-  <pattern> ра3с4тињ</pattern>
-  <pattern> ра3с4тој</pattern>
-  <pattern> раст2о1</pattern>
-  <pattern> ра3с4трел</pattern>
-  <pattern> раст2р</pattern>
-  <pattern> растр2е1</pattern>
-  <pattern> ра3с4трет</pattern>
-  <pattern> ра3с4трој</pattern>
-  <pattern> растр2о1</pattern>
-  <pattern> ра3с4т2р1т</pattern>
-  <pattern> ра3с4туп</pattern>
-  <pattern> раст2у1</pattern>
-  <pattern> ра3с4тур</pattern>
-  <pattern> ра3с4тућ</pattern>
-  <pattern> ра4с5ту2р1ч</pattern>
-  <pattern> ра2ш3ћ</pattern>
-  <pattern> ра2ш3ч</pattern>
-  <pattern> ра3ш4ћењ</pattern>
-  <pattern> рашћ2е1</pattern>
-  <pattern> ра3ш4чић</pattern>
-  <pattern> рашч2и1</pattern>
-  <pattern> у2з3б</pattern>
-  <pattern> у2з3д</pattern>
-  <pattern> у2з3г</pattern>
-  <pattern> у2з3и1</pattern>
-  <pattern> у2з3ј</pattern>
-  <pattern> у2з3л</pattern>
-  <pattern> у2з3м</pattern>
-  <pattern> у2з3н</pattern>
-  <pattern> у2з3љ</pattern>
-  <pattern> у2з3р</pattern>
-  <pattern> у2з3в</pattern>
-  <pattern> у2з3њ</pattern>
-  <pattern> у3з4бор</pattern>
-  <pattern> узб2о1</pattern>
-  <pattern> у3з4ван</pattern>
-  <pattern> узв2а1</pattern>
-  <pattern> у3з4ват</pattern>
-  <pattern> у3з4виж</pattern>
-  <pattern> узв2и1</pattern>
-  <pattern> у3з4виј2о1</pattern>
-  <pattern> 2у3з4виј2у1</pattern>
-  <pattern> у3з4виј2а1</pattern>
-  <pattern> у3з4виј2е1</pattern>
-  <pattern> у3з4вој</pattern>
-  <pattern> узв2о1</pattern>
-  <pattern> у3з4диц</pattern>
-  <pattern> узд2и1</pattern>
-  <pattern> у2з3иг2р</pattern>
-  <pattern> у2з3инат</pattern>
-  <pattern> узин2а1</pattern>
-  <pattern> у2з3иск2р</pattern>
-  <pattern> узис2к</pattern>
-  <pattern> у3з4лан</pattern>
-  <pattern> узл2а1</pattern>
-  <pattern> у3з4лат</pattern>
-  <pattern> у3з4лим</pattern>
-  <pattern> узл2и1</pattern>
-  <pattern> у3з4лит</pattern>
-  <pattern> у3з4лић</pattern>
-  <pattern> у3з4лиц</pattern>
-  <pattern> у3з4лов</pattern>
-  <pattern> узл2о1</pattern>
-  <pattern> у3з4лудоб</pattern>
-  <pattern> узл2у1</pattern>
-  <pattern> узлуд2о1</pattern>
-  <pattern> у3з4нак</pattern>
-  <pattern> узн2а1</pattern>
-  <pattern> у3з4нач</pattern>
-  <pattern> у3з4н2е1в2е1</pattern>
-  <pattern> узн2е1</pattern>
-  <pattern> у3з4н2е1вј2е1</pattern>
-  <pattern> узнев2ј</pattern>
-  <pattern> у3з4нич</pattern>
-  <pattern> узн2и1</pattern>
-  <pattern> у3з4ниц</pattern>
-  <pattern> у3з4ној</pattern>
-  <pattern> узн2о1</pattern>
-  <pattern> у2з3обес2т</pattern>
-  <pattern> уз2о1</pattern>
-  <pattern> узоб2е1</pattern>
-  <pattern> у2з3обијес2т</pattern>
-  <pattern> узоб2и1</pattern>
-  <pattern> узобиј2е1</pattern>
-  <pattern> у2з3орат</pattern>
-  <pattern> узор2а1</pattern>
-  <pattern> у2з3орав</pattern>
-  <pattern> у2з3о1х2о1</pattern>
-  <pattern> у3з4рет</pattern>
-  <pattern> узр2е1</pattern>
-  <pattern> у3з4рев</pattern>
-  <pattern> у3з4ријет</pattern>
-  <pattern> узр2и1</pattern>
-  <pattern> узриј2е1</pattern>
-  <pattern> у3з4ријев</pattern>
-  <pattern> у3з4р1н</pattern>
-  <pattern> у3з4р1њ</pattern>
-  <pattern> у3з4р2о1к2о1</pattern>
-  <pattern> узр2о1</pattern>
-  <pattern> 2у3з4рок2у1</pattern>
-  <pattern> у3з4рок2а1</pattern>
-  <pattern> у3з4роч</pattern>
-  <pattern> у3з4руј</pattern>
-  <pattern> узр2у1</pattern>
-  <pattern> у2з3угар</pattern>
-  <pattern> уз2у1</pattern>
-  <pattern> узуг2а1</pattern>
-  <pattern> у2с3ц</pattern>
-  <pattern> у2с3к</pattern>
-  <pattern> у2с3п</pattern>
-  <pattern> у3с4как</pattern>
-  <pattern> уск2а1</pattern>
-  <pattern> у3с4клађ</pattern>
-  <pattern> уск2л</pattern>
-  <pattern> ускл2а1</pattern>
-  <pattern> у3с4клад</pattern>
-  <pattern> у3с4к2о1</pattern>
-  <pattern> у4с5ком</pattern>
-  <pattern> у4с5ков</pattern>
-  <pattern> у4с5кош</pattern>
-  <pattern> у4с5к2о1к2о1</pattern>
-  <pattern> 2у4с5кол2у1</pattern>
-  <pattern> у4с5кол2е1</pattern>
-  <pattern> у4с5коп2а1</pattern>
-  <pattern> у4с5кор2а1</pattern>
-  <pattern> у4с5кос2и1</pattern>
-  <pattern> у4с5кот2р</pattern>
-  <pattern> у3с4куп</pattern>
-  <pattern> уск2у1</pattern>
-  <pattern> у3с4пав</pattern>
-  <pattern> усп2а1</pattern>
-  <pattern> у3с4пал2о1</pattern>
-  <pattern> у3с4пех</pattern>
-  <pattern> усп2е1</pattern>
-  <pattern> у3с4пел</pattern>
-  <pattern> у3с4пем</pattern>
-  <pattern> у3с4пет</pattern>
-  <pattern> у3с4пев</pattern>
-  <pattern> у3с4пеш</pattern>
-  <pattern> у3с4пјех</pattern>
-  <pattern> усп2ј</pattern>
-  <pattern> успј2е1</pattern>
-  <pattern> у3с4пјел</pattern>
-  <pattern> у3с4пјем</pattern>
-  <pattern> у3с4пјет</pattern>
-  <pattern> у3с4пјев</pattern>
-  <pattern> у3с4пјеш</pattern>
-  <pattern> у3с4пе2н1т</pattern>
-  <pattern> у3с4пиј2а1</pattern>
-  <pattern> усп2и1</pattern>
-  <pattern> у3с4пиј2е1</pattern>
-  <pattern> у3с4пијуш</pattern>
-  <pattern> успиј2у1</pattern>
-  <pattern> у3с4пикуш</pattern>
-  <pattern> успик2у1</pattern>
-  <pattern> у3с4пон</pattern>
-  <pattern> усп2о1</pattern>
-  <pattern> у3с4пор2и1</pattern>
-  <pattern> у3с4пор2а1</pattern>
-  <pattern> у3с4порен</pattern>
-  <pattern> успор2е1</pattern>
-  <pattern> у3с4порењ</pattern>
-  <pattern> у3с4пореч</pattern>
-  <pattern> у3с4пособ</pattern>
-  <pattern> успос2о1</pattern>
-  <pattern> у3с4прем2и1</pattern>
-  <pattern> усп2р</pattern>
-  <pattern> успр2е1</pattern>
-  <pattern> у3с4прем2а1</pattern>
-  <pattern> у3с4р1к</pattern>
-  <pattern> ус2р</pattern>
-  <pattern> у3с4р1н</pattern>
-  <pattern> у3с4р1п</pattern>
-  <pattern> у3с4р1љ</pattern>
-  <pattern> у3с4р1т</pattern>
-  <pattern> у3с4р1ђ</pattern>
-  <pattern> у3с4р1ж</pattern>
-  <pattern> у3с4р2а1</pattern>
-  <pattern> у3с4р1д</pattern>
-  <pattern> у3с4р2е1</pattern>
-  <pattern> у3с4ријед</pattern>
-  <pattern> уср2и1</pattern>
-  <pattern> усриј2е1</pattern>
-  <pattern> у2с3талас</pattern>
-  <pattern> ус2т</pattern>
-  <pattern> уст2а1</pattern>
-  <pattern> устал2а1</pattern>
-  <pattern> у2с3т2а1р2а1</pattern>
-  <pattern> у2с3тв2р1ђ</pattern>
-  <pattern> уст2в</pattern>
-  <pattern> уств2р</pattern>
-  <pattern> у2с3тв2р1д</pattern>
-  <pattern> у2с3тер</pattern>
-  <pattern> уст2е1</pattern>
-  <pattern> у2с3тећ</pattern>
-  <pattern> у2с3тег</pattern>
-  <pattern> у2с3тов</pattern>
-  <pattern> уст2о1</pattern>
-  <pattern> у2с3трај</pattern>
-  <pattern> уст2р</pattern>
-  <pattern> устр2а1</pattern>
-  <pattern> у2с3трал</pattern>
-  <pattern> у2с3т2р1г</pattern>
-  <pattern> у2с3треп</pattern>
-  <pattern> устр2е1</pattern>
-  <pattern> у2с3трес</pattern>
-  <pattern> у2с3треб</pattern>
-  <pattern> у2с3т2р1к</pattern>
-  <pattern> у2с3т2р1н</pattern>
-  <pattern> у2с3т2р1п</pattern>
-  <pattern> у2с3т2р1ћ</pattern>
-  <pattern> у2с3т2р1ч</pattern>
-  <pattern> у2с3тум</pattern>
-  <pattern> 2у1ст2у1</pattern>
-  <pattern> у2с3тур</pattern>
-  <pattern> у2с3тућ</pattern>
-  <pattern> у2ш3ћ</pattern>
-  <pattern> у2ш3ч</pattern>
-  <pattern> а2б3алиј</pattern>
-  <pattern> 2а1б2а1</pattern>
-  <pattern> абал2и1</pattern>
-  <pattern> а2б3анац</pattern>
-  <pattern> абан2а1</pattern>
-  <pattern> а2б3евак</pattern>
-  <pattern> аб2е1</pattern>
-  <pattern> абев2а1</pattern>
-  <pattern> а2б3ерац</pattern>
-  <pattern> абер2а1</pattern>
-  <pattern> а2б3ерир</pattern>
-  <pattern> абер2и1</pattern>
-  <pattern> а2б3ирит</pattern>
-  <pattern> аб2и1</pattern>
-  <pattern> абир2и1</pattern>
-  <pattern> а2б3ј2у1</pattern>
-  <pattern> аб2ј</pattern>
-  <pattern> 2а2б3л2а1</pattern>
-  <pattern> аб2л</pattern>
-  <pattern> а2б3лег</pattern>
-  <pattern> абл2е1</pattern>
-  <pattern> а2б3леп</pattern>
-  <pattern> а2б3лок</pattern>
-  <pattern> абл2о1</pattern>
-  <pattern> а2б3л2у1</pattern>
-  <pattern> а2б3ориг</pattern>
-  <pattern> аб2о1</pattern>
-  <pattern> абор2и1</pattern>
-  <pattern> а2б3реак</pattern>
-  <pattern> аб2р</pattern>
-  <pattern> абр2е1</pattern>
-  <pattern> 2а1бре3а1</pattern>
-  <pattern> а2б3рог</pattern>
-  <pattern> абр2о1</pattern>
-  <pattern> а2б3узус</pattern>
-  <pattern> аб2у1</pattern>
-  <pattern> абуз2у1</pattern>
-  <pattern> а2д3ерац</pattern>
-  <pattern> ад2е1</pattern>
-  <pattern> адер2а1</pattern>
-  <pattern> а2д3ве2р1б</pattern>
-  <pattern> ад2в</pattern>
-  <pattern> адв2е1</pattern>
-  <pattern> а2д3ј</pattern>
-  <pattern> а2д3лат</pattern>
-  <pattern> ад2л</pattern>
-  <pattern> адл2а1</pattern>
-  <pattern> а2д3рен</pattern>
-  <pattern> ад2р</pattern>
-  <pattern> адр2е1</pattern>
-  <pattern> а2д3рог</pattern>
-  <pattern> адр2о1</pattern>
-  <pattern> а3г2нос</pattern>
-  <pattern> а2г1н</pattern>
-  <pattern> агн2о1</pattern>
-  <pattern> а3г2ноз</pattern>
-  <pattern> а2набап</pattern>
-  <pattern> 2а1н2а1</pattern>
-  <pattern> 2а1н2а1б2а1</pattern>
-  <pattern> а2набаз</pattern>
-  <pattern> а2набат</pattern>
-  <pattern> а2наби3о1</pattern>
-  <pattern> анаб2и1</pattern>
-  <pattern> а2набол</pattern>
-  <pattern> анаб2о1</pattern>
-  <pattern> а2наген</pattern>
-  <pattern> анаг2е1</pattern>
-  <pattern> а2нагн2о1</pattern>
-  <pattern> ана2г1н</pattern>
-  <pattern> а2н3аг2о1</pattern>
-  <pattern> 2а2н2а1гр2а1</pattern>
-  <pattern> анаг2р</pattern>
-  <pattern> а2надем</pattern>
-  <pattern> анад2е1</pattern>
-  <pattern> а2надип2л</pattern>
-  <pattern> анад2и1</pattern>
-  <pattern> а2надоз</pattern>
-  <pattern> анад2о1</pattern>
-  <pattern> а2н3а4е2р2о1</pattern>
-  <pattern> ана3е1</pattern>
-  <pattern> а2накал</pattern>
-  <pattern> 2а1н2а1к2а1</pattern>
-  <pattern> а2накам</pattern>
-  <pattern> а2накат</pattern>
-  <pattern> а2накеф</pattern>
-  <pattern> анак2е1</pattern>
-  <pattern> 2а2н2а1кл2а1</pattern>
-  <pattern> анак2л</pattern>
-  <pattern> а2накл2и1</pattern>
-  <pattern> а2накој</pattern>
-  <pattern> анак2о1</pattern>
-  <pattern> а2н3акуз</pattern>
-  <pattern> анак2у1</pattern>
-  <pattern> а2н3а2л1г</pattern>
-  <pattern> а2н3а2л1д</pattern>
-  <pattern> а2налеп</pattern>
-  <pattern> анал2е1</pattern>
-  <pattern> а2нализ</pattern>
-  <pattern> анал2и1</pattern>
-  <pattern> а2налис</pattern>
-  <pattern> а2налит</pattern>
-  <pattern> а2н3аме2р1т</pattern>
-  <pattern> анам2е1</pattern>
-  <pattern> а2намн2е1</pattern>
-  <pattern> ана2м1н</pattern>
-  <pattern> а2н3анд2р</pattern>
-  <pattern> ана2н1д</pattern>
-  <pattern> а2нане3о1</pattern>
-  <pattern> анан2е1</pattern>
-  <pattern> а2н3а2н1т</pattern>
-  <pattern> 2а2н2а1пл2а1</pattern>
-  <pattern> анап2л</pattern>
-  <pattern> а2напл2е1</pattern>
-  <pattern> а2напн2е1</pattern>
-  <pattern> ана2п1н</pattern>
-  <pattern> а2напн2о1</pattern>
-  <pattern> а2напр2о1</pattern>
-  <pattern> анап2р</pattern>
-  <pattern> а2напт2и1</pattern>
-  <pattern> ана2п1т</pattern>
-  <pattern> а2н3апт2о1</pattern>
-  <pattern> а2на2р1т</pattern>
-  <pattern> а2н3а2р1х</pattern>
-  <pattern> а2насар</pattern>
-  <pattern> анас2а1</pattern>
-  <pattern> а2насе3и1</pattern>
-  <pattern> анас2е1</pattern>
-  <pattern> а2наспаз</pattern>
-  <pattern> анас2п</pattern>
-  <pattern> анасп2а1</pattern>
-  <pattern> 2а2н2а1ст2а1</pattern>
-  <pattern> анас2т</pattern>
-  <pattern> а2настиг</pattern>
-  <pattern> анаст2и1</pattern>
-  <pattern> а2настом</pattern>
-  <pattern> анаст2о1</pattern>
-  <pattern> а2натим</pattern>
-  <pattern> анат2и1</pattern>
-  <pattern> а2натом</pattern>
-  <pattern> анат2о1</pattern>
-  <pattern> а2натоц</pattern>
-  <pattern> а2натр2е1</pattern>
-  <pattern> анат2р</pattern>
-  <pattern> а2натр2и1</pattern>
-  <pattern> а2натр2о1</pattern>
-  <pattern> а2нафаз</pattern>
-  <pattern> анаф2а1</pattern>
-  <pattern> а2н3афиј</pattern>
-  <pattern> анаф2и1</pattern>
-  <pattern> 2а2н2а1фил2а1</pattern>
-  <pattern> а2нафон</pattern>
-  <pattern> анаф2о1</pattern>
-  <pattern> а2н3афрод</pattern>
-  <pattern> анаф2р</pattern>
-  <pattern> анафр2о1</pattern>
-  <pattern> а2накол</pattern>
-  <pattern> а2накрон</pattern>
-  <pattern> анак2р</pattern>
-  <pattern> анакр2о1</pattern>
-  <pattern> а2накр2у1</pattern>
-  <pattern> 2а2н3а1лф2а1</pattern>
-  <pattern> ана2л1ф</pattern>
-  <pattern> а2нафор</pattern>
-  <pattern> а2нахор</pattern>
-  <pattern> анах2о1</pattern>
-  <pattern> а2нахр2о1</pattern>
-  <pattern> анах2р</pattern>
-  <pattern> а2н3егер</pattern>
-  <pattern> ан2е1</pattern>
-  <pattern> анег2е1</pattern>
-  <pattern> а2н3ек2л</pattern>
-  <pattern> а2н3екум</pattern>
-  <pattern> анек2у1</pattern>
-  <pattern> а2н3елек</pattern>
-  <pattern> анел2е1</pattern>
-  <pattern> а2н3енер</pattern>
-  <pattern> анен2е1</pattern>
-  <pattern> а2н3еп2и1</pattern>
-  <pattern> а2неор</pattern>
-  <pattern> ане3о1</pattern>
-  <pattern> а2н3е2р1г</pattern>
-  <pattern> а2н3ерит</pattern>
-  <pattern> анер2и1</pattern>
-  <pattern> а2н3е1ст2е1</pattern>
-  <pattern> анес2т</pattern>
-  <pattern> а2н3ид2р</pattern>
-  <pattern> ан2и1</pattern>
-  <pattern> а2н3изог</pattern>
-  <pattern> аниз2о1</pattern>
-  <pattern> а2н3изом</pattern>
-  <pattern> а2н3изур</pattern>
-  <pattern> аниз2у1</pattern>
-  <pattern> а2н3ирид</pattern>
-  <pattern> анир2и1</pattern>
-  <pattern> а2н3овар</pattern>
-  <pattern> ан2о1</pattern>
-  <pattern> анов2а1</pattern>
-  <pattern> а2н3о2к1с</pattern>
-  <pattern> а2н3опис</pattern>
-  <pattern> аноп2и1</pattern>
-  <pattern> а2н3о2р1х</pattern>
-  <pattern> а2н3о2ф1т</pattern>
-  <pattern> а2н3о2р1г</pattern>
-  <pattern> ди2с3акор</pattern>
-  <pattern> д2и1</pattern>
-  <pattern> дис2а1</pattern>
-  <pattern> дисак2о1</pattern>
-  <pattern> ди2с3ју2н1к</pattern>
-  <pattern> дис2ј</pattern>
-  <pattern> дисј2у1</pattern>
-  <pattern> ди2с3квал</pattern>
-  <pattern> дис2к</pattern>
-  <pattern> диск2в</pattern>
-  <pattern> дискв2а1</pattern>
-  <pattern> ди2с3ко2н1т</pattern>
-  <pattern> диск2о1</pattern>
-  <pattern> ди2с3ко2р1д</pattern>
-  <pattern> ди2с3кр2е1</pattern>
-  <pattern> диск2р</pattern>
-  <pattern> д2и2с3кр2и1</pattern>
-  <pattern> ди2с3кур</pattern>
-  <pattern> диск2у1</pattern>
-  <pattern> ди2с3л2о1</pattern>
-  <pattern> дис2л</pattern>
-  <pattern> ди2с3ориј</pattern>
-  <pattern> дис2о1</pattern>
-  <pattern> дисор2и1</pattern>
-  <pattern> ди2с3парит</pattern>
-  <pattern> дис2п</pattern>
-  <pattern> дисп2а1</pattern>
-  <pattern> диспар2и1</pattern>
-  <pattern> ди2с3поз</pattern>
-  <pattern> дисп2о1</pattern>
-  <pattern> ди2с3пон</pattern>
-  <pattern> ди2с3проп</pattern>
-  <pattern> дисп2р</pattern>
-  <pattern> диспр2о1</pattern>
-  <pattern> ди2с3тон</pattern>
-  <pattern> дис2т</pattern>
-  <pattern> дист2о1</pattern>
-  <pattern> ди2с3трак</pattern>
-  <pattern> дист2р</pattern>
-  <pattern> дистр2а1</pattern>
-  <pattern> и2н3абруп</pattern>
-  <pattern> ин2а1</pattern>
-  <pattern> инаб2р</pattern>
-  <pattern> инабр2у1</pattern>
-  <pattern> и2н3адек</pattern>
-  <pattern> инад2е1</pattern>
-  <pattern> и2н3акур</pattern>
-  <pattern> инак2у1</pattern>
-  <pattern> и2н3акц2е1</pattern>
-  <pattern> ина2к1ц</pattern>
-  <pattern> и2н3амор</pattern>
-  <pattern> инам2о1</pattern>
-  <pattern> и2н3аниц</pattern>
-  <pattern> инан2и1</pattern>
-  <pattern> и2н3аплик</pattern>
-  <pattern> инап2л</pattern>
-  <pattern> инапл2и1</pattern>
-  <pattern> и2н3апс2т</pattern>
-  <pattern> ина2п1с</pattern>
-  <pattern> и2н3а2р1т</pattern>
-  <pattern> и2н3аугур</pattern>
-  <pattern> ина3у1</pattern>
-  <pattern> инауг2у1</pattern>
-  <pattern> и2н3а1ур2а1</pattern>
-  <pattern> и2н3афек</pattern>
-  <pattern> инаф2е1</pattern>
-  <pattern> и2н3евид</pattern>
-  <pattern> ин2е1</pattern>
-  <pattern> инев2и1</pattern>
-  <pattern> и2н3ег</pattern>
-  <pattern> и2н3ед</pattern>
-  <pattern> и2н3ек2в</pattern>
-  <pattern> и2н3е2к1с</pattern>
-  <pattern> и2н3елиг</pattern>
-  <pattern> инел2и1</pattern>
-  <pattern> и2н3е2п1ц</pattern>
-  <pattern> и2н3ефек</pattern>
-  <pattern> инеф2е1</pattern>
-  <pattern> и2н3об2л</pattern>
-  <pattern> ин2о1</pattern>
-  <pattern> и2ноген</pattern>
-  <pattern> иног2е1</pattern>
-  <pattern> и2нокор</pattern>
-  <pattern> инок2о1</pattern>
-  <pattern> и2н3окуп</pattern>
-  <pattern> инок2у1</pattern>
-  <pattern> и2н3опер</pattern>
-  <pattern> иноп2е1</pattern>
-  <pattern> и2н3опор</pattern>
-  <pattern> иноп2о1</pattern>
-  <pattern> и2н3опс2е1</pattern>
-  <pattern> ино2п1с</pattern>
-  <pattern> и2н3офиц</pattern>
-  <pattern> иноф2и1</pattern>
-  <pattern> и2н3умб2р</pattern>
-  <pattern> ин2у1</pattern>
-  <pattern> ину2м1б</pattern>
-  <pattern> и2н3унд2а1</pattern>
-  <pattern> ину2н1д</pattern>
-  <pattern> и2н3у2н1к</pattern>
-  <pattern> и2н3утил</pattern>
-  <pattern> инут2и1</pattern>
-  <pattern> 2и1нте2р3и1</pattern>
-  <pattern> и2н1т</pattern>
-  <pattern> инт2е1</pattern>
-  <pattern> инте2р3о1</pattern>
-  <pattern> инте2р3у1</pattern>
-  <pattern> инте2р3а1</pattern>
-  <pattern> инт2е2р3е1</pattern>
-  <pattern> инте3р4е2г1н</pattern>
-  <pattern> 2и1нте3р4ес2и1</pattern>
-  <pattern> инте3р4ес2н</pattern>
-  <pattern> инте3р4ес2о1</pattern>
-  <pattern> инте3р4ес2у1</pattern>
-  <pattern> инте3р4ес2а1</pattern>
-  <pattern> инт2е3р4е1с2е1</pattern>
-  <pattern> инте3р4е2ж1џ</pattern>
-  <pattern> инт2е3р4иј2е1</pattern>
-  <pattern> инт2е3р3ј2е1</pattern>
-  <pattern> инте2р1ј</pattern>
-  <pattern> инте3р4огат</pattern>
-  <pattern> интерог2а1</pattern>
-  <pattern> јури2с3к</pattern>
-  <pattern> ј2у1</pattern>
-  <pattern> јур2и1</pattern>
-  <pattern> јури2с3п</pattern>
-  <pattern> ну2з3бел</pattern>
-  <pattern> н2у1</pattern>
-  <pattern> нуз2б</pattern>
-  <pattern> нузб2е1</pattern>
-  <pattern> ну2з3биљ</pattern>
-  <pattern> нузб2и1</pattern>
-  <pattern> ну2з3љуб</pattern>
-  <pattern> нуз2љ</pattern>
-  <pattern> нузљ2у1</pattern>
-  <pattern> ну2з3р2е1</pattern>
-  <pattern> нуз2р</pattern>
-  <pattern> ну2з3р2ј2е1</pattern>
-  <pattern> нуз2р1ј</pattern>
-  <pattern> ну2з3уж</pattern>
-  <pattern> нуз2у1</pattern>
-  <pattern> ну2с3пос</pattern>
-  <pattern> нус2п</pattern>
-  <pattern> нусп2о1</pattern>
-  <pattern> ну2с3пр2о1</pattern>
-  <pattern> нусп2р</pattern>
-  <pattern> по2ст3е2г1з</pattern>
-  <pattern> пос2т</pattern>
-  <pattern> пост2е1</pattern>
-  <pattern> по2ст3инд2у1</pattern>
-  <pattern> пост2и1</pattern>
-  <pattern> пости2н1д</pattern>
-  <pattern> по2ст3лим</pattern>
-  <pattern> по2с3т2л</pattern>
-  <pattern> постл2и1</pattern>
-  <pattern> по2ст3о2н1к</pattern>
-  <pattern> п2о1ст2о1</pattern>
-  <pattern> по2ст3опер</pattern>
-  <pattern> постоп2е1</pattern>
-  <pattern> су2б3а1</pattern>
-  <pattern> с2у1</pattern>
-  <pattern> су2б3л</pattern>
-  <pattern> су3б4аш</pattern>
-  <pattern> су2б3и2н1в</pattern>
-  <pattern> суб2и1</pattern>
-  <pattern> су2б3ју2н1к</pattern>
-  <pattern> суб2ј</pattern>
-  <pattern> субј2у1</pattern>
-  <pattern> су2б3о2к1с</pattern>
-  <pattern> суб2о1</pattern>
-  <pattern> су2б3реп</pattern>
-  <pattern> суб2р</pattern>
-  <pattern> субр2е1</pattern>
-  <pattern> су2б3рог</pattern>
-  <pattern> субр2о1</pattern>
-  <pattern> су2б3о2р1д</pattern>
-  <pattern> супе2р3и1</pattern>
-  <pattern> суп2е1</pattern>
-  <pattern> супе2р3о1</pattern>
-  <pattern> с2у1пе2р3у1</pattern>
-  <pattern> супе2р3а1</pattern>
-  <pattern> суп2е2р3е1</pattern>
-  <pattern> супе3р4иор</pattern>
-  <pattern> супери3о1</pattern>
-  <pattern> тр2а1н2с3а1</pattern>
-  <pattern> т2р</pattern>
-  <pattern> тр2а1</pattern>
-  <pattern> тра2н1с</pattern>
-  <pattern> тран2с3ц</pattern>
-  <pattern> тран2с3е1</pattern>
-  <pattern> тран2с3к</pattern>
-  <pattern> тран2с3л</pattern>
-  <pattern> тран2с3м</pattern>
-  <pattern> тран2с3н</pattern>
-  <pattern> тран2с3о1</pattern>
-  <pattern> тран2с3п</pattern>
-  <pattern> тран2с3т</pattern>
-  <pattern> тран2с3у1</pattern>
-  <pattern> тран2с3в</pattern>
-  <pattern> тран2с3њ</pattern>
-  <pattern> тран3с4еп</pattern>
-  <pattern> тран3с4кр2и1</pattern>
-  <pattern> транск2р</pattern>
-  <pattern> тран3с4ум</pattern>
-  <pattern> тран3с4уд</pattern>
-  <pattern>на5дно</pattern>
-  <pattern>на5тка</pattern>
-  <pattern>на5тка5ти</pattern>
-  <pattern>на5тка5ше</pattern>
-  <pattern>о5дно</pattern>
-  <pattern>о5тка</pattern>
-  <pattern>о5тка5ти</pattern>
-  <pattern>о5тка5ше</pattern>
-  <pattern>по5дно</pattern>
-  <pattern>по5дне</pattern>
-  <pattern>по5тку</pattern>
-  <pattern>по5тки</pattern>
-  <pattern>по5тке</pattern>
-  <pattern>по5тка</pattern>
-  <pattern>у5дно</pattern>
-  <pattern>и5где</pattern>
-  <pattern>и5гдје</pattern>
-  <pattern>сву5где</pattern>
-  <pattern>све5где</pattern>
-  <pattern>сву5гдје</pattern>
-  <pattern>све5гдје</pattern>
-  <pattern>по5не5где</pattern>
-  <pattern>по5не5гдје</pattern>
-  <pattern>и5зби</pattern>
-  <pattern>и5збе</pattern>
-  <pattern>и5зба</pattern>
-  <pattern>и5зби5ци</pattern>
-  <pattern>и5зби5це</pattern>
-  <pattern>и5зби5ца</pattern>
-  <pattern>и5звит</pattern>
-  <pattern>и5зим</pattern>
-  <pattern>изо5ба5ру</pattern>
-  <pattern>изо5ба5ри</pattern>
-  <pattern>изо5ба5ре</pattern>
-  <pattern>изо5ба5ра</pattern>
-  <pattern>и5скок</pattern>
-  <pattern>и5ско5ку</pattern>
-  <pattern>и5ско5ка</pattern>
-  <pattern>и5скон</pattern>
-  <pattern>и5ско5ну</pattern>
-  <pattern>и5ско5ни</pattern>
-  <pattern>и5ско5на</pattern>
-  <pattern>и5скру</pattern>
-  <pattern>и5скре</pattern>
-  <pattern>и5скри</pattern>
-  <pattern>и5скра</pattern>
-  <pattern>и5скрав</pattern>
-  <pattern>и5спод</pattern>
-  <pattern>и5спо5да</pattern>
-  <pattern>и5стру</pattern>
-  <pattern>и5стри</pattern>
-  <pattern>и5стро</pattern>
-  <pattern>и5стре</pattern>
-  <pattern>и5стра</pattern>
-  <pattern>на5ју</pattern>
-  <pattern>на5ји</pattern>
-  <pattern>на5јо</pattern>
-  <pattern>на5је</pattern>
-  <pattern>на5ја</pattern>
-  <pattern>на5јам</pattern>
-  <pattern>на5јест</pattern>
-  <pattern>о5браз</pattern>
-  <pattern>о5брет</pattern>
-  <pattern>о5дви5ка</pattern>
-  <pattern>о5дран</pattern>
-  <pattern>о5дра5ти</pattern>
-  <pattern>пре5двој</pattern>
-  <pattern>ра5зму</pattern>
-  <pattern>ра5зми</pattern>
-  <pattern>ра5змо</pattern>
-  <pattern>ра5зме</pattern>
-  <pattern>ра5зма</pattern>
-  <pattern>ра5зну</pattern>
-  <pattern>ра5зни</pattern>
-  <pattern>ра5зно</pattern>
-  <pattern>ра5зне</pattern>
-  <pattern>ра5зна</pattern>
-  <pattern>ра5склоп</pattern>
-  <pattern>ра5спе5лу</pattern>
-  <pattern>ра5спе5ло</pattern>
-  <pattern>ра5спе5ла</pattern>
-  <pattern>ра5спе5ћа</pattern>
-  <pattern>ра5спе5ћу</pattern>
-  <pattern>ра5спе5ће</pattern>
-  <pattern>ра5сту</pattern>
-  <pattern>ра5сти</pattern>
-  <pattern>ра5сте</pattern>
-  <pattern>ра5ста</pattern>
-  <pattern>ра5стом</pattern>
-  <pattern>ра5стер</pattern>
-  <pattern>ра5шћу</pattern>
-  <pattern>ра5шћи</pattern>
-  <pattern>ра5шћо</pattern>
-  <pattern>ра5шће</pattern>
-  <pattern>ра5шћа</pattern>
-  <pattern>у5зно</pattern>
-  <pattern>у5зна</pattern>
-  <pattern>у5зни</pattern>
-  <pattern>у5зник</pattern>
-  <pattern>у5зрок</pattern>
-  <pattern>у5ску</pattern>
-  <pattern>у5ски</pattern>
-  <pattern>у5ско</pattern>
-  <pattern>у5ске</pattern>
-  <pattern>у5ска</pattern>
-  <pattern>ус5кос</pattern>
-  <pattern>у5спио</pattern>
-  <pattern>у5спео</pattern>
-  <pattern>у5спор</pattern>
-  <pattern>у5шћу</pattern>
-  <pattern>у5шће</pattern>
-  <pattern>у5шћа</pattern>
-  <pattern>ин5те5рес</pattern>
-  <pattern>тран5су</pattern>
-  <pattern>тран5са</pattern>
-  <pattern>тран5сом</pattern>
-  <pattern>те5ле5ви5зор</pattern>
-  <pattern>те5ле5ви5зо5ру</pattern>
-  <pattern>те5ле5ви5зо5ром</pattern>
-  <pattern>те5ле5ви5зо5ра</pattern>
-  <pattern>те5ле5ви5зо5ри</pattern>
-  <pattern>при5ти5сак</pattern>
-  <pattern>при5ти5с5ком</pattern>
-  <pattern>при5ти5с5ку</pattern>
-  <pattern>при5ти5с5ка</pattern>
-  <pattern>по5ја5ви5ће</pattern>
-  <pattern>на5пу5шта</pattern>
-  <pattern>про5гра5ми5ра5ње</pattern>
-  <pattern>сни5ма5ња</pattern>
-  <pattern>сни5ма5ње</pattern>
+<pattern>т2ј</pattern>
+<pattern>т2л</pattern>
+<pattern>т2љ</pattern>
+<pattern>т2р</pattern>
+<pattern>т2в</pattern>
+<pattern>д2ј</pattern>
+<pattern>д2л</pattern>
+<pattern>д2љ</pattern>
+<pattern>д3р</pattern>
+<pattern>д2в</pattern>
+<pattern>г2ј</pattern>
+<pattern>г2л</pattern>
+<pattern>г2љ</pattern>
+<pattern>г2р</pattern>
+<pattern>г2в</pattern>
+<pattern>х2ј</pattern>
+<pattern>х2л</pattern>
+<pattern>х2љ</pattern>
+<pattern>х2р</pattern>
+<pattern>х2в</pattern>
+<pattern>к2ј</pattern>
+<pattern>к2л</pattern>
+<pattern>к2љ</pattern>
+<pattern>к2р</pattern>
+<pattern>к2в</pattern>
+<pattern>2д1ж</pattern>
+<pattern>2д1б</pattern>
+<pattern>2д1ц</pattern>
+<pattern>2д1д</pattern>
+<pattern>2д1ф</pattern>
+<pattern>2д1г</pattern>
+<pattern>2д1х</pattern>
+<pattern>2д1к</pattern>
+<pattern>2д1м</pattern>
+<pattern>2д1н</pattern>
+<pattern>2д1п</pattern>
+<pattern>2д1с</pattern>
+<pattern>2д1т</pattern>
+<pattern>2д1њ</pattern>
+<pattern>2д1џ</pattern>
+<pattern>2д1з</pattern>
+<pattern>2д1ш</pattern>
+<pattern>2д1ђ</pattern>
+<pattern>2д1ћ</pattern>
+<pattern>2д1ч</pattern>
+<pattern>2г1ж</pattern>
+<pattern>2г1б</pattern>
+<pattern>2г1ц</pattern>
+<pattern>2г1д</pattern>
+<pattern>2г1ф</pattern>
+<pattern>2г1г</pattern>
+<pattern>2г1х</pattern>
+<pattern>2г1к</pattern>
+<pattern>2г1м</pattern>
+<pattern>2г1н</pattern>
+<pattern>2г1п</pattern>
+<pattern>2г1с</pattern>
+<pattern>2г1т</pattern>
+<pattern>2г1њ</pattern>
+<pattern>2г1џ</pattern>
+<pattern>2г1з</pattern>
+<pattern>2г1ш</pattern>
+<pattern>2г1ђ</pattern>
+<pattern>2г1ћ</pattern>
+<pattern>2г1ч</pattern>
+<pattern>2х1ж</pattern>
+<pattern>2х1б</pattern>
+<pattern>2х1ц</pattern>
+<pattern>2х1д</pattern>
+<pattern>2х1ф</pattern>
+<pattern>2х1г</pattern>
+<pattern>2х1х</pattern>
+<pattern>2х1к</pattern>
+<pattern>2х1м</pattern>
+<pattern>2х1н</pattern>
+<pattern>2х1п</pattern>
+<pattern>2х1с</pattern>
+<pattern>2х1т</pattern>
+<pattern>2х1њ</pattern>
+<pattern>2х1џ</pattern>
+<pattern>2х1з</pattern>
+<pattern>2х1ш</pattern>
+<pattern>2х1ђ</pattern>
+<pattern>2х1ћ</pattern>
+<pattern>2х1ч</pattern>
+<pattern>2к1ж</pattern>
+<pattern>2к1б</pattern>
+<pattern>2к1ц</pattern>
+<pattern>2к1д</pattern>
+<pattern>2к1ф</pattern>
+<pattern>2к1г</pattern>
+<pattern>2к1х</pattern>
+<pattern>2к1к</pattern>
+<pattern>2к1м</pattern>
+<pattern>2к1н</pattern>
+<pattern>2к1п</pattern>
+<pattern>2к1с</pattern>
+<pattern>2к1т</pattern>
+<pattern>2к1њ</pattern>
+<pattern>2к1џ</pattern>
+<pattern>2к1з</pattern>
+<pattern>2к1ш</pattern>
+<pattern>2к1ђ</pattern>
+<pattern>2к1ћ</pattern>
+<pattern>2к1ч</pattern>
+<pattern>2т1ж</pattern>
+<pattern>2т1б</pattern>
+<pattern>2т1ц</pattern>
+<pattern>2т1д</pattern>
+<pattern>2т1ф</pattern>
+<pattern>2т1г</pattern>
+<pattern>2т1х</pattern>
+<pattern>2т1к</pattern>
+<pattern>2т1м</pattern>
+<pattern>2т1н</pattern>
+<pattern>2т1п</pattern>
+<pattern>2т1с</pattern>
+<pattern>2т1т</pattern>
+<pattern>2т1њ</pattern>
+<pattern>2т1џ</pattern>
+<pattern>2т1з</pattern>
+<pattern>2т1ш</pattern>
+<pattern>2т1ђ</pattern>
+<pattern>2т1ћ</pattern>
+<pattern>2т1ч</pattern>
+<pattern>2дј </pattern>
+<pattern>2дл </pattern>
+<pattern>2дљ </pattern>
+<pattern>2др </pattern>
+<pattern>2дв </pattern>
+<pattern>2гј </pattern>
+<pattern>2гл </pattern>
+<pattern>2гљ </pattern>
+<pattern>2гр </pattern>
+<pattern>2гв </pattern>
+<pattern>2хј </pattern>
+<pattern>2хл </pattern>
+<pattern>2хљ </pattern>
+<pattern>2хр </pattern>
+<pattern>2хв </pattern>
+<pattern>2кј </pattern>
+<pattern>2кл </pattern>
+<pattern>2кљ </pattern>
+<pattern>2кр </pattern>
+<pattern>2кв </pattern>
+<pattern>2тј </pattern>
+<pattern>2тл </pattern>
+<pattern>2тљ </pattern>
+<pattern>2тр </pattern>
+<pattern>2тв </pattern>
+<pattern>п2ј</pattern>
+<pattern>п2л</pattern>
+<pattern>п2љ</pattern>
+<pattern>п2р</pattern>
+<pattern>в2ј</pattern>
+<pattern>в2л</pattern>
+<pattern>в2љ</pattern>
+<pattern>в2р</pattern>
+<pattern>б2ј</pattern>
+<pattern>б2л</pattern>
+<pattern>б2љ</pattern>
+<pattern>б2р</pattern>
+<pattern>ф2ј</pattern>
+<pattern>ф2л</pattern>
+<pattern>ф2љ</pattern>
+<pattern>ф2р</pattern>
+<pattern>м2ј</pattern>
+<pattern>м2л</pattern>
+<pattern>м2љ</pattern>
+<pattern>м2р</pattern>
+<pattern>2б1ж</pattern>
+<pattern>2б1б</pattern>
+<pattern>2б1ц</pattern>
+<pattern>2б1д</pattern>
+<pattern>2б1ф</pattern>
+<pattern>2б1г</pattern>
+<pattern>2б1х</pattern>
+<pattern>2б1к</pattern>
+<pattern>2б1м</pattern>
+<pattern>2б1н</pattern>
+<pattern>2б1п</pattern>
+<pattern>2б1с</pattern>
+<pattern>2б1т</pattern>
+<pattern>2б1в</pattern>
+<pattern>2б1њ</pattern>
+<pattern>2б1џ</pattern>
+<pattern>2б1з</pattern>
+<pattern>2б1ш</pattern>
+<pattern>2б1ђ</pattern>
+<pattern>2б1ћ</pattern>
+<pattern>2б1ч</pattern>
+<pattern>2ф1ж</pattern>
+<pattern>2ф1б</pattern>
+<pattern>2ф1ц</pattern>
+<pattern>2ф1д</pattern>
+<pattern>2ф1ф</pattern>
+<pattern>2ф1г</pattern>
+<pattern>2ф1х</pattern>
+<pattern>2ф1к</pattern>
+<pattern>2ф1м</pattern>
+<pattern>2ф1н</pattern>
+<pattern>2ф1п</pattern>
+<pattern>2ф1с</pattern>
+<pattern>2ф1т</pattern>
+<pattern>2ф1в</pattern>
+<pattern>2ф1њ</pattern>
+<pattern>2ф1џ</pattern>
+<pattern>2ф1з</pattern>
+<pattern>2ф1ш</pattern>
+<pattern>2ф1ђ</pattern>
+<pattern>2ф1ћ</pattern>
+<pattern>2ф1ч</pattern>
+<pattern>2м1ж</pattern>
+<pattern>2м1б</pattern>
+<pattern>2м1ц</pattern>
+<pattern>2м1д</pattern>
+<pattern>2м1ф</pattern>
+<pattern>2м1г</pattern>
+<pattern>2м1х</pattern>
+<pattern>2м1к</pattern>
+<pattern>2м1м</pattern>
+<pattern>2м1н</pattern>
+<pattern>2м1п</pattern>
+<pattern>2м1с</pattern>
+<pattern>2м1т</pattern>
+<pattern>2м1в</pattern>
+<pattern>2м1њ</pattern>
+<pattern>2м1џ</pattern>
+<pattern>2м1з</pattern>
+<pattern>2м1ш</pattern>
+<pattern>2м1ђ</pattern>
+<pattern>2м1ћ</pattern>
+<pattern>2м1ч</pattern>
+<pattern>2п1ж</pattern>
+<pattern>2п1б</pattern>
+<pattern>2п1ц</pattern>
+<pattern>2п1д</pattern>
+<pattern>2п1ф</pattern>
+<pattern>2п1г</pattern>
+<pattern>2п1х</pattern>
+<pattern>2п1к</pattern>
+<pattern>2п1м</pattern>
+<pattern>2п1н</pattern>
+<pattern>2п1п</pattern>
+<pattern>2п1с</pattern>
+<pattern>2п1т</pattern>
+<pattern>2п1в</pattern>
+<pattern>2п1њ</pattern>
+<pattern>2п1џ</pattern>
+<pattern>2п1з</pattern>
+<pattern>2п1ш</pattern>
+<pattern>2п1ђ</pattern>
+<pattern>2п1ћ</pattern>
+<pattern>2п1ч</pattern>
+<pattern>2в1ж</pattern>
+<pattern>2в1б</pattern>
+<pattern>2в1ц</pattern>
+<pattern>2в1д</pattern>
+<pattern>2в1ф</pattern>
+<pattern>2в1г</pattern>
+<pattern>2в1х</pattern>
+<pattern>2в1к</pattern>
+<pattern>2в1м</pattern>
+<pattern>2в1н</pattern>
+<pattern>2в1п</pattern>
+<pattern>2в1с</pattern>
+<pattern>2в1т</pattern>
+<pattern>2в1в</pattern>
+<pattern>2в1њ</pattern>
+<pattern>2в1џ</pattern>
+<pattern>2в1з</pattern>
+<pattern>2в1ш</pattern>
+<pattern>2в1ђ</pattern>
+<pattern>2в1ћ</pattern>
+<pattern>2в1ч</pattern>
+<pattern>2бј </pattern>
+<pattern>2бл </pattern>
+<pattern>2бљ </pattern>
+<pattern>2бр </pattern>
+<pattern>2фј </pattern>
+<pattern>2фл </pattern>
+<pattern>2фљ </pattern>
+<pattern>2фр </pattern>
+<pattern>2мј </pattern>
+<pattern>2мл </pattern>
+<pattern>2мљ </pattern>
+<pattern>2мр </pattern>
+<pattern>2пј </pattern>
+<pattern>2пл </pattern>
+<pattern>2пљ </pattern>
+<pattern>2пр </pattern>
+<pattern>2вј </pattern>
+<pattern>2вл </pattern>
+<pattern>2вљ </pattern>
+<pattern>2вр </pattern>
+<pattern>с2ц</pattern>
+<pattern>с2ј</pattern>
+<pattern>с2к</pattern>
+<pattern>с2л</pattern>
+<pattern>с2м</pattern>
+<pattern>с2н</pattern>
+<pattern>с2п</pattern>
+<pattern>с2љ</pattern>
+<pattern>с2р</pattern>
+<pattern>с2т</pattern>
+<pattern>с2в</pattern>
+<pattern>с2њ</pattern>
+<pattern>2с1ж</pattern>
+<pattern>2с1б</pattern>
+<pattern>2с1д</pattern>
+<pattern>2с1ф</pattern>
+<pattern>2с1г</pattern>
+<pattern>2с1х</pattern>
+<pattern>2с1с</pattern>
+<pattern>2с1џ</pattern>
+<pattern>2с1з</pattern>
+<pattern>2с1ш</pattern>
+<pattern>2с1ђ</pattern>
+<pattern>2с1ћ</pattern>
+<pattern>2с1ч</pattern>
+<pattern>2сј </pattern>
+<pattern>2ск </pattern>
+<pattern>2сл </pattern>
+<pattern>2см </pattern>
+<pattern>2сн </pattern>
+<pattern>2сп </pattern>
+<pattern>2сљ </pattern>
+<pattern>2ср </pattern>
+<pattern>2ст </pattern>
+<pattern>2св </pattern>
+<pattern>2сњ </pattern>
+<pattern>2сц </pattern>
+<pattern>з2б</pattern>
+<pattern>з2д</pattern>
+<pattern>з2г</pattern>
+<pattern>з2ј</pattern>
+<pattern>з2л</pattern>
+<pattern>з2м</pattern>
+<pattern>з2н</pattern>
+<pattern>з2љ</pattern>
+<pattern>з2р</pattern>
+<pattern>з2в</pattern>
+<pattern>з2њ</pattern>
+<pattern>2з1ж</pattern>
+<pattern>2з1ц</pattern>
+<pattern>2з1ф</pattern>
+<pattern>2з1х</pattern>
+<pattern>2з1к</pattern>
+<pattern>2з1п</pattern>
+<pattern>2з1с</pattern>
+<pattern>2з1т</pattern>
+<pattern>2з1џ</pattern>
+<pattern>2з1з</pattern>
+<pattern>2з1ш</pattern>
+<pattern>2з1ђ</pattern>
+<pattern>2з1ћ</pattern>
+<pattern>2з1ч</pattern>
+<pattern>2зј </pattern>
+<pattern>2зл </pattern>
+<pattern>2зм </pattern>
+<pattern>2зн </pattern>
+<pattern>2зљ </pattern>
+<pattern>2зр </pattern>
+<pattern>2зв </pattern>
+<pattern>2зњ </pattern>
+<pattern>2зб </pattern>
+<pattern>2зд </pattern>
+<pattern>2зг </pattern>
+<pattern>ш2ц</pattern>
+<pattern>ш2к</pattern>
+<pattern>ш2л</pattern>
+<pattern>ш2м</pattern>
+<pattern>ш2н</pattern>
+<pattern>ш2п</pattern>
+<pattern>ш2љ</pattern>
+<pattern>ш2т</pattern>
+<pattern>ш2в</pattern>
+<pattern>ш2њ</pattern>
+<pattern>ш2ћ</pattern>
+<pattern>ш2ч</pattern>
+<pattern>2ш1ж</pattern>
+<pattern>2ш1б</pattern>
+<pattern>2ш1д</pattern>
+<pattern>2ш1ф</pattern>
+<pattern>2ш1г</pattern>
+<pattern>2ш1х</pattern>
+<pattern>2ш1с</pattern>
+<pattern>2ш1џ</pattern>
+<pattern>2ш1з</pattern>
+<pattern>2ш1ш</pattern>
+<pattern>2ш1ђ</pattern>
+<pattern>2ш1ј</pattern>
+<pattern>2ш1р</pattern>
+<pattern>2шк </pattern>
+<pattern>2шл </pattern>
+<pattern>2шм </pattern>
+<pattern>2шн </pattern>
+<pattern>2шп </pattern>
+<pattern>2шљ </pattern>
+<pattern>2шт </pattern>
+<pattern>2шв </pattern>
+<pattern>2шњ </pattern>
+<pattern>2шћ </pattern>
+<pattern>2шч </pattern>
+<pattern>2шц </pattern>
+<pattern>ж2б</pattern>
+<pattern>ж2д</pattern>
+<pattern>ж2г</pattern>
+<pattern>ж2л</pattern>
+<pattern>ж2м</pattern>
+<pattern>ж2н</pattern>
+<pattern>ж2љ</pattern>
+<pattern>ж2в</pattern>
+<pattern>ж2њ</pattern>
+<pattern>ж2ђ</pattern>
+<pattern>2ж1ж</pattern>
+<pattern>2ж1ц</pattern>
+<pattern>2ж1ф</pattern>
+<pattern>2ж1х</pattern>
+<pattern>2ж1к</pattern>
+<pattern>2ж1п</pattern>
+<pattern>2ж1с</pattern>
+<pattern>2ж1т</pattern>
+<pattern>2ж1џ</pattern>
+<pattern>2ж1з</pattern>
+<pattern>2ж1ш</pattern>
+<pattern>2ж1ћ</pattern>
+<pattern>2ж1ч</pattern>
+<pattern>2ж1ј</pattern>
+<pattern>2ж1р</pattern>
+<pattern>2жл </pattern>
+<pattern>2жм </pattern>
+<pattern>2жн </pattern>
+<pattern>2жљ </pattern>
+<pattern>2жв </pattern>
+<pattern>2жњ </pattern>
+<pattern>2жђ </pattern>
+<pattern>2жб </pattern>
+<pattern>2жд </pattern>
+<pattern>2жг </pattern>
+<pattern>ц2ј</pattern>
+<pattern>ц2р</pattern>
+<pattern>ц2в</pattern>
+<pattern>2ц1ж</pattern>
+<pattern>2ц1б</pattern>
+<pattern>2ц1ц</pattern>
+<pattern>2ц1д</pattern>
+<pattern>2ц1ф</pattern>
+<pattern>2ц1г</pattern>
+<pattern>2ц1х</pattern>
+<pattern>2ц1к</pattern>
+<pattern>2ц1л</pattern>
+<pattern>2ц1м</pattern>
+<pattern>2ц1н</pattern>
+<pattern>2ц1п</pattern>
+<pattern>2ц1љ</pattern>
+<pattern>2ц1с</pattern>
+<pattern>2ц1т</pattern>
+<pattern>2ц1њ</pattern>
+<pattern>2ц1џ</pattern>
+<pattern>2ц1з</pattern>
+<pattern>2ц1ш</pattern>
+<pattern>2ц1ђ</pattern>
+<pattern>2ц1ћ</pattern>
+<pattern>2ц1ч</pattern>
+<pattern>2цј </pattern>
+<pattern>2цр </pattern>
+<pattern>2цв </pattern>
+<pattern>ч2в</pattern>
+<pattern>2ч1ж</pattern>
+<pattern>2ч1б</pattern>
+<pattern>2ч1ц</pattern>
+<pattern>2ч1д</pattern>
+<pattern>2ч1ф</pattern>
+<pattern>2ч1г</pattern>
+<pattern>2ч1х</pattern>
+<pattern>2ч1ј</pattern>
+<pattern>2ч1к</pattern>
+<pattern>2ч1л</pattern>
+<pattern>2ч1м</pattern>
+<pattern>2ч1н</pattern>
+<pattern>2ч1п</pattern>
+<pattern>2ч1љ</pattern>
+<pattern>2ч1р</pattern>
+<pattern>2ч1с</pattern>
+<pattern>2ч1т</pattern>
+<pattern>2ч1њ</pattern>
+<pattern>2ч1џ</pattern>
+<pattern>2ч1з</pattern>
+<pattern>2ч1ш</pattern>
+<pattern>2ч1ђ</pattern>
+<pattern>2ч1ћ</pattern>
+<pattern>2ч1ч</pattern>
+<pattern>2чв </pattern>
+<pattern>2ј1ж</pattern>
+<pattern>2ј1б</pattern>
+<pattern>2ј1ц</pattern>
+<pattern>2ј1д</pattern>
+<pattern>2ј1ф</pattern>
+<pattern>2ј1г</pattern>
+<pattern>2ј1х</pattern>
+<pattern>2ј1ј</pattern>
+<pattern>2ј1к</pattern>
+<pattern>2ј1л</pattern>
+<pattern>2ј1м</pattern>
+<pattern>2ј1н</pattern>
+<pattern>2ј1п</pattern>
+<pattern>2ј1љ</pattern>
+<pattern>2ј1р</pattern>
+<pattern>2ј1с</pattern>
+<pattern>2ј1т</pattern>
+<pattern>2ј1в</pattern>
+<pattern>2ј1њ</pattern>
+<pattern>2ј1џ</pattern>
+<pattern>2ј1з</pattern>
+<pattern>2ј1ш</pattern>
+<pattern>2ј1ђ</pattern>
+<pattern>2ј1ћ</pattern>
+<pattern>2ј1ч</pattern>
+<pattern>2л1ж</pattern>
+<pattern>2л1б</pattern>
+<pattern>2л1ц</pattern>
+<pattern>2л1д</pattern>
+<pattern>2л1ф</pattern>
+<pattern>2л1г</pattern>
+<pattern>2л1х</pattern>
+<pattern>2л1ј</pattern>
+<pattern>2л1к</pattern>
+<pattern>2л1л</pattern>
+<pattern>2л1м</pattern>
+<pattern>2л1н</pattern>
+<pattern>2л1п</pattern>
+<pattern>2л1љ</pattern>
+<pattern>2л1р</pattern>
+<pattern>2л1с</pattern>
+<pattern>2л1т</pattern>
+<pattern>2л1в</pattern>
+<pattern>2л1њ</pattern>
+<pattern>2л1џ</pattern>
+<pattern>2л1з</pattern>
+<pattern>2л1ш</pattern>
+<pattern>2л1ђ</pattern>
+<pattern>2л1ћ</pattern>
+<pattern>2л1ч</pattern>
+<pattern>2н1ж</pattern>
+<pattern>2н1б</pattern>
+<pattern>2н1ц</pattern>
+<pattern>2н1д</pattern>
+<pattern>2н1ф</pattern>
+<pattern>2н1г</pattern>
+<pattern>2н1х</pattern>
+<pattern>2н1ј</pattern>
+<pattern>2н1к</pattern>
+<pattern>2н1л</pattern>
+<pattern>2н1м</pattern>
+<pattern>2н1н</pattern>
+<pattern>2н1п</pattern>
+<pattern>2н1љ</pattern>
+<pattern>2н1р</pattern>
+<pattern>2н1с</pattern>
+<pattern>2н1т</pattern>
+<pattern>2н1в</pattern>
+<pattern>2н1њ</pattern>
+<pattern>2н1џ</pattern>
+<pattern>2н1з</pattern>
+<pattern>2н1ш</pattern>
+<pattern>2н1ђ</pattern>
+<pattern>2н1ћ</pattern>
+<pattern>2н1ч</pattern>
+<pattern>2љ1ж</pattern>
+<pattern>2љ1б</pattern>
+<pattern>2љ1ц</pattern>
+<pattern>2љ1д</pattern>
+<pattern>2љ1ф</pattern>
+<pattern>2љ1г</pattern>
+<pattern>2љ1х</pattern>
+<pattern>2љ1ј</pattern>
+<pattern>2љ1к</pattern>
+<pattern>2љ1л</pattern>
+<pattern>2љ1м</pattern>
+<pattern>2љ1н</pattern>
+<pattern>2љ1п</pattern>
+<pattern>2љ1љ</pattern>
+<pattern>2љ1р</pattern>
+<pattern>2љ1с</pattern>
+<pattern>2љ1т</pattern>
+<pattern>2љ1в</pattern>
+<pattern>2љ1њ</pattern>
+<pattern>2љ1џ</pattern>
+<pattern>2љ1з</pattern>
+<pattern>2љ1ш</pattern>
+<pattern>2љ1ђ</pattern>
+<pattern>2љ1ћ</pattern>
+<pattern>2љ1ч</pattern>
+<pattern>2р1ж</pattern>
+<pattern>2р1б</pattern>
+<pattern>2р1ц</pattern>
+<pattern>2р1д</pattern>
+<pattern>2р1ф</pattern>
+<pattern>2р1г</pattern>
+<pattern>2р1х</pattern>
+<pattern>2р1ј</pattern>
+<pattern>2р1к</pattern>
+<pattern>2р1л</pattern>
+<pattern>2р1м</pattern>
+<pattern>2р1н</pattern>
+<pattern>2р1п</pattern>
+<pattern>2р1љ</pattern>
+<pattern>2р1р</pattern>
+<pattern>2р1с</pattern>
+<pattern>2р1т</pattern>
+<pattern>2р1в</pattern>
+<pattern>2р1њ</pattern>
+<pattern>2р1џ</pattern>
+<pattern>2р1з</pattern>
+<pattern>2р1ш</pattern>
+<pattern>2р1ђ</pattern>
+<pattern>2р1ћ</pattern>
+<pattern>2р1ч</pattern>
+<pattern>2њ1ж</pattern>
+<pattern>2њ1б</pattern>
+<pattern>2њ1ц</pattern>
+<pattern>2њ1д</pattern>
+<pattern>2њ1ф</pattern>
+<pattern>2њ1г</pattern>
+<pattern>2њ1х</pattern>
+<pattern>2њ1ј</pattern>
+<pattern>2њ1к</pattern>
+<pattern>2њ1л</pattern>
+<pattern>2њ1м</pattern>
+<pattern>2њ1н</pattern>
+<pattern>2њ1п</pattern>
+<pattern>2њ1љ</pattern>
+<pattern>2њ1р</pattern>
+<pattern>2њ1с</pattern>
+<pattern>2њ1т</pattern>
+<pattern>2њ1в</pattern>
+<pattern>2њ1њ</pattern>
+<pattern>2њ1џ</pattern>
+<pattern>2њ1з</pattern>
+<pattern>2њ1ш</pattern>
+<pattern>2њ1ђ</pattern>
+<pattern>2њ1ћ</pattern>
+<pattern>2њ1ч</pattern>
+<pattern>2џ1ж</pattern>
+<pattern>2џ1б</pattern>
+<pattern>2џ1ц</pattern>
+<pattern>2џ1д</pattern>
+<pattern>2џ1ф</pattern>
+<pattern>2џ1г</pattern>
+<pattern>2џ1х</pattern>
+<pattern>2џ1ј</pattern>
+<pattern>2џ1к</pattern>
+<pattern>2џ1л</pattern>
+<pattern>2џ1м</pattern>
+<pattern>2џ1н</pattern>
+<pattern>2џ1п</pattern>
+<pattern>2џ1љ</pattern>
+<pattern>2џ1р</pattern>
+<pattern>2џ1с</pattern>
+<pattern>2џ1т</pattern>
+<pattern>2џ1в</pattern>
+<pattern>2џ1њ</pattern>
+<pattern>2џ1џ</pattern>
+<pattern>2џ1з</pattern>
+<pattern>2џ1ш</pattern>
+<pattern>2џ1ђ</pattern>
+<pattern>2џ1ћ</pattern>
+<pattern>2џ1ч</pattern>
+<pattern>2ђ1ж</pattern>
+<pattern>2ђ1б</pattern>
+<pattern>2ђ1ц</pattern>
+<pattern>2ђ1д</pattern>
+<pattern>2ђ1ф</pattern>
+<pattern>2ђ1г</pattern>
+<pattern>2ђ1х</pattern>
+<pattern>2ђ1ј</pattern>
+<pattern>2ђ1к</pattern>
+<pattern>2ђ1л</pattern>
+<pattern>2ђ1м</pattern>
+<pattern>2ђ1н</pattern>
+<pattern>2ђ1п</pattern>
+<pattern>2ђ1љ</pattern>
+<pattern>2ђ1р</pattern>
+<pattern>2ђ1с</pattern>
+<pattern>2ђ1т</pattern>
+<pattern>2ђ1в</pattern>
+<pattern>2ђ1њ</pattern>
+<pattern>2ђ1џ</pattern>
+<pattern>2ђ1з</pattern>
+<pattern>2ђ1ш</pattern>
+<pattern>2ђ1ђ</pattern>
+<pattern>2ђ1ћ</pattern>
+<pattern>2ђ1ч</pattern>
+<pattern>2ћ1ж</pattern>
+<pattern>2ћ1б</pattern>
+<pattern>2ћ1ц</pattern>
+<pattern>2ћ1д</pattern>
+<pattern>2ћ1ф</pattern>
+<pattern>2ћ1г</pattern>
+<pattern>2ћ1х</pattern>
+<pattern>2ћ1ј</pattern>
+<pattern>2ћ1к</pattern>
+<pattern>2ћ1л</pattern>
+<pattern>2ћ1м</pattern>
+<pattern>2ћ1н</pattern>
+<pattern>2ћ1п</pattern>
+<pattern>2ћ1љ</pattern>
+<pattern>2ћ1р</pattern>
+<pattern>2ћ1с</pattern>
+<pattern>2ћ1т</pattern>
+<pattern>2ћ1в</pattern>
+<pattern>2ћ1њ</pattern>
+<pattern>2ћ1џ</pattern>
+<pattern>2ћ1з</pattern>
+<pattern>2ћ1ш</pattern>
+<pattern>2ћ1ђ</pattern>
+<pattern>2ћ1ћ</pattern>
+<pattern>2ћ1ч</pattern>
+<pattern> х2</pattern>
+<pattern> ј2</pattern>
+<pattern> к2</pattern>
+<pattern> л2</pattern>
+<pattern> м2</pattern>
+<pattern> н2</pattern>
+<pattern> п2</pattern>
+<pattern> љ2</pattern>
+<pattern> р2</pattern>
+<pattern> с2</pattern>
+<pattern> т2</pattern>
+<pattern> в2</pattern>
+<pattern> њ2</pattern>
+<pattern> џ2</pattern>
+<pattern> з2</pattern>
+<pattern> ш2</pattern>
+<pattern> ђ2</pattern>
+<pattern> ћ2</pattern>
+<pattern> ч2</pattern>
+<pattern> ж2</pattern>
+<pattern> б2</pattern>
+<pattern> ц2</pattern>
+<pattern> д2</pattern>
+<pattern> ф2</pattern>
+<pattern> г2</pattern>
+<pattern>2о1</pattern>
+<pattern>о3а1</pattern>
+<pattern>о3е1</pattern>
+<pattern>о3и1</pattern>
+<pattern>2о3о1</pattern>
+<pattern>о3у1</pattern>
+<pattern>2у1</pattern>
+<pattern>у3а1</pattern>
+<pattern>у3е1</pattern>
+<pattern>у3и1</pattern>
+<pattern>у3о1</pattern>
+<pattern>2у3у1</pattern>
+<pattern>2а1</pattern>
+<pattern>2а3а1</pattern>
+<pattern>а3е1</pattern>
+<pattern>а3и1</pattern>
+<pattern>а3о1</pattern>
+<pattern>а3у1</pattern>
+<pattern>2е1</pattern>
+<pattern>е3а1</pattern>
+<pattern>2е3е1</pattern>
+<pattern>е3и1</pattern>
+<pattern>е3о1</pattern>
+<pattern>е3у1</pattern>
+<pattern>2и1</pattern>
+<pattern>и3а1</pattern>
+<pattern>и3е1</pattern>
+<pattern>2и3и1</pattern>
+<pattern>и3о1</pattern>
+<pattern>и3у1</pattern>
+<pattern>2с2к1б</pattern>
+<pattern>2с2к1ц</pattern>
+<pattern>2с2к1д</pattern>
+<pattern>2с2к1ф</pattern>
+<pattern>2с2к1г</pattern>
+<pattern>2с2к1х</pattern>
+<pattern>2с2к1к</pattern>
+<pattern>2с2к1м</pattern>
+<pattern>2с2к1н</pattern>
+<pattern>2с2к1п</pattern>
+<pattern>2с2к1с</pattern>
+<pattern>2с2к1т</pattern>
+<pattern>2с2к1њ</pattern>
+<pattern>2с2к1џ</pattern>
+<pattern>2с2к1з</pattern>
+<pattern>2с2к1ш</pattern>
+<pattern>2с2к1ђ</pattern>
+<pattern>2с2к1ћ</pattern>
+<pattern>2с2к1ч</pattern>
+<pattern>2с2к1ж</pattern>
+<pattern>2с2т1б</pattern>
+<pattern>2с2т1ц</pattern>
+<pattern>2с2т1д</pattern>
+<pattern>2с2т1ф</pattern>
+<pattern>2с2т1г</pattern>
+<pattern>2с2т1х</pattern>
+<pattern>2с2т1к</pattern>
+<pattern>2с2т1м</pattern>
+<pattern>2с2т1н</pattern>
+<pattern>2с2т1п</pattern>
+<pattern>2с2т1с</pattern>
+<pattern>2с2т1т</pattern>
+<pattern>2с2т1њ</pattern>
+<pattern>2с2т1џ</pattern>
+<pattern>2с2т1з</pattern>
+<pattern>2с2т1ш</pattern>
+<pattern>2с2т1ђ</pattern>
+<pattern>2с2т1ћ</pattern>
+<pattern>2с2т1ч</pattern>
+<pattern>2с2т1ж</pattern>
+<pattern>2ш2к1б</pattern>
+<pattern>2ш2к1ц</pattern>
+<pattern>2ш2к1д</pattern>
+<pattern>2ш2к1ф</pattern>
+<pattern>2ш2к1г</pattern>
+<pattern>2ш2к1х</pattern>
+<pattern>2ш2к1к</pattern>
+<pattern>2ш2к1м</pattern>
+<pattern>2ш2к1н</pattern>
+<pattern>2ш2к1п</pattern>
+<pattern>2ш2к1с</pattern>
+<pattern>2ш2к1т</pattern>
+<pattern>2ш2к1њ</pattern>
+<pattern>2ш2к1џ</pattern>
+<pattern>2ш2к1з</pattern>
+<pattern>2ш2к1ш</pattern>
+<pattern>2ш2к1ђ</pattern>
+<pattern>2ш2к1ћ</pattern>
+<pattern>2ш2к1ч</pattern>
+<pattern>2ш2к1ж</pattern>
+<pattern>2ш2т1б</pattern>
+<pattern>2ш2т1ц</pattern>
+<pattern>2ш2т1д</pattern>
+<pattern>2ш2т1ф</pattern>
+<pattern>2ш2т1г</pattern>
+<pattern>2ш2т1х</pattern>
+<pattern>2ш2т1к</pattern>
+<pattern>2ш2т1м</pattern>
+<pattern>2ш2т1н</pattern>
+<pattern>2ш2т1п</pattern>
+<pattern>2ш2т1с</pattern>
+<pattern>2ш2т1т</pattern>
+<pattern>2ш2т1њ</pattern>
+<pattern>2ш2т1џ</pattern>
+<pattern>2ш2т1з</pattern>
+<pattern>2ш2т1ш</pattern>
+<pattern>2ш2т1ђ</pattern>
+<pattern>2ш2т1ћ</pattern>
+<pattern>2ш2т1ч</pattern>
+<pattern>2ш2т1ж</pattern>
+<pattern>2с2п1б</pattern>
+<pattern>2с2п1ц</pattern>
+<pattern>2с2п1д</pattern>
+<pattern>2с2п1ф</pattern>
+<pattern>2с2п1г</pattern>
+<pattern>2с2п1х</pattern>
+<pattern>2с2п1к</pattern>
+<pattern>2с2п1м</pattern>
+<pattern>2с2п1н</pattern>
+<pattern>2с2п1п</pattern>
+<pattern>2с2п1с</pattern>
+<pattern>2с2п1т</pattern>
+<pattern>2с2п1в</pattern>
+<pattern>2с2п1њ</pattern>
+<pattern>2с2п1џ</pattern>
+<pattern>2с2п1з</pattern>
+<pattern>2с2п1ш</pattern>
+<pattern>2с2п1ђ</pattern>
+<pattern>2с2п1ћ</pattern>
+<pattern>2с2п1ч</pattern>
+<pattern>2с2п1ж</pattern>
+<pattern>2с2в1б</pattern>
+<pattern>2с2в1ц</pattern>
+<pattern>2с2в1д</pattern>
+<pattern>2с2в1ф</pattern>
+<pattern>2с2в1г</pattern>
+<pattern>2с2в1х</pattern>
+<pattern>2с2в1к</pattern>
+<pattern>2с2в1м</pattern>
+<pattern>2с2в1н</pattern>
+<pattern>2с2в1п</pattern>
+<pattern>2с2в1с</pattern>
+<pattern>2с2в1т</pattern>
+<pattern>2с2в1в</pattern>
+<pattern>2с2в1њ</pattern>
+<pattern>2с2в1џ</pattern>
+<pattern>2с2в1з</pattern>
+<pattern>2с2в1ш</pattern>
+<pattern>2с2в1ђ</pattern>
+<pattern>2с2в1ћ</pattern>
+<pattern>2с2в1ч</pattern>
+<pattern>2с2в1ж</pattern>
+<pattern>2ш2п1б</pattern>
+<pattern>2ш2п1ц</pattern>
+<pattern>2ш2п1д</pattern>
+<pattern>2ш2п1ф</pattern>
+<pattern>2ш2п1г</pattern>
+<pattern>2ш2п1х</pattern>
+<pattern>2ш2п1к</pattern>
+<pattern>2ш2п1м</pattern>
+<pattern>2ш2п1н</pattern>
+<pattern>2ш2п1п</pattern>
+<pattern>2ш2п1с</pattern>
+<pattern>2ш2п1т</pattern>
+<pattern>2ш2п1в</pattern>
+<pattern>2ш2п1њ</pattern>
+<pattern>2ш2п1џ</pattern>
+<pattern>2ш2п1з</pattern>
+<pattern>2ш2п1ш</pattern>
+<pattern>2ш2п1ђ</pattern>
+<pattern>2ш2п1ћ</pattern>
+<pattern>2ш2п1ч</pattern>
+<pattern>2ш2п1ж</pattern>
+<pattern>2ш2в1б</pattern>
+<pattern>2ш2в1ц</pattern>
+<pattern>2ш2в1д</pattern>
+<pattern>2ш2в1ф</pattern>
+<pattern>2ш2в1г</pattern>
+<pattern>2ш2в1х</pattern>
+<pattern>2ш2в1к</pattern>
+<pattern>2ш2в1м</pattern>
+<pattern>2ш2в1н</pattern>
+<pattern>2ш2в1п</pattern>
+<pattern>2ш2в1с</pattern>
+<pattern>2ш2в1т</pattern>
+<pattern>2ш2в1в</pattern>
+<pattern>2ш2в1њ</pattern>
+<pattern>2ш2в1џ</pattern>
+<pattern>2ш2в1з</pattern>
+<pattern>2ш2в1ш</pattern>
+<pattern>2ш2в1ђ</pattern>
+<pattern>2ш2в1ћ</pattern>
+<pattern>2ш2в1ч</pattern>
+<pattern>2ш2в1ж</pattern>
+<pattern>2ж2д1б</pattern>
+<pattern>2ж2д1ц</pattern>
+<pattern>2ж2д1д</pattern>
+<pattern>2ж2д1ф</pattern>
+<pattern>2ж2д1г</pattern>
+<pattern>2ж2д1х</pattern>
+<pattern>2ж2д1к</pattern>
+<pattern>2ж2д1м</pattern>
+<pattern>2ж2д1н</pattern>
+<pattern>2ж2д1п</pattern>
+<pattern>2ж2д1с</pattern>
+<pattern>2ж2д1т</pattern>
+<pattern>2ж2д1њ</pattern>
+<pattern>2ж2д1џ</pattern>
+<pattern>2ж2д1з</pattern>
+<pattern>2ж2д1ш</pattern>
+<pattern>2ж2д1ђ</pattern>
+<pattern>2ж2д1ћ</pattern>
+<pattern>2ж2д1ч</pattern>
+<pattern>2ж2д1ж</pattern>
+<pattern>2ж2г1б</pattern>
+<pattern>2ж2г1ц</pattern>
+<pattern>2ж2г1д</pattern>
+<pattern>2ж2г1ф</pattern>
+<pattern>2ж2г1г</pattern>
+<pattern>2ж2г1х</pattern>
+<pattern>2ж2г1к</pattern>
+<pattern>2ж2г1м</pattern>
+<pattern>2ж2г1н</pattern>
+<pattern>2ж2г1п</pattern>
+<pattern>2ж2г1с</pattern>
+<pattern>2ж2г1т</pattern>
+<pattern>2ж2г1њ</pattern>
+<pattern>2ж2г1џ</pattern>
+<pattern>2ж2г1з</pattern>
+<pattern>2ж2г1ш</pattern>
+<pattern>2ж2г1ђ</pattern>
+<pattern>2ж2г1ћ</pattern>
+<pattern>2ж2г1ч</pattern>
+<pattern>2ж2г1ж</pattern>
+<pattern>2з2д1б</pattern>
+<pattern>2з2д1ц</pattern>
+<pattern>2з2д1д</pattern>
+<pattern>2з2д1ф</pattern>
+<pattern>2з2д1г</pattern>
+<pattern>2з2д1х</pattern>
+<pattern>2з2д1к</pattern>
+<pattern>2з2д1м</pattern>
+<pattern>2з2д1н</pattern>
+<pattern>2з2д1п</pattern>
+<pattern>2з2д1с</pattern>
+<pattern>2з2д1т</pattern>
+<pattern>2з2д1њ</pattern>
+<pattern>2з2д1џ</pattern>
+<pattern>2з2д1з</pattern>
+<pattern>2з2д1ш</pattern>
+<pattern>2з2д1ђ</pattern>
+<pattern>2з2д1ћ</pattern>
+<pattern>2з2д1ч</pattern>
+<pattern>2з2д1ж</pattern>
+<pattern>2з2г1б</pattern>
+<pattern>2з2г1ц</pattern>
+<pattern>2з2г1д</pattern>
+<pattern>2з2г1ф</pattern>
+<pattern>2з2г1г</pattern>
+<pattern>2з2г1х</pattern>
+<pattern>2з2г1к</pattern>
+<pattern>2з2г1м</pattern>
+<pattern>2з2г1н</pattern>
+<pattern>2з2г1п</pattern>
+<pattern>2з2г1с</pattern>
+<pattern>2з2г1т</pattern>
+<pattern>2з2г1њ</pattern>
+<pattern>2з2г1џ</pattern>
+<pattern>2з2г1з</pattern>
+<pattern>2з2г1ш</pattern>
+<pattern>2з2г1ђ</pattern>
+<pattern>2з2г1ћ</pattern>
+<pattern>2з2г1ч</pattern>
+<pattern>2з2г1ж</pattern>
+<pattern>2ж2в1б</pattern>
+<pattern>2ж2в1ц</pattern>
+<pattern>2ж2в1д</pattern>
+<pattern>2ж2в1ф</pattern>
+<pattern>2ж2в1г</pattern>
+<pattern>2ж2в1х</pattern>
+<pattern>2ж2в1к</pattern>
+<pattern>2ж2в1м</pattern>
+<pattern>2ж2в1н</pattern>
+<pattern>2ж2в1п</pattern>
+<pattern>2ж2в1с</pattern>
+<pattern>2ж2в1т</pattern>
+<pattern>2ж2в1в</pattern>
+<pattern>2ж2в1њ</pattern>
+<pattern>2ж2в1џ</pattern>
+<pattern>2ж2в1з</pattern>
+<pattern>2ж2в1ш</pattern>
+<pattern>2ж2в1ђ</pattern>
+<pattern>2ж2в1ћ</pattern>
+<pattern>2ж2в1ч</pattern>
+<pattern>2ж2в1ж</pattern>
+<pattern>2ж2б1б</pattern>
+<pattern>2ж2б1ц</pattern>
+<pattern>2ж2б1д</pattern>
+<pattern>2ж2б1ф</pattern>
+<pattern>2ж2б1г</pattern>
+<pattern>2ж2б1х</pattern>
+<pattern>2ж2б1к</pattern>
+<pattern>2ж2б1м</pattern>
+<pattern>2ж2б1н</pattern>
+<pattern>2ж2б1п</pattern>
+<pattern>2ж2б1с</pattern>
+<pattern>2ж2б1т</pattern>
+<pattern>2ж2б1в</pattern>
+<pattern>2ж2б1њ</pattern>
+<pattern>2ж2б1џ</pattern>
+<pattern>2ж2б1з</pattern>
+<pattern>2ж2б1ш</pattern>
+<pattern>2ж2б1ђ</pattern>
+<pattern>2ж2б1ћ</pattern>
+<pattern>2ж2б1ч</pattern>
+<pattern>2ж2б1ж</pattern>
+<pattern>2з2в1б</pattern>
+<pattern>2з2в1ц</pattern>
+<pattern>2з2в1д</pattern>
+<pattern>2з2в1ф</pattern>
+<pattern>2з2в1г</pattern>
+<pattern>2з2в1х</pattern>
+<pattern>2з2в1к</pattern>
+<pattern>2з2в1м</pattern>
+<pattern>2з2в1н</pattern>
+<pattern>2з2в1п</pattern>
+<pattern>2з2в1с</pattern>
+<pattern>2з2в1т</pattern>
+<pattern>2з2в1в</pattern>
+<pattern>2з2в1њ</pattern>
+<pattern>2з2в1џ</pattern>
+<pattern>2з2в1з</pattern>
+<pattern>2з2в1ш</pattern>
+<pattern>2з2в1ђ</pattern>
+<pattern>2з2в1ћ</pattern>
+<pattern>2з2в1ч</pattern>
+<pattern>2з2в1ж</pattern>
+<pattern>2з2б1б</pattern>
+<pattern>2з2б1ц</pattern>
+<pattern>2з2б1д</pattern>
+<pattern>2з2б1ф</pattern>
+<pattern>2з2б1г</pattern>
+<pattern>2з2б1х</pattern>
+<pattern>2з2б1к</pattern>
+<pattern>2з2б1м</pattern>
+<pattern>2з2б1н</pattern>
+<pattern>2з2б1п</pattern>
+<pattern>2з2б1с</pattern>
+<pattern>2з2б1т</pattern>
+<pattern>2з2б1в</pattern>
+<pattern>2з2б1њ</pattern>
+<pattern>2з2б1џ</pattern>
+<pattern>2з2б1з</pattern>
+<pattern>2з2б1ш</pattern>
+<pattern>2з2б1ђ</pattern>
+<pattern>2з2б1ћ</pattern>
+<pattern>2з2б1ч</pattern>
+<pattern>2з2б1ж</pattern>
+<pattern>2ж2м1б</pattern>
+<pattern>2ж2м1ц</pattern>
+<pattern>2ж2м1д</pattern>
+<pattern>2ж2м1ф</pattern>
+<pattern>2ж2м1г</pattern>
+<pattern>2ж2м1х</pattern>
+<pattern>2ж2м1к</pattern>
+<pattern>2ж2м1м</pattern>
+<pattern>2ж2м1н</pattern>
+<pattern>2ж2м1п</pattern>
+<pattern>2ж2м1с</pattern>
+<pattern>2ж2м1т</pattern>
+<pattern>2ж2м1в</pattern>
+<pattern>2ж2м1њ</pattern>
+<pattern>2ж2м1џ</pattern>
+<pattern>2ж2м1з</pattern>
+<pattern>2ж2м1ш</pattern>
+<pattern>2ж2м1ђ</pattern>
+<pattern>2ж2м1ћ</pattern>
+<pattern>2ж2м1ч</pattern>
+<pattern>2ж2м1ж</pattern>
+<pattern>2с2м1б</pattern>
+<pattern>2с2м1ц</pattern>
+<pattern>2с2м1д</pattern>
+<pattern>2с2м1ф</pattern>
+<pattern>2с2м1г</pattern>
+<pattern>2с2м1х</pattern>
+<pattern>2с2м1к</pattern>
+<pattern>2с2м1м</pattern>
+<pattern>2с2м1н</pattern>
+<pattern>2с2м1п</pattern>
+<pattern>2с2м1с</pattern>
+<pattern>2с2м1т</pattern>
+<pattern>2с2м1в</pattern>
+<pattern>2с2м1њ</pattern>
+<pattern>2с2м1џ</pattern>
+<pattern>2с2м1з</pattern>
+<pattern>2с2м1ш</pattern>
+<pattern>2с2м1ђ</pattern>
+<pattern>2с2м1ћ</pattern>
+<pattern>2с2м1ч</pattern>
+<pattern>2с2м1ж</pattern>
+<pattern>2з2м1б</pattern>
+<pattern>2з2м1ц</pattern>
+<pattern>2з2м1д</pattern>
+<pattern>2з2м1ф</pattern>
+<pattern>2з2м1г</pattern>
+<pattern>2з2м1х</pattern>
+<pattern>2з2м1к</pattern>
+<pattern>2з2м1м</pattern>
+<pattern>2з2м1н</pattern>
+<pattern>2з2м1п</pattern>
+<pattern>2з2м1с</pattern>
+<pattern>2з2м1т</pattern>
+<pattern>2з2м1в</pattern>
+<pattern>2з2м1њ</pattern>
+<pattern>2з2м1џ</pattern>
+<pattern>2з2м1з</pattern>
+<pattern>2з2м1ш</pattern>
+<pattern>2з2м1ђ</pattern>
+<pattern>2з2м1ћ</pattern>
+<pattern>2з2м1ч</pattern>
+<pattern>2з2м1ж</pattern>
+<pattern>2ш2м1б</pattern>
+<pattern>2ш2м1ц</pattern>
+<pattern>2ш2м1д</pattern>
+<pattern>2ш2м1ф</pattern>
+<pattern>2ш2м1г</pattern>
+<pattern>2ш2м1х</pattern>
+<pattern>2ш2м1к</pattern>
+<pattern>2ш2м1м</pattern>
+<pattern>2ш2м1н</pattern>
+<pattern>2ш2м1п</pattern>
+<pattern>2ш2м1с</pattern>
+<pattern>2ш2м1т</pattern>
+<pattern>2ш2м1в</pattern>
+<pattern>2ш2м1њ</pattern>
+<pattern>2ш2м1џ</pattern>
+<pattern>2ш2м1з</pattern>
+<pattern>2ш2м1ш</pattern>
+<pattern>2ш2м1ђ</pattern>
+<pattern>2ш2м1ћ</pattern>
+<pattern>2ш2м1ч</pattern>
+<pattern>2ш2м1ж</pattern>
+<pattern>2с2ц1б</pattern>
+<pattern>2с2ц1ц</pattern>
+<pattern>2с2ц1д</pattern>
+<pattern>2с2ц1ф</pattern>
+<pattern>2с2ц1г</pattern>
+<pattern>2с2ц1х</pattern>
+<pattern>2с2ц1к</pattern>
+<pattern>2с2ц1л</pattern>
+<pattern>2с2ц1м</pattern>
+<pattern>2с2ц1н</pattern>
+<pattern>2с2ц1п</pattern>
+<pattern>2с2ц1љ</pattern>
+<pattern>2сц2р</pattern>
+<pattern>2с2ц1с</pattern>
+<pattern>2с2ц1т</pattern>
+<pattern>2с2ц1њ</pattern>
+<pattern>2с2ц1џ</pattern>
+<pattern>2с2ц1з</pattern>
+<pattern>2с2ц1ш</pattern>
+<pattern>2с2ц1ђ</pattern>
+<pattern>2с2ц1ћ</pattern>
+<pattern>2с2ц1ч</pattern>
+<pattern>2с2ц1ж</pattern>
+<pattern>2ш2ц1б</pattern>
+<pattern>2ш2ц1ц</pattern>
+<pattern>2ш2ц1д</pattern>
+<pattern>2ш2ц1ф</pattern>
+<pattern>2ш2ц1г</pattern>
+<pattern>2ш2ц1х</pattern>
+<pattern>2ш2ц1к</pattern>
+<pattern>2ш2ц1л</pattern>
+<pattern>2ш2ц1м</pattern>
+<pattern>2ш2ц1н</pattern>
+<pattern>2ш2ц1п</pattern>
+<pattern>2ш2ц1љ</pattern>
+<pattern>2шц2р</pattern>
+<pattern>2ш2ц1с</pattern>
+<pattern>2ш2ц1т</pattern>
+<pattern>2ш2ц1њ</pattern>
+<pattern>2ш2ц1џ</pattern>
+<pattern>2ш2ц1з</pattern>
+<pattern>2ш2ц1ш</pattern>
+<pattern>2ш2ц1ђ</pattern>
+<pattern>2ш2ц1ћ</pattern>
+<pattern>2ш2ц1ч</pattern>
+<pattern>2ш2ц1ж</pattern>
+<pattern>2ш2ч1б</pattern>
+<pattern>2ш2ч1ц</pattern>
+<pattern>2ш2ч1д</pattern>
+<pattern>2ш2ч1ф</pattern>
+<pattern>2ш2ч1г</pattern>
+<pattern>2ш2ч1х</pattern>
+<pattern>2ш2ч1ј</pattern>
+<pattern>2ш2ч1к</pattern>
+<pattern>2ш2ч1л</pattern>
+<pattern>2ш2ч1м</pattern>
+<pattern>2ш2ч1н</pattern>
+<pattern>2ш2ч1п</pattern>
+<pattern>2ш2ч1љ</pattern>
+<pattern>2ш2ч1р</pattern>
+<pattern>2ш2ч1с</pattern>
+<pattern>2ш2ч1т</pattern>
+<pattern>2ш2ч1њ</pattern>
+<pattern>2ш2ч1џ</pattern>
+<pattern>2ш2ч1з</pattern>
+<pattern>2ш2ч1ш</pattern>
+<pattern>2ш2ч1ђ</pattern>
+<pattern>2ш2ч1ћ</pattern>
+<pattern>2ш2ч1ч</pattern>
+<pattern>2ш2ч1ж</pattern>
+<pattern>2х2в1б</pattern>
+<pattern>2х2в1ц</pattern>
+<pattern>2х2в1д</pattern>
+<pattern>2х2в1ф</pattern>
+<pattern>2х2в1г</pattern>
+<pattern>2х2в1х</pattern>
+<pattern>2х2в1к</pattern>
+<pattern>2х2в1м</pattern>
+<pattern>2х2в1н</pattern>
+<pattern>2х2в1п</pattern>
+<pattern>2х2в1с</pattern>
+<pattern>2х2в1т</pattern>
+<pattern>2х2в1њ</pattern>
+<pattern>2х2в1џ</pattern>
+<pattern>2х2в1з</pattern>
+<pattern>2х2в1ш</pattern>
+<pattern>2х2в1ђ</pattern>
+<pattern>2х2в1ћ</pattern>
+<pattern>2х2в1ч</pattern>
+<pattern>2х2в1ж</pattern>
+<pattern>2ж3в2л</pattern>
+<pattern>2ж3в2љ</pattern>
+<pattern>2ц3в2л</pattern>
+<pattern>2ц3в2љ</pattern>
+<pattern>2з3в2л</pattern>
+<pattern>2з3в2љ</pattern>
+<pattern>2ш3в2л</pattern>
+<pattern>2ш3в2љ</pattern>
+<pattern>2ч3в2л</pattern>
+<pattern>2ч3в2љ</pattern>
+<pattern>2ч3в2ј</pattern>
+<pattern>2с3в2љ</pattern>
+<pattern>2д3в2л</pattern>
+<pattern>2д3в2љ</pattern>
+<pattern>2д3в2р</pattern>
+<pattern>2к3в2ј</pattern>
+<pattern>2к3в2л</pattern>
+<pattern>2к3в2љ</pattern>
+<pattern>2т3в2ј</pattern>
+<pattern>2т3в2л</pattern>
+<pattern>2т3в2љ</pattern>
+<pattern>2г3в2ј</pattern>
+<pattern>2г3в2л</pattern>
+<pattern>2г3в2љ</pattern>
+<pattern>2г3в2р</pattern>
+<pattern>2х3в2ј</pattern>
+<pattern>2х3в2л</pattern>
+<pattern>2х3в2љ</pattern>
+<pattern>2х3в2р</pattern>
+<pattern>2ж3м2ј</pattern>
+<pattern>2ж3м2л</pattern>
+<pattern>2ж3м2љ</pattern>
+<pattern>2ж3м2р</pattern>
+<pattern>2з3м2л</pattern>
+<pattern>2з3м2р</pattern>
+<pattern>2ш3м2ј</pattern>
+<pattern>2ш3м2л</pattern>
+<pattern>2ш3м2љ</pattern>
+<pattern>2ш3ц2ј</pattern>
+<pattern>2ш3ц2в</pattern>
+<pattern>2ш3ч2в</pattern>
+<pattern>2ш3т2ј</pattern>
+<pattern>2ш3т2л</pattern>
+<pattern>2ш3т2љ</pattern>
+<pattern>2с3т2л</pattern>
+<pattern>2с3к2ј</pattern>
+<pattern>2с3к2љ</pattern>
+<pattern>2ш3п2ј</pattern>
+<pattern>2ш3п2л</pattern>
+<pattern>2ш3п2љ</pattern>
+<pattern>2ж3д2ј</pattern>
+<pattern>2ж3д2л</pattern>
+<pattern>2ж3д2љ</pattern>
+<pattern>2ж3д2в</pattern>
+<pattern>2ж3г2ј</pattern>
+<pattern>2ж3г2л</pattern>
+<pattern>2ж3г2љ</pattern>
+<pattern>2ж3г2р</pattern>
+<pattern>2ж3г2в</pattern>
+<pattern>2з3д2л</pattern>
+<pattern>2з3д2љ</pattern>
+<pattern>2з3д2в</pattern>
+<pattern>2з3г2ј</pattern>
+<pattern>2з3г2љ</pattern>
+<pattern>2ж3б2ј</pattern>
+<pattern>2ж3б2л</pattern>
+<pattern>2ж3б2љ</pattern>
+<pattern>2ж3б2р</pattern>
+<pattern>2з3б2љ</pattern>
+<pattern> а4е2р2о1</pattern>
+<pattern> 2а1</pattern>
+<pattern> а3е1</pattern>
+<pattern> бе4о1</pattern>
+<pattern> б2е1</pattern>
+<pattern> би4о1</pattern>
+<pattern> б2и1</pattern>
+<pattern> ге4о1</pattern>
+<pattern> г2е1</pattern>
+<pattern> за3г2н</pattern>
+<pattern> з2а1</pattern>
+<pattern> з2а3т2к2а1</pattern>
+<pattern> за2т1к</pattern>
+<pattern> иза3г2н</pattern>
+<pattern> 2и1</pattern>
+<pattern> из2а1</pattern>
+<pattern> иза3т2к</pattern>
+<pattern> и2з3г</pattern>
+<pattern> и2з3г2н</pattern>
+<pattern> и2з3д</pattern>
+<pattern> изд2н2о1</pattern>
+<pattern> и2з2д1н</pattern>
+<pattern> изд2н2у1</pattern>
+<pattern> изд2н2а1</pattern>
+<pattern> и2з3р</pattern>
+<pattern> из2р2к</pattern>
+<pattern> и2с3т</pattern>
+<pattern> и2с2т2к</pattern>
+<pattern> на2г2н</pattern>
+<pattern> н2а1</pattern>
+<pattern> на2г2њ</pattern>
+<pattern> на3д2нев</pattern>
+<pattern> на2д1н</pattern>
+<pattern> надн2е1</pattern>
+<pattern> на3д2нич</pattern>
+<pattern> надн2и1</pattern>
+<pattern> на3д2ниц</pattern>
+<pattern> на3т2ках</pattern>
+<pattern> на2т1к</pattern>
+<pattern> н2а1тк2а1</pattern>
+<pattern> на3т2кам</pattern>
+<pattern> на3т2кас2м</pattern>
+<pattern> на3т2кас2т</pattern>
+<pattern> ода3г2н</pattern>
+<pattern> 2о1</pattern>
+<pattern> од2а1</pattern>
+<pattern> ода3д2н</pattern>
+<pattern> од3г2н</pattern>
+<pattern> о2д1г</pattern>
+<pattern> од3м2н</pattern>
+<pattern> о2д1м</pattern>
+<pattern> о3т2ках</pattern>
+<pattern> о2т1к</pattern>
+<pattern> отк2а1</pattern>
+<pattern> о3т2кам</pattern>
+<pattern> о3т2кас2м</pattern>
+<pattern> о3т2кас2т</pattern>
+<pattern> по3г2н</pattern>
+<pattern> п2о1</pattern>
+<pattern> по3д2нев</pattern>
+<pattern> по2д1н</pattern>
+<pattern> подн2е1</pattern>
+<pattern> по3м2н</pattern>
+<pattern> по3м2њ</pattern>
+<pattern> по3р2в</pattern>
+<pattern> по3р2ђ</pattern>
+<pattern> по3т2ках</pattern>
+<pattern> по2т1к</pattern>
+<pattern> потк2а1</pattern>
+<pattern> по3т2кам</pattern>
+<pattern> по3т2кат</pattern>
+<pattern> по3т2кав</pattern>
+<pattern> пред3м2н</pattern>
+<pattern> п2р</pattern>
+<pattern> пр2е1</pattern>
+<pattern> пре2д1м</pattern>
+<pattern> пред3м2њ</pattern>
+<pattern> пре3т2ках</pattern>
+<pattern> пре2т1к</pattern>
+<pattern> претк2а1</pattern>
+<pattern> пре3т2кам</pattern>
+<pattern> пре3т2кат</pattern>
+<pattern> про3г2н</pattern>
+<pattern> пр2о1</pattern>
+<pattern> про3т2к2и1</pattern>
+<pattern> про2т1к</pattern>
+<pattern> про3т2к2а1</pattern>
+<pattern> раза3г2н</pattern>
+<pattern> р2а1</pattern>
+<pattern> р2а1з2а1</pattern>
+<pattern> ра2з3г</pattern>
+<pattern> ра2з3г2н</pattern>
+<pattern> ра2з3д</pattern>
+<pattern> раз3д2н2и1</pattern>
+<pattern> ра2з2д1н</pattern>
+<pattern> р2а1з2а3т2к2а1</pattern>
+<pattern> раза2т1к</pattern>
+<pattern> у3г2м2и1</pattern>
+<pattern> 2у1</pattern>
+<pattern> у2г1м</pattern>
+<pattern> у3г2н</pattern>
+<pattern> уз2а3т2к2а1</pattern>
+<pattern> уз2а1</pattern>
+<pattern> уза2т1к</pattern>
+<pattern>3х2тет2и1</pattern>
+<pattern>хт2е1</pattern>
+<pattern>3х2тјет2и1</pattern>
+<pattern>хт2ј</pattern>
+<pattern>хтј2е1</pattern>
+<pattern>3х2тел</pattern>
+<pattern>3х2тев</pattern>
+<pattern>3х2тењ</pattern>
+<pattern>3х2тјел</pattern>
+<pattern>3х2тјев</pattern>
+<pattern>3х2тјењ</pattern>
+<pattern>3г2дегод </pattern>
+<pattern>гд2е1</pattern>
+<pattern>гдег2о1</pattern>
+<pattern>3г2дјегод </pattern>
+<pattern>гд2ј</pattern>
+<pattern>гдј2е1</pattern>
+<pattern>гдјег2о1</pattern>
+<pattern>3г2декак</pattern>
+<pattern>гдек2а1</pattern>
+<pattern>3г2декад</pattern>
+<pattern>3г2дјекак</pattern>
+<pattern>гдјек2а1</pattern>
+<pattern>3г2дјекад</pattern>
+<pattern>ни3г2де </pattern>
+<pattern>н2и1</pattern>
+<pattern>ни2г1д</pattern>
+<pattern>нигд2е1</pattern>
+<pattern>не3г2де </pattern>
+<pattern>н2е1</pattern>
+<pattern>не2г1д</pattern>
+<pattern>негд2е1</pattern>
+<pattern>ни3г2дје </pattern>
+<pattern>нигд2ј</pattern>
+<pattern>нигдј2е1</pattern>
+<pattern>не3г2дје </pattern>
+<pattern>негд2ј</pattern>
+<pattern>негдј2е1</pattern>
+<pattern>3б2дет</pattern>
+<pattern>бд2е1</pattern>
+<pattern>3б2дењ</pattern>
+<pattern>3б2дјет</pattern>
+<pattern>бд2ј</pattern>
+<pattern>бдј2е1</pattern>
+<pattern>3б2дјењ</pattern>
+<pattern>3г2мил</pattern>
+<pattern>гм2и1</pattern>
+<pattern>3г2миљ</pattern>
+<pattern>3г2миз</pattern>
+<pattern>3г2нос</pattern>
+<pattern>гн2о1</pattern>
+<pattern>3г2ноз</pattern>
+<pattern>3г2ној</pattern>
+<pattern>3г2нај</pattern>
+<pattern>гн2а1</pattern>
+<pattern>3г2нез2д</pattern>
+<pattern>гн2е1</pattern>
+<pattern>3г2нијез2д</pattern>
+<pattern>гн2и1</pattern>
+<pattern>гниј2е1</pattern>
+<pattern>3г2неж2ђ</pattern>
+<pattern>3г2нијеж2ђ</pattern>
+<pattern>3г2нев</pattern>
+<pattern>3г2њев</pattern>
+<pattern>гњ2е1</pattern>
+<pattern>3г2њав</pattern>
+<pattern>гњ2а1</pattern>
+<pattern>3г2њес</pattern>
+<pattern>3г2њет</pattern>
+<pattern>3г2њеч</pattern>
+<pattern>3г2њил</pattern>
+<pattern>гњ2и1</pattern>
+<pattern>3г2њи3о1</pattern>
+<pattern>3г2њиљ</pattern>
+<pattern>3г2њит</pattern>
+<pattern>3г2њур</pattern>
+<pattern>гњ2у1</pattern>
+<pattern>3к2нез</pattern>
+<pattern>кн2е1</pattern>
+<pattern>3к2неж</pattern>
+<pattern>3к2њиж</pattern>
+<pattern>књ2и1</pattern>
+<pattern>3к2њиг</pattern>
+<pattern>3м2нож</pattern>
+<pattern>мн2о1</pattern>
+<pattern>3м2ног</pattern>
+<pattern>3м2наж</pattern>
+<pattern>мн2а1</pattern>
+<pattern>3п2сик</pattern>
+<pattern>пс2и1</pattern>
+<pattern>3п2сич</pattern>
+<pattern>3п2сов</pattern>
+<pattern>пс2о1</pattern>
+<pattern>3п2суј</pattern>
+<pattern>пс2у1</pattern>
+<pattern>3р2ђ2а1</pattern>
+<pattern>3с2фер</pattern>
+<pattern>сф2е1</pattern>
+<pattern>3т2мас2т</pattern>
+<pattern>тм2а1</pattern>
+<pattern>3т2мул</pattern>
+<pattern>тм2у1</pattern>
+<pattern>3т2му3о1</pattern>
+<pattern>3т2муљ</pattern>
+<pattern>3т2мур</pattern>
+<pattern>3ц2миз</pattern>
+<pattern>цм2и1</pattern>
+<pattern>3ц2мак</pattern>
+<pattern>цм2а1</pattern>
+<pattern>3ц2мач</pattern>
+<pattern>3ц2мок</pattern>
+<pattern>цм2о1</pattern>
+<pattern>3ч2лан</pattern>
+<pattern>чл2а1</pattern>
+<pattern>3ч2лањ</pattern>
+<pattern>3р2ј2е1</pattern>
+<pattern>4р3јем</pattern>
+<pattern>4р3је </pattern>
+<pattern> бе2з3ј</pattern>
+<pattern> бе2з3л</pattern>
+<pattern> бе2з3м</pattern>
+<pattern> бе2з3н</pattern>
+<pattern> бе2з3љ</pattern>
+<pattern> бе2з3р</pattern>
+<pattern> бе2з3в</pattern>
+<pattern> бе2з3њ</pattern>
+<pattern> бе2з3б</pattern>
+<pattern> бе2з3д</pattern>
+<pattern> бе2з3г</pattern>
+<pattern> бе2з3и1</pattern>
+<pattern> бе2з3о1</pattern>
+<pattern> бе2з3у1</pattern>
+<pattern> бе2з3алкохол</pattern>
+<pattern> без2а1</pattern>
+<pattern> беза2л1к</pattern>
+<pattern> безалк2о1</pattern>
+<pattern> безалкох2о1</pattern>
+<pattern> бе2з3атомс2к</pattern>
+<pattern> безат2о1</pattern>
+<pattern> безато2м1с</pattern>
+<pattern> бе3з4бе2д1н</pattern>
+<pattern> б2е1зб2е1</pattern>
+<pattern> бе3з4бед2а1</pattern>
+<pattern> бе3з4бје2д1н</pattern>
+<pattern> безб2ј</pattern>
+<pattern> б2е1збј2е1</pattern>
+<pattern> бе3з4бјед2а1</pattern>
+<pattern> бе3з4бел2и1</pattern>
+<pattern> бе3з4бол</pattern>
+<pattern> безб2о1</pattern>
+<pattern> бе3з4ву2ч1н</pattern>
+<pattern> безв2у1</pattern>
+<pattern> бе3з4вуч2а1</pattern>
+<pattern> бе3з4истан</pattern>
+<pattern> безис2т</pattern>
+<pattern> безист2а1</pattern>
+<pattern> бе3з4истен</pattern>
+<pattern> безист2е1</pattern>
+<pattern> бе3з4јак</pattern>
+<pattern> безј2а1</pattern>
+<pattern> бе3з4јач</pattern>
+<pattern> бе3з4ло2б1н</pattern>
+<pattern> безл2о1</pattern>
+<pattern> бе3з4лоб2а1</pattern>
+<pattern> бе3з4начај</pattern>
+<pattern> безн2а1</pattern>
+<pattern> безнач2а1</pattern>
+<pattern> бе3з4ра2ч1н</pattern>
+<pattern> безр2а1</pattern>
+<pattern> бе3з4р2а1ч2а1</pattern>
+<pattern> бе3з4уп</pattern>
+<pattern> бе3з4уб</pattern>
+<pattern> бе2с3ц</pattern>
+<pattern> бе2с3к</pattern>
+<pattern> бе2с3п</pattern>
+<pattern> бе2с3т</pattern>
+<pattern> бе3с4крупул</pattern>
+<pattern> беск2р</pattern>
+<pattern> бескр2у1</pattern>
+<pattern> бескруп2у1</pattern>
+<pattern> бе3с4поко2ј1н</pattern>
+<pattern> бесп2о1</pattern>
+<pattern> бесп2о1к2о1</pattern>
+<pattern> бе3с4покој2а1</pattern>
+<pattern> бе3с4по2р1н</pattern>
+<pattern> бе3с4пор2а1</pattern>
+<pattern> бе3с4твар</pattern>
+<pattern> бест2в</pattern>
+<pattern> беств2а1</pattern>
+<pattern> бе3с4тид</pattern>
+<pattern> бест2и1</pattern>
+<pattern> бе3с4тиј2а1</pattern>
+<pattern> бе3с4тил2у1</pattern>
+<pattern> бе3с4тиљ</pattern>
+<pattern> бе3с4тр2а1н2а1</pattern>
+<pattern> бест2р</pattern>
+<pattern> бестр2а1</pattern>
+<pattern> бе3с4трас</pattern>
+<pattern> бес4тселер</pattern>
+<pattern> бе2с2т1с</pattern>
+<pattern> бестс2е1</pattern>
+<pattern> бестсел2е1</pattern>
+<pattern> бе2ш3ћ</pattern>
+<pattern> бе2ш3ч</pattern>
+<pattern> ва2н3ев2р</pattern>
+<pattern> в2а1</pattern>
+<pattern> ван2е1</pattern>
+<pattern> ва2н3устав</pattern>
+<pattern> ван2у1</pattern>
+<pattern> ванус2т</pattern>
+<pattern> вануст2а1</pattern>
+<pattern> и2з3б</pattern>
+<pattern> и2з3ј</pattern>
+<pattern> и2з3л</pattern>
+<pattern> и2з3м</pattern>
+<pattern> и2з3н</pattern>
+<pattern> и2з3љ</pattern>
+<pattern> и2з3в</pattern>
+<pattern> и2з3њ</pattern>
+<pattern> 2и2з3и1</pattern>
+<pattern> и2з3о1</pattern>
+<pattern> и2з3у1</pattern>
+<pattern> и2з3биј2а1</pattern>
+<pattern> 2и1зб2и1</pattern>
+<pattern> и2з3бив2а1</pattern>
+<pattern> 2и2з3вед2и1</pattern>
+<pattern> изв2е1</pattern>
+<pattern> и2з3ве2д1н</pattern>
+<pattern> и2з3ве2д1б</pattern>
+<pattern> и2з3в2е1д2е1</pattern>
+<pattern> и2з3дај</pattern>
+<pattern> изд2а1</pattern>
+<pattern> и2з3а1б2а1</pattern>
+<pattern> и2з3а1к2а1</pattern>
+<pattern> и2з3анал</pattern>
+<pattern> изан2а1</pattern>
+<pattern> и3з4бав</pattern>
+<pattern> изб2а1</pattern>
+<pattern> и3з4бичк2а1в2а1</pattern>
+<pattern> изби2ч1к</pattern>
+<pattern> избичк2а1</pattern>
+<pattern> и3з4блеушан</pattern>
+<pattern> изб2л</pattern>
+<pattern> избл2е1</pattern>
+<pattern> избле3у1</pattern>
+<pattern> изблеуш2а1</pattern>
+<pattern> и3з4бојак</pattern>
+<pattern> изб2о1</pattern>
+<pattern> избој2а1</pattern>
+<pattern> и3з4бо2ј1к</pattern>
+<pattern> 2и3з4вал2и1</pattern>
+<pattern> изв2а1</pattern>
+<pattern> и3з4вал2у1</pattern>
+<pattern> и3з4в2а1л2а1</pattern>
+<pattern> и3з4вал2е1</pattern>
+<pattern> 2и3з4ваљ2и1</pattern>
+<pattern> и3з4виж2д</pattern>
+<pattern> 2и1зв2и1</pattern>
+<pattern> и3з4вииск2р</pattern>
+<pattern> 2и1зв2и3и1</pattern>
+<pattern> извиис2к</pattern>
+<pattern> и3з4виј2а1</pattern>
+<pattern> и3з4вијен</pattern>
+<pattern> извиј2е1</pattern>
+<pattern> и3з4вин</pattern>
+<pattern> и3з4вир</pattern>
+<pattern> и3з4вињ</pattern>
+<pattern> и3з4витоп</pattern>
+<pattern> извит2о1</pattern>
+<pattern> и3з4вјед</pattern>
+<pattern> изв2ј</pattern>
+<pattern> извј2е1</pattern>
+<pattern> и3з4војац</pattern>
+<pattern> изв2о1</pattern>
+<pattern> извој2а1</pattern>
+<pattern> и3з4во2ј1ц</pattern>
+<pattern> и3з4вор</pattern>
+<pattern> и3з4гомет</pattern>
+<pattern> изг2о1</pattern>
+<pattern> изгом2е1</pattern>
+<pattern> и3з4гред</pattern>
+<pattern> изг2р</pattern>
+<pattern> изгр2е1</pattern>
+<pattern> и3з4г2р1н</pattern>
+<pattern> и3з4г2р1т</pattern>
+<pattern> и3з4драв</pattern>
+<pattern> изд2р</pattern>
+<pattern> издр2а1</pattern>
+<pattern> и3з4иђ</pattern>
+<pattern> и3з4ид</pattern>
+<pattern> 2и3з4и1м2и1</pattern>
+<pattern> и3з4јеж2љ</pattern>
+<pattern> изј2е1</pattern>
+<pattern> и3з4лоз</pattern>
+<pattern> изл2о1</pattern>
+<pattern> и3з4лож</pattern>
+<pattern> и3з4лог</pattern>
+<pattern> и3з4лопаћ</pattern>
+<pattern> излоп2а1</pattern>
+<pattern> и3з4ним</pattern>
+<pattern> изн2и1</pattern>
+<pattern> и3з4ној</pattern>
+<pattern> изн2о1</pattern>
+<pattern> из4оанем</pattern>
+<pattern> изо3а1</pattern>
+<pattern> изоан2е1</pattern>
+<pattern> из4оаном</pattern>
+<pattern> изоан2о1</pattern>
+<pattern> из4обат</pattern>
+<pattern> изоб2а1</pattern>
+<pattern> из4оброн</pattern>
+<pattern> изоб2р</pattern>
+<pattern> изобр2о1</pattern>
+<pattern> из4огам</pattern>
+<pattern> изог2а1</pattern>
+<pattern> из4о1ге3о1</pattern>
+<pattern> изог2е1</pattern>
+<pattern> из4оглос</pattern>
+<pattern> изог2л</pattern>
+<pattern> изогл2о1</pattern>
+<pattern> из4огон</pattern>
+<pattern> изог2о1</pattern>
+<pattern> из4ограф</pattern>
+<pattern> изог2р</pattern>
+<pattern> изогр2а1</pattern>
+<pattern> из4одим</pattern>
+<pattern> 2и1зод2и1</pattern>
+<pattern> из4один</pattern>
+<pattern> из4одоз</pattern>
+<pattern> изод2о1</pattern>
+<pattern> из4оклин</pattern>
+<pattern> изок2л</pattern>
+<pattern> изокл2и1</pattern>
+<pattern> из4околон</pattern>
+<pattern> изок2о1</pattern>
+<pattern> изокол2о1</pattern>
+<pattern> и3з4олат</pattern>
+<pattern> изол2а1</pattern>
+<pattern> и3з4олац</pattern>
+<pattern> и3з4олир</pattern>
+<pattern> изол2и1</pattern>
+<pattern> и3з4олов</pattern>
+<pattern> изол2о1</pattern>
+<pattern> из4оле2к1с</pattern>
+<pattern> изол2е1</pattern>
+<pattern> из4олу2к1с</pattern>
+<pattern> изол2у1</pattern>
+<pattern> из4омер</pattern>
+<pattern> изом2е1</pattern>
+<pattern> из4омет2р</pattern>
+<pattern> из4омо2р1ф</pattern>
+<pattern> изом2о1</pattern>
+<pattern> из4онеф</pattern>
+<pattern> изон2е1</pattern>
+<pattern> из4оном</pattern>
+<pattern> изон2о1</pattern>
+<pattern> из4опат</pattern>
+<pattern> изоп2а1</pattern>
+<pattern> из4опер</pattern>
+<pattern> изоп2е1</pattern>
+<pattern> из4опл2е1</pattern>
+<pattern> изоп2л</pattern>
+<pattern> из4опол</pattern>
+<pattern> изоп2о1</pattern>
+<pattern> из4опсеф</pattern>
+<pattern> изо2п1с</pattern>
+<pattern> изопс2е1</pattern>
+<pattern> из4орах</pattern>
+<pattern> изор2а1</pattern>
+<pattern> 2и1з4осе3и1</pattern>
+<pattern> изос2е1</pattern>
+<pattern> из4оси2н1т</pattern>
+<pattern> 2и1зос2и1</pattern>
+<pattern> из4осис2т</pattern>
+<pattern> из4оскел</pattern>
+<pattern> изос2к</pattern>
+<pattern> изоск2е1</pattern>
+<pattern> из4оскоп</pattern>
+<pattern> изоск2о1</pattern>
+<pattern> из4остаз</pattern>
+<pattern> изос2т</pattern>
+<pattern> изост2а1</pattern>
+<pattern> из4ост2е1</pattern>
+<pattern> из4отах</pattern>
+<pattern> изот2а1</pattern>
+<pattern> из4отал</pattern>
+<pattern> из4отер</pattern>
+<pattern> изот2е1</pattern>
+<pattern> из4отон</pattern>
+<pattern> из2о1т2о1</pattern>
+<pattern> из4отоп</pattern>
+<pattern> из4о1тр2о1</pattern>
+<pattern> изот2р</pattern>
+<pattern> из4офон</pattern>
+<pattern> из2о1ф2о1</pattern>
+<pattern> из4офот</pattern>
+<pattern> из4охал</pattern>
+<pattern> изох2а1</pattern>
+<pattern> из4охаз</pattern>
+<pattern> из4охел</pattern>
+<pattern> изох2е1</pattern>
+<pattern> из4охиј</pattern>
+<pattern> 2и1зох2и1</pattern>
+<pattern> из4охим</pattern>
+<pattern> из4охит</pattern>
+<pattern> из4охи2п1с</pattern>
+<pattern> из4охор</pattern>
+<pattern> изох2о1</pattern>
+<pattern> из4о1хр2о1</pattern>
+<pattern> изох2р</pattern>
+<pattern> и3з4раел</pattern>
+<pattern> изр2а1</pattern>
+<pattern> изра3е1</pattern>
+<pattern> и3з4раиљ</pattern>
+<pattern> 2и1зра3и1</pattern>
+<pattern> 2и3з4рач2и1</pattern>
+<pattern> и3з4ун</pattern>
+<pattern> и3з4у2п1ч</pattern>
+<pattern> и2с3ц</pattern>
+<pattern> и2с3к</pattern>
+<pattern> и2с3п</pattern>
+<pattern> и3с4как</pattern>
+<pattern> иск2а1</pattern>
+<pattern> и3с4кат</pattern>
+<pattern> и3с4кањ</pattern>
+<pattern> и3с4кариот</pattern>
+<pattern> искар2и1</pattern>
+<pattern> искари3о1</pattern>
+<pattern> и3с4квас</pattern>
+<pattern> иск2в</pattern>
+<pattern> искв2а1</pattern>
+<pattern> и3с4кв2р1ч</pattern>
+<pattern> искв2р</pattern>
+<pattern> и3с4кин</pattern>
+<pattern> 2и1ск2и1</pattern>
+<pattern> и3с4кит2а1</pattern>
+<pattern> и3с4конс2к</pattern>
+<pattern> иск2о1</pattern>
+<pattern> иско2н1с</pattern>
+<pattern> и3с4коч</pattern>
+<pattern> и3с4крам</pattern>
+<pattern> иск2р</pattern>
+<pattern> искр2а1</pattern>
+<pattern> и3с4крит</pattern>
+<pattern> 2и1скр2и1</pattern>
+<pattern> и3с4криш</pattern>
+<pattern> и3с4крич</pattern>
+<pattern> и3с4криц</pattern>
+<pattern> и3с4крат</pattern>
+<pattern> и3с4крен</pattern>
+<pattern> искр2е1</pattern>
+<pattern> и3с4крењ</pattern>
+<pattern> и3с4крој</pattern>
+<pattern> искр2о1</pattern>
+<pattern> и3с4крс2н</pattern>
+<pattern> иск2р1с</pattern>
+<pattern> и3с4крс2а1</pattern>
+<pattern> и3с4купљ2а1</pattern>
+<pattern> иск2у1</pattern>
+<pattern> искуп2љ</pattern>
+<pattern> и3с4лам</pattern>
+<pattern> ис2л</pattern>
+<pattern> исл2а1</pattern>
+<pattern> и3с4лаб</pattern>
+<pattern> и3с4леђ</pattern>
+<pattern> исл2е1</pattern>
+<pattern> и3с4лед</pattern>
+<pattern> и3с4лијеђ</pattern>
+<pattern> 2и1сл2и1</pattern>
+<pattern> ислиј2е1</pattern>
+<pattern> и3с4лијед</pattern>
+<pattern> и3с4љеђ</pattern>
+<pattern> ис2љ</pattern>
+<pattern> исљ2е1</pattern>
+<pattern> и3с4љед</pattern>
+<pattern> и3с4лик</pattern>
+<pattern> и3с4лин</pattern>
+<pattern> и3с4лов</pattern>
+<pattern> исл2о1</pattern>
+<pattern> и3с4луш</pattern>
+<pattern> исл2у1</pattern>
+<pattern> и3с4луж</pattern>
+<pattern> и3с4м2е1</pattern>
+<pattern> ис2м</pattern>
+<pattern> и3с4миј2е1</pattern>
+<pattern> исм2и1</pattern>
+<pattern> и3с4мј2е1</pattern>
+<pattern> исм2ј</pattern>
+<pattern> и3с4пав</pattern>
+<pattern> исп2а1</pattern>
+<pattern> и3с4паљив</pattern>
+<pattern> испаљ2и1</pattern>
+<pattern> и3с4пир2а1</pattern>
+<pattern> исп2и1</pattern>
+<pattern> и3с4плит</pattern>
+<pattern> исп2л</pattern>
+<pattern> 2и1спл2и1</pattern>
+<pattern> и3с4плић</pattern>
+<pattern> и3с4покој</pattern>
+<pattern> исп2о1</pattern>
+<pattern> испок2о1</pattern>
+<pattern> и3с4полин</pattern>
+<pattern> испол2и1</pattern>
+<pattern> и3с4пон</pattern>
+<pattern> и3с4порав</pattern>
+<pattern> испор2а1</pattern>
+<pattern> 2и3с4прав2и1</pattern>
+<pattern> исп2р</pattern>
+<pattern> испр2а1</pattern>
+<pattern> и3с4пра2в1к</pattern>
+<pattern> и3с4пра2в1н</pattern>
+<pattern> и3с4прав2љ</pattern>
+<pattern> и3с4пр2а1в2а1</pattern>
+<pattern> и3с4пу2п1ч</pattern>
+<pattern> исп2у1</pattern>
+<pattern> и3с4пур</pattern>
+<pattern> и3с4ред</pattern>
+<pattern> ис2р</pattern>
+<pattern> иср2е1</pattern>
+<pattern> и3с4р1к</pattern>
+<pattern> 2и3с4тав2и1</pattern>
+<pattern> ист2а1</pattern>
+<pattern> и3с4тав2љ</pattern>
+<pattern> и3с4та2к1н</pattern>
+<pattern> и3с4там</pattern>
+<pattern> и3с4тар</pattern>
+<pattern> и3с4тас</pattern>
+<pattern> и3с4таћ</pattern>
+<pattern> и3с4тин</pattern>
+<pattern> 2и1ст2и1</pattern>
+<pattern> и3с4тир</pattern>
+<pattern> и3с4тиц</pattern>
+<pattern> и3с4тифан</pattern>
+<pattern> истиф2а1</pattern>
+<pattern> и3с4ток</pattern>
+<pattern> ист2о1</pattern>
+<pattern> 2и3с4тор2и1</pattern>
+<pattern> и3с4то2ч1н</pattern>
+<pattern> и3с4то2ч1њ</pattern>
+<pattern> и3с4точ2а1</pattern>
+<pattern> и3с4трав</pattern>
+<pattern> ист2р</pattern>
+<pattern> истр2а1</pattern>
+<pattern> и3с4трад</pattern>
+<pattern> и3с4тран</pattern>
+<pattern> и3с4трић</pattern>
+<pattern> 2и1стр2и1</pattern>
+<pattern> и3с4триж</pattern>
+<pattern> и3с4триц</pattern>
+<pattern> и3с4труг</pattern>
+<pattern> истр2у1</pattern>
+<pattern> и3с4туп</pattern>
+<pattern> ист2у1</pattern>
+<pattern> и3с4ук</pattern>
+<pattern> ис2у1</pattern>
+<pattern> и3с4ус</pattern>
+<pattern> и3с4ут</pattern>
+<pattern> и3с4уш</pattern>
+<pattern> и2ж3ђ</pattern>
+<pattern> и2ш3ћ</pattern>
+<pattern> и2ш3ч</pattern>
+<pattern> из3бе2з3об2р</pattern>
+<pattern> изб2е1</pattern>
+<pattern> избез2о1</pattern>
+<pattern> из3бе2з3ум</pattern>
+<pattern> избез2у1</pattern>
+<pattern> из3ва2н3ев2р</pattern>
+<pattern> изван2е1</pattern>
+<pattern> на2д3л</pattern>
+<pattern> на2д3љ</pattern>
+<pattern> на2д3в</pattern>
+<pattern> на3д4вал</pattern>
+<pattern> надв2а1</pattern>
+<pattern> на3д4вес2и1</pattern>
+<pattern> надв2е1</pattern>
+<pattern> на3д4вес2т</pattern>
+<pattern> на3д4виј</pattern>
+<pattern> надв2и1</pattern>
+<pattern> на3д4вит</pattern>
+<pattern> н2а3д4вл2а1</pattern>
+<pattern> на2д3в2л</pattern>
+<pattern> на3д4вој2е1</pattern>
+<pattern> надв2о1</pattern>
+<pattern> на3д4вор</pattern>
+<pattern> на2д3иг2р</pattern>
+<pattern> над2и1</pattern>
+<pattern> на2д3и2н1ж</pattern>
+<pattern> н2а2д3ин2а1</pattern>
+<pattern> на2д3ис2к</pattern>
+<pattern> на2д3јах</pattern>
+<pattern> над2ј</pattern>
+<pattern> н2а1дј2а1</pattern>
+<pattern> на2д3јач</pattern>
+<pattern> на2д3јек</pattern>
+<pattern> надј2е1</pattern>
+<pattern> на2д3јез</pattern>
+<pattern> на2д3јеч</pattern>
+<pattern> на2д3јун</pattern>
+<pattern> надј2у1</pattern>
+<pattern> на3д4лан</pattern>
+<pattern> надл2а1</pattern>
+<pattern> на3д4леш</pattern>
+<pattern> надл2е1</pattern>
+<pattern> на3д4леж</pattern>
+<pattern> н2а2д3ор2а1</pattern>
+<pattern> над2о1</pattern>
+<pattern> на2д3о1с2о1</pattern>
+<pattern> на2д3ос2е1</pattern>
+<pattern> на2д3осј2е1</pattern>
+<pattern> надос2ј</pattern>
+<pattern> на2д3оф2и1</pattern>
+<pattern> на2д3оч</pattern>
+<pattern> на2д3ран</pattern>
+<pattern> над2р</pattern>
+<pattern> н2а1др2а1</pattern>
+<pattern> на2д3рач</pattern>
+<pattern> на2д3рас2т</pattern>
+<pattern> на2д3раш2ћ</pattern>
+<pattern> на2д3реал</pattern>
+<pattern> надр2е1</pattern>
+<pattern> н2а1дре3а1</pattern>
+<pattern> на2д3реп</pattern>
+<pattern> на2д3рук</pattern>
+<pattern> надр2у1</pattern>
+<pattern> на2д3руч</pattern>
+<pattern> на2д3руг</pattern>
+<pattern> на2д3удар</pattern>
+<pattern> над2у1</pattern>
+<pattern> надуд2а1</pattern>
+<pattern> на2д3ум</pattern>
+<pattern> на2д3уч</pattern>
+<pattern> н2а2ј3а1</pattern>
+<pattern> на2ј3е1</pattern>
+<pattern> на2ј3и1</pattern>
+<pattern> на2ј3о1</pattern>
+<pattern> на2ј3у1</pattern>
+<pattern> на3ј4ав2и1</pattern>
+<pattern> на3ј4ав2љ</pattern>
+<pattern> н2а3ј4а1в2а1</pattern>
+<pattern> на3ј4ав2е1</pattern>
+<pattern> на3ј4ад2и1</pattern>
+<pattern> н2а3ј4а1д2а1</pattern>
+<pattern> на3ј4ад2е1</pattern>
+<pattern> на3ј4аж2и1</pattern>
+<pattern> на3ј4аз2и1</pattern>
+<pattern> на3ј4ак2о1</pattern>
+<pattern> н2а3ј4а1к2а1</pattern>
+<pattern> на3ј4ал2о1</pattern>
+<pattern> на3ј4ам2и1</pattern>
+<pattern> на3ј4ам2л</pattern>
+<pattern> на3ј4а2м1н</pattern>
+<pattern> на3ј4ар2и1</pattern>
+<pattern> на3ј4а2р1м</pattern>
+<pattern> на3ј4а2р1ц</pattern>
+<pattern> на3ј4ат2и1</pattern>
+<pattern> на3ј4аук</pattern>
+<pattern> наја3у1</pattern>
+<pattern> на3ј4ах</pattern>
+<pattern> на3ј4аш</pattern>
+<pattern> на3ј4ед2и1</pattern>
+<pattern> на3ј4е2д1н</pattern>
+<pattern> на3ј4ед2р</pattern>
+<pattern> н2а3ј4ед2а1</pattern>
+<pattern> на3ј4еж2и1</pattern>
+<pattern> на3ј4еж2у1</pattern>
+<pattern> на3ј4е1ж2е1</pattern>
+<pattern> на3ј4ез2н</pattern>
+<pattern> на3ј4ез2д</pattern>
+<pattern> на3ј4ест2и1</pattern>
+<pattern> најес2т</pattern>
+<pattern> на3ј4е2т1к</pattern>
+<pattern> на3ј4ец</pattern>
+<pattern> на3ј4ур2и1</pattern>
+<pattern> на3ј4урен</pattern>
+<pattern> најур2е1</pattern>
+<pattern> о2б3ј</pattern>
+<pattern> о2б3љ</pattern>
+<pattern> о2б3р</pattern>
+<pattern> обе2з3б</pattern>
+<pattern> об2е1</pattern>
+<pattern> обе2з3д</pattern>
+<pattern> обе2з3г</pattern>
+<pattern> обе2з3ј</pattern>
+<pattern> обе2з3л</pattern>
+<pattern> обе2з3м</pattern>
+<pattern> обе2з3н</pattern>
+<pattern> 2о1бе2з3о1</pattern>
+<pattern> обе2з3љ</pattern>
+<pattern> обе2з3р</pattern>
+<pattern> обе2з3у1</pattern>
+<pattern> обе2з3в</pattern>
+<pattern> обе3з4виј</pattern>
+<pattern> обезв2и1</pattern>
+<pattern> обе3з4нан</pattern>
+<pattern> обезн2а1</pattern>
+<pattern> обе3з4нањ</pattern>
+<pattern> обе3з4нач</pattern>
+<pattern> обе3з4уб</pattern>
+<pattern> обе2с3ц</pattern>
+<pattern> обе2с3к</pattern>
+<pattern> обе2с3п</pattern>
+<pattern> обе2с3т</pattern>
+<pattern> обе3с4тан</pattern>
+<pattern> обест2а1</pattern>
+<pattern> обе3с4тиј</pattern>
+<pattern> обест2и1</pattern>
+<pattern> обе3с4тран</pattern>
+<pattern> обест2р</pattern>
+<pattern> обестр2а1</pattern>
+<pattern> обе2ш3ћ</pattern>
+<pattern> обе2ш3ч</pattern>
+<pattern> о2б3иг2р</pattern>
+<pattern> об2и1</pattern>
+<pattern> о2б3истин</pattern>
+<pattern> обис2т</pattern>
+<pattern> об2и1ст2и1</pattern>
+<pattern> о2б3истињ</pattern>
+<pattern> о3б4јек</pattern>
+<pattern> обј2е1</pattern>
+<pattern> о3б4јер</pattern>
+<pattern> о3б4јес2и1</pattern>
+<pattern> о3б4јет</pattern>
+<pattern> о3б4јеш</pattern>
+<pattern> о2б3лај</pattern>
+<pattern> об2л</pattern>
+<pattern> обл2а1</pattern>
+<pattern> о2б3лам</pattern>
+<pattern> о2б3ла2к1ш</pattern>
+<pattern> о2б3лас2к</pattern>
+<pattern> о2б3леп</pattern>
+<pattern> обл2е1</pattern>
+<pattern> о2б3лет</pattern>
+<pattern> о2б3лећ</pattern>
+<pattern> о2б3леж</pattern>
+<pattern> о2б3лег</pattern>
+<pattern> о2б3лијеп</pattern>
+<pattern> обл2и1</pattern>
+<pattern> облиј2е1</pattern>
+<pattern> о2б3лијет</pattern>
+<pattern> о2б3лијеж</pattern>
+<pattern> о2б3лијег</pattern>
+<pattern> о2б3леден</pattern>
+<pattern> облед2е1</pattern>
+<pattern> о2б3лив</pattern>
+<pattern> о2б3лизат</pattern>
+<pattern> облиз2а1</pattern>
+<pattern> о2б3лизав</pattern>
+<pattern> о2б3л2и1з2и1</pattern>
+<pattern> о2б3лис2т</pattern>
+<pattern> о2б3лок2а1</pattern>
+<pattern> обл2о1</pattern>
+<pattern> о2б3лук</pattern>
+<pattern> обл2у1</pattern>
+<pattern> о2б3луч</pattern>
+<pattern> о3б4љан</pattern>
+<pattern> обљ2а1</pattern>
+<pattern> о3б4љут</pattern>
+<pattern> обљ2у1</pattern>
+<pattern> о3б4љуз</pattern>
+<pattern> о2б3ор2у1</pattern>
+<pattern> об2о1</pattern>
+<pattern> о3б4раж2е1</pattern>
+<pattern> обр2а1</pattern>
+<pattern> о3б4раз2и1</pattern>
+<pattern> о3б4раз2н</pattern>
+<pattern> 2о3б4раз2о1</pattern>
+<pattern> о3б4раз2у1</pattern>
+<pattern> о3б4р2а1з2а1</pattern>
+<pattern> о3б4раз2д</pattern>
+<pattern> о3б4ра2м1б</pattern>
+<pattern> о3б4ран</pattern>
+<pattern> о3б4рањ</pattern>
+<pattern> о3б4рат</pattern>
+<pattern> о3б4раћ</pattern>
+<pattern> о3б4раш2н</pattern>
+<pattern> о3б4раш2ч</pattern>
+<pattern> о3б4р1в</pattern>
+<pattern> о3б4р1ђ</pattern>
+<pattern> о3б4рем</pattern>
+<pattern> обр2е1</pattern>
+<pattern> о3б4рес</pattern>
+<pattern> о3б4ређ</pattern>
+<pattern> о3б4реч</pattern>
+<pattern> о3б4реж</pattern>
+<pattern> о3б4рец</pattern>
+<pattern> о3б4ред</pattern>
+<pattern> о3б4рет2и1</pattern>
+<pattern> о3б4ре2т1н</pattern>
+<pattern> о3б4риј</pattern>
+<pattern> обр2и1</pattern>
+<pattern> о3б4рис</pattern>
+<pattern> о3б4рит</pattern>
+<pattern> о3б4рив</pattern>
+<pattern> о3б4рич</pattern>
+<pattern> о3б4риц</pattern>
+<pattern> о3б4р1к</pattern>
+<pattern> о3б4р1л</pattern>
+<pattern> о3б4р1н</pattern>
+<pattern> о3б4р1љ</pattern>
+<pattern> о3б4р1с</pattern>
+<pattern> о3б4р1т</pattern>
+<pattern> о3б4р1ш</pattern>
+<pattern> о3б4р1ч</pattern>
+<pattern> о3б4рок</pattern>
+<pattern> 2о1бр2о1</pattern>
+<pattern> о3б4рон</pattern>
+<pattern> о3б4роњ</pattern>
+<pattern> о3б4роћ</pattern>
+<pattern> о3б4роч</pattern>
+<pattern> о3б4ров2а1</pattern>
+<pattern> о3б4ро2в1ц</pattern>
+<pattern> о3б4рук</pattern>
+<pattern> обр2у1</pattern>
+<pattern> о3б4рун</pattern>
+<pattern> о3б4рус</pattern>
+<pattern> о3б4руњ</pattern>
+<pattern> о3б4руш</pattern>
+<pattern> о3б4руч</pattern>
+<pattern> о2б3убож</pattern>
+<pattern> об2у1</pattern>
+<pattern> обуб2о1</pattern>
+<pattern> о2б3уз</pattern>
+<pattern> о2б3уж</pattern>
+<pattern> о2б3уд</pattern>
+<pattern> о2б3ум2и1</pattern>
+<pattern> о2б3ум2ј</pattern>
+<pattern> о2б3ум2р</pattern>
+<pattern> о2б3ум2е1</pattern>
+<pattern> о2д3ј</pattern>
+<pattern> о2д3л</pattern>
+<pattern> о2д3љ</pattern>
+<pattern> о2д3р</pattern>
+<pattern> о2д3в</pattern>
+<pattern> о2д3а2р1г</pattern>
+<pattern> о3д4вај</pattern>
+<pattern> одв2а1</pattern>
+<pattern> о3д4важ</pattern>
+<pattern> о3д4вес2н</pattern>
+<pattern> одв2е1</pattern>
+<pattern> о3д4вес2т</pattern>
+<pattern> о3д4вес2а1</pattern>
+<pattern> о3д4викав</pattern>
+<pattern> одв2и1</pattern>
+<pattern> одвик2а1</pattern>
+<pattern> о3д4ви2к1н</pattern>
+<pattern> о3д4вис</pattern>
+<pattern> о3д4вић</pattern>
+<pattern> о3д4вој</pattern>
+<pattern> одв2о1</pattern>
+<pattern> о2д3иг2р</pattern>
+<pattern> од2и1</pattern>
+<pattern> о2д3и2з3в</pattern>
+<pattern> о2д3и2з3д</pattern>
+<pattern> о2д3ис2к</pattern>
+<pattern> о2д3и1ст2и1</pattern>
+<pattern> одис2т</pattern>
+<pattern> о3д4јел</pattern>
+<pattern> одј2е1</pattern>
+<pattern> о3д4јен</pattern>
+<pattern> о3д4јев</pattern>
+<pattern> о3д4јећ</pattern>
+<pattern> о3д4лаз</pattern>
+<pattern> одл2а1</pattern>
+<pattern> о3д4лаж</pattern>
+<pattern> о3д4лаг</pattern>
+<pattern> о3д4л2а1к2а1</pattern>
+<pattern> о3д4лук</pattern>
+<pattern> одл2у1</pattern>
+<pattern> о3д4луч</pattern>
+<pattern> о2д3оз2д</pattern>
+<pattern> 2о1д2о1</pattern>
+<pattern> о2д3оз2г</pattern>
+<pattern> о2д3ок</pattern>
+<pattern> о2д3о2н1л</pattern>
+<pattern> 2о2д3о1н2о1</pattern>
+<pattern> о2д3он2у1</pattern>
+<pattern> о2д3о2н1д</pattern>
+<pattern> о3д4ран2и1</pattern>
+<pattern> одр2а1</pattern>
+<pattern> 2о3д4ран2о1</pattern>
+<pattern> о3д4ран2у1</pattern>
+<pattern> о3д4р2а1н2а1</pattern>
+<pattern> о3д4ран2е1</pattern>
+<pattern> о3д4раз</pattern>
+<pattern> о3д4раћ</pattern>
+<pattern> о3д4раж</pattern>
+<pattern> о3д4рап2и1</pattern>
+<pattern> о3д4рап2љ</pattern>
+<pattern> о3д4р2а1п2а1</pattern>
+<pattern> о3д4рач2и1</pattern>
+<pattern> о3д4рвен</pattern>
+<pattern> од2р1в</pattern>
+<pattern> одрв2е1</pattern>
+<pattern> о3д4рвењ</pattern>
+<pattern> о3д4рвеч</pattern>
+<pattern> о3д4рем</pattern>
+<pattern> одр2е1</pattern>
+<pattern> о3д4рен</pattern>
+<pattern> о3д4рет</pattern>
+<pattern> о3д4ређ</pattern>
+<pattern> о3д4ред</pattern>
+<pattern> о3д4р1л</pattern>
+<pattern> о3д4р1н</pattern>
+<pattern> о3д4р1п</pattern>
+<pattern> о3д4р1љ</pattern>
+<pattern> о3д4р1т</pattern>
+<pattern> о3д4р1ж</pattern>
+<pattern> о3д4рин</pattern>
+<pattern> одр2и1</pattern>
+<pattern> о3д4рињ</pattern>
+<pattern> о3д4риш</pattern>
+<pattern> о3д4рич</pattern>
+<pattern> о3д4риб</pattern>
+<pattern> о3д4риц</pattern>
+<pattern> о3д4рон</pattern>
+<pattern> 2о1др2о1</pattern>
+<pattern> о3д4роњ</pattern>
+<pattern> о3д4руж</pattern>
+<pattern> одр2у1</pattern>
+<pattern> о3д4руг</pattern>
+<pattern> о2д3ув2и1</pattern>
+<pattern> од2у1</pattern>
+<pattern> о2д3ув2е1</pattern>
+<pattern> о2д3уз2и1</pattern>
+<pattern> о2д3уз2л</pattern>
+<pattern> о2д3уз2д</pattern>
+<pattern> о2д3уз2е1</pattern>
+<pattern> о2д3ук</pattern>
+<pattern> о2д3ул</pattern>
+<pattern> о2д3ум</pattern>
+<pattern> о2д3уч</pattern>
+<pattern> по2д3а2д1м</pattern>
+<pattern> под2а1</pattern>
+<pattern> по2д3вариј</pattern>
+<pattern> под2в</pattern>
+<pattern> подв2а1</pattern>
+<pattern> подвар2и1</pattern>
+<pattern> по2д3вез</pattern>
+<pattern> подв2е1</pattern>
+<pattern> по2д3веч</pattern>
+<pattern> по2д3веж</pattern>
+<pattern> по2д3вик</pattern>
+<pattern> подв2и1</pattern>
+<pattern> по2д3вил</pattern>
+<pattern> по2д3вир</pattern>
+<pattern> по2д3вињ</pattern>
+<pattern> по2д3влас</pattern>
+<pattern> по2д3в2л</pattern>
+<pattern> подвл2а1</pattern>
+<pattern> по2д3влаш</pattern>
+<pattern> по2д3воз</pattern>
+<pattern> п2о1дв2о1</pattern>
+<pattern> по2д3вођ</pattern>
+<pattern> по2д3вож</pattern>
+<pattern> по2д3вод</pattern>
+<pattern> по2д3врат</pattern>
+<pattern> по2д3в2р</pattern>
+<pattern> подвр2а1</pattern>
+<pattern> по2д3враћ</pattern>
+<pattern> по2д3в2р1ћ</pattern>
+<pattern> по2д3в2р1ж</pattern>
+<pattern> по2д3в2р1г</pattern>
+<pattern> по2д3врис</pattern>
+<pattern> подвр2и1</pattern>
+<pattern> по2д3в2р1с</pattern>
+<pattern> по2д3вућ</pattern>
+<pattern> подв2у1</pattern>
+<pattern> по2д3иг2р</pattern>
+<pattern> под2и1</pattern>
+<pattern> по2д3из2в</pattern>
+<pattern> по2д3ј</pattern>
+<pattern> по3д4јен</pattern>
+<pattern> подј2е1</pattern>
+<pattern> по3д4јеч</pattern>
+<pattern> по2д3лакат</pattern>
+<pattern> под2л</pattern>
+<pattern> подл2а1</pattern>
+<pattern> подлак2а1</pattern>
+<pattern> по2д3ла2к1т</pattern>
+<pattern> по2д3леп</pattern>
+<pattern> подл2е1</pattern>
+<pattern> по2д3лет</pattern>
+<pattern> по2д3лећ</pattern>
+<pattern> по2д3леж</pattern>
+<pattern> по2д3лег</pattern>
+<pattern> по2д3лиз</pattern>
+<pattern> подл2и1</pattern>
+<pattern> по2д3лијеп</pattern>
+<pattern> подлиј2е1</pattern>
+<pattern> по2д3лијет</pattern>
+<pattern> по2д3лијећ</pattern>
+<pattern> по2д3лијеж</pattern>
+<pattern> по2д3лијег</pattern>
+<pattern> по2д3лис2т</pattern>
+<pattern> по2д3лок</pattern>
+<pattern> п2о1дл2о1</pattern>
+<pattern> по2д3лом</pattern>
+<pattern> по2д3луп</pattern>
+<pattern> подл2у1</pattern>
+<pattern> по2д3луч</pattern>
+<pattern> по2д3луж</pattern>
+<pattern> по2д3љут</pattern>
+<pattern> под2љ</pattern>
+<pattern> подљ2у1</pattern>
+<pattern> по2д3о2к1н</pattern>
+<pattern> п2о1д2о1</pattern>
+<pattern> по2д3ош</pattern>
+<pattern> по2д3оч</pattern>
+<pattern> по2д3оф</pattern>
+<pattern> по2д3ра2в1н</pattern>
+<pattern> под2р</pattern>
+<pattern> подр2а1</pattern>
+<pattern> по2д3ра2в1њ</pattern>
+<pattern> по2д3рад</pattern>
+<pattern> по2д3ра2з3д</pattern>
+<pattern> по2д3раз2р</pattern>
+<pattern> по2д3раз2у1</pattern>
+<pattern> по2д3рам</pattern>
+<pattern> по2д3ран</pattern>
+<pattern> по2д3рас</pattern>
+<pattern> по2д3рањ</pattern>
+<pattern> по2д3реп</pattern>
+<pattern> подр2е1</pattern>
+<pattern> по2д3рес</pattern>
+<pattern> по2д3рез</pattern>
+<pattern> по2д3рик</pattern>
+<pattern> подр2и1</pattern>
+<pattern> по2д3рит</pattern>
+<pattern> по2д3рон</pattern>
+<pattern> п2о1др2о1</pattern>
+<pattern> по2д3ров</pattern>
+<pattern> по2д3рож</pattern>
+<pattern> по2д3рук</pattern>
+<pattern> подр2у1</pattern>
+<pattern> по2д3руб</pattern>
+<pattern> по2д3руч2и1</pattern>
+<pattern> по2д3ру2ч1н</pattern>
+<pattern> по2д3руч2а1</pattern>
+<pattern> по2д3упл2а1</pattern>
+<pattern> под2у1</pattern>
+<pattern> подуп2л</pattern>
+<pattern> по2д3ус2м</pattern>
+<pattern> по2д3ус2н</pattern>
+<pattern> пре2д3ј</pattern>
+<pattern> пре2д3в</pattern>
+<pattern> пре3д4вај</pattern>
+<pattern> предв2а1</pattern>
+<pattern> пре3д4вар</pattern>
+<pattern> пре3д4вес2т</pattern>
+<pattern> предв2е1</pattern>
+<pattern> пре3д4вој2и1</pattern>
+<pattern> предв2о1</pattern>
+<pattern> пре3д4вој2а1</pattern>
+<pattern> пр2е3д4вој2е1</pattern>
+<pattern> пре3д4вор</pattern>
+<pattern> пре3д4вос</pattern>
+<pattern> пре3д4јен</pattern>
+<pattern> предј2е1</pattern>
+<pattern> пре2д3иг2р</pattern>
+<pattern> пред2и1</pattern>
+<pattern> пре2д3ид</pattern>
+<pattern> пре2д3из2б</pattern>
+<pattern> пре2д3и1сп2и1</pattern>
+<pattern> предис2п</pattern>
+<pattern> пре2д3ист2о1</pattern>
+<pattern> предис2т</pattern>
+<pattern> пре2д3ист2р</pattern>
+<pattern> пре2д3об2ј</pattern>
+<pattern> пред2о1</pattern>
+<pattern> пр2е2д3одр2е1</pattern>
+<pattern> предод2р</pattern>
+<pattern> пре2д3окус</pattern>
+<pattern> предок2у1</pattern>
+<pattern> пре2д3ос2в</pattern>
+<pattern> пр2е2д3ос2е1</pattern>
+<pattern> пр2е2д3осј2е1</pattern>
+<pattern> предос2ј</pattern>
+<pattern> пре2д3рат</pattern>
+<pattern> пред2р</pattern>
+<pattern> предр2а1</pattern>
+<pattern> пре2д3рач</pattern>
+<pattern> пре2д3рад</pattern>
+<pattern> пре2д3руч</pattern>
+<pattern> предр2у1</pattern>
+<pattern> пре2д3убеђ</pattern>
+<pattern> пред2у1</pattern>
+<pattern> предуб2е1</pattern>
+<pattern> пре2д3убијеђ</pattern>
+<pattern> предуб2и1</pattern>
+<pattern> предубиј2е1</pattern>
+<pattern> пре2д3убјеђ</pattern>
+<pattern> предуб2ј</pattern>
+<pattern> предубј2е1</pattern>
+<pattern> пре2д3увер</pattern>
+<pattern> предув2е1</pattern>
+<pattern> пре2д3увјер</pattern>
+<pattern> предув2ј</pattern>
+<pattern> пр2е1дувј2е1</pattern>
+<pattern> пре2д3увјет</pattern>
+<pattern> пре2д3угов</pattern>
+<pattern> предуг2о1</pattern>
+<pattern> пре2д3удар</pattern>
+<pattern> предуд2а1</pattern>
+<pattern> пре2д3упис</pattern>
+<pattern> предуп2и1</pattern>
+<pattern> пре2д3усл2о1</pattern>
+<pattern> предус2л</pattern>
+<pattern> проти2в3а2к1ц</pattern>
+<pattern> прот2и1</pattern>
+<pattern> против2а1</pattern>
+<pattern> проти2в3от2р</pattern>
+<pattern> пр2о1тив2о1</pattern>
+<pattern> проти2в3оф</pattern>
+<pattern> проти2в3р</pattern>
+<pattern> проти2в3ус</pattern>
+<pattern> против2у1</pattern>
+<pattern> проти2в3уд</pattern>
+<pattern> ра2ж3ђ</pattern>
+<pattern> ра2з3б</pattern>
+<pattern> ра2з3е1</pattern>
+<pattern> ра2з3и1</pattern>
+<pattern> ра2з3ј</pattern>
+<pattern> ра2з3л</pattern>
+<pattern> ра2з3м</pattern>
+<pattern> ра2з3н</pattern>
+<pattern> ра2з3љ</pattern>
+<pattern> ра2з3р</pattern>
+<pattern> ра2з3в</pattern>
+<pattern> ра2з3њ</pattern>
+<pattern> ра2з3анал</pattern>
+<pattern> разан2а1</pattern>
+<pattern> ра3з4бан</pattern>
+<pattern> р2а1зб2а1</pattern>
+<pattern> ра3з4бар</pattern>
+<pattern> ра3з4ба3у1</pattern>
+<pattern> ра3з4бад</pattern>
+<pattern> ра3з4башур</pattern>
+<pattern> разбаш2у1</pattern>
+<pattern> ра3з4бој</pattern>
+<pattern> разб2о1</pattern>
+<pattern> ра3з4бор</pattern>
+<pattern> ра3з4вал</pattern>
+<pattern> разв2а1</pattern>
+<pattern> ра3з4в2е1д2е1</pattern>
+<pattern> разв2е1</pattern>
+<pattern> ра3з4вес2т</pattern>
+<pattern> ра3з4виг2о1</pattern>
+<pattern> разв2и1</pattern>
+<pattern> ра3з4виј2у1</pattern>
+<pattern> р2а3з4виј2а1</pattern>
+<pattern> ра3з4виј2е1</pattern>
+<pattern> ра3з4вит</pattern>
+<pattern> ра3з4вић</pattern>
+<pattern> ра3з4вој</pattern>
+<pattern> разв2о1</pattern>
+<pattern> ра3з4вон</pattern>
+<pattern> ра3з4врат</pattern>
+<pattern> разв2р</pattern>
+<pattern> р2а1звр2а1</pattern>
+<pattern> ра3з4враћ</pattern>
+<pattern> ра3з4в2р1т</pattern>
+<pattern> ра3з4в2р1ћ</pattern>
+<pattern> ра3з4гађ</pattern>
+<pattern> разг2а1</pattern>
+<pattern> ра3з4г2р1т</pattern>
+<pattern> разг2р</pattern>
+<pattern> ра3з4ев</pattern>
+<pattern> ра3з4иј</pattern>
+<pattern> ра3з4ил</pattern>
+<pattern> ра3з4ин</pattern>
+<pattern> ра3з4ир</pattern>
+<pattern> ра3з4ит</pattern>
+<pattern> ра3з4из</pattern>
+<pattern> ра3з4иђ</pattern>
+<pattern> ра3з4ић</pattern>
+<pattern> ра3з4ид</pattern>
+<pattern> ра3з4лаз</pattern>
+<pattern> р2а1зл2а1</pattern>
+<pattern> ра3з4лаг</pattern>
+<pattern> ра3з4лик</pattern>
+<pattern> разл2и1</pattern>
+<pattern> ра3з4лич</pattern>
+<pattern> ра3з4лоз</pattern>
+<pattern> разл2о1</pattern>
+<pattern> ра3з4лож</pattern>
+<pattern> ра3з4лог</pattern>
+<pattern> ра3з4мет</pattern>
+<pattern> разм2е1</pattern>
+<pattern> ра3з4мећ</pattern>
+<pattern> ра3з4мрс2к</pattern>
+<pattern> ра2з3м2р</pattern>
+<pattern> разм2р1с</pattern>
+<pattern> ра3з4нат</pattern>
+<pattern> разн2а1</pattern>
+<pattern> ра2з3об2л</pattern>
+<pattern> раз2о1</pattern>
+<pattern> ра2з3об2р</pattern>
+<pattern> р2а2з3об2а1</pattern>
+<pattern> ра2з3од</pattern>
+<pattern> ра2з3орат</pattern>
+<pattern> р2а1зор2а1</pattern>
+<pattern> ра2з3орав</pattern>
+<pattern> ра2з3о2р1т</pattern>
+<pattern> ра2з3ор2у1</pattern>
+<pattern> ра2з3от</pattern>
+<pattern> ра3з4ред</pattern>
+<pattern> разр2е1</pattern>
+<pattern> ра3з4рок</pattern>
+<pattern> разр2о1</pattern>
+<pattern> ра3з4роч</pattern>
+<pattern> ра2з3ув2е1</pattern>
+<pattern> раз2у1</pattern>
+<pattern> ра2з3уд2и1</pattern>
+<pattern> р2а2з3уд2а1</pattern>
+<pattern> ра2з3у2д1б</pattern>
+<pattern> ра2з3уз2и1</pattern>
+<pattern> ра2з3уз2д</pattern>
+<pattern> ра2з3уз2е1</pattern>
+<pattern> ра2з3улар</pattern>
+<pattern> разул2а1</pattern>
+<pattern> ра2з3ум2р</pattern>
+<pattern> ра2с3ц</pattern>
+<pattern> ра2с3к</pattern>
+<pattern> ра2с3п</pattern>
+<pattern> ра2с3т</pattern>
+<pattern> ра3с4как</pattern>
+<pattern> р2а1ск2а1</pattern>
+<pattern> ра3с4ка2н1д</pattern>
+<pattern> ра3с4кин</pattern>
+<pattern> раск2и1</pattern>
+<pattern> ра3с4клап</pattern>
+<pattern> раск2л</pattern>
+<pattern> р2а1скл2а1</pattern>
+<pattern> ра3с4клањ</pattern>
+<pattern> ра3с4клад</pattern>
+<pattern> ра3с4клон</pattern>
+<pattern> раскл2о1</pattern>
+<pattern> ра3с4клоп2и1</pattern>
+<pattern> ра3с4клоп2љ</pattern>
+<pattern> р2а3с4клоп2а1</pattern>
+<pattern> ра3с4кош</pattern>
+<pattern> раск2о1</pattern>
+<pattern> ра3с4кроп</pattern>
+<pattern> раск2р</pattern>
+<pattern> раскр2о1</pattern>
+<pattern> ра3с4пај</pattern>
+<pattern> р2а1сп2а1</pattern>
+<pattern> ра3с4пав</pattern>
+<pattern> ра3с4пет2и1</pattern>
+<pattern> расп2е1</pattern>
+<pattern> ра3с4пет2о1</pattern>
+<pattern> р2а3с4пет2а1</pattern>
+<pattern> ра3с4п2е1т2е1</pattern>
+<pattern> ра3с4пик2у1</pattern>
+<pattern> расп2и1</pattern>
+<pattern> ра3с4пињ</pattern>
+<pattern> ра3с4плин</pattern>
+<pattern> расп2л</pattern>
+<pattern> распл2и1</pattern>
+<pattern> ра3с4плињ</pattern>
+<pattern> ра3с4п1н</pattern>
+<pattern> ра3с4полож</pattern>
+<pattern> расп2о1</pattern>
+<pattern> распол2о1</pattern>
+<pattern> ра3с4пон</pattern>
+<pattern> ра3с4пор</pattern>
+<pattern> ра3с4прав</pattern>
+<pattern> расп2р</pattern>
+<pattern> распр2а1</pattern>
+<pattern> ра3с4прем</pattern>
+<pattern> распр2е1</pattern>
+<pattern> ра3с4р1ђ</pattern>
+<pattern> рас2р</pattern>
+<pattern> ра3с4р1д</pattern>
+<pattern> ра3с4р2е1</pattern>
+<pattern> ра3с4тај</pattern>
+<pattern> р2а1ст2а1</pattern>
+<pattern> ра3с4тан</pattern>
+<pattern> ра3с4тат</pattern>
+<pattern> ра3с4тав</pattern>
+<pattern> ра3с4тењ</pattern>
+<pattern> раст2е1</pattern>
+<pattern> ра3с4тил</pattern>
+<pattern> раст2и1</pattern>
+<pattern> ра3с4тир</pattern>
+<pattern> ра3с4тис</pattern>
+<pattern> ра3с4тит</pattern>
+<pattern> ра3с4тињ</pattern>
+<pattern> ра3с4тој</pattern>
+<pattern> раст2о1</pattern>
+<pattern> ра3с4трел</pattern>
+<pattern> раст2р</pattern>
+<pattern> растр2е1</pattern>
+<pattern> ра3с4трет</pattern>
+<pattern> ра3с4трој</pattern>
+<pattern> растр2о1</pattern>
+<pattern> ра3с4т2р1т</pattern>
+<pattern> ра3с4туп</pattern>
+<pattern> раст2у1</pattern>
+<pattern> ра3с4тур</pattern>
+<pattern> ра3с4тућ</pattern>
+<pattern> ра4с5ту2р1ч</pattern>
+<pattern> ра2ш3ћ</pattern>
+<pattern> ра2ш3ч</pattern>
+<pattern> ра3ш4ћењ</pattern>
+<pattern> рашћ2е1</pattern>
+<pattern> ра3ш4чић</pattern>
+<pattern> рашч2и1</pattern>
+<pattern> у2з3б</pattern>
+<pattern> у2з3д</pattern>
+<pattern> у2з3г</pattern>
+<pattern> у2з3и1</pattern>
+<pattern> у2з3ј</pattern>
+<pattern> у2з3л</pattern>
+<pattern> у2з3м</pattern>
+<pattern> у2з3н</pattern>
+<pattern> у2з3љ</pattern>
+<pattern> у2з3р</pattern>
+<pattern> у2з3в</pattern>
+<pattern> у2з3њ</pattern>
+<pattern> у3з4бор</pattern>
+<pattern> узб2о1</pattern>
+<pattern> у3з4ван</pattern>
+<pattern> узв2а1</pattern>
+<pattern> у3з4ват</pattern>
+<pattern> у3з4виж</pattern>
+<pattern> узв2и1</pattern>
+<pattern> у3з4виј2о1</pattern>
+<pattern> 2у3з4виј2у1</pattern>
+<pattern> у3з4виј2а1</pattern>
+<pattern> у3з4виј2е1</pattern>
+<pattern> у3з4вој</pattern>
+<pattern> узв2о1</pattern>
+<pattern> у3з4диц</pattern>
+<pattern> узд2и1</pattern>
+<pattern> у2з3иг2р</pattern>
+<pattern> у2з3инат</pattern>
+<pattern> узин2а1</pattern>
+<pattern> у2з3иск2р</pattern>
+<pattern> узис2к</pattern>
+<pattern> у3з4лан</pattern>
+<pattern> узл2а1</pattern>
+<pattern> у3з4лат</pattern>
+<pattern> у3з4лим</pattern>
+<pattern> узл2и1</pattern>
+<pattern> у3з4лит</pattern>
+<pattern> у3з4лић</pattern>
+<pattern> у3з4лиц</pattern>
+<pattern> у3з4лов</pattern>
+<pattern> узл2о1</pattern>
+<pattern> у3з4лудоб</pattern>
+<pattern> узл2у1</pattern>
+<pattern> узлуд2о1</pattern>
+<pattern> у3з4нак</pattern>
+<pattern> узн2а1</pattern>
+<pattern> у3з4нач</pattern>
+<pattern> у3з4н2е1в2е1</pattern>
+<pattern> узн2е1</pattern>
+<pattern> у3з4н2е1вј2е1</pattern>
+<pattern> узнев2ј</pattern>
+<pattern> у3з4нич</pattern>
+<pattern> узн2и1</pattern>
+<pattern> у3з4ниц</pattern>
+<pattern> у3з4ној</pattern>
+<pattern> узн2о1</pattern>
+<pattern> у2з3обес2т</pattern>
+<pattern> уз2о1</pattern>
+<pattern> узоб2е1</pattern>
+<pattern> у2з3обијес2т</pattern>
+<pattern> узоб2и1</pattern>
+<pattern> узобиј2е1</pattern>
+<pattern> у2з3орат</pattern>
+<pattern> узор2а1</pattern>
+<pattern> у2з3орав</pattern>
+<pattern> у2з3о1х2о1</pattern>
+<pattern> у3з4рет</pattern>
+<pattern> узр2е1</pattern>
+<pattern> у3з4рев</pattern>
+<pattern> у3з4ријет</pattern>
+<pattern> узр2и1</pattern>
+<pattern> узриј2е1</pattern>
+<pattern> у3з4ријев</pattern>
+<pattern> у3з4р1н</pattern>
+<pattern> у3з4р1њ</pattern>
+<pattern> у3з4р2о1к2о1</pattern>
+<pattern> узр2о1</pattern>
+<pattern> 2у3з4рок2у1</pattern>
+<pattern> у3з4рок2а1</pattern>
+<pattern> у3з4роч</pattern>
+<pattern> у3з4руј</pattern>
+<pattern> узр2у1</pattern>
+<pattern> у2з3угар</pattern>
+<pattern> уз2у1</pattern>
+<pattern> узуг2а1</pattern>
+<pattern> у2с3ц</pattern>
+<pattern> у2с3к</pattern>
+<pattern> у2с3п</pattern>
+<pattern> у3с4как</pattern>
+<pattern> уск2а1</pattern>
+<pattern> у3с4клађ</pattern>
+<pattern> уск2л</pattern>
+<pattern> ускл2а1</pattern>
+<pattern> у3с4клад</pattern>
+<pattern> у3с4к2о1</pattern>
+<pattern> у4с5ком</pattern>
+<pattern> у4с5ков</pattern>
+<pattern> у4с5кош</pattern>
+<pattern> у4с5к2о1к2о1</pattern>
+<pattern> 2у4с5кол2у1</pattern>
+<pattern> у4с5кол2е1</pattern>
+<pattern> у4с5коп2а1</pattern>
+<pattern> у4с5кор2а1</pattern>
+<pattern> у4с5кос2и1</pattern>
+<pattern> у4с5кот2р</pattern>
+<pattern> у3с4куп</pattern>
+<pattern> уск2у1</pattern>
+<pattern> у3с4пав</pattern>
+<pattern> усп2а1</pattern>
+<pattern> у3с4пал2о1</pattern>
+<pattern> у3с4пех</pattern>
+<pattern> усп2е1</pattern>
+<pattern> у3с4пел</pattern>
+<pattern> у3с4пем</pattern>
+<pattern> у3с4пет</pattern>
+<pattern> у3с4пев</pattern>
+<pattern> у3с4пеш</pattern>
+<pattern> у3с4пјех</pattern>
+<pattern> усп2ј</pattern>
+<pattern> успј2е1</pattern>
+<pattern> у3с4пјел</pattern>
+<pattern> у3с4пјем</pattern>
+<pattern> у3с4пјет</pattern>
+<pattern> у3с4пјев</pattern>
+<pattern> у3с4пјеш</pattern>
+<pattern> у3с4пе2н1т</pattern>
+<pattern> у3с4пиј2а1</pattern>
+<pattern> усп2и1</pattern>
+<pattern> у3с4пиј2е1</pattern>
+<pattern> у3с4пијуш</pattern>
+<pattern> успиј2у1</pattern>
+<pattern> у3с4пикуш</pattern>
+<pattern> успик2у1</pattern>
+<pattern> у3с4пон</pattern>
+<pattern> усп2о1</pattern>
+<pattern> у3с4пор2и1</pattern>
+<pattern> у3с4пор2а1</pattern>
+<pattern> у3с4порен</pattern>
+<pattern> успор2е1</pattern>
+<pattern> у3с4порењ</pattern>
+<pattern> у3с4пореч</pattern>
+<pattern> у3с4пособ</pattern>
+<pattern> успос2о1</pattern>
+<pattern> у3с4прем2и1</pattern>
+<pattern> усп2р</pattern>
+<pattern> успр2е1</pattern>
+<pattern> у3с4прем2а1</pattern>
+<pattern> у3с4р1к</pattern>
+<pattern> ус2р</pattern>
+<pattern> у3с4р1н</pattern>
+<pattern> у3с4р1п</pattern>
+<pattern> у3с4р1љ</pattern>
+<pattern> у3с4р1т</pattern>
+<pattern> у3с4р1ђ</pattern>
+<pattern> у3с4р1ж</pattern>
+<pattern> у3с4р2а1</pattern>
+<pattern> у3с4р1д</pattern>
+<pattern> у3с4р2е1</pattern>
+<pattern> у3с4ријед</pattern>
+<pattern> уср2и1</pattern>
+<pattern> усриј2е1</pattern>
+<pattern> у2с3талас</pattern>
+<pattern> ус2т</pattern>
+<pattern> уст2а1</pattern>
+<pattern> устал2а1</pattern>
+<pattern> у2с3т2а1р2а1</pattern>
+<pattern> у2с3тв2р1ђ</pattern>
+<pattern> уст2в</pattern>
+<pattern> уств2р</pattern>
+<pattern> у2с3тв2р1д</pattern>
+<pattern> у2с3тер</pattern>
+<pattern> уст2е1</pattern>
+<pattern> у2с3тећ</pattern>
+<pattern> у2с3тег</pattern>
+<pattern> у2с3тов</pattern>
+<pattern> уст2о1</pattern>
+<pattern> у2с3трај</pattern>
+<pattern> уст2р</pattern>
+<pattern> устр2а1</pattern>
+<pattern> у2с3трал</pattern>
+<pattern> у2с3т2р1г</pattern>
+<pattern> у2с3треп</pattern>
+<pattern> устр2е1</pattern>
+<pattern> у2с3трес</pattern>
+<pattern> у2с3треб</pattern>
+<pattern> у2с3т2р1к</pattern>
+<pattern> у2с3т2р1н</pattern>
+<pattern> у2с3т2р1п</pattern>
+<pattern> у2с3т2р1ћ</pattern>
+<pattern> у2с3т2р1ч</pattern>
+<pattern> у2с3тум</pattern>
+<pattern> 2у1ст2у1</pattern>
+<pattern> у2с3тур</pattern>
+<pattern> у2с3тућ</pattern>
+<pattern> у2ш3ћ</pattern>
+<pattern> у2ш3ч</pattern>
+<pattern> а2б3алиј</pattern>
+<pattern> 2а1б2а1</pattern>
+<pattern> абал2и1</pattern>
+<pattern> а2б3анац</pattern>
+<pattern> абан2а1</pattern>
+<pattern> а2б3евак</pattern>
+<pattern> аб2е1</pattern>
+<pattern> абев2а1</pattern>
+<pattern> а2б3ерац</pattern>
+<pattern> абер2а1</pattern>
+<pattern> а2б3ерир</pattern>
+<pattern> абер2и1</pattern>
+<pattern> а2б3ирит</pattern>
+<pattern> аб2и1</pattern>
+<pattern> абир2и1</pattern>
+<pattern> а2б3ј2у1</pattern>
+<pattern> аб2ј</pattern>
+<pattern> 2а2б3л2а1</pattern>
+<pattern> аб2л</pattern>
+<pattern> а2б3лег</pattern>
+<pattern> абл2е1</pattern>
+<pattern> а2б3леп</pattern>
+<pattern> а2б3лок</pattern>
+<pattern> абл2о1</pattern>
+<pattern> а2б3л2у1</pattern>
+<pattern> а2б3ориг</pattern>
+<pattern> аб2о1</pattern>
+<pattern> абор2и1</pattern>
+<pattern> а2б3реак</pattern>
+<pattern> аб2р</pattern>
+<pattern> абр2е1</pattern>
+<pattern> 2а1бре3а1</pattern>
+<pattern> а2б3рог</pattern>
+<pattern> абр2о1</pattern>
+<pattern> а2б3узус</pattern>
+<pattern> аб2у1</pattern>
+<pattern> абуз2у1</pattern>
+<pattern> а2д3ерац</pattern>
+<pattern> ад2е1</pattern>
+<pattern> адер2а1</pattern>
+<pattern> а2д3ве2р1б</pattern>
+<pattern> ад2в</pattern>
+<pattern> адв2е1</pattern>
+<pattern> а2д3ј</pattern>
+<pattern> а2д3лат</pattern>
+<pattern> ад2л</pattern>
+<pattern> адл2а1</pattern>
+<pattern> а2д3рен</pattern>
+<pattern> ад2р</pattern>
+<pattern> адр2е1</pattern>
+<pattern> а2д3рог</pattern>
+<pattern> адр2о1</pattern>
+<pattern> а3г2нос</pattern>
+<pattern> а2г1н</pattern>
+<pattern> агн2о1</pattern>
+<pattern> а3г2ноз</pattern>
+<pattern> а2набап</pattern>
+<pattern> 2а1н2а1</pattern>
+<pattern> 2а1н2а1б2а1</pattern>
+<pattern> а2набаз</pattern>
+<pattern> а2набат</pattern>
+<pattern> а2наби3о1</pattern>
+<pattern> анаб2и1</pattern>
+<pattern> а2набол</pattern>
+<pattern> анаб2о1</pattern>
+<pattern> а2наген</pattern>
+<pattern> анаг2е1</pattern>
+<pattern> а2нагн2о1</pattern>
+<pattern> ана2г1н</pattern>
+<pattern> а2н3аг2о1</pattern>
+<pattern> 2а2н2а1гр2а1</pattern>
+<pattern> анаг2р</pattern>
+<pattern> а2надем</pattern>
+<pattern> анад2е1</pattern>
+<pattern> а2надип2л</pattern>
+<pattern> анад2и1</pattern>
+<pattern> а2надоз</pattern>
+<pattern> анад2о1</pattern>
+<pattern> а2н3а4е2р2о1</pattern>
+<pattern> ана3е1</pattern>
+<pattern> а2накал</pattern>
+<pattern> 2а1н2а1к2а1</pattern>
+<pattern> а2накам</pattern>
+<pattern> а2накат</pattern>
+<pattern> а2накеф</pattern>
+<pattern> анак2е1</pattern>
+<pattern> 2а2н2а1кл2а1</pattern>
+<pattern> анак2л</pattern>
+<pattern> а2накл2и1</pattern>
+<pattern> а2накој</pattern>
+<pattern> анак2о1</pattern>
+<pattern> а2н3акуз</pattern>
+<pattern> анак2у1</pattern>
+<pattern> а2н3а2л1г</pattern>
+<pattern> а2н3а2л1д</pattern>
+<pattern> а2налеп</pattern>
+<pattern> анал2е1</pattern>
+<pattern> а2нализ</pattern>
+<pattern> анал2и1</pattern>
+<pattern> а2налис</pattern>
+<pattern> а2налит</pattern>
+<pattern> а2н3аме2р1т</pattern>
+<pattern> анам2е1</pattern>
+<pattern> а2намн2е1</pattern>
+<pattern> ана2м1н</pattern>
+<pattern> а2н3анд2р</pattern>
+<pattern> ана2н1д</pattern>
+<pattern> а2нане3о1</pattern>
+<pattern> анан2е1</pattern>
+<pattern> а2н3а2н1т</pattern>
+<pattern> 2а2н2а1пл2а1</pattern>
+<pattern> анап2л</pattern>
+<pattern> а2напл2е1</pattern>
+<pattern> а2напн2е1</pattern>
+<pattern> ана2п1н</pattern>
+<pattern> а2напн2о1</pattern>
+<pattern> а2напр2о1</pattern>
+<pattern> анап2р</pattern>
+<pattern> а2напт2и1</pattern>
+<pattern> ана2п1т</pattern>
+<pattern> а2н3апт2о1</pattern>
+<pattern> а2на2р1т</pattern>
+<pattern> а2н3а2р1х</pattern>
+<pattern> а2насар</pattern>
+<pattern> анас2а1</pattern>
+<pattern> а2насе3и1</pattern>
+<pattern> анас2е1</pattern>
+<pattern> а2наспаз</pattern>
+<pattern> анас2п</pattern>
+<pattern> анасп2а1</pattern>
+<pattern> 2а2н2а1ст2а1</pattern>
+<pattern> анас2т</pattern>
+<pattern> а2настиг</pattern>
+<pattern> анаст2и1</pattern>
+<pattern> а2настом</pattern>
+<pattern> анаст2о1</pattern>
+<pattern> а2натим</pattern>
+<pattern> анат2и1</pattern>
+<pattern> а2натом</pattern>
+<pattern> анат2о1</pattern>
+<pattern> а2натоц</pattern>
+<pattern> а2натр2е1</pattern>
+<pattern> анат2р</pattern>
+<pattern> а2натр2и1</pattern>
+<pattern> а2натр2о1</pattern>
+<pattern> а2нафаз</pattern>
+<pattern> анаф2а1</pattern>
+<pattern> а2н3афиј</pattern>
+<pattern> анаф2и1</pattern>
+<pattern> 2а2н2а1фил2а1</pattern>
+<pattern> а2нафон</pattern>
+<pattern> анаф2о1</pattern>
+<pattern> а2н3афрод</pattern>
+<pattern> анаф2р</pattern>
+<pattern> анафр2о1</pattern>
+<pattern> а2накол</pattern>
+<pattern> а2накрон</pattern>
+<pattern> анак2р</pattern>
+<pattern> анакр2о1</pattern>
+<pattern> а2накр2у1</pattern>
+<pattern> 2а2н3а1лф2а1</pattern>
+<pattern> ана2л1ф</pattern>
+<pattern> а2нафор</pattern>
+<pattern> а2нахор</pattern>
+<pattern> анах2о1</pattern>
+<pattern> а2нахр2о1</pattern>
+<pattern> анах2р</pattern>
+<pattern> а2н3егер</pattern>
+<pattern> ан2е1</pattern>
+<pattern> анег2е1</pattern>
+<pattern> а2н3ек2л</pattern>
+<pattern> а2н3екум</pattern>
+<pattern> анек2у1</pattern>
+<pattern> а2н3елек</pattern>
+<pattern> анел2е1</pattern>
+<pattern> а2н3енер</pattern>
+<pattern> анен2е1</pattern>
+<pattern> а2н3еп2и1</pattern>
+<pattern> а2неор</pattern>
+<pattern> ане3о1</pattern>
+<pattern> а2н3е2р1г</pattern>
+<pattern> а2н3ерит</pattern>
+<pattern> анер2и1</pattern>
+<pattern> а2н3е1ст2е1</pattern>
+<pattern> анес2т</pattern>
+<pattern> а2н3ид2р</pattern>
+<pattern> ан2и1</pattern>
+<pattern> а2н3изог</pattern>
+<pattern> аниз2о1</pattern>
+<pattern> а2н3изом</pattern>
+<pattern> а2н3изур</pattern>
+<pattern> аниз2у1</pattern>
+<pattern> а2н3ирид</pattern>
+<pattern> анир2и1</pattern>
+<pattern> а2н3овар</pattern>
+<pattern> ан2о1</pattern>
+<pattern> анов2а1</pattern>
+<pattern> а2н3о2к1с</pattern>
+<pattern> а2н3опис</pattern>
+<pattern> аноп2и1</pattern>
+<pattern> а2н3о2р1х</pattern>
+<pattern> а2н3о2ф1т</pattern>
+<pattern> а2н3о2р1г</pattern>
+<pattern> ди2с3акор</pattern>
+<pattern> д2и1</pattern>
+<pattern> дис2а1</pattern>
+<pattern> дисак2о1</pattern>
+<pattern> ди2с3ју2н1к</pattern>
+<pattern> дис2ј</pattern>
+<pattern> дисј2у1</pattern>
+<pattern> ди2с3квал</pattern>
+<pattern> дис2к</pattern>
+<pattern> диск2в</pattern>
+<pattern> дискв2а1</pattern>
+<pattern> ди2с3ко2н1т</pattern>
+<pattern> диск2о1</pattern>
+<pattern> ди2с3ко2р1д</pattern>
+<pattern> ди2с3кр2е1</pattern>
+<pattern> диск2р</pattern>
+<pattern> д2и2с3кр2и1</pattern>
+<pattern> ди2с3кур</pattern>
+<pattern> диск2у1</pattern>
+<pattern> ди2с3л2о1</pattern>
+<pattern> дис2л</pattern>
+<pattern> ди2с3ориј</pattern>
+<pattern> дис2о1</pattern>
+<pattern> дисор2и1</pattern>
+<pattern> ди2с3парит</pattern>
+<pattern> дис2п</pattern>
+<pattern> дисп2а1</pattern>
+<pattern> диспар2и1</pattern>
+<pattern> ди2с3поз</pattern>
+<pattern> дисп2о1</pattern>
+<pattern> ди2с3пон</pattern>
+<pattern> ди2с3проп</pattern>
+<pattern> дисп2р</pattern>
+<pattern> диспр2о1</pattern>
+<pattern> ди2с3тон</pattern>
+<pattern> дис2т</pattern>
+<pattern> дист2о1</pattern>
+<pattern> ди2с3трак</pattern>
+<pattern> дист2р</pattern>
+<pattern> дистр2а1</pattern>
+<pattern> и2н3абруп</pattern>
+<pattern> ин2а1</pattern>
+<pattern> инаб2р</pattern>
+<pattern> инабр2у1</pattern>
+<pattern> и2н3адек</pattern>
+<pattern> инад2е1</pattern>
+<pattern> и2н3акур</pattern>
+<pattern> инак2у1</pattern>
+<pattern> и2н3акц2е1</pattern>
+<pattern> ина2к1ц</pattern>
+<pattern> и2н3амор</pattern>
+<pattern> инам2о1</pattern>
+<pattern> и2н3аниц</pattern>
+<pattern> инан2и1</pattern>
+<pattern> и2н3аплик</pattern>
+<pattern> инап2л</pattern>
+<pattern> инапл2и1</pattern>
+<pattern> и2н3апс2т</pattern>
+<pattern> ина2п1с</pattern>
+<pattern> и2н3а2р1т</pattern>
+<pattern> и2н3аугур</pattern>
+<pattern> ина3у1</pattern>
+<pattern> инауг2у1</pattern>
+<pattern> и2н3а1ур2а1</pattern>
+<pattern> и2н3афек</pattern>
+<pattern> инаф2е1</pattern>
+<pattern> и2н3евид</pattern>
+<pattern> ин2е1</pattern>
+<pattern> инев2и1</pattern>
+<pattern> и2н3ег</pattern>
+<pattern> и2н3ед</pattern>
+<pattern> и2н3ек2в</pattern>
+<pattern> и2н3е2к1с</pattern>
+<pattern> и2н3елиг</pattern>
+<pattern> инел2и1</pattern>
+<pattern> и2н3е2п1ц</pattern>
+<pattern> и2н3ефек</pattern>
+<pattern> инеф2е1</pattern>
+<pattern> и2н3об2л</pattern>
+<pattern> ин2о1</pattern>
+<pattern> и2ноген</pattern>
+<pattern> иног2е1</pattern>
+<pattern> и2нокор</pattern>
+<pattern> инок2о1</pattern>
+<pattern> и2н3окуп</pattern>
+<pattern> инок2у1</pattern>
+<pattern> и2н3опер</pattern>
+<pattern> иноп2е1</pattern>
+<pattern> и2н3опор</pattern>
+<pattern> иноп2о1</pattern>
+<pattern> и2н3опс2е1</pattern>
+<pattern> ино2п1с</pattern>
+<pattern> и2н3офиц</pattern>
+<pattern> иноф2и1</pattern>
+<pattern> и2н3умб2р</pattern>
+<pattern> ин2у1</pattern>
+<pattern> ину2м1б</pattern>
+<pattern> и2н3унд2а1</pattern>
+<pattern> ину2н1д</pattern>
+<pattern> и2н3у2н1к</pattern>
+<pattern> и2н3утил</pattern>
+<pattern> инут2и1</pattern>
+<pattern> 2и1нте2р3и1</pattern>
+<pattern> и2н1т</pattern>
+<pattern> инт2е1</pattern>
+<pattern> инте2р3о1</pattern>
+<pattern> инте2р3у1</pattern>
+<pattern> инте2р3а1</pattern>
+<pattern> инт2е2р3е1</pattern>
+<pattern> инте3р4е2г1н</pattern>
+<pattern> 2и1нте3р4ес2и1</pattern>
+<pattern> инте3р4ес2н</pattern>
+<pattern> инте3р4ес2о1</pattern>
+<pattern> инте3р4ес2у1</pattern>
+<pattern> инте3р4ес2а1</pattern>
+<pattern> инт2е3р4е1с2е1</pattern>
+<pattern> инте3р4е2ж1џ</pattern>
+<pattern> инт2е3р4иј2е1</pattern>
+<pattern> инт2е3р3ј2е1</pattern>
+<pattern> инте2р1ј</pattern>
+<pattern> инте3р4огат</pattern>
+<pattern> интерог2а1</pattern>
+<pattern> јури2с3к</pattern>
+<pattern> ј2у1</pattern>
+<pattern> јур2и1</pattern>
+<pattern> јури2с3п</pattern>
+<pattern> ну2з3бел</pattern>
+<pattern> н2у1</pattern>
+<pattern> нуз2б</pattern>
+<pattern> нузб2е1</pattern>
+<pattern> ну2з3биљ</pattern>
+<pattern> нузб2и1</pattern>
+<pattern> ну2з3љуб</pattern>
+<pattern> нуз2љ</pattern>
+<pattern> нузљ2у1</pattern>
+<pattern> ну2з3р2е1</pattern>
+<pattern> нуз2р</pattern>
+<pattern> ну2з3р2ј2е1</pattern>
+<pattern> нуз2р1ј</pattern>
+<pattern> ну2з3уж</pattern>
+<pattern> нуз2у1</pattern>
+<pattern> ну2с3пос</pattern>
+<pattern> нус2п</pattern>
+<pattern> нусп2о1</pattern>
+<pattern> ну2с3пр2о1</pattern>
+<pattern> нусп2р</pattern>
+<pattern> по2ст3е2г1з</pattern>
+<pattern> пос2т</pattern>
+<pattern> пост2е1</pattern>
+<pattern> по2ст3инд2у1</pattern>
+<pattern> пост2и1</pattern>
+<pattern> пости2н1д</pattern>
+<pattern> по2ст3лим</pattern>
+<pattern> по2с3т2л</pattern>
+<pattern> постл2и1</pattern>
+<pattern> по2ст3о2н1к</pattern>
+<pattern> п2о1ст2о1</pattern>
+<pattern> по2ст3опер</pattern>
+<pattern> постоп2е1</pattern>
+<pattern> су2б3а1</pattern>
+<pattern> с2у1</pattern>
+<pattern> су2б3л</pattern>
+<pattern> су3б4аш</pattern>
+<pattern> су2б3и2н1в</pattern>
+<pattern> суб2и1</pattern>
+<pattern> су2б3ју2н1к</pattern>
+<pattern> суб2ј</pattern>
+<pattern> субј2у1</pattern>
+<pattern> су2б3о2к1с</pattern>
+<pattern> суб2о1</pattern>
+<pattern> су2б3реп</pattern>
+<pattern> суб2р</pattern>
+<pattern> субр2е1</pattern>
+<pattern> су2б3рог</pattern>
+<pattern> субр2о1</pattern>
+<pattern> су2б3о2р1д</pattern>
+<pattern> супе2р3и1</pattern>
+<pattern> суп2е1</pattern>
+<pattern> супе2р3о1</pattern>
+<pattern> с2у1пе2р3у1</pattern>
+<pattern> супе2р3а1</pattern>
+<pattern> суп2е2р3е1</pattern>
+<pattern> супе3р4иор</pattern>
+<pattern> супери3о1</pattern>
+<pattern> тр2а1н2с3а1</pattern>
+<pattern> т2р</pattern>
+<pattern> тр2а1</pattern>
+<pattern> тра2н1с</pattern>
+<pattern> тран2с3ц</pattern>
+<pattern> тран2с3е1</pattern>
+<pattern> тран2с3к</pattern>
+<pattern> тран2с3л</pattern>
+<pattern> тран2с3м</pattern>
+<pattern> тран2с3н</pattern>
+<pattern> тран2с3о1</pattern>
+<pattern> тран2с3п</pattern>
+<pattern> тран2с3т</pattern>
+<pattern> тран2с3у1</pattern>
+<pattern> тран2с3в</pattern>
+<pattern> тран2с3њ</pattern>
+<pattern> тран3с4еп</pattern>
+<pattern> тран3с4кр2и1</pattern>
+<pattern> транск2р</pattern>
+<pattern> тран3с4ум</pattern>
+<pattern> тран3с4уд</pattern>
+<pattern>t2j</pattern>
+<pattern>t2l</pattern>
+<pattern>t2l2j</pattern>
+<pattern>t2r</pattern>
+<pattern>t2v</pattern>
+<pattern>d2j</pattern>
+<pattern>d2l</pattern>
+<pattern>d2l2j</pattern>
+<pattern>d2r</pattern>
+<pattern>d2v</pattern>
+<pattern>g2j</pattern>
+<pattern>g2l</pattern>
+<pattern>g2l2j</pattern>
+<pattern>g2r</pattern>
+<pattern>g2v</pattern>
+<pattern>h2j</pattern>
+<pattern>h2l</pattern>
+<pattern>h2l2j</pattern>
+<pattern>h2r</pattern>
+<pattern>h2v</pattern>
+<pattern>k2j</pattern>
+<pattern>k2l</pattern>
+<pattern>k2l2j</pattern>
+<pattern>k2r</pattern>
+<pattern>k2v</pattern>
+<pattern>2d1b</pattern>
+<pattern>2d1c</pattern>
+<pattern>2d1d</pattern>
+<pattern>2d1f</pattern>
+<pattern>2d1g</pattern>
+<pattern>2d1h</pattern>
+<pattern>2d1k</pattern>
+<pattern>2d1m</pattern>
+<pattern>2d1n</pattern>
+<pattern>2d1p</pattern>
+<pattern>2d1s</pattern>
+<pattern>2d1t</pattern>
+<pattern>2d1n2j</pattern>
+<pattern>2d1d2ž</pattern>
+<pattern>2d1z</pattern>
+<pattern>2d1š</pattern>
+<pattern>2d1đ</pattern>
+<pattern>2d1ć</pattern>
+<pattern>2d1č</pattern>
+<pattern>2g1ž</pattern>
+<pattern>2g1b</pattern>
+<pattern>2g1c</pattern>
+<pattern>2g1d</pattern>
+<pattern>2g1f</pattern>
+<pattern>2g1g</pattern>
+<pattern>2g1h</pattern>
+<pattern>2g1k</pattern>
+<pattern>2g1m</pattern>
+<pattern>2g1n</pattern>
+<pattern>2g1p</pattern>
+<pattern>2g1s</pattern>
+<pattern>2g1t</pattern>
+<pattern>2g1n2j</pattern>
+<pattern>2g1d2ž</pattern>
+<pattern>2g1z</pattern>
+<pattern>2g1š</pattern>
+<pattern>2g1đ</pattern>
+<pattern>2g1ć</pattern>
+<pattern>2g1č</pattern>
+<pattern>2h1ž</pattern>
+<pattern>2h1b</pattern>
+<pattern>2h1c</pattern>
+<pattern>2h1d</pattern>
+<pattern>2h1f</pattern>
+<pattern>2h1g</pattern>
+<pattern>2h1h</pattern>
+<pattern>2h1k</pattern>
+<pattern>2h1m</pattern>
+<pattern>2h1n</pattern>
+<pattern>2h1p</pattern>
+<pattern>2h1s</pattern>
+<pattern>2h1t</pattern>
+<pattern>2h1n2j</pattern>
+<pattern>2h1d2ž</pattern>
+<pattern>2h1z</pattern>
+<pattern>2h1š</pattern>
+<pattern>2h1đ</pattern>
+<pattern>2h1ć</pattern>
+<pattern>2h1č</pattern>
+<pattern>2k1ž</pattern>
+<pattern>2k1b</pattern>
+<pattern>2k1c</pattern>
+<pattern>2k1d</pattern>
+<pattern>2k1f</pattern>
+<pattern>2k1g</pattern>
+<pattern>2k1h</pattern>
+<pattern>2k1k</pattern>
+<pattern>2k1m</pattern>
+<pattern>2k1n</pattern>
+<pattern>2k1p</pattern>
+<pattern>2k1s</pattern>
+<pattern>2k1t</pattern>
+<pattern>2k1n2j</pattern>
+<pattern>2k1d2ž</pattern>
+<pattern>2k1z</pattern>
+<pattern>2k1š</pattern>
+<pattern>2k1đ</pattern>
+<pattern>2k1ć</pattern>
+<pattern>2k1č</pattern>
+<pattern>2t1ž</pattern>
+<pattern>2t1b</pattern>
+<pattern>2t1c</pattern>
+<pattern>2t1d</pattern>
+<pattern>2t1f</pattern>
+<pattern>2t1g</pattern>
+<pattern>2t1h</pattern>
+<pattern>2t1k</pattern>
+<pattern>2t1m</pattern>
+<pattern>2t1n</pattern>
+<pattern>2t1p</pattern>
+<pattern>2t1s</pattern>
+<pattern>2t1t</pattern>
+<pattern>2t1n2j</pattern>
+<pattern>2t1d2ž</pattern>
+<pattern>2t1z</pattern>
+<pattern>2t1š</pattern>
+<pattern>2t1đ</pattern>
+<pattern>2t1ć</pattern>
+<pattern>2t1č</pattern>
+<pattern>2dj </pattern>
+<pattern>2dl </pattern>
+<pattern>2dlj </pattern>
+<pattern>2dr </pattern>
+<pattern>2dv </pattern>
+<pattern>2gj </pattern>
+<pattern>2gl </pattern>
+<pattern>2glj </pattern>
+<pattern>2gr </pattern>
+<pattern>2gv </pattern>
+<pattern>2hj </pattern>
+<pattern>2hl </pattern>
+<pattern>2hlj </pattern>
+<pattern>2hr </pattern>
+<pattern>2hv </pattern>
+<pattern>2kj </pattern>
+<pattern>2kl </pattern>
+<pattern>2klj </pattern>
+<pattern>2kr </pattern>
+<pattern>2kv </pattern>
+<pattern>2tj </pattern>
+<pattern>2tl </pattern>
+<pattern>2tlj </pattern>
+<pattern>2tr </pattern>
+<pattern>2tv </pattern>
+<pattern>p2j</pattern>
+<pattern>p2l</pattern>
+<pattern>p2l2j</pattern>
+<pattern>p2r</pattern>
+<pattern>v2j</pattern>
+<pattern>v2l</pattern>
+<pattern>v2l2j</pattern>
+<pattern>v2r</pattern>
+<pattern>b2j</pattern>
+<pattern>b2l</pattern>
+<pattern>b2l2j</pattern>
+<pattern>b2r</pattern>
+<pattern>f2j</pattern>
+<pattern>f2l</pattern>
+<pattern>f2l2j</pattern>
+<pattern>f2r</pattern>
+<pattern>m2j</pattern>
+<pattern>m2l</pattern>
+<pattern>m2l2j</pattern>
+<pattern>m2r</pattern>
+<pattern>2b1ž</pattern>
+<pattern>2b1b</pattern>
+<pattern>2b1c</pattern>
+<pattern>2b1d</pattern>
+<pattern>2b1f</pattern>
+<pattern>2b1g</pattern>
+<pattern>2b1h</pattern>
+<pattern>2b1k</pattern>
+<pattern>2b1m</pattern>
+<pattern>2b1n</pattern>
+<pattern>2b1p</pattern>
+<pattern>2b1s</pattern>
+<pattern>2b1t</pattern>
+<pattern>2b1v</pattern>
+<pattern>2b1n2j</pattern>
+<pattern>2b1d2ž</pattern>
+<pattern>2b1z</pattern>
+<pattern>2b1š</pattern>
+<pattern>2b1đ</pattern>
+<pattern>2b1ć</pattern>
+<pattern>2b1č</pattern>
+<pattern>2f1ž</pattern>
+<pattern>2f1b</pattern>
+<pattern>2f1c</pattern>
+<pattern>2f1d</pattern>
+<pattern>2f1f</pattern>
+<pattern>2f1g</pattern>
+<pattern>2f1h</pattern>
+<pattern>2f1k</pattern>
+<pattern>2f1m</pattern>
+<pattern>2f1n</pattern>
+<pattern>2f1p</pattern>
+<pattern>2f1s</pattern>
+<pattern>2f1t</pattern>
+<pattern>2f1v</pattern>
+<pattern>2f1n2j</pattern>
+<pattern>2f1d2ž</pattern>
+<pattern>2f1z</pattern>
+<pattern>2f1š</pattern>
+<pattern>2f1đ</pattern>
+<pattern>2f1ć</pattern>
+<pattern>2f1č</pattern>
+<pattern>2m1ž</pattern>
+<pattern>2m1b</pattern>
+<pattern>2m1c</pattern>
+<pattern>2m1d</pattern>
+<pattern>2m1f</pattern>
+<pattern>2m1g</pattern>
+<pattern>2m1h</pattern>
+<pattern>2m1k</pattern>
+<pattern>2m1m</pattern>
+<pattern>2m1n</pattern>
+<pattern>2m1p</pattern>
+<pattern>2m1s</pattern>
+<pattern>2m1t</pattern>
+<pattern>2m1v</pattern>
+<pattern>2m1n2j</pattern>
+<pattern>2m1d2ž</pattern>
+<pattern>2m1z</pattern>
+<pattern>2m1š</pattern>
+<pattern>2m1đ</pattern>
+<pattern>2m1ć</pattern>
+<pattern>2m1č</pattern>
+<pattern>2p1ž</pattern>
+<pattern>2p1b</pattern>
+<pattern>2p1c</pattern>
+<pattern>2p1d</pattern>
+<pattern>2p1f</pattern>
+<pattern>2p1g</pattern>
+<pattern>2p1h</pattern>
+<pattern>2p1k</pattern>
+<pattern>2p1m</pattern>
+<pattern>2p1n</pattern>
+<pattern>2p1p</pattern>
+<pattern>2p1s</pattern>
+<pattern>2p1t</pattern>
+<pattern>2p1v</pattern>
+<pattern>2p1n2j</pattern>
+<pattern>2p1d2ž</pattern>
+<pattern>2p1z</pattern>
+<pattern>2p1š</pattern>
+<pattern>2p1đ</pattern>
+<pattern>2p1ć</pattern>
+<pattern>2p1č</pattern>
+<pattern>2v1ž</pattern>
+<pattern>2v1b</pattern>
+<pattern>2v1c</pattern>
+<pattern>2v1d</pattern>
+<pattern>2v1f</pattern>
+<pattern>2v1g</pattern>
+<pattern>2v1h</pattern>
+<pattern>2v1k</pattern>
+<pattern>2v1m</pattern>
+<pattern>2v1n</pattern>
+<pattern>2v1p</pattern>
+<pattern>2v1s</pattern>
+<pattern>2v1t</pattern>
+<pattern>2v1v</pattern>
+<pattern>2v1n2j</pattern>
+<pattern>2v1d2ž</pattern>
+<pattern>2v1z</pattern>
+<pattern>2v1š</pattern>
+<pattern>2v1đ</pattern>
+<pattern>2v1ć</pattern>
+<pattern>2v1č</pattern>
+<pattern>2bj </pattern>
+<pattern>2bl </pattern>
+<pattern>2blj </pattern>
+<pattern>2br </pattern>
+<pattern>2fj </pattern>
+<pattern>2fl </pattern>
+<pattern>2flj </pattern>
+<pattern>2fr </pattern>
+<pattern>2mj </pattern>
+<pattern>2ml </pattern>
+<pattern>2mlj </pattern>
+<pattern>2mr </pattern>
+<pattern>2pj </pattern>
+<pattern>2pl </pattern>
+<pattern>2plj </pattern>
+<pattern>2pr </pattern>
+<pattern>2vj </pattern>
+<pattern>2vl </pattern>
+<pattern>2vlj </pattern>
+<pattern>2vr </pattern>
+<pattern>s2c</pattern>
+<pattern>s2j</pattern>
+<pattern>s2k</pattern>
+<pattern>s2l</pattern>
+<pattern>s2m</pattern>
+<pattern>s2n</pattern>
+<pattern>s2p</pattern>
+<pattern>s2l2j</pattern>
+<pattern>s2r</pattern>
+<pattern>s2t</pattern>
+<pattern>s2v</pattern>
+<pattern>s2n2j</pattern>
+<pattern>2s1ž</pattern>
+<pattern>2s1b</pattern>
+<pattern>2s1d</pattern>
+<pattern>2s1f</pattern>
+<pattern>2s1g</pattern>
+<pattern>2s1h</pattern>
+<pattern>2s1s</pattern>
+<pattern>2s1d2ž</pattern>
+<pattern>2s1z</pattern>
+<pattern>2s1š</pattern>
+<pattern>2s1đ</pattern>
+<pattern>2s1ć</pattern>
+<pattern>2s1č</pattern>
+<pattern>2sj </pattern>
+<pattern>2sk </pattern>
+<pattern>2sl </pattern>
+<pattern>2sm </pattern>
+<pattern>2sn </pattern>
+<pattern>2sp </pattern>
+<pattern>2slj </pattern>
+<pattern>2sr </pattern>
+<pattern>2st </pattern>
+<pattern>2sv </pattern>
+<pattern>2snj </pattern>
+<pattern>2sc </pattern>
+<pattern>z2b</pattern>
+<pattern>z2d</pattern>
+<pattern>z2g</pattern>
+<pattern>z2j</pattern>
+<pattern>z2l</pattern>
+<pattern>z2m</pattern>
+<pattern>z2n</pattern>
+<pattern>z2l2j</pattern>
+<pattern>z2r</pattern>
+<pattern>z2v</pattern>
+<pattern>z2n2j</pattern>
+<pattern>2z1ž</pattern>
+<pattern>2z1c</pattern>
+<pattern>2z1f</pattern>
+<pattern>2z1h</pattern>
+<pattern>2z1k</pattern>
+<pattern>2z1p</pattern>
+<pattern>2z1s</pattern>
+<pattern>2z1t</pattern>
+<pattern>2z1d2ž</pattern>
+<pattern>2z1z</pattern>
+<pattern>2z1š</pattern>
+<pattern>2z1đ</pattern>
+<pattern>2z1ć</pattern>
+<pattern>2z1č</pattern>
+<pattern>2zj </pattern>
+<pattern>2zl </pattern>
+<pattern>2zm </pattern>
+<pattern>2zn </pattern>
+<pattern>2zlj </pattern>
+<pattern>2zr </pattern>
+<pattern>2zv </pattern>
+<pattern>2znj </pattern>
+<pattern>2zb </pattern>
+<pattern>2zd </pattern>
+<pattern>2zg </pattern>
+<pattern>š2c</pattern>
+<pattern>š2k</pattern>
+<pattern>š2l</pattern>
+<pattern>š2m</pattern>
+<pattern>š2n</pattern>
+<pattern>š2p</pattern>
+<pattern>š2l2j</pattern>
+<pattern>š2t</pattern>
+<pattern>š2v</pattern>
+<pattern>š2n2j</pattern>
+<pattern>š2ć</pattern>
+<pattern>š2č</pattern>
+<pattern>2š1ž</pattern>
+<pattern>2š1b</pattern>
+<pattern>2š1d</pattern>
+<pattern>2š1f</pattern>
+<pattern>2š1g</pattern>
+<pattern>2š1h</pattern>
+<pattern>2š1s</pattern>
+<pattern>2š1d2ž</pattern>
+<pattern>2š1z</pattern>
+<pattern>2š1š</pattern>
+<pattern>2š1đ</pattern>
+<pattern>2š1j</pattern>
+<pattern>2š1r</pattern>
+<pattern>2šk </pattern>
+<pattern>2šl </pattern>
+<pattern>2šm </pattern>
+<pattern>2šn </pattern>
+<pattern>2šp </pattern>
+<pattern>2šlj </pattern>
+<pattern>2št </pattern>
+<pattern>2šv </pattern>
+<pattern>2šnj </pattern>
+<pattern>2šć </pattern>
+<pattern>2šč </pattern>
+<pattern>2šc </pattern>
+<pattern>ž2b</pattern>
+<pattern>ž2d</pattern>
+<pattern>ž2g</pattern>
+<pattern>ž2l</pattern>
+<pattern>ž2m</pattern>
+<pattern>ž2n</pattern>
+<pattern>ž2l2j</pattern>
+<pattern>ž2v</pattern>
+<pattern>ž2n2j</pattern>
+<pattern>ž2đ</pattern>
+<pattern>2ž1ž</pattern>
+<pattern>2ž1c</pattern>
+<pattern>2ž1f</pattern>
+<pattern>2ž1h</pattern>
+<pattern>2ž1k</pattern>
+<pattern>2ž1p</pattern>
+<pattern>2ž1s</pattern>
+<pattern>2ž1t</pattern>
+<pattern>2ž1d2ž</pattern>
+<pattern>2ž1z</pattern>
+<pattern>2ž1š</pattern>
+<pattern>2ž1ć</pattern>
+<pattern>2ž1č</pattern>
+<pattern>2ž1j</pattern>
+<pattern>2ž1r</pattern>
+<pattern>2žl </pattern>
+<pattern>2žm </pattern>
+<pattern>2žn </pattern>
+<pattern>2žlj </pattern>
+<pattern>2žv </pattern>
+<pattern>2žnj </pattern>
+<pattern>2žđ </pattern>
+<pattern>2žb </pattern>
+<pattern>2žd </pattern>
+<pattern>2žg </pattern>
+<pattern>c2j</pattern>
+<pattern>c2r</pattern>
+<pattern>c2v</pattern>
+<pattern>2c1ž</pattern>
+<pattern>2c1b</pattern>
+<pattern>2c1c</pattern>
+<pattern>2c1d</pattern>
+<pattern>2c1f</pattern>
+<pattern>2c1g</pattern>
+<pattern>2c1h</pattern>
+<pattern>2c1k</pattern>
+<pattern>2c1l</pattern>
+<pattern>2c1m</pattern>
+<pattern>2c1n</pattern>
+<pattern>2c1p</pattern>
+<pattern>2c1l2j</pattern>
+<pattern>2c1s</pattern>
+<pattern>2c1t</pattern>
+<pattern>2c1n2j</pattern>
+<pattern>2c1d2ž</pattern>
+<pattern>2c1z</pattern>
+<pattern>2c1š</pattern>
+<pattern>2c1đ</pattern>
+<pattern>2c1ć</pattern>
+<pattern>2c1č</pattern>
+<pattern>2cj </pattern>
+<pattern>2cr </pattern>
+<pattern>2cv </pattern>
+<pattern>č2v</pattern>
+<pattern>2č1ž</pattern>
+<pattern>2č1b</pattern>
+<pattern>2č1c</pattern>
+<pattern>2č1d</pattern>
+<pattern>2č1f</pattern>
+<pattern>2č1g</pattern>
+<pattern>2č1h</pattern>
+<pattern>2č1j</pattern>
+<pattern>2č1k</pattern>
+<pattern>2č1l</pattern>
+<pattern>2č1m</pattern>
+<pattern>2č1n</pattern>
+<pattern>2č1p</pattern>
+<pattern>2č1l2j</pattern>
+<pattern>2č1r</pattern>
+<pattern>2č1s</pattern>
+<pattern>2č1t</pattern>
+<pattern>2č1n2j</pattern>
+<pattern>2č1d2ž</pattern>
+<pattern>2č1z</pattern>
+<pattern>2č1š</pattern>
+<pattern>2č1đ</pattern>
+<pattern>2č1ć</pattern>
+<pattern>2č1č</pattern>
+<pattern>2čv </pattern>
+<pattern>2j1ž</pattern>
+<pattern>2j1b</pattern>
+<pattern>2j1c</pattern>
+<pattern>2j1d</pattern>
+<pattern>2j1f</pattern>
+<pattern>2j1g</pattern>
+<pattern>2j1h</pattern>
+<pattern>2j1j</pattern>
+<pattern>2j1k</pattern>
+<pattern>2j1l</pattern>
+<pattern>2j1m</pattern>
+<pattern>2j1n</pattern>
+<pattern>2j1p</pattern>
+<pattern>2j1l2j</pattern>
+<pattern>2j1r</pattern>
+<pattern>2j1s</pattern>
+<pattern>2j1t</pattern>
+<pattern>2j1v</pattern>
+<pattern>2j1n2j</pattern>
+<pattern>2j1d2ž</pattern>
+<pattern>2j1z</pattern>
+<pattern>2j1š</pattern>
+<pattern>2j1đ</pattern>
+<pattern>2j1ć</pattern>
+<pattern>2j1č</pattern>
+<pattern>2l1ž</pattern>
+<pattern>2l1b</pattern>
+<pattern>2l1c</pattern>
+<pattern>2l1d</pattern>
+<pattern>2l1f</pattern>
+<pattern>2l1g</pattern>
+<pattern>2l1h</pattern>
+<pattern>2l1k</pattern>
+<pattern>2l1l</pattern>
+<pattern>2l1m</pattern>
+<pattern>2l1n</pattern>
+<pattern>2l1p</pattern>
+<pattern>2l1l2j</pattern>
+<pattern>2l1r</pattern>
+<pattern>2l1s</pattern>
+<pattern>2l1t</pattern>
+<pattern>2l1v</pattern>
+<pattern>2l1n2j</pattern>
+<pattern>2l1d2ž</pattern>
+<pattern>2l1z</pattern>
+<pattern>2l1š</pattern>
+<pattern>2l1đ</pattern>
+<pattern>2l1ć</pattern>
+<pattern>2l1č</pattern>
+<pattern>2n1ž</pattern>
+<pattern>2n1b</pattern>
+<pattern>2n1c</pattern>
+<pattern>2n1d</pattern>
+<pattern>2n1f</pattern>
+<pattern>2n1g</pattern>
+<pattern>2n1h</pattern>
+<pattern>2n1k</pattern>
+<pattern>2n1l</pattern>
+<pattern>2n1m</pattern>
+<pattern>2n1n</pattern>
+<pattern>2n1p</pattern>
+<pattern>2n1l2j</pattern>
+<pattern>2n1r</pattern>
+<pattern>2n1s</pattern>
+<pattern>2n1t</pattern>
+<pattern>2n1v</pattern>
+<pattern>2n1n2j</pattern>
+<pattern>2n1d2ž</pattern>
+<pattern>2n1z</pattern>
+<pattern>2n1š</pattern>
+<pattern>2n1đ</pattern>
+<pattern>2n1ć</pattern>
+<pattern>2n1č</pattern>
+<pattern>l2j</pattern>
+<pattern>2l2j1ž</pattern>
+<pattern>2l2j1b</pattern>
+<pattern>2l2j1c</pattern>
+<pattern>2l2j1d</pattern>
+<pattern>2l2j1f</pattern>
+<pattern>2l2j1g</pattern>
+<pattern>2l2j1h</pattern>
+<pattern>2l2j1j</pattern>
+<pattern>2l2j1k</pattern>
+<pattern>2l2j1l</pattern>
+<pattern>2l2j1m</pattern>
+<pattern>2l2j1n</pattern>
+<pattern>2l2j1p</pattern>
+<pattern>2l2j1l2j</pattern>
+<pattern>2l2j1r</pattern>
+<pattern>2l2j1s</pattern>
+<pattern>2l2j1t</pattern>
+<pattern>2l2j1v</pattern>
+<pattern>2l2j1n2j</pattern>
+<pattern>2l2j1d2ž</pattern>
+<pattern>2l2j1z</pattern>
+<pattern>2l2j1š</pattern>
+<pattern>2l2j1đ</pattern>
+<pattern>2l2j1ć</pattern>
+<pattern>2l2j1č</pattern>
+<pattern>2r1ž</pattern>
+<pattern>2r1b</pattern>
+<pattern>2r1c</pattern>
+<pattern>2r1d</pattern>
+<pattern>2r1f</pattern>
+<pattern>2r1g</pattern>
+<pattern>2r1h</pattern>
+<pattern>2r1j</pattern>
+<pattern>2r1k</pattern>
+<pattern>2r1l</pattern>
+<pattern>2r1m</pattern>
+<pattern>2r1n</pattern>
+<pattern>2r1p</pattern>
+<pattern>2r1l2j</pattern>
+<pattern>2r1r</pattern>
+<pattern>2r1s</pattern>
+<pattern>2r1t</pattern>
+<pattern>2r1v</pattern>
+<pattern>2r1n2j</pattern>
+<pattern>2r1d2ž</pattern>
+<pattern>2r1z</pattern>
+<pattern>2r1š</pattern>
+<pattern>2r1đ</pattern>
+<pattern>2r1ć</pattern>
+<pattern>2r1č</pattern>
+<pattern>n2j</pattern>
+<pattern>2n2j1ž</pattern>
+<pattern>2n2j1b</pattern>
+<pattern>2n2j1c</pattern>
+<pattern>2n2j1d</pattern>
+<pattern>2n2j1f</pattern>
+<pattern>2n2j1g</pattern>
+<pattern>2n2j1h</pattern>
+<pattern>2n2j1j</pattern>
+<pattern>2n2j1k</pattern>
+<pattern>2n2j1l</pattern>
+<pattern>2n2j1m</pattern>
+<pattern>2n2j1n</pattern>
+<pattern>2n2j1p</pattern>
+<pattern>2n2j1l2j</pattern>
+<pattern>2n2j1r</pattern>
+<pattern>2n2j1s</pattern>
+<pattern>2n2j1t</pattern>
+<pattern>2n2j1v</pattern>
+<pattern>2n2j1n2j</pattern>
+<pattern>2n2j1d2ž</pattern>
+<pattern>2n2j1z</pattern>
+<pattern>2n2j1š</pattern>
+<pattern>2n2j1đ</pattern>
+<pattern>2n2j1ć</pattern>
+<pattern>2n2j1č</pattern>
+<pattern>d2ž</pattern>
+<pattern>2d2ž1ž</pattern>
+<pattern>2dž2b</pattern>
+<pattern>2d2ž1c</pattern>
+<pattern>2dž2d</pattern>
+<pattern>2d2ž1f</pattern>
+<pattern>2dž2g</pattern>
+<pattern>2d2ž1h</pattern>
+<pattern>2d2ž1j</pattern>
+<pattern>2d2ž1k</pattern>
+<pattern>2dž2l</pattern>
+<pattern>2dž2m</pattern>
+<pattern>2dž2n</pattern>
+<pattern>2d2ž1p</pattern>
+<pattern>2dž2l2j</pattern>
+<pattern>2d2ž1r</pattern>
+<pattern>2d2ž1s</pattern>
+<pattern>2d2ž1t</pattern>
+<pattern>2dž2v</pattern>
+<pattern>2dž2n2j</pattern>
+<pattern>2d2ž1d2ž</pattern>
+<pattern>2d2ž1z</pattern>
+<pattern>2d2ž1š</pattern>
+<pattern>2dž2đ</pattern>
+<pattern>2d2ž1ć</pattern>
+<pattern>2d2ž1č</pattern>
+<pattern>2đ1ž</pattern>
+<pattern>2đ1b</pattern>
+<pattern>2đ1c</pattern>
+<pattern>2đ1d</pattern>
+<pattern>2đ1f</pattern>
+<pattern>2đ1g</pattern>
+<pattern>2đ1h</pattern>
+<pattern>2đ1j</pattern>
+<pattern>2đ1k</pattern>
+<pattern>2đ1l</pattern>
+<pattern>2đ1m</pattern>
+<pattern>2đ1n</pattern>
+<pattern>2đ1p</pattern>
+<pattern>2đ1l2j</pattern>
+<pattern>2đ1r</pattern>
+<pattern>2đ1s</pattern>
+<pattern>2đ1t</pattern>
+<pattern>2đ1v</pattern>
+<pattern>2đ1n2j</pattern>
+<pattern>2đ1d2ž</pattern>
+<pattern>2đ1z</pattern>
+<pattern>2đ1š</pattern>
+<pattern>2đ1đ</pattern>
+<pattern>2đ1ć</pattern>
+<pattern>2đ1č</pattern>
+<pattern>2ć1ž</pattern>
+<pattern>2ć1b</pattern>
+<pattern>2ć1c</pattern>
+<pattern>2ć1d</pattern>
+<pattern>2ć1f</pattern>
+<pattern>2ć1g</pattern>
+<pattern>2ć1h</pattern>
+<pattern>2ć1j</pattern>
+<pattern>2ć1k</pattern>
+<pattern>2ć1l</pattern>
+<pattern>2ć1m</pattern>
+<pattern>2ć1n</pattern>
+<pattern>2ć1p</pattern>
+<pattern>2ć1l2j</pattern>
+<pattern>2ć1r</pattern>
+<pattern>2ć1s</pattern>
+<pattern>2ć1t</pattern>
+<pattern>2ć1v</pattern>
+<pattern>2ć1n2j</pattern>
+<pattern>2ć1d2ž</pattern>
+<pattern>2ć1z</pattern>
+<pattern>2ć1š</pattern>
+<pattern>2ć1đ</pattern>
+<pattern>2ć1ć</pattern>
+<pattern>2ć1č</pattern>
+<pattern> h2</pattern>
+<pattern> j2</pattern>
+<pattern> k2</pattern>
+<pattern> l2</pattern>
+<pattern> m2</pattern>
+<pattern> n2</pattern>
+<pattern> p2</pattern>
+<pattern> l2j2</pattern>
+<pattern> r2</pattern>
+<pattern> s2</pattern>
+<pattern> t2</pattern>
+<pattern> v2</pattern>
+<pattern> n2j2</pattern>
+<pattern> d2</pattern>
+<pattern> d2ž2</pattern>
+<pattern> z2</pattern>
+<pattern> š2</pattern>
+<pattern> đ2</pattern>
+<pattern> ć2</pattern>
+<pattern> č2</pattern>
+<pattern> ž2</pattern>
+<pattern> b2</pattern>
+<pattern> c2</pattern>
+<pattern> f2</pattern>
+<pattern> g2</pattern>
+<pattern>2o1</pattern>
+<pattern>o3a1</pattern>
+<pattern>o3e1</pattern>
+<pattern>o3i1</pattern>
+<pattern>2o3o1</pattern>
+<pattern>o3u1</pattern>
+<pattern>2u1</pattern>
+<pattern>u3a1</pattern>
+<pattern>u3e1</pattern>
+<pattern>u3i1</pattern>
+<pattern>u3o1</pattern>
+<pattern>2u3u1</pattern>
+<pattern>2a1</pattern>
+<pattern>2a3a1</pattern>
+<pattern>a3e1</pattern>
+<pattern>a3i1</pattern>
+<pattern>a3o1</pattern>
+<pattern>a3u1</pattern>
+<pattern>2e1</pattern>
+<pattern>e3a1</pattern>
+<pattern>2e3e1</pattern>
+<pattern>e3i1</pattern>
+<pattern>e3o1</pattern>
+<pattern>e3u1</pattern>
+<pattern>2i1</pattern>
+<pattern>i3a1</pattern>
+<pattern>i3e1</pattern>
+<pattern>2i3i1</pattern>
+<pattern>i3o1</pattern>
+<pattern>i3u1</pattern>
+<pattern>2s2k1b</pattern>
+<pattern>2s2k1c</pattern>
+<pattern>2s2k1d</pattern>
+<pattern>2s2k1f</pattern>
+<pattern>2s2k1g</pattern>
+<pattern>2s2k1h</pattern>
+<pattern>2s2k1k</pattern>
+<pattern>2s2k1m</pattern>
+<pattern>2s2k1n</pattern>
+<pattern>2s2k1p</pattern>
+<pattern>2s2k1s</pattern>
+<pattern>2s2k1t</pattern>
+<pattern>2s2k1n2j</pattern>
+<pattern>2s2k1d2ž</pattern>
+<pattern>2s2k1z</pattern>
+<pattern>2s2k1š</pattern>
+<pattern>2s2k1đ</pattern>
+<pattern>2s2k1ć</pattern>
+<pattern>2s2k1č</pattern>
+<pattern>2s2k1ž</pattern>
+<pattern>2s2t1b</pattern>
+<pattern>2s2t1c</pattern>
+<pattern>2s2t1d</pattern>
+<pattern>2s2t1f</pattern>
+<pattern>2s2t1g</pattern>
+<pattern>2s2t1h</pattern>
+<pattern>2s2t1k</pattern>
+<pattern>2s2t1m</pattern>
+<pattern>2s2t1n</pattern>
+<pattern>2s2t1p</pattern>
+<pattern>2s2t1s</pattern>
+<pattern>2s2t1t</pattern>
+<pattern>2s2t1n2j</pattern>
+<pattern>2s2t1d2ž</pattern>
+<pattern>2s2t1z</pattern>
+<pattern>2s2t1š</pattern>
+<pattern>2s2t1đ</pattern>
+<pattern>2s2t1ć</pattern>
+<pattern>2s2t1č</pattern>
+<pattern>2s2t1ž</pattern>
+<pattern>2š2k1b</pattern>
+<pattern>2š2k1c</pattern>
+<pattern>2š2k1d</pattern>
+<pattern>2š2k1f</pattern>
+<pattern>2š2k1g</pattern>
+<pattern>2š2k1h</pattern>
+<pattern>2š2k1k</pattern>
+<pattern>2š2k1m</pattern>
+<pattern>2š2k1n</pattern>
+<pattern>2š2k1p</pattern>
+<pattern>2š2k1s</pattern>
+<pattern>2š2k1t</pattern>
+<pattern>2š2k1n2j</pattern>
+<pattern>2š2k1d2ž</pattern>
+<pattern>2š2k1z</pattern>
+<pattern>2š2k1š</pattern>
+<pattern>2š2k1đ</pattern>
+<pattern>2š2k1ć</pattern>
+<pattern>2š2k1č</pattern>
+<pattern>2š2k1ž</pattern>
+<pattern>2š2t1b</pattern>
+<pattern>2š2t1c</pattern>
+<pattern>2š2t1d</pattern>
+<pattern>2š2t1f</pattern>
+<pattern>2š2t1g</pattern>
+<pattern>2š2t1h</pattern>
+<pattern>2š2t1k</pattern>
+<pattern>2š2t1m</pattern>
+<pattern>2š2t1n</pattern>
+<pattern>2š2t1p</pattern>
+<pattern>2š2t1s</pattern>
+<pattern>2š2t1t</pattern>
+<pattern>2š2t1n2j</pattern>
+<pattern>2š2t1d2ž</pattern>
+<pattern>2š2t1z</pattern>
+<pattern>2š2t1š</pattern>
+<pattern>2š2t1đ</pattern>
+<pattern>2š2t1ć</pattern>
+<pattern>2š2t1č</pattern>
+<pattern>2š2t1ž</pattern>
+<pattern>2s2p1b</pattern>
+<pattern>2s2p1c</pattern>
+<pattern>2s2p1d</pattern>
+<pattern>2s2p1f</pattern>
+<pattern>2s2p1g</pattern>
+<pattern>2s2p1h</pattern>
+<pattern>2s2p1k</pattern>
+<pattern>2s2p1m</pattern>
+<pattern>2s2p1n</pattern>
+<pattern>2s2p1p</pattern>
+<pattern>2s2p1s</pattern>
+<pattern>2s2p1t</pattern>
+<pattern>2s2p1v</pattern>
+<pattern>2s2p1n2j</pattern>
+<pattern>2s2p1d2ž</pattern>
+<pattern>2s2p1z</pattern>
+<pattern>2s2p1š</pattern>
+<pattern>2s2p1đ</pattern>
+<pattern>2s2p1ć</pattern>
+<pattern>2s2p1č</pattern>
+<pattern>2s2p1ž</pattern>
+<pattern>2s2v1b</pattern>
+<pattern>2s2v1c</pattern>
+<pattern>2s2v1d</pattern>
+<pattern>2s2v1f</pattern>
+<pattern>2s2v1g</pattern>
+<pattern>2s2v1h</pattern>
+<pattern>2s2v1k</pattern>
+<pattern>2s2v1m</pattern>
+<pattern>2s2v1n</pattern>
+<pattern>2s2v1p</pattern>
+<pattern>2s2v1s</pattern>
+<pattern>2s2v1t</pattern>
+<pattern>2s2v1v</pattern>
+<pattern>2s2v1n2j</pattern>
+<pattern>2s2v1d2ž</pattern>
+<pattern>2s2v1z</pattern>
+<pattern>2s2v1š</pattern>
+<pattern>2s2v1đ</pattern>
+<pattern>2s2v1ć</pattern>
+<pattern>2s2v1č</pattern>
+<pattern>2s2v1ž</pattern>
+<pattern>2š2p1b</pattern>
+<pattern>2š2p1c</pattern>
+<pattern>2š2p1d</pattern>
+<pattern>2š2p1f</pattern>
+<pattern>2š2p1g</pattern>
+<pattern>2š2p1h</pattern>
+<pattern>2š2p1k</pattern>
+<pattern>2š2p1m</pattern>
+<pattern>2š2p1n</pattern>
+<pattern>2š2p1p</pattern>
+<pattern>2š2p1s</pattern>
+<pattern>2š2p1t</pattern>
+<pattern>2š2p1v</pattern>
+<pattern>2š2p1n2j</pattern>
+<pattern>2š2p1d2ž</pattern>
+<pattern>2š2p1z</pattern>
+<pattern>2š2p1š</pattern>
+<pattern>2š2p1đ</pattern>
+<pattern>2š2p1ć</pattern>
+<pattern>2š2p1č</pattern>
+<pattern>2š2p1ž</pattern>
+<pattern>2š2v1b</pattern>
+<pattern>2š2v1c</pattern>
+<pattern>2š2v1d</pattern>
+<pattern>2š2v1f</pattern>
+<pattern>2š2v1g</pattern>
+<pattern>2š2v1h</pattern>
+<pattern>2š2v1k</pattern>
+<pattern>2š2v1m</pattern>
+<pattern>2š2v1n</pattern>
+<pattern>2š2v1p</pattern>
+<pattern>2š2v1s</pattern>
+<pattern>2š2v1t</pattern>
+<pattern>2š2v1v</pattern>
+<pattern>2š2v1n2j</pattern>
+<pattern>2š2v1d2ž</pattern>
+<pattern>2š2v1z</pattern>
+<pattern>2š2v1š</pattern>
+<pattern>2š2v1đ</pattern>
+<pattern>2š2v1ć</pattern>
+<pattern>2š2v1č</pattern>
+<pattern>2š2v1ž</pattern>
+<pattern>2ž2d1b</pattern>
+<pattern>2ž2d1c</pattern>
+<pattern>2ž2d1d</pattern>
+<pattern>2ž2d1f</pattern>
+<pattern>2ž2d1g</pattern>
+<pattern>2ž2d1h</pattern>
+<pattern>2ž2d1k</pattern>
+<pattern>2ž2d1m</pattern>
+<pattern>2ž2d1n</pattern>
+<pattern>2ž2d1p</pattern>
+<pattern>2ž2d1s</pattern>
+<pattern>2ž2d1t</pattern>
+<pattern>2ž2d1n2j</pattern>
+<pattern>2ž2d1d2ž</pattern>
+<pattern>2ž2d1z</pattern>
+<pattern>2ž2d1š</pattern>
+<pattern>2ž2d1đ</pattern>
+<pattern>2ž2d1ć</pattern>
+<pattern>2ž2d1č</pattern>
+<pattern>2ž2g1b</pattern>
+<pattern>2ž2g1c</pattern>
+<pattern>2ž2g1d</pattern>
+<pattern>2ž2g1f</pattern>
+<pattern>2ž2g1g</pattern>
+<pattern>2ž2g1h</pattern>
+<pattern>2ž2g1k</pattern>
+<pattern>2ž2g1m</pattern>
+<pattern>2ž2g1n</pattern>
+<pattern>2ž2g1p</pattern>
+<pattern>2ž2g1s</pattern>
+<pattern>2ž2g1t</pattern>
+<pattern>2ž2g1n2j</pattern>
+<pattern>2ž2g1d2ž</pattern>
+<pattern>2ž2g1z</pattern>
+<pattern>2ž2g1š</pattern>
+<pattern>2ž2g1đ</pattern>
+<pattern>2ž2g1ć</pattern>
+<pattern>2ž2g1č</pattern>
+<pattern>2ž2g1ž</pattern>
+<pattern>2z2d1b</pattern>
+<pattern>2z2d1c</pattern>
+<pattern>2z2d1d</pattern>
+<pattern>2z2d1f</pattern>
+<pattern>2z2d1g</pattern>
+<pattern>2z2d1h</pattern>
+<pattern>2z2d1k</pattern>
+<pattern>2z2d1m</pattern>
+<pattern>2z2d1n</pattern>
+<pattern>2z2d1p</pattern>
+<pattern>2z2d1s</pattern>
+<pattern>2z2d1t</pattern>
+<pattern>2z2d1n2j</pattern>
+<pattern>2z2d1d2ž</pattern>
+<pattern>2z2d1z</pattern>
+<pattern>2z2d1š</pattern>
+<pattern>2z2d1đ</pattern>
+<pattern>2z2d1ć</pattern>
+<pattern>2z2d1č</pattern>
+<pattern>2z2g1b</pattern>
+<pattern>2z2g1c</pattern>
+<pattern>2z2g1d</pattern>
+<pattern>2z2g1f</pattern>
+<pattern>2z2g1g</pattern>
+<pattern>2z2g1h</pattern>
+<pattern>2z2g1k</pattern>
+<pattern>2z2g1m</pattern>
+<pattern>2z2g1n</pattern>
+<pattern>2z2g1p</pattern>
+<pattern>2z2g1s</pattern>
+<pattern>2z2g1t</pattern>
+<pattern>2z2g1n2j</pattern>
+<pattern>2z2g1d2ž</pattern>
+<pattern>2z2g1z</pattern>
+<pattern>2z2g1š</pattern>
+<pattern>2z2g1đ</pattern>
+<pattern>2z2g1ć</pattern>
+<pattern>2z2g1č</pattern>
+<pattern>2z2g1ž</pattern>
+<pattern>2ž2v1b</pattern>
+<pattern>2ž2v1c</pattern>
+<pattern>2ž2v1d</pattern>
+<pattern>2ž2v1f</pattern>
+<pattern>2ž2v1g</pattern>
+<pattern>2ž2v1h</pattern>
+<pattern>2ž2v1k</pattern>
+<pattern>2ž2v1m</pattern>
+<pattern>2ž2v1n</pattern>
+<pattern>2ž2v1p</pattern>
+<pattern>2ž2v1s</pattern>
+<pattern>2ž2v1t</pattern>
+<pattern>2ž2v1v</pattern>
+<pattern>2ž2v1n2j</pattern>
+<pattern>2ž2v1d2ž</pattern>
+<pattern>2ž2v1z</pattern>
+<pattern>2ž2v1š</pattern>
+<pattern>2ž2v1đ</pattern>
+<pattern>2ž2v1ć</pattern>
+<pattern>2ž2v1č</pattern>
+<pattern>2ž2v1ž</pattern>
+<pattern>2ž2b1b</pattern>
+<pattern>2ž2b1c</pattern>
+<pattern>2ž2b1d</pattern>
+<pattern>2ž2b1f</pattern>
+<pattern>2ž2b1g</pattern>
+<pattern>2ž2b1h</pattern>
+<pattern>2ž2b1k</pattern>
+<pattern>2ž2b1m</pattern>
+<pattern>2ž2b1n</pattern>
+<pattern>2ž2b1p</pattern>
+<pattern>2ž2b1s</pattern>
+<pattern>2ž2b1t</pattern>
+<pattern>2ž2b1v</pattern>
+<pattern>2ž2b1n2j</pattern>
+<pattern>2ž2b1d2ž</pattern>
+<pattern>2ž2b1z</pattern>
+<pattern>2ž2b1š</pattern>
+<pattern>2ž2b1đ</pattern>
+<pattern>2ž2b1ć</pattern>
+<pattern>2ž2b1č</pattern>
+<pattern>2ž2b1ž</pattern>
+<pattern>2z2v1b</pattern>
+<pattern>2z2v1c</pattern>
+<pattern>2z2v1d</pattern>
+<pattern>2z2v1f</pattern>
+<pattern>2z2v1g</pattern>
+<pattern>2z2v1h</pattern>
+<pattern>2z2v1k</pattern>
+<pattern>2z2v1m</pattern>
+<pattern>2z2v1n</pattern>
+<pattern>2z2v1p</pattern>
+<pattern>2z2v1s</pattern>
+<pattern>2z2v1t</pattern>
+<pattern>2z2v1v</pattern>
+<pattern>2z2v1n2j</pattern>
+<pattern>2z2v1d2ž</pattern>
+<pattern>2z2v1z</pattern>
+<pattern>2z2v1š</pattern>
+<pattern>2z2v1đ</pattern>
+<pattern>2z2v1ć</pattern>
+<pattern>2z2v1č</pattern>
+<pattern>2z2v1ž</pattern>
+<pattern>2z2b1b</pattern>
+<pattern>2z2b1c</pattern>
+<pattern>2z2b1d</pattern>
+<pattern>2z2b1f</pattern>
+<pattern>2z2b1g</pattern>
+<pattern>2z2b1h</pattern>
+<pattern>2z2b1k</pattern>
+<pattern>2z2b1m</pattern>
+<pattern>2z2b1n</pattern>
+<pattern>2z2b1p</pattern>
+<pattern>2z2b1s</pattern>
+<pattern>2z2b1t</pattern>
+<pattern>2z2b1v</pattern>
+<pattern>2z2b1n2j</pattern>
+<pattern>2z2b1d2ž</pattern>
+<pattern>2z2b1z</pattern>
+<pattern>2z2b1š</pattern>
+<pattern>2z2b1đ</pattern>
+<pattern>2z2b1ć</pattern>
+<pattern>2z2b1č</pattern>
+<pattern>2z2b1ž</pattern>
+<pattern>2ž2m1b</pattern>
+<pattern>2ž2m1c</pattern>
+<pattern>2ž2m1d</pattern>
+<pattern>2ž2m1f</pattern>
+<pattern>2ž2m1g</pattern>
+<pattern>2ž2m1h</pattern>
+<pattern>2ž2m1k</pattern>
+<pattern>2ž2m1m</pattern>
+<pattern>2ž2m1n</pattern>
+<pattern>2ž2m1p</pattern>
+<pattern>2ž2m1s</pattern>
+<pattern>2ž2m1t</pattern>
+<pattern>2ž2m1v</pattern>
+<pattern>2ž2m1n2j</pattern>
+<pattern>2ž2m1d2ž</pattern>
+<pattern>2ž2m1z</pattern>
+<pattern>2ž2m1š</pattern>
+<pattern>2ž2m1đ</pattern>
+<pattern>2ž2m1ć</pattern>
+<pattern>2ž2m1č</pattern>
+<pattern>2ž2m1ž</pattern>
+<pattern>2s2m1b</pattern>
+<pattern>2s2m1c</pattern>
+<pattern>2s2m1d</pattern>
+<pattern>2s2m1f</pattern>
+<pattern>2s2m1g</pattern>
+<pattern>2s2m1h</pattern>
+<pattern>2s2m1k</pattern>
+<pattern>2s2m1m</pattern>
+<pattern>2s2m1n</pattern>
+<pattern>2s2m1p</pattern>
+<pattern>2s2m1s</pattern>
+<pattern>2s2m1t</pattern>
+<pattern>2s2m1v</pattern>
+<pattern>2s2m1n2j</pattern>
+<pattern>2s2m1d2ž</pattern>
+<pattern>2s2m1z</pattern>
+<pattern>2s2m1š</pattern>
+<pattern>2s2m1đ</pattern>
+<pattern>2s2m1ć</pattern>
+<pattern>2s2m1č</pattern>
+<pattern>2s2m1ž</pattern>
+<pattern>2z2m1b</pattern>
+<pattern>2z2m1c</pattern>
+<pattern>2z2m1d</pattern>
+<pattern>2z2m1f</pattern>
+<pattern>2z2m1g</pattern>
+<pattern>2z2m1h</pattern>
+<pattern>2z2m1k</pattern>
+<pattern>2z2m1m</pattern>
+<pattern>2z2m1n</pattern>
+<pattern>2z2m1p</pattern>
+<pattern>2z2m1s</pattern>
+<pattern>2z2m1t</pattern>
+<pattern>2z2m1v</pattern>
+<pattern>2z2m1n2j</pattern>
+<pattern>2z2m1d2ž</pattern>
+<pattern>2z2m1z</pattern>
+<pattern>2z2m1š</pattern>
+<pattern>2z2m1đ</pattern>
+<pattern>2z2m1ć</pattern>
+<pattern>2z2m1č</pattern>
+<pattern>2z2m1ž</pattern>
+<pattern>2š2m1b</pattern>
+<pattern>2š2m1c</pattern>
+<pattern>2š2m1d</pattern>
+<pattern>2š2m1f</pattern>
+<pattern>2š2m1g</pattern>
+<pattern>2š2m1h</pattern>
+<pattern>2š2m1k</pattern>
+<pattern>2š2m1m</pattern>
+<pattern>2š2m1n</pattern>
+<pattern>2š2m1p</pattern>
+<pattern>2š2m1s</pattern>
+<pattern>2š2m1t</pattern>
+<pattern>2š2m1v</pattern>
+<pattern>2š2m1n2j</pattern>
+<pattern>2š2m1d2ž</pattern>
+<pattern>2š2m1z</pattern>
+<pattern>2š2m1š</pattern>
+<pattern>2š2m1đ</pattern>
+<pattern>2š2m1ć</pattern>
+<pattern>2š2m1č</pattern>
+<pattern>2š2m1ž</pattern>
+<pattern>2s2c1b</pattern>
+<pattern>2s2c1c</pattern>
+<pattern>2s2c1d</pattern>
+<pattern>2s2c1f</pattern>
+<pattern>2s2c1g</pattern>
+<pattern>2s2c1h</pattern>
+<pattern>2s2c1k</pattern>
+<pattern>2s2c1l</pattern>
+<pattern>2s2c1m</pattern>
+<pattern>2s2c1n</pattern>
+<pattern>2s2c1p</pattern>
+<pattern>2s2c1l2j</pattern>
+<pattern>2sc2r</pattern>
+<pattern>2s2c1s</pattern>
+<pattern>2s2c1t</pattern>
+<pattern>2s2c1n2j</pattern>
+<pattern>2s2c1d2ž</pattern>
+<pattern>2s2c1z</pattern>
+<pattern>2s2c1š</pattern>
+<pattern>2s2c1đ</pattern>
+<pattern>2s2c1ć</pattern>
+<pattern>2s2c1č</pattern>
+<pattern>2s2c1ž</pattern>
+<pattern>2š2c1b</pattern>
+<pattern>2š2c1c</pattern>
+<pattern>2š2c1d</pattern>
+<pattern>2š2c1f</pattern>
+<pattern>2š2c1g</pattern>
+<pattern>2š2c1h</pattern>
+<pattern>2š2c1k</pattern>
+<pattern>2š2c1l</pattern>
+<pattern>2š2c1m</pattern>
+<pattern>2š2c1n</pattern>
+<pattern>2š2c1p</pattern>
+<pattern>2š2c1l2j</pattern>
+<pattern>2šc2r</pattern>
+<pattern>2š2c1s</pattern>
+<pattern>2š2c1t</pattern>
+<pattern>2š2c1n2j</pattern>
+<pattern>2š2c1d2ž</pattern>
+<pattern>2š2c1z</pattern>
+<pattern>2š2c1š</pattern>
+<pattern>2š2c1đ</pattern>
+<pattern>2š2c1ć</pattern>
+<pattern>2š2c1č</pattern>
+<pattern>2š2c1ž</pattern>
+<pattern>2š2č1b</pattern>
+<pattern>2š2č1c</pattern>
+<pattern>2š2č1d</pattern>
+<pattern>2š2č1f</pattern>
+<pattern>2š2č1g</pattern>
+<pattern>2š2č1h</pattern>
+<pattern>2š2č1j</pattern>
+<pattern>2š2č1k</pattern>
+<pattern>2š2č1l</pattern>
+<pattern>2š2č1m</pattern>
+<pattern>2š2č1n</pattern>
+<pattern>2š2č1p</pattern>
+<pattern>2š2č1l2j</pattern>
+<pattern>2š2č1r</pattern>
+<pattern>2š2č1s</pattern>
+<pattern>2š2č1t</pattern>
+<pattern>2š2č1n2j</pattern>
+<pattern>2š2č1d2ž</pattern>
+<pattern>2š2č1z</pattern>
+<pattern>2š2č1š</pattern>
+<pattern>2š2č1đ</pattern>
+<pattern>2š2č1ć</pattern>
+<pattern>2š2č1č</pattern>
+<pattern>2š2č1ž</pattern>
+<pattern>2h2v1b</pattern>
+<pattern>2h2v1c</pattern>
+<pattern>2h2v1d</pattern>
+<pattern>2h2v1f</pattern>
+<pattern>2h2v1g</pattern>
+<pattern>2h2v1h</pattern>
+<pattern>2h2v1k</pattern>
+<pattern>2h2v1m</pattern>
+<pattern>2h2v1n</pattern>
+<pattern>2h2v1p</pattern>
+<pattern>2h2v1s</pattern>
+<pattern>2h2v1t</pattern>
+<pattern>2h2v1n2j</pattern>
+<pattern>2h2v1d2ž</pattern>
+<pattern>2h2v1z</pattern>
+<pattern>2h2v1š</pattern>
+<pattern>2h2v1đ</pattern>
+<pattern>2h2v1ć</pattern>
+<pattern>2h2v1č</pattern>
+<pattern>2h2v1ž</pattern>
+<pattern>2ž3v2l</pattern>
+<pattern>2ž3v2l2j</pattern>
+<pattern>2c3v2l</pattern>
+<pattern>2c3v2l2j</pattern>
+<pattern>2z3v2l</pattern>
+<pattern>2z3v2l2j</pattern>
+<pattern>2š3v2l</pattern>
+<pattern>2š3v2l2j</pattern>
+<pattern>2č3v2l</pattern>
+<pattern>2č3v2l2j</pattern>
+<pattern>2č3v2j</pattern>
+<pattern>2s3v2l2j</pattern>
+<pattern>sv2l</pattern>
+<pattern>2d3v2l</pattern>
+<pattern>2d3v2l2j</pattern>
+<pattern>2d3v2r</pattern>
+<pattern>2k3v2j</pattern>
+<pattern>2k3v2l</pattern>
+<pattern>2k3v2l2j</pattern>
+<pattern>2t3v2j</pattern>
+<pattern>2t3v2l</pattern>
+<pattern>2t3v2l2j</pattern>
+<pattern>2g3v2j</pattern>
+<pattern>2g3v2l</pattern>
+<pattern>2g3v2l2j</pattern>
+<pattern>2g3v2r</pattern>
+<pattern>2h3v2j</pattern>
+<pattern>2h3v2l</pattern>
+<pattern>2h3v2l2j</pattern>
+<pattern>2h3v2r</pattern>
+<pattern>2ž3m2j</pattern>
+<pattern>2ž3m2l</pattern>
+<pattern>2ž3m2l2j</pattern>
+<pattern>2ž3m2r</pattern>
+<pattern>2z3m2l</pattern>
+<pattern>2z3m2r</pattern>
+<pattern>2š3m2j</pattern>
+<pattern>2š3m2l</pattern>
+<pattern>2š3m2l2j</pattern>
+<pattern>2š3c2j</pattern>
+<pattern>2š3c2v</pattern>
+<pattern>2š3č2v</pattern>
+<pattern>2š3t2j</pattern>
+<pattern>2š3t2l</pattern>
+<pattern>2š3t2l2j</pattern>
+<pattern>2s3t2l</pattern>
+<pattern>2s3k2j</pattern>
+<pattern>2s3k2l2j</pattern>
+<pattern>sk2l</pattern>
+<pattern>2š3p2j</pattern>
+<pattern>2š3p2l</pattern>
+<pattern>2š3p2l2j</pattern>
+<pattern>2ž3d2j</pattern>
+<pattern>2ž3d2l</pattern>
+<pattern>2ž3d2l2j</pattern>
+<pattern>2ž3d2v</pattern>
+<pattern>2ž3g2j</pattern>
+<pattern>2ž3g2l</pattern>
+<pattern>2ž3g2l2j</pattern>
+<pattern>2ž3g2r</pattern>
+<pattern>2ž3g2v</pattern>
+<pattern>2z3d2l</pattern>
+<pattern>2z3d2l2j</pattern>
+<pattern>2z3d2v</pattern>
+<pattern>2z3g2j</pattern>
+<pattern>2z3g2l2j</pattern>
+<pattern>zg2l</pattern>
+<pattern>2ž3b2j</pattern>
+<pattern>2ž3b2l</pattern>
+<pattern>2ž3b2l2j</pattern>
+<pattern>2ž3b2r</pattern>
+<pattern>2z3b2l2j</pattern>
+<pattern>zb2l</pattern>
+<pattern> a4e2r2o1</pattern>
+<pattern> 2a1</pattern>
+<pattern> a3e1</pattern>
+<pattern> be4o1</pattern>
+<pattern> b2e1</pattern>
+<pattern> bi4o1</pattern>
+<pattern> b2i1</pattern>
+<pattern> ge4o1</pattern>
+<pattern> g2e1</pattern>
+<pattern> za3g2n</pattern>
+<pattern> z2a1</pattern>
+<pattern> z2a3t2k2a1</pattern>
+<pattern> za2t1k</pattern>
+<pattern> iza3g2n</pattern>
+<pattern> 2i1</pattern>
+<pattern> iz2a1</pattern>
+<pattern> iza3t2k</pattern>
+<pattern> i2z3g</pattern>
+<pattern> i2z3g2n</pattern>
+<pattern> i2z3d</pattern>
+<pattern> izd2n2o1</pattern>
+<pattern> i2z2d1n</pattern>
+<pattern> izd2n2u1</pattern>
+<pattern> izd2n2a1</pattern>
+<pattern> i2z3r</pattern>
+<pattern> iz2r2k</pattern>
+<pattern> i2s3t</pattern>
+<pattern> i2s2t2k</pattern>
+<pattern> na2g2n</pattern>
+<pattern> n2a1</pattern>
+<pattern> na2g2n2j</pattern>
+<pattern> na3d2nev</pattern>
+<pattern> na2d1n</pattern>
+<pattern> nadn2e1</pattern>
+<pattern> na3d2nič</pattern>
+<pattern> nadn2i1</pattern>
+<pattern> na3d2nic</pattern>
+<pattern> na3t2kah</pattern>
+<pattern> na2t1k</pattern>
+<pattern> n2a1tk2a1</pattern>
+<pattern> na3t2kam</pattern>
+<pattern> na3t2kas2m</pattern>
+<pattern> na3t2kas2t</pattern>
+<pattern> oda3g2n</pattern>
+<pattern> 2o1</pattern>
+<pattern> od2a1</pattern>
+<pattern> oda3d2n</pattern>
+<pattern> od3g2n</pattern>
+<pattern> o2d1g</pattern>
+<pattern> od3m2n</pattern>
+<pattern> o2d1m</pattern>
+<pattern> o3t2kah</pattern>
+<pattern> o2t1k</pattern>
+<pattern> otk2a1</pattern>
+<pattern> o3t2kam</pattern>
+<pattern> o3t2kas2m</pattern>
+<pattern> o3t2kas2t</pattern>
+<pattern> po3g2n</pattern>
+<pattern> p2o1</pattern>
+<pattern> po3d2nev</pattern>
+<pattern> po2d1n</pattern>
+<pattern> podn2e1</pattern>
+<pattern> po3m2n</pattern>
+<pattern> po3m2n2j</pattern>
+<pattern> po3r2v</pattern>
+<pattern> po3r2đ</pattern>
+<pattern> po3t2kah</pattern>
+<pattern> po2t1k</pattern>
+<pattern> potk2a1</pattern>
+<pattern> po3t2kam</pattern>
+<pattern> po3t2kat</pattern>
+<pattern> po3t2kav</pattern>
+<pattern> pred3m2n</pattern>
+<pattern> p2r</pattern>
+<pattern> pr2e1</pattern>
+<pattern> pre2d1m</pattern>
+<pattern> pred3m2n2j</pattern>
+<pattern> pre3t2kah</pattern>
+<pattern> pre2t1k</pattern>
+<pattern> pretk2a1</pattern>
+<pattern> pre3t2kam</pattern>
+<pattern> pre3t2kat</pattern>
+<pattern> pro3g2n</pattern>
+<pattern> pr2o1</pattern>
+<pattern> pro3t2k2i1</pattern>
+<pattern> pro2t1k</pattern>
+<pattern> pro3t2k2a1</pattern>
+<pattern> raza3g2n</pattern>
+<pattern> r2a1</pattern>
+<pattern> r2a1z2a1</pattern>
+<pattern> ra2z3g</pattern>
+<pattern> ra2z3g2n</pattern>
+<pattern> ra2z3d</pattern>
+<pattern> raz3d2n2i1</pattern>
+<pattern> ra2z2d1n</pattern>
+<pattern> r2a1z2a3t2k2a1</pattern>
+<pattern> raza2t1k</pattern>
+<pattern> u3g2m2i1</pattern>
+<pattern> 2u1</pattern>
+<pattern> u2g1m</pattern>
+<pattern> u3g2n</pattern>
+<pattern> uz2a3t2k2a1</pattern>
+<pattern> uz2a1</pattern>
+<pattern> uza2t1k</pattern>
+<pattern>3h2tet2i1</pattern>
+<pattern>ht2e1</pattern>
+<pattern>3h2tjet2i1</pattern>
+<pattern>ht2j</pattern>
+<pattern>htj2e1</pattern>
+<pattern>3h2tel</pattern>
+<pattern>3h2tev</pattern>
+<pattern>3h2ten2j</pattern>
+<pattern>3h2tjel</pattern>
+<pattern>3h2tjev</pattern>
+<pattern>3h2tjen2j</pattern>
+<pattern>3g2degod </pattern>
+<pattern>gd2e1</pattern>
+<pattern>gdeg2o1</pattern>
+<pattern>3g2djegod </pattern>
+<pattern>gd2j</pattern>
+<pattern>gdj2e1</pattern>
+<pattern>gdjeg2o1</pattern>
+<pattern>3g2dekak</pattern>
+<pattern>gdek2a1</pattern>
+<pattern>3g2dekad</pattern>
+<pattern>3g2djekak</pattern>
+<pattern>gdjek2a1</pattern>
+<pattern>3g2djekad</pattern>
+<pattern>ni3g2de </pattern>
+<pattern>n2i1</pattern>
+<pattern>ni2g1d</pattern>
+<pattern>nigd2e1</pattern>
+<pattern>ne3g2de </pattern>
+<pattern>n2e1</pattern>
+<pattern>ne2g1d</pattern>
+<pattern>negd2e1</pattern>
+<pattern>ni3g2dje </pattern>
+<pattern>nigd2j</pattern>
+<pattern>nigdj2e1</pattern>
+<pattern>ne3g2dje </pattern>
+<pattern>negd2j</pattern>
+<pattern>negdj2e1</pattern>
+<pattern>3b2det</pattern>
+<pattern>bd2e1</pattern>
+<pattern>3b2den2j</pattern>
+<pattern>3b2djet</pattern>
+<pattern>bd2j</pattern>
+<pattern>bdj2e1</pattern>
+<pattern>3b2djen2j</pattern>
+<pattern>3g2mil</pattern>
+<pattern>gm2i1</pattern>
+<pattern>3g2mil2j</pattern>
+<pattern>3g2miz</pattern>
+<pattern>3g2nos</pattern>
+<pattern>gn2o1</pattern>
+<pattern>3g2noz</pattern>
+<pattern>3g2noj</pattern>
+<pattern>3g2naj</pattern>
+<pattern>gn2a1</pattern>
+<pattern>3g2nez2d</pattern>
+<pattern>gn2e1</pattern>
+<pattern>3g2nijez2d</pattern>
+<pattern>gn2i1</pattern>
+<pattern>gnij2e1</pattern>
+<pattern>3g2než2đ</pattern>
+<pattern>3g2nijež2đ</pattern>
+<pattern>3g2nev</pattern>
+<pattern>3g2njev</pattern>
+<pattern>gnj2e1</pattern>
+<pattern>3g2njav</pattern>
+<pattern>gnj2a1</pattern>
+<pattern>3g2njes</pattern>
+<pattern>3g2njet</pattern>
+<pattern>3g2nječ</pattern>
+<pattern>3g2njil</pattern>
+<pattern>gnj2i1</pattern>
+<pattern>3g2nji3o1</pattern>
+<pattern>3g2njil2j</pattern>
+<pattern>3g2njit</pattern>
+<pattern>3g2njur</pattern>
+<pattern>gnj2u1</pattern>
+<pattern>3k2nez</pattern>
+<pattern>kn2e1</pattern>
+<pattern>3k2než</pattern>
+<pattern>3k2njiž</pattern>
+<pattern>knj2i1</pattern>
+<pattern>3k2njig</pattern>
+<pattern>3m2nož</pattern>
+<pattern>mn2o1</pattern>
+<pattern>3m2nog</pattern>
+<pattern>3m2naž</pattern>
+<pattern>mn2a1</pattern>
+<pattern>3p2sik</pattern>
+<pattern>ps2i1</pattern>
+<pattern>3p2sič</pattern>
+<pattern>3p2sov</pattern>
+<pattern>ps2o1</pattern>
+<pattern>3p2suj</pattern>
+<pattern>ps2u1</pattern>
+<pattern>3r2đ2a1</pattern>
+<pattern>3s2fer</pattern>
+<pattern>sf2e1</pattern>
+<pattern>3t2mas2t</pattern>
+<pattern>tm2a1</pattern>
+<pattern>3t2mul</pattern>
+<pattern>tm2u1</pattern>
+<pattern>3t2mu3o1</pattern>
+<pattern>3t2mul2j</pattern>
+<pattern>3t2mur</pattern>
+<pattern>3c2miz</pattern>
+<pattern>cm2i1</pattern>
+<pattern>3c2mak</pattern>
+<pattern>cm2a1</pattern>
+<pattern>3c2mač</pattern>
+<pattern>3c2mok</pattern>
+<pattern>cm2o1</pattern>
+<pattern>3č2lan</pattern>
+<pattern>čl2a1</pattern>
+<pattern>3č2lan2j</pattern>
+<pattern>3r2j2e1</pattern>
+<pattern>4r3jem</pattern>
+<pattern>4r3je </pattern>
+<pattern> be2z3j</pattern>
+<pattern> be2z3l</pattern>
+<pattern> be2z3m</pattern>
+<pattern> be2z3n</pattern>
+<pattern> be2z3l2j</pattern>
+<pattern> be2z3r</pattern>
+<pattern> be2z3v</pattern>
+<pattern> be2z3n2j</pattern>
+<pattern> be2z3b</pattern>
+<pattern> be2z3d</pattern>
+<pattern> be2z3g</pattern>
+<pattern> be2z3i1</pattern>
+<pattern> be2z3o1</pattern>
+<pattern> be2z3u1</pattern>
+<pattern> be2z3alkohol</pattern>
+<pattern> bez2a1</pattern>
+<pattern> beza2l1k</pattern>
+<pattern> bezalk2o1</pattern>
+<pattern> bezalkoh2o1</pattern>
+<pattern> be2z3atoms2k</pattern>
+<pattern> bezat2o1</pattern>
+<pattern> bezato2m1s</pattern>
+<pattern> be3z4be2d1n</pattern>
+<pattern> b2e1zb2e1</pattern>
+<pattern> be3z4bed2a1</pattern>
+<pattern> be3z4bje2d1n</pattern>
+<pattern> bezb2j</pattern>
+<pattern> b2e1zbj2e1</pattern>
+<pattern> be3z4bjed2a1</pattern>
+<pattern> be3z4bel2i1</pattern>
+<pattern> be3z4bol</pattern>
+<pattern> bezb2o1</pattern>
+<pattern> be3z4vu2č1n</pattern>
+<pattern> bezv2u1</pattern>
+<pattern> be3z4vuč2a1</pattern>
+<pattern> be3z4istan</pattern>
+<pattern> bezis2t</pattern>
+<pattern> bezist2a1</pattern>
+<pattern> be3z4isten</pattern>
+<pattern> bezist2e1</pattern>
+<pattern> be3z4jak</pattern>
+<pattern> bezj2a1</pattern>
+<pattern> be3z4jač</pattern>
+<pattern> be3z4lo2b1n</pattern>
+<pattern> bezl2o1</pattern>
+<pattern> be3z4lob2a1</pattern>
+<pattern> be3z4načaj</pattern>
+<pattern> bezn2a1</pattern>
+<pattern> beznač2a1</pattern>
+<pattern> be3z4ra2č1n</pattern>
+<pattern> bezr2a1</pattern>
+<pattern> be3z4r2a1č2a1</pattern>
+<pattern> be3z4up</pattern>
+<pattern> be3z4ub</pattern>
+<pattern> be2s3c</pattern>
+<pattern> be2s3k</pattern>
+<pattern> be2s3p</pattern>
+<pattern> be2s3t</pattern>
+<pattern> be3s4krupul</pattern>
+<pattern> besk2r</pattern>
+<pattern> beskr2u1</pattern>
+<pattern> beskrup2u1</pattern>
+<pattern> be3s4poko2j1n</pattern>
+<pattern> besp2o1</pattern>
+<pattern> besp2o1k2o1</pattern>
+<pattern> be3s4pokoj2a1</pattern>
+<pattern> be3s4po2r1n</pattern>
+<pattern> be3s4por2a1</pattern>
+<pattern> be3s4tvar</pattern>
+<pattern> best2v</pattern>
+<pattern> bestv2a1</pattern>
+<pattern> be3s4tid</pattern>
+<pattern> best2i1</pattern>
+<pattern> be3s4tij2a1</pattern>
+<pattern> be3s4til2u1</pattern>
+<pattern> be3s4til2j</pattern>
+<pattern> be3s4tr2a1n2a1</pattern>
+<pattern> best2r</pattern>
+<pattern> bestr2a1</pattern>
+<pattern> be3s4tras</pattern>
+<pattern> bes4tseler</pattern>
+<pattern> be2s2t1s</pattern>
+<pattern> bests2e1</pattern>
+<pattern> bestsel2e1</pattern>
+<pattern> be2š3ć</pattern>
+<pattern> be2š3č</pattern>
+<pattern> va2n3ev2r</pattern>
+<pattern> v2a1</pattern>
+<pattern> van2e1</pattern>
+<pattern> va2n3ustav</pattern>
+<pattern> van2u1</pattern>
+<pattern> vanus2t</pattern>
+<pattern> vanust2a1</pattern>
+<pattern> i2z3b</pattern>
+<pattern> i2z3j</pattern>
+<pattern> i2z3l</pattern>
+<pattern> i2z3m</pattern>
+<pattern> i2z3n</pattern>
+<pattern> i2z3l2j</pattern>
+<pattern> i2z3v</pattern>
+<pattern> i2z3n2j</pattern>
+<pattern> 2i2z3i1</pattern>
+<pattern> i2z3o1</pattern>
+<pattern> i2z3u1</pattern>
+<pattern> i2z3bij2a1</pattern>
+<pattern> 2i1zb2i1</pattern>
+<pattern> i2z3biv2a1</pattern>
+<pattern> 2i2z3ved2i1</pattern>
+<pattern> izv2e1</pattern>
+<pattern> i2z3ve2d1n</pattern>
+<pattern> i2z3ve2d1b</pattern>
+<pattern> i2z3v2e1d2e1</pattern>
+<pattern> i2z3daj</pattern>
+<pattern> izd2a1</pattern>
+<pattern> i2z3a1b2a1</pattern>
+<pattern> i2z3a1k2a1</pattern>
+<pattern> i2z3anal</pattern>
+<pattern> izan2a1</pattern>
+<pattern> i3z4bav</pattern>
+<pattern> izb2a1</pattern>
+<pattern> i3z4bičk2a1v2a1</pattern>
+<pattern> izbi2č1k</pattern>
+<pattern> izbičk2a1</pattern>
+<pattern> i3z4bleušan</pattern>
+<pattern> izb2l</pattern>
+<pattern> izbl2e1</pattern>
+<pattern> izble3u1</pattern>
+<pattern> izbleuš2a1</pattern>
+<pattern> i3z4bojak</pattern>
+<pattern> izb2o1</pattern>
+<pattern> izboj2a1</pattern>
+<pattern> i3z4bo2j1k</pattern>
+<pattern> 2i3z4val2i1</pattern>
+<pattern> izv2a1</pattern>
+<pattern> i3z4val2u1</pattern>
+<pattern> i3z4v2a1l2a1</pattern>
+<pattern> i3z4val2e1</pattern>
+<pattern> 2i3z4valj2i1</pattern>
+<pattern> izval2j</pattern>
+<pattern> i3z4viž2d</pattern>
+<pattern> 2i1zv2i1</pattern>
+<pattern> i3z4viisk2r</pattern>
+<pattern> 2i1zv2i3i1</pattern>
+<pattern> izviis2k</pattern>
+<pattern> i3z4vij2a1</pattern>
+<pattern> i3z4vijen</pattern>
+<pattern> izvij2e1</pattern>
+<pattern> i3z4vin</pattern>
+<pattern> i3z4vir</pattern>
+<pattern> i3z4vin2j</pattern>
+<pattern> i3z4vitop</pattern>
+<pattern> izvit2o1</pattern>
+<pattern> i3z4vjed</pattern>
+<pattern> izv2j</pattern>
+<pattern> izvj2e1</pattern>
+<pattern> i3z4vojac</pattern>
+<pattern> izv2o1</pattern>
+<pattern> izvoj2a1</pattern>
+<pattern> i3z4vo2j1c</pattern>
+<pattern> i3z4vor</pattern>
+<pattern> i3z4gomet</pattern>
+<pattern> izg2o1</pattern>
+<pattern> izgom2e1</pattern>
+<pattern> i3z4gred</pattern>
+<pattern> izg2r</pattern>
+<pattern> izgr2e1</pattern>
+<pattern> i3z4g2r1n</pattern>
+<pattern> i3z4g2r1t</pattern>
+<pattern> i3z4drav</pattern>
+<pattern> izd2r</pattern>
+<pattern> izdr2a1</pattern>
+<pattern> i3z4iđ</pattern>
+<pattern> i3z4id</pattern>
+<pattern> 2i3z4i1m2i1</pattern>
+<pattern> i3z4jež2l2j</pattern>
+<pattern> izj2e1</pattern>
+<pattern> izjež2l</pattern>
+<pattern> i3z4loz</pattern>
+<pattern> izl2o1</pattern>
+<pattern> i3z4lož</pattern>
+<pattern> i3z4log</pattern>
+<pattern> i3z4lopać</pattern>
+<pattern> izlop2a1</pattern>
+<pattern> i3z4nim</pattern>
+<pattern> izn2i1</pattern>
+<pattern> i3z4noj</pattern>
+<pattern> izn2o1</pattern>
+<pattern> iz4oanem</pattern>
+<pattern> izo3a1</pattern>
+<pattern> izoan2e1</pattern>
+<pattern> iz4oanom</pattern>
+<pattern> izoan2o1</pattern>
+<pattern> iz4obat</pattern>
+<pattern> izob2a1</pattern>
+<pattern> iz4obron</pattern>
+<pattern> izob2r</pattern>
+<pattern> izobr2o1</pattern>
+<pattern> iz4ogam</pattern>
+<pattern> izog2a1</pattern>
+<pattern> iz4o1ge3o1</pattern>
+<pattern> izog2e1</pattern>
+<pattern> iz4oglos</pattern>
+<pattern> izog2l</pattern>
+<pattern> izogl2o1</pattern>
+<pattern> iz4ogon</pattern>
+<pattern> izog2o1</pattern>
+<pattern> iz4ograf</pattern>
+<pattern> izog2r</pattern>
+<pattern> izogr2a1</pattern>
+<pattern> iz4odim</pattern>
+<pattern> 2i1zod2i1</pattern>
+<pattern> iz4odin</pattern>
+<pattern> iz4odoz</pattern>
+<pattern> izod2o1</pattern>
+<pattern> iz4oklin</pattern>
+<pattern> izok2l</pattern>
+<pattern> izokl2i1</pattern>
+<pattern> iz4okolon</pattern>
+<pattern> izok2o1</pattern>
+<pattern> izokol2o1</pattern>
+<pattern> i3z4olat</pattern>
+<pattern> izol2a1</pattern>
+<pattern> i3z4olac</pattern>
+<pattern> i3z4olir</pattern>
+<pattern> izol2i1</pattern>
+<pattern> i3z4olov</pattern>
+<pattern> izol2o1</pattern>
+<pattern> iz4ole2k1s</pattern>
+<pattern> izol2e1</pattern>
+<pattern> iz4olu2k1s</pattern>
+<pattern> izol2u1</pattern>
+<pattern> iz4omer</pattern>
+<pattern> izom2e1</pattern>
+<pattern> iz4omet2r</pattern>
+<pattern> iz4omo2r1f</pattern>
+<pattern> izom2o1</pattern>
+<pattern> iz4onef</pattern>
+<pattern> izon2e1</pattern>
+<pattern> iz4onom</pattern>
+<pattern> izon2o1</pattern>
+<pattern> iz4opat</pattern>
+<pattern> izop2a1</pattern>
+<pattern> iz4oper</pattern>
+<pattern> izop2e1</pattern>
+<pattern> iz4opl2e1</pattern>
+<pattern> izop2l</pattern>
+<pattern> iz4opol</pattern>
+<pattern> izop2o1</pattern>
+<pattern> iz4opsef</pattern>
+<pattern> izo2p1s</pattern>
+<pattern> izops2e1</pattern>
+<pattern> iz4orah</pattern>
+<pattern> izor2a1</pattern>
+<pattern> 2i1z4ose3i1</pattern>
+<pattern> izos2e1</pattern>
+<pattern> iz4osi2n1t</pattern>
+<pattern> 2i1zos2i1</pattern>
+<pattern> iz4osis2t</pattern>
+<pattern> iz4oskel</pattern>
+<pattern> izos2k</pattern>
+<pattern> izosk2e1</pattern>
+<pattern> iz4oskop</pattern>
+<pattern> izosk2o1</pattern>
+<pattern> iz4ostaz</pattern>
+<pattern> izos2t</pattern>
+<pattern> izost2a1</pattern>
+<pattern> iz4ost2e1</pattern>
+<pattern> iz4otah</pattern>
+<pattern> izot2a1</pattern>
+<pattern> iz4otal</pattern>
+<pattern> iz4oter</pattern>
+<pattern> izot2e1</pattern>
+<pattern> iz4oton</pattern>
+<pattern> iz2o1t2o1</pattern>
+<pattern> iz4otop</pattern>
+<pattern> iz4o1tr2o1</pattern>
+<pattern> izot2r</pattern>
+<pattern> iz4ofon</pattern>
+<pattern> iz2o1f2o1</pattern>
+<pattern> iz4ofot</pattern>
+<pattern> iz4ohal</pattern>
+<pattern> izoh2a1</pattern>
+<pattern> iz4ohaz</pattern>
+<pattern> iz4ohel</pattern>
+<pattern> izoh2e1</pattern>
+<pattern> iz4ohij</pattern>
+<pattern> 2i1zoh2i1</pattern>
+<pattern> iz4ohim</pattern>
+<pattern> iz4ohit</pattern>
+<pattern> iz4ohi2p1s</pattern>
+<pattern> iz4ohor</pattern>
+<pattern> izoh2o1</pattern>
+<pattern> iz4o1hr2o1</pattern>
+<pattern> izoh2r</pattern>
+<pattern> i3z4rael</pattern>
+<pattern> izr2a1</pattern>
+<pattern> izra3e1</pattern>
+<pattern> i3z4rail2j</pattern>
+<pattern> 2i1zra3i1</pattern>
+<pattern> 2i3z4rač2i1</pattern>
+<pattern> i3z4un</pattern>
+<pattern> i3z4u2p1č</pattern>
+<pattern> i2s3c</pattern>
+<pattern> i2s3k</pattern>
+<pattern> i2s3p</pattern>
+<pattern> i3s4kak</pattern>
+<pattern> isk2a1</pattern>
+<pattern> i3s4kat</pattern>
+<pattern> i3s4kan2j</pattern>
+<pattern> i3s4kariot</pattern>
+<pattern> iskar2i1</pattern>
+<pattern> iskari3o1</pattern>
+<pattern> i3s4kvas</pattern>
+<pattern> isk2v</pattern>
+<pattern> iskv2a1</pattern>
+<pattern> i3s4kv2r1č</pattern>
+<pattern> iskv2r</pattern>
+<pattern> i3s4kin</pattern>
+<pattern> 2i1sk2i1</pattern>
+<pattern> i3s4kit2a1</pattern>
+<pattern> i3s4kons2k</pattern>
+<pattern> isk2o1</pattern>
+<pattern> isko2n1s</pattern>
+<pattern> i3s4koč</pattern>
+<pattern> i3s4kram</pattern>
+<pattern> isk2r</pattern>
+<pattern> iskr2a1</pattern>
+<pattern> i3s4krit</pattern>
+<pattern> 2i1skr2i1</pattern>
+<pattern> i3s4kriš</pattern>
+<pattern> i3s4krič</pattern>
+<pattern> i3s4kric</pattern>
+<pattern> i3s4krat</pattern>
+<pattern> i3s4kren</pattern>
+<pattern> iskr2e1</pattern>
+<pattern> i3s4kren2j</pattern>
+<pattern> i3s4kroj</pattern>
+<pattern> iskr2o1</pattern>
+<pattern> i3s4krs2n</pattern>
+<pattern> isk2r1s</pattern>
+<pattern> i3s4krs2a1</pattern>
+<pattern> i3s4kuplj2a1</pattern>
+<pattern> isk2u1</pattern>
+<pattern> iskup2l</pattern>
+<pattern> iskup2l2j</pattern>
+<pattern> i3s4lam</pattern>
+<pattern> is2l</pattern>
+<pattern> isl2a1</pattern>
+<pattern> i3s4lab</pattern>
+<pattern> i3s4leđ</pattern>
+<pattern> isl2e1</pattern>
+<pattern> i3s4led</pattern>
+<pattern> i3s4lijeđ</pattern>
+<pattern> 2i1sl2i1</pattern>
+<pattern> islij2e1</pattern>
+<pattern> i3s4lijed</pattern>
+<pattern> i3s4ljeđ</pattern>
+<pattern> is2l2j</pattern>
+<pattern> islj2e1</pattern>
+<pattern> i3s4ljed</pattern>
+<pattern> i3s4lik</pattern>
+<pattern> i3s4lin</pattern>
+<pattern> i3s4lov</pattern>
+<pattern> isl2o1</pattern>
+<pattern> i3s4luš</pattern>
+<pattern> isl2u1</pattern>
+<pattern> i3s4luž</pattern>
+<pattern> i3s4m2e1</pattern>
+<pattern> is2m</pattern>
+<pattern> i3s4mij2e1</pattern>
+<pattern> ism2i1</pattern>
+<pattern> i3s4mj2e1</pattern>
+<pattern> ism2j</pattern>
+<pattern> i3s4pav</pattern>
+<pattern> isp2a1</pattern>
+<pattern> i3s4paljiv</pattern>
+<pattern> ispal2j</pattern>
+<pattern> ispalj2i1</pattern>
+<pattern> i3s4pir2a1</pattern>
+<pattern> isp2i1</pattern>
+<pattern> i3s4plit</pattern>
+<pattern> isp2l</pattern>
+<pattern> 2i1spl2i1</pattern>
+<pattern> i3s4plić</pattern>
+<pattern> i3s4pokoj</pattern>
+<pattern> isp2o1</pattern>
+<pattern> ispok2o1</pattern>
+<pattern> i3s4polin</pattern>
+<pattern> ispol2i1</pattern>
+<pattern> i3s4pon</pattern>
+<pattern> i3s4porav</pattern>
+<pattern> ispor2a1</pattern>
+<pattern> 2i3s4prav2i1</pattern>
+<pattern> isp2r</pattern>
+<pattern> ispr2a1</pattern>
+<pattern> i3s4pra2v1k</pattern>
+<pattern> i3s4pra2v1n</pattern>
+<pattern> i3s4prav2l2j</pattern>
+<pattern> isprav2l</pattern>
+<pattern> i3s4pr2a1v2a1</pattern>
+<pattern> i3s4pu2p1č</pattern>
+<pattern> isp2u1</pattern>
+<pattern> i3s4pur</pattern>
+<pattern> i3s4red</pattern>
+<pattern> is2r</pattern>
+<pattern> isr2e1</pattern>
+<pattern> i3s4r1k</pattern>
+<pattern> 2i3s4tav2i1</pattern>
+<pattern> ist2a1</pattern>
+<pattern> i3s4tav2l2j</pattern>
+<pattern> istav2l</pattern>
+<pattern> i3s4ta2k1n</pattern>
+<pattern> i3s4tam</pattern>
+<pattern> i3s4tar</pattern>
+<pattern> i3s4tas</pattern>
+<pattern> i3s4tać</pattern>
+<pattern> i3s4tin</pattern>
+<pattern> 2i1st2i1</pattern>
+<pattern> i3s4tir</pattern>
+<pattern> i3s4tic</pattern>
+<pattern> i3s4tifan</pattern>
+<pattern> istif2a1</pattern>
+<pattern> i3s4tok</pattern>
+<pattern> ist2o1</pattern>
+<pattern> 2i3s4tor2i1</pattern>
+<pattern> i3s4to2č1n</pattern>
+<pattern> i3s4to2č1n2j</pattern>
+<pattern> i3s4toč2a1</pattern>
+<pattern> i3s4trav</pattern>
+<pattern> ist2r</pattern>
+<pattern> istr2a1</pattern>
+<pattern> i3s4trad</pattern>
+<pattern> i3s4tran</pattern>
+<pattern> i3s4trić</pattern>
+<pattern> 2i1str2i1</pattern>
+<pattern> i3s4triž</pattern>
+<pattern> i3s4tric</pattern>
+<pattern> i3s4trug</pattern>
+<pattern> istr2u1</pattern>
+<pattern> i3s4tup</pattern>
+<pattern> ist2u1</pattern>
+<pattern> i3s4uk</pattern>
+<pattern> is2u1</pattern>
+<pattern> i3s4us</pattern>
+<pattern> i3s4ut</pattern>
+<pattern> i3s4uš</pattern>
+<pattern> i2ž3đ</pattern>
+<pattern> i2š3ć</pattern>
+<pattern> i2š3č</pattern>
+<pattern> iz3be2z3ob2r</pattern>
+<pattern> izb2e1</pattern>
+<pattern> izbez2o1</pattern>
+<pattern> iz3be2z3um</pattern>
+<pattern> izbez2u1</pattern>
+<pattern> iz3va2n3ev2r</pattern>
+<pattern> izvan2e1</pattern>
+<pattern> na2d3l</pattern>
+<pattern> na2d3l2j</pattern>
+<pattern> na2d3v</pattern>
+<pattern> na3d4val</pattern>
+<pattern> nadv2a1</pattern>
+<pattern> na3d4ves2i1</pattern>
+<pattern> nadv2e1</pattern>
+<pattern> na3d4ves2t</pattern>
+<pattern> na3d4vij</pattern>
+<pattern> nadv2i1</pattern>
+<pattern> na3d4vit</pattern>
+<pattern> n2a3d4vl2a1</pattern>
+<pattern> na2d3v2l</pattern>
+<pattern> na3d4voj2e1</pattern>
+<pattern> nadv2o1</pattern>
+<pattern> na3d4vor</pattern>
+<pattern> na2d3ig2r</pattern>
+<pattern> nad2i1</pattern>
+<pattern> na2d3i2n1ž</pattern>
+<pattern> n2a2d3in2a1</pattern>
+<pattern> na2d3is2k</pattern>
+<pattern> na2d3jah</pattern>
+<pattern> nad2j</pattern>
+<pattern> n2a1dj2a1</pattern>
+<pattern> na2d3jač</pattern>
+<pattern> na2d3jek</pattern>
+<pattern> nadj2e1</pattern>
+<pattern> na2d3jez</pattern>
+<pattern> na2d3ječ</pattern>
+<pattern> na2d3jun</pattern>
+<pattern> nadj2u1</pattern>
+<pattern> na3d4lan</pattern>
+<pattern> nadl2a1</pattern>
+<pattern> na3d4leš</pattern>
+<pattern> nadl2e1</pattern>
+<pattern> na3d4lež</pattern>
+<pattern> n2a2d3or2a1</pattern>
+<pattern> nad2o1</pattern>
+<pattern> na2d3o1s2o1</pattern>
+<pattern> na2d3os2e1</pattern>
+<pattern> na2d3osj2e1</pattern>
+<pattern> nados2j</pattern>
+<pattern> na2d3of2i1</pattern>
+<pattern> na2d3oč</pattern>
+<pattern> na2d3ran</pattern>
+<pattern> nad2r</pattern>
+<pattern> n2a1dr2a1</pattern>
+<pattern> na2d3rač</pattern>
+<pattern> na2d3ras2t</pattern>
+<pattern> na2d3raš2ć</pattern>
+<pattern> na2d3real</pattern>
+<pattern> nadr2e1</pattern>
+<pattern> n2a1dre3a1</pattern>
+<pattern> na2d3rep</pattern>
+<pattern> na2d3ruk</pattern>
+<pattern> nadr2u1</pattern>
+<pattern> na2d3ruč</pattern>
+<pattern> na2d3rug</pattern>
+<pattern> na2d3udar</pattern>
+<pattern> nad2u1</pattern>
+<pattern> nadud2a1</pattern>
+<pattern> na2d3um</pattern>
+<pattern> na2d3uč</pattern>
+<pattern> n2a2j3a1</pattern>
+<pattern> na2j3e1</pattern>
+<pattern> na2j3i1</pattern>
+<pattern> na2j3o1</pattern>
+<pattern> na2j3u1</pattern>
+<pattern> na3j4av2i1</pattern>
+<pattern> na3j4av2l2j</pattern>
+<pattern> najav2l</pattern>
+<pattern> n2a3j4a1v2a1</pattern>
+<pattern> na3j4av2e1</pattern>
+<pattern> na3j4ad2i1</pattern>
+<pattern> n2a3j4a1d2a1</pattern>
+<pattern> na3j4ad2e1</pattern>
+<pattern> na3j4až2i1</pattern>
+<pattern> na3j4az2i1</pattern>
+<pattern> na3j4ak2o1</pattern>
+<pattern> n2a3j4a1k2a1</pattern>
+<pattern> na3j4al2o1</pattern>
+<pattern> na3j4am2i1</pattern>
+<pattern> na3j4am2l</pattern>
+<pattern> na3j4a2m1n</pattern>
+<pattern> na3j4ar2i1</pattern>
+<pattern> na3j4a2r1m</pattern>
+<pattern> na3j4a2r1c</pattern>
+<pattern> na3j4at2i1</pattern>
+<pattern> na3j4auk</pattern>
+<pattern> naja3u1</pattern>
+<pattern> na3j4ah</pattern>
+<pattern> na3j4aš</pattern>
+<pattern> na3j4ed2i1</pattern>
+<pattern> na3j4e2d1n</pattern>
+<pattern> na3j4ed2r</pattern>
+<pattern> n2a3j4ed2a1</pattern>
+<pattern> na3j4ež2i1</pattern>
+<pattern> na3j4ež2u1</pattern>
+<pattern> na3j4e1ž2e1</pattern>
+<pattern> na3j4ez2n</pattern>
+<pattern> na3j4ez2d</pattern>
+<pattern> na3j4est2i1</pattern>
+<pattern> najes2t</pattern>
+<pattern> na3j4e2t1k</pattern>
+<pattern> na3j4ec</pattern>
+<pattern> na3j4ur2i1</pattern>
+<pattern> na3j4uren</pattern>
+<pattern> najur2e1</pattern>
+<pattern> o2b3j</pattern>
+<pattern> o2b3l2j</pattern>
+<pattern> ob2l</pattern>
+<pattern> o2b3r</pattern>
+<pattern> obe2z3b</pattern>
+<pattern> ob2e1</pattern>
+<pattern> obe2z3d</pattern>
+<pattern> obe2z3g</pattern>
+<pattern> obe2z3j</pattern>
+<pattern> obe2z3l</pattern>
+<pattern> obe2z3m</pattern>
+<pattern> obe2z3n</pattern>
+<pattern> 2o1be2z3o1</pattern>
+<pattern> obe2z3l2j</pattern>
+<pattern> obe2z3r</pattern>
+<pattern> obe2z3u1</pattern>
+<pattern> obe2z3v</pattern>
+<pattern> obe3z4vij</pattern>
+<pattern> obezv2i1</pattern>
+<pattern> obe3z4nan</pattern>
+<pattern> obezn2a1</pattern>
+<pattern> obe3z4nan2j</pattern>
+<pattern> obe3z4nač</pattern>
+<pattern> obe3z4ub</pattern>
+<pattern> obe2s3c</pattern>
+<pattern> obe2s3k</pattern>
+<pattern> obe2s3p</pattern>
+<pattern> obe2s3t</pattern>
+<pattern> obe3s4tan</pattern>
+<pattern> obest2a1</pattern>
+<pattern> obe3s4tij</pattern>
+<pattern> obest2i1</pattern>
+<pattern> obe3s4tran</pattern>
+<pattern> obest2r</pattern>
+<pattern> obestr2a1</pattern>
+<pattern> obe2š3ć</pattern>
+<pattern> obe2š3č</pattern>
+<pattern> o2b3ig2r</pattern>
+<pattern> ob2i1</pattern>
+<pattern> o2b3istin</pattern>
+<pattern> obis2t</pattern>
+<pattern> ob2i1st2i1</pattern>
+<pattern> o2b3istin2j</pattern>
+<pattern> o3b4jek</pattern>
+<pattern> obj2e1</pattern>
+<pattern> o3b4jer</pattern>
+<pattern> o3b4jes2i1</pattern>
+<pattern> o3b4jet</pattern>
+<pattern> o3b4ješ</pattern>
+<pattern> o2b3laj</pattern>
+<pattern> obl2a1</pattern>
+<pattern> o2b3lam</pattern>
+<pattern> o2b3la2k1š</pattern>
+<pattern> o2b3las2k</pattern>
+<pattern> o2b3lep</pattern>
+<pattern> obl2e1</pattern>
+<pattern> o2b3let</pattern>
+<pattern> o2b3leć</pattern>
+<pattern> o2b3lež</pattern>
+<pattern> o2b3leg</pattern>
+<pattern> o2b3lijep</pattern>
+<pattern> obl2i1</pattern>
+<pattern> oblij2e1</pattern>
+<pattern> o2b3lijet</pattern>
+<pattern> o2b3lijež</pattern>
+<pattern> o2b3lijeg</pattern>
+<pattern> o2b3leden</pattern>
+<pattern> obled2e1</pattern>
+<pattern> o2b3liv</pattern>
+<pattern> o2b3lizat</pattern>
+<pattern> obliz2a1</pattern>
+<pattern> o2b3lizav</pattern>
+<pattern> o2b3l2i1z2i1</pattern>
+<pattern> o2b3lis2t</pattern>
+<pattern> o2b3lok2a1</pattern>
+<pattern> obl2o1</pattern>
+<pattern> o2b3luk</pattern>
+<pattern> obl2u1</pattern>
+<pattern> o2b3luč</pattern>
+<pattern> o3b4ljan</pattern>
+<pattern> oblj2a1</pattern>
+<pattern> o3b4ljut</pattern>
+<pattern> oblj2u1</pattern>
+<pattern> o3b4ljuz</pattern>
+<pattern> o2b3or2u1</pattern>
+<pattern> ob2o1</pattern>
+<pattern> o3b4raž2e1</pattern>
+<pattern> obr2a1</pattern>
+<pattern> o3b4raz2i1</pattern>
+<pattern> o3b4raz2n</pattern>
+<pattern> 2o3b4raz2o1</pattern>
+<pattern> o3b4raz2u1</pattern>
+<pattern> o3b4r2a1z2a1</pattern>
+<pattern> o3b4raz2d</pattern>
+<pattern> o3b4ra2m1b</pattern>
+<pattern> o3b4ran</pattern>
+<pattern> o3b4ran2j</pattern>
+<pattern> o3b4rat</pattern>
+<pattern> o3b4rać</pattern>
+<pattern> o3b4raš2n</pattern>
+<pattern> o3b4raš2č</pattern>
+<pattern> o3b4r1v</pattern>
+<pattern> o3b4r1đ</pattern>
+<pattern> o3b4rem</pattern>
+<pattern> obr2e1</pattern>
+<pattern> o3b4res</pattern>
+<pattern> o3b4ređ</pattern>
+<pattern> o3b4reč</pattern>
+<pattern> o3b4rež</pattern>
+<pattern> o3b4rec</pattern>
+<pattern> o3b4red</pattern>
+<pattern> o3b4ret2i1</pattern>
+<pattern> o3b4re2t1n</pattern>
+<pattern> o3b4rij</pattern>
+<pattern> obr2i1</pattern>
+<pattern> o3b4ris</pattern>
+<pattern> o3b4rit</pattern>
+<pattern> o3b4riv</pattern>
+<pattern> o3b4rič</pattern>
+<pattern> o3b4ric</pattern>
+<pattern> o3b4r1k</pattern>
+<pattern> o3b4r1l</pattern>
+<pattern> o3b4r1n</pattern>
+<pattern> o3b4r1l2j</pattern>
+<pattern> o3b4r1s</pattern>
+<pattern> o3b4r1t</pattern>
+<pattern> o3b4r1š</pattern>
+<pattern> o3b4r1č</pattern>
+<pattern> o3b4rok</pattern>
+<pattern> 2o1br2o1</pattern>
+<pattern> o3b4ron</pattern>
+<pattern> o3b4ron2j</pattern>
+<pattern> o3b4roć</pattern>
+<pattern> o3b4roč</pattern>
+<pattern> o3b4rov2a1</pattern>
+<pattern> o3b4ro2v1c</pattern>
+<pattern> o3b4ruk</pattern>
+<pattern> obr2u1</pattern>
+<pattern> o3b4run</pattern>
+<pattern> o3b4rus</pattern>
+<pattern> o3b4run2j</pattern>
+<pattern> o3b4ruš</pattern>
+<pattern> o3b4ruč</pattern>
+<pattern> o2b3ubož</pattern>
+<pattern> ob2u1</pattern>
+<pattern> obub2o1</pattern>
+<pattern> o2b3uz</pattern>
+<pattern> o2b3už</pattern>
+<pattern> o2b3ud</pattern>
+<pattern> o2b3um2i1</pattern>
+<pattern> o2b3um2j</pattern>
+<pattern> o2b3um2r</pattern>
+<pattern> o2b3um2e1</pattern>
+<pattern> o2d3j</pattern>
+<pattern> o2d3l</pattern>
+<pattern> o2d3l2j</pattern>
+<pattern> o2d3r</pattern>
+<pattern> o2d3v</pattern>
+<pattern> o2d3a2r1g</pattern>
+<pattern> o3d4vaj</pattern>
+<pattern> odv2a1</pattern>
+<pattern> o3d4važ</pattern>
+<pattern> o3d4ves2n</pattern>
+<pattern> odv2e1</pattern>
+<pattern> o3d4ves2t</pattern>
+<pattern> o3d4ves2a1</pattern>
+<pattern> o3d4vikav</pattern>
+<pattern> odv2i1</pattern>
+<pattern> odvik2a1</pattern>
+<pattern> o3d4vi2k1n</pattern>
+<pattern> o3d4vis</pattern>
+<pattern> o3d4vić</pattern>
+<pattern> o3d4voj</pattern>
+<pattern> odv2o1</pattern>
+<pattern> o2d3ig2r</pattern>
+<pattern> od2i1</pattern>
+<pattern> o2d3i2z3v</pattern>
+<pattern> o2d3i2z3d</pattern>
+<pattern> o2d3is2k</pattern>
+<pattern> o2d3i1st2i1</pattern>
+<pattern> odis2t</pattern>
+<pattern> o3d4jel</pattern>
+<pattern> odj2e1</pattern>
+<pattern> o3d4jen</pattern>
+<pattern> o3d4jev</pattern>
+<pattern> o3d4jeć</pattern>
+<pattern> o3d4laz</pattern>
+<pattern> odl2a1</pattern>
+<pattern> o3d4laž</pattern>
+<pattern> o3d4lag</pattern>
+<pattern> o3d4l2a1k2a1</pattern>
+<pattern> o3d4luk</pattern>
+<pattern> odl2u1</pattern>
+<pattern> o3d4luč</pattern>
+<pattern> o2d3oz2d</pattern>
+<pattern> 2o1d2o1</pattern>
+<pattern> o2d3oz2g</pattern>
+<pattern> o2d3ok</pattern>
+<pattern> o2d3o2n1l</pattern>
+<pattern> 2o2d3o1n2o1</pattern>
+<pattern> o2d3on2u1</pattern>
+<pattern> o2d3o2n1d</pattern>
+<pattern> o3d4ran2i1</pattern>
+<pattern> odr2a1</pattern>
+<pattern> 2o3d4ran2o1</pattern>
+<pattern> o3d4ran2u1</pattern>
+<pattern> o3d4r2a1n2a1</pattern>
+<pattern> o3d4ran2e1</pattern>
+<pattern> o3d4raz</pattern>
+<pattern> o3d4rać</pattern>
+<pattern> o3d4raž</pattern>
+<pattern> o3d4rap2i1</pattern>
+<pattern> o3d4rap2l2j</pattern>
+<pattern> odrap2l</pattern>
+<pattern> o3d4r2a1p2a1</pattern>
+<pattern> o3d4rač2i1</pattern>
+<pattern> o3d4rven</pattern>
+<pattern> od2r1v</pattern>
+<pattern> odrv2e1</pattern>
+<pattern> o3d4rven2j</pattern>
+<pattern> o3d4rveč</pattern>
+<pattern> o3d4rem</pattern>
+<pattern> odr2e1</pattern>
+<pattern> o3d4ren</pattern>
+<pattern> o3d4ret</pattern>
+<pattern> o3d4ređ</pattern>
+<pattern> o3d4red</pattern>
+<pattern> o3d4r1l</pattern>
+<pattern> o3d4r1n</pattern>
+<pattern> o3d4r1p</pattern>
+<pattern> o3d4r1l2j</pattern>
+<pattern> o3d4r1t</pattern>
+<pattern> o3d4r1ž</pattern>
+<pattern> o3d4rin</pattern>
+<pattern> odr2i1</pattern>
+<pattern> o3d4rin2j</pattern>
+<pattern> o3d4riš</pattern>
+<pattern> o3d4rič</pattern>
+<pattern> o3d4rib</pattern>
+<pattern> o3d4ric</pattern>
+<pattern> o3d4ron</pattern>
+<pattern> 2o1dr2o1</pattern>
+<pattern> o3d4ron2j</pattern>
+<pattern> o3d4ruž</pattern>
+<pattern> odr2u1</pattern>
+<pattern> o3d4rug</pattern>
+<pattern> o2d3uv2i1</pattern>
+<pattern> od2u1</pattern>
+<pattern> o2d3uv2e1</pattern>
+<pattern> o2d3uz2i1</pattern>
+<pattern> o2d3uz2l</pattern>
+<pattern> o2d3uz2d</pattern>
+<pattern> o2d3uz2e1</pattern>
+<pattern> o2d3uk</pattern>
+<pattern> o2d3ul</pattern>
+<pattern> o2d3um</pattern>
+<pattern> o2d3uč</pattern>
+<pattern> po2d3a2d1m</pattern>
+<pattern> pod2a1</pattern>
+<pattern> po2d3varij</pattern>
+<pattern> pod2v</pattern>
+<pattern> podv2a1</pattern>
+<pattern> podvar2i1</pattern>
+<pattern> po2d3vez</pattern>
+<pattern> podv2e1</pattern>
+<pattern> po2d3več</pattern>
+<pattern> po2d3vež</pattern>
+<pattern> po2d3vik</pattern>
+<pattern> podv2i1</pattern>
+<pattern> po2d3vil</pattern>
+<pattern> po2d3vir</pattern>
+<pattern> po2d3vin2j</pattern>
+<pattern> po2d3vlas</pattern>
+<pattern> po2d3v2l</pattern>
+<pattern> podvl2a1</pattern>
+<pattern> po2d3vlaš</pattern>
+<pattern> po2d3voz</pattern>
+<pattern> p2o1dv2o1</pattern>
+<pattern> po2d3vođ</pattern>
+<pattern> po2d3vož</pattern>
+<pattern> po2d3vod</pattern>
+<pattern> po2d3vrat</pattern>
+<pattern> po2d3v2r</pattern>
+<pattern> podvr2a1</pattern>
+<pattern> po2d3vrać</pattern>
+<pattern> po2d3v2r1ć</pattern>
+<pattern> po2d3v2r1ž</pattern>
+<pattern> po2d3v2r1g</pattern>
+<pattern> po2d3vris</pattern>
+<pattern> podvr2i1</pattern>
+<pattern> po2d3v2r1s</pattern>
+<pattern> po2d3vuć</pattern>
+<pattern> podv2u1</pattern>
+<pattern> po2d3ig2r</pattern>
+<pattern> pod2i1</pattern>
+<pattern> po2d3iz2v</pattern>
+<pattern> po2d3j</pattern>
+<pattern> po3d4jen</pattern>
+<pattern> podj2e1</pattern>
+<pattern> po3d4ječ</pattern>
+<pattern> po2d3lakat</pattern>
+<pattern> pod2l</pattern>
+<pattern> podl2a1</pattern>
+<pattern> podlak2a1</pattern>
+<pattern> po2d3la2k1t</pattern>
+<pattern> po2d3lep</pattern>
+<pattern> podl2e1</pattern>
+<pattern> po2d3let</pattern>
+<pattern> po2d3leć</pattern>
+<pattern> po2d3lež</pattern>
+<pattern> po2d3leg</pattern>
+<pattern> po2d3liz</pattern>
+<pattern> podl2i1</pattern>
+<pattern> po2d3lijep</pattern>
+<pattern> podlij2e1</pattern>
+<pattern> po2d3lijet</pattern>
+<pattern> po2d3lijeć</pattern>
+<pattern> po2d3lijež</pattern>
+<pattern> po2d3lijeg</pattern>
+<pattern> po2d3lis2t</pattern>
+<pattern> po2d3lok</pattern>
+<pattern> p2o1dl2o1</pattern>
+<pattern> po2d3lom</pattern>
+<pattern> po2d3lup</pattern>
+<pattern> podl2u1</pattern>
+<pattern> po2d3luč</pattern>
+<pattern> po2d3luž</pattern>
+<pattern> po2d3ljut</pattern>
+<pattern> pod2l2j</pattern>
+<pattern> podlj2u1</pattern>
+<pattern> po2d3o2k1n</pattern>
+<pattern> p2o1d2o1</pattern>
+<pattern> po2d3oš</pattern>
+<pattern> po2d3oč</pattern>
+<pattern> po2d3of</pattern>
+<pattern> po2d3ra2v1n</pattern>
+<pattern> pod2r</pattern>
+<pattern> podr2a1</pattern>
+<pattern> po2d3ra2v1n2j</pattern>
+<pattern> po2d3rad</pattern>
+<pattern> po2d3ra2z3d</pattern>
+<pattern> po2d3raz2r</pattern>
+<pattern> po2d3raz2u1</pattern>
+<pattern> po2d3ram</pattern>
+<pattern> po2d3ran</pattern>
+<pattern> po2d3ras</pattern>
+<pattern> po2d3ran2j</pattern>
+<pattern> po2d3rep</pattern>
+<pattern> podr2e1</pattern>
+<pattern> po2d3res</pattern>
+<pattern> po2d3rez</pattern>
+<pattern> po2d3rik</pattern>
+<pattern> podr2i1</pattern>
+<pattern> po2d3rit</pattern>
+<pattern> po2d3ron</pattern>
+<pattern> p2o1dr2o1</pattern>
+<pattern> po2d3rov</pattern>
+<pattern> po2d3rož</pattern>
+<pattern> po2d3ruk</pattern>
+<pattern> podr2u1</pattern>
+<pattern> po2d3rub</pattern>
+<pattern> po2d3ruč2i1</pattern>
+<pattern> po2d3ru2č1n</pattern>
+<pattern> po2d3ruč2a1</pattern>
+<pattern> po2d3upl2a1</pattern>
+<pattern> pod2u1</pattern>
+<pattern> podup2l</pattern>
+<pattern> po2d3us2m</pattern>
+<pattern> po2d3us2n</pattern>
+<pattern> pre2d3j</pattern>
+<pattern> pre2d3v</pattern>
+<pattern> pre3d4vaj</pattern>
+<pattern> predv2a1</pattern>
+<pattern> pre3d4var</pattern>
+<pattern> pre3d4ves2t</pattern>
+<pattern> predv2e1</pattern>
+<pattern> pre3d4voj2i1</pattern>
+<pattern> predv2o1</pattern>
+<pattern> pre3d4voj2a1</pattern>
+<pattern> pr2e3d4voj2e1</pattern>
+<pattern> pre3d4vor</pattern>
+<pattern> pre3d4vos</pattern>
+<pattern> pre3d4jen</pattern>
+<pattern> predj2e1</pattern>
+<pattern> pre2d3ig2r</pattern>
+<pattern> pred2i1</pattern>
+<pattern> pre2d3id</pattern>
+<pattern> pre2d3iz2b</pattern>
+<pattern> pre2d3i1sp2i1</pattern>
+<pattern> predis2p</pattern>
+<pattern> pre2d3ist2o1</pattern>
+<pattern> predis2t</pattern>
+<pattern> pre2d3ist2r</pattern>
+<pattern> pre2d3ob2j</pattern>
+<pattern> pred2o1</pattern>
+<pattern> pr2e2d3odr2e1</pattern>
+<pattern> predod2r</pattern>
+<pattern> pre2d3okus</pattern>
+<pattern> predok2u1</pattern>
+<pattern> pre2d3os2v</pattern>
+<pattern> pr2e2d3os2e1</pattern>
+<pattern> pr2e2d3osj2e1</pattern>
+<pattern> predos2j</pattern>
+<pattern> pre2d3rat</pattern>
+<pattern> pred2r</pattern>
+<pattern> predr2a1</pattern>
+<pattern> pre2d3rač</pattern>
+<pattern> pre2d3rad</pattern>
+<pattern> pre2d3ruč</pattern>
+<pattern> predr2u1</pattern>
+<pattern> pre2d3ubeđ</pattern>
+<pattern> pred2u1</pattern>
+<pattern> predub2e1</pattern>
+<pattern> pre2d3ubijeđ</pattern>
+<pattern> predub2i1</pattern>
+<pattern> predubij2e1</pattern>
+<pattern> pre2d3ubjeđ</pattern>
+<pattern> predub2j</pattern>
+<pattern> predubj2e1</pattern>
+<pattern> pre2d3uver</pattern>
+<pattern> preduv2e1</pattern>
+<pattern> pre2d3uvjer</pattern>
+<pattern> preduv2j</pattern>
+<pattern> pr2e1duvj2e1</pattern>
+<pattern> pre2d3uvjet</pattern>
+<pattern> pre2d3ugov</pattern>
+<pattern> predug2o1</pattern>
+<pattern> pre2d3udar</pattern>
+<pattern> predud2a1</pattern>
+<pattern> pre2d3upis</pattern>
+<pattern> predup2i1</pattern>
+<pattern> pre2d3usl2o1</pattern>
+<pattern> predus2l</pattern>
+<pattern> proti2v3a2k1c</pattern>
+<pattern> prot2i1</pattern>
+<pattern> protiv2a1</pattern>
+<pattern> proti2v3ot2r</pattern>
+<pattern> pr2o1tiv2o1</pattern>
+<pattern> proti2v3of</pattern>
+<pattern> proti2v3r</pattern>
+<pattern> proti2v3us</pattern>
+<pattern> protiv2u1</pattern>
+<pattern> proti2v3ud</pattern>
+<pattern> ra2ž3đ</pattern>
+<pattern> ra2z3b</pattern>
+<pattern> ra2z3e1</pattern>
+<pattern> ra2z3i1</pattern>
+<pattern> ra2z3j</pattern>
+<pattern> ra2z3l</pattern>
+<pattern> ra2z3m</pattern>
+<pattern> ra2z3n</pattern>
+<pattern> ra2z3l2j</pattern>
+<pattern> ra2z3r</pattern>
+<pattern> ra2z3v</pattern>
+<pattern> ra2z3n2j</pattern>
+<pattern> ra2z3anal</pattern>
+<pattern> razan2a1</pattern>
+<pattern> ra3z4ban</pattern>
+<pattern> r2a1zb2a1</pattern>
+<pattern> ra3z4bar</pattern>
+<pattern> ra3z4ba3u1</pattern>
+<pattern> ra3z4bad</pattern>
+<pattern> ra3z4bašur</pattern>
+<pattern> razbaš2u1</pattern>
+<pattern> ra3z4boj</pattern>
+<pattern> razb2o1</pattern>
+<pattern> ra3z4bor</pattern>
+<pattern> ra3z4val</pattern>
+<pattern> razv2a1</pattern>
+<pattern> ra3z4v2e1d2e1</pattern>
+<pattern> razv2e1</pattern>
+<pattern> ra3z4ves2t</pattern>
+<pattern> ra3z4vig2o1</pattern>
+<pattern> razv2i1</pattern>
+<pattern> ra3z4vij2u1</pattern>
+<pattern> r2a3z4vij2a1</pattern>
+<pattern> ra3z4vij2e1</pattern>
+<pattern> ra3z4vit</pattern>
+<pattern> ra3z4vić</pattern>
+<pattern> ra3z4voj</pattern>
+<pattern> razv2o1</pattern>
+<pattern> ra3z4von</pattern>
+<pattern> ra3z4vrat</pattern>
+<pattern> razv2r</pattern>
+<pattern> r2a1zvr2a1</pattern>
+<pattern> ra3z4vrać</pattern>
+<pattern> ra3z4v2r1t</pattern>
+<pattern> ra3z4v2r1ć</pattern>
+<pattern> ra3z4gađ</pattern>
+<pattern> razg2a1</pattern>
+<pattern> ra3z4g2r1t</pattern>
+<pattern> razg2r</pattern>
+<pattern> ra3z4ev</pattern>
+<pattern> ra3z4ij</pattern>
+<pattern> ra3z4il</pattern>
+<pattern> ra3z4in</pattern>
+<pattern> ra3z4ir</pattern>
+<pattern> ra3z4it</pattern>
+<pattern> ra3z4iz</pattern>
+<pattern> ra3z4iđ</pattern>
+<pattern> ra3z4ić</pattern>
+<pattern> ra3z4id</pattern>
+<pattern> ra3z4laz</pattern>
+<pattern> r2a1zl2a1</pattern>
+<pattern> ra3z4lag</pattern>
+<pattern> ra3z4lik</pattern>
+<pattern> razl2i1</pattern>
+<pattern> ra3z4lič</pattern>
+<pattern> ra3z4loz</pattern>
+<pattern> razl2o1</pattern>
+<pattern> ra3z4lož</pattern>
+<pattern> ra3z4log</pattern>
+<pattern> ra3z4met</pattern>
+<pattern> razm2e1</pattern>
+<pattern> ra3z4meć</pattern>
+<pattern> ra3z4mrs2k</pattern>
+<pattern> ra2z3m2r</pattern>
+<pattern> razm2r1s</pattern>
+<pattern> ra3z4nat</pattern>
+<pattern> razn2a1</pattern>
+<pattern> ra2z3ob2l</pattern>
+<pattern> raz2o1</pattern>
+<pattern> ra2z3ob2r</pattern>
+<pattern> r2a2z3ob2a1</pattern>
+<pattern> ra2z3od</pattern>
+<pattern> ra2z3orat</pattern>
+<pattern> r2a1zor2a1</pattern>
+<pattern> ra2z3orav</pattern>
+<pattern> ra2z3o2r1t</pattern>
+<pattern> ra2z3or2u1</pattern>
+<pattern> ra2z3ot</pattern>
+<pattern> ra3z4red</pattern>
+<pattern> razr2e1</pattern>
+<pattern> ra3z4rok</pattern>
+<pattern> razr2o1</pattern>
+<pattern> ra3z4roč</pattern>
+<pattern> ra2z3uv2e1</pattern>
+<pattern> raz2u1</pattern>
+<pattern> ra2z3ud2i1</pattern>
+<pattern> r2a2z3ud2a1</pattern>
+<pattern> ra2z3u2d1b</pattern>
+<pattern> ra2z3uz2i1</pattern>
+<pattern> ra2z3uz2d</pattern>
+<pattern> ra2z3uz2e1</pattern>
+<pattern> ra2z3ular</pattern>
+<pattern> razul2a1</pattern>
+<pattern> ra2z3um2r</pattern>
+<pattern> ra2s3c</pattern>
+<pattern> ra2s3k</pattern>
+<pattern> ra2s3p</pattern>
+<pattern> ra2s3t</pattern>
+<pattern> ra3s4kak</pattern>
+<pattern> r2a1sk2a1</pattern>
+<pattern> ra3s4ka2n1d</pattern>
+<pattern> ra3s4kin</pattern>
+<pattern> rask2i1</pattern>
+<pattern> ra3s4klap</pattern>
+<pattern> rask2l</pattern>
+<pattern> r2a1skl2a1</pattern>
+<pattern> ra3s4klan2j</pattern>
+<pattern> ra3s4klad</pattern>
+<pattern> ra3s4klon</pattern>
+<pattern> raskl2o1</pattern>
+<pattern> ra3s4klop2i1</pattern>
+<pattern> ra3s4klop2l2j</pattern>
+<pattern> rasklop2l</pattern>
+<pattern> r2a3s4klop2a1</pattern>
+<pattern> ra3s4koš</pattern>
+<pattern> rask2o1</pattern>
+<pattern> ra3s4krop</pattern>
+<pattern> rask2r</pattern>
+<pattern> raskr2o1</pattern>
+<pattern> ra3s4paj</pattern>
+<pattern> r2a1sp2a1</pattern>
+<pattern> ra3s4pav</pattern>
+<pattern> ra3s4pet2i1</pattern>
+<pattern> rasp2e1</pattern>
+<pattern> ra3s4pet2o1</pattern>
+<pattern> r2a3s4pet2a1</pattern>
+<pattern> ra3s4p2e1t2e1</pattern>
+<pattern> ra3s4pik2u1</pattern>
+<pattern> rasp2i1</pattern>
+<pattern> ra3s4pin2j</pattern>
+<pattern> ra3s4plin</pattern>
+<pattern> rasp2l</pattern>
+<pattern> raspl2i1</pattern>
+<pattern> ra3s4plin2j</pattern>
+<pattern> ra3s4p1n</pattern>
+<pattern> ra3s4polož</pattern>
+<pattern> rasp2o1</pattern>
+<pattern> raspol2o1</pattern>
+<pattern> ra3s4pon</pattern>
+<pattern> ra3s4por</pattern>
+<pattern> ra3s4prav</pattern>
+<pattern> rasp2r</pattern>
+<pattern> raspr2a1</pattern>
+<pattern> ra3s4prem</pattern>
+<pattern> raspr2e1</pattern>
+<pattern> ra3s4r1đ</pattern>
+<pattern> ras2r</pattern>
+<pattern> ra3s4r1d</pattern>
+<pattern> ra3s4r2e1</pattern>
+<pattern> ra3s4taj</pattern>
+<pattern> r2a1st2a1</pattern>
+<pattern> ra3s4tan</pattern>
+<pattern> ra3s4tat</pattern>
+<pattern> ra3s4tav</pattern>
+<pattern> ra3s4ten2j</pattern>
+<pattern> rast2e1</pattern>
+<pattern> ra3s4til</pattern>
+<pattern> rast2i1</pattern>
+<pattern> ra3s4tir</pattern>
+<pattern> ra3s4tis</pattern>
+<pattern> ra3s4tit</pattern>
+<pattern> ra3s4tin2j</pattern>
+<pattern> ra3s4toj</pattern>
+<pattern> rast2o1</pattern>
+<pattern> ra3s4trel</pattern>
+<pattern> rast2r</pattern>
+<pattern> rastr2e1</pattern>
+<pattern> ra3s4tret</pattern>
+<pattern> ra3s4troj</pattern>
+<pattern> rastr2o1</pattern>
+<pattern> ra3s4t2r1t</pattern>
+<pattern> ra3s4tup</pattern>
+<pattern> rast2u1</pattern>
+<pattern> ra3s4tur</pattern>
+<pattern> ra3s4tuć</pattern>
+<pattern> ra4s5tu2r1č</pattern>
+<pattern> ra2š3ć</pattern>
+<pattern> ra2š3č</pattern>
+<pattern> ra3š4ćen2j</pattern>
+<pattern> rašć2e1</pattern>
+<pattern> ra3š4čić</pattern>
+<pattern> rašč2i1</pattern>
+<pattern> u2z3b</pattern>
+<pattern> u2z3d</pattern>
+<pattern> u2z3g</pattern>
+<pattern> u2z3i1</pattern>
+<pattern> u2z3j</pattern>
+<pattern> u2z3l</pattern>
+<pattern> u2z3m</pattern>
+<pattern> u2z3n</pattern>
+<pattern> u2z3l2j</pattern>
+<pattern> u2z3r</pattern>
+<pattern> u2z3v</pattern>
+<pattern> u2z3n2j</pattern>
+<pattern> u3z4bor</pattern>
+<pattern> uzb2o1</pattern>
+<pattern> u3z4van</pattern>
+<pattern> uzv2a1</pattern>
+<pattern> u3z4vat</pattern>
+<pattern> u3z4viž</pattern>
+<pattern> uzv2i1</pattern>
+<pattern> u3z4vij2o1</pattern>
+<pattern> 2u3z4vij2u1</pattern>
+<pattern> u3z4vij2a1</pattern>
+<pattern> u3z4vij2e1</pattern>
+<pattern> u3z4voj</pattern>
+<pattern> uzv2o1</pattern>
+<pattern> u3z4dic</pattern>
+<pattern> uzd2i1</pattern>
+<pattern> u2z3ig2r</pattern>
+<pattern> u2z3inat</pattern>
+<pattern> uzin2a1</pattern>
+<pattern> u2z3isk2r</pattern>
+<pattern> uzis2k</pattern>
+<pattern> u3z4lan</pattern>
+<pattern> uzl2a1</pattern>
+<pattern> u3z4lat</pattern>
+<pattern> u3z4lim</pattern>
+<pattern> uzl2i1</pattern>
+<pattern> u3z4lit</pattern>
+<pattern> u3z4lić</pattern>
+<pattern> u3z4lic</pattern>
+<pattern> u3z4lov</pattern>
+<pattern> uzl2o1</pattern>
+<pattern> u3z4ludob</pattern>
+<pattern> uzl2u1</pattern>
+<pattern> uzlud2o1</pattern>
+<pattern> u3z4nak</pattern>
+<pattern> uzn2a1</pattern>
+<pattern> u3z4nač</pattern>
+<pattern> u3z4n2e1v2e1</pattern>
+<pattern> uzn2e1</pattern>
+<pattern> u3z4n2e1vj2e1</pattern>
+<pattern> uznev2j</pattern>
+<pattern> u3z4nič</pattern>
+<pattern> uzn2i1</pattern>
+<pattern> u3z4nic</pattern>
+<pattern> u3z4noj</pattern>
+<pattern> uzn2o1</pattern>
+<pattern> u2z3obes2t</pattern>
+<pattern> uz2o1</pattern>
+<pattern> uzob2e1</pattern>
+<pattern> u2z3obijes2t</pattern>
+<pattern> uzob2i1</pattern>
+<pattern> uzobij2e1</pattern>
+<pattern> u2z3orat</pattern>
+<pattern> uzor2a1</pattern>
+<pattern> u2z3orav</pattern>
+<pattern> u2z3o1h2o1</pattern>
+<pattern> u3z4ret</pattern>
+<pattern> uzr2e1</pattern>
+<pattern> u3z4rev</pattern>
+<pattern> u3z4rijet</pattern>
+<pattern> uzr2i1</pattern>
+<pattern> uzrij2e1</pattern>
+<pattern> u3z4rijev</pattern>
+<pattern> u3z4r1n</pattern>
+<pattern> u3z4r1n2j</pattern>
+<pattern> u3z4r2o1k2o1</pattern>
+<pattern> uzr2o1</pattern>
+<pattern> 2u3z4rok2u1</pattern>
+<pattern> u3z4rok2a1</pattern>
+<pattern> u3z4roč</pattern>
+<pattern> u3z4ruj</pattern>
+<pattern> uzr2u1</pattern>
+<pattern> u2z3ugar</pattern>
+<pattern> uz2u1</pattern>
+<pattern> uzug2a1</pattern>
+<pattern> u2s3c</pattern>
+<pattern> u2s3k</pattern>
+<pattern> u2s3p</pattern>
+<pattern> u3s4kak</pattern>
+<pattern> usk2a1</pattern>
+<pattern> u3s4klađ</pattern>
+<pattern> usk2l</pattern>
+<pattern> uskl2a1</pattern>
+<pattern> u3s4klad</pattern>
+<pattern> u3s4k2o1</pattern>
+<pattern> u4s5kom</pattern>
+<pattern> u4s5kov</pattern>
+<pattern> u4s5koš</pattern>
+<pattern> u4s5k2o1k2o1</pattern>
+<pattern> 2u4s5kol2u1</pattern>
+<pattern> u4s5kol2e1</pattern>
+<pattern> u4s5kop2a1</pattern>
+<pattern> u4s5kor2a1</pattern>
+<pattern> u4s5kos2i1</pattern>
+<pattern> u4s5kot2r</pattern>
+<pattern> u3s4kup</pattern>
+<pattern> usk2u1</pattern>
+<pattern> u3s4pav</pattern>
+<pattern> usp2a1</pattern>
+<pattern> u3s4pal2o1</pattern>
+<pattern> u3s4peh</pattern>
+<pattern> usp2e1</pattern>
+<pattern> u3s4pel</pattern>
+<pattern> u3s4pem</pattern>
+<pattern> u3s4pet</pattern>
+<pattern> u3s4pev</pattern>
+<pattern> u3s4peš</pattern>
+<pattern> u3s4pjeh</pattern>
+<pattern> usp2j</pattern>
+<pattern> uspj2e1</pattern>
+<pattern> u3s4pjel</pattern>
+<pattern> u3s4pjem</pattern>
+<pattern> u3s4pjet</pattern>
+<pattern> u3s4pjev</pattern>
+<pattern> u3s4pješ</pattern>
+<pattern> u3s4pe2n1t</pattern>
+<pattern> u3s4pij2a1</pattern>
+<pattern> usp2i1</pattern>
+<pattern> u3s4pij2e1</pattern>
+<pattern> u3s4pijuš</pattern>
+<pattern> uspij2u1</pattern>
+<pattern> u3s4pikuš</pattern>
+<pattern> uspik2u1</pattern>
+<pattern> u3s4pon</pattern>
+<pattern> usp2o1</pattern>
+<pattern> u3s4por2i1</pattern>
+<pattern> u3s4por2a1</pattern>
+<pattern> u3s4poren</pattern>
+<pattern> uspor2e1</pattern>
+<pattern> u3s4poren2j</pattern>
+<pattern> u3s4poreč</pattern>
+<pattern> u3s4posob</pattern>
+<pattern> uspos2o1</pattern>
+<pattern> u3s4prem2i1</pattern>
+<pattern> usp2r</pattern>
+<pattern> uspr2e1</pattern>
+<pattern> u3s4prem2a1</pattern>
+<pattern> u3s4r1k</pattern>
+<pattern> us2r</pattern>
+<pattern> u3s4r1n</pattern>
+<pattern> u3s4r1p</pattern>
+<pattern> u3s4r1l2j</pattern>
+<pattern> us2r1l</pattern>
+<pattern> u3s4r1t</pattern>
+<pattern> u3s4r1đ</pattern>
+<pattern> u3s4r1ž</pattern>
+<pattern> u3s4r2a1</pattern>
+<pattern> u3s4r1d</pattern>
+<pattern> u3s4r2e1</pattern>
+<pattern> u3s4rijed</pattern>
+<pattern> usr2i1</pattern>
+<pattern> usrij2e1</pattern>
+<pattern> u2s3talas</pattern>
+<pattern> us2t</pattern>
+<pattern> ust2a1</pattern>
+<pattern> ustal2a1</pattern>
+<pattern> u2s3t2a1r2a1</pattern>
+<pattern> u2s3tv2r1đ</pattern>
+<pattern> ust2v</pattern>
+<pattern> ustv2r</pattern>
+<pattern> u2s3tv2r1d</pattern>
+<pattern> u2s3ter</pattern>
+<pattern> ust2e1</pattern>
+<pattern> u2s3teć</pattern>
+<pattern> u2s3teg</pattern>
+<pattern> u2s3tov</pattern>
+<pattern> ust2o1</pattern>
+<pattern> u2s3traj</pattern>
+<pattern> ust2r</pattern>
+<pattern> ustr2a1</pattern>
+<pattern> u2s3tral</pattern>
+<pattern> u2s3t2r1g</pattern>
+<pattern> u2s3trep</pattern>
+<pattern> ustr2e1</pattern>
+<pattern> u2s3tres</pattern>
+<pattern> u2s3treb</pattern>
+<pattern> u2s3t2r1k</pattern>
+<pattern> u2s3t2r1n</pattern>
+<pattern> u2s3t2r1p</pattern>
+<pattern> u2s3t2r1ć</pattern>
+<pattern> u2s3t2r1č</pattern>
+<pattern> u2s3tum</pattern>
+<pattern> 2u1st2u1</pattern>
+<pattern> u2s3tur</pattern>
+<pattern> u2s3tuć</pattern>
+<pattern> u2š3ć</pattern>
+<pattern> u2š3č</pattern>
+<pattern> a2b3alij</pattern>
+<pattern> 2a1b2a1</pattern>
+<pattern> abal2i1</pattern>
+<pattern> a2b3anac</pattern>
+<pattern> aban2a1</pattern>
+<pattern> a2b3evak</pattern>
+<pattern> ab2e1</pattern>
+<pattern> abev2a1</pattern>
+<pattern> a2b3erac</pattern>
+<pattern> aber2a1</pattern>
+<pattern> a2b3erir</pattern>
+<pattern> aber2i1</pattern>
+<pattern> a2b3irit</pattern>
+<pattern> ab2i1</pattern>
+<pattern> abir2i1</pattern>
+<pattern> a2b3j2u1</pattern>
+<pattern> ab2j</pattern>
+<pattern> 2a2b3l2a1</pattern>
+<pattern> ab2l</pattern>
+<pattern> a2b3leg</pattern>
+<pattern> abl2e1</pattern>
+<pattern> a2b3lep</pattern>
+<pattern> a2b3lok</pattern>
+<pattern> abl2o1</pattern>
+<pattern> a2b3l2u1</pattern>
+<pattern> a2b3orig</pattern>
+<pattern> ab2o1</pattern>
+<pattern> abor2i1</pattern>
+<pattern> a2b3reak</pattern>
+<pattern> ab2r</pattern>
+<pattern> abr2e1</pattern>
+<pattern> 2a1bre3a1</pattern>
+<pattern> a2b3rog</pattern>
+<pattern> abr2o1</pattern>
+<pattern> a2b3uzus</pattern>
+<pattern> ab2u1</pattern>
+<pattern> abuz2u1</pattern>
+<pattern> a2d3erac</pattern>
+<pattern> ad2e1</pattern>
+<pattern> ader2a1</pattern>
+<pattern> a2d3ve2r1b</pattern>
+<pattern> ad2v</pattern>
+<pattern> adv2e1</pattern>
+<pattern> a2d3j</pattern>
+<pattern> a2d3lat</pattern>
+<pattern> ad2l</pattern>
+<pattern> adl2a1</pattern>
+<pattern> a2d3ren</pattern>
+<pattern> ad2r</pattern>
+<pattern> adr2e1</pattern>
+<pattern> a2d3rog</pattern>
+<pattern> adr2o1</pattern>
+<pattern> a3g2nos</pattern>
+<pattern> a2g1n</pattern>
+<pattern> agn2o1</pattern>
+<pattern> a3g2noz</pattern>
+<pattern> a2nabap</pattern>
+<pattern> 2a1n2a1</pattern>
+<pattern> 2a1n2a1b2a1</pattern>
+<pattern> a2nabaz</pattern>
+<pattern> a2nabat</pattern>
+<pattern> a2nabi3o1</pattern>
+<pattern> anab2i1</pattern>
+<pattern> a2nabol</pattern>
+<pattern> anab2o1</pattern>
+<pattern> a2nagen</pattern>
+<pattern> anag2e1</pattern>
+<pattern> a2nagn2o1</pattern>
+<pattern> ana2g1n</pattern>
+<pattern> a2n3ag2o1</pattern>
+<pattern> 2a2n2a1gr2a1</pattern>
+<pattern> anag2r</pattern>
+<pattern> a2nadem</pattern>
+<pattern> anad2e1</pattern>
+<pattern> a2nadip2l</pattern>
+<pattern> anad2i1</pattern>
+<pattern> a2nadoz</pattern>
+<pattern> anad2o1</pattern>
+<pattern> a2n3a4e2r2o1</pattern>
+<pattern> ana3e1</pattern>
+<pattern> a2nakal</pattern>
+<pattern> 2a1n2a1k2a1</pattern>
+<pattern> a2nakam</pattern>
+<pattern> a2nakat</pattern>
+<pattern> a2nakef</pattern>
+<pattern> anak2e1</pattern>
+<pattern> 2a2n2a1kl2a1</pattern>
+<pattern> anak2l</pattern>
+<pattern> a2nakl2i1</pattern>
+<pattern> a2nakoj</pattern>
+<pattern> anak2o1</pattern>
+<pattern> a2n3akuz</pattern>
+<pattern> anak2u1</pattern>
+<pattern> a2n3a2l1g</pattern>
+<pattern> a2n3a2l1d</pattern>
+<pattern> a2nalep</pattern>
+<pattern> anal2e1</pattern>
+<pattern> a2naliz</pattern>
+<pattern> anal2i1</pattern>
+<pattern> a2nalis</pattern>
+<pattern> a2nalit</pattern>
+<pattern> a2n3ame2r1t</pattern>
+<pattern> anam2e1</pattern>
+<pattern> a2namn2e1</pattern>
+<pattern> ana2m1n</pattern>
+<pattern> a2n3and2r</pattern>
+<pattern> ana2n1d</pattern>
+<pattern> a2nane3o1</pattern>
+<pattern> anan2e1</pattern>
+<pattern> a2n3a2n1t</pattern>
+<pattern> 2a2n2a1pl2a1</pattern>
+<pattern> anap2l</pattern>
+<pattern> a2napl2e1</pattern>
+<pattern> a2napn2e1</pattern>
+<pattern> ana2p1n</pattern>
+<pattern> a2napn2o1</pattern>
+<pattern> a2napr2o1</pattern>
+<pattern> anap2r</pattern>
+<pattern> a2napt2i1</pattern>
+<pattern> ana2p1t</pattern>
+<pattern> a2n3apt2o1</pattern>
+<pattern> a2na2r1t</pattern>
+<pattern> a2n3a2r1h</pattern>
+<pattern> a2nasar</pattern>
+<pattern> anas2a1</pattern>
+<pattern> a2nase3i1</pattern>
+<pattern> anas2e1</pattern>
+<pattern> a2naspaz</pattern>
+<pattern> anas2p</pattern>
+<pattern> anasp2a1</pattern>
+<pattern> 2a2n2a1st2a1</pattern>
+<pattern> anas2t</pattern>
+<pattern> a2nastig</pattern>
+<pattern> anast2i1</pattern>
+<pattern> a2nastom</pattern>
+<pattern> anast2o1</pattern>
+<pattern> a2natim</pattern>
+<pattern> anat2i1</pattern>
+<pattern> a2natom</pattern>
+<pattern> anat2o1</pattern>
+<pattern> a2natoc</pattern>
+<pattern> a2natr2e1</pattern>
+<pattern> anat2r</pattern>
+<pattern> a2natr2i1</pattern>
+<pattern> a2natr2o1</pattern>
+<pattern> a2nafaz</pattern>
+<pattern> anaf2a1</pattern>
+<pattern> a2n3afij</pattern>
+<pattern> anaf2i1</pattern>
+<pattern> 2a2n2a1fil2a1</pattern>
+<pattern> a2nafon</pattern>
+<pattern> anaf2o1</pattern>
+<pattern> a2n3afrod</pattern>
+<pattern> anaf2r</pattern>
+<pattern> anafr2o1</pattern>
+<pattern> a2nakol</pattern>
+<pattern> a2nakron</pattern>
+<pattern> anak2r</pattern>
+<pattern> anakr2o1</pattern>
+<pattern> a2nakr2u1</pattern>
+<pattern> 2a2n3a1lf2a1</pattern>
+<pattern> ana2l1f</pattern>
+<pattern> a2nafor</pattern>
+<pattern> a2nahor</pattern>
+<pattern> anah2o1</pattern>
+<pattern> a2nahr2o1</pattern>
+<pattern> anah2r</pattern>
+<pattern> a2n3eger</pattern>
+<pattern> an2e1</pattern>
+<pattern> aneg2e1</pattern>
+<pattern> a2n3ek2l</pattern>
+<pattern> a2n3ekum</pattern>
+<pattern> anek2u1</pattern>
+<pattern> a2n3elek</pattern>
+<pattern> anel2e1</pattern>
+<pattern> a2n3ener</pattern>
+<pattern> anen2e1</pattern>
+<pattern> a2n3ep2i1</pattern>
+<pattern> a2neor</pattern>
+<pattern> ane3o1</pattern>
+<pattern> a2n3e2r1g</pattern>
+<pattern> a2n3erit</pattern>
+<pattern> aner2i1</pattern>
+<pattern> a2n3e1st2e1</pattern>
+<pattern> anes2t</pattern>
+<pattern> a2n3id2r</pattern>
+<pattern> an2i1</pattern>
+<pattern> a2n3izog</pattern>
+<pattern> aniz2o1</pattern>
+<pattern> a2n3izom</pattern>
+<pattern> a2n3izur</pattern>
+<pattern> aniz2u1</pattern>
+<pattern> a2n3irid</pattern>
+<pattern> anir2i1</pattern>
+<pattern> a2n3ovar</pattern>
+<pattern> an2o1</pattern>
+<pattern> anov2a1</pattern>
+<pattern> a2n3o2k1s</pattern>
+<pattern> a2n3opis</pattern>
+<pattern> anop2i1</pattern>
+<pattern> a2n3o2r1h</pattern>
+<pattern> a2n3o2f1t</pattern>
+<pattern> a2n3o2r1g</pattern>
+<pattern> di2s3akor</pattern>
+<pattern> d2i1</pattern>
+<pattern> dis2a1</pattern>
+<pattern> disak2o1</pattern>
+<pattern> di2s3ju2n1k</pattern>
+<pattern> dis2j</pattern>
+<pattern> disj2u1</pattern>
+<pattern> di2s3kval</pattern>
+<pattern> dis2k</pattern>
+<pattern> disk2v</pattern>
+<pattern> diskv2a1</pattern>
+<pattern> di2s3ko2n1t</pattern>
+<pattern> disk2o1</pattern>
+<pattern> di2s3ko2r1d</pattern>
+<pattern> di2s3kr2e1</pattern>
+<pattern> disk2r</pattern>
+<pattern> d2i2s3kr2i1</pattern>
+<pattern> di2s3kur</pattern>
+<pattern> disk2u1</pattern>
+<pattern> di2s3l2o1</pattern>
+<pattern> dis2l</pattern>
+<pattern> di2s3orij</pattern>
+<pattern> dis2o1</pattern>
+<pattern> disor2i1</pattern>
+<pattern> di2s3parit</pattern>
+<pattern> dis2p</pattern>
+<pattern> disp2a1</pattern>
+<pattern> dispar2i1</pattern>
+<pattern> di2s3poz</pattern>
+<pattern> disp2o1</pattern>
+<pattern> di2s3pon</pattern>
+<pattern> di2s3prop</pattern>
+<pattern> disp2r</pattern>
+<pattern> dispr2o1</pattern>
+<pattern> di2s3ton</pattern>
+<pattern> dis2t</pattern>
+<pattern> dist2o1</pattern>
+<pattern> di2s3trak</pattern>
+<pattern> dist2r</pattern>
+<pattern> distr2a1</pattern>
+<pattern> i2n3abrup</pattern>
+<pattern> in2a1</pattern>
+<pattern> inab2r</pattern>
+<pattern> inabr2u1</pattern>
+<pattern> i2n3adek</pattern>
+<pattern> inad2e1</pattern>
+<pattern> i2n3akur</pattern>
+<pattern> inak2u1</pattern>
+<pattern> i2n3akc2e1</pattern>
+<pattern> ina2k1c</pattern>
+<pattern> i2n3amor</pattern>
+<pattern> inam2o1</pattern>
+<pattern> i2n3anic</pattern>
+<pattern> inan2i1</pattern>
+<pattern> i2n3aplik</pattern>
+<pattern> inap2l</pattern>
+<pattern> inapl2i1</pattern>
+<pattern> i2n3aps2t</pattern>
+<pattern> ina2p1s</pattern>
+<pattern> i2n3a2r1t</pattern>
+<pattern> i2n3augur</pattern>
+<pattern> ina3u1</pattern>
+<pattern> inaug2u1</pattern>
+<pattern> i2n3a1ur2a1</pattern>
+<pattern> i2n3afek</pattern>
+<pattern> inaf2e1</pattern>
+<pattern> i2n3evid</pattern>
+<pattern> in2e1</pattern>
+<pattern> inev2i1</pattern>
+<pattern> i2n3eg</pattern>
+<pattern> i2n3ed</pattern>
+<pattern> i2n3ek2v</pattern>
+<pattern> i2n3e2k1s</pattern>
+<pattern> i2n3elig</pattern>
+<pattern> inel2i1</pattern>
+<pattern> i2n3e2p1c</pattern>
+<pattern> i2n3efek</pattern>
+<pattern> inef2e1</pattern>
+<pattern> i2n3ob2l</pattern>
+<pattern> in2o1</pattern>
+<pattern> i2nogen</pattern>
+<pattern> inog2e1</pattern>
+<pattern> i2nokor</pattern>
+<pattern> inok2o1</pattern>
+<pattern> i2n3okup</pattern>
+<pattern> inok2u1</pattern>
+<pattern> i2n3oper</pattern>
+<pattern> inop2e1</pattern>
+<pattern> i2n3opor</pattern>
+<pattern> inop2o1</pattern>
+<pattern> i2n3ops2e1</pattern>
+<pattern> ino2p1s</pattern>
+<pattern> i2n3ofic</pattern>
+<pattern> inof2i1</pattern>
+<pattern> i2n3umb2r</pattern>
+<pattern> in2u1</pattern>
+<pattern> inu2m1b</pattern>
+<pattern> i2n3und2a1</pattern>
+<pattern> inu2n1d</pattern>
+<pattern> i2n3u2n1k</pattern>
+<pattern> i2n3util</pattern>
+<pattern> inut2i1</pattern>
+<pattern> 2i1nte2r3i1</pattern>
+<pattern> i2n1t</pattern>
+<pattern> int2e1</pattern>
+<pattern> inte2r3o1</pattern>
+<pattern> inte2r3u1</pattern>
+<pattern> inte2r3a1</pattern>
+<pattern> int2e2r3e1</pattern>
+<pattern> inte3r4e2g1n</pattern>
+<pattern> 2i1nte3r4es2i1</pattern>
+<pattern> inte3r4es2n</pattern>
+<pattern> inte3r4es2o1</pattern>
+<pattern> inte3r4es2u1</pattern>
+<pattern> inte3r4es2a1</pattern>
+<pattern> int2e3r4e1s2e1</pattern>
+<pattern> inte3r4e2ž1d2ž</pattern>
+<pattern> interež2d</pattern>
+<pattern> int2e3r4ij2e1</pattern>
+<pattern> int2e3r3j2e1</pattern>
+<pattern> inte2r1j</pattern>
+<pattern> inte3r4ogat</pattern>
+<pattern> interog2a1</pattern>
+<pattern> juri2s3k</pattern>
+<pattern> j2u1</pattern>
+<pattern> jur2i1</pattern>
+<pattern> juri2s3p</pattern>
+<pattern> nu2z3bel</pattern>
+<pattern> n2u1</pattern>
+<pattern> nuz2b</pattern>
+<pattern> nuzb2e1</pattern>
+<pattern> nu2z3bil2j</pattern>
+<pattern> nuzb2i1</pattern>
+<pattern> nu2z3ljub</pattern>
+<pattern> nuz2l</pattern>
+<pattern> nuz2l2j</pattern>
+<pattern> nuzlj2u1</pattern>
+<pattern> nu2z3r2e1</pattern>
+<pattern> nuz2r</pattern>
+<pattern> nu2z3r2j2e1</pattern>
+<pattern> nuz2r1j</pattern>
+<pattern> nu2z3už</pattern>
+<pattern> nuz2u1</pattern>
+<pattern> nu2s3pos</pattern>
+<pattern> nus2p</pattern>
+<pattern> nusp2o1</pattern>
+<pattern> nu2s3pr2o1</pattern>
+<pattern> nusp2r</pattern>
+<pattern> po2st3e2g1z</pattern>
+<pattern> pos2t</pattern>
+<pattern> post2e1</pattern>
+<pattern> po2st3ind2u1</pattern>
+<pattern> post2i1</pattern>
+<pattern> posti2n1d</pattern>
+<pattern> po2st3lim</pattern>
+<pattern> po2s3t2l</pattern>
+<pattern> postl2i1</pattern>
+<pattern> po2st3o2n1k</pattern>
+<pattern> p2o1st2o1</pattern>
+<pattern> po2st3oper</pattern>
+<pattern> postop2e1</pattern>
+<pattern> su2b3a1</pattern>
+<pattern> s2u1</pattern>
+<pattern> su2b3l</pattern>
+<pattern> su3b4aš</pattern>
+<pattern> su2b3i2n1v</pattern>
+<pattern> sub2i1</pattern>
+<pattern> su2b3ju2n1k</pattern>
+<pattern> sub2j</pattern>
+<pattern> subj2u1</pattern>
+<pattern> su2b3o2k1s</pattern>
+<pattern> sub2o1</pattern>
+<pattern> su2b3rep</pattern>
+<pattern> sub2r</pattern>
+<pattern> subr2e1</pattern>
+<pattern> su2b3rog</pattern>
+<pattern> subr2o1</pattern>
+<pattern> su2b3o2r1d</pattern>
+<pattern> supe2r3i1</pattern>
+<pattern> sup2e1</pattern>
+<pattern> supe2r3o1</pattern>
+<pattern> s2u1pe2r3u1</pattern>
+<pattern> supe2r3a1</pattern>
+<pattern> sup2e2r3e1</pattern>
+<pattern> supe3r4ior</pattern>
+<pattern> superi3o1</pattern>
+<pattern> tr2a1n2s3a1</pattern>
+<pattern> t2r</pattern>
+<pattern> tr2a1</pattern>
+<pattern> tra2n1s</pattern>
+<pattern> tran2s3c</pattern>
+<pattern> tran2s3e1</pattern>
+<pattern> tran2s3k</pattern>
+<pattern> tran2s3l</pattern>
+<pattern> tran2s3m</pattern>
+<pattern> tran2s3n</pattern>
+<pattern> tran2s3o1</pattern>
+<pattern> tran2s3p</pattern>
+<pattern> tran2s3t</pattern>
+<pattern> tran2s3u1</pattern>
+<pattern> tran2s3v</pattern>
+<pattern> tran2s3n2j</pattern>
+<pattern> tran3s4ep</pattern>
+<pattern> tran3s4kr2i1</pattern>
+<pattern> transk2r</pattern>
+<pattern> tran3s4um</pattern>
+<pattern> tran3s4ud</pattern>
+<pattern> a2n3jon</pattern>
+<pattern> an2j</pattern>
+<pattern> anj2o1</pattern>
+<pattern> i2n3jek</pattern>
+<pattern> in2j</pattern>
+<pattern> inj2e1</pattern>
+<pattern> i2n3jur</pattern>
+<pattern> inj2u1</pattern>
+<pattern> i2n3jus2t</pattern>
+<pattern> o2d3žal</pattern>
+<pattern> od2ž</pattern>
+<pattern> odž2a1</pattern>
+<pattern> o2d3žal2j</pattern>
+<pattern> o2d3ž2i1</pattern>
+<pattern> o2d3ž2v</pattern>
+<pattern> o2d3ž2e1</pattern>
+<pattern> pre2d3ž2i1</pattern>
+<pattern> pred2ž</pattern>
+<pattern> pr2e2d3ž2e1</pattern>
+<pattern> na2d3žd2r</pattern>
+<pattern> nad2ž</pattern>
+<pattern> na2dž2d</pattern>
+<pattern> na2d3ž2n2j</pattern>
+<pattern> na2dž2n</pattern>
+<pattern> na2d3ž2e1</pattern>
+<pattern> na2d3žan2j</pattern>
+<pattern> nadž2a1</pattern>
+<pattern> na2d3žir</pattern>
+<pattern> nadž2i1</pattern>
+<pattern> na2d3živ</pattern>
+<pattern> na2d3žup</pattern>
+<pattern> nadž2u1</pattern>
+<pattern>2dž </pattern>
 </HyphenationDescription>


### PR DESCRIPTION
This pull request continues on the pull request #372.
As Serbian language uses two scripts with different codepoints, it is safe to combine the patterns into one file. In that way, it doesn't matter which script is used, and even texts that use both scripts will be properly hyphenated. Only the main part of the language tag in (X)HTML should be consulted to load the appropriate patterns. So sr, sr-Cyrl, sr-Latn, and regional versions of these (like sr_RS) should all load the same pattern file.
This approach is already successfully implemented in ConTeXt.

Patterns have been converted from https://devbase.net/dict-sr/ same ones used in LibreOffice extension Serbian Spellchecker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/566)
<!-- Reviewable:end -->
