### PR TITLE
lvtinydom: buildSyntheticPageMap(): fix counting

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -20997,10 +20997,11 @@ void ldomDocument::buildSyntheticPageMap( int chars_per_synthetic_page )
                     }
                 }
                 else { // isText()
-                    lString32 text = n->getText().trim();
+                    lString32 text = n->getText();
                     int len = text.length();
+                    int offset = 0;
                     while (len > count) {
-                        int offset = count;
+                        offset += count;
                         len -= count;
                         count = chars_per_synthetic_page;
                         page_num++;


### PR DESCRIPTION
Fix previous commit (from #637), which was bad with paragraphs larger than chars_per_synthetic_page.
See https://github.com/koreader/koreader/pull/14426#issuecomment-3414600114 .

Also avoid trimming (would be ok with block nodes, but may not with many inline nodes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/638)
<!-- Reviewable:end -->
