### PR TITLE
xml parser: fix a regression in 40082dcf/b3874805

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5749,7 +5749,7 @@ bool LVXMLParser::ReadText()
         const lChar32 *begin = m_read_buffer + m_read_buffer_pos;
         const lChar32 *ptr = begin;
         const lChar32 *end = m_read_buffer + m_read_buffer_len;
-        const lChar32 *limit = m_read_buffer + (TEXT_SPLIT_SIZE - tlen);
+        const lChar32 *limit = begin + (TEXT_SPLIT_SIZE - tlen);
         if (limit > end)
             limit = end;
         // If m_eof (m_read_buffer_pos == m_read_buffer_len), this 'for' won't loop


### PR DESCRIPTION
Wrongly calculated `limit` could be smaller than `ptr`, causing infinite loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/602)
<!-- Reviewable:end -->
