### PR TITLE
Don't break lines on curly quotes in Russian

### DIFF
--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -1149,6 +1149,9 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
         */
     }
     else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
+        // The following rule is disabled because Russian texts often
+        // use quotation marks from Word (“”)
+        // has_left_double_quotation_mark_closing = true;
         has_left_double_angle_quotation_mark_opening = true;
         has_right_double_angle_quotation_mark_closing = true;
     }

--- a/crengine/src/textlang.cpp
+++ b/crengine/src/textlang.cpp
@@ -1149,7 +1149,6 @@ TextLangCfg::TextLangCfg( lString32 lang_tag ) {
         */
     }
     else if ( LANG_STARTS_WITH(("ru")) ) { // Russian
-        has_left_double_quotation_mark_closing = true;
         has_left_double_angle_quotation_mark_opening = true;
         has_right_double_angle_quotation_mark_closing = true;
     }


### PR DESCRIPTION
Many Russian texts are using quotes from Word (“”), so this rule leads to incorrect line breaks. It also isn't correct for Russian_En-US and Russian_En-GB variants, because English words are using these quotes extensively.

See the following screenshot, I've marked the hanging curly quote with red color. It should stay together on the next line with the word "_маркий_", but it's left hanging on the previous line instead.
<img src="https://github.com/user-attachments/assets/9e03c24b-4e08-4b86-bb78-351fe32e64fb" width="400">

@hius07, what do you think?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/577)
<!-- Reviewable:end -->
