### PR TITLE
Add hint-based footnote extension

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -465,8 +465,8 @@ enum css_generic_value_t {
 #define CSS_CR_HINT_FOOTNOTE_IGNORE         0x08000000 // -cr-hint: footnote-ignore block is not a footnote (even if
                                                        //                           everything else indicates it is)
 
-// To be set on a block element: it is a continuation of an inpage footnote and will
-// be displayed as part of it on the bottom of pages that contain a link to it
+// To be set on a block element: it may be considered a continuation of an inpage footnote
+// and will be displayed as part of it on the bottom of pages that contain a link to it
 // (see `-cr-hint: footnote-inpage` above)
 #define CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE  0x10000000 // -cr-hint: extend-footnote-inpage
 

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -465,6 +465,9 @@ enum css_generic_value_t {
 #define CSS_CR_HINT_FOOTNOTE_IGNORE         0x08000000 // -cr-hint: footnote-ignore block is not a footnote (even if
                                                        //                           everything else indicates it is)
 
+// To be set on a block element: it is a continuation of an inpage footnote and will
+// be displayed as part of it on the bottom of pages that contain a link to it
+// (see `-cr-hint: footnote-inpage` above)
 #define CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE  0x10000000 // -cr-hint: extend-footnote-inpage
 
 // A few of them are inheritable, most are not.

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -464,6 +464,7 @@ enum css_generic_value_t {
                                                        //                           footnote block container)
 #define CSS_CR_HINT_FOOTNOTE_IGNORE         0x08000000 // -cr-hint: footnote-ignore block is not a footnote (even if
                                                        //                           everything else indicates it is)
+#define CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE  0x10000000 // -cr-hint: extend-footnote-inpage
 
 // A few of them are inheritable, most are not.
 #define CSS_CR_HINT_INHERITABLE_MASK        0x0000000E

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -464,6 +464,7 @@ enum css_generic_value_t {
                                                        //                           footnote block container)
 #define CSS_CR_HINT_FOOTNOTE_IGNORE         0x08000000 // -cr-hint: footnote-ignore block is not a footnote (even if
                                                        //                           everything else indicates it is)
+
 #define CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE  0x10000000 // -cr-hint: extend-footnote-inpage
 
 // A few of them are inheritable, most are not.

--- a/crengine/include/lvpagesplitter.h
+++ b/crengine/include/lvpagesplitter.h
@@ -452,8 +452,8 @@ class LVRendPageContext
                     // its content. (This is consistent with the way crengine handle id= when
                     // building the DOM: later ones override ealier ones).
                     // Exception: When `allow_appending` we extend an already created footnote
-                    // trust that the caller has ensured that this is contiguous with already
-                    // accumulated lines by calling `getCurrentFootNoteId`
+                    // and trust that the caller has ensured that this is contiguous with
+                    // already accumulated lines by calling `getCurrentFootNoteId`
                     ref.get()->clear();
                 }
                 // Make a non-actual (which may be a proxy or not) actual

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -193,7 +193,8 @@ void LVRendPageContext::AddLine( int starty, int endy, int flags )
     if ( curr_note != NULL ) {
         //CRLog::trace("adding line to note (%d)", line->start);
         curr_note->addLine( line );
-    } else {
+    }
+    else {
         // Once we add a non-footnote line we can't append to the last footnote anymore
         curr_note_id.clear();
     }

--- a/crengine/src/lvpagesplitter.cpp
+++ b/crengine/src/lvpagesplitter.cpp
@@ -113,7 +113,7 @@ void LVRendPageContext::addLink( lString32 id, int pos )
     }
     if ( lines.empty() )
         return;
-    LVFootNoteRef note = getOrCreateFootNote( id, false ); // not yet actual
+    LVFootNoteRef note = getOrCreateFootNote( id, false, false ); // not yet actual
     lines.last()->addLink(note.get(), pos);
 }
 
@@ -127,10 +127,10 @@ void LVRendPageContext::enterFootNote( lString32 id )
         CRLog::error("Nested entering note" );
         return;
     }
-    curr_note = getOrCreateFootNote( id ).get();
+    curr_note = getOrCreateFootNote( id, true, false ).get();
 }
 
-void LVRendPageContext::enterFootNote( lString32Collection & ids )
+void LVRendPageContext::enterFootNote( lString32Collection & ids, bool appending )
 {
     if ( !page_list )
         return;
@@ -138,7 +138,8 @@ void LVRendPageContext::enterFootNote( lString32Collection & ids )
         CRLog::error("Nested entering note" );
         return;
     }
-    curr_note = getOrCreateFootNote( ids ).get();
+    curr_note = getOrCreateFootNote( ids, appending ).get();
+    curr_note_id = curr_note->getId();
 }
 
 /// mark end of foot note
@@ -151,6 +152,9 @@ void LVRendPageContext::leaveFootNote()
         CRLog::error("leaveFootNote() w/o current note set");
     }
     curr_note = NULL;
+    // Don't reset curr_note_id here but when the next line is passed to AddLine
+    // This allows appending to the footnote from the next consecutive block via
+    // -cr-hint: extend-footnote-inpage
 }
 
 void LVRendPageContext::newFlow( bool nonlinear )
@@ -189,6 +193,9 @@ void LVRendPageContext::AddLine( int starty, int endy, int flags )
     if ( curr_note != NULL ) {
         //CRLog::trace("adding line to note (%d)", line->start);
         curr_note->addLine( line );
+    } else {
+        // Once we add a non-footnote line we can't append to the last footnote anymore
+        curr_note_id.clear();
     }
 }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7285,9 +7285,10 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     if ( enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES)) {
         if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) ) {
             enode->getAllInnerAttributeValues(attr_id, footnoteIds);
-        } else if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
-            if (lString32 last_footnoteid = flow->getPageContext()->getCurrentFootNoteId();
-                 ! last_footnoteid.empty()) {
+        }
+        else if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
+            lString32 last_footnoteid = flow->getPageContext()->getCurrentFootNoteId();
+            if ( ! last_footnoteid.empty() ) {
                 enode->getAllInnerAttributeValues(attr_id, footnoteIds);
                 footnoteIds.insert(0, last_footnoteid);
                 appendingFootnote = true;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7287,10 +7287,13 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             enode->getAllInnerAttributeValues(attr_id, footnoteIds);
         }
         else if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
-            lString32 last_footnoteid = flow->getPageContext()->getCurrentFootNoteId();
-            if ( ! last_footnoteid.empty() ) {
+            lString32 previousActualFootnoteId = flow->getPageContext()->getCurrentFootNoteId();
+            if ( ! previousActualFootnoteId.empty() ) {
+                // prepend the id with which the footnote block that we are appending to
+                // is tracked within the PageContext to ensure any lines we add end up
+                // there and Ids in the current block are linked to it.
                 enode->getAllInnerAttributeValues(attr_id, footnoteIds);
-                footnoteIds.insert(0, last_footnoteid);
+                footnoteIds.insert(0, previousActualFootnoteId);
                 appendingFootnote = true;
             }
         }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7278,14 +7278,25 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // See if this block is a footnote container, so we can deal with it accordingly
     bool isFootNoteBody = false;
+    bool appendingFootnote = false;
     lString32Collection footnoteIds;
     // Allow displaying footnote content at the bottom of all pages that contain a link
     // to it, when -cr-hint: footnote-inpage is set on the footnote block container.
-    if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) &&
-                enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES)) {
-        enode->getAllInnerAttributeValues(attr_id, footnoteIds);
-        if ( footnoteIds.length() > 0 )
+    if ( enode->getDocument()->getDocFlag(DOC_FLAG_ENABLE_FOOTNOTES)) {
+        if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) ) {
+            enode->getAllInnerAttributeValues(attr_id, footnoteIds);
+        } else if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
+            if (lString32 last_footnoteid = flow->getPageContext()->getCurrentFootNoteId();
+                 ! last_footnoteid.empty()) {
+                enode->getAllInnerAttributeValues(attr_id, footnoteIds);
+                footnoteIds.insert(0, last_footnoteid);
+                appendingFootnote = true;
+            }
+        }
+
+        if ( footnoteIds.length() > 0 ) {
             isFootNoteBody = true;
+        }
         // Notes:
         // enterFootNote() takes care of not creating a new footnote if we are already
         // inside a footnotebody (in case of nested "-cr-hint: footnote-inpage"), which
@@ -8198,7 +8209,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 fmt.push();
 
                 if ( isFootNoteBody )
-                    flow->getPageContext()->enterFootNote( footnoteIds );
+                    flow->getPageContext()->enterFootNote( footnoteIds , appendingFootnote );
 
                 // Ensure page-break-inside avoid, from the table's style or
                 // from outer containers
@@ -8387,7 +8398,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     if (padding_top==0) {
                         flow->addContentLine(0, RN_SPLIT_AFTER_AVOID, 0, true);
                     }
-                    flow->getPageContext()->enterFootNote( footnoteIds );
+                    flow->getPageContext()->enterFootNote( footnoteIds , appendingFootnote );
                 }
 
                 // recurse all sub-blocks for blocks
@@ -8864,7 +8875,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     if (padding_top==0) {
                         flow->addContentLine(0, RN_SPLIT_AFTER_AVOID, 0, true);
                     }
-                    flow->getPageContext()->enterFootNote( footnoteIds );
+                    flow->getPageContext()->enterFootNote( footnoteIds, appendingFootnote );
                 }
 
                 // We have lines of text in 'txform', that we should register

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3416,6 +3416,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             hints = CSS_CR_HINT_NONE_NO_INHERIT;
                         }
                         else if ( substr_icompare("footnote-inpage", decl) )        hints |= CSS_CR_HINT_FOOTNOTE_INPAGE|CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE;
+                        else if ( substr_icompare("extend-footnote-inpage", decl) ) hints |= CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE|CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE;
                         else if ( substr_icompare("non-linear", decl) )             hints |= CSS_CR_HINT_NON_LINEAR;
                         else if ( substr_icompare("non-linear-combining", decl) )   hints |= CSS_CR_HINT_NON_LINEAR_COMBINING;
                         else if ( substr_icompare("strut-confined", decl) )         hints |= CSS_CR_HINT_STRUT_CONFINED;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5364,7 +5364,6 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                             if ( prevsibling == NULL || prevsibling->isNull() ) {
                                 return false;
                             }
-
                             css_style_ref_t prevstyle = prevsibling->getStyle();
                             if ( prevstyle.isNull() ) {
                                 return false;
@@ -5380,9 +5379,6 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                                 // siblings before this one.
                                 return false;
                             }
-
-                            // NOTE: This needs to skip over text nodes because they don't have a style here that we can check
-                            // They can still be matched via the `autoBoxing` selector
                             prevsibling = prevsibling->getUnboxedPrevSibling(true);
                         }
                     }();

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5353,6 +5353,8 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                     }
                 }
                 else if ( only_if == cr_only_if_following_inpage_footnote || cr_only_if_not_following_inpage_footnote ) {
+                    // Immediately invoked anonymous function
+                    // Will be inlined by any self-respecting compiler
                     bool does_follow_footnote = [&]() {
                         if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE)) {
                             return false;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3420,6 +3420,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             hints = CSS_CR_HINT_NONE_NO_INHERIT;
                         }
                         else if ( substr_icompare("footnote-inpage", decl) )        hints |= CSS_CR_HINT_FOOTNOTE_INPAGE|CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE;
+                        // For now, always set CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE even if the node might not end up extending a previous footnote
                         else if ( substr_icompare("extend-footnote-inpage", decl) ) hints |= CSS_CR_HINT_EXTEND_FOOTNOTE_INPAGE|CSS_CR_HINT_INSIDE_FOOTNOTE_INPAGE;
                         else if ( substr_icompare("non-linear", decl) )             hints |= CSS_CR_HINT_NON_LINEAR;
                         else if ( substr_icompare("non-linear-combining", decl) )   hints |= CSS_CR_HINT_NON_LINEAR_COMBINING;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5354,7 +5354,10 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                             break;
                         }
                         if ( ! STYLE_HAS_CR_HINT(prevstyle, EXTEND_FOOTNOTE_INPAGE) ) {
-                            // found a node that's not part of the footnote chain
+                            // if the sibling doesn't have `extend-footnote-inpage` then the chain
+                            // of footnote extensions has been explicitly broken and we want to stop.
+                            // Otherwise, we continue to look for an actual footnote node in the
+                            // siblings before this one.
                             return; // don't apply anything more of this declaration to this style
                         }
 

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3074,6 +3074,8 @@ static const char * css_cr_only_if_names[]={
         "not-inpage-footnote",
         "inside-inpage-footnote",
         "not-inside-inpage-footnote",
+        "extended-inpage-footnote",
+        "not-extended-inpage-footnote",
         "following-inpage-footnote",
         "not-following-inpage-footnote",
         "line-height-normal",
@@ -3115,6 +3117,8 @@ enum cr_only_if_t {
     cr_only_if_not_inpage_footnote,
     cr_only_if_inside_inpage_footnote,
     cr_only_if_not_inside_inpage_footnote,
+    cr_only_if_extended_inpage_footnote,
+    cr_only_if_not_extended_inpage_footnote,
     cr_only_if_following_inpage_footnote,
     cr_only_if_not_following_inpage_footnote,
     cr_only_if_line_height_normal,
@@ -5335,6 +5339,16 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                     }
                     else {
                         if ( only_if == cr_only_if_inside_inpage_footnote )
+                            return; // don't apply anything more of this declaration to this style
+                    }
+                }
+                else if ( only_if == cr_only_if_extended_inpage_footnote || only_if == cr_only_if_not_extended_inpage_footnote ) {
+                    if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
+                        if ( only_if == cr_only_if_not_extended_inpage_footnote )
+                            return; // don't apply anything more of this declaration to this style
+                    }
+                    else {
+                        if ( only_if == cr_only_if_extended_inpage_footnote )
                             return; // don't apply anything more of this declaration to this style
                     }
                 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3074,6 +3074,7 @@ static const char * css_cr_only_if_names[]={
         "not-inpage-footnote",
         "inside-inpage-footnote",
         "not-inside-inpage-footnote",
+        "following-inpage-footnote",
         "line-height-normal",
         "not-line-height-normal",
         NULL
@@ -3113,6 +3114,7 @@ enum cr_only_if_t {
     cr_only_if_not_inpage_footnote,
     cr_only_if_inside_inpage_footnote,
     cr_only_if_not_inside_inpage_footnote,
+    cr_only_if_following_inpage_footnote,
     cr_only_if_line_height_normal,
     cr_only_if_not_line_height_normal,
 };
@@ -5331,6 +5333,34 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                     else {
                         if ( only_if == cr_only_if_inside_inpage_footnote )
                             return; // don't apply anything more of this declaration to this style
+                    }
+                }
+                else if ( only_if == cr_only_if_following_inpage_footnote) {
+                    if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE)) {
+                        return; // don't apply anything more of this declaration to this style
+                    }
+                    ldomNode * prevsibling = node->getUnboxedPrevSibling(true);
+                    while (true) {
+                        if ( prevsibling == NULL || prevsibling->isNull() ) {
+                            return; // don't apply anything more of this declaration to this style
+                        }
+
+                        css_style_ref_t prevstyle = prevsibling->getStyle();
+                        if ( prevstyle.isNull() ) {
+                            return; // don't apply anything more of this declaration to this style
+                        }
+                        if ( STYLE_HAS_CR_HINT(prevstyle, FOOTNOTE_INPAGE)) {
+                            // found a footnote that we are following
+                            break;
+                        }
+                        if ( ! STYLE_HAS_CR_HINT(prevstyle, EXTEND_FOOTNOTE_INPAGE) ) {
+                            // found a node that's not part of the footnote chain
+                            return; // don't apply anything more of this declaration to this style
+                        }
+
+                        // NOTE: This needs to skip over text nodes because they don't have a style here that we can check
+                        // They can still be matched via the `autoBoxing` selector
+                        prevsibling = prevsibling->getUnboxedPrevSibling(true);
                     }
                 }
                 else if ( only_if == cr_only_if_line_height_normal || only_if == cr_only_if_not_line_height_normal ) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5352,7 +5352,7 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                             return; // don't apply anything more of this declaration to this style
                     }
                 }
-                else if ( only_if == cr_only_if_following_inpage_footnote || cr_only_if_not_following_inpage_footnote ) {
+                else if ( only_if == cr_only_if_following_inpage_footnote || only_if == cr_only_if_not_following_inpage_footnote ) {
                     // Immediately invoked anonymous function
                     // Will be inlined by any self-respecting compiler
                     bool does_follow_footnote = [&]() {


### PR DESCRIPTION
# What / Why

As promised (threatened?) in #617, this adds support for in-page footnotes that span more than one node.

This adds a hint-based way to allow marking nodes that continue an in-page footnote that starts in a previous node. This is necessary to make in-page footnotes usable in many books with footnotes like this:

```
<p class="footnote" id="f1">footnote 1 starts here</p>
<p>footnote 1 continues here</p>
<p class="footnote" id="f2">footnote 2 starts here</p>
```

(one could of course argue that the publisher did a poor job)
# How

This introduces a new hint to mark such footnotes, as well as a way to target this hint more accurately. These are split across two commits that work independently.

## `-cr-hint: extend-footnote-inpage`

If there is a node with `-cr-hint: footnote-inpage` immediately followed by a node with `-cr-hint: extend-footnote-inpage` then this new hint causes the nodes to act like one joined footnote block. Specifically:

- Append lines from the `extend-footnote-inpage` block to the lines in the `actual` footnote of the first block.
- Accumulate anchor `id`s for targeting the footnote across both blocks
 
It's allowed to chain this across multiple consecutive blocks with `-cr-hint: extend-footnote-inpage`.

## `-cr-only-if: following-inpage-footnote`

In theory `-cr-hint: extend-footnote-inpage` is enough to extend footnotes using e.g. the `~` sibling selector if one is willing to write enough css (and if `crengine` supports the necessary selectors). For example to allow footnote extension for all footnotes matched by koreader's _In-page classic classname footnotes_, one can write

```
.footnote ~ *, .footnotes ~ *, .fn ~ *,
.note ~ *, .note1 ~ *, .note2 ~ *, .note3 ~ *,
.ntb ~ *, .ntb-txt ~ *, .ntb-txt-j ~ *,
.przypis ~ *, .przypis1 ~ *,
.voetnoten ~ *
{
    -cr-only-if: -inpage-footnote;
    -cr-hint: extend-footnote-inpage;
}

.footnote ~ autoBoxing, .footnotes ~ autoBoxing, .fn ~ autoBoxing,
.note ~ autoBoxing, .note1 ~ autoBoxing, .note2 ~ autoBoxing, .note3 ~ autoBoxing,
.ntb ~ autoBoxing, .ntb-txt ~ autoBoxing, .ntb-txt-j ~ autoBoxing,
.przypis ~ autoBoxing, .przypis1 ~ autoBoxing,
.voetnoten ~ autoBoxing
{
    -cr-only-if: -inpage-footnote;
    -cr-hint: extend-footnote-inpage;
}
```

To extend all footnotes as far as possible (assuming there are no non-footnote nodes between them)

But this is quite repetitive and does not allow writing a generic style tweak independent of the specific footnote class. It would be nice to write something like this (pseudocode)

```
*[-cr-only-if: inpage-footnote] ~ *, *[-cr-only-if: inpage-footnote] ~ autoBoxing {
    -cr-only-if: -inpage-footnote;
    -cr-hint: extend-footnote-inpage;
}
```

This adds implements something close to these semantics as `-cr-only-if: following-inpage-footnote`, which matches if the previous sibling is an inpage footnote (potentially extended as per the rules above).

That allows writing the above much simpler like this (which I would propose as a footnote style tweak in `koreader` if this lands in `crengine`):

```
*, autoBoxing {
    -cr-only-if: following-inpage-footnote -inpage-footnote;
    -cr-hint: extend-footnote-inpage;
}
```

If new rules are added to set `-cr-hint: footnote-inpage` on other nodes, the rule to extend them does not need to be changed.

The simplification is even better if the selector is more complicated, e.g. if the footnotes are separated by headings:

```
*:not(h1, h2, h3, h4, h5, h6), autoBoxing{
    -cr-only-if: following-inpage-footnote -inpage-footnote;
    -cr-hint: extend-footnote-inpage;
}
```

This might be impossible to express in vanilla css selectors because unlike `~`, it will stop at the heading and not continue afterwards. That is:

```
<p class="footnote" />  ← footnote
<p />                   ← above hint applies
<h1 />                  ← hint doesn't apply
<p />                   ← hint dosen't apply, but `~` would
```

In the books that I have been able to test with, this matches what one wants. _"Footnotes are continued until element X or class Y_

## Why Both

You might think that `-cr-only-if: following-inpage-footnote` might be enough because one could write

```
*, autoBoxing {
    -cr-only-if: following-inpage-footnote -inpage-footnote;
    -cr-hint: footnote-inpage;
}
```

Indeed, this works in simple cases but breaks as soon as the extended footnote (recursively) contains another `id` attribute. Then its lines will be added to a separate `LVFootNote`. This will happen if the footnote contains nested footnote links, as these usually have `id`s for back-links. (I've seen this in my copy of _Infinite Jest_)

On the other hand, just having `-cr-hint: extend-footnote-inpage` works, but writing style tweaks is less ergonomic. Being able to use `*:not(...)` with `-cr-only-if: following-inpage-footnote` is much less error prone to exclude unwanted nodes.

# Test Case

I've been testing with a few different books that are heavy on footnotes and even nested footnotes (with #617 also applied). Especially _Infinite Jest_ and _Jonathan Strange & Mr Norrell_. I've also made those even worse in an attempt to break this code and find edge cases, but even something like e.g. the following works:

```
<div class="footnote" id="endnote_text_24">
	<p>
		<a href="chap-8.xhtml#endnote_reference_24">
			24.
		</a>
		first text with sub-footnote reference
		<sup>
			<a href="note-1a.xhtml#footnote_number_4" id="footnote_reference_4">
				a
			</a>
		</sup>
	</p>
</div>
<p class="more-footnote">
	extended footnote text
</p>
free-floating footnote text in autoBox
<p class="more-footnote">
	more of the same footnote with another sub-footnote
	<sup>
		<a href="note-1a.xhtml#footnote_number_5" id="footnote_reference_5">
			b
		</a>
	</sup>
</p>
<p class="more-footnote">
	even more extended footnote text
</p>
<p class="footnote" id="footnote_number_4">
	sub-footnote text
</p>
<!-- more sub footnotes and normal footnotes -->
```

With the style tweak suggested above, this produces a footnote along the lines of

> 24. first text with sub-footnote referenceᵃ
>   extended footnote text
>   free-floating footnote text in autoBox
>   more of the same footnote with another sub-footnoteᵇ
>   even more extended footnote text
> ... nested footnotes follow

(unless I made a mistake in editing my example for this description)

# Implementation notes

Does *not* depend on #617 (though I also tested them together).

I originally tried to keep track if a given block can extend a previous footnote inside `lvrend` / `renderBlockElementEnhanced`, but that turned out quit error prone due to its recursive nature. So I moved to tracking this in `LVRendPageContext`. I believe this is much more robust and the logic of _"if no regular lines have been added the footnote can still be extended"_ makes intuitive sense and makes the change quite small. But I'd be open to suggestions if there's a better way.

# Aside: Previous Attempts

As originally threatened in #617, I did also attempt to achieve extending footnotes by re-using the heuristic in `koreader-base` that is used in popup footnotes.

I extended `ldomDocument` to allow passing an `ldomCallback` that detects footnotes and stores them as ranges in `ldomDocument`. This callback wound be invoked after parsing but before rendering.

While this works it does not really fit with `crengine` design and has big risks of regressing user experience for books with exceptionally bad markup. It would also need a lot of knobs in `koreader` to adjust the footnote detection.

I also hit some insurmountable problems with this approach because you'd want to use `-cr-hint`'s as inputs to the footnote heuristic to mark footnotes.  But you also want to style nodes after they were detected as footnotes.

If you're curious, that attempt is at:

- https://github.com/moben/crengine/commits/footnotes_heuristic
- https://github.com/moben/koreader-base/commits/footnotes_heuristic
- https://github.com/moben/koreader/commits/footnotes_heuristic

Thanks @poire-z for the thoughts and links in https://github.com/koreader/crengine/pull/617#issuecomment-2676469220, that led me to exploring this hint-based solution and I think it's much better :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/618)
<!-- Reviewable:end -->
