### PR TITLE
ci: fix stylelint linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         sudo dpkg -i *.deb
         # Install stylelint.
         npm init --yes
-        npm install stylelint stylelint-config-standard
+        npm install @csstools/stylelint-formatter-github stylelint stylelint-config-standard
 
     - name: Setup problem matchers
       run: |

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,10 +15,16 @@
     }],
     "no-descending-specificity": [true, { "severity": "warning" }],
     "no-duplicate-selectors": [true, { "severity": "warning" }],
+    "property-no-deprecated": [true, {
+      "ignoreProperties": [
+	"page-break-after",
+	"page-break-before",
+	"page-break-inside"
+      ]
+    }],
     "property-no-unknown": [true, {
       "ignoreProperties": [
         "binding",
-
         "hyphenate"
       ]
     }],

--- a/utils/lint.mk
+++ b/utils/lint.mk
@@ -295,7 +295,7 @@ endef
 
 define STYLELINT_FLAGS
 $(if $(CLICOLOR_FORCE),--color)
---formatter=$(if $(GITHUB_ACTIONS),github,unix)
+$(if $(GITHUB_ACTIONS),--custom-formatter=@csstools/stylelint-formatter-github,--formatter=unix)
 endef
 
 define stylelint_rule


### PR DESCRIPTION
- update configuration: ignore deprecation warnings about `page-break-xxx` properties
- switch to the `@csstools/stylelint-formatter-github` formatter, since the builtin one is deprecated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/627)
<!-- Reviewable:end -->
