### PR TITLE
RegisterDocumentFont: handle %-encoded urls

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6192,6 +6192,8 @@ public:
         }
         name.trim(); // Remove any " " appended to avoid url override with duplicates
         LVStreamRef stream = container->OpenStream(name.c_str(), LVOM_READ);
+        if (stream.isNull()) // Try again in case it is percent-encoded
+            stream = container->OpenStream(DecodeHTMLUrlString(name).c_str(), LVOM_READ);
         if (stream.isNull())
             return false;
         lUInt32 size = (lUInt32)stream->GetSize();


### PR DESCRIPTION
Handle `@font-face {src:  url("../Fonts/%2A%2A%3..."}` in publishers' stylesheets.
See https://github.com/koreader/koreader/issues/14056#issuecomment-3112798934.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/625)
<!-- Reviewable:end -->
