### PR TITLE
xml parser: fix regressions

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -93,7 +93,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.74k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.75k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0033
 

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5737,7 +5737,7 @@ bool LVXMLParser::ReadText()
         const lChar32 *begin = m_read_buffer + m_read_buffer_pos;
         const lChar32 *ptr = begin;
         const lChar32 *end = m_read_buffer + m_read_buffer_len;
-        const lChar32 *limit = m_read_buffer + (TEXT_SPLIT_SIZE + 1 - tlen);
+        const lChar32 *limit = m_read_buffer + (TEXT_SPLIT_SIZE - tlen);
         if (limit > end)
             limit = end;
         // If m_eof (m_read_buffer_pos == m_read_buffer_len), this 'for' won't loop
@@ -5811,13 +5811,13 @@ end_of_node:
             m_txt_buf.append( m_read_buffer + m_read_buffer_pos, ptr - begin);
             m_read_buffer_pos = ptr - m_read_buffer;
         }
-        if ( tlen > TEXT_SPLIT_SIZE || flgBreak || splitParas) {
+        if ( tlen >= TEXT_SPLIT_SIZE || flgBreak || splitParas) {
             //=====================================================
             // Provide accumulated text to callback
             lChar32 * buf = m_txt_buf.modify();
 
             int last_split_txtlen = tlen;
-            if (tlen > TEXT_SPLIT_SIZE) {
+            if (tlen >= TEXT_SPLIT_SIZE) {
                 for (const lChar32 *ptr = buf + m_txt_buf.length() - 1; ptr >= buf; --ptr) {
                     lChar32 ch = *ptr;
                     if (ch <= ' ') [[unlikely]] {

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5741,7 +5741,7 @@ bool LVXMLParser::ReadText()
         if (limit > end)
             limit = end;
         // If m_eof (m_read_buffer_pos == m_read_buffer_len), this 'for' won't loop
-        for (; ptr < end; ++ptr) {
+        for (; ptr < limit; ++ptr) {
             lChar32 ch = *ptr;
             if ( m_in_cdata ) { // we're done only when we meet ']]>'
                 if ( ch==']' ) {
@@ -5825,7 +5825,7 @@ end_of_node:
                             // Not sure what this last_split_txtlen is about: may be to avoid spliting
                             // a word into multiple text nodes (when tlen > TEXT_SPLIT_SIZE), so splitting
                             // on spaces, \r and \n when giving the text to the callback?
-                            last_split_txtlen = ptr - buf;
+                            last_split_txtlen = ptr - buf + 1;
                             break;
                         } else if (ch == '\r' || ch == '\n') {
                             // Not sure what happens when \r\n at buffer boundary, and we would have \r at end
@@ -5836,7 +5836,8 @@ end_of_node:
                             if (ptr < buf + m_txt_buf.length() - 1)
                                 nextch = ptr[1];
                             if ((ch == '\r' && nextch != '\n') || (ch == '\n' && nextch != '\r')) {
-                                last_split_txtlen = ptr - buf;
+                                last_split_txtlen = ptr - buf + 1;
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
- in 40082dcf, limit was not applied
- in 9d70a2e5,
    - loop should terminate if a qualified newline is encountered
    - `last_split_txtlen` should take the space/newline into account

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/584)
<!-- Reviewable:end -->
