### PR TITLE
lvtinydom: fix compiler warning [-Wunused-private-field]

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2052,7 +2052,7 @@ public:
     /// returns true if this interval intersects specified interval
     bool checkIntersection( ldomXRange & v );
     /// returns text between two XPointer positions
-    lString32 getRangeText( lChar32 blockDelimiter='\n', int maxTextLen=0, lChar32 imageReplacement=0, LVArray<ldomNode*> * imageNodes=NULL);
+    lString32 getRangeText( lChar32 blockDelimiter='\n', lChar32 imageReplacement=0, LVArray<ldomNode*> * imageNodes=NULL);
     /// get all words from specified range
     void getRangeWords( LVArray<ldomWord> & list );
     /// returns href attribute of <A> element, null string if not found

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -14279,13 +14279,12 @@ class ldomTextCollector : public ldomNodeCallback
 private:
     bool newBlock;
     lChar32  delimiter;
-    int  maxLen;
     lChar32 imageReplacement;
     LVArray<ldomNode*> * imageNodes;
     lString32 text;
 public:
-    ldomTextCollector( lChar32 blockDelimiter, int maxTextLen, lChar32 imageReplacementChar, LVArray<ldomNode*> * imageNodesArray )
-        : newBlock(true), delimiter( blockDelimiter), maxLen( maxTextLen )
+    ldomTextCollector( lChar32 blockDelimiter, lChar32 imageReplacementChar, LVArray<ldomNode*> * imageNodesArray )
+        : newBlock(true), delimiter( blockDelimiter)
         , imageReplacement(imageReplacementChar), imageNodes(imageNodesArray)
     {
     }
@@ -14368,9 +14367,9 @@ public:
 };
 
 /// returns text between two XPointer positions
-lString32 ldomXRange::getRangeText( lChar32 blockDelimiter, int maxTextLen, lChar32 imageReplacement, LVArray<ldomNode*> * imageNodes )
+lString32 ldomXRange::getRangeText( lChar32 blockDelimiter, lChar32 imageReplacement, LVArray<ldomNode*> * imageNodes )
 {
-    ldomTextCollector callback( blockDelimiter, maxTextLen, imageReplacement, imageNodes );
+    ldomTextCollector callback( blockDelimiter, imageReplacement, imageNodes );
     forEach( &callback );
     if ( imageReplacement && _end.isImage() ) {
         // ldomXRange::forEach will consider _end as excluded. If _end is an image,


### PR DESCRIPTION
With the `int maxLen` private field of `ldomTextCollector` removed, the `int maxTextLen` arguments to `ldomTextCollector(…)` and to `ldomXRange::getRangeText` can also be removed.

Note: calls to `getRangeText` in `cre.cpp` will need to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/597)
<!-- Reviewable:end -->
