### PR TITLE
Fix various stylesheet issues

### DIFF
--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -1248,17 +1248,24 @@ public:
         lString8 css_ = deletecomment(css);
         for (int i=0; i<css_.length(); i++) {
             char ch = css_[i];
-            if (insideQuotes || _state == 13) {
-                if (ch == insideQuotes || (_state == 13 && ch == ')')) {
+            if (insideQuotes) {
+                if (ch == insideQuotes) {
                     onQuotedText(token);
-                    insideQuotes =  0;
-                    if (_state == 13)
-                        onToken(ch);
+                    insideQuotes = 0;
                 } else {
-                    if (_state == 13 && token.empty() && (ch == '\'' || ch=='\"')) {
+                    token << ch;
+                }
+                continue;
+            }
+            else if (_state == 13) {
+                if (ch == ')') {
+                    onQuotedText(token);
+                } else {
+                    if (token.empty() && (ch == '\'' || ch=='\"')) {
                         insideQuotes = ch;
-                    } else if (ch != ' ' || _state != 13)
+                    } else if (ch != ' ') {
                         token << ch;
+                    }
                 }
                 continue;
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -9570,6 +9570,9 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
     if (!style->background_image.empty()) {
         lString32 filepath = lString32(style->background_image.c_str());
         LVImageSourceRef img = enode->getParentNode()->getDocument()->getObjectImageSource(filepath);
+        if (img.isNull()) { // filepath may be url-encoded
+            img = enode->getParentNode()->getDocument()->getObjectImageSource(DecodeHTMLUrlString(filepath));
+        }
         if (!img.isNull()) {
             // Native image size
             int img_w =img->GetWidth();

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -548,8 +548,13 @@ static inline bool skip_to_next( const char * & str, char stop_char_to_skip, cha
             if ( *str == closing_paren_ch ) {
                 closing_paren_ch = 0;
             }
+            else if ( *str == '\'' || *str=='\"' ) {
+                quote_ch = *str;
+            }
             // skip closing paren, or anything not this closing paren when
-            // inside parens and not inside quotes (handled above)
+            // inside parens and not inside quotes (handled above);
+            // if we meet a quote, we are now inside quotes and should then ignore
+            // any further closing paren until after we see a closing quote.
         }
         else if ( *str == stop_char_to_skip ) {
             // i.e. ';' after "property:value;" if not inside quotes/parens nor escaped

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3641,7 +3641,9 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     if ( g >= 0 ) {
                         if ( g == css_g_initial ) {
                             n = css_ff_sans_serif; // lvfntman's default
-                            if ( doc ) { strValue = doc->getRootNode()->getStyle()->font_name; }
+                            if ( doc && ((ldomDocument*)doc)->isDefStyleSet() ) {
+                                strValue = ((ldomDocument*)doc)->getDefaultStyle()->font_name;
+                            }
                         }
                         else { // inherit/unset
                             n = css_ff_inherit;
@@ -4054,7 +4056,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             // Done with those that accept 1 to 4 length values.
 
             case cssd_color:
-                IF_g_PUSH_LENGTH_AND_break(1, true, css_val_color, (doc ? doc->getRootNode()->getStyle()->color.value : 0x000000));
+                IF_g_PUSH_LENGTH_AND_break(1, true, css_val_color, (doc && ((ldomDocument*)doc)->isDefStyleSet() ? ((ldomDocument*)doc)->getDefaultStyle()->color.value : 0x000000));
             case cssd_background_color:
                 IF_g_PUSH_LENGTH_AND_break(1, false, css_val_color, CSS_COLOR_TRANSPARENT);
             case cssd_border_top_color:

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5973,8 +5973,11 @@ ldomElementWriter::ldomElementWriter(ldomDocument * document, lUInt16 nsid, lUIn
     _flags = 0;
     if ( (_typeDef && _typeDef->white_space >= css_ws_pre_line) || (_parent && _parent->getFlags()&TXTFLG_PRE) )
         _flags |= TXTFLG_PRE; // Parse as PRE: pre-line, pre, pre-wrap and break-spaces
-        // This will be updated in ldomElementWriter::onBodyEnter() after we have
-        // set styles to this node, so we'll get the real white_space value to use.
+    if ( _typeDef )
+        _isBlock = _typeDef->display > css_d_inline && _typeDef->display != css_d_none;
+        // These will be updated in ldomElementWriter::onBodyEnter() after we have
+        // set styles to this node, so we'll get the real white_space and display
+        // values to use for parsing any children text node.
 
     _isSection = (id==el_section);
 


### PR DESCRIPTION
#### DrawBackgroundImage: handle %-encoded urls

Another adhoc quick fix, until we get the brain bandwidth to fix all these generically.
Should allow closing https://github.com/koreader/koreader/issues/14056

#### lvstsheet: parsing: ignore parens inside quotes

When inside quotes, don't trigger anything on a closing paren. Stuff like this would cause the remaining of the stylesheet to fail being parsed:
    `@font-face { font-family: "abc"; src: local("汉仪楷体(GB18030版)"); }`
Fix this both in epubftm.cpp's `EmbeddedFontStyleParser()` (used early to extract embedded fonts) and in our main stylesheet parsing code.
Should allow closing https://github.com/koreader/koreader/issues/14052.

#### lvstsheet: fix crash on "color/font-family: initial"

At the time of parsing the user-agent stylesheet (which includes style tweaks that may have `color: initial` or `font-family: initial`), the root node has not yet any style set.
Directly use the default style (which is later applied to the root node).
(color and font-family were the only 2 properties accessing the root node's style.)
Should allow closing https://github.com/koreader/koreader/issues/13934

#### ldomElementWriter: fix minor parsing issue

On HTML documents (on which the fb2def.h HTML elements defaults for display and white-space are used), when no default style are set (ie. getBalancedHTML()), we were ignoring the default "block" property, which could cause some relevant leading space on inline nodes to be removed.
Should allow closing https://github.com/koreader/koreader/issues/13485