### PR TITLE
 lvstsheet: `-cr-only-if: inpage-footnote` matches extended footnotes

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3074,8 +3074,6 @@ static const char * css_cr_only_if_names[]={
         "not-inpage-footnote",
         "inside-inpage-footnote",
         "not-inside-inpage-footnote",
-        "extended-inpage-footnote",
-        "not-extended-inpage-footnote",
         "following-inpage-footnote",
         "not-following-inpage-footnote",
         "line-height-normal",
@@ -3117,8 +3115,6 @@ enum cr_only_if_t {
     cr_only_if_not_inpage_footnote,
     cr_only_if_inside_inpage_footnote,
     cr_only_if_not_inside_inpage_footnote,
-    cr_only_if_extended_inpage_footnote,
-    cr_only_if_not_extended_inpage_footnote,
     cr_only_if_following_inpage_footnote,
     cr_only_if_not_following_inpage_footnote,
     cr_only_if_line_height_normal,
@@ -5339,16 +5335,6 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                     }
                     else {
                         if ( only_if == cr_only_if_inside_inpage_footnote )
-                            return; // don't apply anything more of this declaration to this style
-                    }
-                }
-                else if ( only_if == cr_only_if_extended_inpage_footnote || only_if == cr_only_if_not_extended_inpage_footnote ) {
-                    if ( STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
-                        if ( only_if == cr_only_if_not_extended_inpage_footnote )
-                            return; // don't apply anything more of this declaration to this style
-                    }
-                    else {
-                        if ( only_if == cr_only_if_extended_inpage_footnote )
                             return; // don't apply anything more of this declaration to this style
                     }
                 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5323,7 +5323,7 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                     }
                 }
                 else if ( only_if == cr_only_if_inpage_footnote || only_if == cr_only_if_not_inpage_footnote ) {
-                    if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) ) {
+                    if ( STYLE_HAS_CR_HINT(style, FOOTNOTE_INPAGE) || STYLE_HAS_CR_HINT(style, EXTEND_FOOTNOTE_INPAGE) ) {
                         if ( only_if == cr_only_if_not_inpage_footnote )
                             return; // don't apply anything more of this declaration to this style
                     }


### PR DESCRIPTION
As suggested in https://github.com/koreader/koreader/pull/13554#discussion_r2053464009

> Logically, `-cr-only-if: inpage-footnote` (named `inpage-foonote`, different from the hint name `footnote-inpage`) should match what has ended up being a footnote, not what had the hint.
> So yes, I think it should also match extended footnotes.

This also means `-cr-only-if: extended-inpage-footnote` is unneeded and less css is needed overall.

> Same for `inside-inpage-footnote`, which should match stuff inside an extended footnote block.

This was already the case