### PR TITLE
Add support for CSS width: fit-content

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -394,6 +394,7 @@ enum css_generic_value_t {
     css_generic_none = -7,         // (css_val_unspecified, css_generic_none), for "max-width: none"
     css_generic_cr_special = -8,   // (css_val_unspecified, css_generic_cr_special), for "padding-left: -cr-special"
                                              //  (could be used with other properties for other special behaviours)
+    css_generic_fit_content = -9   // (css_val_unspecified, css_generic_fit_content), for "width/height: fit-content"
 };
 
 // color 'transparent' is transparent black rgba(0,0,0,0) per specs

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -343,7 +343,8 @@ bool parse_number_value( const char * & str, css_length_t & value,
                                     bool accept_unspecified=false,
                                     bool accept_contain_cover=false,
                                     bool accept_cr_special=false,
-                                    bool is_font_size=false );
+                                    bool is_font_size=false,
+                                    bool accept_fit_content=false );
 
 /// parse color value like #334455, #345 or red
 bool parse_color_value( const char * & str, css_length_t & value );

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -343,8 +343,8 @@ bool parse_number_value( const char * & str, css_length_t & value,
                                     bool accept_unspecified=false,
                                     bool accept_contain_cover=false,
                                     bool accept_cr_special=false,
-                                    bool is_font_size=false,
-                                    bool accept_fit_content=false );
+                                    bool accept_fit_content=false,
+                                    bool is_font_size=false );
 
 /// parse color value like #334455, #345 or red
 bool parse_color_value( const char * & str, css_length_t & value );

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7464,7 +7464,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         // We always use the style height for <HR>, to actually have a height to fill
         // with its color (as some of our css files render them via height)
         css_length_t style_height = style->height;
-        // If css_generic_fit_content, nothing special to do
+        // If css_generic_fit_content, nothing to do, it is our default behaviour
         if ( is_empty_line_elem && style_height.type == css_val_unspecified ) {
             // No height specified: default to line-height, just like
             // if it were rendered final.
@@ -7762,9 +7762,10 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // when !ENSURE_STYLE_WIDTH.)
                 table_shrink_to_fit = true;
             }
-            // Also only if ENSURE_STYLE_WIDTH as we may prefer having
-            // full width text blocks to not waste reading width with blank areas.
+
             else if ( is_fit_content_width ) {
+				// Also only if ENSURE_STYLE_WIDTH as we may prefer having
+				// full width text blocks to not waste reading width with blank areas.
                 if ( BLOCK_RENDERING(flags, ENSURE_STYLE_WIDTH) )
                     apply_style_width = true;
             }
@@ -7773,8 +7774,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
             if ( is_fit_content_width ) {
                 int max_content_width = 0;
                 int min_content_width = 0;
-                int rend_flags = flags | BLOCK_RENDERING_ENSURE_STYLE_WIDTH |
-                                 BLOCK_RENDERING_ALLOW_STYLE_W_H_ABSOLUTE_UNITS;
+                int rend_flags = flags | BLOCK_RENDERING_ENSURE_STYLE_WIDTH | BLOCK_RENDERING_ALLOW_STYLE_W_H_ABSOLUTE_UNITS;
                 // Compute shrink-to-fit width from rendered content, ignoring this element's
                 // own margins, and clamp it to the available container width.
                 getRenderedWidths(enode, max_content_width, min_content_width,
@@ -7785,7 +7785,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     width = available_width;
                 auto_width = false;
             }
-            else { // the original
+            else { // Fixed specified width
                 width = lengthToPx( enode, style_width, container_width );
             }
             // In all crengine computation, width/fmt.getWidth() is the width
@@ -7835,10 +7835,6 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 }
             }
             css_length_t style_min_width = style->min_width;
-            // Check for fit-content in min-width
-            if ( style_min_width.type == css_val_unspecified && style_min_width.value == css_generic_fit_content ) {
-                style_min_width.value = css_generic_auto; // treat as no min-width constraint
-            }
             if ( style_min_width.type != css_val_unspecified ) {
                 if ( BLOCK_RENDERING(flags, ALLOW_STYLE_W_H_ABSOLUTE_UNITS) ||
                      style_min_width.type == css_val_screen_px || // in case it was converted to screen_px beforehand
@@ -11690,9 +11686,8 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         bool is_boxing_elem = nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START;
         bool use_style_width = false;
         css_length_t style_width = style->width;
-        // Check for fit-content: treat as shrink-to-content width (don't use fixed width)
-        bool has_fit_content_width = (style_width.type == css_val_unspecified && 
-                                      style_width.value == css_generic_fit_content);
+        // ('width: fit-content' is actually what this function returns as maxWidth)
+        bool has_fit_content_width = (style_width.type == css_val_unspecified && style_width.value == css_generic_fit_content);
         if ( BLOCK_RENDERING(rendFlags, ENSURE_STYLE_WIDTH) && !has_fit_content_width ) {
             // Ignore width for table sub-elements - but allow it for our boxing elements, as we can set it
             // for some explicit rendering purpose (i.e. for the MathML <msqrt> mathBox root symbol)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7735,7 +7735,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     else { // regular element (non-float)
         bool apply_style_width = false;
         css_length_t style_width = style->width;
-        bool is_fit_content_width = ( style_width.type == css_val_unspecified && style_width.value == css_generic_fit_content );
+        bool is_fit_content_width = style_width.type == css_val_unspecified && style_width.value == css_generic_fit_content;
         // table sub-elements widths are managed by the table layout algorithm
         // (but trust width if the table sub element is one of our boxing elements)
         if ( style->display <= css_d_table || is_boxing_elem ) {
@@ -7762,7 +7762,6 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // when !ENSURE_STYLE_WIDTH.)
                 table_shrink_to_fit = true;
             }
-
             else if ( is_fit_content_width ) {
 				// Also only if ENSURE_STYLE_WIDTH as we may prefer having
 				// full width text blocks to not waste reading width with blank areas.
@@ -7777,8 +7776,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 int rend_flags = flags | BLOCK_RENDERING_ENSURE_STYLE_WIDTH | BLOCK_RENDERING_ALLOW_STYLE_W_H_ABSOLUTE_UNITS;
                 // Compute shrink-to-fit width from rendered content, ignoring this element's
                 // own margins, and clamp it to the available container width.
-                getRenderedWidths(enode, max_content_width, min_content_width,
-                                  direction, true, rend_flags);
+                getRenderedWidths(enode, max_content_width, min_content_width, direction, true, rend_flags);
                 int available_width = container_width - margin_left - margin_right;
                 width = max_content_width;
                 if ( width > available_width )
@@ -11687,7 +11685,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         bool use_style_width = false;
         css_length_t style_width = style->width;
         // ('width: fit-content' is actually what this function returns as maxWidth)
-        bool has_fit_content_width = (style_width.type == css_val_unspecified && style_width.value == css_generic_fit_content);
+        bool has_fit_content_width = style_width.type == css_val_unspecified && style_width.value == css_generic_fit_content;
         if ( BLOCK_RENDERING(rendFlags, ENSURE_STYLE_WIDTH) && !has_fit_content_width ) {
             // Ignore width for table sub-elements - but allow it for our boxing elements, as we can set it
             // for some explicit rendering purpose (i.e. for the MathML <msqrt> mathBox root symbol)

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1354,7 +1354,7 @@ bool parse_color_value( const char * & str, css_length_t & value )
         bool has_comma_separator = false;
         for ( int i=1; i<=3; i++ ) {
             css_length_t num;
-            if ( parse_number_value(str, num, true, true, false, false, false, true, false, false, false, false) ) { // accept percent, negative, unspecified
+            if ( parse_number_value(str, num, true, true, false, false, false, true) ) { // accept percent, negative, unspecified
                 // Firefox actually caps the values (-123 is considered as 0, 300 as 255)
                 int n = 0; // defaults to 0 if negative met below
                 if ( allow_unspecified && num.type == css_val_unspecified ) {
@@ -1419,7 +1419,7 @@ bool parse_color_value( const char * & str, css_length_t & value )
                 }
             }
             if ( expecting_4th_number ) {
-                if ( parse_number_value(str, num, true, true, false, false, false, true, false, false, false, false) ) {
+                if ( parse_number_value(str, num, true, true, false, false, false, true) ) {
                     int n = 0;
                     if ( num.type == css_val_unspecified ) {
                         if (num.value >= 0 ) {
@@ -2284,7 +2284,7 @@ protected:
                         break;
                     }
                     css_length_t val;
-                    if ( parse_number_value(str, val, false, false, false, false, false, false, false, false, false, false) ) {
+                    if ( parse_number_value(str, val, false) ) {
                         int size = lengthToPx(doc->getRootNode(), val, 0);
                         // This CSS length has been scaled according to gRenderDPI from CSS pixels to screen pixels,
                         // so we can compare it with the viewport or screen width/height which are in screen pixels
@@ -3740,7 +3740,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         buf<<(lUInt32) len.value;
                     }
                     else {
-                        if ( parse_number_value( decl, len, true, true, false, false, false, false, false, false, false, false ) ) { // accepts a negative value
+                        if ( parse_number_value( decl, len, true, true ) ) { // accepts a negative value
                             buf<<(lUInt32) (prop_code | importance | parse_important(decl));
                             buf<<(lUInt32) len.type;
                             buf<<(lUInt32) len.value;
@@ -3991,7 +3991,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     // read length
                     css_length_t len;
                     const char * orig_pos = decl;
-                    if ( parse_number_value( decl, len, true, true, false, false, false, false, false, false, false, false ) ) { // accepts % and negative values
+                    if ( parse_number_value( decl, len, true, true ) ) { // accepts % and negative values
                         // Read optional "hanging" flag
                         // Note: "1em hanging" is not the same as "-1em"; the former shifts
                         // all other but first line by 1em to the right, while the latter
@@ -4143,7 +4143,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     css_length_t len[4];
                     int i;
                     for (i = 0; i < 4; i++) {
-                        if (parse_number_value( decl, len[i], accept_percent, accept_negative, accept_auto, false, false, false, false, false, false, false )) {
+                        if (parse_number_value( decl, len[i], accept_percent, accept_negative, accept_auto )) {
                             continue;
                         }
                         if (prop_code == cssd_border_width && parse_named_border_width( decl, len[i] )) {
@@ -4284,7 +4284,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                                 found_width = true;
                                 continue;
                             }
-                            if ( parse_number_value( decl, width, false, false, false, false, false, false, false, false, false, false ) ) { // accept_percent=false
+                            if ( parse_number_value( decl, width, false ) ) { // accept_percent=false
                                 found_width = true;
                                 continue;
                             }
@@ -4577,7 +4577,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     int i;
                     for (i = 0; i < 2; i++) {
                         // accept percent, auto and contain/cover
-                        if ( !parse_number_value( decl, len[i], true, false, true, false, false, false, true, false, false, false ) )
+                        if ( !parse_number_value( decl, len[i], true, false, true, false, false, false, true ) )
                             break;
                     }
                     if (i) {
@@ -4606,7 +4606,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     int i;
                     for (i = 0; i < 2; i++) {
                         // border-spacing doesn't accept values in %
-                        if ( !parse_number_value( decl, len[i], false, false, false, false, false, false, false, false, false, false ) )
+                        if ( !parse_number_value( decl, len[i], false ) )
                             break;
                     }
                     if (i) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -628,8 +628,8 @@ bool parse_number_value( const char * & str, css_length_t & value,
                                     bool accept_unspecified,
                                     bool accept_contain_cover,
                                     bool accept_cr_special,
-                                    bool is_font_size,
-                                    bool accept_fit_content )
+                                    bool accept_fit_content,
+                                    bool is_font_size )
 {
     const char * orig_pos = str;
     value.type = css_val_unspecified;
@@ -4114,7 +4114,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     bool accept_cr_special = false;
                     if ( prop_code==cssd_padding_left || prop_code==cssd_padding_right )
                         accept_cr_special = true;
-                    if ( parse_number_value( decl, len, accept_percent, accept_negative, accept_auto, accept_none, accept_normal, accept_unspecified, false, accept_cr_special, is_font_size, accept_fit_content) ) {
+                    if ( parse_number_value( decl, len, accept_percent, accept_negative, accept_auto, accept_none, accept_normal, accept_unspecified, false, accept_cr_special, accept_fit_content, is_font_size) ) {
                         buf<<(lUInt32) (prop_code | importance | parse_important(decl));
                         buf<<(lUInt32) len.type;
                         buf<<(lUInt32) len.value;


### PR DESCRIPTION
The implementation of the `fit-content` keyword _(written using GPT-5.2, no coding experience)_  

This provides support in cases where alignment should be applied to the text block itself rather than the text inside the block: poetry, epigraphs, quotations, etc.  

For example, according to classical book typography rules, poems are aligned to the center of the page relative to their longest line. Without fit-content, this could only be achieved using `display: table` (which removed margin inside the block) or `display: inline-block` (which prevented the block from breaking across pages).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/647)
<!-- Reviewable:end -->
