### PR TITLE
CSS: first-line and fit-content fixes, improve getNodeByPoint() fallback

### DIFF
--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -2810,6 +2810,33 @@ ldomXPointer LVDocView::getNodeByPoint(lvPoint pt, bool strictBounds, bool forTe
 					direction = -direction;
 				}
 				ptr = m_doc->createXPointer(pt, direction, strictBounds);
+				// If this ptr is null or not on the screen. we may find a better one looking in the other direction
+				bool try_other_dir = false;
+				if ( ptr.isNull() ) {
+					try_other_dir = true;
+				}
+				else if ( ptr.isText() && ptr.getRect(rc) ) {
+					lvRect page_rect;
+					GetPos(page_rect);
+					if ( rc.bottom <= page_rect.top || rc.top >= page_rect.bottom ) { // Not in the current page
+						try_other_dir = true;
+					}
+				}
+				if ( try_other_dir ) {
+					ldomXPointer ptr2 = m_doc->createXPointer(pt, -direction, strictBounds);
+					if ( ptr.isNull() ) {
+						// Use it instead
+						ptr = ptr2;
+					}
+					else if ( !ptr2.isNull() && ptr2.isText() && ptr2.getRect(rc) ) {
+						lvRect page_rect;
+						GetPos(page_rect);
+						if ( !(rc.bottom <= page_rect.top || rc.top >= page_rect.bottom) ) {
+							// It is in current page: use it instead of previous one
+							ptr = ptr2;
+						}
+					}
+				}
 			}
 		}
 		return ptr;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7941,7 +7941,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // should have it used - but we don't, to not complexify out table
                 // rendering algorithm
             }
-            else if ( style->box_sizing == css_bs_content_box && !is_fit_content_width ) {
+            else if ( style->box_sizing == css_bs_content_box || is_fit_content_width ) {
                 // If W3C box model requested, CSS width specifies the width
                 // of the content box.
                 // In crengine, the width we deal with is the border box, so we

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -4731,7 +4731,7 @@ public:
         // split paragraph into lines, export lines
         int pos = 0;
 
-        bool is_css_first_line = m_srcs[0]->flags & LTEXT_IS_FIRST_LINE_CLONE;
+        bool is_css_first_line = m_srcs[0] ? (m_srcs[0]->flags & LTEXT_IS_FIRST_LINE_CLONE) : false;
 
         #if (USE_LIBUNIBREAK!=1)
         int upSkipPos = -1;


### PR DESCRIPTION
#### CSS first-line: fix possible crash

Noticed when displaying a page having some items with 'list-style-type: none'.
See https://github.com/koreader/crengine/pull/653#issuecomment-4274400361.

#### CSS width: fit-content: account for the element padding

We measure the inner content, but forgot to add the container element own paddings/borders.
See https://github.com/koreader/crengine/pull/647#discussion_r3107195648
Fix issue noticed at https://www.mobileread.com/forums/showthread.php?p=4580669#post4580669

#### getNodeByPoint(): improve fallback check

When not exactly on an element, we fallback to search an element in some direction (depending on x). If no element is foud, or the one found happens to not be on the screen (ie. on previous page), try a 3rd search looking in the reverse direction, and use it if on the screen.
Tried to fix the issue noticed at https://github.com/koreader/crengine/issues/659#issuecomment-4239605204 - it would fix it if there is some text or an inline image (actually not, but frontend onHold would now detect and show that image), but not in the case of this book where there is an inline-block image (which is quite more cumbersome to fix, so well...).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/662)
<!-- Reviewable:end -->
