### PR TITLE
FB2: Make single image a block level element

### DIFF
--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -11,7 +11,6 @@ a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 a[type="note"]::before { content: "\2060" } /* word joiner, avoid break before */
 
 image { text-indent: 0; display: block; margin: 0 auto; }
-p image { display: inline }
 li image { display: inline }
 
 li { display: list-item; text-indent: 0;  }

--- a/cr3gui/data/fb2.css
+++ b/cr3gui/data/fb2.css
@@ -11,6 +11,8 @@ a[type="note"] { vertical-align: super; font-size: 70%; text-decoration: none }
 a[type="note"]::before { content: "\2060" } /* word joiner, avoid break before */
 
 image { text-indent: 0; display: block; margin: 0 auto; }
+p image { display: inline }
+p image:only-child { display: block; }
 li image { display: inline }
 
 li { display: list-item; text-indent: 0;  }


### PR DESCRIPTION
When we have a paragraph which contains only a single image inside, it makes sense to make this image a block element.  Currently, it's marked as inline, which is good for inline image formulas, etc., but not for the use case below.

The paragraph contains a single image, nothing else.

| Before this change | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/6d453a4d-2048-4a64-88bf-994784f63160" width="400"> | <img src="https://github.com/user-attachments/assets/b372cd80-0ce4-41b3-8b3b-ed185bd21c43" width="400"> | 

As you can see, previously the image was cropped at the right border and indented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/610)
<!-- Reviewable:end -->
