### PR TITLE
Some minor LVFormatter::measureText() changes

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1845,7 +1845,6 @@ public:
         #define MAX_TEXT_CHUNK_SIZE 4096
         static lUInt16 widths[MAX_TEXT_CHUNK_SIZE+1];
         static lUInt8 flags[MAX_TEXT_CHUNK_SIZE+1];
-        int tabIndex = -1;
         #if (USE_FRIBIDI==1)
             FriBidiLevel lastBidiLevel = 0;
             FriBidiLevel newBidiLevel;
@@ -1864,9 +1863,6 @@ public:
             LVFont * newFont = NULL;
             lInt16 newLetterSpacing = 0;
             src_text_fragment_t * newSrc = NULL;
-            if ( tabIndex<0 && m_text[i]=='\t' ) {
-                tabIndex = i;
-            }
             bool isObject = false;
             bool prevCharIsObject = false;
             if ( i<m_length ) {
@@ -2422,14 +2418,17 @@ public:
                     lastBidiLevel = newBidiLevel;
             #endif
         }
-        if ( tabIndex >= 0 && m_srcs[0]->indent < 0) {
+        if (m_srcs[0] && m_srcs[0]->indent < 0) {
             // Used by obsolete rendering of css_d_list_item_legacy when css_lsp_outside,
             // where the marker width is provided as negative/hanging indent.
             int tabPosition = -m_srcs[0]->indent; // has been set to marker_width
-            if ( tabPosition>0 && tabPosition > m_widths[tabIndex] ) {
-                int dx = tabPosition - m_widths[tabIndex];
-                for ( i=tabIndex; i<m_length; i++ )
-                    m_widths[i] += dx;
+            for (int j = 0; j < m_length && m_widths[j] >= tabPosition; ++j) {
+                if (m_text[j] == '\t') {
+                    int dx = tabPosition - m_widths[j];
+                    for ( int i=j; i<m_length; i++ )
+                        m_widths[i] += dx;
+                    break;
+                }
             }
         }
 //        // debug dump

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -1850,8 +1850,7 @@ public:
             FriBidiLevel newBidiLevel;
         #endif
         #if (USE_HARFBUZZ==1)
-            bool checkIfHarfbuzz = true;
-            bool usingHarfbuzz = false;
+            bool usingHarfbuzz = m_kerning_mode == KERNING_MODE_HARFBUZZ;
             // Unicode script change (note: hb_script_t is uint32_t)
             lUInt32 prevScript = HB_SCRIPT_COMMON;
             hb_unicode_funcs_t* _hb_unicode_funcs = hb_unicode_funcs_get_default();
@@ -1870,15 +1869,6 @@ public:
                 isObject = m_flags[i] & LCHAR_IS_OBJECT; // image, float or inline box
                 newFont = isObject ? NULL : (LVFont *)newSrc->t.font;
                 newLetterSpacing = newSrc->letter_spacing; // 0 for objects
-                #if (USE_HARFBUZZ==1)
-                    // Check if we are using Harfbuzz kerning with the first font met
-                    if ( checkIfHarfbuzz && newFont ) {
-                        if ( m_kerning_mode == KERNING_MODE_HARFBUZZ ) {
-                            usingHarfbuzz = true;
-                        }
-                        checkIfHarfbuzz = false;
-                    }
-                #endif
             }
             if (i > 0)
                 prevCharIsObject = m_flags[i-1] & LCHAR_IS_OBJECT; // image, float or inline box


### PR DESCRIPTION
I'm finalizing a major optimization to `LVFormatter::measureText()`, so I'd like these smaller ones to be reviewed and merged first.

The first 2 commits have around 0.5% and 0.2% performance gain in my Load and Render test.