### PR TITLE
comment out / don't compile concurrency code

### DIFF
--- a/crengine/include/crlocks.h
+++ b/crengine/include/crlocks.h
@@ -1,6 +1,8 @@
 #ifndef CRLOCKS_H
 #define CRLOCKS_H
 
+#if 0
+
 #include "lvautoptr.h"
 
 class CRMutex {
@@ -73,5 +75,16 @@ extern CRMutex * _crengineMutex;
 
 /// call to create mutexes for different parts of CoolReader engine
 void CRSetupEngineConcurrency();
+
+#else
+
+#define REF_GUARD
+#define FONT_GUARD
+#define FONT_MAN_GUARD
+#define FONT_GLYPH_CACHE_GUARD
+#define FONT_LOCAL_GLYPH_CACHE_GUARD
+#define CRENGINE_GUARD
+
+#endif
 
 #endif // CRLOCKS_H

--- a/utils/lint.mk
+++ b/utils/lint.mk
@@ -60,7 +60,6 @@ define CPPFILES+=
 crengine/qimagescale/qimagescale.cpp
 crengine/src/chmfmt.cpp
 crengine/src/cp_stats.cpp
-crengine/src/crconcurrent.cpp
 crengine/src/cri18n.cpp
 crengine/src/crtxtenc.cpp
 crengine/src/docxfmt.cpp


### PR DESCRIPTION
- it's already stubbed anyway, stub it more!
- I have seen at least one crash with the default stub (clang emulator)
- cppcheck is not happy about it

NOTE: this need a corresponding change in base:
```diff
--- i/thirdparty/kpvcrlib/CMakeLists.txt
+++ w/thirdparty/kpvcrlib/CMakeLists.txt
@@ -30,7 +30,6 @@ add_library(crengine STATIC
     ${CRE_DIR}/qimagescale/qimagescale.cpp
     ${CRE_DIR}/src/chmfmt.cpp
     ${CRE_DIR}/src/cp_stats.cpp
-    ${CRE_DIR}/src/crconcurrent.cpp
     ${CRE_DIR}/src/cri18n.cpp
     ${CRE_DIR}/src/crtxtenc.cpp
     ${CRE_DIR}/src/docxfmt.cpp
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/585)
<!-- Reviewable:end -->
