### PR TITLE
Revert #561

### DIFF
--- a/cr3gui/data/hyph/Russian.pattern
+++ b/cr3gui/data/hyph/Russian.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не1</pattern>
+<pattern> не8</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>

--- a/cr3gui/data/hyph/Russian_EnGB.pattern
+++ b/cr3gui/data/hyph/Russian_EnGB.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не1</pattern>
+<pattern> не8</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>

--- a/cr3gui/data/hyph/Russian_EnUS.pattern
+++ b/cr3gui/data/hyph/Russian_EnUS.pattern
@@ -4790,7 +4790,7 @@
 <pattern>ь2щё</pattern>
 <pattern>ю1ё</pattern>
 <pattern>яб3рё</pattern>
-<pattern> не1</pattern>
+<pattern> не8</pattern>
 <pattern>8не </pattern>
 <pattern>8бъ </pattern>
 <pattern>8въ </pattern>


### PR DESCRIPTION
As @Abradoks correctly mentioned, this rule existed for a reason:

> This is a common sense typographical rule. "Не" is a negative prefix or particle, so separating it makes the text easy to be misread:
> 
> > Недопустимы неблагозвучные переносы, а также переносы, ведущие к двусмысленному прочтению текста, способные запутать читателя, привести к недоразумениям, нарушить нормальный процесс чтения. Например, нельзя отделять отрицание «не» от следующего слова или переносить конечный слог «не» какого-либо слова в другую строку, если далее следует глагол
> > https://print-standart.ru/printing-reference/174-technical-rules-of-typing
> > https://www.nrap.ru/pub10_90_1_1054.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/568)
<!-- Reviewable:end -->
