### PR TITLE
LVXMLParser::ReadText() Optimizations

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5749,13 +5749,8 @@ bool LVXMLParser::ReadText()
                         if ( ptr[1] == ']' ) {
                             if ( ptr + 2 < end ) {
                                 if ( ptr[2] == '>' ) {
-                                    flgBreak = true;
                                     nbCharToSkipOnFlgBreak = 3;
-                                    if (!tlen && ptr == begin) {
-                                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
-                                        return false;
-                                    }
-                                    break;
+                                    goto end_of_node;
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5776,13 +5771,8 @@ bool LVXMLParser::ReadText()
                                 const lChar32 * buf = ptr + 2;
                                 lString32 tag(buf, 6);
                                 if ( tag.lowercase() == U"script" ) {
-                                    flgBreak = true;
                                     nbCharToSkipOnFlgBreak = 1;
-                                    if (!tlen && ptr == begin) {
-                                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
-                                        return false;
-                                    }
-                                    break;
+                                    goto end_of_node;
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5795,13 +5785,8 @@ bool LVXMLParser::ReadText()
                     }
                 }
                 else { // '<' marks the end of this text node
-                    flgBreak = true;
                     nbCharToSkipOnFlgBreak = 1;
-                    if (!tlen && ptr == begin) {
-                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
-                        return false;
-                    }
-                    break;
+                    goto end_of_node;
                 }
             }
             if (pre_para_splitting) {
@@ -5812,6 +5797,14 @@ bool LVXMLParser::ReadText()
                     break;
                 last_eol = ch == '\r' || ch == '\n';
             }
+            continue;
+end_of_node:
+            flgBreak = true;
+            if (!tlen && ptr == begin) {
+                m_read_buffer_pos += nbCharToSkipOnFlgBreak;
+                return false;
+            }
+            break;
         }
         if ( ptr > begin) { // Append passed-by regular text content to m_txt_buf
             tlen += ptr - begin;

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5748,6 +5748,10 @@ bool LVXMLParser::ReadText()
                                 if ( m_read_buffer[m_read_buffer_pos+i+2] == '>' ) {
                                     flgBreak = true;
                                     nbCharToSkipOnFlgBreak = 3;
+                                    if (!tlen) {
+                                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
+                                        return false;
+                                    }
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5770,6 +5774,10 @@ bool LVXMLParser::ReadText()
                                 if ( tag.lowercase() == U"script" ) {
                                     flgBreak = true;
                                     nbCharToSkipOnFlgBreak = 1;
+                                    if (!tlen) {
+                                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
+                                        return false;
+                                    }
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5784,11 +5792,11 @@ bool LVXMLParser::ReadText()
                 else { // '<' marks the end of this text node
                     flgBreak = true;
                     nbCharToSkipOnFlgBreak = 1;
+                    if (!tlen) {
+                        m_read_buffer_pos += nbCharToSkipOnFlgBreak;
+                        return false;
+                    }
                 }
-            }
-            if ( flgBreak && !tlen ) { // no passed-by text content to provide to callback
-                m_read_buffer_pos += nbCharToSkipOnFlgBreak;
-                return false;
             }
             splitParas = false;
             if (pre_para_splitting && last_eol && (ch==' ' || ch=='\t' || ch==160) && tlen>0 ) {

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5702,7 +5702,6 @@ bool LVXMLParser::ReadText()
         // be sure we have 10 chars available (to get '</script') so we
         // don't uneedlessly loop 8 times with needMoreData=true.
         #define TEXT_READ_AHEAD_NEEDED_SIZE 10
-        bool needMoreData = false; // set when more buffer data needed to properly check for things
         bool hasNoMoreData = false;
         int available = m_read_buffer_len - m_read_buffer_pos;
         if ( available < TEXT_READ_AHEAD_NEEDED_SIZE ) {
@@ -5755,12 +5754,12 @@ bool LVXMLParser::ReadText()
                                 }
                             }
                             else if ( !hasNoMoreData ) {
-                                needMoreData = true;
+                                goto break_inner_loop;
                             }
                         }
                     }
                     else if ( !hasNoMoreData ) {
-                        needMoreData = true;
+                        goto break_inner_loop;
                     }
                 }
             }
@@ -5781,12 +5780,12 @@ bool LVXMLParser::ReadText()
                                 }
                             }
                             else if ( !hasNoMoreData ) {
-                                needMoreData = true;
+                                goto break_inner_loop;
                             }
                         }
                     }
                     else if ( !hasNoMoreData ) {
-                        needMoreData = true;
+                        goto break_inner_loop;
                     }
                 }
                 else { // '<' marks the end of this text node
@@ -5804,10 +5803,11 @@ bool LVXMLParser::ReadText()
                 // by a line starting with a few spaces.
                 splitParas = true;
             }
-            if (!flgBreak && !splitParas && !needMoreData) { // regular char, passed-by text content
+            if (!flgBreak && !splitParas) { // regular char, passed-by text content
                 tlen++;
             }
-            if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas || needMoreData ) {
+            if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas ) {
+break_inner_loop:
                 // m_txt_buf filled, end of text node, para splitting, or need more data
                 if ( last_split_txtlen==0 || flgBreak || splitParas )
                     last_split_txtlen = tlen;

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5735,16 +5735,16 @@ bool LVXMLParser::ReadText()
             }
         }
         // Walk buffer without updating m_read_buffer_pos
-        int i=0;
+        const lChar32 *ptr = m_read_buffer + m_read_buffer_pos;
         // If m_eof (m_read_buffer_pos == m_read_buffer_len), this 'for' won't loop
-        for ( ; m_read_buffer_pos+i<m_read_buffer_len; i++ ) {
-            lChar32 ch = m_read_buffer[m_read_buffer_pos + i];
+        for (const lChar32 *end = m_read_buffer + m_read_buffer_len; ptr < end; ++ptr) {
+            lChar32 ch = *ptr;
             if ( m_in_cdata ) { // we're done only when we meet ']]>'
                 if ( ch==']' ) {
-                    if ( m_read_buffer_pos+i+1 < m_read_buffer_len ) {
-                        if ( m_read_buffer[m_read_buffer_pos+i+1] == ']' ) {
-                            if ( m_read_buffer_pos+i+2 < m_read_buffer_len ) {
-                                if ( m_read_buffer[m_read_buffer_pos+i+2] == '>' ) {
+                    if ( ptr + 1 < end ) {
+                        if ( ptr[1] == ']' ) {
+                            if ( ptr + 2 < end ) {
+                                if ( ptr[2] == '>' ) {
                                     flgBreak = true;
                                     nbCharToSkipOnFlgBreak = 3;
                                     if (!tlen) {
@@ -5766,10 +5766,10 @@ bool LVXMLParser::ReadText()
             }
             else if ( ch=='<' ) {
                 if ( m_in_html_script_tag ) { // we're done only when we meet </script>
-                    if ( m_read_buffer_pos+i+1 < m_read_buffer_len ) {
-                        if ( m_read_buffer[m_read_buffer_pos+i+1] == '/' ) {
-                            if ( m_read_buffer_pos+i+7 < m_read_buffer_len ) {
-                                const lChar32 * buf = (const lChar32 *)(m_read_buffer + m_read_buffer_pos + i + 2);
+                    if ( ptr + 1 < end ) {
+                        if ( ptr[1] == '/' ) {
+                            if ( ptr + 7 < end ) {
+                                const lChar32 * buf = ptr + 2;
                                 lString32 tag(buf, 6);
                                 if ( tag.lowercase() == U"script" ) {
                                     flgBreak = true;
@@ -5827,15 +5827,15 @@ break_inner_loop:
                 // of a first text node, and the next one starting with \n.
                 // We could just 'break' if !hasNoMoreData and go fetch more char - but as this
                 // is hard to test, just be conservative and keep doing it this way.
-                lChar32 nextch = m_read_buffer_pos+i+1 < m_read_buffer_len ? m_read_buffer[m_read_buffer_pos+i+1] : 0;
+                lChar32 nextch = ptr + 1 < end ? ptr[1] : 0;
                 if ( (ch=='\r' && nextch!='\n') || (ch=='\n' && nextch!='\r') ) {
                     last_split_txtlen = tlen;
                 }
             }
         }
-        if ( i>0 ) { // Append passed-by regular text content to m_txt_buf
-            m_txt_buf.append( m_read_buffer + m_read_buffer_pos, i );
-            m_read_buffer_pos += i;
+        if ( ptr > m_read_buffer + m_read_buffer_pos) { // Append passed-by regular text content to m_txt_buf
+            m_txt_buf.append( m_read_buffer + m_read_buffer_pos, ptr - m_read_buffer - m_read_buffer_pos);
+            m_read_buffer_pos = ptr - m_read_buffer;
         }
         if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas) {
             //=====================================================

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5751,6 +5751,7 @@ bool LVXMLParser::ReadText()
                                         m_read_buffer_pos += nbCharToSkipOnFlgBreak;
                                         return false;
                                     }
+                                    goto break_inner_loop;
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5777,6 +5778,7 @@ bool LVXMLParser::ReadText()
                                         m_read_buffer_pos += nbCharToSkipOnFlgBreak;
                                         return false;
                                     }
+                                    goto break_inner_loop;
                                 }
                             }
                             else if ( !hasNoMoreData ) {
@@ -5795,6 +5797,7 @@ bool LVXMLParser::ReadText()
                         m_read_buffer_pos += nbCharToSkipOnFlgBreak;
                         return false;
                     }
+                    goto break_inner_loop;
                 }
             }
             splitParas = false;
@@ -5803,7 +5806,7 @@ bool LVXMLParser::ReadText()
                 // by a line starting with a few spaces.
                 splitParas = true;
             }
-            if (!flgBreak && !splitParas) { // regular char, passed-by text content
+            if (!splitParas) { // regular char, passed-by text content
                 tlen++;
             }
             if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas ) {


### PR DESCRIPTION
This part of code are not very testable, so I submit these small commits which I find easier to verify by eyes. Basically I removed unnecessary checks in the inner loop. 

In my test on mid-size Project Gutenberg epubs, these commits can save ~2% total load & render time.

| pct |  chg%|  epub  |
|----:|-----:|-------:|
| best| -3.13|  pg1204|
| 25th| -2.66|  pg6884|
| 50th| -2.40| pg50816|
| 75th| -2.11| pg61089|
|worst| -1.17| pg31015|

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/567)
<!-- Reviewable:end -->
