### PR TITLE
Add support for variable fonts

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -189,6 +189,13 @@ enum css_font_weight_t {
     css_fw_900
 };
 
+/// font-optical-sizing property values
+enum css_font_optical_sizing_t {
+    css_fos_inherit,
+    css_fos_auto,   // set opsz axis from font-size in typographic points (CSS default)
+    css_fos_none    // do not adjust the opsz axis
+};
+
 /// font-family property values
 enum css_font_family_t {
     css_ff_inherit,

--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -189,13 +189,6 @@ enum css_font_weight_t {
     css_fw_900
 };
 
-/// font-optical-sizing property values
-enum css_font_optical_sizing_t {
-    css_fos_inherit,
-    css_fos_auto,   // set opsz axis from font-size in typographic points (CSS default)
-    css_fos_none    // do not adjust the opsz axis
-};
-
 /// font-family property values
 enum css_font_family_t {
     css_ff_inherit,

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -581,6 +581,8 @@ enum font_antialiasing_t
 #endif
 #define LVFONT_TAG_WGHT  LVFONT_TAG('w','g','h','t')  // weight axis
 #define LVFONT_TAG_OPSZ  LVFONT_TAG('o','p','s','z')  // optical size axis
+#define LVFONT_TAG_ITAL  LVFONT_TAG('i','t','a','l')  // italic axis
+#define LVFONT_TAG_SLNT  LVFONT_TAG('s','l','n','t')  // slant axis
 
 /// Metadata for one variable-font axis as reported by FreeType at registration time
 struct LVFontAxisInfo {

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -571,6 +571,23 @@ enum font_antialiasing_t
     font_aa_all
 };
 
+// 4-char axis tags used in variable font variation axes
+#ifndef LVFONT_TAG
+#define LVFONT_TAG(a,b,c,d) ((lUInt32)((lUInt8)(a))<<24 | (lUInt32)((lUInt8)(b))<<16 \
+                             | (lUInt32)((lUInt8)(c))<<8  | (lUInt32)((lUInt8)(d)))
+#endif
+#define LVFONT_TAG_WGHT  LVFONT_TAG('w','g','h','t')  // weight axis
+#define LVFONT_TAG_OPSZ  LVFONT_TAG('o','p','s','z')  // optical size axis
+
+/// A single variable-font axis value (design-space coordinates)
+struct LVFontVariation {
+    lUInt32 tag;   // 4-char axis tag packed as uint32
+    float   value; // design-space value (e.g. 100..900 for wght)
+    bool operator==(const LVFontVariation& o) const {
+        return tag == o.tag && value == o.value;
+    }
+};
+
 class LVEmbeddedFontDef {
     lString32 _url;
     lString8 _face;
@@ -621,7 +638,8 @@ public:
     virtual void gc() = 0;
     /// returns most similar font
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
-                                int features=0, int documentId = -1, bool useBias=false) = 0;
+                                int features=0, int documentId = -1, bool useBias=false,
+                                const LVArray<LVFontVariation>* variations=NULL) = 0;
 
     /// return available font weight values
     virtual void GetAvailableFontWeights(LVArray<int>& weights, lString8 typeface) = 0;

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -583,14 +583,7 @@ enum font_antialiasing_t
 #define LVFONT_TAG_OPSZ  LVFONT_TAG('o','p','s','z')  // optical size axis
 #define LVFONT_TAG_ITAL  LVFONT_TAG('i','t','a','l')  // italic axis
 #define LVFONT_TAG_SLNT  LVFONT_TAG('s','l','n','t')  // slant axis
-
-/// Metadata for one variable-font axis as reported by FreeType at registration time
-struct LVFontAxisInfo {
-    lUInt32 tag;       // 4-char axis tag packed as uint32
-    float   minValue;  // minimum design-space value
-    float   defValue;  // default design-space value
-    float   maxValue;  // maximum design-space value
-};
+#define LVFONT_TAG_WDTH  LVFONT_TAG('w','d','t','h')  // width axis
 
 /// A single variable-font axis value (design-space coordinates)
 struct LVFontVariation {

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -520,6 +520,9 @@ public:
     /// set OpenType features (bitmap)
     virtual void setFeatures( int features ) { }
 
+    /// hash of the active variable-font axis values; 0 for static fonts or no variations
+    virtual lUInt32 getVariationHash() const { return 0; }
+
     /// sets current kerning mode
     virtual void setKerningMode( kerning_mode_t /*mode*/ ) { }
     /// returns current kerning mode

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -585,12 +585,73 @@ enum font_antialiasing_t
 #define LVFONT_TAG_SLNT  LVFONT_TAG('s','l','n','t')  // slant axis
 #define LVFONT_TAG_WDTH  LVFONT_TAG('w','d','t','h')  // width axis
 
-/// A single variable-font axis value (design-space coordinates)
-struct LVFontVariation {
-    lUInt32 tag;   // 4-char axis tag packed as uint32
-    float   value; // design-space value (e.g. 100..900 for wght)
-    bool operator==(const LVFontVariation& o) const {
-        return tag == o.tag && value == o.value;
+/// Active design-space values for the five registered variable-font axes.
+/// Axes not explicitly set carry no value and do not affect the cache key.
+struct LVFontVariations {
+    bool  wght_set; float wght;
+    bool  opsz_set; float opsz;
+    bool  ital_set; float ital;
+    bool  slnt_set; float slnt;
+    bool  wdth_set; float wdth;
+
+    LVFontVariations()
+        : wght_set(false), wght(0.0f)
+        , opsz_set(false), opsz(0.0f)
+        , ital_set(false), ital(0.0f)
+        , slnt_set(false), slnt(0.0f)
+        , wdth_set(false), wdth(0.0f)
+    {}
+
+    bool empty() const { return !wght_set && !opsz_set && !ital_set && !slnt_set && !wdth_set; }
+
+    bool has(lUInt32 tag) const {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return wght_set;
+            case LVFONT_TAG_OPSZ: return opsz_set;
+            case LVFONT_TAG_ITAL: return ital_set;
+            case LVFONT_TAG_SLNT: return slnt_set;
+            case LVFONT_TAG_WDTH: return wdth_set;
+            default: return false;
+        }
+    }
+    float get(lUInt32 tag, float fallback = 0.0f) const {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return wght_set ? wght : fallback;
+            case LVFONT_TAG_OPSZ: return opsz_set ? opsz : fallback;
+            case LVFONT_TAG_ITAL: return ital_set ? ital : fallback;
+            case LVFONT_TAG_SLNT: return slnt_set ? slnt : fallback;
+            case LVFONT_TAG_WDTH: return wdth_set ? wdth : fallback;
+            default: return fallback;
+        }
+    }
+    void set(lUInt32 tag, float value) {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: wght_set = true; wght = value; break;
+            case LVFONT_TAG_OPSZ: opsz_set = true; opsz = value; break;
+            case LVFONT_TAG_ITAL: ital_set = true; ital = value; break;
+            case LVFONT_TAG_SLNT: slnt_set = true; slnt = value; break;
+            case LVFONT_TAG_WDTH: wdth_set = true; wdth = value; break;
+            default: break;
+        }
+    }
+
+    bool operator==(const LVFontVariations& o) const {
+        return wght_set == o.wght_set && (!wght_set || wght == o.wght)
+            && opsz_set == o.opsz_set && (!opsz_set || opsz == o.opsz)
+            && ital_set == o.ital_set && (!ital_set || ital == o.ital)
+            && slnt_set == o.slnt_set && (!slnt_set || slnt == o.slnt)
+            && wdth_set == o.wdth_set && (!wdth_set || wdth == o.wdth);
+    }
+    bool operator!=(const LVFontVariations& o) const { return !(*this == o); }
+
+    lUInt32 hash() const {
+        lUInt32 h = 0, b;
+        if (wght_set) { memcpy(&b, &wght, 4); h = h*31 + LVFONT_TAG_WGHT; h = h*31 + b; }
+        if (opsz_set) { memcpy(&b, &opsz, 4); h = h*31 + LVFONT_TAG_OPSZ; h = h*31 + b; }
+        if (ital_set) { memcpy(&b, &ital, 4); h = h*31 + LVFONT_TAG_ITAL; h = h*31 + b; }
+        if (slnt_set) { memcpy(&b, &slnt, 4); h = h*31 + LVFONT_TAG_SLNT; h = h*31 + b; }
+        if (wdth_set) { memcpy(&b, &wdth, 4); h = h*31 + LVFONT_TAG_WDTH; h = h*31 + b; }
+        return h;
     }
 };
 
@@ -645,7 +706,7 @@ public:
     /// returns most similar font
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features=0, int documentId = -1, bool useBias=false,
-                                const LVArray<LVFontVariation>* variations=NULL) = 0;
+                                const LVFontVariations* variations=NULL) = 0;
 
     /// return available font weight values
     virtual void GetAvailableFontWeights(LVArray<int>& weights, lString8 typeface) = 0;

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -582,6 +582,14 @@ enum font_antialiasing_t
 #define LVFONT_TAG_WGHT  LVFONT_TAG('w','g','h','t')  // weight axis
 #define LVFONT_TAG_OPSZ  LVFONT_TAG('o','p','s','z')  // optical size axis
 
+/// Metadata for one variable-font axis as reported by FreeType at registration time
+struct LVFontAxisInfo {
+    lUInt32 tag;       // 4-char axis tag packed as uint32
+    float   minValue;  // minimum design-space value
+    float   defValue;  // default design-space value
+    float   maxValue;  // maximum design-space value
+};
+
 /// A single variable-font axis value (design-space coordinates)
 struct LVFontVariation {
     lUInt32 tag;   // 4-char axis tag packed as uint32

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -646,11 +646,11 @@ struct LVFontVariations {
 
     lUInt32 hash() const {
         lUInt32 h = 0, b;
-        if (wght_set) { memcpy(&b, &wght, 4); h = h*31 + LVFONT_TAG_WGHT; h = h*31 + b; }
-        if (opsz_set) { memcpy(&b, &opsz, 4); h = h*31 + LVFONT_TAG_OPSZ; h = h*31 + b; }
-        if (ital_set) { memcpy(&b, &ital, 4); h = h*31 + LVFONT_TAG_ITAL; h = h*31 + b; }
-        if (slnt_set) { memcpy(&b, &slnt, 4); h = h*31 + LVFONT_TAG_SLNT; h = h*31 + b; }
-        if (wdth_set) { memcpy(&b, &wdth, 4); h = h*31 + LVFONT_TAG_WDTH; h = h*31 + b; }
+        if (wght_set) { memcpy(&b, &wght, sizeof(b)); h = h*31 + LVFONT_TAG_WGHT; h = h*31 + b; }
+        if (opsz_set) { memcpy(&b, &opsz, sizeof(b)); h = h*31 + LVFONT_TAG_OPSZ; h = h*31 + b; }
+        if (ital_set) { memcpy(&b, &ital, sizeof(b)); h = h*31 + LVFONT_TAG_ITAL; h = h*31 + b; }
+        if (slnt_set) { memcpy(&b, &slnt, sizeof(b)); h = h*31 + LVFONT_TAG_SLNT; h = h*31 + b; }
+        if (wdth_set) { memcpy(&b, &wdth, sizeof(b)); h = h*31 + LVFONT_TAG_WDTH; h = h*31 + b; }
         return h;
     }
 };

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -94,9 +94,11 @@ enum css_style_rec_important_bit {
     imp_bit_caption_side,
     imp_bit_ruby_position,
     imp_bit_content,
-    imp_bit_cr_hint
+    imp_bit_cr_hint,
+    imp_bit_font_optical_sizing,
+    imp_bit_font_variation_settings
 };
-#define NB_IMP_BITS 71 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 73 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -140,9 +142,11 @@ struct css_style_rec_tag {
     css_font_family_t    font_family;
     lString8             font_name;
     css_length_t         font_size;
-    css_font_style_t     font_style;
-    css_font_weight_t    font_weight;
-    css_length_t         font_features;
+    css_font_style_t           font_style;
+    css_font_weight_t          font_weight;
+    css_length_t               font_features;
+    css_font_optical_sizing_t  font_optical_sizing;
+    LVArray<LVFontVariation>   font_variations; // from font-variation-settings
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -212,6 +216,7 @@ struct css_style_rec_tag {
     , font_style(css_fs_inherit)
     , font_weight(css_fw_inherit)
     , font_features(css_val_inherited, 0)
+    , font_optical_sizing(css_fos_inherit)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, css_generic_auto)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -146,7 +146,7 @@ struct css_style_rec_tag {
     css_font_weight_t          font_weight;
     css_length_t               font_features;
     css_font_optical_sizing_t  font_optical_sizing;
-    LVArray<LVFontVariation>   font_variations; // from font-variation-settings
+    LVFontVariations           font_variations; // from font-variation-settings
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -37,6 +37,7 @@ enum css_style_rec_important_bit {
     imp_bit_font_style,
     imp_bit_font_weight,
     imp_bit_font_features,
+    imp_bit_font_optical_sizing,
     imp_bit_text_indent,
     imp_bit_line_height,
     imp_bit_width,
@@ -94,8 +95,7 @@ enum css_style_rec_important_bit {
     imp_bit_caption_side,
     imp_bit_ruby_position,
     imp_bit_content,
-    imp_bit_cr_hint,
-    imp_bit_font_optical_sizing
+    imp_bit_cr_hint
 };
 #define NB_IMP_BITS 72 // The number of lines in the enum above: KEEP IT UPDATED.
 

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -94,11 +94,9 @@ enum css_style_rec_important_bit {
     imp_bit_caption_side,
     imp_bit_ruby_position,
     imp_bit_content,
-    imp_bit_cr_hint,
-    imp_bit_font_optical_sizing,
-    imp_bit_font_variation_settings
+    imp_bit_cr_hint
 };
-#define NB_IMP_BITS 73 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 71 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -142,11 +140,9 @@ struct css_style_rec_tag {
     css_font_family_t    font_family;
     lString8             font_name;
     css_length_t         font_size;
-    css_font_style_t           font_style;
-    css_font_weight_t          font_weight;
-    css_length_t               font_features;
-    css_font_optical_sizing_t  font_optical_sizing;
-    LVFontVariations           font_variations; // from font-variation-settings
+    css_font_style_t     font_style;
+    css_font_weight_t    font_weight;
+    css_length_t         font_features;
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -216,7 +212,6 @@ struct css_style_rec_tag {
     , font_style(css_fs_inherit)
     , font_weight(css_fw_inherit)
     , font_features(css_val_inherited, 0)
-    , font_optical_sizing(css_fos_inherit)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, css_generic_auto)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -94,9 +94,10 @@ enum css_style_rec_important_bit {
     imp_bit_caption_side,
     imp_bit_ruby_position,
     imp_bit_content,
-    imp_bit_cr_hint
+    imp_bit_cr_hint,
+    imp_bit_font_optical_sizing
 };
-#define NB_IMP_BITS 71 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 72 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -143,6 +144,7 @@ struct css_style_rec_tag {
     css_font_style_t     font_style;
     css_font_weight_t    font_weight;
     css_length_t         font_features;
+    css_font_optical_sizing_t  font_optical_sizing;
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -212,6 +214,7 @@ struct css_style_rec_tag {
     , font_style(css_fs_inherit)
     , font_weight(css_fw_inherit)
     , font_features(css_val_inherited, 0)
+    , font_optical_sizing(css_fos_inherit)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, css_generic_auto)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -99,7 +99,7 @@ enum css_style_rec_important_bit {
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 72 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 74 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -38,6 +38,7 @@ enum css_style_rec_important_bit {
     imp_bit_font_weight,
     imp_bit_font_features,
     imp_bit_font_optical_sizing,
+    imp_bit_font_stretch,
     imp_bit_text_indent,
     imp_bit_line_height,
     imp_bit_width,
@@ -145,6 +146,7 @@ struct css_style_rec_tag {
     css_font_weight_t    font_weight;
     css_length_t         font_features;
     css_font_optical_sizing_t  font_optical_sizing;
+    css_length_t               font_stretch; // percentage (wdth); css_val_inherited when not set
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -215,6 +217,7 @@ struct css_style_rec_tag {
     , font_weight(css_fw_inherit)
     , font_features(css_val_inherited, 0)
     , font_optical_sizing(css_fos_inherit)
+    , font_stretch(css_val_inherited, 0)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, css_generic_auto)

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -98,7 +98,7 @@ enum css_style_rec_important_bit {
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 74 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 73 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -38,7 +38,6 @@ enum css_style_rec_important_bit {
     imp_bit_font_weight,
     imp_bit_font_features,
     imp_bit_font_optical_sizing,
-    imp_bit_font_stretch,
     imp_bit_text_indent,
     imp_bit_line_height,
     imp_bit_width,
@@ -147,7 +146,6 @@ struct css_style_rec_tag {
     css_font_weight_t    font_weight;
     css_length_t         font_features;
     css_font_optical_sizing_t  font_optical_sizing;
-    css_length_t               font_stretch; // percentage (wdth); css_val_inherited when not set
     css_length_t         text_indent;
     css_length_t         line_height;
     css_length_t         width;
@@ -219,7 +217,6 @@ struct css_style_rec_tag {
     , font_weight(css_fw_inherit)
     , font_features(css_val_inherited, 0)
     , font_optical_sizing(css_fos_inherit)
-    , font_stretch(css_val_inherited, 0)
     , text_indent(css_val_inherited, 0)
     , line_height(css_val_inherited, 0)
     , width(css_val_unspecified, css_generic_auto)

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -735,6 +735,26 @@ public:
             default: return false;
         }
     }
+    float getAxisMin(lUInt32 tag, float fallback = 0.0f) const {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return _has_wght ? _wght_min : fallback;
+            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_min : fallback;
+            case LVFONT_TAG_ITAL: return _has_ital ? _ital_min : fallback;
+            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_min : fallback;
+            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_min : fallback;
+            default: return fallback;
+        }
+    }
+    float getAxisMax(lUInt32 tag, float fallback = 0.0f) const {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return _has_wght ? _wght_max : fallback;
+            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_max : fallback;
+            case LVFONT_TAG_ITAL: return _has_ital ? _ital_max : fallback;
+            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_max : fallback;
+            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_max : fallback;
+            default: return fallback;
+        }
+    }
     bool hasWghtAxis() const { return _has_wght; }
     float getWghtAxisMin() const { return _wght_min; }
     float getWghtAxisMax() const { return _wght_max; }
@@ -6052,12 +6072,14 @@ public:
 #ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
+#endif
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
                         float   minValue = mm_var->axis[ai].minimum / 65536.0f;
                         float   defValue = mm_var->axis[ai].def     / 65536.0f;
                         float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
                         def2.setAxisInfo(tag, minValue, defValue, maxValue);
+#ifdef DEBUG_VAR_FONT
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
@@ -6066,7 +6088,9 @@ public:
                                                    (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
                                                    minValue, defValue, maxValue);
                         }
+#endif
                     }
+#ifdef DEBUG_VAR_FONT
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def2.getName().c_str(), axisBuf);
 #endif
@@ -6576,12 +6600,14 @@ public:
 #ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
+#endif
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
                         float   minValue = mm_var->axis[ai].minimum / 65536.0f;
                         float   defValue = mm_var->axis[ai].def     / 65536.0f;
                         float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
                         def.setAxisInfo(tag, minValue, defValue, maxValue);
+#ifdef DEBUG_VAR_FONT
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
@@ -6590,7 +6616,9 @@ public:
                                                    (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
                                                    minValue, defValue, maxValue);
                         }
+#endif
                     }
+#ifdef DEBUG_VAR_FONT
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
 #endif
@@ -6823,12 +6851,14 @@ public:
 #ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
+#endif
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
                         float   minValue = mm_var->axis[ai].minimum / 65536.0f;
                         float   defValue = mm_var->axis[ai].def     / 65536.0f;
                         float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
                         def.setAxisInfo(tag, minValue, defValue, maxValue);
+#ifdef DEBUG_VAR_FONT
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
@@ -6837,7 +6867,9 @@ public:
                                                    (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
                                                    minValue, defValue, maxValue);
                         }
+#endif
                     }
+#ifdef DEBUG_VAR_FONT
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
 #endif

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -28,6 +28,9 @@
 // #define DEBUG_MEASURE_TEXT
 // #define DEBUG_DRAW_TEXT
 
+// Uncomment for debugging variable fonts loading and use
+//#define DEBUG_VAR_FONT 1
+
 // define to filter out all fonts except .ttf
 //#define LOAD_TTF_FONTS_ONLY
 // DEBUG ONLY
@@ -2210,6 +2213,7 @@ public:
                 }
                 FT_Set_Var_Design_Coordinates(_face, mm_var->num_axis, coords);
                 delete[] coords;
+#ifdef DEBUG_VAR_FONT
                 {
                     // Log the set axes in font order
                     char axisBuf[256] = "";
@@ -2226,6 +2230,7 @@ public:
                     }
                     CRLog::info("Variable font %s: axes [%s]", _fileName.c_str(), axisBuf);
                 }
+#endif
                 FT_DONE_MM_VAR(_library, mm_var);
             }
         }
@@ -6064,6 +6069,7 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+#ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
@@ -6083,6 +6089,7 @@ public:
                     }
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def2.getName().c_str(), axisBuf);
+#endif
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }
@@ -6210,8 +6217,10 @@ public:
             effectiveVariations.set(LVFONT_TAG_WGHT, (float)weight);
             static lString8 s_last_tf; static int s_last_sz = -1, s_last_wt = -1;
             if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
+#ifdef DEBUG_VAR_FONT
                 CRLog::info("Variable font GetFont: injecting wght=%.0f for \"%s\" size=%d",
                     (float)weight, typeface.c_str(), size);
+#endif
                 s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
             }
             def.setVariations(effectiveVariations);
@@ -6227,8 +6236,10 @@ public:
             effectiveVariations.set(LVFONT_TAG_ITAL, 1.0f);
             static lString8 s_last_tf_ital; static int s_last_sz_ital = -1;
             if (typeface != s_last_tf_ital || size != s_last_sz_ital) {
+#ifdef DEBUG_VAR_FONT
                 CRLog::info("Variable font GetFont: injecting ital=1 for \"%s\" size=%d",
                     typeface.c_str(), size);
+#endif  
                 s_last_tf_ital = typeface; s_last_sz_ital = size;
             }
             def.setVariations(effectiveVariations);
@@ -6242,8 +6253,10 @@ public:
             effectiveVariations.set(LVFONT_TAG_SLNT, -12.0f);
             static lString8 s_last_tf_slnt; static int s_last_sz_slnt = -1;
             if (typeface != s_last_tf_slnt || size != s_last_sz_slnt) {
+#ifdef DEBUG_VAR_FONT
                 CRLog::info("Variable font GetFont: injecting slnt=-12 for \"%s\" size=%d",
                     typeface.c_str(), size);
+#endif
                 s_last_tf_slnt = typeface; s_last_sz_slnt = size;
             }
             def.setVariations(effectiveVariations);
@@ -6335,6 +6348,7 @@ public:
         }
         // Set variations before loadFromFile so that setupFace() can apply them
         font->setVariations(effectiveVariations);
+#ifdef DEBUG_VAR_FONT
         if (!effectiveVariations.empty()) {
             char varBuf[256] = "";
             int pos = 0;
@@ -6350,9 +6364,11 @@ public:
             logAxis(effectiveVariations.ital_set, LVFONT_TAG_ITAL, effectiveVariations.ital);
             logAxis(effectiveVariations.slnt_set, LVFONT_TAG_SLNT, effectiveVariations.slnt);
             logAxis(effectiveVariations.wdth_set, LVFONT_TAG_WDTH, effectiveVariations.wdth);
+            
             CRLog::info("Variable font new instance: \"%s\" size=%d  [%s]",
                 item->getDef()->getTypeFace().c_str(), size, varBuf);
         }
+#endif
         if (item->getDef()->getBuf().isNull())
             loaded = font->loadFromFile( pathname.c_str(), item->getDef()->getIndex(), size, family, isBitmapModeForSize(size), italicize, item->getDef()->getWeight(), face_size );
         else
@@ -6577,6 +6593,7 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+#ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
@@ -6596,6 +6613,7 @@ public:
                     }
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
+#endif
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }
@@ -6822,6 +6840,7 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+#ifdef DEBUG_VAR_FONT
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
@@ -6841,6 +6860,7 @@ public:
                     }
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
+#endif
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -728,6 +728,12 @@ public:
     bool hasWghtAxis() const { return hasAxis(LVFONT_TAG_WGHT); }
     float getWghtAxisMin() const { return getAxisMin(LVFONT_TAG_WGHT, 400.0f); }
     float getWghtAxisMax() const { return getAxisMax(LVFONT_TAG_WGHT, 400.0f); }
+    bool hasItalAxis() const { return hasAxis(LVFONT_TAG_ITAL); }
+    float getItalAxisMin() const { return getAxisMin(LVFONT_TAG_ITAL, 0.0f); }
+    float getItalAxisMax() const { return getAxisMax(LVFONT_TAG_ITAL, 1.0f); }
+    bool hasSlntAxis() const { return hasAxis(LVFONT_TAG_SLNT); }
+    float getSlntAxisMin() const { return getAxisMin(LVFONT_TAG_SLNT, 0.0f); }
+    float getSlntAxisMax() const { return getAxisMax(LVFONT_TAG_SLNT, 0.0f); }
     int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
     LVByteArrayRef getBuf() const { return _buf; }
@@ -6247,6 +6253,73 @@ public:
             // Keep using item (registered font) for instantiation below
         }
 
+        // If the best-matched font has an ital axis and italic is requested but no explicit ital variation was supplied, inject ital=1
+        bool hasExplicitItal = false;
+        for (int vi = 0; vi < effectiveVariations.length(); vi++)
+            if (effectiveVariations[vi].tag == LVFONT_TAG_ITAL) { hasExplicitItal = true; break; }
+        if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis() && !hasExplicitItal) {
+            LVFontVariation italVar; italVar.tag = LVFONT_TAG_ITAL; italVar.value = 1.0f;
+            effectiveVariations.add(italVar);
+            static lString8 s_last_tf_ital; static int s_last_sz_ital = -1;
+            if (typeface != s_last_tf_ital || size != s_last_sz_ital) {
+                CRLog::info("Variable font GetFont: injecting ital=1 for \"%s\" size=%d",
+                    typeface.c_str(), size);
+                s_last_tf_ital = typeface; s_last_sz_ital = size;
+            }
+            // Sort into canonical order then redo cache lookup with the fully-resolved
+            // variation set to find any already-instantiated variable font instance.
+            sortVariations(effectiveVariations);
+            def.setVariations(effectiveVariations);
+            LVFontCacheItem * item3 = _cache.find(&def, useBias);
+            if (item3 != NULL && !item3->getFont().isNull()
+                    && item3->getDef()->getFeatures() == features) {
+                // Verify variations match exactly
+                const LVArray<LVFontVariation>& cachedVars3 = item3->getDef()->getVariations();
+                if (cachedVars3.length() == effectiveVariations.length()) {
+                    bool varMatch3 = true;
+                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                        if (!(cachedVars3[vi] == effectiveVariations[vi])) { varMatch3 = false; break; }
+                    if (varMatch3)
+                        return item3->getFont();
+                }
+            }
+            // Keep using item (registered font) for instantiation below
+        }
+        // If still no italic font and has slnt axis, inject slnt=-12
+        else if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasSlntAxis() && !hasExplicitItal) {
+            bool hasExplicitSlnt = false;
+            for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                if (effectiveVariations[vi].tag == LVFONT_TAG_SLNT) { hasExplicitSlnt = true; break; }
+            if (!hasExplicitSlnt) {
+                LVFontVariation slntVar; slntVar.tag = LVFONT_TAG_SLNT; slntVar.value = -12.0f; // typical slant value
+                effectiveVariations.add(slntVar);
+                static lString8 s_last_tf_slnt; static int s_last_sz_slnt = -1;
+                if (typeface != s_last_tf_slnt || size != s_last_sz_slnt) {
+                    CRLog::info("Variable font GetFont: injecting slnt=-12 for \"%s\" size=%d",
+                        typeface.c_str(), size);
+                    s_last_tf_slnt = typeface; s_last_sz_slnt = size;
+                }
+                // Sort into canonical order then redo cache lookup with the fully-resolved
+                // variation set to find any already-instantiated variable font instance.
+                sortVariations(effectiveVariations);
+                def.setVariations(effectiveVariations);
+                LVFontCacheItem * item4 = _cache.find(&def, useBias);
+                if (item4 != NULL && !item4->getFont().isNull()
+                        && item4->getDef()->getFeatures() == features) {
+                    // Verify variations match exactly
+                    const LVArray<LVFontVariation>& cachedVars4 = item4->getDef()->getVariations();
+                    if (cachedVars4.length() == effectiveVariations.length()) {
+                        bool varMatch4 = true;
+                        for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                            if (!(cachedVars4[vi] == effectiveVariations[vi])) { varMatch4 = false; break; }
+                        if (varMatch4)
+                            return item4->getFont();
+                    }
+                }
+                // Keep using item (registered font) for instantiation below
+            }
+        }
+
         bool italicize = false;
 
         LVFontDef newDef(*item->getDef());
@@ -7356,11 +7429,25 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     }
 
     // italic
-    int italic_match = (_italic == def._italic || _italic==-1 || def._italic==-1) ?
+    int this_italic = _italic;
+    if (_italic == 0) {
+        for (int i = 0; i < _variations.length(); i++) {
+            if (_variations[i].tag == LVFONT_TAG_ITAL && _variations[i].value == 1.0f) { this_italic = 1; break; }
+            else if (_variations[i].tag == LVFONT_TAG_SLNT && _variations[i].value != 0.0f) { this_italic = 2; break; }
+        }
+    }
+    int def_italic = def._italic;
+    if (def._italic == 0) {
+        for (int i = 0; i < def._variations.length(); i++) {
+            if (def._variations[i].tag == LVFONT_TAG_ITAL && def._variations[i].value == 1.0f) { def_italic = 1; break; }
+            else if (def._variations[i].tag == LVFONT_TAG_SLNT && def._variations[i].value != 0.0f) { def_italic = 2; break; }
+        }
+    }
+    int italic_match = (this_italic == def_italic || this_italic==-1 || def_italic==-1) ?
               256
             :   0;
     // lower the score if any is fake italic
-    if ( (_italic==2 || def._italic==2) && _italic>0 && def._italic>0 )
+    if ( (this_italic==2 || def_italic==2) && this_italic>0 && def_italic>0 )
         italic_match = 128;
 
     // OpenType features

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -598,8 +598,8 @@ private:
     // Store some info we can know about a font at registration time
     bool _has_ot_math;
     bool _has_emojis;
-    // Variable font axis values for this instance (empty = default/static)
-    LVArray<LVFontVariation> _variations;
+    // Variable font axis values for this instance (all unset = default/static)
+    LVFontVariations _variations;
     // The five registered variable-font axes, detected at registration time.
     // Non-standard axes are not tracked.
     bool  _has_wght; float _wght_min, _wght_def, _wght_max;
@@ -658,11 +658,8 @@ public:
     /// returns true if definitions are equal
     bool operator == ( const LVFontDef & def ) const
     {
-        if (_variations.length() != def._variations.length())
+        if (_variations != def._variations)
             return false;
-        for (int i = 0; i < _variations.length(); i++)
-            if (!(_variations[i] == def._variations[i]))
-                return false;
         return ( _size == def._size || _size == -1 || def._size == -1 )
             && ( _weight == def._weight || _weight==-1 || def._weight==-1 )
             && ( _italic == def._italic || _italic==-1 || def._italic==-1 )
@@ -678,14 +675,7 @@ public:
 
     lUInt32 getHash() const {
         lUInt32 h =  (((((_size * 31) + _weight)*31  + _italic)*31 + _features)*31+ _family)*31 + _name.getHash();
-        // Mix in variation axis values so different instances of the same file are distinct
-        for (int i = 0; i < _variations.length(); i++) {
-            h = h * 31 + _variations[i].tag;
-            float fval = _variations[i].value; // copy to lvalue for memcpy
-            lUInt32 vbits;
-            memcpy(&vbits, &fval, sizeof(vbits));
-            h = h * 31 + vbits;
-        }
+        h = h * 31 + _variations.hash();
         // _bias is not a static property, and can be set/unset on these definitions.
         // If a same _bias value is moved from one font to another, *adding* _bias
         // to this hash may result in a final identical GetFontListHash() value
@@ -719,8 +709,8 @@ public:
     void setHasOTMath(bool has_ot_math) { _has_ot_math = has_ot_math; }
     bool hasEmojis() const { return _has_emojis; }
     void setHasEmojis(bool has_emojis) { _has_emojis = has_emojis; }
-    const LVArray<LVFontVariation>& getVariations() const { return _variations; }
-    void setVariations(const LVArray<LVFontVariation>& v) { _variations = v; }
+    const LVFontVariations& getVariations() const { return _variations; }
+    void setVariations(const LVFontVariations& v) { _variations = v; }
     // Store axis info for a single standard axis; non-standard tags are silently ignored.
     void setAxisInfo(lUInt32 tag, float minVal, float defVal, float maxVal) {
         switch (tag) {
@@ -1612,7 +1602,7 @@ protected:
     FT_Pos         _synth_weight_strength; // for emboldening with FT_Outline_Embolden()
     FT_Pos         _synth_weight_half_strength;
     int            _features; // requested OpenType features bitmap
-    LVArray<LVFontVariation> _variations; // variable font axis values applied to this instance
+    LVFontVariations _variations; // variable font axis values applied to this instance
 #if USE_HARFBUZZ==1
     hb_font_t* _hb_font;
     hb_buffer_t* _hb_buffer;
@@ -2016,20 +2006,12 @@ public:
     virtual int getFeatures() const {
         return _features;
     }
-    void setVariations( const LVArray<LVFontVariation>& variations ) {
+    void setVariations( const LVFontVariations& variations ) {
         _variations = variations;
         _hash = 0; // force calcHash(font_ref_t) to recompute
     }
     virtual lUInt32 getVariationHash() const {
-        lUInt32 h = 0;
-        for (int i = 0; i < _variations.length(); i++) {
-            h = h * 31 + _variations[i].tag;
-            lUInt32 vbits;
-            float fval = _variations[i].value;
-            memcpy(&vbits, &fval, sizeof(vbits));
-            h = h * 31 + vbits;
-        }
-        return h;
+        return _variations.hash();
     }
 
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
@@ -2221,28 +2203,26 @@ public:
                 // Build axis coord array (FT_Fixed = 16.16) starting from defaults
                 FT_Fixed * coords = new FT_Fixed[mm_var->num_axis];
                 for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                    coords[ai] = mm_var->axis[ai].def; // start at default
                     lUInt32 axTag = (lUInt32)mm_var->axis[ai].tag;
-                    for (int vi = 0; vi < _variations.length(); vi++) {
-                        if (_variations[vi].tag == axTag) {
-                            coords[ai] = (FT_Fixed)(_variations[vi].value * 65536.0f);
-                            break;
-                        }
-                    }
+                    coords[ai] = _variations.has(axTag)
+                        ? (FT_Fixed)(_variations.get(axTag) * 65536.0f)
+                        : mm_var->axis[ai].def;
                 }
                 FT_Set_Var_Design_Coordinates(_face, mm_var->num_axis, coords);
                 delete[] coords;
                 {
+                    // Log the set axes in font order
                     char axisBuf[256] = "";
                     int pos = 0;
-                    for (int vi = 0; vi < _variations.length() && pos < (int)sizeof(axisBuf) - 20; vi++) {
-                        lUInt32 t = _variations[vi].tag;
-                        pos += snprintf(axisBuf + pos, sizeof(axisBuf) - pos,
-                                        "%s%c%c%c%c=%.1f",
-                                        vi ? ", " : "",
-                                        (char)((t >> 24) & 0xFF), (char)((t >> 16) & 0xFF),
-                                        (char)((t >>  8) & 0xFF), (char)(t & 0xFF),
-                                        _variations[vi].value);
+                    for (FT_UInt ai = 0; ai < mm_var->num_axis && pos < (int)sizeof(axisBuf) - 20; ai++) {
+                        lUInt32 t = (lUInt32)mm_var->axis[ai].tag;
+                        if (_variations.has(t))
+                            pos += snprintf(axisBuf + pos, sizeof(axisBuf) - pos,
+                                            "%s%c%c%c%c=%.1f",
+                                            pos ? ", " : "",
+                                            (char)((t >> 24) & 0xFF), (char)((t >> 16) & 0xFF),
+                                            (char)((t >>  8) & 0xFF), (char)(t & 0xFF),
+                                            _variations.get(t));
                     }
                     CRLog::info("Variable font %s: axes [%s]", _fileName.c_str(), axisBuf);
                 }
@@ -2276,13 +2256,14 @@ public:
                 hb_ft_font_set_load_flags(_hb_font, flags);
                 // Apply variable font variations to the HarfBuzz font as well
                 if (!_variations.empty()) {
-                    hb_variation_t * hbvars = new hb_variation_t[_variations.length()];
-                    for (int vi = 0; vi < _variations.length(); vi++) {
-                        hbvars[vi].tag   = _variations[vi].tag;
-                        hbvars[vi].value = _variations[vi].value;
-                    }
-                    hb_font_set_variations(_hb_font, hbvars, (unsigned int)_variations.length());
-                    delete[] hbvars;
+                    hb_variation_t hbvars[5]; // at most 5 standard axes
+                    unsigned int nvar = 0;
+                    if (_variations.wght_set) { hbvars[nvar].tag = LVFONT_TAG_WGHT; hbvars[nvar++].value = _variations.wght; }
+                    if (_variations.opsz_set) { hbvars[nvar].tag = LVFONT_TAG_OPSZ; hbvars[nvar++].value = _variations.opsz; }
+                    if (_variations.ital_set) { hbvars[nvar].tag = LVFONT_TAG_ITAL; hbvars[nvar++].value = _variations.ital; }
+                    if (_variations.slnt_set) { hbvars[nvar].tag = LVFONT_TAG_SLNT; hbvars[nvar++].value = _variations.slnt; }
+                    if (_variations.wdth_set) { hbvars[nvar].tag = LVFONT_TAG_WDTH; hbvars[nvar++].value = _variations.wdth; }
+                    hb_font_set_variations(_hb_font, hbvars, nvar);
                 }
             }
         }
@@ -6136,7 +6117,7 @@ public:
 
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features, int documentId, bool useBias=false,
-                                const LVArray<LVFontVariation>* variations=NULL)
+                                const LVFontVariations* variations=NULL)
     {
         FONT_MAN_GUARD
         #if (DEBUG_FONT_MAN==1)
@@ -6146,23 +6127,9 @@ public:
             }
         #endif
         // Build effective variations: start from caller-supplied list
-        LVArray<LVFontVariation> effectiveVariations;
+        LVFontVariations effectiveVariations;
         if (variations)
             effectiveVariations = *variations;
-
-        // Sort helper: canonical tag order so cache keys are insertion-order-independent.
-        // Insertion sort is fine — arrays are at most ~16 elements.
-        auto sortVariations = [](LVArray<LVFontVariation> & arr) {
-            for (int i = 1; i < arr.length(); i++) {
-                LVFontVariation key = arr[i];
-                int j = i - 1;
-                while (j >= 0 && arr[j].tag > key.tag) {
-                    arr[j + 1] = arr[j];
-                    j--;
-                }
-                arr[j + 1] = key;
-            }
-        };
 
         lString8 fontname;
         LVFontDef def(
@@ -6205,20 +6172,14 @@ public:
             return LVFontRef(NULL);
         }
 
-        // Strip variations for axes the matched font doesn't actually have, so they don't
-        // pollute the cache key (FreeType ignores them silently, but different values would
-        // create redundant cache entries with identical rendering output).
-        if (!effectiveVariations.empty()) {
-            for (int vi = effectiveVariations.length() - 1; vi >= 0; vi--) {
-                if (!item->getDef()->hasAxis(effectiveVariations[vi].tag))
-                    effectiveVariations.remove(vi);
-            }
-        }
+        // Strip variations for axes the matched font doesn't actually have.
+        if (effectiveVariations.wght_set && !item->getDef()->hasAxis(LVFONT_TAG_WGHT)) effectiveVariations.wght_set = false;
+        if (effectiveVariations.opsz_set && !item->getDef()->hasAxis(LVFONT_TAG_OPSZ)) effectiveVariations.opsz_set = false;
+        if (effectiveVariations.ital_set && !item->getDef()->hasAxis(LVFONT_TAG_ITAL)) effectiveVariations.ital_set = false;
+        if (effectiveVariations.slnt_set && !item->getDef()->hasAxis(LVFONT_TAG_SLNT)) effectiveVariations.slnt_set = false;
+        if (effectiveVariations.wdth_set && !item->getDef()->hasAxis(LVFONT_TAG_WDTH)) effectiveVariations.wdth_set = false;
 
-        // Sort into canonical tag order and sync def. The first _cache.find used the
-        // unstripped variations; now that we know which axes are supported, update def
-        // so any subsequent lookup uses the correct (shorter, sorted) key.
-        sortVariations(effectiveVariations);
+        // Sync def with the stripped set for all subsequent lookups.
         def.setVariations(effectiveVariations);
 
         // Check whether an already-instantiated font with these exact stripped
@@ -6227,131 +6188,70 @@ public:
         if (!effectiveVariations.empty()) {
             LVFontCacheItem * strippedItem = _cache.find(&def, useBias);
             if (strippedItem != NULL && !strippedItem->getFont().isNull()
-                    && strippedItem->getDef()->getFeatures() == features) {
-                const LVArray<LVFontVariation>& sv = strippedItem->getDef()->getVariations();
-                if (sv.length() == effectiveVariations.length()) {
-                    bool varMatch = true;
-                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                        if (!(sv[vi] == effectiveVariations[vi])) { varMatch = false; break; }
-                    if (varMatch) {
-                        // Mirror the synthesis guard in the instantiated-instance block:
-                        // don't return this cached instance if weight synthesis would
-                        // be needed but the font has no wght axis to handle it.
-                        bool needsSynth = false;
-                    #ifdef USE_FT_EMBOLDEN
-                        needsSynth = (myabs(weight - strippedItem->getDef()->getWeight()) >= 25
-                                      && !strippedItem->getDef()->hasWghtAxis());
-                    #else
-                        needsSynth = (weight - strippedItem->getDef()->getWeight() >= 200
-                                      && !strippedItem->getDef()->hasWghtAxis());
-                    #endif
-                        if (!needsSynth)
-                            return strippedItem->getFont();
-                    }
-                }
+                    && strippedItem->getDef()->getFeatures() == features
+                    && strippedItem->getDef()->getVariations() == effectiveVariations) {
+                bool needsSynth = false;
+            #ifdef USE_FT_EMBOLDEN
+                needsSynth = (myabs(weight - strippedItem->getDef()->getWeight()) >= 25
+                              && !strippedItem->getDef()->hasWghtAxis());
+            #else
+                needsSynth = (weight - strippedItem->getDef()->getWeight() >= 200
+                              && !strippedItem->getDef()->hasWghtAxis());
+            #endif
+                if (!needsSynth)
+                    return strippedItem->getFont();
             }
         }
 
         // If the best-matched font has a wght axis and no explicit wght variation was
         // supplied, inject one so the face is set to exactly the requested weight instead
         // of using FT_Outline_Embolden synthesis.
-        bool hasExplicitWght = false;
-        for (int vi = 0; vi < effectiveVariations.length(); vi++)
-            if (effectiveVariations[vi].tag == LVFONT_TAG_WGHT) { hasExplicitWght = true; break; }
-        if (item->getDef()->hasWghtAxis() && !hasExplicitWght) {
-            LVFontVariation wghtVar; wghtVar.tag = LVFONT_TAG_WGHT; wghtVar.value = (float)weight;
-            effectiveVariations.add(wghtVar);
+        if (item->getDef()->hasWghtAxis() && !effectiveVariations.wght_set) {
+            effectiveVariations.set(LVFONT_TAG_WGHT, (float)weight);
             static lString8 s_last_tf; static int s_last_sz = -1, s_last_wt = -1;
             if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
                 CRLog::info("Variable font GetFont: injecting wght=%.0f for \"%s\" size=%d",
                     (float)weight, typeface.c_str(), size);
                 s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
             }
-            // Sort into canonical order then redo cache lookup with the fully-resolved
-            // variation set to find any already-instantiated variable font instance.
-            sortVariations(effectiveVariations);
             def.setVariations(effectiveVariations);
             LVFontCacheItem * item2 = _cache.find(&def, useBias);
             if (item2 != NULL && !item2->getFont().isNull()
-                    && item2->getDef()->getFeatures() == features) {
-                // Verify variations match exactly
-                const LVArray<LVFontVariation>& cachedVars2 = item2->getDef()->getVariations();
-                if (cachedVars2.length() == effectiveVariations.length()) {
-                    bool varMatch2 = true;
-                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                        if (!(cachedVars2[vi] == effectiveVariations[vi])) { varMatch2 = false; break; }
-                    if (varMatch2)
-                        return item2->getFont();
-                }
-            }
-            // Keep using item (registered font) for instantiation below
+                    && item2->getDef()->getFeatures() == features
+                    && item2->getDef()->getVariations() == effectiveVariations)
+                return item2->getFont();
         }
 
-        // If the best-matched font has an ital axis and italic is requested but no explicit ital variation was supplied, inject ital=1
-        bool hasExplicitItal = false;
-        for (int vi = 0; vi < effectiveVariations.length(); vi++)
-            if (effectiveVariations[vi].tag == LVFONT_TAG_ITAL) { hasExplicitItal = true; break; }
-        if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis() && !hasExplicitItal) {
-            LVFontVariation italVar; italVar.tag = LVFONT_TAG_ITAL; italVar.value = 1.0f;
-            effectiveVariations.add(italVar);
+        if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis()
+                && !effectiveVariations.ital_set) {
+            effectiveVariations.set(LVFONT_TAG_ITAL, 1.0f);
             static lString8 s_last_tf_ital; static int s_last_sz_ital = -1;
             if (typeface != s_last_tf_ital || size != s_last_sz_ital) {
                 CRLog::info("Variable font GetFont: injecting ital=1 for \"%s\" size=%d",
                     typeface.c_str(), size);
                 s_last_tf_ital = typeface; s_last_sz_ital = size;
             }
-            // Sort into canonical order then redo cache lookup with the fully-resolved
-            // variation set to find any already-instantiated variable font instance.
-            sortVariations(effectiveVariations);
             def.setVariations(effectiveVariations);
             LVFontCacheItem * item3 = _cache.find(&def, useBias);
             if (item3 != NULL && !item3->getFont().isNull()
-                    && item3->getDef()->getFeatures() == features) {
-                // Verify variations match exactly
-                const LVArray<LVFontVariation>& cachedVars3 = item3->getDef()->getVariations();
-                if (cachedVars3.length() == effectiveVariations.length()) {
-                    bool varMatch3 = true;
-                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                        if (!(cachedVars3[vi] == effectiveVariations[vi])) { varMatch3 = false; break; }
-                    if (varMatch3)
-                        return item3->getFont();
-                }
+                    && item3->getDef()->getFeatures() == features
+                    && item3->getDef()->getVariations() == effectiveVariations)
+                return item3->getFont();
+        } else if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasSlntAxis()
+                   && !effectiveVariations.slnt_set) {
+            effectiveVariations.set(LVFONT_TAG_SLNT, -12.0f);
+            static lString8 s_last_tf_slnt; static int s_last_sz_slnt = -1;
+            if (typeface != s_last_tf_slnt || size != s_last_sz_slnt) {
+                CRLog::info("Variable font GetFont: injecting slnt=-12 for \"%s\" size=%d",
+                    typeface.c_str(), size);
+                s_last_tf_slnt = typeface; s_last_sz_slnt = size;
             }
-            // Keep using item (registered font) for instantiation below
-        }
-        // If still no italic font and has slnt axis, inject slnt=-12
-        else if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasSlntAxis() && !hasExplicitItal) {
-            bool hasExplicitSlnt = false;
-            for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                if (effectiveVariations[vi].tag == LVFONT_TAG_SLNT) { hasExplicitSlnt = true; break; }
-            if (!hasExplicitSlnt) {
-                LVFontVariation slntVar; slntVar.tag = LVFONT_TAG_SLNT; slntVar.value = -12.0f; // typical slant value
-                effectiveVariations.add(slntVar);
-                static lString8 s_last_tf_slnt; static int s_last_sz_slnt = -1;
-                if (typeface != s_last_tf_slnt || size != s_last_sz_slnt) {
-                    CRLog::info("Variable font GetFont: injecting slnt=-12 for \"%s\" size=%d",
-                        typeface.c_str(), size);
-                    s_last_tf_slnt = typeface; s_last_sz_slnt = size;
-                }
-                // Sort into canonical order then redo cache lookup with the fully-resolved
-                // variation set to find any already-instantiated variable font instance.
-                sortVariations(effectiveVariations);
-                def.setVariations(effectiveVariations);
-                LVFontCacheItem * item4 = _cache.find(&def, useBias);
-                if (item4 != NULL && !item4->getFont().isNull()
-                        && item4->getDef()->getFeatures() == features) {
-                    // Verify variations match exactly
-                    const LVArray<LVFontVariation>& cachedVars4 = item4->getDef()->getVariations();
-                    if (cachedVars4.length() == effectiveVariations.length()) {
-                        bool varMatch4 = true;
-                        for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                            if (!(cachedVars4[vi] == effectiveVariations[vi])) { varMatch4 = false; break; }
-                        if (varMatch4)
-                            return item4->getFont();
-                    }
-                }
-                // Keep using item (registered font) for instantiation below
-            }
+            def.setVariations(effectiveVariations);
+            LVFontCacheItem * item4 = _cache.find(&def, useBias);
+            if (item4 != NULL && !item4->getFont().isNull()
+                    && item4->getDef()->getFeatures() == features
+                    && item4->getDef()->getVariations() == effectiveVariations)
+                return item4->getFont();
         }
 
         bool italicize = false;
@@ -6364,19 +6264,11 @@ public:
                 // Be sure we ignore any instantiated font found in cache that
                 // has features different than the ones requested.
             }
-            else if (item->getDef()->getVariations().length() != effectiveVariations.length()) {
+            else if (item->getDef()->getVariations() != effectiveVariations) {
                 // Variations mismatch: ignore this cached instance
             }
             else {
-                bool varMatch = true;
-                const LVArray<LVFontVariation>& cachedVars = item->getDef()->getVariations();
-                for (int vi = 0; vi < effectiveVariations.length(); vi++) {
-                    if (!(cachedVars[vi] == effectiveVariations[vi])) { varMatch = false; break; }
-                }
-                if (!varMatch) {
-                    // Variations mismatch: ignore this cached instance
-                }
-                else {
+                {
             #ifdef USE_FT_EMBOLDEN
                 int deltaWeight = myabs(weight - item->getDef()->getWeight());
                 if (deltaWeight >= 25 && !item->getDef()->hasWghtAxis()) {
@@ -6445,16 +6337,19 @@ public:
         font->setVariations(effectiveVariations);
         if (!effectiveVariations.empty()) {
             char varBuf[256] = "";
-            int varBufPos = 0;
-            for (int vi = 0; vi < effectiveVariations.length() && varBufPos < (int)sizeof(varBuf) - 20; vi++) {
-                lUInt32 t = effectiveVariations[vi].tag;
-                varBufPos += snprintf(varBuf + varBufPos, sizeof(varBuf) - varBufPos,
-                                      "%s%c%c%c%c=%.1f",
-                                      vi ? ", " : "",
-                                      (char)((t >> 24) & 0xFF), (char)((t >> 16) & 0xFF),
-                                      (char)((t >>  8) & 0xFF), (char)(t & 0xFF),
-                                      effectiveVariations[vi].value);
-            }
+            int pos = 0;
+            auto logAxis = [&](bool set, lUInt32 tag, float val) {
+                if (!set || pos >= (int)sizeof(varBuf) - 20) return;
+                pos += snprintf(varBuf + pos, sizeof(varBuf) - pos, "%s%c%c%c%c=%.1f",
+                                pos ? ", " : "",
+                                (char)((tag>>24)&0xFF),(char)((tag>>16)&0xFF),
+                                (char)((tag>> 8)&0xFF),(char)(tag&0xFF), val);
+            };
+            logAxis(effectiveVariations.wght_set, LVFONT_TAG_WGHT, effectiveVariations.wght);
+            logAxis(effectiveVariations.opsz_set, LVFONT_TAG_OPSZ, effectiveVariations.opsz);
+            logAxis(effectiveVariations.ital_set, LVFONT_TAG_ITAL, effectiveVariations.ital);
+            logAxis(effectiveVariations.slnt_set, LVFONT_TAG_SLNT, effectiveVariations.slnt);
+            logAxis(effectiveVariations.wdth_set, LVFONT_TAG_WDTH, effectiveVariations.wdth);
             CRLog::info("Variable font new instance: \"%s\" size=%d  [%s]",
                 item->getDef()->getTypeFace().c_str(), size, varBuf);
         }
@@ -6477,9 +6372,7 @@ public:
             //item->setFont( ref );
             //_cache.update( def, ref );
             // Check whether weight variation handles weight; if not, fall back to synthesis
-            bool usingWghtAxis = false;
-            for (int vi = 0; vi < effectiveVariations.length(); vi++)
-                if (effectiveVariations[vi].tag == LVFONT_TAG_WGHT) { usingWghtAxis = true; break; }
+            bool usingWghtAxis = effectiveVariations.wght_set;
         #ifdef USE_FT_EMBOLDEN
             int deltaWeight = myabs(weight - newDef.getWeight());
             if (deltaWeight >= 25 && !usingWghtAxis) {
@@ -7035,7 +6928,7 @@ public:
     }
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
                                 int features, int documentId, bool useBias=false,
-                                const LVArray<LVFontVariation>* /*variations*/=NULL)
+                                const LVFontVariations* /*variations*/=NULL)
     {
         LVFontDef * def = new LVFontDef(
             lString8::empty_str,
@@ -7443,32 +7336,19 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     int variations_match = 256;
     if (!_variations.empty() && !def._variations.empty()) {
         // Both have explicit variations — require exact match
-        if (_variations.length() != def._variations.length()) {
-            variations_match = 0;
-        } else {
-            for (int vi = 0; vi < _variations.length(); vi++) {
-                if (!(_variations[vi] == def._variations[vi])) {
-                    variations_match = 0;
-                    break;
-                }
-            }
-        }
+        variations_match = (_variations == def._variations) ? 256 : 0;
     }
 
     // italic
     int this_italic = _italic;
     if (_italic == 0) {
-        for (int i = 0; i < _variations.length(); i++) {
-            if (_variations[i].tag == LVFONT_TAG_ITAL && _variations[i].value == 1.0f) { this_italic = 1; break; }
-            else if (_variations[i].tag == LVFONT_TAG_SLNT && _variations[i].value != 0.0f) { this_italic = 2; break; }
-        }
+        if (_variations.ital_set && _variations.ital == 1.0f)       this_italic = 1;
+        else if (_variations.slnt_set && _variations.slnt != 0.0f)  this_italic = 2;
     }
     int def_italic = def._italic;
     if (def._italic == 0) {
-        for (int i = 0; i < def._variations.length(); i++) {
-            if (def._variations[i].tag == LVFONT_TAG_ITAL && def._variations[i].value == 1.0f) { def_italic = 1; break; }
-            else if (def._variations[i].tag == LVFONT_TAG_SLNT && def._variations[i].value != 0.0f) { def_italic = 2; break; }
-        }
+        if (def._variations.ital_set && def._variations.ital == 1.0f)      def_italic = 1;
+        else if (def._variations.slnt_set && def._variations.slnt != 0.0f) def_italic = 2;
     }
     int italic_match = (this_italic == def_italic || this_italic==-1 || def_italic==-1) ?
               256

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -728,7 +728,6 @@ public:
     bool hasWghtAxis() const { return hasAxis(LVFONT_TAG_WGHT); }
     float getWghtAxisMin() const { return getAxisMin(LVFONT_TAG_WGHT, 400.0f); }
     float getWghtAxisMax() const { return getAxisMax(LVFONT_TAG_WGHT, 400.0f); }
-    bool hasOpszAxis() const { return hasAxis(LVFONT_TAG_OPSZ); }
     int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
     LVByteArrayRef getBuf() const { return _buf; }
@@ -6179,8 +6178,21 @@ public:
                     bool varMatch = true;
                     for (int vi = 0; vi < effectiveVariations.length(); vi++)
                         if (!(sv[vi] == effectiveVariations[vi])) { varMatch = false; break; }
-                    if (varMatch)
-                        return strippedItem->getFont();
+                    if (varMatch) {
+                        // Mirror the synthesis guard in the instantiated-instance block:
+                        // don't return this cached instance if weight synthesis would
+                        // be needed but the font has no wght axis to handle it.
+                        bool needsSynth = false;
+                    #ifdef USE_FT_EMBOLDEN
+                        needsSynth = (myabs(weight - strippedItem->getDef()->getWeight()) >= 25
+                                      && !strippedItem->getDef()->hasWghtAxis());
+                    #else
+                        needsSynth = (weight - strippedItem->getDef()->getWeight() >= 200
+                                      && !strippedItem->getDef()->hasWghtAxis());
+                    #endif
+                        if (!needsSynth)
+                            return strippedItem->getFont();
+                    }
                 }
             }
         }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -600,11 +600,8 @@ private:
     bool _has_emojis;
     // Variable font axis values for this instance (empty = default/static)
     LVArray<LVFontVariation> _variations;
-    // Variable font axis ranges detected at registration time
-    bool  _has_wght_axis;
-    float _wght_axis_min, _wght_axis_max;
-    bool  _has_opsz_axis;
-    float _opsz_axis_min, _opsz_axis_max;
+    // All variable font axes supported by this font, detected at registration time
+    LVArray<LVFontAxisInfo> _axes;
 public:
     LVFontDef(const lString8 & name, int size, int weight, int italic, int features, css_font_family_t family,
                 const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
@@ -622,10 +619,6 @@ public:
         , _real_weight(true)
         , _has_ot_math(false)
         , _has_emojis(false)
-        , _has_wght_axis(false)
-        , _wght_axis_min(400.0f), _wght_axis_max(400.0f)
-        , _has_opsz_axis(false)
-        , _opsz_axis_min(12.0f), _opsz_axis_max(12.0f)
         {
         }
     LVFontDef(const LVFontDef & def)
@@ -644,10 +637,7 @@ public:
         , _has_ot_math(def._has_ot_math)
         , _has_emojis(def._has_emojis)
         , _variations(def._variations)
-        , _has_wght_axis(def._has_wght_axis)
-        , _wght_axis_min(def._wght_axis_min), _wght_axis_max(def._wght_axis_max)
-        , _has_opsz_axis(def._has_opsz_axis)
-        , _opsz_axis_min(def._opsz_axis_min), _opsz_axis_max(def._opsz_axis_max)
+        , _axes(def._axes)
         {
         }
 
@@ -717,16 +707,28 @@ public:
     void setHasEmojis(bool has_emojis) { _has_emojis = has_emojis; }
     const LVArray<LVFontVariation>& getVariations() const { return _variations; }
     void setVariations(const LVArray<LVFontVariation>& v) { _variations = v; }
-    bool hasWghtAxis() const { return _has_wght_axis; }
-    float getWghtAxisMin() const { return _wght_axis_min; }
-    float getWghtAxisMax() const { return _wght_axis_max; }
-    bool hasOpszAxis() const { return _has_opsz_axis; }
-    float getOpszAxisMin() const { return _opsz_axis_min; }
-    float getOpszAxisMax() const { return _opsz_axis_max; }
-    void setAxisInfo(bool hasWght, float wMin, float wMax, bool hasOpsz, float oMin, float oMax) {
-        _has_wght_axis = hasWght; _wght_axis_min = wMin; _wght_axis_max = wMax;
-        _has_opsz_axis = hasOpsz; _opsz_axis_min = oMin; _opsz_axis_max = oMax;
+    const LVArray<LVFontAxisInfo>& getAxes() const { return _axes; }
+    void setAxes(const LVArray<LVFontAxisInfo>& axes) { _axes = axes; }
+    bool hasAxis(lUInt32 tag) const {
+        for (int i = 0; i < _axes.length(); i++)
+            if (_axes[i].tag == tag) return true;
+        return false;
     }
+    // Returns the min/max for a named axis, or the fallback if not present
+    float getAxisMin(lUInt32 tag, float fallback = 0.0f) const {
+        for (int i = 0; i < _axes.length(); i++)
+            if (_axes[i].tag == tag) return _axes[i].minValue;
+        return fallback;
+    }
+    float getAxisMax(lUInt32 tag, float fallback = 0.0f) const {
+        for (int i = 0; i < _axes.length(); i++)
+            if (_axes[i].tag == tag) return _axes[i].maxValue;
+        return fallback;
+    }
+    bool hasWghtAxis() const { return hasAxis(LVFONT_TAG_WGHT); }
+    float getWghtAxisMin() const { return getAxisMin(LVFONT_TAG_WGHT, 400.0f); }
+    float getWghtAxisMax() const { return getAxisMax(LVFONT_TAG_WGHT, 400.0f); }
+    bool hasOpszAxis() const { return hasAxis(LVFONT_TAG_OPSZ); }
     int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
     LVByteArrayRef getBuf() const { return _buf; }
@@ -6039,27 +6041,26 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    bool hasWght = false, hasOpsz = false;
-                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
-                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
-                        float defVal = mm_var->axis[ai].def     / 65536.0f;
-                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
-                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
-                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        LVFontAxisInfo axinfo;
+                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
+                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
+                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        axes.add(axinfo);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
-                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
-                                                   minVal, defVal, maxVal);
+                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
+                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
+                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
                         }
                     }
-                    def2.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    def2.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def2.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
@@ -6156,9 +6157,7 @@ public:
         // create redundant cache entries with identical rendering output).
         if (!effectiveVariations.empty()) {
             for (int vi = effectiveVariations.length() - 1; vi >= 0; vi--) {
-                lUInt32 tag = effectiveVariations[vi].tag;
-                if ((tag == LVFONT_TAG_OPSZ && !item->getDef()->hasOpszAxis()) ||
-                    (tag == LVFONT_TAG_WGHT && !item->getDef()->hasWghtAxis()))
+                if (!item->getDef()->hasAxis(effectiveVariations[vi].tag))
                     effectiveVariations.remove(vi);
             }
         }
@@ -6317,10 +6316,7 @@ public:
             newDef.setSize( size );
             newDef.setVariations( effectiveVariations );
             // Copy axis info from the registered def so the instantiated def also exposes it
-            newDef.setAxisInfo(item->getDef()->hasWghtAxis(),
-                               item->getDef()->getWghtAxisMin(), item->getDef()->getWghtAxisMax(),
-                               item->getDef()->hasOpszAxis(),
-                               item->getDef()->getOpszAxisMin(), item->getDef()->getOpszAxisMax());
+            newDef.setAxes(item->getDef()->getAxes());
             //item->setFont( ref );
             //_cache.update( def, ref );
             // Check whether weight variation handles weight; if not, fall back to synthesis
@@ -6531,27 +6527,26 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    bool hasWght = false, hasOpsz = false;
-                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
-                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
-                        float defVal = mm_var->axis[ai].def     / 65536.0f;
-                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
-                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
-                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        LVFontAxisInfo axinfo;
+                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
+                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
+                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        axes.add(axinfo);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
-                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
-                                                   minVal, defVal, maxVal);
+                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
+                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
+                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
                         }
                     }
-                    def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    def.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
@@ -6780,27 +6775,26 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    bool hasWght = false, hasOpsz = false;
-                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
-                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
-                        float defVal = mm_var->axis[ai].def     / 65536.0f;
-                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
-                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
-                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        LVFontAxisInfo axinfo;
+                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
+                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
+                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        axes.add(axinfo);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
-                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
-                                                   minVal, defVal, maxVal);
+                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
+                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
+                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
                         }
                     }
-                    def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    def.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
@@ -7273,8 +7267,8 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     if ( weight_diff > 800 )
         weight_diff = 800;
     int weight_match;
-    if ( _has_wght_axis && def._weight != -1 && _weight != -1
-            && def._weight >= (int)_wght_axis_min && def._weight <= (int)_wght_axis_max ) {
+    if ( hasWghtAxis() && def._weight != -1 && _weight != -1
+            && def._weight >= (int)getWghtAxisMin() && def._weight <= (int)getWghtAxisMax() ) {
         weight_match = 257; // variable font can hit exact requested weight
     } else {
         weight_match = (_weight==-1 || def._weight==-1) ?

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6110,6 +6110,20 @@ public:
         if (variations)
             effectiveVariations = *variations;
 
+        // Sort helper: canonical tag order so cache keys are insertion-order-independent.
+        // Insertion sort is fine — arrays are at most ~16 elements.
+        auto sortVariations = [](LVArray<LVFontVariation> & arr) {
+            for (int i = 1; i < arr.length(); i++) {
+                LVFontVariation key = arr[i];
+                int j = i - 1;
+                while (j >= 0 && arr[j].tag > key.tag) {
+                    arr[j + 1] = arr[j];
+                    j--;
+                }
+                arr[j + 1] = key;
+            }
+        };
+
         lString8 fontname;
         LVFontDef def(
             fontname,
@@ -6161,9 +6175,10 @@ public:
             }
         }
 
-        // Sync def with the stripped set. The first _cache.find used the unstripped
-        // variations; now that we know which axes are supported, update def so any
-        // subsequent lookup uses the correct (shorter) key.
+        // Sort into canonical tag order and sync def. The first _cache.find used the
+        // unstripped variations; now that we know which axes are supported, update def
+        // so any subsequent lookup uses the correct (shorter, sorted) key.
+        sortVariations(effectiveVariations);
         def.setVariations(effectiveVariations);
 
         // Check whether an already-instantiated font with these exact stripped
@@ -6212,8 +6227,9 @@ public:
                     (float)weight, typeface.c_str(), size);
                 s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
             }
-            // Redo cache lookup with the fully-resolved variation set so we can
-            // find any already-instantiated variable font instance.
+            // Sort into canonical order then redo cache lookup with the fully-resolved
+            // variation set to find any already-instantiated variable font instance.
+            sortVariations(effectiveVariations);
             def.setVariations(effectiveVariations);
             LVFontCacheItem * item2 = _cache.find(&def, useBias);
             if (item2 != NULL && !item2->getFont().isNull()

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -50,6 +50,13 @@
 #include <freetype/ftsynth.h>    // for FT_GlyphSlot_Oblique()
 #include <freetype/ftglyph.h>    // for FT_Matrix_Multiply()
 #include <freetype/tttables.h>   // for FT_Get_Sfnt_Table()
+#include <freetype/ftmm.h>       // for FT_Get_MM_Var() / FT_Set_Var_Design_Coordinates()
+// FT_Done_MM_Var was added in FreeType 2.9; fall back to free() on older versions
+#if FREETYPE_MINOR >= 9 || FREETYPE_MAJOR > 2
+#  define FT_DONE_MM_VAR(lib, p) FT_Done_MM_Var(lib, p)
+#else
+#  define FT_DONE_MM_VAR(lib, p) free(p)
+#endif
 
 // Use Freetype embolden API instead of LVFontBoldTransform to
 // make fake bold (for fonts that do not provide a bold face).
@@ -591,6 +598,13 @@ private:
     // Store some info we can know about a font at registration time
     bool _has_ot_math;
     bool _has_emojis;
+    // Variable font axis values for this instance (empty = default/static)
+    LVArray<LVFontVariation> _variations;
+    // Variable font axis ranges detected at registration time
+    bool  _has_wght_axis;
+    float _wght_axis_min, _wght_axis_max;
+    bool  _has_opsz_axis;
+    float _opsz_axis_min, _opsz_axis_max;
 public:
     LVFontDef(const lString8 & name, int size, int weight, int italic, int features, css_font_family_t family,
                 const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
@@ -608,6 +622,10 @@ public:
         , _real_weight(true)
         , _has_ot_math(false)
         , _has_emojis(false)
+        , _has_wght_axis(false)
+        , _wght_axis_min(400.0f), _wght_axis_max(400.0f)
+        , _has_opsz_axis(false)
+        , _opsz_axis_min(12.0f), _opsz_axis_max(12.0f)
         {
         }
     LVFontDef(const LVFontDef & def)
@@ -625,12 +643,22 @@ public:
         , _real_weight(def._real_weight)
         , _has_ot_math(def._has_ot_math)
         , _has_emojis(def._has_emojis)
+        , _variations(def._variations)
+        , _has_wght_axis(def._has_wght_axis)
+        , _wght_axis_min(def._wght_axis_min), _wght_axis_max(def._wght_axis_max)
+        , _has_opsz_axis(def._has_opsz_axis)
+        , _opsz_axis_min(def._opsz_axis_min), _opsz_axis_max(def._opsz_axis_max)
         {
         }
 
     /// returns true if definitions are equal
     bool operator == ( const LVFontDef & def ) const
     {
+        if (_variations.length() != def._variations.length())
+            return false;
+        for (int i = 0; i < _variations.length(); i++)
+            if (!(_variations[i] == def._variations[i]))
+                return false;
         return ( _size == def._size || _size == -1 || def._size == -1 )
             && ( _weight == def._weight || _weight==-1 || def._weight==-1 )
             && ( _italic == def._italic || _italic==-1 || def._italic==-1 )
@@ -646,6 +674,14 @@ public:
 
     lUInt32 getHash() const {
         lUInt32 h =  (((((_size * 31) + _weight)*31  + _italic)*31 + _features)*31+ _family)*31 + _name.getHash();
+        // Mix in variation axis values so different instances of the same file are distinct
+        for (int i = 0; i < _variations.length(); i++) {
+            h = h * 31 + _variations[i].tag;
+            float fval = _variations[i].value; // copy to lvalue for memcpy
+            lUInt32 vbits;
+            memcpy(&vbits, &fval, sizeof(vbits));
+            h = h * 31 + vbits;
+        }
         // _bias is not a static property, and can be set/unset on these definitions.
         // If a same _bias value is moved from one font to another, *adding* _bias
         // to this hash may result in a final identical GetFontListHash() value
@@ -679,6 +715,18 @@ public:
     void setHasOTMath(bool has_ot_math) { _has_ot_math = has_ot_math; }
     bool hasEmojis() const { return _has_emojis; }
     void setHasEmojis(bool has_emojis) { _has_emojis = has_emojis; }
+    const LVArray<LVFontVariation>& getVariations() const { return _variations; }
+    void setVariations(const LVArray<LVFontVariation>& v) { _variations = v; }
+    bool hasWghtAxis() const { return _has_wght_axis; }
+    float getWghtAxisMin() const { return _wght_axis_min; }
+    float getWghtAxisMax() const { return _wght_axis_max; }
+    bool hasOpszAxis() const { return _has_opsz_axis; }
+    float getOpszAxisMin() const { return _opsz_axis_min; }
+    float getOpszAxisMax() const { return _opsz_axis_max; }
+    void setAxisInfo(bool hasWght, float wMin, float wMax, bool hasOpsz, float oMin, float oMax) {
+        _has_wght_axis = hasWght; _wght_axis_min = wMin; _wght_axis_max = wMax;
+        _has_opsz_axis = hasOpsz; _opsz_axis_min = oMin; _opsz_axis_max = oMax;
+    }
     int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
     LVByteArrayRef getBuf() const { return _buf; }
@@ -1520,6 +1568,7 @@ protected:
     FT_Pos         _synth_weight_strength; // for emboldening with FT_Outline_Embolden()
     FT_Pos         _synth_weight_half_strength;
     int            _features; // requested OpenType features bitmap
+    LVArray<LVFontVariation> _variations; // variable font axis values applied to this instance
 #if USE_HARFBUZZ==1
     hb_font_t* _hb_font;
     hb_buffer_t* _hb_buffer;
@@ -1923,6 +1972,9 @@ public:
     virtual int getFeatures() const {
         return _features;
     }
+    void setVariations( const LVArray<LVFontVariation>& variations ) {
+        _variations = variations;
+    }
 
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
         _kerningMode = kerningMode;
@@ -2106,6 +2158,45 @@ public:
             0,        /* pixel_width           */
             _face_size );  /* pixel_height          */
 
+        // Apply variable font axis coordinates (wght, opsz, ...) if any were requested
+        if (!_variations.empty())
+            CRLog::info("Variable font setupFace: %s variations=%d ft_error=%d",
+                _fileName.c_str(), _variations.length(), error);
+        if (!_variations.empty() && FT_Err_Ok == error) {
+            FT_MM_Var* mm_var = NULL;
+            if (FT_Get_MM_Var(_face, &mm_var) == FT_Err_Ok && mm_var) {
+                // Build axis coord array (FT_Fixed = 16.16) starting from defaults
+                FT_Fixed * coords = new FT_Fixed[mm_var->num_axis];
+                for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
+                    coords[ai] = mm_var->axis[ai].def; // start at default
+                    lUInt32 axTag = (lUInt32)mm_var->axis[ai].tag;
+                    for (int vi = 0; vi < _variations.length(); vi++) {
+                        if (_variations[vi].tag == axTag) {
+                            coords[ai] = (FT_Fixed)(_variations[vi].value * 65536.0f);
+                            break;
+                        }
+                    }
+                }
+                FT_Set_Var_Design_Coordinates(_face, mm_var->num_axis, coords);
+                delete[] coords;
+                {
+                    char axisBuf[256] = "";
+                    int pos = 0;
+                    for (int vi = 0; vi < _variations.length() && pos < (int)sizeof(axisBuf) - 20; vi++) {
+                        lUInt32 t = _variations[vi].tag;
+                        pos += snprintf(axisBuf + pos, sizeof(axisBuf) - pos,
+                                        "%s%c%c%c%c=%.1f",
+                                        vi ? ", " : "",
+                                        (char)((t >> 24) & 0xFF), (char)((t >> 16) & 0xFF),
+                                        (char)((t >>  8) & 0xFF), (char)(t & 0xFF),
+                                        _variations[vi].value);
+                    }
+                    CRLog::info("Variable font %s: axes [%s]", _fileName.c_str(), axisBuf);
+                }
+                FT_DONE_MM_VAR(_library, mm_var);
+            }
+        }
+
         #if USE_HARFBUZZ==1
         if (FT_Err_Ok == error) {
             if (_hb_font)
@@ -2130,6 +2221,16 @@ public:
                 if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
                     flags |= FT_LOAD_COLOR;
                 hb_ft_font_set_load_flags(_hb_font, flags);
+                // Apply variable font variations to the HarfBuzz font as well
+                if (!_variations.empty()) {
+                    hb_variation_t * hbvars = new hb_variation_t[_variations.length()];
+                    for (int vi = 0; vi < _variations.length(); vi++) {
+                        hbvars[vi].tag   = _variations[vi].tag;
+                        hbvars[vi].value = _variations[vi].value;
+                    }
+                    hb_font_set_variations(_hb_font, hbvars, (unsigned int)_variations.length());
+                    delete[] hbvars;
+                }
             }
         }
         #endif
@@ -5925,6 +6026,28 @@ public:
                 hb_face_destroy(hb_face);
             #endif
 
+            // Detect variable font axes (wght, opsz) for smarter weight matching
+            {
+                FT_MM_Var* mm_var = NULL;
+                if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+                    bool hasWght = false, hasOpsz = false;
+                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
+                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
+                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
+                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
+                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                    }
+                    def2.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
+                        def2.getName().c_str(),
+                        hasWght ? "yes" : "no", wMin, wMax,
+                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    FT_DONE_MM_VAR(_library, mm_var);
+                }
+            }
+
             if ( face ) {
                 FT_Done_Face( face );
                 face = NULL;
@@ -5954,7 +6077,8 @@ public:
     }
 
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
-                                int features, int documentId, bool useBias=false)
+                                int features, int documentId, bool useBias=false,
+                                const LVArray<LVFontVariation>* variations=NULL)
     {
         FONT_MAN_GUARD
         #if (DEBUG_FONT_MAN==1)
@@ -5963,6 +6087,11 @@ public:
                     size, weight, italic?1:0, (int)family, typeface.c_str() );
             }
         #endif
+        // Build effective variations: start from caller-supplied list
+        LVArray<LVFontVariation> effectiveVariations;
+        if (variations)
+            effectiveVariations = *variations;
+
         lString8 fontname;
         LVFontDef def(
             fontname,
@@ -5975,6 +6104,8 @@ public:
             -1,
             documentId
         );
+        // Pass variations to cache query so instantiated variable fonts are found exactly
+        def.setVariations(effectiveVariations);
         #if (DEBUG_FONT_MAN==1)
             if ( _log )
                 fprintf( _log, "GetFont: %s %d %s %s\n",
@@ -6002,6 +6133,36 @@ public:
             return LVFontRef(NULL);
         }
 
+        // If the best-matched font has a wght axis and no explicit wght variation was
+        // supplied, inject one so the face is set to exactly the requested weight instead
+        // of using FT_Outline_Embolden synthesis.
+        bool hasExplicitWght = false;
+        for (int vi = 0; vi < effectiveVariations.length(); vi++)
+            if (effectiveVariations[vi].tag == LVFONT_TAG_WGHT) { hasExplicitWght = true; break; }
+        if (item->getDef()->hasWghtAxis() && !hasExplicitWght) {
+            LVFontVariation wghtVar; wghtVar.tag = LVFONT_TAG_WGHT; wghtVar.value = (float)weight;
+            effectiveVariations.add(wghtVar);
+            CRLog::info("Variable font GetFont: injecting wght=%.0f for %s size=%d",
+                (float)weight, typeface.c_str(), size);
+            // Redo cache lookup with the fully-resolved variation set so we can
+            // find any already-instantiated variable font instance.
+            def.setVariations(effectiveVariations);
+            LVFontCacheItem * item2 = _cache.find(&def, useBias);
+            if (item2 != NULL && !item2->getFont().isNull()
+                    && item2->getDef()->getFeatures() == features) {
+                // Verify variations match exactly
+                const LVArray<LVFontVariation>& cachedVars2 = item2->getDef()->getVariations();
+                if (cachedVars2.length() == effectiveVariations.length()) {
+                    bool varMatch2 = true;
+                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                        if (!(cachedVars2[vi] == effectiveVariations[vi])) { varMatch2 = false; break; }
+                    if (varMatch2)
+                        return item2->getFont();
+                }
+            }
+            // Keep using item (registered font) for instantiation below
+        }
+
         bool italicize = false;
 
         LVFontDef newDef(*item->getDef());
@@ -6012,17 +6173,30 @@ public:
                 // Be sure we ignore any instantiated font found in cache that
                 // has features different than the ones requested.
             }
+            else if (item->getDef()->getVariations().length() != effectiveVariations.length()) {
+                // Variations mismatch: ignore this cached instance
+            }
             else {
+                bool varMatch = true;
+                const LVArray<LVFontVariation>& cachedVars = item->getDef()->getVariations();
+                for (int vi = 0; vi < effectiveVariations.length(); vi++) {
+                    if (!(cachedVars[vi] == effectiveVariations[vi])) { varMatch = false; break; }
+                }
+                if (!varMatch) {
+                    // Variations mismatch: ignore this cached instance
+                }
+                else {
             #ifdef USE_FT_EMBOLDEN
                 int deltaWeight = myabs(weight - item->getDef()->getWeight());
-                if (deltaWeight >= 25) {
+                if (deltaWeight >= 25 && !item->getDef()->hasWghtAxis()) {
                     // This instantiated cached font has a too different weight
                     // when USE_FT_EMBOLDEN, ignore this other-weight cached font instance
                     // and go loading from the font file again to apply embolden.
+                    // (Skip this check when wght axis is used — weight is controlled by variation)
                 }
             #else
                 int deltaWeight = weight - item->getDef()->getWeight();
-                if ( deltaWeight >= 200 ) {
+                if ( deltaWeight >= 200 && !item->getDef()->hasWghtAxis() ) {
                     // This instantiated cached font has a too low weight
                         // embolden using LVFontBoldTransform
                         CRLog::debug("font: apply Embolding to increase weight from %d to %d",
@@ -6036,6 +6210,7 @@ public:
                 else {
                     //fprintf(_log, "    : fount existing\n");
                     return item->getFont();
+                }
                 }
             }
         }
@@ -6075,6 +6250,8 @@ public:
         if ( family == css_ff_monospace && GetMonospaceSizeScale() != 100 ) {
             face_size = size * GetMonospaceSizeScale() / 100;
         }
+        // Set variations before loadFromFile so that setupFace() can apply them
+        font->setVariations(effectiveVariations);
         if (item->getDef()->getBuf().isNull())
             loaded = font->loadFromFile( pathname.c_str(), item->getDef()->getIndex(), size, family, isBitmapModeForSize(size), italicize, item->getDef()->getWeight(), face_size );
         else
@@ -6083,17 +6260,27 @@ public:
             //fprintf(_log, "    : loading from file %s : %s %d\n", item->getDef()->getName().c_str(),
             //    item->getDef()->getTypeFace().c_str(), item->getDef()->getSize() );
             LVFontRef ref(font);
-            // Instantiate this font with the requested OpenType features
+            // Instantiate this font with the requested OpenType features and variations
             newDef.setFeatures( features );
             font->setFeatures( features ); // followup setKerningMode() will create/update hb_features if needed
             font->setKerningMode( GetKerningMode() );
             font->setFaceName( item->getDef()->getTypeFace() );
             newDef.setSize( size );
+            newDef.setVariations( effectiveVariations );
+            // Copy axis info from the registered def so the instantiated def also exposes it
+            newDef.setAxisInfo(item->getDef()->hasWghtAxis(),
+                               item->getDef()->getWghtAxisMin(), item->getDef()->getWghtAxisMax(),
+                               item->getDef()->hasOpszAxis(),
+                               item->getDef()->getOpszAxisMin(), item->getDef()->getOpszAxisMax());
             //item->setFont( ref );
             //_cache.update( def, ref );
+            // Check whether weight variation handles weight; if not, fall back to synthesis
+            bool usingWghtAxis = false;
+            for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                if (effectiveVariations[vi].tag == LVFONT_TAG_WGHT) { usingWghtAxis = true; break; }
         #ifdef USE_FT_EMBOLDEN
             int deltaWeight = myabs(weight - newDef.getWeight());
-            if (deltaWeight >= 25) {
+            if (deltaWeight >= 25 && !usingWghtAxis) {
                 // embolden
                 // Will make some of this font's methods do embolden the glyphs and widths
                 font->setSynthWeight(weight);
@@ -6102,7 +6289,7 @@ public:
             }
         #else
             int deltaWeight = weight - newDef.getWeight();
-            if ( deltaWeight >= 200 ) {
+            if ( deltaWeight >= 200 && !usingWghtAxis ) {
                 CRLog::debug("font: apply Embolding to increase weight from %d to %d",
                                     newDef.getWeight(), newDef.getWeight() + 200 );
                 // Create a wrapper with LVFontBoldTransform which will bolden the glyphs
@@ -6291,6 +6478,27 @@ public:
                     def.setHasOTMath(true);
                 hb_face_destroy(hb_face);
             #endif
+            // Detect variable font axes for smarter weight matching
+            {
+                FT_MM_Var* mm_var = NULL;
+                if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+                    bool hasWght = false, hasOpsz = false;
+                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
+                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
+                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
+                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
+                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                    }
+                    def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
+                        def.getName().c_str(),
+                        hasWght ? "yes" : "no", wMin, wMax,
+                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    FT_DONE_MM_VAR(_library, mm_var);
+                }
+            }
             #if (DEBUG_FONT_MAN==1)
                 if ( _log ) {
                     fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
@@ -6510,6 +6718,27 @@ public:
                     def.setHasOTMath(true);
                 hb_face_destroy(hb_face);
             #endif
+            // Detect variable font axes (wght, opsz) for smarter weight matching
+            {
+                FT_MM_Var* mm_var = NULL;
+                if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
+                    bool hasWght = false, hasOpsz = false;
+                    float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
+                        lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
+                        float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float maxVal = mm_var->axis[ai].maximum / 65536.0f;
+                        if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
+                        if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                    }
+                    def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
+                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
+                        def.getName().c_str(),
+                        hasWght ? "yes" : "no", wMin, wMax,
+                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    FT_DONE_MM_VAR(_library, mm_var);
+                }
+            }
             #if (DEBUG_FONT_MAN==1)
                 if ( _log ) {
                     fprintf(_log, "registering font: (file=%s[%d], size=%d, weight=%d, italic=%d, family=%d, typeface=%s)\n",
@@ -6593,7 +6822,8 @@ public:
         return filename;
     }
     virtual LVFontRef GetFont(int size, int weight, bool italic, css_font_family_t family, lString8 typeface,
-                                int features, int documentId, bool useBias=false)
+                                int features, int documentId, bool useBias=false,
+                                const LVArray<LVFontVariation>* /*variations*/=NULL)
     {
         LVFontDef * def = new LVFontDef(
             lString8::empty_str,
@@ -6967,23 +7197,51 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
                     : def._size*256/_size );
 
     // weight
+    // Variable fonts with a wght axis that covers the requested weight get a
+    // perfect score (257) — slightly above the 256 cap for a static font match
+    // so they are preferred over synthesis from a static weight.
     int weight_diff = def._weight - _weight;
     if ( weight_diff < 0 )
         weight_diff = -weight_diff;
     if ( weight_diff > 800 )
         weight_diff = 800;
-    int weight_match = (_weight==-1 || def._weight==-1) ?
-                256
-            : ( 256 - weight_diff * 256 / 800 );
-    // It might happen that 2 fonts with different weights can get the same
-    // score, e.g. with def._weight=550, a font with _weight=400 and an other
-    // with _weight=700. Any could then be picked depending on their random
-    // ordering in the cache, which may mess a book on re-openings.
-    // To avoid this inconsistency, we give arbitrarily a small increase to
-    // the score of the smaller weight font (mostly so that with the above
-    // case, we keep synthesizing the 550 from the 400)
-    if ( _weight < def._weight )
-        weight_match += 1;
+    int weight_match;
+    if ( _has_wght_axis && def._weight != -1 && _weight != -1
+            && def._weight >= (int)_wght_axis_min && def._weight <= (int)_wght_axis_max ) {
+        weight_match = 257; // variable font can hit exact requested weight
+    } else {
+        weight_match = (_weight==-1 || def._weight==-1) ?
+                    256
+                : ( 256 - weight_diff * 256 / 800 );
+        // It might happen that 2 fonts with different weights can get the same
+        // score, e.g. with def._weight=550, a font with _weight=400 and an other
+        // with _weight=700. Any could then be picked depending on their random
+        // ordering in the cache, which may mess a book on re-openings.
+        // To avoid this inconsistency, we give arbitrarily a small increase to
+        // the score of the smaller weight font (mostly so that with the above
+        // case, we keep synthesizing the 550 from the 400)
+        if ( _weight < def._weight )
+            weight_match += 1;
+    }
+
+    // variations: registered fonts have an empty _variations array (wildcard).
+    // Instantiated fonts must match the requested variations exactly.
+    // The requested def also has an empty array when no variations were requested,
+    // in which case any instance matches.
+    int variations_match = 256;
+    if (!_variations.empty() && !def._variations.empty()) {
+        // Both have explicit variations — require exact match
+        if (_variations.length() != def._variations.length()) {
+            variations_match = 0;
+        } else {
+            for (int vi = 0; vi < _variations.length(); vi++) {
+                if (!(_variations[vi] == def._variations[vi])) {
+                    variations_match = 0;
+                    break;
+                }
+            }
+        }
+    }
 
     // italic
     int italic_match = (_italic == def._italic || _italic==-1 || def._italic==-1) ?
@@ -7066,12 +7324,13 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
 
     // final score
     int score = bias
-        + (size_match     * 100)
-        + (weight_match   * 5)
-        + (italic_match   * 5)
-        + (features_match * 1000)
-        + (family_match   * 100)
-        + (typeface_match * 10000);
+        + (size_match       * 100)
+        + (weight_match     * 5)
+        + (italic_match     * 5)
+        + (features_match   * 1000)
+        + (variations_match * 1000)
+        + (family_match     * 100)
+        + (typeface_match   * 10000);
 
 //    printf("### %s (%d) vs %s (%d): size=%d weight=%d italic=%d family=%d typeface=%d bias=%d => %d\n",
 //        _typeface.c_str(), _family, def._typeface.c_str(), def._family,

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7363,12 +7363,14 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
 
     // variations: registered fonts have an empty _variations array (wildcard).
     // Instantiated fonts must match the requested variations exactly.
-    // The requested def also has an empty array when no variations were requested,
-    // in which case any instance matches.
+    // If no variations are requested, instances with variations are deprioritised
+    // so the first cache lookup reliably returns the registered font.
     int variations_match = 256;
-    if (!_variations.empty() && !def._variations.empty()) {
-        // Both have explicit variations — require exact match
-        variations_match = (_variations == def._variations) ? 256 : 0;
+    if (!_variations.empty()) {
+        if (def._variations.empty())
+            variations_match = 128; // instance with variations, but none requested: deprioritise
+        else
+            variations_match = (_variations == def._variations) ? 256 : 0;
     }
 
     // italic

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -600,8 +600,13 @@ private:
     bool _has_emojis;
     // Variable font axis values for this instance (empty = default/static)
     LVArray<LVFontVariation> _variations;
-    // All variable font axes supported by this font, detected at registration time
-    LVArray<LVFontAxisInfo> _axes;
+    // The five registered variable-font axes, detected at registration time.
+    // Non-standard axes are not tracked.
+    bool  _has_wght; float _wght_min, _wght_def, _wght_max;
+    bool  _has_opsz; float _opsz_min, _opsz_def, _opsz_max;
+    bool  _has_ital; float _ital_min, _ital_def, _ital_max;
+    bool  _has_slnt; float _slnt_min, _slnt_def, _slnt_max;
+    bool  _has_wdth; float _wdth_min, _wdth_def, _wdth_max;
 public:
     LVFontDef(const lString8 & name, int size, int weight, int italic, int features, css_font_family_t family,
                 const lString8 & typeface, int index=-1, int documentId=-1, LVByteArrayRef buf = LVByteArrayRef())
@@ -619,6 +624,11 @@ public:
         , _real_weight(true)
         , _has_ot_math(false)
         , _has_emojis(false)
+        , _has_wght(false), _wght_min(100.0f), _wght_def(400.0f), _wght_max(900.0f)
+        , _has_opsz(false), _opsz_min(6.0f),   _opsz_def(12.0f),  _opsz_max(72.0f)
+        , _has_ital(false), _ital_min(0.0f),   _ital_def(0.0f),   _ital_max(1.0f)
+        , _has_slnt(false), _slnt_min(-90.0f), _slnt_def(0.0f),   _slnt_max(90.0f)
+        , _has_wdth(false), _wdth_min(50.0f),  _wdth_def(100.0f), _wdth_max(200.0f)
         {
         }
     LVFontDef(const LVFontDef & def)
@@ -637,7 +647,11 @@ public:
         , _has_ot_math(def._has_ot_math)
         , _has_emojis(def._has_emojis)
         , _variations(def._variations)
-        , _axes(def._axes)
+        , _has_wght(def._has_wght), _wght_min(def._wght_min), _wght_def(def._wght_def), _wght_max(def._wght_max)
+        , _has_opsz(def._has_opsz), _opsz_min(def._opsz_min), _opsz_def(def._opsz_def), _opsz_max(def._opsz_max)
+        , _has_ital(def._has_ital), _ital_min(def._ital_min), _ital_def(def._ital_def), _ital_max(def._ital_max)
+        , _has_slnt(def._has_slnt), _slnt_min(def._slnt_min), _slnt_def(def._slnt_def), _slnt_max(def._slnt_max)
+        , _has_wdth(def._has_wdth), _wdth_min(def._wdth_min), _wdth_def(def._wdth_def), _wdth_max(def._wdth_max)
         {
         }
 
@@ -707,33 +721,56 @@ public:
     void setHasEmojis(bool has_emojis) { _has_emojis = has_emojis; }
     const LVArray<LVFontVariation>& getVariations() const { return _variations; }
     void setVariations(const LVArray<LVFontVariation>& v) { _variations = v; }
-    const LVArray<LVFontAxisInfo>& getAxes() const { return _axes; }
-    void setAxes(const LVArray<LVFontAxisInfo>& axes) { _axes = axes; }
-    bool hasAxis(lUInt32 tag) const {
-        for (int i = 0; i < _axes.length(); i++)
-            if (_axes[i].tag == tag) return true;
-        return false;
+    // Store axis info for a single standard axis; non-standard tags are silently ignored.
+    void setAxisInfo(lUInt32 tag, float minVal, float defVal, float maxVal) {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: _has_wght=true; _wght_min=minVal; _wght_def=defVal; _wght_max=maxVal; break;
+            case LVFONT_TAG_OPSZ: _has_opsz=true; _opsz_min=minVal; _opsz_def=defVal; _opsz_max=maxVal; break;
+            case LVFONT_TAG_ITAL: _has_ital=true; _ital_min=minVal; _ital_def=defVal; _ital_max=maxVal; break;
+            case LVFONT_TAG_SLNT: _has_slnt=true; _slnt_min=minVal; _slnt_def=defVal; _slnt_max=maxVal; break;
+            case LVFONT_TAG_WDTH: _has_wdth=true; _wdth_min=minVal; _wdth_def=defVal; _wdth_max=maxVal; break;
+            default: break;
+        }
     }
-    // Returns the min/max for a named axis, or the fallback if not present
+    bool hasAxis(lUInt32 tag) const {
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return _has_wght;
+            case LVFONT_TAG_OPSZ: return _has_opsz;
+            case LVFONT_TAG_ITAL: return _has_ital;
+            case LVFONT_TAG_SLNT: return _has_slnt;
+            case LVFONT_TAG_WDTH: return _has_wdth;
+            default: return false;
+        }
+    }
     float getAxisMin(lUInt32 tag, float fallback = 0.0f) const {
-        for (int i = 0; i < _axes.length(); i++)
-            if (_axes[i].tag == tag) return _axes[i].minValue;
-        return fallback;
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return _has_wght ? _wght_min : fallback;
+            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_min : fallback;
+            case LVFONT_TAG_ITAL: return _has_ital ? _ital_min : fallback;
+            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_min : fallback;
+            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_min : fallback;
+            default: return fallback;
+        }
     }
     float getAxisMax(lUInt32 tag, float fallback = 0.0f) const {
-        for (int i = 0; i < _axes.length(); i++)
-            if (_axes[i].tag == tag) return _axes[i].maxValue;
-        return fallback;
+        switch (tag) {
+            case LVFONT_TAG_WGHT: return _has_wght ? _wght_max : fallback;
+            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_max : fallback;
+            case LVFONT_TAG_ITAL: return _has_ital ? _ital_max : fallback;
+            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_max : fallback;
+            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_max : fallback;
+            default: return fallback;
+        }
     }
-    bool hasWghtAxis() const { return hasAxis(LVFONT_TAG_WGHT); }
-    float getWghtAxisMin() const { return getAxisMin(LVFONT_TAG_WGHT, 400.0f); }
-    float getWghtAxisMax() const { return getAxisMax(LVFONT_TAG_WGHT, 400.0f); }
-    bool hasItalAxis() const { return hasAxis(LVFONT_TAG_ITAL); }
-    float getItalAxisMin() const { return getAxisMin(LVFONT_TAG_ITAL, 0.0f); }
-    float getItalAxisMax() const { return getAxisMax(LVFONT_TAG_ITAL, 1.0f); }
-    bool hasSlntAxis() const { return hasAxis(LVFONT_TAG_SLNT); }
-    float getSlntAxisMin() const { return getAxisMin(LVFONT_TAG_SLNT, 0.0f); }
-    float getSlntAxisMax() const { return getAxisMax(LVFONT_TAG_SLNT, 0.0f); }
+    bool hasWghtAxis() const { return _has_wght; }
+    float getWghtAxisMin() const { return _wght_min; }
+    float getWghtAxisMax() const { return _wght_max; }
+    bool hasItalAxis() const { return _has_ital; }
+    float getItalAxisMin() const { return _ital_min; }
+    float getItalAxisMax() const { return _ital_max; }
+    bool hasSlntAxis() const { return _has_slnt; }
+    float getSlntAxisMin() const { return _slnt_min; }
+    float getSlntAxisMax() const { return _slnt_max; }
     int getDocumentId() const { return _documentId; }
     void setDocumentId(int id) { _documentId = id; }
     LVByteArrayRef getBuf() const { return _buf; }
@@ -6046,26 +6083,23 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        LVFontAxisInfo axinfo;
-                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
-                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
-                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
-                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
-                        axes.add(axinfo);
+                        lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
+                        float   minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        float   defValue = mm_var->axis[ai].def     / 65536.0f;
+                        float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        def2.setAxisInfo(tag, minValue, defValue, maxValue);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
-                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
-                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minValue, defValue, maxValue);
                         }
                     }
-                    def2.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def2.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
@@ -6439,8 +6473,7 @@ public:
             font->setFaceName( item->getDef()->getTypeFace() );
             newDef.setSize( size );
             newDef.setVariations( effectiveVariations );
-            // Copy axis info from the registered def so the instantiated def also exposes it
-            newDef.setAxes(item->getDef()->getAxes());
+            // Axis info was already copied when newDef was constructed from *item->getDef()
             //item->setFont( ref );
             //_cache.update( def, ref );
             // Check whether weight variation handles weight; if not, fall back to synthesis
@@ -6651,26 +6684,23 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        LVFontAxisInfo axinfo;
-                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
-                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
-                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
-                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
-                        axes.add(axinfo);
+                        lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
+                        float   minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        float   defValue = mm_var->axis[ai].def     / 65536.0f;
+                        float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        def.setAxisInfo(tag, minValue, defValue, maxValue);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
-                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
-                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minValue, defValue, maxValue);
                         }
                     }
-                    def.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
@@ -6899,26 +6929,23 @@ public:
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
-                    LVArray<LVFontAxisInfo> axes;
                     char axisBuf[512] = "";
                     int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
-                        LVFontAxisInfo axinfo;
-                        axinfo.tag      = (lUInt32)mm_var->axis[ai].tag;
-                        axinfo.minValue = mm_var->axis[ai].minimum / 65536.0f;
-                        axinfo.defValue = mm_var->axis[ai].def     / 65536.0f;
-                        axinfo.maxValue = mm_var->axis[ai].maximum / 65536.0f;
-                        axes.add(axinfo);
+                        lUInt32 tag      = (lUInt32)mm_var->axis[ai].tag;
+                        float   minValue = mm_var->axis[ai].minimum / 65536.0f;
+                        float   defValue = mm_var->axis[ai].def     / 65536.0f;
+                        float   maxValue = mm_var->axis[ai].maximum / 65536.0f;
+                        def.setAxisInfo(tag, minValue, defValue, maxValue);
                         if (axisBufPos < (int)sizeof(axisBuf) - 40) {
                             axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
                                                    "%s%c%c%c%c [%.0f..%.0f..%.0f]",
                                                    ai ? ", " : "",
-                                                   (char)((axinfo.tag >> 24) & 0xFF), (char)((axinfo.tag >> 16) & 0xFF),
-                                                   (char)((axinfo.tag >>  8) & 0xFF), (char)(axinfo.tag & 0xFF),
-                                                   axinfo.minValue, axinfo.defValue, axinfo.maxValue);
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minValue, defValue, maxValue);
                         }
                     }
-                    def.setAxes(axes);
                     CRLog::info("Variable font found: \"%s\"  axes: %s",
                         def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6219,14 +6219,15 @@ public:
         // of using FT_Outline_Embolden synthesis.
         if (item->getDef()->hasWghtAxis() && !effectiveVariations.wght_set) {
             effectiveVariations.set(LVFONT_TAG_WGHT, (float)weight);
-            static lString8 s_last_tf; static int s_last_sz = -1, s_last_wt = -1;
-            if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
 #ifdef DEBUG_VAR_FONT
+            static lString8 s_last_tf;
+            static int s_last_sz = -1, s_last_wt = -1;
+            if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
                 CRLog::info("Variable font GetFont: injecting wght=%.0f for \"%s\" size=%d",
                     (float)weight, typeface.c_str(), size);
-#endif
                 s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
             }
+#endif
             def.setVariations(effectiveVariations);
             LVFontCacheItem * item2 = _cache.find(&def, useBias);
             if (item2 != NULL && !item2->getFont().isNull()
@@ -6238,14 +6239,15 @@ public:
         if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis()
                 && !effectiveVariations.ital_set) {
             effectiveVariations.set(LVFONT_TAG_ITAL, 1.0f);
-            static lString8 s_last_tf_ital; static int s_last_sz_ital = -1;
-            if (typeface != s_last_tf_ital || size != s_last_sz_ital) {
 #ifdef DEBUG_VAR_FONT
+            static lString8 s_last_tf_ital;
+            static int s_last_sz_ital = -1;
+            if (typeface != s_last_tf_ital || size != s_last_sz_ital) {
                 CRLog::info("Variable font GetFont: injecting ital=1 for \"%s\" size=%d",
                     typeface.c_str(), size);
-#endif  
                 s_last_tf_ital = typeface; s_last_sz_ital = size;
             }
+#endif  
             def.setVariations(effectiveVariations);
             LVFontCacheItem * item3 = _cache.find(&def, useBias);
             if (item3 != NULL && !item3->getFont().isNull()
@@ -6285,7 +6287,6 @@ public:
                 // Variations mismatch: ignore this cached instance
             }
             else {
-                {
             #ifdef USE_FT_EMBOLDEN
                 int deltaWeight = myabs(weight - item->getDef()->getWeight());
                 if (deltaWeight >= 25 && !item->getDef()->hasWghtAxis()) {
@@ -6310,7 +6311,6 @@ public:
                 else {
                     //fprintf(_log, "    : fount existing\n");
                     return item->getFont();
-                }
                 }
             }
         }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6162,6 +6162,29 @@ public:
             }
         }
 
+        // Sync def with the stripped set. The first _cache.find used the unstripped
+        // variations; now that we know which axes are supported, update def so any
+        // subsequent lookup uses the correct (shorter) key.
+        def.setVariations(effectiveVariations);
+
+        // Check whether an already-instantiated font with these exact stripped
+        // variations exists. With def now matching the stripped key, find() will
+        // prefer the instance over the registered entry on a tie (>= comparison).
+        if (!effectiveVariations.empty()) {
+            LVFontCacheItem * strippedItem = _cache.find(&def, useBias);
+            if (strippedItem != NULL && !strippedItem->getFont().isNull()
+                    && strippedItem->getDef()->getFeatures() == features) {
+                const LVArray<LVFontVariation>& sv = strippedItem->getDef()->getVariations();
+                if (sv.length() == effectiveVariations.length()) {
+                    bool varMatch = true;
+                    for (int vi = 0; vi < effectiveVariations.length(); vi++)
+                        if (!(sv[vi] == effectiveVariations[vi])) { varMatch = false; break; }
+                    if (varMatch)
+                        return strippedItem->getFont();
+                }
+            }
+        }
+
         // If the best-matched font has a wght axis and no explicit wght variation was
         // supplied, inject one so the face is set to exactly the requested weight instead
         // of using FT_Outline_Embolden synthesis.

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1974,6 +1974,18 @@ public:
     }
     void setVariations( const LVArray<LVFontVariation>& variations ) {
         _variations = variations;
+        _hash = 0; // force calcHash(font_ref_t) to recompute
+    }
+    virtual lUInt32 getVariationHash() const {
+        lUInt32 h = 0;
+        for (int i = 0; i < _variations.length(); i++) {
+            h = h * 31 + _variations[i].tag;
+            lUInt32 vbits;
+            float fval = _variations[i].value;
+            memcpy(&vbits, &fval, sizeof(vbits));
+            h = h * 31 + vbits;
+        }
+        return h;
     }
 
     virtual void setKerningMode( kerning_mode_t kerningMode ) {
@@ -6162,7 +6174,7 @@ public:
             effectiveVariations.add(wghtVar);
             static lString8 s_last_tf; static int s_last_sz = -1, s_last_wt = -1;
             if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
-                CRLog::info("Variable font GetFont: injecting wght=%.0f for %s size=%d",
+                CRLog::info("Variable font GetFont: injecting wght=%.0f for \"%s\" size=%d",
                     (float)weight, typeface.c_str(), size);
                 s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
             }
@@ -8486,6 +8498,7 @@ bool operator == (const LVFont & r1, const LVFont & r2)
             && r1.getTypeFace() == r2.getTypeFace()
             && r1.getKerningMode() == r2.getKerningMode()
             && r1.getHintingMode() == r2.getHintingMode()
+            && r1.getVariationHash() == r2.getVariationHash()
             ;
 }
 

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -735,26 +735,6 @@ public:
             default: return false;
         }
     }
-    float getAxisMin(lUInt32 tag, float fallback = 0.0f) const {
-        switch (tag) {
-            case LVFONT_TAG_WGHT: return _has_wght ? _wght_min : fallback;
-            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_min : fallback;
-            case LVFONT_TAG_ITAL: return _has_ital ? _ital_min : fallback;
-            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_min : fallback;
-            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_min : fallback;
-            default: return fallback;
-        }
-    }
-    float getAxisMax(lUInt32 tag, float fallback = 0.0f) const {
-        switch (tag) {
-            case LVFONT_TAG_WGHT: return _has_wght ? _wght_max : fallback;
-            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_max : fallback;
-            case LVFONT_TAG_ITAL: return _has_ital ? _ital_max : fallback;
-            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_max : fallback;
-            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_max : fallback;
-            default: return fallback;
-        }
-    }
     bool hasWghtAxis() const { return _has_wght; }
     float getWghtAxisMin() const { return _wght_min; }
     float getWghtAxisMax() const { return _wght_max; }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6139,6 +6139,18 @@ public:
             return LVFontRef(NULL);
         }
 
+        // Strip variations for axes the matched font doesn't actually have, so they don't
+        // pollute the cache key (FreeType ignores them silently, but different values would
+        // create redundant cache entries with identical rendering output).
+        if (!effectiveVariations.empty()) {
+            for (int vi = effectiveVariations.length() - 1; vi >= 0; vi--) {
+                lUInt32 tag = effectiveVariations[vi].tag;
+                if ((tag == LVFONT_TAG_OPSZ && !item->getDef()->hasOpszAxis()) ||
+                    (tag == LVFONT_TAG_WGHT && !item->getDef()->hasWghtAxis()))
+                    effectiveVariations.remove(vi);
+            }
+        }
+
         // If the best-matched font has a wght axis and no explicit wght variation was
         // supplied, inject one so the face is set to exactly the requested weight instead
         // of using FT_Outline_Embolden synthesis.

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -2159,9 +2159,6 @@ public:
             _face_size );  /* pixel_height          */
 
         // Apply variable font axis coordinates (wght, opsz, ...) if any were requested
-        if (!_variations.empty())
-            CRLog::info("Variable font setupFace: %s variations=%d ft_error=%d",
-                _fileName.c_str(), _variations.length(), error);
         if (!_variations.empty() && FT_Err_Ok == error) {
             FT_MM_Var* mm_var = NULL;
             if (FT_Get_MM_Var(_face, &mm_var) == FT_Err_Ok && mm_var) {
@@ -6032,18 +6029,27 @@ public:
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
                     bool hasWght = false, hasOpsz = false;
                     float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    char axisBuf[512] = "";
+                    int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
                         float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float defVal = mm_var->axis[ai].def     / 65536.0f;
                         float maxVal = mm_var->axis[ai].maximum / 65536.0f;
                         if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
                         if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        if (axisBufPos < (int)sizeof(axisBuf) - 40) {
+                            axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
+                                                   "%s%c%c%c%c [%.0f..%.0f..%.0f]",
+                                                   ai ? ", " : "",
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minVal, defVal, maxVal);
+                        }
                     }
                     def2.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
-                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
-                        def2.getName().c_str(),
-                        hasWght ? "yes" : "no", wMin, wMax,
-                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    CRLog::info("Variable font found: \"%s\"  axes: %s",
+                        def2.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }
@@ -6142,8 +6148,12 @@ public:
         if (item->getDef()->hasWghtAxis() && !hasExplicitWght) {
             LVFontVariation wghtVar; wghtVar.tag = LVFONT_TAG_WGHT; wghtVar.value = (float)weight;
             effectiveVariations.add(wghtVar);
-            CRLog::info("Variable font GetFont: injecting wght=%.0f for %s size=%d",
-                (float)weight, typeface.c_str(), size);
+            static lString8 s_last_tf; static int s_last_sz = -1, s_last_wt = -1;
+            if (typeface != s_last_tf || size != s_last_sz || weight != s_last_wt) {
+                CRLog::info("Variable font GetFont: injecting wght=%.0f for %s size=%d",
+                    (float)weight, typeface.c_str(), size);
+                s_last_tf = typeface; s_last_sz = size; s_last_wt = weight;
+            }
             // Redo cache lookup with the fully-resolved variation set so we can
             // find any already-instantiated variable font instance.
             def.setVariations(effectiveVariations);
@@ -6252,6 +6262,21 @@ public:
         }
         // Set variations before loadFromFile so that setupFace() can apply them
         font->setVariations(effectiveVariations);
+        if (!effectiveVariations.empty()) {
+            char varBuf[256] = "";
+            int varBufPos = 0;
+            for (int vi = 0; vi < effectiveVariations.length() && varBufPos < (int)sizeof(varBuf) - 20; vi++) {
+                lUInt32 t = effectiveVariations[vi].tag;
+                varBufPos += snprintf(varBuf + varBufPos, sizeof(varBuf) - varBufPos,
+                                      "%s%c%c%c%c=%.1f",
+                                      vi ? ", " : "",
+                                      (char)((t >> 24) & 0xFF), (char)((t >> 16) & 0xFF),
+                                      (char)((t >>  8) & 0xFF), (char)(t & 0xFF),
+                                      effectiveVariations[vi].value);
+            }
+            CRLog::info("Variable font new instance: \"%s\" size=%d  [%s]",
+                item->getDef()->getTypeFace().c_str(), size, varBuf);
+        }
         if (item->getDef()->getBuf().isNull())
             loaded = font->loadFromFile( pathname.c_str(), item->getDef()->getIndex(), size, family, isBitmapModeForSize(size), italicize, item->getDef()->getWeight(), face_size );
         else
@@ -6484,18 +6509,27 @@ public:
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
                     bool hasWght = false, hasOpsz = false;
                     float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    char axisBuf[512] = "";
+                    int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
                         float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float defVal = mm_var->axis[ai].def     / 65536.0f;
                         float maxVal = mm_var->axis[ai].maximum / 65536.0f;
                         if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
                         if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        if (axisBufPos < (int)sizeof(axisBuf) - 40) {
+                            axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
+                                                   "%s%c%c%c%c [%.0f..%.0f..%.0f]",
+                                                   ai ? ", " : "",
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minVal, defVal, maxVal);
+                        }
                     }
                     def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
-                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
-                        def.getName().c_str(),
-                        hasWght ? "yes" : "no", wMin, wMax,
-                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    CRLog::info("Variable font found: \"%s\"  axes: %s",
+                        def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }
@@ -6724,18 +6758,27 @@ public:
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
                     bool hasWght = false, hasOpsz = false;
                     float wMin = 400.0f, wMax = 400.0f, oMin = 12.0f, oMax = 12.0f;
+                    char axisBuf[512] = "";
+                    int axisBufPos = 0;
                     for (FT_UInt ai = 0; ai < mm_var->num_axis; ai++) {
                         lUInt32 tag = (lUInt32)mm_var->axis[ai].tag;
                         float minVal = mm_var->axis[ai].minimum / 65536.0f;
+                        float defVal = mm_var->axis[ai].def     / 65536.0f;
                         float maxVal = mm_var->axis[ai].maximum / 65536.0f;
                         if (tag == LVFONT_TAG_WGHT) { hasWght = true; wMin = minVal; wMax = maxVal; }
                         if (tag == LVFONT_TAG_OPSZ) { hasOpsz = true; oMin = minVal; oMax = maxVal; }
+                        if (axisBufPos < (int)sizeof(axisBuf) - 40) {
+                            axisBufPos += snprintf(axisBuf + axisBufPos, sizeof(axisBuf) - axisBufPos,
+                                                   "%s%c%c%c%c [%.0f..%.0f..%.0f]",
+                                                   ai ? ", " : "",
+                                                   (char)((tag >> 24) & 0xFF), (char)((tag >> 16) & 0xFF),
+                                                   (char)((tag >>  8) & 0xFF), (char)(tag & 0xFF),
+                                                   minVal, defVal, maxVal);
+                        }
                     }
                     def.setAxisInfo(hasWght, wMin, wMax, hasOpsz, oMin, oMax);
-                    CRLog::info("Variable font registered: %s  wght=%s [%.0f..%.0f]  opsz=%s [%.0f..%.0f]",
-                        def.getName().c_str(),
-                        hasWght ? "yes" : "no", wMin, wMax,
-                        hasOpsz ? "yes" : "no", oMin, oMax);
+                    CRLog::info("Variable font found: \"%s\"  axes: %s",
+                        def.getName().c_str(), axisBuf);
                     FT_DONE_MM_VAR(_library, mm_var);
                 }
             }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6343,7 +6343,8 @@ public:
         //    pathname = lString8("arial.ttf");
         //}
 
-        if ( !item->getDef()->isRealItalic() && italic ) {
+        if ( !item->getDef()->isRealItalic() && italic
+                && !effectiveVariations.ital_set && !effectiveVariations.slnt_set ) {
             //CRLog::debug("font: fake italic");
             newDef.setItalic(2);
             italicize = true;
@@ -6400,6 +6401,12 @@ public:
             font->setFaceName( item->getDef()->getTypeFace() );
             newDef.setSize( size );
             newDef.setVariations( effectiveVariations );
+            // Reflect the effective italic state in newDef so CalcMatch can score it
+            // correctly without peeking into variations.
+            if (effectiveVariations.ital_set && effectiveVariations.ital == 1.0f)
+                newDef.setItalic(1); // ital axis: real italic design
+            else if (effectiveVariations.slnt_set && effectiveVariations.slnt != 0.0f)
+                newDef.setItalic(2); // slnt axis: synthesised italic
             // Axis info was already copied when newDef was constructed from *item->getDef()
             //item->setFont( ref );
             //_cache.update( def, ref );
@@ -7388,17 +7395,10 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
             variations_match = (_variations == def._variations) ? 256 : 0;
     }
 
-    // italic
+    // italic: _italic is set correctly on both registered and instantiated entries
+    // (instantiated ital/slnt axis fonts have _italic set at cache time, not inferred here)
     int this_italic = _italic;
-    if (_italic == 0) {
-        if (_variations.ital_set && _variations.ital == 1.0f)       this_italic = 1;
-        else if (_variations.slnt_set && _variations.slnt != 0.0f)  this_italic = 2;
-    }
     int def_italic = def._italic;
-    if (def._italic == 0) {
-        if (def._variations.ital_set && def._variations.ital == 1.0f)      def_italic = 1;
-        else if (def._variations.slnt_set && def._variations.slnt != 0.0f) def_italic = 2;
-    }
     int italic_match = (this_italic == def_italic || this_italic==-1 || def_italic==-1) ?
               256
             :   0;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7374,14 +7374,17 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
             weight_match += 1;
     }
 
-    // variations: registered fonts always have empty _variations and therefore
-    // match any variation request. Instantiated fonts must match exactly.
-    // If no variations are requested, an instantiated font with variations is
-    // deprioritised so the registered font is always preferred on the initial
-    // lookup — GetFont() needs that registered entry to inspect the font's axes
-    // and decide which variations to inject before instantiating.
+    // variations scoring covers three cases for 'this':
+    // - Registered fonts always have empty _variations and score 256, matching any request.
+    // - Instantiated non-variable fonts also have empty _variations (no axes were injected)
+    //   and score 256 too; they are distinguished from registered fonts by size, weight,
+    //   features, etc., not by variations.
+    // - Instantiated variable fonts have non-empty _variations:
+    //   if no variations are requested, they are deprioritised (128) so the registered font
+    //   wins the initial lookup — GetFont() needs that entry to inspect axes and decide which
+    //   variations to inject; if variations are requested, they must match exactly (256 or 0).
     int variations_match = 256; // registered fonts (empty _variations) always score 256
-    if (!_variations.empty()) { // 'this' is an instantiated font
+    if (!_variations.empty()) { // 'this' is an instantiated variable font
         if (def._variations.empty())
             variations_match = 128; // none requested: deprioritise so registered font wins
         else

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -737,26 +737,6 @@ public:
             default: return false;
         }
     }
-    float getAxisMin(lUInt32 tag, float fallback = 0.0f) const {
-        switch (tag) {
-            case LVFONT_TAG_WGHT: return _has_wght ? _wght_min : fallback;
-            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_min : fallback;
-            case LVFONT_TAG_ITAL: return _has_ital ? _ital_min : fallback;
-            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_min : fallback;
-            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_min : fallback;
-            default: return fallback;
-        }
-    }
-    float getAxisMax(lUInt32 tag, float fallback = 0.0f) const {
-        switch (tag) {
-            case LVFONT_TAG_WGHT: return _has_wght ? _wght_max : fallback;
-            case LVFONT_TAG_OPSZ: return _has_opsz ? _opsz_max : fallback;
-            case LVFONT_TAG_ITAL: return _has_ital ? _ital_max : fallback;
-            case LVFONT_TAG_SLNT: return _has_slnt ? _slnt_max : fallback;
-            case LVFONT_TAG_WDTH: return _has_wdth ? _wdth_max : fallback;
-            default: return fallback;
-        }
-    }
     bool hasWghtAxis() const { return _has_wght; }
     float getWghtAxisMin() const { return _wght_min; }
     float getWghtAxisMax() const { return _wght_max; }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -627,11 +627,13 @@ public:
         , _real_weight(true)
         , _has_ot_math(false)
         , _has_emojis(false)
-        , _has_wght(false), _wght_min(100.0f), _wght_def(400.0f), _wght_max(900.0f)
-        , _has_opsz(false), _opsz_min(6.0f),   _opsz_def(12.0f),  _opsz_max(72.0f)
-        , _has_ital(false), _ital_min(0.0f),   _ital_def(0.0f),   _ital_max(1.0f)
-        , _has_slnt(false), _slnt_min(-90.0f), _slnt_def(0.0f),   _slnt_max(90.0f)
-        , _has_wdth(false), _wdth_min(50.0f),  _wdth_def(100.0f), _wdth_max(200.0f)
+        // Variable font axes are all unset by default, and their min/def/max values are 0 until registration time,
+        // when they will be updated if the font is a variable font and has these registered axes.
+        , _has_wght(false), _wght_min(0.0f), _wght_def(0.0f), _wght_max(0.0f)  // Weight in CSS weight values (100-900)
+        , _has_opsz(false), _opsz_min(0.0f), _opsz_def(0.0f), _opsz_max(0.0f)  // Optical size in pt
+        , _has_ital(false), _ital_min(0.0f), _ital_def(0.0f), _ital_max(0.0f)  // Flag - 0.0 indicates non-italic, 0.0 italic
+        , _has_slnt(false), _slnt_min(0.0f), _slnt_def(0.0f), _slnt_max(0.0f)  // Slant in degrees, with negative values for italic slant
+        , _has_wdth(false), _wdth_min(0.0f), _wdth_def(0.0f), _wdth_max(0.0f)  // Width in CSS percentage values (50-200, with 100 as normal width)
         {
         }
     LVFontDef(const LVFontDef & def)

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7374,10 +7374,10 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
     // deprioritised so the registered font is always preferred on the initial
     // lookup — GetFont() needs that registered entry to inspect the font's axes
     // and decide which variations to inject before instantiating.
-    int variations_match = 256;
-    if (!_variations.empty()) {
+    int variations_match = 256; // registered fonts (empty _variations) always score 256
+    if (!_variations.empty()) { // 'this' is an instantiated font
         if (def._variations.empty())
-            variations_match = 128; // instance with variations, but none requested: deprioritise
+            variations_match = 128; // none requested: deprioritise so registered font wins
         else
             variations_match = (_variations == def._variations) ? 256 : 0;
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6228,10 +6228,9 @@ public:
             }
         }
 
-        // (2) If the best-matched font has a wght axis and no explicit wght variation was
-        // supplied, inject one so the face is set to exactly the requested weight instead
-        // of using FT_Outline_Embolden synthesis.
-        if (item->getDef()->hasWghtAxis() && !effectiveVariations.wght_set) {
+        // (2) If the best-matched font has a wght axis, inject wght set to the requested
+        // weight so the face renders at exactly that weight instead of using synthesis.
+        if (item->getDef()->hasWghtAxis()) {
             effectiveVariations.set(LVFONT_TAG_WGHT, (float)weight);
 #ifdef DEBUG_VAR_FONT
             static lString8 s_last_tf;
@@ -6251,8 +6250,7 @@ public:
         }
 
         // (3) If italic was requested but the font has no italic face, inject ital or slnt.
-        if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis()
-                && !effectiveVariations.ital_set) {
+        if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis()) {
             effectiveVariations.set(LVFONT_TAG_ITAL, 1.0f);
 #ifdef DEBUG_VAR_FONT
             static lString8 s_last_tf_ital;
@@ -6269,8 +6267,7 @@ public:
                     && item3->getDef()->getFeatures() == features
                     && item3->getDef()->getVariations() == effectiveVariations)
                 return item3->getFont();
-        } else if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasSlntAxis()
-                   && !effectiveVariations.slnt_set) {
+        } else if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasSlntAxis()) {
             effectiveVariations.set(LVFONT_TAG_SLNT, -12.0f);
             static lString8 s_last_tf_slnt; static int s_last_sz_slnt = -1;
             if (typeface != s_last_tf_slnt || size != s_last_sz_slnt) {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7378,6 +7378,22 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
             weight_match += 1;
     }
 
+    // italic: _italic is set correctly on both registered and instantiated entries
+    // (instantiated ital/slnt axis fonts have _italic set at cache time, not inferred here)
+    int this_italic = _italic;
+    int def_italic = def._italic;
+    int italic_match = (this_italic == def_italic || this_italic==-1 || def_italic==-1) ?
+              256
+            :   0;
+    // lower the score if any is fake italic
+    if ( (this_italic==2 || def_italic==2) && this_italic>0 && def_italic>0 )
+        italic_match = 128;
+
+    // OpenType features
+    int features_match = (_features == def._features || _features==-1 || def._features==-1) ?
+              256
+            :   0;
+
     // variations scoring covers three cases for 'this':
     // - Registered fonts always have empty _variations and score 256, matching any request.
     // - Instantiated non-variable fonts also have empty _variations (no axes were injected)
@@ -7394,22 +7410,6 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
         else
             variations_match = (_variations == def._variations) ? 256 : 0;
     }
-
-    // italic: _italic is set correctly on both registered and instantiated entries
-    // (instantiated ital/slnt axis fonts have _italic set at cache time, not inferred here)
-    int this_italic = _italic;
-    int def_italic = def._italic;
-    int italic_match = (this_italic == def_italic || this_italic==-1 || def_italic==-1) ?
-              256
-            :   0;
-    // lower the score if any is fake italic
-    if ( (this_italic==2 || def_italic==2) && this_italic>0 && def_italic>0 )
-        italic_match = 128;
-
-    // OpenType features
-    int features_match = (_features == def._features || _features==-1 || def._features==-1) ?
-              256
-            :   0;
 
     // family
     int family_match = (_family==css_ff_inherit || def._family==css_ff_inherit || def._family == _family) ?

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6194,7 +6194,14 @@ public:
         // Sync def with the stripped set for all subsequent lookups.
         def.setVariations(effectiveVariations);
 
-        // Check whether an already-instantiated font with these exact stripped
+        // The three blocks below are independent of each other:
+        // (1) is gated on effectiveVariations being non-empty — it returns early if an
+        //     exact cached instance already exists for the stripped variation set.
+        // (2) and (3) inject wght/ital/slnt based on what axes the matched font exposes,
+        //     and can fire even when effectiveVariations is empty after stripping above
+        //     (e.g. a variable font with only a wght axis and optical sizing disabled).
+
+        // (1) Check whether an already-instantiated font with these exact stripped
         // variations exists. With def now matching the stripped key, find() will
         // prefer the instance over the registered entry on a tie (>= comparison).
         if (!effectiveVariations.empty()) {
@@ -6215,7 +6222,7 @@ public:
             }
         }
 
-        // If the best-matched font has a wght axis and no explicit wght variation was
+        // (2) If the best-matched font has a wght axis and no explicit wght variation was
         // supplied, inject one so the face is set to exactly the requested weight instead
         // of using FT_Outline_Embolden synthesis.
         if (item->getDef()->hasWghtAxis() && !effectiveVariations.wght_set) {
@@ -6237,6 +6244,7 @@ public:
                 return item2->getFont();
         }
 
+        // (3) If italic was requested but the font has no italic face, inject ital or slnt.
         if (italic && item->getDef()->getItalic() == 0 && item->getDef()->hasItalAxis()
                 && !effectiveVariations.ital_set) {
             effectiveVariations.set(LVFONT_TAG_ITAL, 1.0f);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7368,10 +7368,12 @@ int LVFontDef::CalcMatch( const LVFontDef & def, bool useBias ) const
             weight_match += 1;
     }
 
-    // variations: registered fonts have an empty _variations array (wildcard).
-    // Instantiated fonts must match the requested variations exactly.
-    // If no variations are requested, instances with variations are deprioritised
-    // so the first cache lookup reliably returns the registered font.
+    // variations: registered fonts always have empty _variations and therefore
+    // match any variation request. Instantiated fonts must match exactly.
+    // If no variations are requested, an instantiated font with variations is
+    // deprioritised so the registered font is always preferred on the initial
+    // lookup — GetFont() needs that registered entry to inspect the font's axes
+    // and decide which variations to inject before instantiating.
     int variations_match = 256;
     if (!_variations.empty()) {
         if (def._variations.empty())

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6067,7 +6067,6 @@ public:
                 hb_face_destroy(hb_face);
             #endif
 
-            // Detect variable font axes (wght, opsz) for smarter weight matching
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
@@ -6595,7 +6594,6 @@ public:
                     def.setHasOTMath(true);
                 hb_face_destroy(hb_face);
             #endif
-            // Detect variable font axes for smarter weight matching
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {
@@ -6846,7 +6844,6 @@ public:
                     def.setHasOTMath(true);
                 hb_face_destroy(hb_face);
             #endif
-            // Detect variable font axes (wght, opsz) for smarter weight matching
             {
                 FT_MM_Var* mm_var = NULL;
                 if (FT_Get_MM_Var(face, &mm_var) == FT_Err_Ok && mm_var) {

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -663,8 +663,6 @@ public:
     /// returns true if definitions are equal
     bool operator == ( const LVFontDef & def ) const
     {
-        if (_variations != def._variations)
-            return false;
         return ( _size == def._size || _size == -1 || def._size == -1 )
             && ( _weight == def._weight || _weight==-1 || def._weight==-1 )
             && ( _italic == def._italic || _italic==-1 || def._italic==-1 )
@@ -676,6 +674,8 @@ public:
             && ( _index == def._index || def._index == -1 )
             && (_documentId == def._documentId || _documentId == -1)
             ;
+        if (_variations != def._variations)
+            return false;
     }
 
     lUInt32 getHash() const {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2428,11 +2428,9 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = 1;
     else if ( fw>999 )
         fw = 999;
-    // Build variation set from CSS font-variation-settings and auto optical sizing
-    LVFontVariations variations = style->font_variations;
-
-    // Auto optical sizing: inject opsz unless disabled or already explicitly set
-    if (!variations.opsz_set && style->font_optical_sizing != css_fos_none && gRenderDPI >= 100) {
+    // Auto optical sizing: inject opsz from font-size in typographic points
+    LVFontVariations variations;
+    if (gRenderDPI >= 100) {
         // Convert sz (screen pixels) to typographic points.
         // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
         // Lua side, so gRenderDPI is the correct divisor.
@@ -11373,15 +11371,6 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     case css_fw_900:
         break;
     }
-
-    // font-optical-sizing (inherited; initial = auto)
-    if (pstyle->font_optical_sizing == css_fos_inherit)
-        pstyle->font_optical_sizing = parent_style->font_optical_sizing;
-
-    // font-variation-settings (inherited; initial = empty)
-    // If child has no explicit setting, inherit parent's variations
-    if (pstyle->font_variations.empty() && !parent_style->font_variations.empty())
-        pstyle->font_variations = parent_style->font_variations;
 
     // font-size
     switch( pstyle->font_size.type )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2428,9 +2428,9 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = 1;
     else if ( fw>999 )
         fw = 999;
-    // Auto optical sizing: inject opsz from font-size in typographic points
+    // Auto optical sizing: inject opsz unless disabled or already handled by wght axis
     LVFontVariations variations;
-    if (gRenderDPI >= 100) {
+    if (style->font_optical_sizing != css_fos_none && gRenderDPI >= 100) {
         // Convert sz (screen pixels) to typographic points.
         // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
         // Lua side, so gRenderDPI is the correct divisor.
@@ -11371,6 +11371,10 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     case css_fw_900:
         break;
     }
+
+    // font-optical-sizing (inherited; initial = auto)
+    if (pstyle->font_optical_sizing == css_fos_inherit)
+        pstyle->font_optical_sizing = parent_style->font_optical_sizing;
 
     // font-size
     switch( pstyle->font_size.type )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2428,25 +2428,15 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = 1;
     else if ( fw>999 )
         fw = 999;
-    // Build variation axes list from CSS font-variation-settings and auto optical sizing
-    LVArray<LVFontVariation> variations;
-    if (!style->font_variations.empty())
-        variations = style->font_variations;
+    // Build variation set from CSS font-variation-settings and auto optical sizing
+    LVFontVariations variations = style->font_variations;
 
     // Auto optical sizing: inject opsz unless disabled or already explicitly set
-    bool hasExplicitOpsz = false;
-    for (int vi = 0; vi < variations.length(); vi++)
-        if (variations[vi].tag == LVFONT_TAG_OPSZ) { hasExplicitOpsz = true; break; }
-    // Only apply auto optical sizing if the user has explicitly set a screen DPI
-    if (!hasExplicitOpsz && style->font_optical_sizing != css_fos_none && gRenderDPI > 100) {
+    if (!variations.opsz_set && style->font_optical_sizing != css_fos_none && gRenderDPI >= 100) {
         // Convert sz (screen pixels) to typographic points.
         // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
         // Lua side, so gRenderDPI is the correct divisor.
-        float opsz = sz * 72.0f / (float)gRenderDPI;
-        LVFontVariation opszVar;
-        opszVar.tag = LVFONT_TAG_OPSZ;
-        opszVar.value = opsz;
-        variations.add(opszVar);
+        variations.set(LVFONT_TAG_OPSZ, sz * 72.0f / (float)gRenderDPI);
     }
 
     // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2437,13 +2437,12 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
     bool hasExplicitOpsz = false;
     for (int vi = 0; vi < variations.length(); vi++)
         if (variations[vi].tag == LVFONT_TAG_OPSZ) { hasExplicitOpsz = true; break; }
-    if (!hasExplicitOpsz && style->font_optical_sizing != css_fos_none) {
+    // Only apply auto optical sizing if the user has explicitly set a screen DPI
+    if (!hasExplicitOpsz && style->font_optical_sizing != css_fos_none && gRenderDPI > 100) {
         // Convert sz (screen pixels) to typographic points.
         // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
-        // Lua side, so gRenderDPI is the correct divisor. Fall back to 96 only when
-        // gRenderDPI is 0 (the legacy "off" mode where no DPI scaling is applied at all).
-        int opszDPI = (gRenderDPI > 0) ? gRenderDPI : 96;
-        float opsz = sz * 72.0f / (float)opszDPI;
+        // Lua side, so gRenderDPI is the correct divisor.
+        float opsz = sz * 72.0f / (float)gRenderDPI;
         LVFontVariation opszVar;
         opszVar.tag = LVFONT_TAG_OPSZ;
         opszVar.value = opsz;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2444,12 +2444,6 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         // gRenderDPI is 0 (the legacy "off" mode where no DPI scaling is applied at all).
         int opszDPI = (gRenderDPI > 0) ? gRenderDPI : 96;
         float opsz = sz * 72.0f / (float)opszDPI;
-        static int s_last_sz = -1, s_last_dpi = -1;
-        if (sz != s_last_sz || opszDPI != s_last_dpi) {
-            CRLog::info("opsz auto: sz=%dpx / %ddpi * 72 = %.1fpt  (type=%d scaleFontWithDPI=%d gRenderDPI=%d)",
-                sz, opszDPI, opsz, (int)style->font_size.type, (int)gRenderScaleFontWithDPI, gRenderDPI);
-            s_last_sz = sz; s_last_dpi = opszDPI;
-        }
         LVFontVariation opszVar;
         opszVar.tag = LVFONT_TAG_OPSZ;
         opszVar.value = opsz;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2428,6 +2428,24 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = 1;
     else if ( fw>999 )
         fw = 999;
+    // Build variation axes list from CSS font-variation-settings and auto optical sizing
+    LVArray<LVFontVariation> variations;
+    if (!style->font_variations.empty())
+        variations = style->font_variations;
+
+    // Auto optical sizing: inject opsz unless disabled or already explicitly set
+    bool hasExplicitOpsz = false;
+    for (int vi = 0; vi < variations.length(); vi++)
+        if (variations[vi].tag == LVFONT_TAG_OPSZ) { hasExplicitOpsz = true; break; }
+    if (!hasExplicitOpsz && style->font_optical_sizing != css_fos_none) {
+        // Convert screen pixels to typographic points using the actual render DPI
+        float opsz = (gRenderDPI > 0) ? sz * 72.0f / (float)gRenderDPI : sz * 72.0f / 96.0f;
+        LVFontVariation opszVar;
+        opszVar.tag = LVFONT_TAG_OPSZ;
+        opszVar.value = opsz;
+        variations.add(opszVar);
+    }
+
     // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());
     LVFontRef fnt = fontMan->GetFont(
         sz,
@@ -2436,7 +2454,8 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         style->font_family,
         lString8(style->font_name.c_str()),
         style->font_features.value, // (.type is always css_val_unspecified after setNodeStyle())
-        documentId, true); // useBias=true, so that our preferred font gets used
+        documentId, true, // useBias=true, so that our preferred font gets used
+        variations.empty() ? NULL : &variations);
     //fnt = LVCreateFontTransform( fnt, LVFONT_TRANSFORM_EMBOLDEN );
     return fnt;
 }
@@ -11361,6 +11380,15 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     case css_fw_900:
         break;
     }
+
+    // font-optical-sizing (inherited; initial = auto)
+    if (pstyle->font_optical_sizing == css_fos_inherit)
+        pstyle->font_optical_sizing = parent_style->font_optical_sizing;
+
+    // font-variation-settings (inherited; initial = empty)
+    // If child has no explicit setting, inherit parent's variations
+    if (pstyle->font_variations.empty() && !parent_style->font_variations.empty())
+        pstyle->font_variations = parent_style->font_variations;
 
     // font-size
     switch( pstyle->font_size.type )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2438,8 +2438,18 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
     for (int vi = 0; vi < variations.length(); vi++)
         if (variations[vi].tag == LVFONT_TAG_OPSZ) { hasExplicitOpsz = true; break; }
     if (!hasExplicitOpsz && style->font_optical_sizing != css_fos_none) {
-        // Convert screen pixels to typographic points using the actual render DPI
-        float opsz = (gRenderDPI > 0) ? sz * 72.0f / (float)gRenderDPI : sz * 72.0f / 96.0f;
+        // Convert sz (screen pixels) to typographic points.
+        // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
+        // Lua side, so gRenderDPI is the correct divisor. Fall back to 96 only when
+        // gRenderDPI is 0 (the legacy "off" mode where no DPI scaling is applied at all).
+        int opszDPI = (gRenderDPI > 0) ? gRenderDPI : 96;
+        float opsz = sz * 72.0f / (float)opszDPI;
+        static int s_last_sz = -1, s_last_dpi = -1;
+        if (sz != s_last_sz || opszDPI != s_last_dpi) {
+            CRLog::info("opsz auto: sz=%dpx / %ddpi * 72 = %.1fpt  (type=%d scaleFontWithDPI=%d gRenderDPI=%d)",
+                sz, opszDPI, opsz, (int)style->font_size.type, (int)gRenderScaleFontWithDPI, gRenderDPI);
+            s_last_sz = sz; s_last_dpi = opszDPI;
+        }
         LVFontVariation opszVar;
         opszVar.tag = LVFONT_TAG_OPSZ;
         opszVar.value = opsz;

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2428,12 +2428,11 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         fw = 1;
     else if ( fw>999 )
         fw = 999;
-    // Auto optical sizing: inject opsz unless disabled or already handled by wght axis
+    // Inject opsz for auto optical sizing, unless disabled or on a low-DPI screen.
     LVFontVariations variations;
     if (style->font_optical_sizing != css_fos_none && gRenderDPI >= 100) {
-        // Convert sz (screen pixels) to typographic points.
-        // sz arrives already scaled to physical screen pixels by Screen:scaleBySize() on the
-        // Lua side, so gRenderDPI is the correct divisor.
+        // Assume that if 96, as no device has such low DPI, it has not been set by the user, and don't do opsz as
+        // we don't know the real DPI. If above 100 assume it's close to the real DPI.
         variations.set(LVFONT_TAG_OPSZ, sz * 72.0f / (float)gRenderDPI);
     }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2435,6 +2435,9 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         // we don't know the real DPI. If above 100 assume it's close to the real DPI.
         variations.set(LVFONT_TAG_OPSZ, sz * 72.0f / (float)gRenderDPI);
     }
+    // Inject wdth from font-stretch / font-width if a non-normal value was specified.
+    if (style->font_stretch.type == css_val_percent && style->font_stretch.value != 100*256)
+        variations.set(LVFONT_TAG_WDTH, style->font_stretch.value / 256.0f);
 
     // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());
     LVFontRef fnt = fontMan->GetFont(

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2436,9 +2436,6 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId)
         // we don't know the real DPI. If above 100 assume it's close to the real DPI.
         variations.set(LVFONT_TAG_OPSZ, sz * 72.0f / (float)gRenderDPI);
     }
-    // Inject wdth from font-stretch / font-width if a non-normal value was specified.
-    if (style->font_stretch.type == css_val_percent && style->font_stretch.value != 100*256)
-        variations.set(LVFONT_TAG_WDTH, style->font_stretch.value / 256.0f);
 
     // printf("cssd_font_family: %d %s", style->font_family, style->font_name.c_str());
     LVFontRef fnt = fontMan->GetFont(

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -2906,22 +2906,13 @@ static const char * css_fs_names[] =
     NULL
 };
 
-static const char * css_fw_names[] = 
+static const char * css_fw_names[] =
 {
     "", // css_fw_inherit
     "normal",
     "bold",
     "bolder",
     "lighter",
-    "100",
-    "200",
-    "300",
-    "400",
-    "500",
-    "600",
-    "700",
-    "800",
-    "900",
     NULL
 };
 static const char * css_va_names[] = 
@@ -3897,6 +3888,16 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             case cssd_font_weight:
                 IF_g_SET_n_AND_break(true, css_fw_inherit, css_fw_400)
                 n = parse_name( decl, css_fw_names, -1 );
+                if ( n == -1 ) {
+                    // CSS Fonts Level 4 allows arbitrary numeric weights; round to nearest 100
+                    unsigned w = 0;
+                    if ( parse_integer( decl, w ) && w > 0 ) {
+                        w = ( w + 50 ) / 100 * 100;
+                        if ( w < 100 ) w = 100;
+                        if ( w > 900 ) w = 900;
+                        n = css_fw_100 + ( (int)w / 100 - 1 );
+                    }
+                }
                 break;
             case cssd_font_features: // font-feature-settings
                 // Not (yet) implemented.

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -64,6 +64,8 @@ enum css_decl_code {
     cssd_font_style,
     cssd_font_weight,
     cssd_font_features,           // font-feature-settings (not yet parsed)
+    cssd_font_optical_sizing,     // font-optical-sizing: auto | none
+    cssd_font_variation_settings, // font-variation-settings: "axis" value, ...
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
     cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
@@ -175,6 +177,8 @@ static const char * css_decl_name[] = {
     "font-style",
     "font-weight",
     "font-feature-settings",
+    "font-optical-sizing",
+    "font-variation-settings",
     "font-variant",
     "font-variant-ligatures",
     "-webkit-font-variant-ligatures",
@@ -3911,6 +3915,74 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 // often, publishers will include both font-variant and font-feature-settings
                 // in a same declaration, so we should be fine).
                 break;
+            case cssd_font_optical_sizing: // font-optical-sizing: auto | none
+                // font-optical-sizing is inherited; initial value is "auto"
+                IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
+                if (substr_icompare("auto", decl))       n = css_fos_auto;
+                else if (substr_icompare("none", decl))  n = css_fos_none;
+                break;
+            case cssd_font_variation_settings: // font-variation-settings: "wght" 700, "opsz" 14
+                // Parse comma-separated list of "tag" value pairs.
+                // Stored as: count, then for each: packed_tag (uint32), float_bits (uint32)
+                {
+                    skip_spaces(decl);
+                    if (substr_icompare("normal", decl)) {
+                        // "normal" resets all variations
+                        buf<<(lUInt32)(prop_code | importance | parse_important(decl));
+                        buf<<(lUInt32)0; // count = 0 means "clear"
+                        // n stays -1 to prevent default enum push below
+                        break;
+                    }
+                    // Collect tag-value pairs
+                    lUInt32 tags[16];
+                    lUInt32 vals[16]; // float bits
+                    int count = 0;
+                    const char * restore_pos = decl;
+                    while (*decl && *decl != ';' && *decl != stop_char && count < 16) {
+                        skip_spaces(decl);
+                        // Expect a quoted 4-char tag
+                        if (*decl != '"' && *decl != '\'') break;
+                        char qchar = *decl++;
+                        if (!*decl || !*(decl+1) || !*(decl+2) || !*(decl+3)) break;
+                        lUInt32 tag = LVFONT_TAG((lUInt8)decl[0], (lUInt8)decl[1],
+                                                  (lUInt8)decl[2], (lUInt8)decl[3]);
+                        decl += 4;
+                        if (*decl != qchar) break;
+                        decl++;
+                        skip_spaces(decl);
+                        // Expect a number
+                        double val = 0.0;
+                        const char * vstart = decl;
+                        bool neg = (*decl == '-');
+                        if (neg) decl++;
+                        if (!*decl || (*decl < '0' || *decl > '9') ) { decl = vstart; break; }
+                        while (*decl >= '0' && *decl <= '9') val = val*10 + (*decl++ - '0');
+                        if (*decl == '.') {
+                            decl++;
+                            double frac = 0.1;
+                            while (*decl >= '0' && *decl <= '9') { val += (*decl++ - '0') * frac; frac *= 0.1; }
+                        }
+                        if (neg) val = -val;
+                        tags[count] = tag;
+                        float fval = (float)val;
+                        memcpy(&vals[count], &fval, sizeof(lUInt32));
+                        count++;
+                        restore_pos = decl;
+                        skip_spaces(decl);
+                        if (*decl == ',') decl++;
+                        else break;
+                    }
+                    if (count > 0) {
+                        buf<<(lUInt32)(prop_code | importance | parse_important(restore_pos));
+                        buf<<(lUInt32)count;
+                        for (int vi = 0; vi < count; vi++) {
+                            buf<<tags[vi];
+                            buf<<vals[vi];
+                        }
+                    }
+                    n = -1; // signal that we handled buf ourselves
+                }
+                break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
             case cssd_font_variant_ligatures2:
@@ -5232,6 +5304,37 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                 }
                 else {
                     style->ApplyAsBitmapOr( font_features, &style->font_features, imp_bit_font_features, is_important );
+                }
+                style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+            }
+            break;
+        case cssd_font_optical_sizing:
+            style->Apply( (css_font_optical_sizing_t) *p++, &style->font_optical_sizing, imp_bit_font_optical_sizing, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+            break;
+        case cssd_font_variation_settings:
+            {
+                int count = (int)*p++;
+                if (count == 0) {
+                    // "normal" — clear all variations
+                    style->font_variations.clear();
+                } else {
+                    for (int vi = 0; vi < count; vi++) {
+                        LVFontVariation var;
+                        var.tag = *p++;
+                        lUInt32 bits = *p++;
+                        memcpy(&var.value, &bits, sizeof(float));
+                        // Replace existing entry for this tag, or append
+                        bool found = false;
+                        for (int ei = 0; ei < style->font_variations.length(); ei++) {
+                            if (style->font_variations[ei].tag == var.tag) {
+                                style->font_variations[ei].value = var.value;
+                                found = true; break;
+                            }
+                        }
+                        if (!found)
+                            style->font_variations.add(var);
+                    }
                 }
                 style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -64,6 +64,7 @@ enum css_decl_code {
     cssd_font_style,
     cssd_font_weight,
     cssd_font_features,           // font-feature-settings (not yet parsed)
+    cssd_font_optical_sizing,     // font-optical-sizing: auto | none
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
     cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
@@ -175,6 +176,7 @@ static const char * css_decl_name[] = {
     "font-style",
     "font-weight",
     "font-feature-settings",
+    "font-optical-sizing",
     "font-variant",
     "font-variant-ligatures",
     "-webkit-font-variant-ligatures",
@@ -3911,6 +3913,12 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 // often, publishers will include both font-variant and font-feature-settings
                 // in a same declaration, so we should be fine).
                 break;
+            case cssd_font_optical_sizing: // font-optical-sizing: auto | none
+                // font-optical-sizing is inherited; initial value is "auto"
+                IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
+                if (substr_icompare("auto", decl))       n = css_fos_auto;
+                else if (substr_icompare("none", decl))  n = css_fos_none;
+                break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
             case cssd_font_variant_ligatures2:
@@ -5235,6 +5243,10 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                 }
                 style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             }
+            break;
+        case cssd_font_optical_sizing:
+            style->Apply( (css_font_optical_sizing_t) *p++, &style->font_optical_sizing, imp_bit_font_optical_sizing, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_indent:
             style->Apply( read_length(p), &style->text_indent, imp_bit_text_indent, is_important );

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -64,8 +64,6 @@ enum css_decl_code {
     cssd_font_style,
     cssd_font_weight,
     cssd_font_features,           // font-feature-settings (not yet parsed)
-    cssd_font_optical_sizing,     // font-optical-sizing: auto | none
-    cssd_font_variation_settings, // font-variation-settings: "axis" value, ...
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
     cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
@@ -177,8 +175,6 @@ static const char * css_decl_name[] = {
     "font-style",
     "font-weight",
     "font-feature-settings",
-    "font-optical-sizing",
-    "font-variation-settings",
     "font-variant",
     "font-variant-ligatures",
     "-webkit-font-variant-ligatures",
@@ -3915,74 +3911,6 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 // often, publishers will include both font-variant and font-feature-settings
                 // in a same declaration, so we should be fine).
                 break;
-            case cssd_font_optical_sizing: // font-optical-sizing: auto | none
-                // font-optical-sizing is inherited; initial value is "auto"
-                IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
-                if (substr_icompare("auto", decl))       n = css_fos_auto;
-                else if (substr_icompare("none", decl))  n = css_fos_none;
-                break;
-            case cssd_font_variation_settings: // font-variation-settings: "wght" 700, "opsz" 14
-                // Parse comma-separated list of "tag" value pairs.
-                // Stored as: count, then for each: packed_tag (uint32), float_bits (uint32)
-                {
-                    skip_spaces(decl);
-                    if (substr_icompare("normal", decl)) {
-                        // "normal" resets all variations
-                        buf<<(lUInt32)(prop_code | importance | parse_important(decl));
-                        buf<<(lUInt32)0; // count = 0 means "clear"
-                        // n stays -1 to prevent default enum push below
-                        break;
-                    }
-                    // Collect tag-value pairs
-                    lUInt32 tags[16];
-                    lUInt32 vals[16]; // float bits
-                    int count = 0;
-                    const char * restore_pos = decl;
-                    while (*decl && *decl != ';' && *decl != stop_char && count < 16) {
-                        skip_spaces(decl);
-                        // Expect a quoted 4-char tag
-                        if (*decl != '"' && *decl != '\'') break;
-                        char qchar = *decl++;
-                        if (!*decl || !*(decl+1) || !*(decl+2) || !*(decl+3)) break;
-                        lUInt32 tag = LVFONT_TAG((lUInt8)decl[0], (lUInt8)decl[1],
-                                                  (lUInt8)decl[2], (lUInt8)decl[3]);
-                        decl += 4;
-                        if (*decl != qchar) break;
-                        decl++;
-                        skip_spaces(decl);
-                        // Expect a number
-                        double val = 0.0;
-                        const char * vstart = decl;
-                        bool neg = (*decl == '-');
-                        if (neg) decl++;
-                        if (!*decl || (*decl < '0' || *decl > '9') ) { decl = vstart; break; }
-                        while (*decl >= '0' && *decl <= '9') val = val*10 + (*decl++ - '0');
-                        if (*decl == '.') {
-                            decl++;
-                            double frac = 0.1;
-                            while (*decl >= '0' && *decl <= '9') { val += (*decl++ - '0') * frac; frac *= 0.1; }
-                        }
-                        if (neg) val = -val;
-                        tags[count] = tag;
-                        float fval = (float)val;
-                        memcpy(&vals[count], &fval, sizeof(lUInt32));
-                        count++;
-                        restore_pos = decl;
-                        skip_spaces(decl);
-                        if (*decl == ',') decl++;
-                        else break;
-                    }
-                    if (count > 0) {
-                        buf<<(lUInt32)(prop_code | importance | parse_important(restore_pos));
-                        buf<<(lUInt32)count;
-                        for (int vi = 0; vi < count; vi++) {
-                            buf<<tags[vi];
-                            buf<<vals[vi];
-                        }
-                    }
-                    n = -1; // signal that we handled buf ourselves
-                }
-                break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
             case cssd_font_variant_ligatures2:
@@ -5304,27 +5232,6 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                 }
                 else {
                     style->ApplyAsBitmapOr( font_features, &style->font_features, imp_bit_font_features, is_important );
-                }
-                style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
-            }
-            break;
-        case cssd_font_optical_sizing:
-            style->Apply( (css_font_optical_sizing_t) *p++, &style->font_optical_sizing, imp_bit_font_optical_sizing, is_important );
-            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
-            break;
-        case cssd_font_variation_settings:
-            {
-                int count = (int)*p++;
-                if (count == 0) {
-                    // "normal" — clear all variations
-                    style->font_variations = LVFontVariations();
-                } else {
-                    for (int vi = 0; vi < count; vi++) {
-                        lUInt32 tag  = *p++;
-                        lUInt32 bits = *p++;
-                        float val; memcpy(&val, &bits, sizeof(float));
-                        style->font_variations.set(tag, val);
-                    }
                 }
                 style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5317,23 +5317,13 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
                 int count = (int)*p++;
                 if (count == 0) {
                     // "normal" — clear all variations
-                    style->font_variations.clear();
+                    style->font_variations = LVFontVariations();
                 } else {
                     for (int vi = 0; vi < count; vi++) {
-                        LVFontVariation var;
-                        var.tag = *p++;
+                        lUInt32 tag  = *p++;
                         lUInt32 bits = *p++;
-                        memcpy(&var.value, &bits, sizeof(float));
-                        // Replace existing entry for this tag, or append
-                        bool found = false;
-                        for (int ei = 0; ei < style->font_variations.length(); ei++) {
-                            if (style->font_variations[ei].tag == var.tag) {
-                                style->font_variations[ei].value = var.value;
-                                found = true; break;
-                            }
-                        }
-                        if (!found)
-                            style->font_variations.add(var);
+                        float val; memcpy(&val, &bits, sizeof(float));
+                        style->font_variations.set(tag, val);
                     }
                 }
                 style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3060,6 +3060,14 @@ static const char * css_f_names[] =
     NULL
 };
 
+static const char * css_fos_names[] =
+{
+    "", // css_fos_inherit
+    "auto",
+    "none",
+    NULL
+};
+
 // clear value names
 static const char * css_c_names[] =
 {
@@ -3917,8 +3925,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
             case cssd_font_optical_sizing: // font-optical-sizing: auto | none
                 // font-optical-sizing is inherited; initial value is "auto"
                 IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
-                if (substr_icompare("auto", decl))       n = css_fos_auto;
-                else if (substr_icompare("none", decl))  n = css_fos_none;
+                n = parse_name( decl, css_fos_names, -1 );
                 break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -65,8 +65,6 @@ enum css_decl_code {
     cssd_font_weight,
     cssd_font_features,           // font-feature-settings (not yet parsed)
     cssd_font_optical_sizing,     // font-optical-sizing: auto | none
-    cssd_font_stretch,            // font-stretch (CSS3)
-    cssd_font_width,              // font-width   (CSS4 alias for font-stretch)
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
     cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
@@ -181,8 +179,6 @@ static const char * css_decl_name[] = {
     "font-weight",
     "font-feature-settings",
     "font-optical-sizing",
-    "font-stretch",
-    "font-width",
     "font-variant",
     "font-variant-ligatures",
     "-webkit-font-variant-ligatures",
@@ -3076,21 +3072,6 @@ static const char * css_fos_names[] =
     NULL
 };
 
-static const char * css_fstretch_names[] =
-{
-    "",                  // css_fstretch_inherit
-    "ultra-condensed",
-    "extra-condensed",
-    "condensed",
-    "semi-condensed",
-    "normal",
-    "semi-expanded",
-    "expanded",
-    "extra-expanded",
-    "ultra-expanded",
-    NULL
-};
-
 // clear value names
 static const char * css_c_names[] =
 {
@@ -3949,30 +3930,6 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 // font-optical-sizing is inherited; initial value is "auto"
                 IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
                 n = parse_name( decl, css_fos_names, -1 );
-                break;
-            case cssd_font_width: // CSS4 alias for font-stretch
-            case cssd_font_stretch: // font-stretch: ultra-condensed | condensed | ... | percentage
-                // font-stretch is inherited; initial value is "normal" (100%)
-                IF_g_PUSH_LENGTH_AND_break(1, true, css_val_percent, 100*256)
-                {
-                    // Keywords map to their wdth percentage values (stored * 256 as fixed-point)
-                    static const int kw_pct[] = { 0, 50*256, 16000, 75*256, 22400,
-                                                  100*256, 28800, 125*256, 150*256, 200*256 };
-                    int kw = parse_name( decl, css_fstretch_names, -1 );
-                    if (kw > 0) { // kw==0 is inherit sentinel, not a real keyword
-                        buf<<(lUInt32)(prop_code | importance | parse_important(decl));
-                        buf<<(lUInt32)css_val_percent;
-                        buf<<(lUInt32)kw_pct[kw];
-                    } else {
-                        css_length_t len;
-                        if (parse_number_value(decl, len, true)) // percentages only
-                            if (len.type == css_val_percent) {
-                                buf<<(lUInt32)(prop_code | importance | parse_important(decl));
-                                buf<<(lUInt32)len.type;
-                                buf<<(lUInt32)len.value;
-                            }
-                    }
-                }
                 break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
@@ -5399,11 +5356,6 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
             break;
         case cssd_font_optical_sizing:
             style->Apply( (css_font_optical_sizing_t) *p++, &style->font_optical_sizing, imp_bit_font_optical_sizing, is_important );
-            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
-            break;
-        case cssd_font_width: // CSS4 alias for font-stretch
-        case cssd_font_stretch:
-            style->Apply( read_length(p), &style->font_stretch, imp_bit_font_stretch, is_important );
             style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_indent:

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -65,6 +65,8 @@ enum css_decl_code {
     cssd_font_weight,
     cssd_font_features,           // font-feature-settings (not yet parsed)
     cssd_font_optical_sizing,     // font-optical-sizing: auto | none
+    cssd_font_stretch,            // font-stretch (CSS3)
+    cssd_font_width,              // font-width   (CSS4 alias for font-stretch)
     cssd_font_variant,            // all these are parsed specifically and mapped into
     cssd_font_variant_ligatures,  // the same style->font_features 31 bits bitmap
     cssd_font_variant_ligatures2, // -webkit-font-variant-ligatures (former Webkit property)
@@ -177,6 +179,8 @@ static const char * css_decl_name[] = {
     "font-weight",
     "font-feature-settings",
     "font-optical-sizing",
+    "font-stretch",
+    "font-width",
     "font-variant",
     "font-variant-ligatures",
     "-webkit-font-variant-ligatures",
@@ -3068,6 +3072,21 @@ static const char * css_fos_names[] =
     NULL
 };
 
+static const char * css_fstretch_names[] =
+{
+    "",                  // css_fstretch_inherit
+    "ultra-condensed",
+    "extra-condensed",
+    "condensed",
+    "semi-condensed",
+    "normal",
+    "semi-expanded",
+    "expanded",
+    "extra-expanded",
+    "ultra-expanded",
+    NULL
+};
+
 // clear value names
 static const char * css_c_names[] =
 {
@@ -3926,6 +3945,30 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 // font-optical-sizing is inherited; initial value is "auto"
                 IF_g_SET_n_AND_break(true, css_fos_inherit, css_fos_auto)
                 n = parse_name( decl, css_fos_names, -1 );
+                break;
+            case cssd_font_width: // CSS4 alias for font-stretch
+            case cssd_font_stretch: // font-stretch: ultra-condensed | condensed | ... | percentage
+                // font-stretch is inherited; initial value is "normal" (100%)
+                IF_g_PUSH_LENGTH_AND_break(1, true, css_val_percent, 100*256)
+                {
+                    // Keywords map to their wdth percentage values (stored * 256 as fixed-point)
+                    static const int kw_pct[] = { 0, 50*256, 16000, 75*256, 22400,
+                                                  100*256, 28800, 125*256, 150*256, 200*256 };
+                    int kw = parse_name( decl, css_fstretch_names, -1 );
+                    if (kw > 0) { // kw==0 is inherit sentinel, not a real keyword
+                        buf<<(lUInt32)(prop_code | importance | parse_important(decl));
+                        buf<<(lUInt32)css_val_percent;
+                        buf<<(lUInt32)kw_pct[kw];
+                    } else {
+                        css_length_t len;
+                        if (parse_number_value(decl, len, true)) // percentages only
+                            if (len.type == css_val_percent) {
+                                buf<<(lUInt32)(prop_code | importance | parse_important(decl));
+                                buf<<(lUInt32)len.type;
+                                buf<<(lUInt32)len.value;
+                            }
+                    }
+                }
                 break;
             case cssd_font_variant:
             case cssd_font_variant_ligatures:
@@ -5254,6 +5297,11 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
             break;
         case cssd_font_optical_sizing:
             style->Apply( (css_font_optical_sizing_t) *p++, &style->font_optical_sizing, imp_bit_font_optical_sizing, is_important );
+            style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+            break;
+        case cssd_font_width: // CSS4 alias for font-stretch
+        case cssd_font_stretch:
+            style->Apply( read_length(p), &style->font_stretch, imp_bit_font_stretch, is_important );
             style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
             break;
         case cssd_text_indent:

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -37,6 +37,7 @@ lUInt32 calcHash(font_ref_t & f)
     v = v * 31 + (lUInt32)f->getBitmapMode();
     v = v * 31 + (lUInt32)f->getTypeFace().getHash();
     v = v * 31 + (lUInt32)f->getBaseline();
+    v = v * 31 + f->getVariationHash();
     f->_hash = v;
     return v;
 }

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -46,7 +46,6 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash ) {
-        lUInt32 variations_hash = rec.font_variations.hash();
         rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
@@ -72,7 +71,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
          + (lUInt32)rec.font_optical_sizing) * 31
-         + variations_hash) * 31
+         + (lUInt32)rec.font_variations.hash()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -45,7 +45,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -69,6 +69,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_style) * 31
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
+         + (lUInt32)rec.font_optical_sizing) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -169,6 +170,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_name == r2.font_name &&
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
+           r1.font_optical_sizing == r2.font_optical_sizing&&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -359,6 +361,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_style);        //    css_font_style_t     font_style;
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
+    ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -434,6 +437,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_style_t, font_style);              //    css_font_style_t     font_style;
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
+    ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -45,7 +45,17 @@ lUInt32 calcHash(font_ref_t & f)
 
 lUInt32 calcHash(css_style_rec_t & rec)
 {
-    if ( !rec.hash )
+    if ( !rec.hash ) {
+        // Mix variation axis tag+value pairs into a single word before the main chain,
+        // since a loop can't be embedded directly in the nested expression below.
+        lUInt32 variations_hash = 0;
+        for (int i = 0; i < rec.font_variations.length(); i++) {
+            variations_hash = variations_hash * 31 + rec.font_variations[i].tag;
+            lUInt32 vbits;
+            float fval = rec.font_variations[i].value;
+            memcpy(&vbits, &fval, sizeof(vbits));
+            variations_hash = variations_hash * 31 + vbits;
+        }
         rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
@@ -71,7 +81,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
          + (lUInt32)rec.font_optical_sizing) * 31
-         + (lUInt32)rec.font_variations.length()) * 31
+         + variations_hash) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -125,6 +135,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
          + (lUInt32)rec.content.getHash());
+    } // if (!rec.hash)
     return rec.hash;
 }
 
@@ -174,7 +185,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_features == r2.font_features&&
            r1.font_optical_sizing == r2.font_optical_sizing&&
            r1.font_variations.length() == r2.font_variations.length() &&
-           [&]() { for (int i=0; i<r1.font_variations.length(); i++) if (!(r1.font_variations[i]==r2.font_variations[i])) return false; return true; }()&&
+           [&]() -> bool { for (int i = 0; i < r1.font_variations.length(); i++) if (!(r1.font_variations[i] == r2.font_variations[i])) return false; return true; }() &&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -46,16 +46,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash ) {
-        // Mix variation axis tag+value pairs into a single word before the main chain,
-        // since a loop can't be embedded directly in the nested expression below.
-        lUInt32 variations_hash = 0;
-        for (int i = 0; i < rec.font_variations.length(); i++) {
-            variations_hash = variations_hash * 31 + rec.font_variations[i].tag;
-            lUInt32 vbits;
-            float fval = rec.font_variations[i].value;
-            memcpy(&vbits, &fval, sizeof(vbits));
-            variations_hash = variations_hash * 31 + vbits;
-        }
+        lUInt32 variations_hash = rec.font_variations.hash();
         rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
@@ -184,8 +175,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
            r1.font_optical_sizing == r2.font_optical_sizing&&
-           r1.font_variations.length() == r2.font_variations.length() &&
-           [&]() -> bool { for (int i = 0; i < r1.font_variations.length(); i++) if (!(r1.font_variations[i] == r2.font_variations[i])) return false; return true; }() &&
+           r1.font_variations == r2.font_variations &&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -377,14 +367,17 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
     ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
-    {   // font_variations: LVArray<LVFontVariation>
-        lUInt32 vcnt = (lUInt32)font_variations.length();
+    {   // font_variations: LVFontVariations (serialised as count + tag/value pairs)
+        lUInt32 vcnt = (font_variations.wght_set ? 1 : 0) + (font_variations.opsz_set ? 1 : 0)
+                     + (font_variations.ital_set ? 1 : 0) + (font_variations.slnt_set ? 1 : 0)
+                     + (font_variations.wdth_set ? 1 : 0);
         buf << vcnt;
-        for (lUInt32 vi = 0; vi < vcnt; vi++) {
-            buf << font_variations[vi].tag;
-            lUInt32 vbits; memcpy(&vbits, &font_variations[vi].value, sizeof(lUInt32));
-            buf << vbits;
-        }
+        lUInt32 vbits;
+        if (font_variations.wght_set) { memcpy(&vbits, &font_variations.wght, 4); buf << (lUInt32)LVFONT_TAG_WGHT; buf << vbits; }
+        if (font_variations.opsz_set) { memcpy(&vbits, &font_variations.opsz, 4); buf << (lUInt32)LVFONT_TAG_OPSZ; buf << vbits; }
+        if (font_variations.ital_set) { memcpy(&vbits, &font_variations.ital, 4); buf << (lUInt32)LVFONT_TAG_ITAL; buf << vbits; }
+        if (font_variations.slnt_set) { memcpy(&vbits, &font_variations.slnt, 4); buf << (lUInt32)LVFONT_TAG_SLNT; buf << vbits; }
+        if (font_variations.wdth_set) { memcpy(&vbits, &font_variations.wdth, 4); buf << (lUInt32)LVFONT_TAG_WDTH; buf << vbits; }
     }
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
@@ -462,16 +455,15 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
     ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
-    {   // font_variations: LVArray<LVFontVariation>
+    {   // font_variations: LVFontVariations (count + tag/value pairs)
         lUInt32 vcnt = 0;
         buf >> vcnt;
-        font_variations.clear();
+        font_variations = LVFontVariations();
         for (lUInt32 vi = 0; vi < vcnt; vi++) {
-            LVFontVariation var;
-            buf >> var.tag;
-            lUInt32 vbits = 0; buf >> vbits;
-            memcpy(&var.value, &vbits, sizeof(float));
-            font_variations.add(var);
+            lUInt32 tag = 0, vbits = 0;
+            buf >> tag; buf >> vbits;
+            float val; memcpy(&val, &vbits, sizeof(float));
+            font_variations.set(tag, val);
         }
     }
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -11,6 +11,7 @@
 
 *******************************************************/
 
+#include <string.h>
 #include "../include/lvstyles.h"
 
 // #include <stdio.h>
@@ -44,7 +45,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -68,6 +69,8 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_style) * 31
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
+         + (lUInt32)rec.font_optical_sizing) * 31
+         + (lUInt32)rec.font_variations.length()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -168,6 +171,9 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_name == r2.font_name &&
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
+           r1.font_optical_sizing == r2.font_optical_sizing&&
+           r1.font_variations.length() == r2.font_variations.length() &&
+           [&]() { for (int i=0; i<r1.font_variations.length(); i++) if (!(r1.font_variations[i]==r2.font_variations[i])) return false; return true; }()&&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -358,6 +364,16 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_style);        //    css_font_style_t     font_style;
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
+    ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
+    {   // font_variations: LVArray<LVFontVariation>
+        lUInt32 vcnt = (lUInt32)font_variations.length();
+        buf << vcnt;
+        for (lUInt32 vi = 0; vi < vcnt; vi++) {
+            buf << font_variations[vi].tag;
+            lUInt32 vbits; memcpy(&vbits, &font_variations[vi].value, sizeof(lUInt32));
+            buf << vbits;
+        }
+    }
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -433,6 +449,19 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_style_t, font_style);              //    css_font_style_t     font_style;
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
+    ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
+    {   // font_variations: LVArray<LVFontVariation>
+        lUInt32 vcnt = 0;
+        buf >> vcnt;
+        font_variations.clear();
+        for (lUInt32 vi = 0; vi < vcnt; vi++) {
+            LVFontVariation var;
+            buf >> var.tag;
+            lUInt32 vbits = 0; buf >> vbits;
+            memcpy(&var.value, &vbits, sizeof(float));
+            font_variations.add(var);
+        }
+    }
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -11,7 +11,6 @@
 
 *******************************************************/
 
-#include <string.h>
 #include "../include/lvstyles.h"
 
 // #include <stdio.h>
@@ -45,8 +44,8 @@ lUInt32 calcHash(font_ref_t & f)
 
 lUInt32 calcHash(css_style_rec_t & rec)
 {
-    if ( !rec.hash ) {
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+    if ( !rec.hash )
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -70,8 +69,6 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_style) * 31
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
-         + (lUInt32)rec.font_optical_sizing) * 31
-         + (lUInt32)rec.font_variations.hash()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -125,7 +122,6 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
          + (lUInt32)rec.content.getHash());
-    } // if (!rec.hash)
     return rec.hash;
 }
 
@@ -173,8 +169,6 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_name == r2.font_name &&
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
-           r1.font_optical_sizing == r2.font_optical_sizing&&
-           r1.font_variations == r2.font_variations &&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -365,19 +359,6 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_style);        //    css_font_style_t     font_style;
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
-    ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
-    {   // font_variations: LVFontVariations (serialised as count + tag/value pairs)
-        lUInt32 vcnt = (font_variations.wght_set ? 1 : 0) + (font_variations.opsz_set ? 1 : 0)
-                     + (font_variations.ital_set ? 1 : 0) + (font_variations.slnt_set ? 1 : 0)
-                     + (font_variations.wdth_set ? 1 : 0);
-        buf << vcnt;
-        lUInt32 vbits;
-        if (font_variations.wght_set) { memcpy(&vbits, &font_variations.wght, 4); buf << (lUInt32)LVFONT_TAG_WGHT; buf << vbits; }
-        if (font_variations.opsz_set) { memcpy(&vbits, &font_variations.opsz, 4); buf << (lUInt32)LVFONT_TAG_OPSZ; buf << vbits; }
-        if (font_variations.ital_set) { memcpy(&vbits, &font_variations.ital, 4); buf << (lUInt32)LVFONT_TAG_ITAL; buf << vbits; }
-        if (font_variations.slnt_set) { memcpy(&vbits, &font_variations.slnt, 4); buf << (lUInt32)LVFONT_TAG_SLNT; buf << vbits; }
-        if (font_variations.wdth_set) { memcpy(&vbits, &font_variations.wdth, 4); buf << (lUInt32)LVFONT_TAG_WDTH; buf << vbits; }
-    }
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -453,18 +434,6 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_style_t, font_style);              //    css_font_style_t     font_style;
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
-    ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
-    {   // font_variations: LVFontVariations (count + tag/value pairs)
-        lUInt32 vcnt = 0;
-        buf >> vcnt;
-        font_variations = LVFontVariations();
-        for (lUInt32 vi = 0; vi < vcnt; vi++) {
-            lUInt32 tag = 0, vbits = 0;
-            buf >> tag; buf >> vbits;
-            float val; memcpy(&val, &vbits, sizeof(float));
-            font_variations.set(tag, val);
-        }
-    }
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -71,7 +71,6 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
          + (lUInt32)rec.font_optical_sizing) * 31
-         + rec.font_stretch.pack()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -178,7 +177,6 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
            r1.font_optical_sizing == r2.font_optical_sizing&&
-           r1.font_stretch == r2.font_stretch&&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -370,7 +368,6 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
     ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
-    ST_PUT_LEN(font_stretch);         //  css_length_t               font_stretch;
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -448,7 +445,6 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
     ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
-    ST_GET_LEN(font_stretch);                                    // css_length_t               font_stretch;
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -45,7 +45,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -70,6 +70,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.font_weight) * 31
          + (lUInt32)rec.font_features.pack()) * 31
          + (lUInt32)rec.font_optical_sizing) * 31
+         + rec.font_stretch.pack()) * 31
          + (lUInt32)rec.line_height.pack()) * 31
          + (lUInt32)rec.color.pack()) * 31
          + (lUInt32)rec.background_color.pack()) * 31
@@ -171,6 +172,7 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.font_family == r2.font_family&&
            r1.font_features == r2.font_features&&
            r1.font_optical_sizing == r2.font_optical_sizing&&
+           r1.font_stretch == r2.font_stretch&&
            r1.border_style_top==r2.border_style_top&&
            r1.border_style_right==r2.border_style_right&&
            r1.border_style_bottom==r2.border_style_bottom&&
@@ -362,6 +364,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(font_weight);       //    css_font_weight_t    font_weight;
     ST_PUT_LEN(font_features);      //    css_length_t         font_features;
     ST_PUT_ENUM(font_optical_sizing); //  css_font_optical_sizing_t  font_optical_sizing;
+    ST_PUT_LEN(font_stretch);         //  css_length_t               font_stretch;
     ST_PUT_LEN(text_indent);        //    css_length_t         text_indent;
     ST_PUT_LEN(line_height);        //    css_length_t         line_height;
     ST_PUT_LEN(width);              //    css_length_t         width;
@@ -438,6 +441,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_font_weight_t, font_weight);            //    css_font_weight_t    font_weight;
     ST_GET_LEN(font_features);                              //    css_length_t         font_features;
     ST_GET_ENUM(css_font_optical_sizing_t, font_optical_sizing); // css_font_optical_sizing_t  font_optical_sizing;
+    ST_GET_LEN(font_stretch);                                    // css_length_t               font_stretch;
     ST_GET_LEN(text_indent);                                //    css_length_t         text_indent;
     ST_GET_LEN(line_height);                                //    css_length_t         line_height;
     ST_GET_LEN(width);                                      //    css_length_t         width;

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -45,7 +45,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5146,7 +5146,6 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
     s->font_features = css_length_t(css_val_unspecified, 0);
-    s->font_optical_sizing = css_fos_auto; // CSS initial value; enables opsz auto-injection
     s->text_indent = css_length_t(css_val_screen_px, 0);
     s->line_height = css_length_t(css_val_unspecified, css_generic_normal); // line-height: normal
     s->letter_spacing = css_length_t(css_val_unspecified, css_generic_normal); // letter-spacing: normal

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5146,6 +5146,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
     s->font_features = css_length_t(css_val_unspecified, 0);
+    s->font_optical_sizing = css_fos_auto; // CSS initial value; enables opsz auto-injection
     s->text_indent = css_length_t(css_val_screen_px, 0);
     s->line_height = css_length_t(css_val_unspecified, css_generic_normal); // line-height: normal
     s->letter_spacing = css_length_t(css_val_unspecified, css_generic_normal); // letter-spacing: normal

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5146,7 +5146,8 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
     s->font_features = css_length_t(css_val_unspecified, 0);
-    s->font_optical_sizing = css_fos_auto; // CSS initial value; enables opsz auto-injection
+    s->font_optical_sizing = css_fos_auto;    // CSS initial value; enables opsz auto-injection
+    s->font_stretch = css_length_t(css_val_percent, 100*256); // CSS initial value: normal (100%)
     s->text_indent = css_length_t(css_val_screen_px, 0);
     s->line_height = css_length_t(css_val_unspecified, css_generic_normal); // line-height: normal
     s->letter_spacing = css_length_t(css_val_unspecified, css_generic_normal); // letter-spacing: normal

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5152,8 +5152,7 @@ bool ldomDocument::setRenderProps( int width, int dy, bool /*showCover*/, int /*
     s->font_weight = css_fw_400;
     s->font_style = css_fs_normal;
     s->font_features = css_length_t(css_val_unspecified, 0);
-    s->font_optical_sizing = css_fos_auto;    // CSS initial value; enables opsz auto-injection
-    s->font_stretch = css_length_t(css_val_percent, 100*256); // CSS initial value: normal (100%)
+    s->font_optical_sizing = css_fos_auto; // CSS initial value; enables opsz auto-injection
     s->text_indent = css_length_t(css_val_screen_px, 0);
     s->line_height = css_length_t(css_val_unspecified, css_generic_normal); // line-height: normal
     s->letter_spacing = css_length_t(css_val_unspecified, css_generic_normal); // letter-spacing: normal


### PR DESCRIPTION
This implementation is entirely within crengine and does not rely on any UI or other Lua changes.

Variable fonts should work seamlessly from the user's point of view with two axes being applied automatically (when available in the font):
- Font weight (wght) follows the font-weight specified in the CSS. The main impact of this for users is any weight in the range supported by the font can be displayed with no synthetic bolding.
- Optical sizing (opsz) is calculated based on the displayed font size and screen dpi (gRenderDPI). See the note below about setting Zoom (dpi) correctly. The benefit of this is better visual appearance for fonts that support optical sizing.

New CSS properties are added (both of these are standard CSS):
- "font-variation-settings" allows other font axes to be set (should work for any axis the font supports).
- "font-optical-sizing: none" disables optical sizing.

In principle it would be possible to add a UI to select font axis values but I don't think that's necessary.  The out of the box functionality - font weight and optical sizing - will probably meet the vast majority of users' needs. If someone really needs to set specific axis values then a CSS override is available using font-variation-settings.

Caveats:
- For optical sizing to work correctly the "Zoom (dpi)" setting in the bottom menu of KOReader needs to be set correctly. If this doesn't match the actual screen resolution then incorrect optical sizes will be used. This is only an issue for fonts that actually support optical sizing.
- Some variable fonts have special characters (especially [ and ]) in the file name that KOReader does not support. These characters need to be removed from the font file name (this doesn't affect the functionality of the font in any way).  I think that would be a simple thing to fix but would be a Lua change rather than crengine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/664)
<!-- Reviewable:end -->
