### PR TITLE
Preserve FB2 cover aspect ratio

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -1155,9 +1155,9 @@ void LVDocView::drawCoverTo(LVDrawBuf * drawBuf, lvRect & rc) {
 			scale_x = scale_y;
 		int dst_dx = (src_dx * scale_x) >> 16;
 		int dst_dy = (src_dy * scale_y) >> 16;
-        if (dst_dx > rc.width() * 6 / 8)
+        if (dst_dx > rc.width())
 			dst_dx = imgrc.width();
-        if (dst_dy > rc.height() * 6 / 8)
+        if (dst_dy > rc.height())
 			dst_dy = imgrc.height();
 		//CRLog::trace("drawCoverTo() - drawing image");
         LVColorDrawBuf buf2(src_dx, src_dy, 32);


### PR DESCRIPTION
If FB2 cover is narrower than the reader screen width but wider than 75% of it (100 % / 6 * 8 math in the code), then the cover will be stretched to occupy 100% of the width. The same applies to height. This results in distorted cover images.

I went down the memory lane, and in 2012 the threshold for ratio change was 7 / 8 in https://github.com/koreader/crengine/commit/7734722fb92556ed23cad57b5d221c1614b36fc5 and in 2010 9 / 10 in https://github.com/koreader/crengine/commit/cad44764cdaf100da965d1feeb302970fdedf83d. I'm not sure why CoolReader's creator added this logic originally in https://github.com/koreader/crengine/commit/fb5a4beca0cf94537e32cdfc785d60e44e7493bc, though.

I suggest removing it, so the cover aspect ratio will be preserved, the same way we do for ePubs and other file types.

Here's some examples of the original cover and the way CREngine renders it:
| Original Cover | Rendered Cover |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/ba9d211d-4cc2-4540-b1d4-659267da5fab) | ![After](https://github.com/user-attachments/assets/7e7a3172-7666-490b-9f18-5756923e7fb5) |
| ![Before-2](https://github.com/user-attachments/assets/f8bc6042-eb27-4e55-aa03-91a73a21e44f) | ![After-2](https://github.com/user-attachments/assets/2118ba79-818c-480d-9648-ead7f20c87b4) | 

See the discussion started here: https://github.com/koreader/koreader-base/pull/1484#issuecomment-1507601302.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/604)
<!-- Reviewable:end -->
