### PR TITLE
lvfntman, lvdrawbuf: add COLR v0 color font rendering support

### DIFF
--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -191,6 +191,10 @@ public:
     virtual void Resize( int dx, int dy ) = 0;
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette ) = 0;
+    /// draws color bitmap (premultiplied BGRA, 4 bytes per pixel)
+    virtual void DrawColorGlyph( int x, int y, const lUInt8 * bitmap, int width, int height, int pitch, const lUInt32 * __restrict palette ) {
+        CR_UNUSED7(x, y, bitmap, width, height, pitch, palette);
+    }
     /// draws image
     virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither=true ) = 0;
     /// draws part of source image, possible rescaled
@@ -424,6 +428,8 @@ public:
     virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
+    /// draws color bitmap (premultiplied BGRA, 4 bytes per pixel)
+    virtual void DrawColorGlyph( int x, int y, const lUInt8 * bitmap, int width, int height, int pitch, const lUInt32 * __restrict palette );
     /// constructor
     LVGrayDrawBuf(int dx, int dy, int bpp=2, void * auxdata = NULL );
     /// destructor
@@ -558,6 +564,8 @@ public:
     virtual void Draw( LVImageSourceRef img, int x, int y, int width, int height, bool dither );
     /// draws bitmap (1 byte per pixel) using specified palette
     virtual void Draw( int x, int y, const lUInt8 * bitmap, int width, int height, const lUInt32 * __restrict palette );
+    /// draws color bitmap (premultiplied BGRA, 4 bytes per pixel)
+    virtual void DrawColorGlyph( int x, int y, const lUInt8 * bitmap, int width, int height, int pitch, const lUInt32 * __restrict palette );
     /// returns scanline pointer
     virtual lUInt8 * GetScanLine( int y ) const;
 

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -131,6 +131,8 @@ struct LVFontGlyphCacheItem
     GlyphCacheItemData data;
     lUInt16 bmp_width;
     lUInt16 bmp_height;
+    lUInt16 bmp_pitch;
+    lUInt8  bmp_pixelformat; // 1=grayscale, 4=BGRA
     lInt16  origin_x;
     lInt16  origin_y;
     lUInt16 advance;
@@ -145,16 +147,19 @@ struct LVFontGlyphCacheItem
         // NOTE: Again, we stash the data *in place of* the bmp array, so, the effective size of our object is:
         //       LVFontGlyphCacheItem-up-to-bmp + the glyph storage size.
         //       Given the alignment constraints on bmp, the only sane way to compute that is via offsetof.
-        return offsetof(LVFontGlyphCacheItem, bmp) + ((bmp_width * bmp_height) * sizeof(*bmp));
+        return offsetof(LVFontGlyphCacheItem, bmp) + (bmp_pitch * bmp_height);
     }
-    static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar32 ch, int w, int h )
+    static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lChar32 ch, int w, int h, int pitch = 0, lUInt8 pixfmt = 1 )
     {
+        if (!pitch) pitch = w * pixfmt;
         LVFontGlyphCacheItem * item = (LVFontGlyphCacheItem *)malloc( offsetof(LVFontGlyphCacheItem, bmp)
-                                                                        + ((w*h) * sizeof(*bmp)) );
+                                                                        + (pitch * h) );
 	if (item) {
 	    item->data.ch = ch;
 	    item->bmp_width = (lUInt16)w;
 	    item->bmp_height = (lUInt16)h;
+	    item->bmp_pitch = (lUInt16)pitch;
+	    item->bmp_pixelformat = pixfmt;
 	    item->origin_x =   0;
 	    item->origin_y =   0;
 	    item->advance =    0;
@@ -167,14 +172,17 @@ struct LVFontGlyphCacheItem
         return item;
     }
     #if USE_HARFBUZZ==1
-    static LVFontGlyphCacheItem *newItem(LVFontLocalGlyphCache* local_cache, lUInt32 glyph_index, int w, int h)
+    static LVFontGlyphCacheItem *newItem(LVFontLocalGlyphCache* local_cache, lUInt32 glyph_index, int w, int h, int pitch = 0, lUInt8 pixfmt = 1)
     {
+        if (!pitch) pitch = w * pixfmt;
         LVFontGlyphCacheItem * item = (LVFontGlyphCacheItem *)malloc( offsetof(LVFontGlyphCacheItem, bmp)
-                                                                        + ((w*h) * sizeof(*bmp)) );
+                                                                        + (pitch * h) );
         if (item) {
             item->data.gindex = glyph_index;
             item->bmp_width = (lUInt16) w;
             item->bmp_height = (lUInt16) h;
+            item->bmp_pitch = (lUInt16) pitch;
+            item->bmp_pixelformat = pixfmt;
             item->origin_x = 0;
             item->origin_y = 0;
             item->advance = 0;

--- a/crengine/src/lvdrawbuf.cpp
+++ b/crengine/src/lvdrawbuf.cpp
@@ -1450,6 +1450,85 @@ void LVGrayDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int he
     CHECK_GUARD_BYTE;
 }
 
+/// Draw a COLR v0 color glyph (premultiplied BGRA) onto 8-bit grayscale buffer
+void LVGrayDrawBuf::DrawColorGlyph( int x, int y, const lUInt8 * bitmap, int width, int height, int pitch, const lUInt32 * __restrict /*palette*/)
+{
+    if ( _bpp != 8 )
+        return;
+    const int initial_height = height;
+    int bx = 0;
+    int by = 0;
+
+    if (x<_clip.left)
+    {
+        width += x-_clip.left;
+        bx -= x-_clip.left;
+        x = _clip.left;
+        if (width<=0)
+            return;
+    }
+    if (y<_clip.top)
+    {
+        height += y-_clip.top;
+        by -= y-_clip.top;
+        y = _clip.top;
+        if (_hidePartialGlyphs && height<=initial_height/2)
+            return;
+        if (height<=0)
+            return;
+    }
+    if (x + width > _clip.right)
+    {
+        width = _clip.right - x;
+    }
+    if (width<=0)
+        return;
+    if (y + height > _clip.bottom)
+    {
+        if (_hidePartialGlyphs && height<=initial_height/2)
+            return;
+        int clip_bottom = _clip.bottom;
+        if ( _hidePartialGlyphs )
+            clip_bottom = this->_dy;
+        if ( y+height > clip_bottom)
+            height = clip_bottom - y;
+    }
+    if (height<=0)
+        return;
+
+    bitmap += bx * 4 + by * pitch;
+
+    lUInt8 * dstline = _data + _rowsize*y + x;
+    while (height--)
+    {
+        const lUInt8 * __restrict src = bitmap;
+        lUInt8 * __restrict dst = dstline;
+        size_t px_count = width;
+        while (px_count--)
+        {
+            lUInt8 b = src[0], g = src[1], r = src[2], a = src[3];
+            // Pre invert colored pixels so night mode page inversion preserves them
+            if (_invertImages && (r != g || r != b)) {
+                b = a - b; g = a - g; r = a - r;
+            }
+            // Premultiplied BGRA source-over: converts to luminance, blends onto grayscale dest
+            if (a == 255) {
+                *dst = (lUInt8)((r * 77 + g * 150 + b * 29) >> 8);
+            } else if (a > 0) {
+                lUInt8 lum = (lUInt8)((r * 77 + g * 150 + b * 29) >> 8);
+                lUInt8 inv_a = 255 - a;
+                int val = lum + ((*dst * inv_a + 127) / 255);
+                *dst = (lUInt8)(val > 255 ? 255 : val);
+            }
+            src += 4;
+            dst++;
+        }
+        bitmap += pitch;
+        dstline += _rowsize;
+    }
+    CHECK_GUARD_BYTE;
+}
+
 void LVBaseDrawBuf::SetClipRect( const lvRect * clipRect )
 {
     if (clipRect)
@@ -2084,6 +2163,86 @@ void LVColorDrawBuf::Draw( int x, int y, const lUInt8 * bitmap, int width, int h
             }
             bitmap += bmp_width;
         }
+    }
+}
+
+/// Draw a COLR v0 color glyph (premultiplied BGRA) onto 32-bit color buffer
+void LVColorDrawBuf::DrawColorGlyph( int x, int y, const lUInt8 * bitmap, int width, int height, int pitch, const lUInt32 * __restrict /*palette*/)
+{
+    if ( !_data || _bpp != 32 )
+        return;
+    const int initial_height = height;
+    int bx = 0;
+    int by = 0;
+
+    if (x<_clip.left)
+    {
+        width += x-_clip.left;
+        bx -= x-_clip.left;
+        x = _clip.left;
+        if (width<=0)
+            return;
+    }
+    if (y<_clip.top)
+    {
+        height += y-_clip.top;
+        by -= y-_clip.top;
+        y = _clip.top;
+        if (_hidePartialGlyphs && height<=initial_height/2)
+            return;
+        if (height<=0)
+            return;
+    }
+    if (x + width > _clip.right)
+    {
+        width = _clip.right - x;
+    }
+    if (width<=0)
+        return;
+    if (y + height > _clip.bottom)
+    {
+        if (_hidePartialGlyphs && height<=initial_height/2)
+            return;
+        int clip_bottom = _clip.bottom;
+        if (_hidePartialGlyphs )
+            clip_bottom = this->_dy;
+        if ( y+height > clip_bottom)
+            height = clip_bottom - y;
+    }
+    if (height<=0)
+        return;
+
+    bitmap += bx * 4 + by * pitch;
+
+    while (height--)
+    {
+        const lUInt8 * __restrict src = bitmap;
+        lUInt32 * __restrict dst = ((lUInt32*)GetScanLine(y++)) + x;
+        size_t px_count = width;
+        while (px_count--)
+        {
+            lUInt8 b = src[0], g = src[1], r = src[2], a = src[3];
+            // Pre invert colored pixels so night mode page inversion preserves them
+            if (_invertImages && (r != g || r != b)) {
+                b = a - b; g = a - g; r = a - r;
+            }
+            // Premultiplied BGRA source-over compositing
+            if (a == 255) {
+                *dst = (r << 16) | (g << 8) | b;
+            } else if (a > 0) {
+                lUInt8 inv_a = 255 - a;
+                lUInt32 bg = *dst;
+                int out_r = r + (((bg >> 16 & 0xFF) * inv_a + 127) / 255);
+                int out_g = g + (((bg >> 8 & 0xFF) * inv_a + 127) / 255);
+                int out_b = b + (((bg & 0xFF) * inv_a + 127) / 255);
+                *dst = ((out_r > 255 ? 255 : out_r) << 16)
+                     | ((out_g > 255 ? 255 : out_g) << 8)
+                     |  (out_b > 255 ? 255 : out_b);
+            }
+            src += 4;
+            dst++;
+        }
+        bitmap += pitch;
     }
 }
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1049,10 +1049,18 @@ static LVFontGlyphCacheItem * newItem( LVFontLocalGlyphCache * local_cache, lCha
     FT_Bitmap*  bitmap = &slot->bitmap;
     int w = bitmap->width;
     int h = bitmap->rows;
-    LVFontGlyphCacheItem * item = LVFontGlyphCacheItem::newItem(local_cache, ch, w, h);
+    lUInt8 pixfmt = (bitmap->pixel_mode == FT_PIXEL_MODE_BGRA) ? 4 : 1;
+    int pitch = w * pixfmt;
+    LVFontGlyphCacheItem * item = LVFontGlyphCacheItem::newItem(local_cache, ch, w, h, pitch, pixfmt);
     if (!item)
         return 0;
-    if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
+    if ( bitmap->pixel_mode == FT_PIXEL_MODE_BGRA ) {
+        if (bitmap->buffer && w > 0 && h > 0) {
+            for (int y = 0; y < h; y++)
+                memcpy(item->bmp + y * pitch, bitmap->buffer + y * bitmap->pitch, w * 4);
+        }
+    }
+    else if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
         lUInt8 mask = 0x80;
         const lUInt8 * ptr = (const lUInt8 *)bitmap->buffer;
         lUInt8 * dst = item->bmp;
@@ -1109,10 +1117,18 @@ static LVFontGlyphCacheItem * newItem(LVFontLocalGlyphCache *local_cache, lUInt3
     FT_Bitmap*  bitmap = &slot->bitmap;
     int w = bitmap->width;
     int h = bitmap->rows;
-    LVFontGlyphCacheItem *item = LVFontGlyphCacheItem::newItem(local_cache, index, w, h);
+    lUInt8 pixfmt = (bitmap->pixel_mode == FT_PIXEL_MODE_BGRA) ? 4 : 1;
+    int pitch = w * pixfmt;
+    LVFontGlyphCacheItem *item = LVFontGlyphCacheItem::newItem(local_cache, index, w, h, pitch, pixfmt);
     if (!item)
         return 0;
-    if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
+    if ( bitmap->pixel_mode == FT_PIXEL_MODE_BGRA ) {
+        if (bitmap->buffer && w > 0 && h > 0) {
+            for (int y = 0; y < h; y++)
+                memcpy(item->bmp + y * pitch, bitmap->buffer + y * bitmap->pitch, w * 4);
+        }
+    }
+    else if ( bitmap->pixel_mode==FT_PIXEL_MODE_MONO ) { //drawMonochrome
         lUInt8 mask = 0x80;
         const lUInt8 * ptr = (const lUInt8 *)bitmap->buffer;
         lUInt8 * dst = item->bmp;
@@ -1145,6 +1161,15 @@ static LVFontGlyphCacheItem * newItem(LVFontLocalGlyphCache *local_cache, lUInt3
     return item;
 }
 #endif
+
+static inline void drawGlyphItem(LVDrawBuf * buf, int x, int y,
+        LVFontGlyphCacheItem * item, const lUInt32 * palette)
+{
+    if (item->bmp_pixelformat == 4)
+        buf->DrawColorGlyph(x, y, item->bmp, item->bmp_width, item->bmp_height, item->bmp_pitch, palette);
+    else
+        buf->Draw(x, y, item->bmp, item->bmp_width, item->bmp_height, palette);
+}
 
 // Each LVFontGlyphCacheItem is put in 2 caches:
 // - the LVFontLocalGlyphCache LVFreeTypeFace->_glyph_cache of the
@@ -1939,6 +1964,9 @@ public:
             else if (_hintingMode == HINTING_MODE_DISABLED) {
                 flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
+            // Allow users to disable color font rendering by toggling hinting mode off
+            if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+                flags |= FT_LOAD_COLOR;
             hb_ft_font_set_load_flags(_hb_font, flags);
         }
         #endif
@@ -2099,6 +2127,8 @@ public:
                 else if (_hintingMode == HINTING_MODE_DISABLED) {
                     flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
                 }
+                if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+                    flags |= FT_LOAD_COLOR;
                 hb_ft_font_set_load_flags(_hb_font, flags);
             }
         }
@@ -3339,6 +3369,8 @@ public:
             else if (_hintingMode == HINTING_MODE_DISABLED) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
+            if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+                rend_flags |= FT_LOAD_COLOR;
             if (_synth_weight > 0 || _italic == 2) { // Don't render yet
                 rend_flags &= ~FT_LOAD_RENDER;
                 // Also disable any hinting, as it would be wrong after embolden.
@@ -3416,6 +3448,8 @@ public:
             else if (_hintingMode == HINTING_MODE_DISABLED) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
             }
+            if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+                rend_flags |= FT_LOAD_COLOR;
 
             if (_synth_weight > 0 || _italic == 2) { // Don't render yet
                 rend_flags &= ~FT_LOAD_RENDER;
@@ -4325,12 +4359,10 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
-                                buf->Draw(x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
+                                drawGlyphItem(buf,
+                                          x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
                                           y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
-                                          item->bmp,
-                                          item->bmp_width,
-                                          item->bmp_height,
-                                          palette);
+                                          item, palette);
                                 x += w;
                             }
                         }
@@ -4364,12 +4396,9 @@ public:
                 LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
                 if (item) {
                     w = item->advance;
-                    buf->Draw( x + item->origin_x,
+                    drawGlyphItem(buf, x + item->origin_x,
                                y + _baseline - item->origin_y,
-                               item->bmp,
-                               item->bmp_width,
-                               item->bmp_height,
-                               palette);
+                               item, palette);
                     x  += w; // + letter_spacing; (let's not add any letter-spacing after hyphen)
                 }
             }
@@ -4477,12 +4506,9 @@ public:
                             x += (posInfo.width * cjk_width_scale_percent / 100 - posInfo.width) / 2;
                             cjk_dx = x0 + width - x - posInfo.width;
                         }
-                        buf->Draw(x + item->origin_x + posInfo.offset,
+                        drawGlyphItem(buf, x + item->origin_x + posInfo.offset,
                             y + _baseline - item->origin_y,
-                            item->bmp,
-                            item->bmp_width,
-                            item->bmp_height,
-                            palette);
+                            item, palette);
                         // Assume zero advance means it's a diacritic, and we should not apply
                         // any letter spacing on this char (now, and when justifying)
                         if ( posInfo.width != 0 )
@@ -4605,12 +4631,9 @@ public:
                         x += (w * cjk_width_scale_percent / 100 - w) / 2;
                         w = x0 + width - x;
                     }
-                    buf->Draw( x + FONT_METRIC_TO_PX(kerning) + item->origin_x,
+                    drawGlyphItem(buf, x + FONT_METRIC_TO_PX(kerning) + item->origin_x,
                         y + _baseline - item->origin_y,
-                        item->bmp,
-                        item->bmp_width,
-                        item->bmp_height,
-                        palette);
+                        item, palette);
 
                     // Assume zero advance means it's a diacritic, and we should not apply
                     // any letter spacing on this char (now, and when justifying)
@@ -4732,6 +4755,8 @@ public:
         else if (_hintingMode == HINTING_MODE_DISABLED) {
             rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
         }
+        if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+            rend_flags |= FT_LOAD_COLOR;
         if (_synth_weight > 0 || _italic == 2) { // Don't render yet
             rend_flags &= ~FT_LOAD_RENDER;
             // Also disable any hinting, as it would be wrong after embolden.
@@ -4775,12 +4800,12 @@ public:
         // This felt needed at some point to draw tall stretchy glyphs, but seems no longer needed
         // buf->setHidePartialGlyphs(false);
 
-        buf->Draw( x + pad_x,
-            y + pad_y,
-            bitmap->buffer,
-            bitmap->width,
-            bitmap->rows,
-            palette);
+        if (bitmap->pixel_mode == FT_PIXEL_MODE_BGRA)
+            buf->DrawColorGlyph( x + pad_x, y + pad_y,
+                bitmap->buffer, bitmap->width, bitmap->rows, bitmap->pitch, palette);
+        else
+            buf->Draw( x + pad_x, y + pad_y,
+                bitmap->buffer, bitmap->width, bitmap->rows, palette);
 
         // Restore original pixel size
         error = FT_Set_Pixel_Sizes(
@@ -5165,12 +5190,9 @@ public:
                 // avoid soft hyphens inside text string
                 w = item->advance;
                 if ( item->bmp_width && item->bmp_height && (!isHyphen || i==len) ) {
-                    buf->Draw( x + item->origin_x,
+                    drawGlyphItem(buf, x + item->origin_x,
                         y + _baseline - item->origin_y,
-                        item->bmp,
-                        item->bmp_width,
-                        item->bmp_height,
-                        palette);
+                        item, palette);
                 }
             }
             x  += w + letter_spacing;
@@ -7109,12 +7131,9 @@ int LVBaseFont::DrawTextString( LVDrawBuf * buf, int x, int y,
                 // avoid soft hyphens inside text string
                 w = item->advance;
                 if ( item->bmp_width && item->bmp_height ) {
-                    buf->Draw( x + item->origin_x,
+                    drawGlyphItem(buf, x + item->origin_x,
                         y + baseline - item->origin_y,
-                        item->bmp,
-                        item->bmp_width,
-                        item->bmp_height,
-                        palette);
+                        item, palette);
                 }
             }
             x  += w; // + letter_spacing;


### PR DESCRIPTION
Pass FT_LOAD_COLOR for fonts with COLR/CPAL tables so FreeType produces premultiplied BGRA bitmaps. Cache them with pitch/pixelformat metadata and composite via DrawColorGlyph onto grayscale and color page buffers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/654)
<!-- Reviewable:end -->
