### PR TITLE
lvfntman: tweak code to be forward compatible with freetype 2.13.3

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2670,13 +2670,11 @@ public:
             // Step 3. for bezier: Q control-point-x control-point-y, destination-x, destination-y
             //         for line:   L x-coord, y-coord
             //         for move:   M x-coord, y-coord
-            FT_Outline outline = _slot->outline;
-            FT_Vector* points = outline.points;
-            char* tags = outline.tags;
-            short* contours = outline.contours;
+            const FT_Outline * outline = &_slot->outline;
+            const FT_Vector * points = outline->points;
             int contour_starti = 0;
-            for (int i = 0 ; i < outline.n_contours ; i++ ) {
-                int contour_endi = contours[i];
+            for (int i = 0 ; i < outline->n_contours ; i++ ) {
+                int contour_endi = outline->contours[i];
                 int offset = contour_starti;
                 int npts = contour_endi - contour_starti + 1;
                 SVGGlyphsCollector_svg_move_to(NULL, svg_collector, NULL, points[contour_starti].x, points[contour_starti].y, NULL);
@@ -2689,9 +2687,9 @@ public:
                     long y =   points[a].y;
                     long nx =  points[nexti].x;
                     long ny =  points[nexti].y;
-                    bool this_tagbit1 = (tags[a] & 1);
-                    bool next_tagbit1 = (tags[nexti] & 1);
-                    bool nextnext_tagbit1 = (tags[ nextnexti ] & 1);
+                    bool this_tagbit1 = (outline->tags[a] & 1);
+                    bool next_tagbit1 = (outline->tags[nexti] & 1);
+                    bool nextnext_tagbit1 = (outline->tags[ nextnexti ] & 1);
                     bool this_isctl = !this_tagbit1;
                     bool next_isctl = !next_tagbit1;
                     bool nextnext_isctl = !nextnext_tagbit1;


### PR DESCRIPTION
Some of the fields of `FT_Outline` changed type:

https://github.com/freetype/freetype/commit/2a7bb4596f566a34fd53932af0ef53b956459d25

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/601)
<!-- Reviewable:end -->
