### PR TITLE
better handling of percent-encoded image references

### DIFF
--- a/crengine/include/lvimg.h
+++ b/crengine/include/lvimg.h
@@ -147,11 +147,4 @@ void LVDrawBatteryIcon( LVDrawBuf * drawbuf, const lvRect & batteryRc, int perce
 
 unsigned char * convertSVGtoPNG(const unsigned char *svg_data, int svg_data_size, float zoom_factor, int *png_data_len);
 
-#define IMAGE_SOURCE_FROM_BYTES( imgvar , bufvar ) \
-    extern unsigned char bufvar []; \
-    extern int bufvar ## _size ; \
-    LVImageSourceRef imgvar = LVCreateStreamImageSource( \
-        LVCreateMemoryStream( bufvar , bufvar ## _size ) )
-
-
 #endif

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1753,18 +1753,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
             LVStreamRef stream = m_arc->OpenStream(cover_xhtml_path.c_str(), LVOM_READ);
             lString32 cover_image_href;
             if ( ExtractCoverFilenameFromCoverPageFragment(stream, cover_image_href, node_scheme, attr_scheme, ns_scheme) ) {
+                cover_image_href = DecodeHTMLUrlString(cover_image_href);
                 lString32 codeBase = LVExtractPath( cover_xhtml_path );
                 if ( codeBase.length()>0 && codeBase.lastChar()!='/' )
                     codeBase.append(1, U'/');
                 lString32 cover_image_path = LVCombinePaths(codeBase, cover_image_href);
                 CRLog::info("EPUB cover image file: %s", LCSTR(cover_image_path));
                 LVStreamRef stream = m_arc->OpenStream(cover_image_path.c_str(), LVOM_READ);
-                if ( stream.isNull() ) {
-                    // Try again in case cover_image_path is percent-encoded
-                    cover_image_path = LVCombinePaths(codeBase, DecodeHTMLUrlString(cover_image_href));
-                    CRLog::info("EPUB cover image file pct-decoded: %s", LCSTR(cover_image_path));
-                    stream = m_arc->OpenStream(cover_image_path.c_str(), LVOM_READ);
-                }
                 if ( !stream.isNull() ) {
                     LVImageSourceRef img = LVCreateStreamImageSource(stream);
                     if ( !img.isNull() ) {

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2077,7 +2077,7 @@ static bool lunasvgDrawImageHelper(lunasvg::external_context_t * xcontext, const
     ldomDocument * doc = ((LVNodeImageSource *)xcontext->external_object)->GetSourceDocument();
     if ( doc ) {
         ldomNode * node = ((LVNodeImageSource *)xcontext->external_object)->GetSourceNode();
-        img = doc->getObjectImageSource(Utf8ToUnicode(url), node);
+        img = doc->getObjectImageSource(DecodeHTMLUrlString(Utf8ToUnicode(url)), node);
     }
     else {
         // We may be used by frontends without a ldomDocument to render SVG, and


### PR DESCRIPTION
- fix `DecodeHTMLUrlString` so it does not mangle non-ASCII characters
- fix `lunasvgDrawImageHelper` to properly handle a percent-encoded image URL

Cf. https://github.com/koreader/koreader/issues/12656.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/605)
<!-- Reviewable:end -->
