### PR TITLE
Add basic support for CSS position attribute

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -396,6 +396,14 @@ enum css_ruby_position_t {
     css_rp_under
 };
 
+/// position property values
+enum css_position_t {
+    css_pos_inherit,
+    css_pos_static,
+    css_pos_absolute,
+    css_pos_fixed
+};
+
 enum css_generic_value_t {
     css_generic_auto = -1,         // (css_val_unspecified, css_generic_auto), for "margin: auto"
     css_generic_normal = -2,       // (css_val_unspecified, css_generic_normal), for "line-height: normal"

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -94,9 +94,14 @@ enum css_style_rec_important_bit {
     imp_bit_caption_side,
     imp_bit_ruby_position,
     imp_bit_content,
-    imp_bit_cr_hint
+    imp_bit_cr_hint,
+    imp_bit_position,
+    imp_bit_top,
+    imp_bit_right,
+    imp_bit_bottom,
+    imp_bit_left
 };
-#define NB_IMP_BITS 71 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 76 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -185,6 +190,11 @@ struct css_style_rec_tag {
     css_box_sizing_t       box_sizing;
     css_caption_side_t     caption_side;
     css_ruby_position_t    ruby_position;
+    css_position_t         position;
+    css_length_t           top;
+    css_length_t           right;
+    css_length_t           bottom;
+    css_length_t           left;
     lString32              content;
     css_length_t           cr_hint;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
@@ -247,6 +257,11 @@ struct css_style_rec_tag {
     , box_sizing(css_bs_content_box)
     , caption_side(css_cs_inherit)
     , ruby_position(css_rp_inherit)
+    , position(css_pos_static)
+    , top(css_val_unspecified, css_generic_auto)
+    , right(css_val_unspecified, css_generic_auto)
+    , bottom(css_val_unspecified, css_generic_auto)
+    , left(css_val_unspecified, css_generic_auto)
     , cr_hint(css_val_inherited, 0)
     , flags(0)
     , pseudo_elem_before_style(NULL)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -7568,6 +7568,16 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     bool margin_left_auto = css_margin_left.type == css_val_unspecified && css_margin_left.value == css_generic_auto;
     bool margin_right_auto = css_margin_right.type == css_val_unspecified && css_margin_right.value == css_generic_auto;
 
+    bool is_positioned = style->position == css_pos_absolute || style->position == css_pos_fixed;
+    bool has_left = style->left.type != css_val_unspecified;
+    bool has_right = style->right.type != css_val_unspecified;
+    bool has_top = style->top.type != css_val_unspecified;
+    bool has_bottom = style->bottom.type != css_val_unspecified;
+    int positioned_left = has_left ? lengthToPx(enode, style->left, container_width) : 0;
+    int positioned_right = has_right ? lengthToPx(enode, style->right, container_width) : 0;
+    int positioned_top = has_top ? lengthToPx(enode, style->top, flow->getPageHeight()) : 0;
+    int positioned_bottom = has_bottom ? lengthToPx(enode, style->bottom, flow->getPageHeight()) : 0;
+
     if ( style->display == css_d_table_cell ) {
         // https://www.w3.org/TR/CSS2/tables.html#table-layout:
         // "Internal table elements do not have margins."
@@ -8288,13 +8298,14 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         break_before = RN_SPLIT_ALWAYS;
     }
 
-    if ( no_margin_collapse ) {
+    if ( no_margin_collapse && !is_positioned ) {
         // Push any earlier margin so it does not get collapsed with this one
         flow->pushVerticalMargin();
     }
     // We don't shift y yet. We accumulate margin, and, after ensuring
     // collapsing, emit it on the first non-margin real content added.
-    flow->addVerticalMargin( enode, margin_top, break_before, true ); // is_top_margin=true
+    if (!is_positioned)
+        flow->addVerticalMargin( enode, margin_top, break_before, true ); // is_top_margin=true
 
     LFormattedTextRef txform;
 
@@ -8311,8 +8322,20 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         else
             fmt.setLangNodeIndex( flow->getLangNodeIndex() );
     }
+    int absolute_y = flow->getCurrentRelativeY();
+    if ( is_positioned ) {
+        if ( has_left ) {
+            x = positioned_left + margin_left;
+        }
+        else if ( has_right ) {
+            x = container_width - width - positioned_right - margin_right;
+        }
+        if ( has_top ) {
+            absolute_y = positioned_top + margin_top;
+        }
+    }
     fmt.setX( x );
-    fmt.setY( flow->getCurrentRelativeY() );
+    fmt.setY( absolute_y );
     fmt.setWidth( width );
     if ( width < 0) {
         // We might be fine with a negative width when recursively rendering
@@ -8323,7 +8346,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     fmt.setHeight( 0 ); // will be updated below
     fmt.push();
     // This has to be delayed till now: it may adjust the Y we just setY() above
-    if ( no_margin_collapse ) {
+    if ( no_margin_collapse && !is_positioned ) {
         flow->pushVerticalMargin();
     }
 
@@ -8456,7 +8479,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 if ( isFootNoteBody )
                     flow->getPageContext()->leaveFootNote();
 
-                flow->addVerticalMargin( enode, margin_bottom, break_after );
+                if (!is_positioned)
+                    flow->addVerticalMargin( enode, margin_bottom, break_after );
                 return;
             }
             break;
@@ -8780,6 +8804,11 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // Original fmt.setY() might have been updated by collapsing margins,
                 // but we got the real final height.
                 fmt.setHeight( h );
+                if ( is_positioned && has_bottom && !has_top ) {
+                    int bottom_y = flow->getPageHeight() - h - positioned_bottom - margin_bottom;
+                    if (bottom_y < 0) bottom_y = 0;
+                    fmt.setY( bottom_y );
+                }
                 fmt.setTopOverflow( top_overflow );
                 fmt.setBottomOverflow( bottom_overflow );
                 fmt.push();
@@ -8805,8 +8834,9 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     }
                 }
 
-                flow->addVerticalMargin( enode, margin_bottom, break_after );
-                if ( no_margin_collapse ) {
+                if (!is_positioned)
+                    flow->addVerticalMargin( enode, margin_bottom, break_after );
+                if ( no_margin_collapse && !is_positioned ) {
                     // Push our margin so it does not get collapsed with some later one
                     flow->pushVerticalMargin();
                 }
@@ -9192,8 +9222,9 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     }
                 }
 
-                flow->addVerticalMargin( enode, margin_bottom, break_after );
-                if ( no_margin_collapse ) {
+                if (!is_positioned)
+                    flow->addVerticalMargin( enode, margin_bottom, break_after );
+                if ( no_margin_collapse && !is_positioned ) {
                     // Push our margin so it does not get collapsed with some later one
                     flow->pushVerticalMargin();
                 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -138,6 +138,11 @@ enum css_decl_code {
     cssd_box_sizing,
     cssd_caption_side,
     cssd_ruby_position,
+    cssd_position,
+    cssd_top,
+    cssd_right,
+    cssd_bottom,
+    cssd_left,
     cssd_content,
     cssd_cr_ignore_if_dom_version_greater_or_equal,
     cssd_cr_hint,
@@ -249,6 +254,11 @@ static const char * css_decl_name[] = {
     "box-sizing",
     "caption-side",
     "ruby-position",
+    "position",
+    "top",
+    "right",
+    "bottom",
+    "left",
     "content",
     "-cr-ignore-if-dom-version-greater-or-equal",
     "-cr-hint",
@@ -3152,6 +3162,16 @@ static const char * css_rp_names[] =
     NULL
 };
 
+// position value names
+static const char * css_pos_names[] =
+{
+    "", // css_pos_inherit
+    "static",
+    "absolute",
+    "fixed",
+    NULL
+};
+
 ///border width value names
 static const char * css_bw_names[]={
     "thin",
@@ -4691,6 +4711,24 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 IF_g_SET_n_AND_break(true, css_rp_inherit, css_rp_alternate);
                 n = parse_name( decl, css_rp_names, -1 );
                 break;
+            case cssd_position:
+                IF_g_SET_n_AND_break(false, css_pos_inherit, css_pos_static);
+                n = parse_name( decl, css_pos_names, -1 );
+                break;
+            case cssd_top:
+            case cssd_right:
+            case cssd_bottom:
+            case cssd_left:
+                IF_g_PUSH_LENGTH_AND_break(1, false, css_val_unspecified, css_generic_auto);
+                {
+                    css_length_t len;
+                    if ( parse_number_value( decl, len, true, true, true ) ) {
+                        buf<<(lUInt32) (prop_code | importance | parse_important(decl));
+                        buf<<(lUInt32) len.type;
+                        buf<<(lUInt32) len.value;
+                    }
+                }
+                break;
             case cssd_content:
                 {
                     if ( g >= 0 ) {
@@ -5431,6 +5469,21 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
         case cssd_ruby_position:
             style->Apply( (css_ruby_position_t) *p++, &style->ruby_position, imp_bit_ruby_position, is_important );
             style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+            break;
+        case cssd_position:
+            style->Apply( (css_position_t) *p++, &style->position, imp_bit_position, is_important );
+            break;
+        case cssd_top:
+            style->Apply( read_length(p), &style->top, imp_bit_top, is_important );
+            break;
+        case cssd_right:
+            style->Apply( read_length(p), &style->right, imp_bit_right, is_important );
+            break;
+        case cssd_bottom:
+            style->Apply( read_length(p), &style->bottom, imp_bit_bottom, is_important );
+            break;
+        case cssd_left:
+            style->Apply( read_length(p), &style->left, imp_bit_left, is_important );
             break;
         case cssd_cr_hint:
             {

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -117,6 +117,11 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.box_sizing) * 31
          + (lUInt32)rec.caption_side) * 31
          + (lUInt32)rec.ruby_position) * 31
+         + (lUInt32)rec.position) * 31
+         + (lUInt32)rec.top.pack()) * 31
+         + (lUInt32)rec.right.pack()) * 31
+         + (lUInt32)rec.bottom.pack()) * 31
+         + (lUInt32)rec.left.pack()) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
@@ -199,6 +204,11 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.box_sizing == r2.box_sizing&&
            r1.caption_side == r2.caption_side&&
            r1.ruby_position == r2.ruby_position&&
+           r1.position == r2.position&&
+           r1.top == r2.top&&
+           r1.right == r2.right&&
+           r1.bottom == r2.bottom&&
+           r1.left == r2.left&&
            r1.content == r2.content&&
            r1.cr_hint==r2.cr_hint;
 }


### PR DESCRIPTION
This is significantly simpler than my other PR :wink: and is independent of it.

This adds basic support for the CSS position element, which in particular is used by epubs from Standard Ebooks with a position of -999em to move text off the page. This change means epubs from Standard Ebooks render correctly.

This focuses on the "easy" parts of the spec, so:
 - position: absolute is supported with left, right, top and bottom positions.
 - position: static is supported (it's the default behaviour)
 - z-index is not supported
 - position: relative is not supported
 - position: fixed is "partially" supported. Claude tells me - and I'm taking this statement at face value:

>  It's treated identically to absolute: taken out of flow and positioned using top/left/right/bottom. However true fixed positioning should be relative to the viewport (and stay fixed during scroll), not the containing block. The renderer makes no distinction between the two — there's no viewport-relative coordinate system or scroll-pinning. So fixed is parsed and partially works (out-of-flow placement), but the viewport-anchoring behaviour is not implemented.
 
 I've tested with Standard Ebooks. In addition text with this element set seems to display at sensible positions though I can't vouch for the nuances of margins, padding, etc. Outside of Standard Ebooks I'm not aware of any ebooks that use this element so don't have a way to test further than that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/665)
<!-- Reviewable:end -->
