### PR TITLE
EPUB: fix possible buffer overflow

### DIFF
--- a/crengine/include/lvstream.h
+++ b/crengine/include/lvstream.h
@@ -237,6 +237,16 @@ public:
 		return false;
 	}
 
+	virtual LVByteArrayRef GetData()
+	{
+		lvsize_t nBytesRead = 0;
+		lvsize_t size = GetSize();
+		LVByteArrayRef buf(new LVByteArray(size, 0));
+		if (Read(buf->get(), size, &nBytesRead) != LVERR_OK || nBytesRead != size)
+			return LVByteArrayRef();
+		return buf;
+	}
+
 	virtual int ReadByte()
 	{
 		unsigned char buf[1];

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -814,13 +814,8 @@ public:
 
     void setIdpfManglingKey(lString32 key) {
         _idpfFontManglingKey.clear();
-        _idpfFontManglingKey.reserve(20);
         lString8 utf = UnicodeToUtf8(key);
-        lUInt8 result[20];
-        sha1digest(result, (lUInt8*)(utf.c_str()), utf.length());
-        for ( int i=0; i < 20; i++ ) {
-            _idpfFontManglingKey.add(result[i]);
-        }
+        sha1digest(_idpfFontManglingKey.addSpace(20), (lUInt8*)(utf.c_str()), utf.length());
     }
 
     bool hasAdobeObfuscatedItems() {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6280,9 +6280,8 @@ public:
         lUInt32 size = (lUInt32)stream->GetSize();
         if (size < 100 || size > 5000000)
             return false;
-        LVByteArrayRef buf(new LVByteArray(size, 0));
-        lvsize_t bytesRead = 0;
-        if (stream->Read(buf->get(), size, &bytesRead) != LVERR_OK || bytesRead != size)
+        LVByteArrayRef buf = stream->GetData();
+        if (!buf)
             return false;
 
         bool res = false;


### PR DESCRIPTION
Handle obfuscated font files smaller than 1040 bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/572)
<!-- Reviewable:end -->
