### PR TITLE
Accept also fonts without any space character

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5275,7 +5275,6 @@ private:
     LVFontCache _cache;
     FT_Library  _library;
     LVFontGlobalGlyphCache _globalCache;
-    lString32 _requiredChars;
     #if (DEBUG_FONT_MAN==1)
     FILE * _log;
     #endif
@@ -5763,11 +5762,6 @@ public:
                 fprintf(_log, "=========================== LOGGING STARTED ===================\n");
             }
         #endif
-        // _requiredChars = U"azAZ09";//\x0410\x042F\x0430\x044F";
-        // Some fonts come without any of these (ie. NotoSansMyanmar.ttf), there's
-        // no reason to prevent them from being used.
-        // So, check only for the presence of the space char, hoping it's there in any font.
-        _requiredChars = U" ";
     }
 
     virtual void gc() // garbage collector
@@ -6115,17 +6109,8 @@ public:
 
     bool checkCharSet( FT_Face face )
     {
-        // TODO: check existance of required characters (e.g. cyrillic)
         if (face==NULL)
             return false; // invalid face
-        for ( int i=0; i<_requiredChars.length(); i++ ) {
-            lChar32 ch = _requiredChars[i];
-            FT_UInt ch_glyph_index = FT_Get_Char_Index( face, ch );
-            if ( ch_glyph_index==0 ) {
-                CRLog::debug("Required char not found in font: %04x", ch);
-                return false; // no required char!!!
-            }
-        }
         return true;
     }
 


### PR DESCRIPTION
This change is just a quick (and untested!) suggestion, but unless I missed a reason for insisting on specific characters, it seems better to just get rid of that code, as there are legitimate (if niche) fonts like [NewGardiner](https://github.com/nederhof/newgardiner) that contain not even a space character.

(And for anyone arriving at this PR via a web search: after adding a space character to fonts derived from NewGardiner by [hieropy](https://github.com/nederhof/hieropy), I'm seeing beautifully arranged hieroglyphs in KOReader, and if something like this PR gets merged, it should work out of the box.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/655)
<!-- Reviewable:end -->
