### PR TITLE
Fix writeNodeEx(), add getBalancedHTML()

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -1021,4 +1021,7 @@ public:
 /// draw book cover, either from image, or generated from title/authors
 void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, bool respectAspectRatio, lString8 fontFace, lString32 title, lString32 authors, lString32 seriesName, int seriesNumber);
 
+/// get balanced and proper HTML from possibly crappy HTML
+bool getBalancedHTML(LVStreamRef stream, lString8 & output, int wflags=0);
+
 #endif

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -7482,3 +7482,15 @@ void LVDrawBookCover(LVDrawBuf & buf, LVImageSourceRef image, bool respectAspect
         CRLog::error("Cannot get font for coverpage");
     }
 }
+
+// (This needs to be in lvdocview.cpp, fb2_elem_table and friends are only available here.)
+bool getBalancedHTML(LVStreamRef stream, lString8 & output, int wflags) {
+    ldomDocument * doc = LVParseHTMLStream( stream, fb2_elem_table, fb2_attr_table, fb2_ns_table );
+    if ( !doc )
+        return false;
+    ldomNode * docRoot = doc->getRootNode()->getChildNode(0);
+    ldomXPointer docxp(docRoot, 0);
+    output = docxp.getHtml(wflags);
+    delete doc;
+    return true;
+}

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4738,8 +4738,10 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                         }
                     }
                     else {
-                        // Ignoring an attribute or its value is left to frontend
-                        *extra_stream << "\t[" << attrName << "=" << attrValue << "]";
+                        // Ignoring an attribute or its value is left to frontend.
+                        // But we don't want to mess the extra_stream specific format
+                        // with a multilines attribute value: replace \n with a space.
+                        *extra_stream << "\t[" << attrName << "=" << attrValue.replace('\n', ' ') << "]";
                     }
                 }
             }


### PR DESCRIPTION
#### writeNodeEx(): fix handling of multilines attribute values

Make them single line in the "extra stream" output giving position of nodes in the main stream, used for handling long-press in the HTML Viewer.
See https://github.com/koreader/koreader/issues/12004#issuecomment-2156748523.

#### Add getBalancedHTML() helper

This helper function makes use of our (nearly) conforming HTML parser (#370), which handles unbalanced HTML and builds a proper DOM, and returns the serialized DOM, so balanced.
This is currently not used by crengine nor frontend, but it's available for use in HTML dict funcs where giving balanced HTML to MuPDF can give better rendering.

I added that to see if it helped with https://github.com/koreader/koreader-base/pull/1586#issuecomment-2143459278.
and used it like this:
```lua
return function(html)
    html = "<html><body>"..html.."</body></html>"
    html = cre.getBalancedHTML(html, 0x50)
    return html
end
```
but it didn't really help: the HTML was bad, and the "balanced" results, although looking more proper, didn't really give anything better.
Anyway, let's have this small helper available, it may help with experimenting and testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/569)
<!-- Reviewable:end -->
