### PR TITLE
ci: fix `stylelint` check

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,6 +4,15 @@
     "comment-empty-line-before": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
+    "declaration-property-value-no-unknown": [true, {
+      "ignoreProperties": {
+	"/^padding.*$/": "-cr-special",
+	"/^text-align.*$/": [
+	  "/^-cr-html-align-(center|left|right)$/",
+	  "/^-cr-(center|left|right)-if-not-first$/"
+	]
+      }
+    }],
     "no-descending-specificity": [true, { "severity": "warning" }],
     "no-duplicate-selectors": [true, { "severity": "warning" }],
     "property-no-unknown": [true, {


### PR DESCRIPTION
With latest styleint (16.13.1):
```
[…]/cr3gui/data/html5.css:185:15: Unexpected unknown value "-cr-html-align-center" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:189:15: Unexpected unknown value "-cr-html-align-left" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:193:15: Unexpected unknown value "-cr-html-align-right" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:197:15: Unexpected unknown value "-cr-html-align-center" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:495:17: Unexpected unknown value "-cr-special" for property "padding-left" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:496:18: Unexpected unknown value "-cr-special" for property "padding-right" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:503:17: Unexpected unknown value "-cr-special" for property "padding-left" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:504:18: Unexpected unknown value "-cr-special" for property "padding-right" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:738:15: Unexpected unknown value "-cr-html-align-left" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:748:15: Unexpected unknown value "-cr-html-align-right" for property "text-align" (declaration-property-value-no-unknown) [error]
[…]/cr3gui/data/html5.css:755:15: Unexpected unknown value "-cr-html-align-center" for property "text-align" (declaration-property-value-no-unknown) [error]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/612)
<!-- Reviewable:end -->
