### PR TITLE
lvdocview: fix and expose functionality for displaying author and book title separately in the status bar

### DIFF
--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -407,7 +407,7 @@ public:
     /// get screen rectangle for specified cursor position, returns false if not visible
     bool getCursorRect( ldomXPointer ptr, lvRect & rc, bool scrollToCursor = false );
     /// set status bar and clock mode
-    void setStatusMode( int newMode, bool showClock, bool showTitle, bool showBattery, bool showChapterMarks, bool showPercent, bool showPageNumber, bool showPageCount );
+    void setStatusMode( int newMode, bool showClock, bool showTitle, bool showAuthor, bool showBattery, bool showChapterMarks, bool showPercent, bool showPageNumber, bool showPageCount );
     /// draw to specified buffer by either Y pos or page number (unused param should be -1)
     void Draw( LVDrawBuf & drawbuf, int pageTopPosition, int pageNumber, bool rotate, bool autoresize = true);
     /// ensure current position is set to current bookmark value

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -46,6 +46,7 @@
 #define PROP_SHOW_TIME               "window.status.clock"
 #define PROP_SHOW_TIME_12HOURS       "window.status.clock.12hours"
 #define PROP_SHOW_TITLE              "window.status.title"
+#define PROP_SHOW_AUTHOR             "window.status.author"
 #define PROP_STATUS_CHAPTER_MARKS    "crengine.page.header.chapter.marks"
 #define PROP_SHOW_BATTERY            "window.status.battery"
 #define PROP_SHOW_POS_PERCENT        "window.status.pos.percent"

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1946,18 +1946,26 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 			authorsw = m_infoFont->getTextWidth(authors.c_str(),
 					authors.length());
 		}
-		int w = info.width() - 10;
-		if (authorsw + titlew + 10 > w) {
-			// Not enough room for both: alternate them
-			if (getExternalPageNumber(pageIndex) & 1)
-				text = title;
-			else {
-				text = authors;
-				if (!text.empty() && text[text.length() - 1] == '.')
-					text = text.substr(0, text.length() - 1);
+		if (phi & PGHDR_AUTHOR && phi & PGHDR_TITLE) {
+			int w = info.width() - 10;
+			if (authorsw + titlew + 10 > w) {
+				// Not enough room for both: alternate them
+				if (getExternalPageNumber(pageIndex) & 1)
+					text = title;
+				else {
+					text = authors;
+					if (!text.empty() && text[text.length() - 1] == '.')
+						text = text.substr(0, text.length() - 1);
+				}
+			} else {
+            	text = authors + "  " + title;
 			}
-		} else {
-            text = authors + "  " + title;
+		} else if (phi & PGHDR_AUTHOR) {
+			text = authors;
+			if (!text.empty() && text[text.length() - 1] == '.')
+				text = text.substr(0, text.length() - 1);
+		} else if (phi & PGHDR_TITLE) {
+			text = title;
 		}
 	}
 	lvRect newcr = headerRc;

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6654,6 +6654,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 	}
 	props->setIntDef(PROP_STATUS_LINE, 0);
 	props->setIntDef(PROP_SHOW_TITLE, 1);
+	props->setIntDef(PROP_SHOW_AUTHOR, 1);
 	props->setIntDef(PROP_SHOW_TIME, 1);
 	props->setIntDef(PROP_SHOW_TIME_12HOURS, 0);
 	props->setIntDef(PROP_SHOW_BATTERY, 1);
@@ -6732,7 +6733,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #define H_MARGIN 8
 #define V_MARGIN 8
 #define ALLOW_BOTTOM_STATUSBAR 0
-void LVDocView::setStatusMode(int newMode, bool showClock, bool showTitle,
+void LVDocView::setStatusMode(int newMode, bool showClock, bool showTitle, bool showAuthor,
         bool showBattery, bool showChapterMarks, bool showPercent, bool showPageNumber, bool showPageCount) {
 	CRLog::debug("LVDocView::setStatusMode(%d, %s %s %s %s)", newMode,
 			showClock ? "clock" : "", showTitle ? "title" : "",
@@ -6749,7 +6750,7 @@ void LVDocView::setStatusMode(int newMode, bool showClock, bool showTitle,
                 | (showClock ? PGHDR_CLOCK : 0)
                 | (showBattery ? PGHDR_BATTERY : 0)
                 | (showPageCount ? PGHDR_PAGE_COUNT : 0)
-				| (showTitle ? PGHDR_AUTHOR : 0)
+				| (showAuthor ? PGHDR_AUTHOR : 0)
 				| (showTitle ? PGHDR_TITLE : 0)
 				| (showChapterMarks ? PGHDR_CHAPTER_MARKS : 0)
                 | (showPercent ? PGHDR_PERCENT : 0)
@@ -6912,13 +6913,15 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         } else if (name == PROP_STATUS_FONT_FACE) {
             setStatusFontFace(UnicodeToUtf8(value));
         } else if (name == PROP_STATUS_LINE || name == PROP_SHOW_TIME
-                   || name	== PROP_SHOW_TITLE || name == PROP_SHOW_BATTERY
-                   || name == PROP_STATUS_CHAPTER_MARKS || name == PROP_SHOW_POS_PERCENT
-                   || name == PROP_SHOW_PAGE_COUNT || name == PROP_SHOW_PAGE_NUMBER) {
+                   || name	== PROP_SHOW_TITLE || name == PROP_SHOW_AUTHOR
+				   || name == PROP_SHOW_BATTERY || name == PROP_STATUS_CHAPTER_MARKS
+				   || name == PROP_SHOW_POS_PERCENT || name == PROP_SHOW_PAGE_COUNT
+				   || name == PROP_SHOW_PAGE_NUMBER) {
             m_props->setString(name.c_str(), value);
             setStatusMode(m_props->getIntDef(PROP_STATUS_LINE, 0),
                           m_props->getBoolDef(PROP_SHOW_TIME, false),
                           m_props->getBoolDef(PROP_SHOW_TITLE, true),
+						  m_props->getBoolDef(PROP_SHOW_AUTHOR, true),
                           m_props->getBoolDef(PROP_SHOW_BATTERY, true),
                           m_props->getBoolDef(PROP_STATUS_CHAPTER_MARKS, true),
                           m_props->getBoolDef(PROP_SHOW_POS_PERCENT, false),

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1958,7 +1958,7 @@ void LVDocView::drawPageHeader(LVDrawBuf * drawbuf, const lvRect & headerRc,
 						text = text.substr(0, text.length() - 1);
 				}
 			} else {
-            	text = authors + "  " + title;
+				text = authors + "  " + title;
 			}
 		} else if (phi & PGHDR_AUTHOR) {
 			text = authors;
@@ -6742,7 +6742,7 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #define V_MARGIN 8
 #define ALLOW_BOTTOM_STATUSBAR 0
 void LVDocView::setStatusMode(int newMode, bool showClock, bool showTitle, bool showAuthor,
-        bool showBattery, bool showChapterMarks, bool showPercent, bool showPageNumber, bool showPageCount) {
+		bool showBattery, bool showChapterMarks, bool showPercent, bool showPageNumber, bool showPageCount) {
 	CRLog::debug("LVDocView::setStatusMode(%d, %s %s %s %s)", newMode,
 			showClock ? "clock" : "", showTitle ? "title" : "",
 			showBattery ? "battery" : "", showChapterMarks ? "marks" : "");
@@ -6922,14 +6922,14 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
             setStatusFontFace(UnicodeToUtf8(value));
         } else if (name == PROP_STATUS_LINE || name == PROP_SHOW_TIME
                    || name	== PROP_SHOW_TITLE || name == PROP_SHOW_AUTHOR
-				   || name == PROP_SHOW_BATTERY || name == PROP_STATUS_CHAPTER_MARKS
-				   || name == PROP_SHOW_POS_PERCENT || name == PROP_SHOW_PAGE_COUNT
-				   || name == PROP_SHOW_PAGE_NUMBER) {
+                   || name == PROP_SHOW_BATTERY || name == PROP_STATUS_CHAPTER_MARKS
+                   || name == PROP_SHOW_POS_PERCENT || name == PROP_SHOW_PAGE_COUNT
+                   || name == PROP_SHOW_PAGE_NUMBER) {
             m_props->setString(name.c_str(), value);
             setStatusMode(m_props->getIntDef(PROP_STATUS_LINE, 0),
                           m_props->getBoolDef(PROP_SHOW_TIME, false),
                           m_props->getBoolDef(PROP_SHOW_TITLE, true),
-						  m_props->getBoolDef(PROP_SHOW_AUTHOR, true),
+                          m_props->getBoolDef(PROP_SHOW_AUTHOR, true),
                           m_props->getBoolDef(PROP_SHOW_BATTERY, true),
                           m_props->getBoolDef(PROP_STATUS_CHAPTER_MARKS, true),
                           m_props->getBoolDef(PROP_SHOW_POS_PERCENT, false),


### PR DESCRIPTION
I enjoy using KOReader, and I especially like using the alt status bar, but the author and title switching every page was distracting on my Kindle PW2's e-ink display. The functionality seemed to be mostly in place already, but wasn't entirely exposed. I have made an implementation of the feature in KOReader and plan to make a pull request to that repo as well, if this pull request gets merged. I have tested the feature in the emulator and it appears to be working properly, but a second opinion would be much appreciated.

![koreader alt status menu](https://github.com/koreader/crengine/assets/63393079/08150c06-b0fc-4e82-9383-9320392ae1fb)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/575)
<!-- Reviewable:end -->
