### PR TITLE
ci: stop linting with nanosvg support enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,6 @@ jobs:
           libfribidi-dev
           libharfbuzz-dev
           libjpeg-turbo8-dev
-          libnanosvg-dev
-          libstb-dev
           libunibreak-dev
           libutf8proc-dev
           libxml2-utils

--- a/utils/lint.mk
+++ b/utils/lint.mk
@@ -198,7 +198,7 @@ define CPPFLAGS+=
 -DUSE_FRIBIDI=1
 -DUSE_HARFBUZZ=1
 -DUSE_LIBUNIBREAK=1
--DUSE_NANOSVG=1
+-DUSE_NANOSVG=0
 -DUSE_UTF8PROC=1
 -DUSE_ZSTD=1
 endef
@@ -224,8 +224,6 @@ libutf8proc
 endef
 CPPFLAGS += $(shell echo 'pkg-config!' >>log; pkg-config --cflags $(strip $(PACKAGES)))
 define CPPFLAGS+=
--I/usr/include/nanosvg
--I/usr/include/stb
 -Ithirdparty/antiword
 -Ithirdparty/chmlib/src
 -Icrengine/include


### PR DESCRIPTION
- this generate a lot of warnings with clang-tidy & cppcheck in nanosvg & stb headers
- it does not match our default configuration on koreader anyway (where lunasvg is used)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/588)
<!-- Reviewable:end -->
