### PR TITLE
testAuthorDotTitleFormat: fix off-by-one error for last character in bookTitle

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -1586,7 +1586,7 @@ public:
             return false;
         bookAuthors = firstLine.substr( 0, dotPos );
         bookTitle = firstLine.substr( dotPos + 2, firstLine.length() - dotPos - 2);
-        if ( bookTitle.empty() || (lGetCharProps(bookTitle[bookTitle.length()]) & CH_PROP_PUNCT) )
+        if ( bookTitle.empty() || (lGetCharProps(bookTitle[bookTitle.length() - 1]) & CH_PROP_PUNCT) )
             return false;
         return true;
     }


### PR DESCRIPTION
Fixes <https://github.com/koreader/koreader/issues/14971>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/651)
<!-- Reviewable:end -->
