### PR TITLE
fix: rule of three for string collections

### DIFF
--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -924,6 +924,16 @@ public:
     lString32Collection()
         : chunks(NULL), count(0), size(0)
     { }
+    lString32Collection(const lString32Collection & src)
+        : chunks(NULL), count(0), size(0)
+    { reserve(src.size); addAll(src); }
+    lString32Collection& operator=(const lString32Collection& other)
+    {
+        clear();
+        reserve(other.size);
+        addAll(other);
+        return *this;
+    }
     /// parse delimiter-separated string
     void parse( lString32 string, lChar32 delimiter, bool flgTrim );
     /// parse delimiter-separated string
@@ -1053,6 +1063,7 @@ public:
 	bool deserialize( SerialBuf & buf );
 
     lString32HashedCollection( lString32HashedCollection & v );
+    lString32HashedCollection& operator=(lString32HashedCollection &) = delete;
     lString32HashedCollection( lUInt32 hashSize );
     ~lString32HashedCollection();
     int add( const lChar32 * s );

--- a/crengine/include/lvstring.h
+++ b/crengine/include/lvstring.h
@@ -1063,6 +1063,7 @@ public:
 	bool deserialize( SerialBuf & buf );
 
     lString32HashedCollection( lString32HashedCollection & v );
+    // No reason `operator=` can't be implemented, but needs to be done manually and not auto-generated
     lString32HashedCollection& operator=(lString32HashedCollection &) = delete;
     lString32HashedCollection( lUInt32 hashSize );
     ~lString32HashedCollection();


### PR DESCRIPTION
Small bugfix for `lString32Collection`

Accidentally found this bug while working on footnote improvements. This was copying the pointers directly instead of doing the correct refcount adjustments.

Didn't end up needing it in #618 but might save someone some debugging time when writing

    lString32Collection strings;
    strings = other_collection;

and wondering about a double free.

Also delete the assignment operator for `lString32HashedCollection`. This is also broken. I didn't feel like implementing it here but this way you'd at least get a compiler error instead of a crash when trying to use it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/619)
<!-- Reviewable:end -->
