### PR TITLE
CSS: support for pseudo element ::first-line, and other CSS fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -322,7 +322,9 @@ enum css_float_t {
     css_f_inherit,
     css_f_none,
     css_f_left,
-    css_f_right
+    css_f_right,
+    css_f_inline_start,
+    css_f_inline_end
 };
 
 /// clear property values
@@ -331,6 +333,8 @@ enum css_clear_t {
     css_c_none,
     css_c_left,
     css_c_right,
+    css_c_inline_start,
+    css_c_inline_end,
     css_c_both
 };
 

--- a/crengine/include/fb2def.h
+++ b/crengine/include/fb2def.h
@@ -29,6 +29,12 @@
 //=====================================================
 XS_BEGIN_TAGS
 
+// Internal element created for ::first-line DOM cloning
+// (clones of source element/text nodes inside pseudoElem[FirstLine])
+// Keep this one first (so its enum value is 1 and we can use it hardcoded
+// in ldomNode::*Effective* methods in lvtinydom.h to allow inlining)
+XS_TAG1D( cloneNode, false, css_d_none, css_ws_inherit )
+
 // Boxing elements (inserted in the DOM tree between original parent and children):
 //
 // Internal element for block wrapping inline elements (without a proper parent
@@ -442,11 +448,14 @@ XS_ATTR2( required_namespace, "required-namespace" ) // <epub:case required-name
 // we explicitely set while building the DOM. So, for our internal elements
 // needs, let's use some uppercase to avoid conflicts with HTML content
 // and the risk to have them matched by publishers CSS selectors.
-XS_ATTR( T )      // to flag subtype of boxing internal elements if needed
+XS_ATTR( T )      // to flag subtype of boxing internal elements if needed (and cloneNode of text nodes)
 XS_ATTR( Before ) // for pseudoElem internal element
 XS_ATTR( After )  // for pseudoElem internal element
 XS_ATTR( FirstLetter )    // for pseudoElem internal element (the actual first-letter holder)
-XS_ATTR( HasFirstLetter ) // on elements matched by ::first-letter that will get an inner pseudoElem FirstLetter
+XS_ATTR( HasFirstLetter ) // on elements matched by ::first-letter that will get an inner pseudoElem[FirstLetter]
+XS_ATTR( FirstLine )      // for pseudoElem internal element (the ::first-line style carrier)
+XS_ATTR( HasFirstLine )   // on elements matched by ::first-line that will get an inner pseudoElem[FirstLine]
+XS_ATTR( SrcId )        // for cloneNode: stores the data index of the source node
 XS_ATTR( ParserHint )   // HTML parser hints (used for Lib.ru support)
 XS_ATTR( NonLinear )    // for non-linear items in EPUB
 XS_ATTR( Source )       // set on DocFragment to the path of the file in the EPUB, for info

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -140,8 +140,8 @@ int initRendMethod( ldomNode * node, bool recurseChildren, bool allowAutoboxing 
 lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction=REND_DIRECTION_UNSET );
 /// renders block as single text formatter object
 void renderFinalBlock( ldomNode * node, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & flags,
-                       int indent, int line_h, TextLangCfg * lang_cfg=NULL, int valign_dy=0, bool * is_link_start=NULL,
-                       lString32 running_bidi_ctrlchars=lString32::empty_str );
+                       int indent, int line_h, TextLangCfg * lang_cfg=NULL, lUInt32 bgcolor=LTEXT_COLOR_CURRENT, int valign_dy=0,
+                       bool * is_link_start=NULL, lString32 running_bidi_ctrlchars=lString32::empty_str );
 /// renders block which contains subblocks (with enode document's rendering flags)
 int renderBlockElement( LVRendPageContext & context, ldomNode * enode, int x, int y, int width,
         int usable_left_overflow=0, int usable_right_overflow=0, int direction=REND_DIRECTION_UNSET, int * baseline=NULL );

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -193,6 +193,7 @@ struct css_style_rec_tag {
     css_style_rec_t *    pseudo_elem_before_style;
     css_style_rec_t *    pseudo_elem_after_style;
     css_style_rec_t *    pseudo_elem_first_letter_catcher_style;
+    css_style_rec_t *    pseudo_elem_first_line_style;
 
     css_style_rec_tag()
     : refCount(0)
@@ -251,6 +252,7 @@ struct css_style_rec_tag {
     , pseudo_elem_before_style(NULL)
     , pseudo_elem_after_style(NULL)
     , pseudo_elem_first_letter_catcher_style(NULL)
+    , pseudo_elem_first_line_style(NULL)
     {
         // css_length_t fields are initialized by css_length_tag()
         // to (css_val_screen_px, 0)

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -78,11 +78,12 @@ extern "C" {
 #define LTEXT_SRC_IS_CLEAR_BOTH      0x03000000  // text follows <BR style="clear: both">
 #define LTEXT_SRC_IS_CLEAR_LAST      0x04000000  // ignorable text, added when nothing follows <BR style="clear: both">
 
-#define LTEXT_FIT_GLYPHS             0x08000000  // Avoid glyph overflows and override at line edges and between text nodes
+#define LTEXT_IS_FIRST_LINE_ENOUGH   0x04000000  // helper for renderFinalBlock (same bit as previous, no conflict the way each are used)
+#define LTEXT_IS_FIRST_LINE_CLONE    0x08000000  // text is duplicated for CSS ::first-line
 
 #define LTEXT_HAS_EXTRA              0x10000000  // Has extra properties (see below)
 #define LTEXT_MATH_TRANSFORM         0x20000000  // Text might need to be stretched or tweaked
-#define LTEXT__AVAILABLE_BIT_31__    0x40000000
+#define LTEXT_FIT_GLYPHS             0x40000000  // Avoid glyph overflows and override at line edges and between text nodes
 #define LTEXT_LEGACY_RENDERING       0x80000000  // Legacy text rendering tweaks
 
 // Object flags (used when LTEXT_SRC_IS_OBJECT is set)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -931,6 +931,67 @@ public:
     /// Find the text node following a FirstLetter pseudoElem, returns NULL if not found
     ldomNode * getFirstLetterTextNode() const;
 
+    // Ensure this node has a ::first-line pseudo element with cloned children.
+    // Called from initNodeRendMethod() after all boxing is complete.
+    void ensureFirstLine();
+
+    /// Get the original node from a cloneNode element (for ::first-line)
+    /// Returns NULL if this is not a cloneNode or if the original node cannot be found
+    ldomNode * getCloneNodeSource() const;
+
+    /// These (with *Effective*) are equivalent to the non-Effective methods, which
+    /// if called on a cloneNode will return what's asked from its source node.
+    /// (hardcoded 1 is el_clonedNode )
+    inline ldomNode * getEffectiveNode() {
+        return (getNodeId() == 1) ? getCloneNodeSource() : this;
+    }
+    inline ldomNode * getEffectiveParentNode() {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getParentNode() : getParentNode();
+    }
+    inline bool isEffectiveElement() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isElement() : isElement();
+    }
+    inline bool isEffectiveText() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isText() : isText();
+    }
+    inline lString32 getEffectiveText() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getText() : getText();
+    }
+    inline lUInt16 getEffectiveNodeId() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getNodeId() : getNodeId();
+    }
+    inline bool hasEffectiveAttribute( lUInt16 id ) const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->hasAttribute(id) : hasAttribute(id);
+    }
+    inline const lString32 & getEffectiveAttributeValue( lUInt16 id ) const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getAttributeValue(id) : getAttributeValue(id);
+    }
+    inline lString32 getEffectiveAttributeValueLC( lUInt16 id ) const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getAttributeValueLC(id) : getAttributeValueLC(id);
+    }
+    inline bool isEffectiveImage() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isImage() : isImage();
+    }
+    inline lvdom_element_render_method getEffectiveRendMethod() {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getRendMethod() : getRendMethod();
+    }
+    inline ldomNode * getEffectiveFirstLetterTextNode() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getFirstLetterTextNode() : getFirstLetterTextNode();
+    }
+    inline ldomNode * getEffectiveFirstLetterPseudoElem(int * textOffset=NULL) const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->getFirstLetterPseudoElem(textOffset) : getFirstLetterPseudoElem(textOffset);
+    }
+    inline bool isEffectiveFloatingBox() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isFloatingBox() : isFloatingBox();
+    }
+    inline bool isEffectiveBoxingInlineBox() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isBoxingInlineBox() : isBoxingInlineBox();
+    }
+    inline bool isEffectiveEmbeddedBlockBoxingInlineBox() const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isEmbeddedBlockBoxingInlineBox() : isEmbeddedBlockBoxingInlineBox();
+    }
+
+
     /// if stylesheet file name is set, and file is found, set stylesheet to its value
     bool applyNodeStylesheet();
 

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4387,6 +4387,9 @@ bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 
 	setRenderProps(0, 0); // to allow apply styles and rend method while loading
 
+	// Reset counters (quotes nesting levels...)
+	TextLangMan::resetCounters();
+
 	if (m_callback) {
 		m_callback->OnLoadFileStart(m_doc_props->getStringDef(
 				DOC_PROP_FILE_NAME, ""));

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2441,22 +2441,23 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
     return fnt;
 }
 
-inline lUInt32 getBackgroundColor(const css_style_ref_t style)
+inline lUInt32 getBackgroundColor(const css_style_ref_t style, lUInt32 parentBackgroundColor)
 {
         if ( style->background_color.type == css_val_color ) {
             if ( IS_COLOR_FULLY_TRANSPARENT(style->background_color.value) ) {
-                return LTEXT_COLOR_CURRENT; // keep using current background color
+                // If "transparent", we somehow ensure its inheritance from the parent
+                return parentBackgroundColor;
             }
             return LTEXT_COLOR_IS_RESERVED(style->background_color.value) ? LTEXT_COLOR_RESERVED_REPLACE : style->background_color.value;
         }
         // Othewise, it is (css_val_unspecified, css_generic_currentcolor), and we must use the font color.
         if ( style->color.type == css_val_color ) { // should always be true
             if ( IS_COLOR_FULLY_TRANSPARENT(style->color.value) ) {
-                return LTEXT_COLOR_CURRENT; // keep using current background color
+                return parentBackgroundColor;
             }
             return LTEXT_COLOR_IS_RESERVED(style->color.value) ? LTEXT_COLOR_RESERVED_REPLACE : style->color.value;
         }
-        return LTEXT_COLOR_CURRENT;
+        return parentBackgroundColor;
 }
 
 inline lUInt32 getForegroundColor(const css_style_ref_t style)
@@ -3268,8 +3269,8 @@ bool renderAsListStylePositionInside( const css_style_ref_t style, bool is_rtl=f
 // the container, which is only needed to compute indent (text-indent) values in %,
 // and to get paragraph direction (LTR/RTL/UNSET).
 void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAccessor * fmt, lUInt32 & baseflags,
-                       int indent, int line_h, TextLangCfg * lang_cfg, int valign_dy, bool * is_link_start,
-                       lString32 running_bidi_ctrlchars )
+                       int indent, int line_h, TextLangCfg * lang_cfg, lUInt32 bgcolor, int valign_dy,
+                       bool * is_link_start, lString32 running_bidi_ctrlchars )
 {
     bool legacy_rendering = !BLOCK_RENDERING_N(enode, ENHANCED);
     if ( enode->isElement() ) {
@@ -3358,6 +3359,18 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // - flags is provided to this node's children (all inline) (becoming baseflags
         //   for them), and should carry inherited text decoration, vertical alignment
         //   and whitespace-pre state.
+
+        // About background-color:
+        // If erm_final, the background will be drawn by DrawDocument, and should not
+        // be drawn by the LFormattedText txform.
+        // Inline nodes' background color (CSS initial value is 'transparent') can specify
+        // a background-color, that will be passed to txform->AddSourceLine() to be drawn
+        // (if non-transparent) by lvtextfm->Draw().
+        // If some upper inline node has set a background color, it should be passed, to be
+        // drawn by, to its children inline nodes (so, getBackgroundColor() somehow ensures
+        // its inheritance among inline nodes; the CSS specs have it non-inheritable, so
+        // it is not handled by CSS).
+        lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style, bgcolor);
 
         int width = fmt->getWidth();
         const int em = enode->getFont()->getSize();
@@ -3835,7 +3848,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 css_list_style_position_t sp = style->list_style_position;
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
-                lUInt32 bgcl = getBackgroundColor(style);
                 int margin = 0;
                 if ( sp >= css_lsp_outside )
                     margin = -marker_width; // will ensure negative/hanging indent-like rendering
@@ -3945,7 +3957,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                     // as done below with standalone block images.
                     LVFontRef font = enode->getFont();
                     lUInt32 cl = getForegroundColor(style);
-                    lUInt32 bgcl = LTEXT_COLOR_CURRENT; // erm_final: any background will be drawn by DrawDocument
                     if ( !suptitle.empty() ) {
                         lString32Collection lines;
                         lines.parse(suptitle, cs32("\\n"), true);
@@ -4086,9 +4097,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // char before, this other char would generate a new line.
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
-                // If erm_final, the background will be drawn by DrawDocument, and should not
-                // be drawn by the LFormattedText txform
-                lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
 
                 // The following is needed for fribidi to do the right thing when the content creator
                 // has provided hints to explicite ambiguous cases.
@@ -4245,13 +4253,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             for (int i=0; i<cnt; i++)
             {
                 ldomNode * child = enode->getChildNode( i );
-                renderFinalBlock( child, txform, fmt, flags, indent, line_h, lang_cfg, valign_dy, is_link_start_p, running_bidi_ctrlchars );
+                renderFinalBlock( child, txform, fmt, flags, indent, line_h, lang_cfg, bgcl, valign_dy, is_link_start_p, running_bidi_ctrlchars );
             }
 
             if ( addGeneratedContent ) {
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
-                lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
                 // See comment above: these are the closing counterpart
                 if ( closeWithPDI ) {
                     txform->AddSourceLine( U"\x2069", 1, cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode);
@@ -4284,7 +4291,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 LVFontRef font = enode->getFont();
                 css_style_ref_t style = enode->getStyle();
                 lUInt32 cl = getForegroundColor(style);
-                lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
                 txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg, LTEXT_LOCKED_SPACING|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode);
                 /*
                 // We used to specify two UNICODE_NO_BREAK_SPACE (that would not collapse)
@@ -4340,7 +4346,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // (This makes consecutive and stuck <br><br><br> work)
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
-                lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
                 txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                                         baseflags | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                                         line_h, valign_dy, 0, enode);
@@ -4400,7 +4405,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             if ( !running_bidi_ctrlchars.empty() && (baseflags & LTEXT_FLAG_NEWLINE)) {
                 LVFontRef font = enode->getFont();
                 lUInt32 cl = getForegroundColor(style);
-                lUInt32 bgcl = rm == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
                 txform->AddSourceLine( running_bidi_ctrlchars.c_str(), running_bidi_ctrlchars.length(), cl, bgcl, font.get(), lang_cfg, baseflags | LTEXT_FLAG_OWNTEXT,
                     line_h, valign_dy, 0, enode );
                 baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
@@ -4415,7 +4419,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // string to text, and just call floatClearText().
             LVFontRef font = enode->getFont();
             lUInt32 cl = getForegroundColor(style);
-            lUInt32 bgcl = LTEXT_COLOR_CURRENT; // erm_final: any background will be drawn by DrawDocument
             txform->AddSourceLine( U" ", 1, cl, bgcl, font.get(), lang_cfg,
                             baseflags | LTEXT_SRC_IS_CLEAR_LAST | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                             line_h, valign_dy, 0, enode);
@@ -4447,9 +4450,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             css_style_ref_t style = parent->getStyle();
 
             lUInt32 cl = getForegroundColor(style);
-            // If erm_final, the background will be drawn by DrawDocument, and should not
-            // be drawn over each word by the LFormattedText txform
-            lUInt32 bgcl = parent->getRendMethod() == erm_final ? LTEXT_COLOR_CURRENT : getBackgroundColor(style);
+            lUInt32 bgcl = bgcolor; // as provided, from parent node
 
             switch (style->text_transform) {
             case css_tt_uppercase:

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10887,6 +10887,30 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->display = css_d_none;
     }
 
+    if ( nodeElementId == el_pseudoElem ) {
+        if ( enode->hasAttribute(attr_FirstLetter) ) {
+            // Many properties are not allowed, but we don't really want
+            // to check them all, as publishers would probably not use those
+            // that don't have any effect.
+            // There are a few (even if not provided, they could be
+            // inherited) that could cause unwanted effects:
+            // - display: avoid issues by ensuring it is either none or inline
+            //   (this has to be done here before the PREPARE_FLOATBOXES block
+            //   below, which may change it to css_d_block for rendering purpose)
+            if ( pstyle->display != css_d_none ) {
+                pstyle->display = css_d_inline;
+            }
+            // - text-indent, if the FirstLetter happens to be a float: there
+            //   shouldn't be any indent in the float (checked on Firefox)
+            pstyle->text_indent.type = css_val_screen_px;
+            pstyle->text_indent.value = 0;
+            // Most of the ones we support but that are not allowed are
+            // block related (width, page-break...), and shouldn't have
+            // any effect.
+        }
+        // The specs mention no property that would be not allowed for ::before/::after
+    }
+
     if ( BLOCK_RENDERING(rend_flags, PREPARE_FLOATBOXES) ) {
         // https://developer.mozilla.org/en-US/docs/Web/CSS/float
         //  As float implies the use of the block layout, it modifies the computed value

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1540,7 +1540,7 @@ public:
                             const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
                             if ( src && src->object ) {
                                 ldomNode * node = (ldomNode*)src->object;
-                                ldomNode * parent = node->getParentNode();
+                                ldomNode * parent = node->getEffectiveParentNode();
                                 while (parent && parent->getNodeId() != el_a)
                                     parent = parent->getParentNode();
                                 if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
@@ -1757,7 +1757,7 @@ public:
                                         const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
                                         if ( src && src->object ) {
                                             ldomNode * node = (ldomNode*)src->object;
-                                            ldomNode * parent = node->getParentNode();
+                                            ldomNode * parent = node->getEffectiveParentNode();
                                             while (parent && parent->getNodeId() != el_a)
                                                 parent = parent->getParentNode();
                                             if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
@@ -3272,19 +3272,36 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                        int indent, int line_h, TextLangCfg * lang_cfg, lUInt32 bgcolor, int valign_dy,
                        bool * is_link_start, lString32 running_bidi_ctrlchars )
 {
+    // In here, we use the *Effective* variants of most enode methods (except getStyle()/getFont()),
+    // to handle cloneNodes involved in the rendering of ::first-line. More details below.
+    // (cloneNodes being added for the ::first-line on a final block, we need to mostly only
+    // use them here, in a few other places dealing with erm_final block (ie. getRenderedWidths(),
+    // getRect() and createXPointer(pt)), and for footnote links in renderBlockElement().
+    // It's possible some other use of them elsewhere is needed, but has not yet been discovered.)
+    // Note that for objects (images, floats and inline-block boxes), we pass the effective/source
+    // node (which seems rather ok, web browsers don't ensure the ::first-ilne style on them) as
+    // it would otherwise get quite complicated (and need to infect renderBlockElement(), which
+    // render these, with the node->*Effective* variants).
+
+    if ( baseflags & LTEXT_IS_FIRST_LINE_ENOUGH ) {
+        // Still a children of pseudoElem[FirstLine], but we have met a <br/> and
+        // we no longer need to AddSourceLine() them.
+        return;
+    }
+
     bool legacy_rendering = !BLOCK_RENDERING_N(enode, ENHANCED);
-    if ( enode->isElement() ) {
+    if ( enode->isEffectiveElement() ) {
         lvdom_element_render_method rm = enode->getRendMethod();
         if ( rm == erm_invisible )
             return; // don't draw invisible
 
-        if ( enode->hasAttribute( attr_lang ) ) {
-            lString32 lang_tag = enode->getAttributeValue( attr_lang );
+        if ( enode->hasEffectiveAttribute( attr_lang ) ) {
+            lString32 lang_tag = enode->getEffectiveAttributeValue( attr_lang );
             if ( !lang_tag.empty() )
                 lang_cfg = TextLangMan::getTextLangCfg( lang_tag );
         }
 
-        if ( enode->isFloatingBox() && rm != erm_final ) {
+        if ( enode->isEffectiveFloatingBox() && rm != erm_final ) {
             // (A floating floatBox can't be erm_final: it is always erm_block,
             // but let's just be sure of that.)
             // If we meet a floatBox here, it's an embedded float (a float
@@ -3294,16 +3311,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // be guessed and renderBlockElement() called to render it
             // and get is height, so LFormattedText knows how to render
             // this erm_final text around it.
-            txform->AddSourceObject(baseflags, LTEXT_OBJECT_IS_FLOAT, line_h, valign_dy, indent, enode, lang_cfg );
+            txform->AddSourceObject(baseflags, LTEXT_OBJECT_IS_FLOAT, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
             baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             return;
         }
 
         css_style_ref_t style = enode->getStyle();
 
-        bool is_object = enode->isImage();
+        bool is_object = enode->isEffectiveImage();
         // inline-block boxes are handled below quite just like inline images/is_object
-        bool is_inline_box = enode->isBoxingInlineBox();
+        bool is_inline_box = enode->isEffectiveBoxingInlineBox();
 
         int direction = RENDER_RECT_PTR_GET_DIRECTION(fmt);
         bool is_rtl = direction == REND_DIRECTION_RTL;
@@ -3360,6 +3377,18 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         //   for them), and should carry inherited text decoration, vertical alignment
         //   and whitespace-pre state.
 
+        // A pseudoElem[FirstLine] contains only <cloneNode>s: they will each carry the
+        // style and font as styled by the ::first-line style. But for everything else (text,
+        // attributes), we will need to fetch them from the cloneNode's source, so the use
+        // of the isEffective/getEffective* variants of many ldomNode methods above and below.
+        // We flag the fragments we will add from these cloneNodes with LTEXT_IS_FIRST_LINE_CLONE,
+        // so that lvtextfm.cpp can skip the sequence once it has added the first line, and
+        // can resume from the normal text sequence.
+        bool is_pseudoElem_FirstLine = enode->getNodeId() == el_pseudoElem && enode->hasAttribute(attr_FirstLine);
+        if ( is_pseudoElem_FirstLine ) {
+            flags |= LTEXT_IS_FIRST_LINE_CLONE;
+        }
+
         // About background-color:
         // If erm_final, the background will be drawn by DrawDocument, and should not
         // be drawn by the LFormattedText txform.
@@ -3378,6 +3407,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // Nodes with "display: run-in" are inline nodes brought at start of the final node
         bool isRunIn = style->display == css_d_run_in;
         if ( isRunIn ) {
+            // (Not modified and not tested with ::first-line.)
             // The text alignment of the paragraph should come from the following
             // sibling node. The one set from the parent final node has probably
             // not yet been consumed, so update it.
@@ -3790,6 +3820,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // Firefox has some specific behaviour with floats, which
         // is not obvious from the specs. Let's do as it does.
         // It looks like we should do the same for inline-block boxes
+        // (Not modified and not tested with ::first-line, if this can ever happen.)
         if ( parent && (parent->isFloatingBox() || parent->isBoxingInlineBox()) ) {
             if ( rm == erm_final && is_object ) {
                 // When an image is the single top final node in a float (which is
@@ -3819,6 +3850,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         }
 
         if ( style->display == css_d_list_item_legacy ) { // obsolete (used only when gDOMVersionRequested < 20180524)
+            // (Not modified and not tested with ::first-line)
             // put item number/marker to list
             lString32 marker;
             int marker_width = 0;
@@ -3868,8 +3900,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // list_item_block rendered as final (containing only text and inline elements)
             // (we don't draw anything when list-style-type=none)
             if ( renderAsListStylePositionInside(style, is_rtl) && style->list_style_type != css_lst_none ) {
+                // This may be emitted before a pseudoElem[FirstLine]: check if we will have one
+                lUInt32 flags_firstline = 0;
+                if (enode->getChildCount() > 0) {
+                    ldomNode * child = enode->getChildNode(0);
+                    if ( child->getNodeId() == el_pseudoElem && child->hasAttribute(attr_FirstLine) && child->getRendMethod() != erm_invisible ) {
+                        flags_firstline = LTEXT_IS_FIRST_LINE_CLONE;
+                    }
+                }
                 int marker_width;
-                lString32 marker = renderListItemMarker( enode, marker_width, NULL, txform, flags, line_h );
+                lString32 marker = renderListItemMarker( enode, marker_width, NULL, txform, flags|flags_firstline, line_h );
                 if ( marker.length() ) {
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH;
                 }
@@ -3887,8 +3927,16 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             int listPropNodeIndex = fmt->getListPropNodeIndex();
             if ( listPropNodeIndex ) {
                 ldomNode * list_item_block_parent = enode->getDocument()->getTinyNode( listPropNodeIndex );
+                // This may be emitted before a pseudoElem[FirstLine]: check if we will have one
+                lUInt32 flags_firstline = 0;
+                if (enode->getChildCount() > 0) {
+                    ldomNode * child = enode->getChildNode(0);
+                    if ( child->getNodeId() == el_pseudoElem && child->hasAttribute(attr_FirstLine) && child->getRendMethod() != erm_invisible ) {
+                        flags_firstline = LTEXT_IS_FIRST_LINE_CLONE;
+                    }
+                }
                 int marker_width;
-                lString32 marker = renderListItemMarker( list_item_block_parent, marker_width, NULL, txform, flags, line_h );
+                lString32 marker = renderListItemMarker( list_item_block_parent, marker_width, NULL, txform, flags|flags_firstline, line_h );
                 if ( marker.length() ) {
                     flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH;
                 }
@@ -3947,9 +3995,9 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // If block image, forget any current flags and start from baseflags (?)
                 lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
                 flags |= linkflags;
-                lString32 suptitle = enode->getAttributeValue(attr_suptitle);
-                lString32 subtitle = enode->getAttributeValue(attr_subtitle);
-                lString32 title = enode->getAttributeValue(attr_title);
+                lString32 suptitle = enode->getEffectiveAttributeValue(attr_suptitle);
+                lString32 subtitle = enode->getEffectiveAttributeValue(attr_subtitle);
+                lString32 title = enode->getEffectiveAttributeValue(attr_title);
                 if ( !suptitle.empty() || !subtitle.empty() || !title.empty() ) {
                     // If any of these exist and are not empty, we add them around the images.
                     // We can't easily ensure and adequate height to the image so they all fit
@@ -3963,7 +4011,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         for ( int i=0; i<lines.length(); i++ )
                             txform->AddSourceLine( lines[i].c_str(), lines[i].length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, 0, enode );
                     }
-                    txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
+                    txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
                     if ( !subtitle.empty() ) {
                         lString32Collection lines;
                         lines.parse(subtitle, cs32("\\n"), true);
@@ -3984,7 +4032,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         line_h = 0;
                         indent = 0;
                     }
-                    txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
+                    txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
                 }
 
             }
@@ -4000,13 +4048,13 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // Forget any current flags and start from baseflags
                 lUInt32 flags = styleToTextFmtFlags( true, enode->getStyle(), baseflags, direction );
                 flags |= linkflags;
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
             }
             else { // inline image
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
                 flags |= linkflags;
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_IMAGE, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
@@ -4014,7 +4062,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             #ifdef DEBUG_DUMP_ENABLED
                 logfile << "+INLINEBOX ";
             #endif
-            if ( enode->isEmbeddedBlockBoxingInlineBox() ) {
+            if ( enode->isEffectiveEmbeddedBlockBoxingInlineBox() ) {
                 // If embedded-block wrapper: it should not be part of the lines
                 // made by the surrounding text/elements: we should ensure a new
                 // line before and after it.
@@ -4051,7 +4099,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // These might have no effect, but let's explicitely drop them.
                 valign_dy = 0;
                 indent = 0;
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX|LTEXT_OBJECT_IS_EMBEDDED_BLOCK, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX|LTEXT_OBJECT_IS_EMBEDDED_BLOCK, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
                 // Let flags unchanged, with their newline/alignment flag as if it
                 // hadn't been consumed, so it is reported back into baseflags below
                 // so that the next sibling (or upper followup inline node) starts
@@ -4066,7 +4114,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             else {
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
@@ -4078,11 +4126,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // Usual elements
 
             // Some elements add some generated content
-            lUInt16 nodeElementId = enode->getNodeId();
+            lUInt16 nodeElementId = enode->getEffectiveNodeId();
             // Don't handle dir= for the erm_final (<p dir="auto"), as it would "isolate"
             // the whole content from the bidi algorithm and we would get a default paragraph
             // direction of LTR. It is handled directly in lvtextfm.cpp.
-            bool hasDirAttribute = rm != erm_final && enode->hasAttribute( attr_dir );
+            bool hasDirAttribute = rm != erm_final && enode->hasEffectiveAttribute( attr_dir );
             bool addGeneratedContent = hasDirAttribute ||
                                        nodeElementId == el_bdi ||
                                        nodeElementId == el_bdo ||
@@ -4104,7 +4152,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // When meeting them, we add the equivalent unicode opening and closing chars so
                 // that fribidi (working on text only) can ensure what's specified with HTML tags.
                 // See http://unicode.org/reports/tr9/#Markup_And_Formatting
-                lString32 dir = enode->getAttributeValueLC( attr_dir );
+                lString32 dir = enode->getEffectiveAttributeValueLC( attr_dir );
                 if ( nodeElementId == el_bdo ) {
                     // <bdo> (bidirectional override): prevents the bidirectional algorithm from
                     //       rearranging the sequence of characters it encloses
@@ -4196,8 +4244,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // BiDi stuff had to be outputed first, before any pseudo element
                 // (if <q dir="rtl">...</q>, the added quote (first child pseudo element)
                 // should be inside the RTL bidi isolation.
-                if ( nodeElementId == el_pseudoElem && (enode->hasAttribute(attr_Before) || enode->hasAttribute(attr_After)) ) {
-                    lString32 content = get_applied_content_property(enode);
+                if ( nodeElementId == el_pseudoElem && (enode->hasEffectiveAttribute(attr_Before) || enode->hasEffectiveAttribute(attr_After)) ) {
+                    lString32 content = get_applied_content_property(enode->getEffectiveNode());
                     if ( !content.empty() ) {
                         switch (style->text_transform) {
                             case css_tt_uppercase: content.uppercase(); break;
@@ -4213,12 +4261,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                         flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                     }
                 }
-                if ( nodeElementId == el_pseudoElem && enode->hasAttribute(attr_FirstLetter) ) {
+                if ( nodeElementId == el_pseudoElem && enode->hasEffectiveAttribute(attr_FirstLetter) ) {
                     // Skip rendering if display:none
                     if ( style->display != css_d_none ) {
-                        int firstLetterEnd = enode->getAttributeValue(attr_FirstLetter).atoi();
+                        int firstLetterEnd = enode->getEffectiveAttributeValue(attr_FirstLetter).atoi();
                         // Find the next sibling text node
-                        ldomNode * textNode = enode->getFirstLetterTextNode();
+                        ldomNode * textNode = enode->getEffectiveFirstLetterTextNode();
                         if ( textNode && firstLetterEnd > 0 ) {
                             lString32 txt = textNode->getText();
                             if ( txt.length() >= firstLetterEnd ) {
@@ -4337,7 +4385,14 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         else { // newline consumed
             baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
         }
-        if ( enode->getNodeId()==el_br ) {
+        if ( enode->getEffectiveNodeId()==el_br ) {
+            if ( flags & LTEXT_IS_FIRST_LINE_CLONE ) {
+                // We meet a <br/> while emiting the text with the CSS ::first-line style,
+                // we don't need to emit any followup text with that style, as the first-line
+                // will be done.
+                baseflags |= LTEXT_IS_FIRST_LINE_ENOUGH;
+                return;
+            }
             if (baseflags & LTEXT_FLAG_NEWLINE) {
                 // We meet a <BR/>, but no text node were met before (or it
                 // would have cleared the newline flag).
@@ -4423,10 +4478,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                             baseflags | LTEXT_SRC_IS_CLEAR_LAST | LTEXT_FLAG_PREFORMATTED | LTEXT_FLAG_OWNTEXT,
                             line_h, valign_dy, 0, enode);
         }
+        // This is not needed as flags is lost when we leave that pseudoElem:
+        // if ( is_pseudoElem_FirstLine ) { flags &= ~LTEXT_IS_FIRST_LINE_CLONE|~LTEXT_IS_FIRST_LINE_ENOUGH; }
     }
-    else if ( enode->isText() ) {
+    else if ( enode->isEffectiveText() ) {
         // text nodes
-        lString32 txt = enode->getText();
+        lString32 txt = enode->getEffectiveText();
         if ( !txt.empty() ) {
             #ifdef DEBUG_DUMP_ENABLED
                 for (int i=0; i<enode->getNodeLevel(); i++)
@@ -4513,7 +4570,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // If this text node has a preceding ::first-letter pseudo element,
             // we should skip adding the leading text rendered by that pseudoElem
             int textOffset = 0;
-            enode->getFirstLetterPseudoElem(&textOffset);
+            enode->getEffectiveFirstLetterPseudoElem(&textOffset);
             // Just below, if it happens that txt.length()=textOffset (single letter
             // text node that got to be a first-letter, with no remaining text),
             // we will let an empty text source be added. An empty text node seems
@@ -5413,7 +5470,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                 const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
                                 if ( src && src->object ) {
                                     ldomNode * node = (ldomNode*)src->object;
-                                    ldomNode * parent = node->getParentNode();
+                                    ldomNode * parent = node->getEffectiveParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
                                     if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
@@ -5449,7 +5506,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                                 const src_text_fragment_t * src = txform->GetSrcInfo( line->words[w].src_text_index );
                                 if ( src && src->object ) {
                                     ldomNode * node = (ldomNode*)src->object;
-                                    ldomNode * parent = node->getParentNode();
+                                    ldomNode * parent = node->getEffectiveParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
                                     if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
@@ -9045,7 +9102,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                                 }
                                 if ( src && src->object ) {
                                     ldomNode * node = (ldomNode*)src->object;
-                                    ldomNode * parent = node->getParentNode();
+                                    ldomNode * parent = node->getEffectiveParentNode();
                                     while (parent && parent->getNodeId() != el_a)
                                         parent = parent->getParentNode();
                                     if ( parent && parent->hasAttribute(LXML_NS_ANY, attr_href)
@@ -10649,6 +10706,23 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // init default style attribute values
     const css_elem_def_props_t * type_ptr = enode->getElementTypePtr();
     bool is_object = enode->isImage();
+
+    if ( nodeElementId == el_cloneNode ) {
+        if ( enode->hasAttribute(attr_T) ) {
+            // CloneNode of a Text node: a style won't be used, but it's safer
+            // to set one, so it is not null and we don't crash in odd places
+            // that check it (ie. recursed resetRendMethodToInline())
+            enode->setStyle( style );
+            // Doing initNodeFont(), even if the font won't ever be used, avoids "style hash mismatch".
+            enode->initNodeFont();
+            return;
+        }
+        ldomNode * sourceNode = enode->getCloneNodeSource();
+        nodeElementId = sourceNode->getNodeId();
+        type_ptr = sourceNode->getElementTypePtr();
+        is_object = sourceNode->isImage();
+    }
+
     if (type_ptr) {
         pstyle->display = type_ptr->display;
         pstyle->white_space = type_ptr->white_space;
@@ -10699,9 +10773,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // Handle <epub:switch> <epub:case required-namespace="..."> <epub:default>
     if ( nodeElementId == el_case ) {
         // We only support MathML and SVG.
-        ldomNode * parent = enode->getParentNode();
+        ldomNode * parent = enode->getEffectiveParentNode();
         if ( parent && parent->getNodeId() == el_switch ) {
-            lString32 required_namespace = enode->getAttributeValue(attr_required_namespace);
+            lString32 required_namespace = enode->getEffectiveAttributeValue(attr_required_namespace);
             if ( false ) {
                 // dummy if
             }
@@ -10726,7 +10800,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
     else if (nodeElementId == el_default ) { // <epub:default>
-        ldomNode * parent = enode->getParentNode();
+        ldomNode * parent = enode->getEffectiveParentNode();
         if (parent && parent->getNodeId() == el_switch) {
             // See if there is a sibling <epub:case> with a supported namespace
             bool has_supported_namespace = false;
@@ -10775,8 +10849,8 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     //////////////////////////////////////////////////////
     // apply node style= attribute
     //////////////////////////////////////////////////////
-    if ( doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasAttribute( LXML_NS_ANY, attr_style ) ) {
-        lString32 nodeStyle = enode->getAttributeValue( LXML_NS_ANY, attr_style );
+    if ( doc->getDocFlag(DOC_FLAG_ENABLE_INTERNAL_STYLES) && enode->hasEffectiveAttribute( attr_style ) ) {
+        lString32 nodeStyle = enode->getEffectiveAttributeValue( attr_style );
         if ( !nodeStyle.empty() ) {
             nodeStyle = cs32("{") + nodeStyle + "}";
             LVCssDeclaration decl;
@@ -10908,6 +10982,24 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // block related (width, page-break...), and shouldn't have
             // any effect.
         }
+        else if ( enode->hasAttribute(attr_FirstLine) ) {
+            // Many properties are not allowed, but we don't really want
+            // to check them all, as publishers would probably not use those
+            // that don't have any effect.
+            // There are a few (even if not provided, they could be
+            // inherited) that could cause unwanted effects:
+            // - display: avoid issues by ensuring it is either none or inline
+            if ( pstyle->display != css_d_none ) {
+                pstyle->display = css_d_inline;
+            }
+            // - float: be sure we don't get it (currently, it would have no effect)
+            pstyle->float_ = css_f_none;
+            // Most of the ones we support but that are not allowed are
+            // block related (width, page-break...), and shouldn't have
+            // any effect.
+            // A few not allowed like margin/padding/border can have some effect
+            // (which might be useful for debugging), but let's not bother.
+        }
         // The specs mention no property that would be not allowed for ::before/::after
     }
 
@@ -10997,7 +11089,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                         pstyle->display = css_d_inline; // become an inline wrapper
                         pstyle->vertical_align = child_style->vertical_align;
                     }
-                    else if ( enode->hasAttribute( attr_T ) ) { // T="EmbeddedBlock"
+                    else if ( enode->hasEffectiveAttribute( attr_T ) ) { // T="EmbeddedBlock"
                                             // (no other possible value yet, no need to compare strings)
                         pstyle->display = css_d_inline; // wrap bogus "block among inlines" in inline
                     }
@@ -11509,6 +11601,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     bool requires_pseudo_element_before = false;
     bool requires_pseudo_element_after = false;
     bool requires_has_first_letter_attribute = false;
+    bool requires_has_first_line_attribute = false;
     if ( pstyle->pseudo_elem_before_style ) {
         if ( pstyle->pseudo_elem_before_style->display != css_d_none
                 && pstyle->pseudo_elem_before_style->content.length() > 0
@@ -11539,6 +11632,14 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         delete pstyle->pseudo_elem_first_letter_catcher_style;
         pstyle->pseudo_elem_first_letter_catcher_style = NULL;
     }
+    if ( pstyle->pseudo_elem_first_line_style ) {
+        if ( pstyle->pseudo_elem_first_line_style->display != css_d_none ) {
+            // Not "display: none": the ::first-line pseudo element can be generated
+            requires_has_first_line_attribute = true;
+        }
+        delete pstyle->pseudo_elem_first_line_style;
+        pstyle->pseudo_elem_first_line_style = NULL;
+    }
 
     if ( nodeElementId == el_pseudoElem && (enode->hasAttribute(attr_Before) || enode->hasAttribute(attr_After)) ) {
         // Pseudo element ->content may need some update if it contains
@@ -11567,12 +11668,20 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
 
     // Now that this node is fully styled, ensure these pseudo elements
     // are there as children, creating them if needed and possible.
-    // Note: we call ensureFirstLetter before ensurePseudoElement(true) to keep things
-    // simpler in these methods and in other first-letter handling bits: if we have both
-    // a ::first-letter and a ::before, the ::before will be inserted before the ::first-letter.
-    // This is not per CSS-specs (a ::first-letter should pick the first-letter
-    // from the ::before, so logically it should come first) but supporting that
-    // would make everything more complicated.
+    // DOM order: FirstLine(0), Before(1), FirstLetter(near first text), After(last).
+    // (Per-specs, FirstLetter should be before Before, and should grab the
+    // first letter from that Before - but this is quite involved and we don't
+    // support it. Having Before first may still allow for aesthetic prefixes.)
+    // FirstLine creation (with cloning) is deferred to initNodeRendMethod(),
+    // after all boxing is complete. Here we just set the attribute flag so
+    // initNodeRendMethod() knows to create the pseudoElem[FirstLine].
+    if ( requires_has_first_line_attribute ) {
+        if ( !enode->hasAttribute(attr_HasFirstLine) ) {
+            enode->setAttributeValue(LXML_NS_NONE, attr_HasFirstLine, U"");
+        }
+    }
+    // Note: we call ensureFirstLetter before ensurePseudoElement(true) to keep things simpler,
+    // but the pseudoElem[FirstLetter] will still end up after a pseudoElem[Before])
     if ( requires_has_first_letter_attribute ) {
         enode->ensureFirstLetter(false); // false = skip init style during stylesheet re-application
     }
@@ -11629,8 +11738,8 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         printf("GRW node: %s\n", UnicodeToLocal(ldomXPointer(node, 0).toString()).c_str());
     #endif
 
-    if ( node->isElement() && !processNodeAsText ) {
-        lUInt16 nodeElementId = node->getNodeId();
+    if ( node->isEffectiveElement() && !processNodeAsText ) {
+        lUInt16 nodeElementId = node->getEffectiveNodeId();
         int m = node->getRendMethod();
         if (m == erm_invisible)
             return;
@@ -11638,13 +11747,13 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         if ( isStartNode ) {
             lang_cfg = TextLangMan::getTextLangCfg( node ); // Fetch it from node or its parents
         }
-        else if ( node->hasAttribute( attr_lang ) ) {
-            lString32 lang_tag = node->getAttributeValue( attr_lang );
+        else if ( node->hasEffectiveAttribute( attr_lang ) ) {
+            lString32 lang_tag = node->getEffectiveAttributeValue( attr_lang );
             if ( !lang_tag.empty() )
                 lang_cfg = TextLangMan::getTextLangCfg( lang_tag );
         }
 
-        if ( isStartNode && node->isBoxingInlineBox() ) {
+        if ( isStartNode && node->isEffectiveBoxingInlineBox() ) {
             // The inlineBox is erm_inline, and we'll be measuring it below
             // as part of measuring other erm_inline in some erm_final.
             // If isStartNode, we want to measure its content, so switch
@@ -11662,14 +11771,14 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         // Get image size early
         bool is_img = false;
         int img_width = 0;
-        if ( node->isImage() ) {
+        if ( node->isEffectiveImage() ) {
             is_img = true;
             int unused_height = 0;
             // We have no container width/height to provide: CSS width and
             // height in % won't apply and default to their initial value
             // of none or auto, so as if there wasn't any.
             // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
-            getStyledImageSize( node, img_width, unused_height );
+            getStyledImageSize( node->getEffectiveNode(), img_width, unused_height );
                 // We got a single width (the normal image width, constrained
                 // between min-width and max-width if any): we use it to update
                 // both minWidth/maxWidth in here (the CSS properties with the
@@ -11704,7 +11813,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             // allowed between left/right pads and their followup/preceeding content)
             int pad_left  = lengthToPx( node, style->margin[0], 0 ) + measureBorder(node, 3) + lengthToPx( node, style->padding[0], 0 );
             int pad_right = lengthToPx( node, style->margin[1], 0 ) + measureBorder(node, 1) + lengthToPx( node, style->padding[1], 0 );
-            if ( is_img || node->isBoxingInlineBox() ) {
+            if ( is_img || node->isEffectiveBoxingInlineBox() ) {
                 if (!nowrap) {
                     // Get done with previous word
                     if (curWordWidth > minWidth)
@@ -11742,7 +11851,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             // and not to next word as it should, if a space follows), but well...
             curMaxWidth += pad_left;
             curWordWidth += pad_left;
-            if ( nodeElementId == el_pseudoElem ) {
+            if ( nodeElementId == el_pseudoElem && !node->hasAttribute(attr_FirstLine) ) {
                 // pseudoElem has no children: reprocess this same node
                 // with processNodeAsText=true, to process its text content.
                 getRenderedWidths(node, maxWidth, minWidth, direction, false, rendFlags,
@@ -11762,6 +11871,20 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             }
             curMaxWidth += pad_right;
             curWordWidth += pad_right;
+            if ( nodeElementId == el_pseudoElem && node->hasAttribute(attr_FirstLine) ) {
+                // End of ::first-line clones sequance: do exactly as above as if we met a <br/>,
+                // so we start afresh with the normal sequence
+                if (lastSpaceWidth)
+                    curMaxWidth -= lastSpaceWidth;
+                if (curMaxWidth > maxWidth)
+                    maxWidth = curMaxWidth;
+                if (curWordWidth > minWidth)
+                    minWidth = curWordWidth;
+                curMaxWidth = indent;
+                curWordWidth = indent;
+                collapseNextSpace = true;
+                lastSpaceWidth = 0;
+            }
             return;
         }
 
@@ -11871,7 +11994,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                         curMaxWidth, curWordWidth, collapseNextSpace, lastSpaceWidth, indent, nowrap_in, lang_cfg);
                     // A <BR/> can happen deep among our children, so we deal with that when erm_inline above
                 }
-                if ( nodeElementId == el_pseudoElem ) {
+                if ( nodeElementId == el_pseudoElem && !node->hasAttribute(attr_FirstLine) ) {
                     // erm_final pseudoElem (which has no children): reprocess this same
                     // node with processNodeAsText=true, to process its text content.
                     getRenderedWidths(node, _maxWidth, _minWidth, direction, false, rendFlags,
@@ -11938,7 +12061,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                             row.reserve(seen_nb_cells);
                             for (int i = 0; i < n->getChildCount(); i++) {
                                 ldomNode * child = n->getChildNode(i);
-                                if ( child->isText() ) {
+                                if ( child->isEffectiveText() ) {
                                     // Ignore text nodes among table elements (they are usually
                                     // dropped when parsing the HTML, but for <ruby>, parsed as
                                     // inline but later acquiring erm_table* rendering methods,
@@ -11978,7 +12101,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                             // Non-recursive sub tree walker (continued)
                             index = n->getChildCount(); // Skip walking/entering that row
                         }
-                        else if ( n->isElement() && n->getStyle()->display == css_d_table_caption && n->getRendMethod() != erm_invisible ) {
+                        else if ( n->isEffectiveElement() && n->getStyle()->display == css_d_table_caption && n->getRendMethod() != erm_invisible ) {
                             // Also measure caption(s)
                             int _maxw = 0;
                             int _minw = 0;
@@ -12139,7 +12262,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 int _maxw = 0;
                 int _minw = 0;
                 ldomNode * child = node->getChildNode(i);
-                if ( child->isText() ) {
+                if ( child->isEffectiveText() ) {
                     // Ignore text nodes between block nodes
                     // (we shouldn't find any, but well)
                     continue;
@@ -12361,8 +12484,8 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         int start = 0;
         int len = 0;
         ldomNode * parent;
-        if ( node->isText() ) {
-            text = node->getText();
+        if ( node->isEffectiveText() ) {
+            text = node->getEffectiveText();
             len = text.length();
             parent = node->getParentNode();
             // Check if this text node has a preceding FirstLetter pseudoElem
@@ -12377,21 +12500,21 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                     len = 0;
             }
         }
-        else if ( node->getNodeId() == el_pseudoElem && (node->hasAttribute(attr_Before) || node->hasAttribute(attr_After)) ) {
-            text = get_applied_content_property(node);
+        else if ( node->getEffectiveNodeId() == el_pseudoElem && (node->hasEffectiveAttribute(attr_Before) || node->hasEffectiveAttribute(attr_After)) ) {
+            text = get_applied_content_property(node->getEffectiveNode());
             len = text.length();
             parent = node; // this pseudoElem node carries the font and style of the text
             if ( isStartNode ) {
                 lang_cfg = TextLangMan::getTextLangCfg( node ); // Fetch it from node or its parents
             }
         }
-        else if ( node->getNodeId() == el_pseudoElem && node->hasAttribute(attr_FirstLetter) ) {
+        else if ( node->getEffectiveNodeId() == el_pseudoElem && node->hasEffectiveAttribute(attr_FirstLetter) ) {
             // FirstLetter pseudoElem: extract first N chars from following text node
             // Skip if display:none
             if ( node->getStyle()->display == css_d_none )
                 return;
-            int firstLetterEnd = node->getAttributeValue(attr_FirstLetter).atoi();
-            ldomNode * textNode = node->getFirstLetterTextNode();
+            int firstLetterEnd = node->getEffectiveAttributeValue(attr_FirstLetter).atoi();
+            ldomNode * textNode = node->getEffectiveFirstLetterTextNode();
             if ( !textNode )
                 return;
             text = textNode->getText();

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4448,6 +4448,12 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             case css_c_right:
                 baseflags |= LTEXT_SRC_IS_CLEAR_RIGHT;
                 break;
+            case css_c_inline_start:
+                baseflags |= (is_rtl ? LTEXT_SRC_IS_CLEAR_RIGHT : LTEXT_SRC_IS_CLEAR_LEFT);
+                break;
+            case css_c_inline_end:
+                baseflags |= (is_rtl ? LTEXT_SRC_IS_CLEAR_LEFT : LTEXT_SRC_IS_CLEAR_RIGHT);
+                break;
             case css_c_both:
                 baseflags |= LTEXT_SRC_IS_CLEAR_BOTH;
                 break;
@@ -6739,6 +6745,12 @@ public:
     void clearFloats( css_clear_t clear ) {
         if (clear <= css_c_none)
             return;
+        if ( clear == css_c_inline_start ) {
+            clear = direction == REND_DIRECTION_RTL ? css_c_right : css_c_left;
+        }
+        else if ( clear == css_c_inline_end ) {
+            clear = direction == REND_DIRECTION_RTL ? css_c_left : css_c_right;
+        }
         int cleared_y = c_y;
         for (int i=0; i<_floats.length(); i++) {
             BlockFloat * flt = _floats[i];
@@ -6782,6 +6794,12 @@ public:
             if ( flt->top > y )
                 y = flt->top;
             if ( clear > css_c_none) {
+                if ( clear == css_c_inline_start ) {
+                    clear = direction == REND_DIRECTION_RTL ? css_c_right : css_c_left;
+                }
+                else if ( clear == css_c_inline_end ) {
+                    clear = direction == REND_DIRECTION_RTL ? css_c_left : css_c_right;
+                }
                 if ( (clear == css_c_both) || (clear == css_c_left && !flt->is_right)
                                            || (clear == css_c_right && flt->is_right) ) {
                     if (flt->bottom > y)
@@ -8574,14 +8592,14 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     //   float on that side BUT the following non-floating blocks should
                     //   not move and continue being rendered at the current y
 
-                    // todo: if needed, implement float: and clear: inline-start / inline-end
-
                     if ( child->isFloatingBox() ) {
                         // Block floats are positioned respecting the current collapsed
                         // margin, without actually globally pushing it, and without
                         // collapsing with it.
                         int flt_vertical_margin = flow->getCurrentVerticalMargin();
-                        bool is_right = child_style->float_ == css_f_right;
+                        bool is_right = ( child_style->float_ == css_f_right ) ||
+                              ( is_rtl && child_style->float_ == css_f_inline_start ) ||
+                              (!is_rtl && child_style->float_ == css_f_inline_end );
                         // (style->clear has not been copied to the floatBox: we must
                         // get it from the floatBox single child)
                         css_clear_t child_clear = child->getChildNode(0)->getStyle()->clear;
@@ -11018,7 +11036,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         // not there yet (or just added, which will be handled by next 'if'), or has
         // not yet got its float_ from its child. So the ->display of the floatBox
         // element will have to be updated too elsewhere.
-        if ( pstyle->float_ == css_f_left || pstyle->float_ == css_f_right ) {
+        if ( pstyle->float_ > css_f_none ) {
             if ( pstyle->display <= css_d_inline ) {
                 pstyle->display = css_d_block;
             }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -320,6 +320,7 @@ enum LVCssSelectorPseudoElement
     csspe_before = 1,   // ::before
     csspe_after  = 2,   // ::after
     csspe_first_letter  = 3,   // ::first-letter
+    csspe_first_line    = 4,   // ::first-line
 };
 
 static const char * css_pseudo_elements[] =
@@ -327,6 +328,7 @@ static const char * css_pseudo_elements[] =
     "before",
     "after",
     "first-letter",
+    "first-line",
     NULL
 };
 
@@ -6338,8 +6340,17 @@ bool LVCssSelectorRule::checkNextRules( const ldomNode * node, bool allow_cache 
 bool LVCssSelector::check( const ldomNode * node, bool allow_cache ) const
 {
     lUInt16 nodeId = node->getNodeId();
+
+    if ( nodeId == el_cloneNode ) {
+        if ( node->isEffectiveText() ) {
+            return false; // text nodes don't match selectors
+        }
+        // Continue checking with the original node
+        node = node->getCloneNodeSource();
+        nodeId = node->getNodeId();
+    }
     if ( nodeId == el_pseudoElem ) {
-        if ( !_pseudo_elem ) { // not a ::before/after/first-letter rule
+        if ( !_pseudo_elem ) { // not a ::before/after/first-letter/first-line rule
             // Our added pseudoElem element should not match any other rules
             // (if we added it as a child of a P element, it should not match P > *)
             return false;
@@ -6365,15 +6376,35 @@ bool LVCssSelector::check( const ldomNode * node, bool allow_cache ) const
             }
             // Now fall through to check the rules against this ancestor element
         }
-        else { // ::before/::after
-            // Start checking the rules starting from the real parent
-            // (except if this selector target a boxing element: we should
-            // stop unboxing at that boxing element).
+        else if ( _pseudo_elem == csspe_first_line && node->hasAttribute(attr_FirstLine) ) {
+            // Find the ancestor with HasFirstLine attribute (the element matched by ::first-line)
+            const ldomNode * ancestor = node->getUnboxedParent();
+            while ( ancestor ) {
+                if ( ancestor->hasAttribute(attr_HasFirstLine) ) {
+                    node = ancestor;
+                    nodeId = ancestor->getNodeId();
+                    break;
+                }
+                ancestor = ancestor->getUnboxedParent();
+            }
+            if ( !ancestor ) {
+                // No matching ancestor found
+                return false;
+            }
+            // Now fall through to check the rules against this ancestor element
+        }
+        else if ( _pseudo_elem == csspe_before || _pseudo_elem == csspe_after ) {
+            // ::before/::after pseudo elements: start checking rules from the real parent
+            // (except if this selector targets a boxing element: stop unboxing there).
             if ( _id <= EL_BOXING_END && _id >= EL_BOXING_START )
                 node = node->getUnboxedParent(_id);
             else
                 node = node->getUnboxedParent();
             nodeId = node->getNodeId();
+        }
+        else {
+            // This pseudo-element node doesn't match this selector's pseudo-element type
+            return false;
         }
     }
     else if ( _id==0 && node->isBoxingNode() ) {
@@ -6507,8 +6538,7 @@ LVCssSelectorRule * parse_attr( const char * &str, lxmlDocBase * doc, bool usera
         // E:pseudo-class (eg: E:first-child)
         str++;
         if (*str==':') {
-            // pseudo element (double ::, eg: E::first-line) are not supported,
-            // except ::before/after which are handled in LVCssSelector::parse()
+            // pseudo element (double ::, eg: E::first-letter): are handled in LVCssSelector::parse()
             str--;
             return NULL;
         }
@@ -6975,10 +7005,16 @@ void LVCssSelector::applyToPseudoElement( const ldomNode * node, css_style_rec_t
     // not apply to the style of this node), and on the actual pseudo element
     // once it has been created as a child (to which we should apply).
     css_style_rec_t * target_style = NULL;
+    if ( node->getNodeId() == el_cloneNode ) {
+        // It masquerades as a pseudoElem: get the source pseudoElem for the following
+        // checks (the style remains the one of the cloneNode).
+        node = node->getCloneNodeSource();
+    }
     if ( node->getNodeId() == el_pseudoElem ) {
         if (    ( _pseudo_elem == csspe_before && node->hasAttribute(attr_Before) )
              || ( _pseudo_elem == csspe_after  && node->hasAttribute(attr_After)  )
-             || ( _pseudo_elem == csspe_first_letter && node->hasAttribute(attr_FirstLetter) ) ) {
+             || ( _pseudo_elem == csspe_first_letter && node->hasAttribute(attr_FirstLetter) )
+             || ( _pseudo_elem == csspe_first_line   && node->hasAttribute(attr_FirstLine)   ) ) {
             target_style = style;
         }
     }
@@ -7006,6 +7042,12 @@ void LVCssSelector::applyToPseudoElement( const ldomNode * node, css_style_rec_t
                 style->pseudo_elem_first_letter_catcher_style = new css_style_rec_t;
             }
             target_style = style->pseudo_elem_first_letter_catcher_style;
+        }
+        else if ( _pseudo_elem == csspe_first_line ) {
+            if ( !style->pseudo_elem_first_line_style ) {
+                style->pseudo_elem_first_line_style = new css_style_rec_t;
+            }
+            target_style = style->pseudo_elem_first_line_style;
         }
     }
 
@@ -7098,13 +7140,40 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
         // (other normal <body> have a non-root parent: <html>)
         return;
     }
+    if ( id == el_cloneNode ) {
+        // For cloneNode, we need to get the original node's id for selector matching,
+        // but apply styles to the cloneNode itself (not the source's style).
+        // (A cloneNode inherits the styles from its ancestor pseudoElem[FirstLine],
+        // which are overloaded by what is applied here).
+        if ( node->isEffectiveText() ) {
+            return; // text nodes don't get to be styled
+        }
+        // Continue with selector matching using the source's id (but keep
+        // node (the cloneNode) and apply to its style)
+        id = node->getEffectiveNodeId();
+    }
     if ( id == el_pseudoElem ) { // get the id chain from the parent/originating element
         // Note that a "div:before {float:left}" will result in: <div><floatBox><pseudoElem>
-        if ( node->hasAttribute(attr_FirstLetter) ) {
+        // (Use *Effective* methods as a cloneNode can originate from a pseudoElem)
+        if ( node->hasEffectiveAttribute(attr_FirstLetter) ) {
             // For ::first-letter, find the ancestor with HasFirstLetter attribute
-            const ldomNode * ancestor = node->getUnboxedParent();
+            const ldomNode * ancestor = const_cast<ldomNode*>(node)->getEffectiveNode()->getUnboxedParent();
             while ( ancestor ) {
                 if ( ancestor->hasAttribute(attr_HasFirstLetter) ) {
+                    id = ancestor->getNodeId();
+                    break;
+                }
+                ancestor = ancestor->getUnboxedParent();
+            }
+            if ( !ancestor ) { // shouldn't happen
+                return;
+            }
+        }
+        else if ( node->hasEffectiveAttribute(attr_FirstLine) ) {
+            // For ::first-line, find the ancestor with HasFirstLine attribute
+            const ldomNode * ancestor = const_cast<ldomNode*>(node)->getEffectiveNode()->getUnboxedParent();
+            while ( ancestor ) {
+                if ( ancestor->hasAttribute(attr_HasFirstLine) ) {
                     id = ancestor->getNodeId();
                     break;
                 }
@@ -7136,7 +7205,7 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
     LVCssSelector * selector_id = id>0 && id<_selectors.length() ? _selectors[id] : NULL;
 
     LVArray<lUInt32> class_hash_array;
-    const lString32 &v = node->getAttributeValue(attr_class);
+    const lString32 &v = node->getEffectiveAttributeValue(attr_class);
     for_each_split(v.c_str(), [&](const lChar32 *begin, const lChar32 *end) {
         class_hash_array.add(lString32::getHash(begin, end));
     });

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3062,6 +3062,8 @@ static const char * css_f_names[] =
     "none",
     "left",
     "right",
+    "inline-start",
+    "inline-end",
     NULL
 };
 
@@ -3072,6 +3074,8 @@ static const char * css_c_names[] =
     "none",
     "left",
     "right",
+    "inline-start",
+    "inline-end",
     "both",
     NULL
 };

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -588,9 +588,18 @@ public:
         flt->srctext = src;
 
         ldomNode * node = (ldomNode *) src->object;
-        flt->is_right = node->getStyle()->float_ == css_f_right;
+        css_float_t float_ = node->getStyle()->float_;
+        flt->is_right = ( ( float_ == css_f_right ) ||
+                          ( m_para_dir_is_rtl && float_ == css_f_inline_start ) ||
+                          (!m_para_dir_is_rtl && float_ == css_f_inline_end ) );
         // clear was not moved to the floatBox: get it from its single child
         flt->clear = node->getChildNode(0)->getStyle()->clear;
+        if ( flt->clear == css_c_inline_start ) {
+            flt->clear = m_para_dir_is_rtl ? css_c_right : css_c_left;
+        }
+        else if ( flt->clear == css_c_inline_end ) {
+            flt->clear = m_para_dir_is_rtl ? css_c_left : css_c_right;
+        }
 
         // Thanks to the wrapping floatBox element, which has no
         // margin, we can set its RenderRectAccessor to be exactly

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -325,7 +325,7 @@ int getLTextExtraProperty( src_text_fragment_t * srcline, ltext_extra_t extra_pr
     if ( !srcline->object )
         return 0;
     ldomNode * node = (ldomNode *) srcline->object;
-    if ( node->isText() )
+    if ( node->isEffectiveText() )
         node = node->getParentNode();
     if ( !node || node->isNull() )
         return 0;
@@ -4721,6 +4721,9 @@ public:
 
         // split paragraph into lines, export lines
         int pos = 0;
+
+        bool is_css_first_line = m_srcs[0]->flags & LTEXT_IS_FIRST_LINE_CLONE;
+
         #if (USE_LIBUNIBREAK!=1)
         int upSkipPos = -1;
         #endif
@@ -4790,9 +4793,20 @@ public:
             // Find candidates where end of line is possible
             bool seen_non_collapsed_space = false;
             bool seen_first_rendered_char = false;
+            bool first_line_sequance_end_reached = false; // ::first-line cloned text end reached
             int i;
             for ( i=pos; i<m_length; i++ ) {
                 if ( m_text[i]=='\n' ) { // might happen in <pre>formatted only (?)
+                    lastMandatoryWrap = i;
+                    break;
+                }
+                if ( is_css_first_line && !(m_srcs[i]->flags & LTEXT_IS_FIRST_LINE_CLONE) ) {
+                    // We reached the non-first-line sequence: the first-line sequence
+                    // did fit all on the first line, don't go at appending the same
+                    // text from the non-first line sequence
+                    first_line_sequance_end_reached = true;
+                    // For the followup wrap position resolution, pretend we met a \n
+                    // after where first line sequence ended
                     lastMandatoryWrap = i;
                     break;
                 }
@@ -5306,6 +5320,63 @@ public:
             #endif
             if (endp > m_length)
                 endp = m_length;
+
+            if ( is_css_first_line ) {
+                is_css_first_line = false;
+                if ( first_line_sequance_end_reached ) {
+                    // We're done: let us be exiting this loop properly
+                    wrapPos = m_length-1;
+                }
+                else {
+                    // We had a copy of the source text with CSS first-line styling,
+                    // and we did not meet its end. We should fast forward skipping
+                    // that first-line sequence, and once in the normal text sequence
+                    // (which includes the full text since the start of the paragraph)
+                    // skip the part that has just been output as first-line to restart
+                    // on after where we wrapped.
+                    // We initially assumed we would get the same text content in the
+                    // first-line sequence as in the normal text copy we get after it,
+                    // but when a list item marker is prepended, we do not.
+                    // So, get the node (a cloneNode) and offset at which we stopped on,
+                    // get its source node, and try to find it in the normal sequence:
+                    // we can then restart on it at the same offset/charindex.
+                    lUInt16 orig_offset = 0;
+                    ldomNode * orig_node = (ldomNode *) m_srcs[wrapPos]->object;
+                    if ( orig_node ) {
+                        orig_node = orig_node->getCloneNodeSource();
+                        orig_offset = m_charindex[wrapPos];
+                    }
+                    // First, skip from here until non-first-line-clone
+                    int i = wrapPos;
+                    while (i < m_length && m_srcs[i]->flags & LTEXT_IS_FIRST_LINE_CLONE)
+                        i++;
+                    int normal_sequence_start = i; // in case !found
+                    bool found = false;
+                    if ( orig_node ) { // look for it
+                        while (i < m_length) {
+                            ldomNode * node = (ldomNode *) m_srcs[i]->object;
+                            if ( node == orig_node ) {
+                                if ( m_charindex[i] == orig_offset ) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            i++;
+                        }
+                    }
+                    if ( !found ) {
+                        // If we did not find it, go with our initial assumption:
+                        // move in the non-first-line as much as we walked until wrap
+                        // in the first-line sequence
+                        i = normal_sequence_start + wrapPos;
+                    }
+                    // And use that as wrapPos for what follows.
+                    wrapPos = i;
+                    if (wrapPos >= m_length)
+                        wrapPos = m_length-1;
+                    // printf("first line done, moving from %d to %d (found=%d)\n", endp, i, found);
+                }
+            }
 
             // Best position to end this line found.
             bool hasInlineBoxes = firstInlineBoxPos >= 0 && firstInlineBoxPos < endp;
@@ -6029,7 +6100,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         if ( srcline->flags & LTEXT_HAS_TOP_BOTTOM_BORDER ) {
                             // Find out the nearest parent node that carries some border
                             ldomNode * tmp = node;
-                            if (tmp->isText())
+                            if (tmp->isEffectiveText())
                                 tmp = tmp->getParentNode();
                             while ( tmp && tmp->getRendMethod() != erm_final ) {
                                 int border = measureBorder(tmp, side);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -93,7 +93,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.76k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.77k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0034
 
@@ -4759,6 +4759,10 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
             }
         }
         if ( WNEFLAG(SHOW_REND_METHOD) ) {
+            // For cloneNode, also show the element name of the source node
+            if ( node->getNodeId() == el_cloneNode && !node->hasAttribute(attr_T) ) {
+                *stream << " " << UnicodeToUtf8(node->getCloneNodeSource()->getNodeName());
+            }
             *stream << " ~";
             switch ( node->getRendMethod() ) {
                 case erm_invisible:          *stream << "X";     break;
@@ -6237,15 +6241,29 @@ void ldomNode::ensurePseudoElement( bool is_before ) {
     int insertChildIndex = -1;
     int nb_children = getChildCount();
     if ( is_before ) { // ::before
-        insertChildIndex = 0; // always to be inserted first, if not already there
+        // ::before should be at position 0, or at position 1 if FirstLine is at position 0.
+        insertChildIndex = 0; // default: insert first
         if ( nb_children > 0 ) {
-            ldomNode * child = getChildNode(0); // should always be found as the first node
+            ldomNode * child = getChildNode(0);
             // pseudoElem might have been wrapped by a inlineBox, autoBoxing, floatBox...
             while ( child && child->isBoxingNode() && child->getChildCount()>0 )
                 child = child->getChildNode(0);
             if ( child && child->getNodeId() == el_pseudoElem && child->hasAttribute(attr_Before) ) {
-                // Already there, no need to create it
+                // Already there at position 0, no need to create it
                 insertChildIndex = -1;
+            }
+            else if ( child && child->getNodeId() == el_pseudoElem && child->hasAttribute(attr_FirstLine) ) {
+                // FirstLine is at position 0; ::before belongs at position 1
+                insertChildIndex = 1;
+                if ( nb_children > 1 ) {
+                    ldomNode * child1 = getChildNode(1);
+                    while ( child1 && child1->isBoxingNode() && child1->getChildCount()>0 )
+                        child1 = child1->getChildNode(0);
+                    if ( child1 && child1->getNodeId() == el_pseudoElem && child1->hasAttribute(attr_Before) ) {
+                        // Already there at position 1, no need to create it
+                        insertChildIndex = -1;
+                    }
+                }
             }
         }
     }
@@ -6308,6 +6326,11 @@ void ldomNode::ensureFirstLetter(bool initStyle) {
     // initStyle parameter:
     //   - true: call initNodeStyle() on newly created pseudoElem (during DOM building from onBodyExit)
     //   - false: skip initNodeStyle() as it will be called during recursive style pass (during stylesheet re-application)
+
+    // Do nothing on a cloneNode, this will have been done on its source
+    if ( getNodeId() == el_cloneNode ) {
+        return;
+    }
 
     // First, ensure the HasFirstLetter attribute is set
     if ( !hasAttribute(attr_HasFirstLetter) ) {
@@ -6510,6 +6533,152 @@ ldomNode * ldomNode::getFirstLetterTextNode() const
         return nextSibling;
     }
     return NULL;
+}
+
+// Helper function for ::first-line, to recursively clone a node and its children.
+// Clones only store a reference (SrcId) to the original node.
+// Queries (element name, attributes, text content...) can be delegated to the original
+// node by using the ldomNode::*Effective*() variants of the existing methods.
+static ldomNode * cloneNodeRecursively(ldomNode * source, ldomNode * parent) {
+#if BUILD_LITE!=1
+    if ( !source || !parent )
+        return NULL;
+
+    // Create a cloneNode element for both text and element nodes
+    ldomNode * clone = parent->insertChildElement( parent->getChildCount(), LXML_NS_NONE, el_cloneNode );
+    // Store a reference to the original node
+    lString32 nodeIdStr;
+    nodeIdStr << fmt::decimal(source->getDataIndex());
+    clone->setAttributeValue(LXML_NS_NONE, attr_SrcId, nodeIdStr.c_str());
+
+    if ( source->isText() ) {
+        // For text node clones, mark with empty attr_T so that setNodeStyle()
+        // can quickly set a dummy style, and for debugging visibility
+        clone->setAttributeValue(LXML_NS_NONE, attr_T, U"");
+        // These shouldn't need a style, but safer to have one to pass checks
+        // of style in various odd places without crashing
+        clone->initNodeStyle();
+    }
+    else if ( source->isElement() ) {
+        clone->initNodeStyle();
+        // Recursively clone children (including pseudoElem[Before/FirstLetter/After],
+        // which get to be styled with the ::first-line style)
+        for ( int i = 0; i < source->getChildCount(); i++ ) {
+            ldomNode * childSource = source->getChildNode(i);
+            cloneNodeRecursively(childSource, clone);
+        }
+    }
+    return clone;
+#else
+    return NULL;
+#endif
+}
+
+// Helper function for ::first-line, to recursively copy rendMethod from source nodes to cloneNodes
+static void copyRendMethodFromSources(ldomNode * node) {
+#if BUILD_LITE!=1
+    if ( !node || !node->isElement() )
+        return;
+    if ( node->getNodeId() == el_cloneNode ) {
+        ldomNode * source = node->getCloneNodeSource();
+        if ( source ) {
+            if ( source->isElement() ) {
+                node->setRendMethod( source->getRendMethod() );
+            }
+            else {
+                // Not really needed, but safer, and let's have ~i (inline)
+                // rather than ~X (invisible) in writeNodeEx() HTML output.
+                node->setRendMethod( erm_inline );
+            }
+        }
+    }
+    for ( int i = 0; i < node->getChildCount(); i++ ) {
+        copyRendMethodFromSources( node->getChildNode(i) );
+    }
+#endif
+}
+
+/// Get the original node from a cloneNode element (for ::first-line)
+/// Returns NULL if this is not a cloneNode or if the original node cannot be found
+ldomNode * ldomNode::getCloneNodeSource() const {
+#if BUILD_LITE!=1
+    if ( !isElement() || getNodeId() != el_cloneNode )
+        return NULL;
+    lString32 srcId = getAttributeValue(attr_SrcId);
+    if ( srcId.empty() )
+        return NULL;
+    int nodeDataIndex = srcId.atoi();
+    if ( nodeDataIndex <= 0 )
+        return NULL;
+    ldomDocument * doc = getDocument();
+    if ( !doc )
+        return NULL;
+    ldomNode * sourceNode = doc->getTinyNode(nodeDataIndex);
+    return sourceNode;
+#else
+    return NULL;
+#endif
+}
+
+void ldomNode::ensureFirstLine() {
+#if BUILD_LITE!=1
+    // This method handles ::first-line pseudo element creation by cloning
+    // the paragraph's inner DOM subtree into the pseudoElem[FirstLine].
+    // The clones naturally inherit from the ::first-line style, solving
+    // the measurement/layout issue.
+    //
+    // Called at the end of initNodeRendMethod() for erm_final nodes with
+    // attr_HasFirstLine, so all boxing (inlineBox, autoBox, etc.) is already
+    // done and children have their final rendMethods.
+        // Note (but a bit uncertain about this): as this is called at initRendMethod() time,
+        // in case of a re-rendering where it happens after the full DOM is styled (unlike
+        // in the initial DOM building), we may have set HasFirstLine, which will cause
+        // the pseudoElem[FirstLine] to be created below, but its initNodeStyle() won't
+        // meet the publisher stylesheets, but only the user-agent stylesheet: if we are
+        // unmasking ::first-line (ie. removing "::first-line {display: none}" from style
+        // tweaks), we may not meet the original publisher styles, so we won't see
+        // them immediately. But as an element was added, the style display hash will change,
+        // and we will be proposed to reload the document, which should make things right.
+
+    // Check if we already have a FirstLine pseudoElem child
+    // Use getUnboxedFirstChild to find it even if it's been boxed (e.g., in an inlineBox)
+    ldomNode * firstLineElem = getUnboxedFirstChild(true, el_pseudoElem);
+    if ( firstLineElem && !firstLineElem->hasAttribute(attr_FirstLine) ) {
+        firstLineElem = NULL; // Found a pseudoElem, but not FirstLine (e.g., ::before)
+    }
+    if ( !firstLineElem ) {
+        // Create the FirstLine pseudo element as the first child of this element.
+        firstLineElem = insertChildElement( 0, LXML_NS_NONE, el_pseudoElem );
+        firstLineElem->setAttributeValue(LXML_NS_NONE, attr_FirstLine, U"");
+        firstLineElem->initNodeStyle();
+    }
+
+    if ( firstLineElem->getStyle()->display == css_d_none ) {
+        firstLineElem->setRendMethod(erm_invisible);
+        // Don't create cloneNodes
+        return;
+    }
+
+    // Clone children if the pseudoElem has no cloneNodes yet.
+    // If some pseudoElem[Before] is introduced later, we won't get it among
+    // our original cloneNode, but as a new element has been added, we will
+    // get proposed to reload the document, which should make things right.
+    if ( firstLineElem->getChildCount() == 0 ) {
+        // Clone all children of this element into firstLineElem
+        // Skip the first child (i=1) since it's the firstLineElem itself (possibly boxed)
+        for ( int i = 1; i < (int)getChildCount(); i++ ) {
+            ldomNode * child = getChildNode(i);
+            cloneNodeRecursively(child, firstLineElem);
+        }
+    }
+
+    // Whether created or already existing, set it erm_inline as not display:none
+    firstLineElem->setRendMethod(erm_inline);
+    // Copy rendMethods from the original (source) nodes to their clones.
+    // Since we're called from initNodeRendMethod() after all boxing is done,
+    // the originals have their final rendMethods.
+    copyRendMethodFromSources(firstLineElem);
+#endif
 }
 
 
@@ -7280,6 +7449,12 @@ void ldomNode::initNodeRendMethod()
         return;
     if ( isRoot() ) {
         setRendMethod(erm_block);
+        return;
+    }
+    if ( getNodeId()==el_cloneNode ) {
+        // Invisible for now, these will be later updated with the value from source
+        // when we meet/create the pseudoElem[FirstLine] that contains them.
+        setRendMethod(erm_invisible);
         return;
     }
 
@@ -8676,6 +8851,14 @@ void ldomNode::initNodeRendMethod()
         }
     #endif
 
+    // If this node is erm_final and has ::first-line CSS rules, create the
+    // pseudoElem[FirstLine] and clone the children now that all boxing is done.
+    // Children have their final rendMethods, so clones will reflect the correct
+    // post-boxing DOM structure.
+    if ( getRendMethod() == erm_final && hasAttribute(attr_HasFirstLine) ) {
+        ensureFirstLine();
+    }
+
     persist();
 }
 #endif
@@ -8718,6 +8901,9 @@ void ldomElementWriter::onBodyExit()
     if ( _element->hasAttribute(attr_HasFirstLetter) ) {
         _element->ensureFirstLetter(true); // true = init style during DOM building
     }
+
+    // pseudoElem[FirstLine] creation is deferred to initNodeRendMethod()
+    // which runs after all boxing is complete (inlineBox, autoBox, etc.).
 
 //    if ( _element->getStyle().isNull() ) {
 //        lString32 path;
@@ -9886,6 +10072,12 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
         finalNode->renderFinalBlock( txtform, &fmt, inner_width );
     }
 
+    // Note: pt may be on the first-line of a ::first-line paragraph,
+    // the word we will find may have as ->object a cloneNode.
+    // The xpointer we will return will reference the effective source node
+    // (too early to guarantee that, but it feels we won't ever return
+    // a xpointer to a cloneNode).
+
     // First, look if pt happens to be in some float
     // (this may not work with floats with negative margins)
     int fcount = txtform->GetFloatCount();
@@ -9896,6 +10088,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             continue;
         if (pt.x >= flt->x && pt.x < flt->x + flt->width && pt.y >= flt->y && pt.y < flt->y + (int)flt->height ) {
             // pt is inside this float.
+            // (For floats in ::first-line, srctext->object references the original float element,
+            // and never the clondeNode, so no need to use getEffectiveNode() here.)
             ldomNode * node = (ldomNode *) flt->srctext->object; // floatBox node
             ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
             if ( !inside_ptr.isNull() ) {
@@ -9977,6 +10171,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             // Found right word/image
             const src_text_fragment_t * src = txtform->GetSrcInfo(word->src_text_index);
             ldomNode * node = (ldomNode *)src->object;
+            // (For inline-boxes and images in ::first-line, srctext->object references the original
+            // element or image, and never the clondeNode, so no need to use getEffectiveNode() here.)
             if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
                 // pt is inside this inline-block inlineBox node
                 ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
@@ -9991,14 +10187,14 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             }
             // It is a word
             if ( find_first ) { // return xpointer to logical start of word
-                if ( node->isElement() ) // (see comment about <br/><br/> below)
-                    return ldomXPointer(node, 0);
-                return ldomXPointer( node, word->t.start );
+                if ( node->isEffectiveElement() ) // (see comment about <br/><br/> below)
+                    return ldomXPointer(node->getEffectiveNode(), 0);
+                return ldomXPointer( node->getEffectiveNode(), word->t.start );
             }
             else { // return xpointer to logical end of word
-                if ( node->isElement() )
-                    return ldomXPointer(node, 0);
-                return ldomXPointer( node, word->t.start + word->t.len );
+                if ( node->isEffectiveElement() )
+                    return ldomXPointer(node->getEffectiveNode(), 0);
+                return ldomXPointer( node->getEffectiveNode(), word->t.start + word->t.len );
             }
         }
 
@@ -10037,6 +10233,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 if ( word->flags & LTEXT_WORD_IS_PAD ) {
                     continue;
                 }
+                // (For inline-boxes and images in ::first-line, srctext->object references the original
+                // element or image, and never the clondeNode, so no need to use getEffectiveNode() here.)
                 if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
                     // pt is inside this inline-block inlineBox node
                     ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
@@ -10062,7 +10260,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 lUInt16 width[512];
                 lUInt8 flg[512];
 
-                lString32 str = node->getText();
+                lString32 str = node->getEffectiveText();
+
                 // We need to transform the node text as it had been when
                 // rendered (the transform may change chars widths) for the
                 // XPointer offset to be correct
@@ -10110,11 +10309,11 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                             // after the logical end of that RTL word
                         }
                     }
-                    if ( node->isElement() ) // possibly some <br> or generated text not part of a text node
-                        return ldomXPointer(node, 0);
+                    if ( node->isEffectiveElement() ) // possibly some <br> or generated text not part of a text node
+                        return ldomXPointer(node->getEffectiveNode(), 0);
                     // printf("word %d/%d, len=%d indice=%d (%d > %d + %d - %d)\n", w+1, wc, word->t.len,
                     //              pos, x, word->x, word->width, pos<word->t.len?width[pos]:-1);
-                    return ldomXPointer( node, word->t.start + pos );
+                    return ldomXPointer( node->getEffectiveNode(), word->t.start + pos );
                 }
                 else {
                     int pos = word->t.len; // default to after this word if we don't find better
@@ -10144,11 +10343,11 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                             // Otherwise (not sure if can happen): use the default of word->t.len
                         }
                     }
-                    if ( node->isElement() ) // possibly some <br> or generated text not part of a text node
-                        return ldomXPointer(node, 0);
+                    if ( node->isEffectiveElement() ) // possibly some <br> or generated text not part of a text node
+                        return ldomXPointer(node->getEffectiveNode(), 0);
                     // printf("word %d/%d, len=%d indice=%d (%d < %d + %d)\n", w+1, wc, word->t.len,
                     //              pos, x, word->x, pos<word->t.len?width[pos]:-1);
-                    return ldomXPointer( node, word->t.start + pos );
+                    return ldomXPointer( node->getEffectiveNode(), word->t.start + pos );
                 }
                 /* Previously, we returned differently whether x was in the left or in the right half of a glyph:
                 if ( word_is_rtl ) {
@@ -10344,13 +10543,27 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         int lastIndex = -1;
         int lastLen = -1;
         int lastOffset = -1;
+        // If txtform contains srclines from the cloned nodes (styled from ::first-line),
+        // we'll find two srclines, one to use when scanning the 1st line, the other when
+        // scanning the next lines
+        int firstLineSrcIndex = -1;
+        int laterLineSrcIndex = -1;
+        // It seems we are always called on a xpointer referencing a real node, and never a cloneNode.
+        // The following has not been tested when being called on a xpointer to a cloneNode.
+
         ldomXPointerEx xp(node, offset);
+        // printf("getRect(%s)\n", LCSTR(xp.toStringV1()));
         for ( int i=0; i<txtform->GetSrcCount(); i++ ) {
             const src_text_fragment_t * src = txtform->GetSrcInfo(i);
             bool isObject = (src->flags&LTEXT_SRC_IS_OBJECT)!=0;
             if ( isObject && src->o.objflags & LTEXT_OBJECT_IS_FLOAT ) // skip floats
                 continue;
-            if ( src->object == node ) {
+            bool is_first_line_clone = src->flags & LTEXT_IS_FIRST_LINE_CLONE;
+            if ( src->object == node || (is_first_line_clone && src->object && ((ldomNode*)(src->object))->getEffectiveNode() == node)) {
+                /*
+                printf(" if (%x==%x || %x==%x)\n", src->object, node , ((ldomNode*)(src->object))->getEffectiveNode(), node);
+                printf(" %d %s %s vs. %d\n", i, LCSTR(ldomXPointer((ldomNode*)(src->object),src->t.offset).toStringV1()),
+                                    LCSTR(ldomXPointer(((ldomNode*)(src->object))->getEffectiveNode() ,src->t.offset).toStringV1()), offset); */
                 // Check and handle the case of ::first-letter
                 if ( src->t.offset > 0 && offset < src->t.offset) {
                     // Currently, we can only get a non-0 src->t.offset if that text
@@ -10364,7 +10577,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                     // could use: srcIndex=i-1 , but this does not handle all
                     // cases, especially when the first-letter is a float.)
                     // So, find the pseudoElem that carries that first-letter
-                    ldomNode * pseudoElem = node->getFirstLetterPseudoElem();
+                    ldomNode * pseudoElem = node->getEffectiveFirstLetterPseudoElem();
                     if ( pseudoElem ) {
                         // Call us again on that pseudoElem with the same offset as provided
                         ldomXPointer xpFirstLetter(pseudoElem, offset);
@@ -10382,18 +10595,34 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                     ldomNode * textNode = node->getFirstLetterTextNode();
                     if ( textNode ) {
                         node = textNode;
+                        srcIndex = i;
+                        srcLen = isObject ? 0 : src->t.len;
+                        // If we were on a ::first-line, we did resolve above the cloneNode to
+                        // its pseudoElem: no need for the first/later LineSrcIndex gathering below.
+                        break;
                     }
                 }
                 // Generic text node case: we found the src that came from our node
-                srcIndex = i;
-                srcLen = isObject ? 0 : src->t.len;
-                break;
+                if ( is_first_line_clone ) {
+                    firstLineSrcIndex = i;
+                    // srcLen should be valid for both srcIndex
+                    // Don't break, we want to find the non-first-line srcIndex
+                }
+                else {
+                    srcIndex = i;
+                    if ( firstLineSrcIndex >= 0)
+                        laterLineSrcIndex = i;
+                    srcLen = isObject ? 0 : src->t.len;
+                    break;
+                }
             }
             lastIndex = i;
             lastLen =  isObject ? 0 : src->t.len;
             lastOffset = isObject ? 0 : src->t.offset;
             ldomXPointerEx xp2((ldomNode*)src->object, lastOffset);
-            if ( xp2.compare(xp)>0 ) {
+            if ( !is_first_line_clone && xp2.compare(xp)>0 ) {
+                // (Not if we are still in the first line clones segment,
+                // we want to use the one from the normal segment.)
                 srcIndex = i;
                 srcLen = lastLen;
                 offset = lastOffset;
@@ -10416,6 +10645,14 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         bool hasBestBidiRect = false;
 
         for ( int l = 0; l<txtform->GetLineCount(); l++ ) {
+            if ( firstLineSrcIndex >= 0) {
+                if ( l == 0 )
+                    srcIndex = firstLineSrcIndex;
+                else if ( laterLineSrcIndex >= 0 )
+                    srcIndex = laterLineSrcIndex;
+                // 'node' is the original text node - below when measuring/transforming,
+                // we should be careful using the srcIndex's ->font and ->object node styles.
+            }
             const formatted_line_t * frmline = txtform->GetLineInfo(l);
             bool line_is_bidi = frmline->flags & LTEXT_LINE_IS_BIDI;
             bool para_is_rtl = frmline->flags & LTEXT_LINE_PARA_IS_RTL;
@@ -10538,10 +10775,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                             }
                             else { // exact word found
                                 // Measure word
-                                LVFont *font = (LVFont *) txtform->GetSrcInfo(srcIndex)->t.font;
+                                const src_text_fragment_t * src = txtform->GetSrcInfo(srcIndex);
+                                LVFont *font = (LVFont *)src->t.font;
                                 lUInt16 w[512];
                                 lUInt8 flg[512];
-                                lString32 str = node->getText();
+                                lString32 str = node->getEffectiveText();
                                 if (offset == word->t.start && str.empty()) {
                                     rect.left = word->x + rc.left + frmline->x;
                                     rect.top = rc.top + frmline->y;
@@ -10557,7 +10795,8 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                 // We need to transform the node text as it had been when
                                 // rendered (the transform may change chars widths) for the
                                 // rect to be correct
-                                switch ( node->getParentNode()->getStyle()->text_transform ) {
+                                css_text_transform_t text_transform = src->object ?  ((ldomNode*)(src->object))->getParentNode()->getStyle()->text_transform : css_tt_none;
+                                switch ( text_transform ) {
                                     case css_tt_uppercase:
                                         str.uppercase();
                                         break;
@@ -10581,8 +10820,8 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                     flg,
                                     word->width+50,
                                     '?',
-                                    txtform->GetSrcInfo(srcIndex)->lang_cfg,
-                                    txtform->GetSrcInfo(srcIndex)->letter_spacing + word->added_letter_spacing,
+                                    src->lang_cfg,
+                                    src->letter_spacing + word->added_letter_spacing,
                                     false,
                                     hints);
                                 rect.top = rc.top + frmline->y;
@@ -10726,10 +10965,11 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                 ( (offset < word->t.start+word->t.len) ||
                                   (offset==srcLen && offset == word->t.start+word->t.len) ) ) {
                         // pointer inside this word
-                        LVFont *font = (LVFont *) txtform->GetSrcInfo(srcIndex)->t.font;
+                        const src_text_fragment_t * src = txtform->GetSrcInfo(srcIndex);
+                        LVFont *font = (LVFont *)src->t.font;
                         lUInt16 w[512];
                         lUInt8 flg[512];
-                        lString32 str = node->getText();
+                        lString32 str = node->getEffectiveText();
                         // With "|| (extended && offset < word->t.start)" added to the first if
                         // above, we may now be here with: offset = word->t.start = 0
                         // and a node->getText() returning THE lString32::empty_str:
@@ -10750,7 +10990,8 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                         // We need to transform the node text as it had been when
                         // rendered (the transform may change chars widths) for the
                         // rect to be correct
-                        switch ( node->getParentNode()->getStyle()->text_transform ) {
+                        css_text_transform_t text_transform = src->object ?  ((ldomNode*)(src->object))->getParentNode()->getStyle()->text_transform : css_tt_none;
+                        switch ( text_transform ) {
                             case css_tt_uppercase:
                                 str.uppercase();
                                 break;
@@ -10774,8 +11015,8 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                             flg,
                             word->width+50,
                             '?',
-                            txtform->GetSrcInfo(srcIndex)->lang_cfg,
-                            txtform->GetSrcInfo(srcIndex)->letter_spacing + word->added_letter_spacing,
+                            src->lang_cfg,
+                            src->letter_spacing + word->added_letter_spacing,
                             false,
                             hints );
                         // chx is the width of previous chars in the word
@@ -17435,10 +17676,13 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered, lUInt32 force_n
                         // elements wrapping floats when toggling BLOCK_RENDERING_ENHANCED
                         if (style.get()->float_ > css_f_none)
                             _nodeDisplayStyleHash += 123;
+                        // printf("h idx=%d id=%s d:%d w:%d\n", buf[j].getDataIndex(), LCSTR(buf[j].getNodeName()), style.get()->display, style.get()->white_space);
                     }
+                    // else { printf("h idx=%d id=%s style is null\n", buf[j].getDataIndex(), LCSTR(buf[j].getNodeName())); }
                     //printf("element %d %d style hash: %x\n", i, j, sh);
                     LVFontRef font = buf[j].getFont();
                     lUInt32 fh = calcHash( font );
+                    // printf("h idx=%d id=%s sh:%x fh:%x\n", buf[j].getDataIndex(), LCSTR(buf[j].getNodeName()), sh, fh);
                     res = res * 31 + fh;
                     //printf("element %d %d font hash: %x\n", i, j, fh);
 //                    if ( maxlog>0 && sh==0 ) {
@@ -17453,6 +17697,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered, lUInt32 force_n
         // because of the presence of a cache file
         if ( _boxingWishedButPreventedByCache )
             _nodeDisplayStyleHash += 79;
+        // printf("done %x %x\n", res, _nodeDisplayStyleHash);
 
         CRLog::debug("  COMPUTED _nodeStyleHash %x", res);
         _nodeStyleHash = res;
@@ -17482,6 +17727,7 @@ lUInt32 tinyNodeCollection::calcStyleHash(bool already_rendered, lUInt32 force_n
     res = (res * 31 + globalHash) * 31 + docFlags;
 //    CRLog::info("Calculated style hash = %08x", res);
     CRLog::debug("calcStyleHash done");
+    // printf("end %x %x\n", res, _nodeDisplayStyleHash);
     return res;
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6174,8 +6174,8 @@ void ldomElementWriter::onBodyEnter()
         if ( nb_children > 0 ) {
             // The only possibility for this element being built to have children
             // is if the above initNodeStyle() has applied to this node some
-            // matching selectors that had ::before or ::after or ::first-letter, which have then
-            // created one or two or three pseudoElem children. But let's be sure of that.
+            // matching selectors that had ::before or ::after, which have then
+            // created one or more pseudoElem children. But let's be sure of that.
             for ( int i=0; i<nb_children; i++ ) {
                 ldomNode * child = _element->getChildNode(i);
                 if ( child->getNodeId() == el_pseudoElem ) {
@@ -6230,11 +6230,10 @@ void ldomNode::ensurePseudoElement( bool is_before ) {
         // (and using pseudo elements on them feels hackish): ignore them.
         return;
     }
-    // This node should have that pseudoElement, but it might already be there,
+    // This node should get that pseudoElement, but it might already be there,
     // so check if there is already one, and if not, create it.
-    // This happens usually in the initial loading phase, but it might in
-    // a re-rendering if the pseudo element is introduced by a change in
-    // styles (we won't be able to create a node if there's a cache file).
+    // This happens usually in the initial loading phase, but it might in a
+    // re-rendering if the pseudo element is introduced by a change in styles.
     int insertChildIndex = -1;
     int nb_children = getChildCount();
     if ( is_before ) { // ::before
@@ -6385,6 +6384,18 @@ void ldomNode::ensureFirstLetter(bool initStyle) {
                     if ( n == topNode && index >= n->getChildCount() )
                         break;
                     continue;
+                }
+                else if ( !n->getStyle().isNull() && n->getStyle()->display == css_d_none ) {
+                    // Skip display:none elements
+                    index = n->getNodeIndex() + 1;
+                    n = n->getParentNode();
+                    if ( n == topNode && index >= n->getChildCount() )
+                        break;
+                    continue;
+                }
+                else if ( n->getNodeId() == el_br ) {
+                    // A <br> before any text makes no first-letter
+                    break;
                 }
             }
             // Process next child


### PR DESCRIPTION
#### `renderFinalBlock()`: fix background color propagation among inlines

If some upper inline node has set a background color, it was not passed to inner inline nodes for them to draw it too.
(Pes CSS-specs, `background-color` is not inherited.  For our drawing, we should somehow ensure that inheritance by passing it all along for drawing.)

In here, a plain `<b>bold</b>` was cutting the backgroud-color of its containing `<span>`.
<img width="582" height="99" alt="image" src="https://github.com/user-attachments/assets/db08c086-4139-495e-93a0-686a917ac412" />


#### first-letter: resets some CSS, ignore invisible, stop on `<br/>`

Various fixes to `::first-letter`:
- resets some CSS properties (`display`, `text-indent`) as expected by the specs (but not all specified, as it is quite unnecessary)
- ignore `display:none` text nodes when looking for first text node
- don't ensure any first-letter if we meet a BR before any first visible text

Also call `TextLangMan::resetCounters()` on document loading (state was conserved from previous document, so a reload of the same document could have generated quotes changed).

#### CSS: support for pseudo element `::first-line`

Handled as a special variation of the pseudoElem internal element we introduced to support `::before`, `::after` and `::first-letter`.
DOM ordering ends up as: FirstLine, Before, FirstLetter, [original nodes], After.

But unlike these, the `pseudoElem[FirstLine]` does not stay empty, and is filled with a subtree of `<cloneNode SrcId=123>` for each node in the paragraph (up to any first `<br/>`).
This is done by `ensureFirstLine()` at the end of `initNodeRendMethod()` when all the nodes in the paragraph have got their rend methods and possibly got boxed, and other `pseudoElem` have been created, so all these get cloned.

Then, CSS application (lvstsheet.cpp) ensures that:
- `pseudoElem[FirstLine]` gets the style associated to `::first-line`
- its children (`cloneNode`s) inherits naturally from that `pseudoElem[FirstLine]`
- the cloneNodes matches the CSS selectors that their source node did match (so a `<b>` inherits from `::first-line`, but stays bold)

On rendering, lvrend.cpp's `renderFinalBlock()` feed the text formatter first with the text and style from the `cloneNode`s (with a flag), and then with the same text, but styled from the original inline nodes.

Then, when text formatting (lvtextfm.cpp), we use the first-line fragments (from the `cloneNode`s), and when done with the first line, we skip the remaining first-line fragments and fast-forward to the normal fragments to the position we stopped on, to resume formatting the 2nd++ lines with the original nodes' styled text.

lvtinydom.cpp's `createXPointer(pt)` and `getRect()`, which uses that `LFormattedText`, are updated to support this new usage, and properly return the original node when pt is on the first line, and correct rects for a xpointer to text that happens to be in the first line.

Alas, because of these `cloneNode` masquerading original nodes, a few methods (`ldomNode::*Effective*()`) have been added, and a few places (that deal with final blocks, that can now have `clonedNode`s) updated to use them, so a `clondeNode` behave transparently as its source node (ie. when getting its text or attributes, getting its element id, etc...)

First lines can be disabled with using
`::first-line { display: none; }`
(`'display:'` being one of the property the specs say we should not support, we can use it to disable them with style tweaks.)

So, for 
```html
<p class="bordered fl1">
tome <b>bold</b> <span style="display: none">and invisible</span> text
</p>
```
we'll get in the DOM (if the `<p>` gets a ::first-line and a ::first-letter):
<img width="492" height="426" alt="image" src="https://github.com/user-attachments/assets/86e934c4-3365-4f2f-984b-0c5521d428d9" />

The cloneNode idea allows the first line to conserve its styles:

Firefox | KOReader:
<img width="1021" height="278" alt="image" src="https://github.com/user-attachments/assets/98829184-efda-4669-94c5-31495e09f187" />

Should allow re-closing https://github.com/koreader/koreader/issues/14391

#### CSS: add support for `float`/`clear`: `inline-start`/`inline-end`

Makes it easier to abuse these ::first-letter/::first-line in style tweaks and have it work with both LTR and RTL text.

If we're tired of our classic Wikipedia articles look, we can revamp them with a style tweak like:
```css
p::first-letter { font-size: 2.2em; float: inline-start; clear: inline-start; margin: -0.05em 0.1em 0 0; }
p { text-indent: 0 !important; clear: inline-start; }
p:first-line { font-weight: bold; font-variant: small-caps; }
p + p::first-line { display:none; }
```
(the values in em unit above need to be tuned by font to get it to show as nice...)
and get
<img width="876" height="586" alt="image" src="https://github.com/user-attachments/assets/93784ed5-0e9c-4441-92d4-da9aceb64758" />

<img width="880" height="591" alt="image" src="https://github.com/user-attachments/assets/932a9085-345c-4afd-9089-282a54480e9f" />

----

Done with the (very limited) help of Github copilot. Experience related in https://github.com/koreader/crengine/issues/646#issuecomment-3947456061.
Full Copilot conversation/copiloting in https://github.com/poire-z/crengine/pull/4 (86 conversation posts, 29 commits).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/653)
<!-- Reviewable:end -->
