### PR TITLE
CSS: add support for initial-letter (in ::first-letter), and other fixes

### DIFF
--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -314,6 +314,7 @@ enum kerning_mode_t {
 enum font_extra_metric_t
 {
     font_metric_x_height = 0,
+    font_metric_cap_height,
     font_metric_ch_width,
     font_metric_y_superscript_y_offset,
     font_metric_y_subscript_y_offset,

--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -42,6 +42,7 @@
 #define RENDER_RECT_FLAG_CHILDREN_RENDERING_REORDERED       0x0200 // for table rows/thead/tfoot/cells reordering
 #define RENDER_RECT_FLAG_BOX_IS_POSITIONNED                 0x0400 // for inlineBox (when X/Y set in its erm_final)
 #define RENDER_RECT_FLAG_DO_MATH_TRANSFORM                  0x0800 // do math glyph stretching
+#define RENDER_RECT_FLAG_BOX_IS_DISCARDED                   0x1000 // source inlineBox hidden in favor of a ::first-line clone owner
 #define RENDER_RECT_FLAG_TEMP_USED_AS_CSS_CHECK_CACHE       0x8000 // has been cleared and is used as a CSS checks cache
 
 #define RENDER_RECT_SET_FLAG(r, f)     ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -56,6 +56,7 @@ enum css_style_rec_important_bit {
     imp_bit_color,
     imp_bit_background_color,
     imp_bit_letter_spacing,
+    imp_bit_initial_letter,
     imp_bit_page_break_before,
     imp_bit_page_break_after,
     imp_bit_page_break_inside,
@@ -96,7 +97,7 @@ enum css_style_rec_important_bit {
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 71 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 72 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -156,6 +157,7 @@ struct css_style_rec_tag {
     css_length_t         color;
     css_length_t         background_color;
     css_length_t         letter_spacing;
+    css_length_t         initial_letter; // css_val_unspecified + (css_generic_normal or packed size/sink in value)
     css_page_break_t     page_break_before;
     css_page_break_t     page_break_after;
     css_page_break_t     page_break_inside;
@@ -223,6 +225,7 @@ struct css_style_rec_tag {
     , color(css_val_inherited, 0)
     , background_color(css_val_color, CSS_COLOR_TRANSPARENT)
     , letter_spacing(css_val_inherited, 0)
+    , initial_letter(css_val_unspecified, css_generic_normal)
     , page_break_before(css_pb_auto)
     , page_break_after(css_pb_auto)
     , page_break_inside(css_pb_auto)

--- a/crengine/include/lvtextfm.h
+++ b/crengine/include/lvtextfm.h
@@ -120,6 +120,7 @@ enum ltext_extra_t {
 typedef struct
 {
     void *          object;   /**< \brief pointer to object which represents source */
+    void *          retained_font_ref; /**< \brief optional LVFontRef* retaining t.font lifetime */
     TextLangCfg *   lang_cfg;
     lInt16          indent;   /**< \brief first line indent (or all but first, when negative) */
     lInt16          valign_dy; /* drift y from baseline */
@@ -142,7 +143,7 @@ typedef struct
             lUInt16        objflags; /**< \brief object flags */
             lInt16         width;    /**< \brief width of image or inline-block-box */
             lInt16         height;   /**< \brief height of image or inline-block box */
-            lUInt16        baseline; /**< \brief baseline of inline-block box */
+            lInt16         baseline; /**< \brief baseline of inline-block box */
         } o;
     };
 } src_text_fragment_t;
@@ -168,7 +169,7 @@ typedef struct
        /// for object
        struct {
            lUInt16  height;          /**< \brief height of image or inline-block box */
-           lUInt16  baseline;        /**< \brief baseline of inline-block box */
+           lInt16   baseline;        /**< \brief baseline of inline-block box */
        } o;
    };
    lInt16   added_letter_spacing;    /* letter-spacing (to reduce spacing when justified) to add when drawing this word */
@@ -285,6 +286,8 @@ typedef struct
    lInt32                frmlinecount;  /**< formatted lines count*/
    embedded_float_t   ** floats;        /**< embedded floats */
    lInt32                floatcount;    /**< embedded floats count*/
+   lInt32              * oversized_inlineboxes; /**< src_text_index of oversized inline boxes (typically initial-letter) */
+   lInt32                oversized_inlinebox_count; /**< oversized inline boxes count */
    lUInt32               height;        /**< height of text fragment */
    lUInt16               width;         /**< width of text fragment */
    lUInt16               page_height;   /**< max page height */
@@ -362,7 +365,8 @@ void lvtextAddSourceLine(
    lInt16          indent,   /* first line indent (or all but first, when negative) */
    void *          object,   /* pointer to custom object */
    lUInt16         offset,    /* offset from node/object start to start of line */
-   lInt16          letter_spacing
+   lInt16          letter_spacing,
+   void *          retained_font_ref /* optional LVFontRef* retaining font lifetime */
                          );
 
 /** Add source object
@@ -462,14 +466,19 @@ public:
            lInt16          indent=0,    /* first line indent (or all but first, when negative) */
            void *          object=NULL,
            lUInt32         offset=0,
-           lInt16          letter_spacing=0
+           lInt16          letter_spacing=0,
+           LVFontRef       retained_font=LVFontRef() /* optional owning ref for temporary used font */
+                             // Pass it only when the passed 'font' instance is not being kept alive by any
+                             // node's style (eg. for initial-letter, it is a local'y computed font instance
+                             // that would soon disappear, causing issues/crashes when t.font is used)
         )
     {
         lvtextAddSourceLine(m_pbuffer,
             font,  //font->GetHandle()
             lang_cfg,
             text, len, color, bgcolor,
-            flags, interval, valign_dy, indent, object, (lUInt16)offset, letter_spacing );
+            flags, interval, valign_dy, indent, object, (lUInt16)offset, letter_spacing,
+            retained_font.isNull() ? NULL : new LVFontRef(retained_font) );
     }
 
     lUInt32 Format(lUInt16 width, lUInt16 page_height,
@@ -511,6 +520,16 @@ public:
     const embedded_float_t * GetFloatInfo(int index)
     {
         return m_pbuffer->floats[index];
+    }
+
+    int GetOversizedInlineBoxCount()
+    {
+        return m_pbuffer->oversized_inlinebox_count;
+    }
+
+    int GetOversizedInlineBoxSrcIndex(int index)
+    {
+        return m_pbuffer->oversized_inlineboxes[index];
     }
 
     lString32Collection * GetInlineBoxLinks( ldomNode * node );

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -987,8 +987,8 @@ public:
     inline bool isEffectiveBoxingInlineBox() const {
         return (getNodeId() == 1) ? getCloneNodeSource()->isBoxingInlineBox() : isBoxingInlineBox();
     }
-    inline bool isEffectiveEmbeddedBlockBoxingInlineBox() const {
-        return (getNodeId() == 1) ? getCloneNodeSource()->isEmbeddedBlockBoxingInlineBox() : isEmbeddedBlockBoxingInlineBox();
+    inline bool isEffectiveEmbeddedBlockBoxingInlineBox(bool inline_box_checks_done=false) const {
+        return (getNodeId() == 1) ? getCloneNodeSource()->isEmbeddedBlockBoxingInlineBox(inline_box_checks_done) : isEmbeddedBlockBoxingInlineBox(inline_box_checks_done);
     }
 
 

--- a/crengine/include/renderutil.h
+++ b/crengine/include/renderutil.h
@@ -1,0 +1,77 @@
+// Shared rendering helpers used across lvtextfm.cpp, lvrend.cpp and
+// lvtinydom.cpp.
+//
+// Keep this header narrow: only expose helpers that need to be shared across
+// those translation units. At the moment, that public surface is entirely
+// about CSS initial-letter support.
+
+#ifndef __RENDERUTIL_H_INCLUDED__
+#define __RENDERUTIL_H_INCLUDED__
+
+#include "lvtinydom.h"
+
+struct InitialLetterInlineBoxMetrics
+{
+    // placement_baseline is the inline-box baseline to use on the first line.
+    // exclusion_height is how far the sunk shape must exclude following lines,
+    // and top_overflow is the real ink that sticks above the first line top.
+    bool valid;
+    int placement_baseline;
+    int exclusion_height;
+    int top_overflow;
+
+    InitialLetterInlineBoxMetrics()
+        : valid(false), placement_baseline(0), exclusion_height(0), top_overflow(0)
+    {
+    }
+};
+
+struct InitialLetterTextLayout
+{
+    // line_height/strut_baseline are for the pseudo-element final block and its
+    // strut. first_letter_line_height is the line-height to use for the actual
+    // AddSourceLine() run that draws the initial. tightened tells whether those
+    // values come from the ink-tight band or from the regular fallback path.
+    bool tightened;
+    int line_height;
+    int strut_baseline;
+    int first_letter_line_height;
+    LVFontRef font;
+
+    InitialLetterTextLayout()
+        : tightened(false), line_height(0), strut_baseline(0), first_letter_line_height(0), font()
+    {
+    }
+};
+
+// Returns true when this style represents an actually displayed applied
+// initial-letter. We keep this predicate shared so style, layout and
+// hit-testing all agree on when initial-letter logic should kick in.
+bool hasAppliedInitialLetter(css_style_rec_t * style);
+
+// Inline-box-backed initials are represented as an inline box whose first child
+// is the ::first-letter pseudo-element. This helper validates that structure
+// and returns the pseudo-element when present.
+ldomNode * getInitialLetterInlineBoxPseudoElem(ldomNode * inline_box);
+
+// Build the rendering bundle for an applied initial-letter pseudo-element.
+// This gives renderFinalBlock() one always-usable place to fetch the enlarged
+// font, the pseudo block strut/band metrics, and the line-height for the
+// actual AddSourceLine() run, while hiding the fallback chain between the
+// tightened ink-band path and the regular line-height path.
+bool getInitialLetterTextLayout(ldomNode * enode, int default_line_height,
+        InitialLetterTextLayout & layout);
+
+// Compute the placement and later-line exclusion geometry for an inline-box
+// that hosts an applied initial-letter. Layout uses this to keep the enlarged
+// first letter aligned with the parent line grid while reserving enough depth
+// for the actual glyph ink below the first line.
+bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseline,
+        InitialLetterInlineBoxMetrics & metrics);
+
+// Return the ink-tight rectangle for an inline-box-backed initial-letter.
+// This keeps the horizontal footprint reserved by layout, but trims the
+// vertical bounds to the actual glyph ink for hit-testing/highlight purposes.
+bool getInitialLetterInlineBoxInkRect(ldomNode * inline_box, lvRect & rect);
+
+#endif // __RENDERUTIL_H_INCLUDED__

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1630,6 +1630,28 @@ public:
         return x_height;
     }
 
+    int getCapHeight() {
+        int cap_height = 0;
+        int glyph_index = getCharIndex( 'H', 0 );
+        if ( glyph_index ) {
+            int error = FT_Load_Glyph( _face, glyph_index, FT_LOAD_DEFAULT );
+            if ( !error ) {
+                cap_height = _slot->metrics.horiBearingY;
+            }
+        }
+        if ( cap_height <= 0 ) {
+            TT_OS2 * os2 = (TT_OS2 *)FT_Get_Sfnt_Table(_face, FT_SFNT_OS2);
+            if ( os2 && os2->sCapHeight > 0 ) {
+                // The OS/2 values are unscaled font units; convert them to pixels.
+                cap_height = FT_MulFix(os2->sCapHeight, _face->size->metrics.y_scale);
+            }
+        }
+        if ( cap_height <= 0 ) {
+            cap_height = _size*64 * 7/10; // 0.7em
+        }
+        return cap_height;
+    }
+
     virtual LVFontRef getDecimalListItemFont() {
         if ( !_DecimalListItemFont.isNull() )
             return _DecimalListItemFont;
@@ -3656,6 +3678,10 @@ public:
                 if ( !value_set ) {
                     value = _size*64 / 2; // 0.5em
                 }
+                break;
+            }
+            case font_metric_cap_height: {
+                value = getCapHeight();
                 break;
             }
             case font_metric_ch_width: {
@@ -8174,4 +8200,3 @@ bool operator == (const LVFont & r1, const LVFont & r2)
             && r1.getHintingMode() == r2.getHintingMode()
             ;
 }
-

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -3278,10 +3278,8 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
     // use them here, in a few other places dealing with erm_final block (ie. getRenderedWidths(),
     // getRect() and createXPointer(pt)), and for footnote links in renderBlockElement().
     // It's possible some other use of them elsewhere is needed, but has not yet been discovered.)
-    // Note that for objects (images, floats and inline-block boxes), we pass the effective/source
-    // node (which seems rather ok, web browsers don't ensure the ::first-ilne style on them) as
-    // it would otherwise get quite complicated (and need to infect renderBlockElement(), which
-    // render these, with the node->*Effective* variants).
+    // Note: we now also pass cloneNodes for objects (floats and inline-block boxes, but not images),
+    // which needs renderBlockElementEnhanced() to also use a few *Effective* variants.
 
     if ( baseflags & LTEXT_IS_FIRST_LINE_ENOUGH ) {
         // Still a children of pseudoElem[FirstLine], but we have met a <br/> and
@@ -3311,7 +3309,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             // be guessed and renderBlockElement() called to render it
             // and get is height, so LFormattedText knows how to render
             // this erm_final text around it.
-            txform->AddSourceObject(baseflags, LTEXT_OBJECT_IS_FLOAT, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
+            txform->AddSourceObject(baseflags, LTEXT_OBJECT_IS_FLOAT, line_h, valign_dy, indent, enode, lang_cfg );
             baseflags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             return;
         }
@@ -3388,7 +3386,6 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         if ( is_pseudoElem_FirstLine ) {
             flags |= LTEXT_IS_FIRST_LINE_CLONE;
         }
-
         // About background-color:
         // If erm_final, the background will be drawn by DrawDocument, and should not
         // be drawn by the LFormattedText txform.
@@ -3821,7 +3818,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
         // is not obvious from the specs. Let's do as it does.
         // It looks like we should do the same for inline-block boxes
         // (Not modified and not tested with ::first-line, if this can ever happen.)
-        if ( parent && (parent->isFloatingBox() || parent->isBoxingInlineBox()) ) {
+        if ( parent && (parent->isEffectiveFloatingBox() || parent->isEffectiveBoxingInlineBox()) ) {
             if ( rm == erm_final && is_object ) {
                 // When an image is the single top final node in a float (which is
                 // the case for individual floating images (<IMG style="float: left">),
@@ -4099,7 +4096,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 // These might have no effect, but let's explicitely drop them.
                 valign_dy = 0;
                 indent = 0;
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX|LTEXT_OBJECT_IS_EMBEDDED_BLOCK, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX|LTEXT_OBJECT_IS_EMBEDDED_BLOCK, line_h, valign_dy, indent, enode, lang_cfg );
                 // Let flags unchanged, with their newline/alignment flag as if it
                 // hadn't been consumed, so it is reported back into baseflags below
                 // so that the next sibling (or upper followup inline node) starts
@@ -4114,7 +4111,7 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             else {
                 // We use the flags computed previously (and not baseflags) as they
                 // carry vertical alignment
-                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode->getEffectiveNode(), lang_cfg );
+                txform->AddSourceObject(flags, LTEXT_OBJECT_IS_INLINE_BOX, line_h, valign_dy, indent, enode, lang_cfg );
                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
             }
         }
@@ -7347,7 +7344,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         return;
 
     css_style_ref_t style = enode->getStyle();
-    lUInt16 nodeElementId = enode->getNodeId();
+    lUInt16 nodeElementId = enode->getEffectiveNodeId();
+    ldomNode * parent = enode->getParentNode();
 
     // <DocFragment NonLinear> in EPUBs are set "-cr-hint: non-linear", and so are 2nd++ <body> in FB2,
     // so they can start a new non-linear sequence/flow, that can be hidden from the normal paging flow.
@@ -7380,8 +7378,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // See if dir= attribute or CSS specified direction
     int direction = flow->getDirection();
-    if ( enode->hasAttribute( attr_dir ) ) {
-        lString32 dir = enode->getAttributeValueLC( attr_dir );
+    if ( enode->hasEffectiveAttribute( attr_dir ) ) {
+        lString32 dir = enode->getEffectiveAttributeValueLC( attr_dir );
         if ( dir == "rtl" ) {
             direction = REND_DIRECTION_RTL;
         }
@@ -7407,7 +7405,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
 
     // See if lang= attribute
     bool has_lang_attribute = false;
-    if ( enode->hasAttribute( attr_lang ) && !enode->getAttributeValue( attr_lang ).empty() ) {
+    if ( enode->hasEffectiveAttribute( attr_lang ) && !enode->getEffectiveAttributeValue( attr_lang ).empty() ) {
         // We'll probably have to check it is a valid lang specification
         // before overriding the upper one.
         //   lString32 lang = enode->getAttributeValue( attr_lang );
@@ -7478,21 +7476,20 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     */
 
     // is this a floating float container (floatBox)?
-    bool is_floating = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES) && enode->isFloatingBox();
-    bool is_floatbox_child = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES)
-            && enode->getParentNode() && enode->getParentNode()->isFloatingBox();
+    bool is_floating = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES) && enode->isEffectiveFloatingBox();
+    bool is_floatbox_child = BLOCK_RENDERING(flags, FLOAT_FLOATBOXES) && parent && parent->isEffectiveFloatingBox();
     // is this a inline block container (inlineBox)?
-    bool is_inline_box = enode->isBoxingInlineBox();
-    bool is_inline_box_child = enode->getParentNode() && enode->getParentNode()->isBoxingInlineBox();
+    bool is_inline_box = enode->isEffectiveBoxingInlineBox();
+    bool is_inline_box_child = parent && parent->isEffectiveBoxingInlineBox();
 
     // In the business of computing width and height, we should handle a bogus
     // embedded block (<inlineBox T="EmbeddedBlock">) (and its child) just
     // like any normal block element (taking the full width of its container
     // if no specified width, without the need to get its rendered width).
-    if ( is_inline_box && enode->isEmbeddedBlockBoxingInlineBox(true) ) {
+    if ( is_inline_box && enode->isEffectiveEmbeddedBlockBoxingInlineBox() ) {
         is_inline_box = false;
     }
-    if ( is_inline_box_child && enode->getParentNode()->isEmbeddedBlockBoxingInlineBox(true) ) {
+    if ( is_inline_box_child && parent->isEffectiveEmbeddedBlockBoxingInlineBox(true) ) {
         is_inline_box_child = false;
     }
 
@@ -7581,7 +7578,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
     // element wheree it is usually ignored
     bool is_boxing_elem = nodeElementId <= EL_BOXING_END && nodeElementId >= EL_BOXING_START;
     // Images needs some specific handling
-    bool is_image = enode->isImage();
+    bool is_image = enode->isEffectiveImage();
     // <HR> gets its style width, height and margin:auto no matter flags
     bool is_hr = nodeElementId == el_hr;
     // <EMPTY-LINE> block element with height added for empty lines in txt document
@@ -8174,8 +8171,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     // https://html.spec.whatwg.org/multipage/rendering.html#align-descendants
                     // An align= should not impact the positionning of its node, only of its
                     // descendants, so we here need to look at the style of the parent.
-                    if ( enode->getParentNode() ) {
-                        css_style_ref_t pstyle = enode->getParentNode()->getStyle();
+                    if ( parent ) {
+                        css_style_ref_t pstyle = parent->getStyle();
                         if (pstyle->text_align >= css_ta_html_align_left && pstyle->text_align <= css_ta_html_align_center) {
                             // Our parent is, or is a descendant of, a <center> or a <div align="left/center/right">
                             // (and had not had this fact overridden by any classic text-align. In Firefox and
@@ -8260,8 +8257,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         // We'll push it immediately below
         no_margin_collapse = true;
     }
-    else if ( flow->getCurrentLevel() == 1 && (enode->getParentNode()->isFloatingBox() ||
-                                               enode->getParentNode()->isBoxingInlineBox()) ) {
+    else if ( flow->getCurrentLevel() == 1 && parent && (parent->isEffectiveFloatingBox() ||
+                                               parent->isEffectiveBoxingInlineBox()) ) {
         // The inner margin of the real float element (the single child of a floatBox)
         // have to be pushed and not collapse with outer margins so they can
         // get accounted in the float height.
@@ -8394,8 +8391,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 int table_width = width;
                 int fitted_width = -1;
                 bool is_ruby_table = false;
-                if ( enode->getParentNode()->isBoxingInlineBox() && enode->getParentNode()->getParentNode()
-                        && enode->getParentNode()->getParentNode()->getStyle()->display == css_d_ruby ) {
+                if ( parent && parent->isEffectiveBoxingInlineBox() && parent->getEffectiveParentNode()
+                        && parent->getEffectiveParentNode()->getStyle()->display == css_d_ruby ) {
                     is_ruby_table = true;
                 }
                 // renderTable has not been updated to use 'flow', and it looks
@@ -8433,8 +8430,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     }
                     else {
                         // No margin auto, see if any HTML align=left/right/center (as done above)
-                        if ( enode->getParentNode() ) {
-                            css_style_ref_t pstyle = enode->getParentNode()->getStyle();
+                        if ( parent ) {
+                            css_style_ref_t pstyle = parent->getStyle();
                             if (pstyle->text_align >= css_ta_html_align_left && pstyle->text_align <= css_ta_html_align_center) {
                                 if ( pstyle->text_align == css_ta_html_align_center )
                                     shift_x = (width - table_width)/2;
@@ -10264,7 +10261,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
         int m = enode->getRendMethod();
         // We should not get erm_inline, except for inlineBox elements, that
         // we must draw as erm_block
-        if ( m == erm_inline && enode->isBoxingInlineBox() ) {
+        if ( m == erm_inline && enode->isEffectiveBoxingInlineBox() ) {
             m = erm_block;
         }
         switch( m )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -17,6 +17,7 @@
 #include "../include/lvtinydom.h"
 #include "../include/fb2def.h"
 #include "../include/lvrend.h"
+#include "../include/renderutil.h"
 
 // Note about box model/sizing in crengine:
 // https://quirksmode.org/css/user-interface/boxsizing.html says:
@@ -3506,6 +3507,15 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
             }
         }
 
+        // Applied initial-letter uses a dedicated rendering layout bundle containing:
+        // the enlarged font, the line-height for the drawn run, and, when possible,
+        // a tighter ink-based inner band for the pseudo final block itself.
+        InitialLetterTextLayout initial_letter_layout;
+        bool has_initial_letter_layout = getInitialLetterTextLayout(enode, line_h, initial_letter_layout);
+        if ( has_initial_letter_layout && initial_letter_layout.tightened ) {
+            line_h = initial_letter_layout.line_height;
+        }
+
         if ( (flags & LTEXT_FLAG_NEWLINE) && ( rm == erm_final || ( legacy_rendering && is_block ) ) ) {
             // Top and single 'final' node (unless in the degenerate case
             // of obsolete css_d_list_item_legacy):
@@ -3602,7 +3612,11 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                 int fh = enode->getFont()->getHeight();
                 int fb = enode->getFont()->getBaseline();
                 int f_half_leading = (line_h - fh) / 2;
-                txform->setStrut(line_h, fb + f_half_leading);
+                int strut_baseline = fb + f_half_leading;
+                if ( has_initial_letter_layout ) {
+                    strut_baseline = initial_letter_layout.strut_baseline;
+                }
+                txform->setStrut(line_h, strut_baseline);
             }
         }
         else if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) ) {
@@ -4277,9 +4291,23 @@ void renderFinalBlock( ldomNode * enode, LFormattedText * txform, RenderRectAcce
                                     case css_tt_none: break;
                                     case css_tt_inherit: break;
                                 }
-                                int em = font->getSize();
+                                int first_letter_line_h = line_h;
+                                LVFontRef initial_letter_font;
+                                if ( has_initial_letter_layout ) {
+                                    first_letter_line_h = initial_letter_layout.first_letter_line_height;
+                                    initial_letter_font = initial_letter_layout.font;
+                                    if ( !initial_letter_font.isNull() ) {
+                                        font = initial_letter_font;
+                                    }
+                                }
+                                int em = enode->getFont()->getSize();
                                 int letter_spacing = lengthToPx(enode, style->letter_spacing, em);
-                                txform->AddSourceLine( firstLetterTxt.c_str(), firstLetterTxt.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, line_h, valign_dy, indent, enode, 0, letter_spacing);
+                                // This is currently the only case where we pass to AddSourceLine()
+                                // a 'LVFontRef retained_font' with our initial_letter_font. It is actually
+                                // the same font as passed as 'font', but its LVFontRef must additionally
+                                // be passed for our here-local initial_letter_font to be kept alive for
+                                // later drawing after we have left this scope.
+                                txform->AddSourceLine( firstLetterTxt.c_str(), firstLetterTxt.length(), cl, bgcl, font.get(), lang_cfg, flags|LTEXT_FLAG_OWNTEXT, first_letter_line_h, valign_dy, indent, enode, 0, letter_spacing, initial_letter_font );
                                 flags &= ~LTEXT_FLAG_NEWLINE & ~LTEXT_SRC_IS_CLEAR_BOTH; // clear newline flag
                             }
                         }
@@ -7902,8 +7930,8 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 table_shrink_to_fit = true;
             }
             else if ( is_fit_content_width ) {
-				// Also only if ENSURE_STYLE_WIDTH as we may prefer having
-				// full width text blocks to not waste reading width with blank areas.
+                // Also only if ENSURE_STYLE_WIDTH as we may prefer having
+                // full width text blocks to not waste reading width with blank areas.
                 if ( BLOCK_RENDERING(flags, ENSURE_STYLE_WIDTH) )
                     apply_style_width = true;
             }
@@ -10697,7 +10725,6 @@ inline bool inheritLength( css_length_t & val, css_length_t & parent_val, int pa
 
 void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef parent_font )
 {
-    CR_UNUSED(parent_font);
     //lvdomElementFormatRec * fmt = node->getRenderData();
     css_style_ref_t style( new css_style_rec_t );
     css_style_rec_t * pstyle = style.get();
@@ -10988,9 +11015,16 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             //   below, which may change it to css_d_block for rendering purpose)
             if ( pstyle->display != css_d_none ) {
                 pstyle->display = css_d_inline;
+                if ( hasAppliedInitialLetter(pstyle) ) {
+                    // But with CSS initial-letter, our support for that
+                    // is done with inline-block: force disable any float.
+                    pstyle->display = css_d_inline_block;
+                    pstyle->float_ = css_f_none;
+                }
             }
-            // - text-indent, if the FirstLetter happens to be a float: there
-            //   shouldn't be any indent in the float (checked on Firefox)
+            // - text-indent: it should apply to the paragraph, not to the
+            //   generated first-letter pseudo-element itself. This is valid
+            //   whether float (checked on Firefox) or not.
             pstyle->text_indent.type = css_val_screen_px;
             pstyle->text_indent.value = 0;
             // Most of the ones we support but that are not allowed are
@@ -11853,6 +11887,13 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
                 _minw += pad_left + pad_right; // these pads should be 0 on an inlineBox
                 _maxw += pad_left + pad_right;
                 curMaxWidth += _maxw;
+                if ( !nowrap && node->isEffectiveBoxingInlineBox() ) {
+                    // Avoid a wrap after, if this inlineBox wraps a pseudoElem[FirstLetter]
+                    ldomNode * child = node->getEffectiveNode()->getChildNode(0);
+                    if ( child && child->getEffectiveNodeId() == el_pseudoElem && child->hasEffectiveAttribute(attr_FirstLetter) ) {
+                        nowrap = true;
+                    }
+                }
                 if (nowrap) {
                     curWordWidth += _minw;
                 }
@@ -12499,6 +12540,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         int start = 0;
         int len = 0;
         ldomNode * parent;
+        bool is_first_letter_pseudo = false;
         if ( node->isEffectiveText() ) {
             text = node->getEffectiveText();
             len = text.length();
@@ -12535,6 +12577,7 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
             text = textNode->getText();
             len = firstLetterEnd; // Only measure the first N characters
             parent = node; // this pseudoElem node carries the font and style of the text
+            is_first_letter_pseudo = true;
             if ( isStartNode ) {
                 lang_cfg = TextLangMan::getTextLangCfg( node ); // Fetch it from node or its parents
             }
@@ -12548,6 +12591,16 @@ void getRenderedWidths(ldomNode * node, int &maxWidth, int &minWidth, int direct
         LVFontRef font = parent->getFont();
         int em = font->getSize();
         css_style_ref_t parent_style = parent->getStyle();
+        if ( is_first_letter_pseudo ) {
+            // initial-letter keeps the CSS 'computed font' for em-based properties such as
+            // letter-spacing, but the text rendered width must be measured with the same
+            // initial-letter layout bundle used by rendering.
+            InitialLetterTextLayout initial_letter_layout;
+            if ( getInitialLetterTextLayout(parent, font->getHeight(), initial_letter_layout)
+                    && !initial_letter_layout.font.isNull() ) {
+                font = initial_letter_layout.font;
+            }
+        }
         int letter_spacing = lengthToPx(parent, parent_style->letter_spacing, em);
         // text-transform
         switch (parent_style->text_transform) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -73,6 +73,8 @@ enum css_decl_code {
     cssd_font_variant_east_asian,
     cssd_font_variant_alternates,
     cssd_text_indent,
+    cssd_initial_letter,
+    cssd_initial_letter2, // -webkit-initial-letter
     cssd_line_height,
     cssd_letter_spacing,
     cssd_width,
@@ -184,6 +186,8 @@ static const char * css_decl_name[] = {
     "font-variant-east-asian",
     "font-variant-alternates",
     "text-indent",
+    "initial-letter",
+    "-webkit-initial-letter",
     "line-height",
     "letter-spacing",
     "width",
@@ -4044,6 +4048,104 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                     }
                 }
                 break;
+            case cssd_initial_letter:
+            case cssd_initial_letter2:
+                {
+                    css_length_t initial_letter(css_val_unspecified, css_generic_normal);
+                    if ( g >= 0 ) {
+                        if ( g == css_g_inherit ) {
+                            initial_letter = css_length_t(css_val_inherited, 0);
+                        }
+                        buf<<(lUInt32) (prop_code | importance | parse_important(decl));
+                        buf<<(lUInt32)initial_letter.type;
+                        buf<<initial_letter.value;
+                        break;
+                    }
+                    css_length_t size_num;
+                    const char * orig_pos = decl;
+                    enum initial_letter_keyword_t {
+                        initial_letter_keyword_none,
+                        initial_letter_keyword_drop,
+                        initial_letter_keyword_raise
+                    };
+                    initial_letter_keyword_t keyword = initial_letter_keyword_none;
+                    int sink = 0;
+                    skip_spaces( decl );
+                    if ( substr_icompare( "drop", decl ) ) {
+                        keyword = initial_letter_keyword_drop;
+                        skip_spaces( decl );
+                    }
+                    else if ( substr_icompare( "raise", decl ) ) {
+                        keyword = initial_letter_keyword_raise;
+                        skip_spaces( decl );
+                    }
+                    if ( parse_number_value( decl, size_num, false, false, false, false, true, true ) ) {
+                        if ( size_num.type == css_val_unspecified && size_num.value == css_generic_normal ) {
+                            initial_letter = css_length_t(css_val_unspecified, css_generic_normal);
+                        }
+                        else if ( size_num.type == css_val_unspecified
+                                && size_num.value >= 256
+                                && size_num.value <= 0x007FFFFF ) {
+                            // Normalize omitted sink to Edge's effective ceil(size) behavior
+                            // so layout code only needs to handle one packed size/sink form.
+                            int default_sink = (size_num.value + 255) >> 8;
+                            if ( default_sink > 255 ) {
+                                decl = orig_pos;
+                                break;
+                            }
+                            const char * before_sink = decl;
+                            skip_spaces( decl );
+                            if ( keyword == initial_letter_keyword_none ) {
+                                if ( substr_icompare( "drop", decl ) ) {
+                                    keyword = initial_letter_keyword_drop;
+                                }
+                                else if ( substr_icompare( "raise", decl ) ) {
+                                    keyword = initial_letter_keyword_raise;
+                                }
+                                else {
+                                    css_length_t sink_num;
+                                    if ( parse_number_value( decl, sink_num, false, false, false, false, false, true ) ) {
+                                        if ( sink_num.type == css_val_unspecified
+                                                && sink_num.value >= 256
+                                                && sink_num.value <= (255 << 8)
+                                                && (sink_num.value & 0xFF) == 0 ) {
+                                            sink = sink_num.value >> 8;
+                                        }
+                                        else {
+                                            decl = orig_pos;
+                                            break;
+                                        }
+                                    }
+                                    else {
+                                        decl = before_sink;
+                                    }
+                                }
+                            }
+                            else if ( *decl && *decl != ';' && *decl != '}' && *decl != '!' ) {
+                                decl = orig_pos;
+                                break;
+                            }
+                            if ( sink == 0 ) {
+                                sink = keyword == initial_letter_keyword_raise ? 1 : default_sink;
+                            }
+                        }
+                        else {
+                            decl = orig_pos;
+                            break;
+                        }
+                        if ( size_num.type != css_val_unspecified || size_num.value != css_generic_normal ) {
+                            initial_letter = css_length_t(css_val_unspecified,
+                                    (size_num.value << 8) | (sink & 0xFF));
+                        }
+                        buf<<(lUInt32) (prop_code | importance | parse_important(decl));
+                        buf<<(lUInt32)initial_letter.type;
+                        buf<<initial_letter.value;
+                    }
+                    else {
+                        decl = orig_pos;
+                    }
+                }
+                break;
 
             // Next ones accept 1 length value (with possibly named values for borders
             // that we map to a length)
@@ -5239,6 +5341,10 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
         case cssd_text_indent:
             style->Apply( read_length(p), &style->text_indent, imp_bit_text_indent, is_important );
             style->flags |= STYLE_REC_FLAG_INHERITABLE_APPLIED;
+            break;
+        case cssd_initial_letter:
+        case cssd_initial_letter2:
+            style->Apply( read_length(p), &style->initial_letter, imp_bit_initial_letter, is_important );
             break;
         case cssd_line_height:
             style->Apply( read_length(p), &style->line_height, imp_bit_line_height, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -59,8 +59,9 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.text_transform) * 31
          + (lUInt32)rec.hyphenate) * 31
          + (lUInt32)rec.list_style_type) * 31
-         + (lUInt32)rec.letter_spacing.pack()) * 31
          + (lUInt32)rec.list_style_position) * 31
+         + (lUInt32)rec.letter_spacing.pack()) * 31
+         + (lUInt32)rec.initial_letter.pack()) * 31
          + (lUInt32)(rec.page_break_before | (rec.page_break_after<<4) | (rec.page_break_inside<<8))) * 31
          + (lUInt32)rec.vertical_align.pack()) * 31
          + (lUInt32)rec.font_size.type) * 31
@@ -144,6 +145,11 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.hyphenate == r2.hyphenate &&
            r1.vertical_align == r2.vertical_align &&
            r1.line_height == r2.line_height &&
+           r1.letter_spacing == r2.letter_spacing &&
+           r1.initial_letter == r2.initial_letter &&
+           r1.page_break_before == r2.page_break_before &&
+           r1.page_break_after == r2.page_break_after &&
+           r1.page_break_inside == r2.page_break_inside &&
            r1.width == r2.width &&
            r1.height == r2.height &&
            r1.min_width == r2.min_width &&
@@ -371,6 +377,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_LEN(color);              //    css_length_t         color;
     ST_PUT_LEN(background_color);   //    css_length_t         background_color;
     ST_PUT_LEN(letter_spacing);     //    css_length_t         letter_spacing;
+    ST_PUT_LEN(initial_letter);     //    css_length_t         initial_letter;
     ST_PUT_ENUM(page_break_before); //    css_page_break_t     page_break_before;
     ST_PUT_ENUM(page_break_after);  //    css_page_break_t     page_break_after;
     ST_PUT_ENUM(page_break_inside); //    css_page_break_t     page_break_inside;
@@ -446,6 +453,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_LEN(color);                                      //    css_length_t         color;
     ST_GET_LEN(background_color);                           //    css_length_t         background_color;
     ST_GET_LEN(letter_spacing);                             //    css_length_t         letter_spacing;
+    ST_GET_LEN(initial_letter);                             //    css_length_t         initial_letter;
     ST_GET_ENUM(css_page_break_t, page_break_before);       //    css_page_break_t     page_break_before;
     ST_GET_ENUM(css_page_break_t, page_break_after);        //    css_page_break_t     page_break_after;
     ST_GET_ENUM(css_page_break_t, page_break_inside);       //    css_page_break_t     page_break_inside;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -686,6 +686,17 @@ public:
                         flt->x = x;
                         flt->y = y;
                         flt->to_position = false;
+                        ldomNode * source_node = node->getEffectiveNode();
+                        if ( source_node != node ) {
+                            // We ended up positionning the cloneNode for an floatBox on
+                            // the ::first-line of the paragraph, which means the original
+                            // floatBox has not been positionned and won't be shown.
+                            // Flag that original node as not-rendered/discarded, so that
+                            // getRect(), when called on a xpointer to the original source,
+                            // know it has to climb to its clondeNode and use its rect.
+                            RenderRectAccessor source_fmt( source_node );
+                            RENDER_RECT_SET_FLAG(source_fmt, BOX_IS_DISCARDED);
+                        }
                         fmt.setX(flt->x);
                         fmt.setY(flt->y);
                         if (flt->is_right)
@@ -725,6 +736,17 @@ public:
             flt->y = y;
             flt->to_position = false;
             ldomNode * node = (ldomNode *) flt->srctext->object;
+            ldomNode * source_node = node->getEffectiveNode();
+            if ( source_node != node ) {
+                // We ended up positionning the cloneNode for an floatBox on
+                // the ::first-line of the paragraph, which means the original
+                // floatBox has not been positionned and won't be shown.
+                // Flag that original node as not-rendered/discarded, so that
+                // getRect(), when called on a xpointer to the original source,
+                // know it has to climb to its clondeNode and use its rect.
+                RenderRectAccessor source_fmt( source_node );
+                RENDER_RECT_SET_FLAG(source_fmt, BOX_IS_DISCARDED);
+            }
             RenderRectAccessor fmt( node );
             fmt.setX(flt->x);
             fmt.setY(flt->y);
@@ -3070,6 +3092,17 @@ public:
                     formatted_word_t * word = &frmline->words[i];
                     src_text_fragment_t * srcline = &m_pbuffer->srctext[word->src_text_index];
                     ldomNode * node = (ldomNode *) srcline->object;
+                    ldomNode * source_node = node->getEffectiveNode();
+                    if ( source_node != node ) {
+                        // We ended up positionning the cloneNode for an inlineBox on
+                        // the ::first-line of the paragraph, which means the original
+                        // inlineBox has not been positionned and won't be shown.
+                        // Flag that original node as not-rendered/discarded, so that
+                        // getRect(), when called on a xpointer to the original source,
+                        // know it has to climb to its clondeNode and use its rect.
+                        RenderRectAccessor source_fmt( source_node );
+                        RENDER_RECT_SET_FLAG(source_fmt, BOX_IS_DISCARDED);
+                    }
                     RenderRectAccessor fmt( node );
                     if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_POSITIONNED) )
                         continue;

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -25,6 +25,7 @@
 #include "../include/lvtinydom.h"
 #include "../include/lvrend.h"
 #include "../include/textlang.h"
+#include "../include/renderutil.h"
 #endif
 
 #if USE_HARFBUZZ==1
@@ -139,6 +140,22 @@ embedded_float_t * lvtextAddEmbeddedFloat( formatted_text_fragment_t * pbuffer )
     return (pbuffer->floats[ pbuffer->floatcount++ ] = lvtextAllocEmbeddedFloat());
 }
 
+static void lvtextAddOversizedInlineBox( formatted_text_fragment_t * pbuffer, int src_text_index )
+{
+    for ( int i=0; i < pbuffer->oversized_inlinebox_count; i++ ) {
+        if ( pbuffer->oversized_inlineboxes[i] == src_text_index ) {
+            return;
+        }
+    }
+    int size = (pbuffer->oversized_inlinebox_count + FLT_ALLOC_SIZE-1) / FLT_ALLOC_SIZE * FLT_ALLOC_SIZE;
+    if (pbuffer->oversized_inlinebox_count >= size)
+    {
+        size += FLT_ALLOC_SIZE;
+        pbuffer->oversized_inlineboxes = cr_realloc( pbuffer->oversized_inlineboxes, size );
+    }
+    pbuffer->oversized_inlineboxes[ pbuffer->oversized_inlinebox_count++ ] = src_text_index;
+}
+
 
 formatted_text_fragment_t * lvtextAllocFormatter( lUInt16 width )
 {
@@ -177,6 +194,8 @@ void lvtextFreeFormatter( formatted_text_fragment_t * pbuffer )
         {
             if (pbuffer->srctext[i].flags & LTEXT_FLAG_OWNTEXT)
                 free( (void*)pbuffer->srctext[i].t.text );
+            if ( pbuffer->srctext[i].retained_font_ref )
+                delete (LVFontRef*)pbuffer->srctext[i].retained_font_ref;
         }
         free( pbuffer->srctext );
     }
@@ -198,6 +217,10 @@ void lvtextFreeFormatter( formatted_text_fragment_t * pbuffer )
             free(pbuffer->floats[i]);
         }
         free( pbuffer->floats );
+    }
+    if (pbuffer->oversized_inlineboxes)
+    {
+        free( pbuffer->oversized_inlineboxes );
     }
     if (pbuffer->inlineboxes_links)
     {
@@ -225,8 +248,9 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
    lInt16          indent,    /* first line indent (or all but first, when negative) */
    void *          object,    /* pointer to custom object */
    lUInt16         offset,
-   lInt16          letter_spacing
-                         )
+   lInt16          letter_spacing,
+   void *          retained_font_ref
+                          )
 {
     int srctextsize = (pbuffer->srctextlen + FRM_ALLOC_SIZE-1) / FRM_ALLOC_SIZE * FRM_ALLOC_SIZE;
     if ( pbuffer->srctextlen >= srctextsize)
@@ -236,6 +260,7 @@ void lvtextAddSourceLine( formatted_text_fragment_t * pbuffer,
     }
     src_text_fragment_t * pline = &pbuffer->srctext[ pbuffer->srctextlen++ ];
     pline->t.font = font;
+    pline->retained_font_ref = retained_font_ref;
 //    if (font) {
 //        // DEBUG: check for crash
 //        CRLog::trace("c font = %08x  txt = %08x", (lUInt32)font, (lUInt32)text);
@@ -296,6 +321,7 @@ void lvtextAddSourceObject(
         pbuffer->srctext = cr_realloc( pbuffer->srctext, srctextsize );
     }
     src_text_fragment_t * pline = &pbuffer->srctext[ pbuffer->srctextlen++ ];
+    pline->retained_font_ref = NULL;
     pline->index = (lUInt16)(pbuffer->srctextlen-1);
     pline->flags = flags | LTEXT_SRC_IS_OBJECT;
     pline->o.objflags = objflags;
@@ -430,6 +456,14 @@ public:
     bool m_has_cjk; // true when some CJK met
     int  m_cjk_prev_line_added_space_div; // Used with CJK justified lines, to
     int  m_cjk_prev_line_added_space_mod; // apply same spacing on last line.
+    struct {
+        bool active;
+        bool is_right;
+        int x;
+        int width;
+        int start_y;
+        int end_y;
+    } m_initial_letter_exclusion;
 
 // These are not unicode codepoints: these values are put where we
 // store text indexes in the source text node.
@@ -468,6 +502,12 @@ public:
         m_usable_left_overflow = 0;
         m_usable_right_overflow = 0;
         m_hanging_punctuation = false;
+        m_initial_letter_exclusion.active = false;
+        m_initial_letter_exclusion.is_right = false;
+        m_initial_letter_exclusion.x = 0;
+        m_initial_letter_exclusion.width = 0;
+        m_initial_letter_exclusion.start_y = 0;
+        m_initial_letter_exclusion.end_y = 0;
         m_has_cjk = false;
         m_cjk_prev_line_added_space_div = 0;
         m_cjk_prev_line_added_space_mod = 0;
@@ -481,6 +521,69 @@ public:
 
     ~LVFormatter()
     {
+    }
+
+    // Handle sinking initial-letter exclusion area (similar to how we handle floats,
+    // but this should not follow floats' clearance/stacking rules and pecularities)
+    void activateInitialLetterInlineBoxExclusion(formatted_line_t * frmline, formatted_word_t * word) {
+        if ( !word || !(word->flags & LTEXT_WORD_IS_INLINE_BOX) ) {
+            return;
+        }
+        src_text_fragment_t * src = &m_pbuffer->srctext[word->src_text_index];
+        ldomNode * node = (ldomNode *) src->object;
+        if ( !getInitialLetterInlineBoxPseudoElem(node) ) {
+            return;
+        }
+        RenderRectAccessor fmt( node );
+        InitialLetterInlineBoxMetrics metrics;
+        if ( !getInitialLetterInlineBoxMetrics(node, fmt.getBaseline(), metrics) ) {
+            m_initial_letter_exclusion.active = false;
+            return;
+        }
+        int exclusion_start = frmline->y + frmline->height;
+        // If the first line had to grow upward for accents/raised initials, the
+        // same vertical shift must extend the later-line exclusion footprint.
+        int exclusion_end = frmline->y + metrics.top_overflow + metrics.exclusion_height;
+        if ( exclusion_end <= exclusion_start ) {
+            m_initial_letter_exclusion.active = false;
+            return;
+        }
+        int exclusion_x = fmt.getX();
+        int exclusion_right = exclusion_x + fmt.getWidth();
+        // This mirrors the width widening done when the inline-box is first measured.
+        lvRect ink_rect;
+        if ( getInitialLetterInlineBoxInkRect(node, ink_rect) ) {
+            lvRect box_rect;
+            node->getAbsRect(box_rect);
+            if ( m_para_dir_is_rtl ) {
+                int left_overflow = box_rect.left - ink_rect.left;
+                if ( left_overflow > 0 ) {
+                    exclusion_x -= left_overflow;
+                }
+            }
+            else {
+                int right_overflow = ink_rect.right - box_rect.right;
+                if ( right_overflow > 0 ) {
+                    exclusion_right += right_overflow;
+                }
+            }
+        }
+        if ( exclusion_right <= 0 || exclusion_x >= m_pbuffer->width ) {
+            m_initial_letter_exclusion.active = false;
+            return;
+        }
+        if ( exclusion_x < 0 ) {
+            exclusion_x = 0;
+        }
+        if ( exclusion_right > m_pbuffer->width ) {
+            exclusion_right = m_pbuffer->width;
+        }
+        m_initial_letter_exclusion.active = true;
+        m_initial_letter_exclusion.is_right = m_para_dir_is_rtl;
+        m_initial_letter_exclusion.x = exclusion_x;
+        m_initial_letter_exclusion.width = exclusion_right - exclusion_x;
+        m_initial_letter_exclusion.start_y = exclusion_start;
+        m_initial_letter_exclusion.end_y = exclusion_end;
     }
 
     // Embedded floats positioning helpers.
@@ -524,8 +627,27 @@ public:
     // Also set offset_x to the x where this width is available
     int getAvailableWidthAtY(int start_y, int h, int & offset_x) {
         if (m_pbuffer->floatcount == 0) { // common short path when no float
-            offset_x = 0;
-            return m_pbuffer->width;
+            int fl_left_max_x = 0;
+            int fl_right_min_x = m_pbuffer->width;
+            if ( m_initial_letter_exclusion.active ) {
+                int y = start_y;
+                while ( y <= start_y + h ) {
+                    if ( y >= m_initial_letter_exclusion.start_y && y < m_initial_letter_exclusion.end_y ) {
+                        if ( m_initial_letter_exclusion.is_right ) {
+                            if ( m_initial_letter_exclusion.x < fl_right_min_x )
+                                fl_right_min_x = m_initial_letter_exclusion.x;
+                        }
+                        else {
+                            int right = m_initial_letter_exclusion.x + m_initial_letter_exclusion.width;
+                            if ( right > fl_left_max_x )
+                                fl_left_max_x = right;
+                        }
+                    }
+                    y += 1;
+                }
+            }
+            offset_x = fl_left_max_x;
+            return fl_right_min_x - fl_left_max_x;
         }
         int fl_left_max_x = 0;
         int fl_right_min_x = m_pbuffer->width;
@@ -545,6 +667,17 @@ public:
                         if (flt->x + flt->width > fl_left_max_x)
                             fl_left_max_x = flt->x + flt->width;
                     }
+                }
+            }
+            if ( m_initial_letter_exclusion.active && y >= m_initial_letter_exclusion.start_y && y < m_initial_letter_exclusion.end_y ) {
+                if ( m_initial_letter_exclusion.is_right ) {
+                    if ( m_initial_letter_exclusion.x < fl_right_min_x )
+                        fl_right_min_x = m_initial_letter_exclusion.x;
+                }
+                else {
+                    int right = m_initial_letter_exclusion.x + m_initial_letter_exclusion.width;
+                    if ( right > fl_left_max_x )
+                        fl_left_max_x = right;
                 }
             }
             y += 1;
@@ -1211,7 +1344,13 @@ public:
                         // to set LCHAR_ALLOW_WRAP_AFTER on it.
                         // (it will allow wrap before and after an object, unless it's near
                         // some punctuation/quote/paren, whose rules will be ensured it seems).
-                        int brk = lb_process_next_char(&lbCtx, (utf32_t)0xFFFC); // OBJECT REPLACEMENT CHARACTER
+                        lChar32 surrogate = 0xFFFC; // OBJECT REPLACEMENT CHARACTER
+                        if ( getInitialLetterInlineBoxPseudoElem((ldomNode *)src->object) ) {
+                            // If that inline box is an initial letter, keep the following text stuck to it
+                            // (if there is a following space, it will naturally cancel this)
+                            surrogate = 0x2060; // WORD JOINER
+                        }
+                        int brk = lb_process_next_char(&lbCtx, (utf32_t)surrogate);
                         if (pos > 0) {
                             if (brk == LINEBREAK_ALLOWBREAK)
                                 m_flags[pos-1] |= LCHAR_ALLOW_WRAP_AFTER;
@@ -2264,6 +2403,35 @@ public:
                         int width = fmt.getWidth();
                         int height = fmt.getHeight();
                         int baseline = fmt.getBaseline();
+                        // If that inline-box is an initial-letter, we need some adjustments
+                        InitialLetterInlineBoxMetrics initial_letter_metrics;
+                        if ( getInitialLetterInlineBoxMetrics(node, baseline, initial_letter_metrics) ) {
+                            baseline = initial_letter_metrics.placement_baseline;
+                            // Widen its word->width to account for ink overflowing on the side
+                            // of the running text (ie. italic 'f').
+                            // (activateInitialLetterInlineBoxExclusion() will do the same for
+                            // the exclusion area).
+                            lvRect ink_rect;
+                            if ( getInitialLetterInlineBoxInkRect(node, ink_rect) ) {
+                                lvRect box_rect;
+                                node->getAbsRect(box_rect);
+                                if ( m_para_dir_is_rtl ) {
+                                    int left_overflow = box_rect.left - ink_rect.left;
+                                    if ( left_overflow > 0 ) {
+                                        width += left_overflow;
+                                    }
+                                }
+                                else {
+                                    int right_overflow = ink_rect.right - box_rect.right;
+                                    if ( right_overflow > 0 ) {
+                                        width += right_overflow;
+                                    }
+                                }
+                            }
+                            // It feels we can let a space following the initial letter
+                            // be expanded by text justification.
+                            // if ( start < m_length-1 ) m_flags[start+1] |= LCHAR_LOCKED_SPACING;
+                        }
                         m_srcs[start]->o.width = width;
                         m_srcs[start]->o.height = height;
                         m_srcs[start]->o.baseline = baseline;
@@ -3108,7 +3276,7 @@ public:
                         continue;
                     RENDER_RECT_SET_FLAG(fmt, BOX_IS_POSITIONNED);
                     fmt.setX( frmline->x + word->x );
-                    fmt.setY( frmline->y + frmline->baseline - word->o.baseline + word->y );
+                    fmt.setY( (int)frmline->y + (int)frmline->baseline - (int)word->o.baseline + (int)word->y );
                     fmt.push();
                     #if MATHML_SUPPORT==1
                         ldomNode * unboxedParent = node->getUnboxedParent();
@@ -3232,6 +3400,9 @@ public:
         // Override it for PRE lines (or in case align has not been set)
         if ( preFormattedOnly || !align )
             align = m_para_dir_is_rtl ? LTEXT_ALIGN_RIGHT : LTEXT_ALIGN_LEFT;
+
+        // single initial-letter word on the logical first line, if any
+        int initial_letter_word_index = -1;
 
         TR("addLine(%d, %d) y=%d  align=%d", start, end, m_y, align);
 
@@ -3466,10 +3637,15 @@ public:
         // increased if some inline elements need more, but not decreased.
         frmline->height = m_pbuffer->strut_height;
         frmline->baseline = m_pbuffer->strut_baseline;
-        if (m_has_ongoing_float)
+        if (m_has_ongoing_float) {
             // Avoid page split when some float that started on a previous line
             // still spans this line
             frmline->flags |= LTEXT_LINE_SPLIT_AVOID_BEFORE;
+        }
+        if ( m_initial_letter_exclusion.active && m_y < m_initial_letter_exclusion.end_y && !first ) {
+            // Avoid page split alongside a sinking initial letter
+            frmline->flags |= LTEXT_LINE_SPLIT_AVOID_BEFORE;
+        }
         if ( lineIsBidi ) {
             // Flag that line, so createXPointer() and getRect() know it's not
             // a regular one and can't assume words and text nodes are linear.
@@ -3786,6 +3962,7 @@ public:
                     word->width = srcline->o.width;
                     word->min_width = word->width;
                     word->o.height = srcline->o.height;
+                    bool is_initial_letter_inline_box = false;
                     if ( srcline->o.objflags & LTEXT_OBJECT_IS_INLINE_BOX ) { // inline-block
                         word->flags = LTEXT_WORD_IS_INLINE_BOX;
                         // For inline-block boxes, the baseline may not be the bottom; it has
@@ -3793,6 +3970,7 @@ public:
                         word->o.baseline = srcline->o.baseline;
                         top_to_baseline = word->o.baseline;
                         baseline_to_bottom = word->o.height - word->o.baseline;
+                        is_initial_letter_inline_box = getInitialLetterInlineBoxPseudoElem((ldomNode *) srcline->object) != NULL;
                         // We can't really ensure strut_confined with inline-block boxes,
                         // or we could miss content (it would be overwritten by next lines)
                         if ( m_pbuffer->inlineboxes_links ) {
@@ -3847,7 +4025,20 @@ public:
                     // For vertical-align: top or bottom, delay computation as we need to
                     // know the final frmline height and baseline, which might change
                     // with upcoming words.
-                    if ( word->flags & LTEXT_WORD_IS_PAD ) {
+                    if ( is_initial_letter_inline_box ) {
+                        if ( initial_letter_word_index < 0 ) {
+                            // There can be only one initial-letter per paragraph. In RTL/BiDi,
+                            // it is not guaranteed to be the visual first word.
+                            // Remember its index for additional fixup when done with that line..
+                            initial_letter_word_index = frmline->word_count - 1;
+                        }
+                        lvtextAddOversizedInlineBox(m_pbuffer, srcline->index);
+                        // We will ensure its specific vertical positionning after all other
+                        // delayed vertical alignments and line-growth have been done
+                        word->y = 0;
+                        adjust_line_box = false;
+                    }
+                    else if ( word->flags & LTEXT_WORD_IS_PAD ) {
                         // We don't care about y/height/baseline
                         word->y = srcline->valign_dy;
                         adjust_line_box = false;
@@ -4654,9 +4845,33 @@ public:
             }
         }
 
+        if ( initial_letter_word_index >= 0 ) {
+            formatted_word_t * word = &frmline->words[initial_letter_word_index];
+            src_text_fragment_t * src = &m_pbuffer->srctext[word->src_text_index];
+            ldomNode * node = (ldomNode *) src->object;
+            InitialLetterInlineBoxMetrics metrics;
+            if ( node && getInitialLetterInlineBoxMetrics(node, word->o.baseline, metrics) ) {
+                // Initial-letter should stay anchored to the paragraph strut baseline,
+                // not to any extra first-line baseline lift caused by superscripts or
+                // other delayed vertical-align adjustments. We still reserve the real
+                // top ink overflow on that first line so accents don't paint upward.
+                if ( metrics.top_overflow > 0 ) {
+                    frmline->baseline += metrics.top_overflow;
+                    frmline->height += metrics.top_overflow;
+                }
+                word->y = m_pbuffer->strut_baseline + metrics.top_overflow - frmline->baseline;
+            }
+        }
+
         if ( !light_formatting ) {
             // Fix up words position and width to ensure requested alignment and indent
             alignLine( frmline, align, rightIndent, hasInlineBoxes );
+        }
+
+        if ( initial_letter_word_index >= 0 ) {
+            // This has to done after alignLine() has possibly repositionned its inline-box.
+            formatted_word_t * word = &frmline->words[initial_letter_word_index];
+            activateInitialLetterInlineBoxExclusion(frmline, word);
         }
 
         // Get ready for next line
@@ -4800,8 +5015,12 @@ public:
             int cjkReduceWidth = 0; // max total line width which can be reduced by narrowing CJK punctuations
             int firstInlineBoxPos = -1;
 
+            // (Let's not do the following when initial-letter is at play: better to cut raw
+            // the first word if it can't be hyphenated, and have bits of it alongside its
+            // initial letter, than having it cut after the initial letter and the next part
+            // way below that initial letter.)
             int maxWidth = getCurrentLineWidth();
-            if (maxWidth <= minWidth) {
+            if (maxWidth <= minWidth && !m_initial_letter_exclusion.active ) {
                 // Find y with available minWidth
                 int unused_x;
                 // We need to provide a height to find some width available over
@@ -5441,6 +5660,19 @@ public:
             }
             #endif
         }
+
+        // If we have an initial-letter still ongoing, extend that paragraph height
+        // so it contains it fully so it does not overlap on the following paragraph.
+        if ( isLastPara && m_initial_letter_exclusion.active && m_y < m_initial_letter_exclusion.end_y
+                && m_pbuffer->frmlinecount > 0 ) {
+            formatted_line_t * last_line = m_pbuffer->frmlines[m_pbuffer->frmlinecount - 1];
+            int extra_height = m_initial_letter_exclusion.end_y - m_y;
+            if ( last_line && extra_height > 0 ) {
+                last_line->height += extra_height;
+                m_y += extra_height;
+                m_pbuffer->height = m_y;
+            }
+        }
     }
 
     void processEmbeddedBlock( int idx )
@@ -5666,6 +5898,12 @@ static void freeFrmLines( formatted_text_fragment_t * m_pbuffer )
     }
     m_pbuffer->floats = NULL;
     m_pbuffer->floatcount = 0;
+
+    // Also clear oversized inlinebox src indices
+    if (m_pbuffer->oversized_inlineboxes)
+        free( m_pbuffer->oversized_inlineboxes );
+    m_pbuffer->oversized_inlineboxes = NULL;
+    m_pbuffer->oversized_inlinebox_count = 0;
 
     // Also clear inlinebox links containers
     if (m_pbuffer->inlineboxes_links)
@@ -6497,6 +6735,50 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             }
         }
         line_y += frmline->height;
+    }
+
+    // Oversized inline boxes (currently initial-letter) are normally drawn when
+    // their owner first line is drawn, which preserves the usual text paint
+    // ordering. When that first line is fully above the viewport, redraw these
+    // here so the sunk part still appears lower down.
+    // (oversized_inlineboxes have been made generic and could contain anything
+    // but we know that currently it can only be an initial-letter on the first line;
+    // as an optimization, we just ensure that looking if the first line was not drawn.)
+    bool first_line_drawn = ignore_clip;
+    if ( !first_line_drawn && m_pbuffer->frmlinecount > 0 ) {
+        first_line_drawn = y + m_pbuffer->frmlines[0]->height > clip.top;
+    }
+    if ( !first_line_drawn ) {
+        for (i=0; i<m_pbuffer->oversized_inlinebox_count; i++) {
+            int src_index = m_pbuffer->oversized_inlineboxes[i];
+            srcline = &m_pbuffer->srctext[src_index];
+            ldomNode * node = (ldomNode *)srcline->object;
+            RenderRectAccessor fmt( node );
+            int top_overflow = fmt.getTopOverflow();
+            int bottom_overflow = fmt.getBottomOverflow();
+            if ( y + fmt.getY() - top_overflow >= clip.bottom
+                    || y + fmt.getY() + fmt.getHeight() + bottom_overflow <= clip.top ) {
+                continue;
+            }
+            int x0 = x + fmt.getX();
+            int y0 = y + fmt.getY();
+            int doc_x = 0 - fmt.getX();
+            int doc_y = 0 - fmt.getY();
+            int dx = m_pbuffer->width;
+            int dy = m_pbuffer->page_height;
+            int page_height = m_pbuffer->page_height;
+            if ( absmarks_update_needed ) {
+                getAbsMarksFromMarks(marks, absmarks, node);
+                absmarks_update_needed = false;
+            }
+            lvRect curclip;
+            buf->GetClipRect( &curclip );
+            if ( draw_extra_info ) {
+                buf->SetClipRect( &draw_extra_info->content_overflow_clip );
+            }
+            DrawDocument( *buf, node, x0, y0, dx, dy, doc_x, doc_y, page_height, absmarks, bookmarks );
+            buf->SetClipRect(&curclip);
+        }
     }
 
     // Draw floats if any

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -13046,6 +13046,9 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
     // Note: this has been updated to also grab inline images (the comments
     // may all still mention "text nodes", which should read ok as we
     // masquerade an image as a single char text node in this processing).
+    // Note: with the added support for initial-letter, whose rect can extend
+    // below the current line height (and that we want as an individual segments),
+    // all .top comparisons below have been updated to also compare .bottom.
 
     // Note: someRect.extend(someOtherRect) and !someRect.isEmpty() expect
     // a rect to have both width and height non-zero. So, make sure
@@ -13200,7 +13203,8 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
                     int prevCharRectCtx;
                     if ( prevPos.getRectEx(prevCharRect, true, &prevCharRectCtx) ) {
                         bool prevIsRtl = (prevCharRectCtx & RECT_CTX_IS_RTL) != 0;
-                        if ( prevIsRtl == startIsRtl && prevCharRect.top == nodeStartRect.top ) {
+                        if ( prevIsRtl == startIsRtl && prevCharRect.top == nodeStartRect.top
+                                && prevCharRect.bottom == nodeStartRect.bottom ) {
                             // On a same paragraph and on a same line, and what comes before is
                             // in the same direction: we should not merge our first segments.
                             forceAddBidiSegment = true;
@@ -13222,8 +13226,10 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
         //   else if (nodeStartRect.left < lineStartRect.right)
         // but it makes a 2-lines-tall single segment if text-indent is larger
         // than previous line end.
-        // So, use .top comparison
-        else if (nodeStartRect.top > lineStartRect.top) {
+        // So, use .top comparison, but also split if a different height starts
+        // on the same top (currently, this can happen only with initial-letter)
+        else if (nodeStartRect.top > lineStartRect.top
+                || (nodeStartRect.top == lineStartRect.top && nodeStartRect.bottom != lineStartRect.bottom)) {
             // We ended last node on a line, but a new node starts (or previous
             // one continues) on a different line.
             if ( hasBidiPendingSegment ) {
@@ -13292,8 +13298,8 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
                 nodeStartRectCtx = RECT_CTX_NONE;
                 continue;
             }
-            if (curCharRect.top == nodeStartRect.top) { // end of range is on current line
-                // (Two offsets in a same text node with the same tops are on the same line)
+            if (curCharRect.top == nodeStartRect.top && curCharRect.bottom == nodeStartRect.bottom) { // end of range is on current line
+                // (Two offsets in a same text node with the same top/bottom are on the same line)
                 lineStartRect.extend(curCharRect);
                 // lineStartRect will be added after loop exit
                 break; // we're done
@@ -13315,7 +13321,7 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
                 nodeStartRectCtx = RECT_CTX_NONE;
                 continue;
             }
-            if (curCharRect.top == nodeStartRect.top) {
+            if (curCharRect.top == nodeStartRect.top && curCharRect.bottom == nodeStartRect.bottom) {
                 // Extend line up to the end of this node, but don't add it yet,
                 // lineStartRect can still be extended with (parts of) next text nodes
                 lineStartRect.extend(curCharRect);
@@ -13361,7 +13367,7 @@ void ldomXRange::getSegmentRects( LVArray<lvRect> & rects, bool includeImages )
                 go_on = false;
                 break;
             }
-            if (curCharRect.top != nodeStartRect.top) { // no more on the same line
+            if (curCharRect.top != nodeStartRect.top || curCharRect.bottom != nodeStartRect.bottom) { // no longer on the same line
                 // Unless BiDi and we didn't take that shortcut, it should not
                 // happen, we should have dealt with it as 2)
                 if ( ! prevCharRect.isEmpty() ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9997,7 +9997,63 @@ bool ldomXPointer::isFinalNode() const
     return false;
 }
 
+static ldomNode * findCloneNodeBySource(ldomNode * root, ldomNode * source)
+{
+    if ( !root || !source )
+        return NULL;
+    ldomNode * n = root;
+    int index = 0;
+    while ( true ) {
+        if ( index == 0 && n->getNodeId() == el_cloneNode && n->getCloneNodeSource() == source ) {
+            return n;
+        }
+        if ( index < n->getChildCount() ) {
+            n = n->getChildNode(index);
+            index = 0;
+            continue;
+        }
+        index = n->getNodeIndex() + 1;
+        if ( n == root ) {
+            break;
+        }
+        n = n->getParentNode();
+    }
+    return NULL;
+}
+
+static ldomNode * findFirstLineCloneForNode(ldomNode * node)
+{
+    if ( !node )
+        return NULL;
+    ldomNode * current = node;
+    ldomNode * ancestor = node;
+    while ( ancestor ) {
+        if ( !ancestor->hasAttribute(attr_HasFirstLine) ) {
+            ancestor = ancestor->getParentNode();
+            continue;
+        }
+        ldomNode * firstLineElem = ancestor->getUnboxedFirstChild(true, el_pseudoElem);
+        if ( !firstLineElem || !firstLineElem->hasAttribute(attr_FirstLine) ) {
+            ancestor = ancestor->getParentNode();
+            continue;
+        }
+        ldomNode * clone = findCloneNodeBySource(firstLineElem, current);
+        if ( !clone ) {
+            ancestor = ancestor->getParentNode();
+            continue;
+        }
+        // Continue from the clone we just found so outer ::first-line ancestors
+        // can resolve clone-of-clone chains for nested first-line content.
+        current = clone;
+        ancestor = current->getParentNode();
+    }
+    return current != node ? current : NULL;
+}
+
 /// create xpointer from doc point
+// (This should always returns a xpointer to the source node: when around a ::first-line,
+// whether we are on the first line and actually on a cloneNode or a second line and on
+// the original source node, it would return the source node.)
 ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool strictBounds, ldomNode * fromNode )
 {
     //
@@ -10111,7 +10167,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
         if (pt.x >= flt->x && pt.x < flt->x + flt->width && pt.y >= flt->y && pt.y < flt->y + (int)flt->height ) {
             // pt is inside this float.
             // (For floats in ::first-line, srctext->object references the original float element,
-            // and never the clondeNode, so no need to use getEffectiveNode() here.)
+            // and never the cloneNode, so no need to use getEffectiveNode() here.)
             ldomNode * node = (ldomNode *) flt->srctext->object; // floatBox node
             ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
             if ( !inside_ptr.isNull() ) {
@@ -10193,8 +10249,6 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             // Found right word/image
             const src_text_fragment_t * src = txtform->GetSrcInfo(word->src_text_index);
             ldomNode * node = (ldomNode *)src->object;
-            // (For inline-boxes and images in ::first-line, srctext->object references the original
-            // element or image, and never the clondeNode, so no need to use getEffectiveNode() here.)
             if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
                 // pt is inside this inline-block inlineBox node
                 ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
@@ -10202,10 +10256,11 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                     return inside_ptr;
                 }
                 // Otherwise, return xpointer to the inlineBox itself
-                return ldomXPointer(node, 0);
+                return ldomXPointer(node->getEffectiveNode(), 0);
             }
             if ( word->flags & LTEXT_WORD_IS_IMAGE ) {
-                return ldomXPointer(node, 0);
+                // (We don't pass images as cloneNode, but be consistent)
+                return ldomXPointer(node->getEffectiveNode(), 0);
             }
             // It is a word
             if ( find_first ) { // return xpointer to logical start of word
@@ -10256,7 +10311,7 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                     continue;
                 }
                 // (For inline-boxes and images in ::first-line, srctext->object references the original
-                // element or image, and never the clondeNode, so no need to use getEffectiveNode() here.)
+                // element or image, and never the cloneNode, so no need to use getEffectiveNode() here.)
                 if ( word->flags & LTEXT_WORD_IS_INLINE_BOX ) {
                     // pt is inside this inline-block inlineBox node
                     ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
@@ -10264,13 +10319,13 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                         return inside_ptr;
                     }
                     // Otherwise, return xpointer to the inlineBox itself
-                    return ldomXPointer(node, 0);
+                    return ldomXPointer(node->getEffectiveNode(), 0);
                 }
                 if ( word->flags & LTEXT_WORD_IS_IMAGE ) {
                     // Object (image)
                     #if 1
                     // return image object itself
-                    return ldomXPointer(node, 0);
+                    return ldomXPointer(node->getEffectiveNode(), 0);
                     #else
                     return ldomXPointer( node->getParentNode(),
                         node->getNodeIndex() + (( x < word->x + word->width/2 ) ? 0 : 1) );
@@ -10420,7 +10475,12 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
 
     if ( isNull() )
         return false;
-    ldomNode * p = isElement() ? getNode() : getNode()->getParentNode();
+    ldomNode * node = getNode();
+    // If provided a cloneNode, we should return the same rect as if call on its source.
+    // So, get the source node: we will jump to the cloneNode if it happens to be the one
+    // renderered and we should return its rect.
+    node = node->getEffectiveNode();
+    ldomNode * p = node->isText() ? node->getParentNode() : node;
     ldomNode * p0 = p;
     ldomNode * finalNode = NULL;
     if ( !p ) {
@@ -10434,7 +10494,23 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         return false;
     }
     ldomNode * mainNode = doc->getRootNode();
-    for ( ; p; p = p->getParentNode() ) {
+    while ( p ) {
+        if ( p->isEffectiveBoxingInlineBox() || p->isEffectiveFloatingBox() ) {
+            RenderRectAccessor fmt( p );
+            if ( RENDER_RECT_HAS_FLAG(fmt, BOX_IS_DISCARDED) ) {
+                // Our inlineBox/floatBox got a clone, and it is that clone that ended up
+                // being rendered (because ::first-line and actually on the first line)
+                // and flagged our source with BOX_IS_DISCARDED.
+                // Jump to that clone, and go on looking for its parent erm_final.
+                ldomNode * cloneNode = findFirstLineCloneForNode(node);
+                if ( cloneNode && cloneNode != p ) {
+                    p = cloneNode->isEffectiveText() ? cloneNode->getParentNode() : cloneNode;
+                    p0 = p;
+                    finalNode = NULL;
+                    continue;
+                }
+            }
+        }
         int rm = p->getRendMethod();
         if ( rm == erm_final ) {
             if ( doc->getDOMVersionRequested() < 20180524 && p->getStyle()->display == css_d_list_item_legacy ) {
@@ -10459,6 +10535,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         }
         if ( p==mainNode )
             break;
+        p = p->getParentNode();
     }
 
     if ( finalNode==NULL ) {
@@ -10506,7 +10583,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         LFormattedTextRef txtform;
         finalNode->renderFinalBlock( txtform, &fmt, inner_width );
 
-        ldomNode *node = getNode();
         int offset = getOffset();
 ////        ldomXPointerEx xp(node, offset);
 ////        if ( !node->isText() ) {
@@ -10553,9 +10629,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
         // scanning the next lines
         int firstLineSrcIndex = -1;
         int laterLineSrcIndex = -1;
-        // It seems we are always called on a xpointer referencing a real node, and never a cloneNode.
-        // The following has not been tested when being called on a xpointer to a cloneNode.
-
         ldomXPointerEx xp(node, offset);
         // printf("getRect(%s)\n", LCSTR(xp.toStringV1()));
         for ( int i=0; i<txtform->GetSrcCount(); i++ ) {
@@ -10564,7 +10637,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
             if ( isObject && src->o.objflags & LTEXT_OBJECT_IS_FLOAT ) // skip floats
                 continue;
             bool is_first_line_clone = src->flags & LTEXT_IS_FIRST_LINE_CLONE;
-            if ( src->object == node || (is_first_line_clone && src->object && ((ldomNode*)(src->object))->getEffectiveNode() == node)) {
+            if ( src->object && ((ldomNode*)(src->object))->getEffectiveNode() == node ) {
                 /*
                 printf(" if (%x==%x || %x==%x)\n", src->object, node , ((ldomNode*)(src->object))->getEffectiveNode(), node);
                 printf(" %d %s %s vs. %d\n", i, LCSTR(ldomXPointer((ldomNode*)(src->object),src->t.offset).toStringV1()),
@@ -10591,7 +10664,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                     }
                     // otherwise fallback to work on that node
                 }
-                else if ( node->getNodeId() == el_pseudoElem && node->hasAttribute(attr_FirstLetter) ) {
+                else if ( node->getEffectiveNodeId() == el_pseudoElem && node->hasEffectiveAttribute(attr_FirstLetter) ) {
                     // We were called (by the xpFirstLetter.getRect() just above) on
                     // a pseudoElem FirstLetter. For it to get access to the text,
                     // we can just (for the code that follows) have our "node"
@@ -10717,7 +10790,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                         else if (word->src_text_index == srcIndex) {
                             // Found word in that exact source text node
                             if ( word->flags & (LTEXT_WORD_IS_IMAGE|LTEXT_WORD_IS_INLINE_BOX) ) {
-                                // An image is the single thing in its srcIndex
+                                // An image or inline-box is the single thing in its srcIndex
                                 rect.top = rc.top + frmline->y;
                                 rect.bottom = rect.top + frmline->height;
                                 rect.left = word->x + rc.left + frmline->x;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10260,27 +10260,10 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 lUInt16 width[512];
                 lUInt8 flg[512];
 
-                lString32 str = node->getEffectiveText();
-
-                // We need to transform the node text as it had been when
-                // rendered (the transform may change chars widths) for the
-                // XPointer offset to be correct
-                switch ( node->getParentNode()->getStyle()->text_transform ) {
-                    case css_tt_uppercase:
-                        str.uppercase();
-                        break;
-                    case css_tt_lowercase:
-                        str.lowercase();
-                        break;
-                    case css_tt_capitalize:
-                        str.capitalize();
-                        break;
-                    case css_tt_full_width:
-                        // str.fullWidthChars(); // disabled for now in lvrend.cpp
-                        break;
-                    default:
-                        break;
-                }
+                // (We measure the exact text fragment that was handed to AddSourceLine(),
+                // it already reflects text-transform and any ::first-letter split/substringing
+                // performed at renderFinalBlock time.)
+                lString32 str = src->t.text ? lString32(src->t.text, src->t.len) : lString32();
 
                 lUInt32 hints = WORD_FLAGS_TO_FNT_FLAGS(word->flags);
                 font->measureText( str.c_str()+word->t.start, word->t.len, width, flg, word->width+50, '?',
@@ -10779,7 +10762,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                 LVFont *font = (LVFont *)src->t.font;
                                 lUInt16 w[512];
                                 lUInt8 flg[512];
-                                lString32 str = node->getEffectiveText();
+                                lString32 str = src->t.text ? lString32(src->t.text, src->t.len) : lString32();
                                 if (offset == word->t.start && str.empty()) {
                                     rect.left = word->x + rc.left + frmline->x;
                                     rect.top = rc.top + frmline->y;
@@ -10791,26 +10774,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                             *ctxFlags |= RECT_CTX_IS_RTL;
                                     }
                                     return true;
-                                }
-                                // We need to transform the node text as it had been when
-                                // rendered (the transform may change chars widths) for the
-                                // rect to be correct
-                                css_text_transform_t text_transform = src->object ?  ((ldomNode*)(src->object))->getParentNode()->getStyle()->text_transform : css_tt_none;
-                                switch ( text_transform ) {
-                                    case css_tt_uppercase:
-                                        str.uppercase();
-                                        break;
-                                    case css_tt_lowercase:
-                                        str.lowercase();
-                                        break;
-                                    case css_tt_capitalize:
-                                        str.capitalize();
-                                        break;
-                                    case css_tt_full_width:
-                                        // str.fullWidthChars(); // disabled for now in lvrend.cpp
-                                        break;
-                                    default:
-                                        break;
                                 }
                                 lUInt32 hints = WORD_FLAGS_TO_FNT_FLAGS(word->flags);
                                 font->measureText(
@@ -10969,7 +10932,7 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                         LVFont *font = (LVFont *)src->t.font;
                         lUInt16 w[512];
                         lUInt8 flg[512];
-                        lString32 str = node->getEffectiveText();
+                        lString32 str = src->t.text ? lString32(src->t.text, src->t.len) : lString32();
                         // With "|| (extended && offset < word->t.start)" added to the first if
                         // above, we may now be here with: offset = word->t.start = 0
                         // and a node->getText() returning THE lString32::empty_str:
@@ -10986,26 +10949,6 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                             rect.bottom = rect.top + frmline->height;
                             // No ctxFlags to set
                             return true;
-                        }
-                        // We need to transform the node text as it had been when
-                        // rendered (the transform may change chars widths) for the
-                        // rect to be correct
-                        css_text_transform_t text_transform = src->object ?  ((ldomNode*)(src->object))->getParentNode()->getStyle()->text_transform : css_tt_none;
-                        switch ( text_transform ) {
-                            case css_tt_uppercase:
-                                str.uppercase();
-                                break;
-                            case css_tt_lowercase:
-                                str.lowercase();
-                                break;
-                            case css_tt_capitalize:
-                                str.capitalize();
-                                break;
-                            case css_tt_full_width:
-                                // str.fullWidthChars(); // disabled for now in lvrend.cpp
-                                break;
-                            default:
-                                break;
                         }
                         lUInt32 hints = WORD_FLAGS_TO_FNT_FLAGS(word->flags);
                         font->measureText(

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -241,6 +241,8 @@ enum CacheFileBlockType {
 #include <xxhash.h>
 #include <lvtextfm.h>
 #include "../include/lvdocviewprops.h"
+#include "../include/renderutil.h"
+
 
 // define to store new text nodes as persistent text, instead of mutable
 #define USE_PERSISTENT_TEXT 1
@@ -4975,6 +4977,10 @@ ldomDocument::~ldomDocument()
 {
 #if BUILD_LITE!=1
     updateMap(); // NOLINT: Call to virtual function during destruction
+    // Our cache of LFormattedTextRefs may have some with a non-null LVFontRef
+    // keeping alive some font instances (eg. for initial-letter).
+    // Drop them before unregistering document fonts.
+    clearRendBlockCache();
 #endif
     _def_font.Clear();
     _fonts.clear();
@@ -10178,6 +10184,30 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
             // (Or should we let just go on looking only at the text in the original final node?)
         }
         // If no containing float, go on looking at the text of the original final node
+    }
+
+    // Then, look in oversized inlineBoxes (such as an initial-letter), which can extend
+    // over later line boxes (no need to do this when !PT_DIR_EXACT).
+    if ( direction == PT_DIR_EXACT ) {
+        int icount = txtform->GetOversizedInlineBoxCount();
+        for ( int i = 0; i < icount; i++ ) {
+            const src_text_fragment_t * src = txtform->GetSrcInfo(txtform->GetOversizedInlineBoxSrcIndex(i));
+            ldomNode * node = src ? (ldomNode *)src->object : NULL;
+            if ( !node ) {
+                continue;
+            }
+            lvRect boxRect;
+            if ( !getInitialLetterInlineBoxInkRect(node, boxRect) ) {
+                node->getAbsRect( boxRect );
+            }
+            if ( boxRect.isPointInside(orig_pt) ) {
+                ldomXPointer inside_ptr = createXPointer( orig_pt, direction, strictBounds, node );
+                if ( !inside_ptr.isNull() ) {
+                    return inside_ptr;
+                }
+                return ldomXPointer(node->getEffectiveNode(), 0);
+            }
+        }
     }
 
     // Look at words in the rendered final node (whether it's the original
@@ -21259,6 +21289,9 @@ void ldomDocument::registerEmbeddedFonts()
 /// unregister embedded document fonts in font manager, if any exist in document
 void ldomDocument::unregisterEmbeddedFonts()
 {
+#if BUILD_LITE!=1
+    clearRendBlockCache();
+#endif
     fontMan->UnregisterDocumentFonts(_docIndex);
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10263,12 +10263,22 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                 return ldomXPointer(node->getEffectiveNode(), 0);
             }
             // It is a word
+            // If it happens to be a pseudoElem[FirstLetter], we will want to return a xpointer
+            // to the original source text node (as if there was no ::first-letter)
+            ldomNode * firstLetterTextNode = NULL;
+            if ( node->getEffectiveNodeId() == el_pseudoElem && node->hasEffectiveAttribute(attr_FirstLetter) ) {
+                firstLetterTextNode = node->getEffectiveFirstLetterTextNode();
+            }
             if ( find_first ) { // return xpointer to logical start of word
+                if ( firstLetterTextNode )
+                    return ldomXPointer( firstLetterTextNode->getEffectiveNode(), word->t.start );
                 if ( node->isEffectiveElement() ) // (see comment about <br/><br/> below)
                     return ldomXPointer(node->getEffectiveNode(), 0);
                 return ldomXPointer( node->getEffectiveNode(), word->t.start );
             }
             else { // return xpointer to logical end of word
+                if ( firstLetterTextNode )
+                    return ldomXPointer( firstLetterTextNode->getEffectiveNode(), word->t.start + word->t.len );
                 if ( node->isEffectiveElement() )
                     return ldomXPointer(node->getEffectiveNode(), 0);
                 return ldomXPointer( node->getEffectiveNode(), word->t.start + word->t.len );
@@ -10332,6 +10342,13 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                     #endif
                 }
 
+                // If it happens to be a pseudoElem[FirstLetter], we will want to return a xpointer
+                // to the original source text node (as if there was no ::first-letter)
+                ldomNode * firstLetterTextNode = NULL;
+                if ( node->getEffectiveNodeId() == el_pseudoElem && node->hasEffectiveAttribute(attr_FirstLetter) ) {
+                    firstLetterTextNode = node->getEffectiveFirstLetterTextNode();
+                }
+
                 // Found word, searching for letters
                 LVFont * font = (LVFont *) src->t.font;
                 lUInt16 width[512];
@@ -10369,6 +10386,8 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                             // after the logical end of that RTL word
                         }
                     }
+                    if ( firstLetterTextNode )
+                        return ldomXPointer( firstLetterTextNode->getEffectiveNode(), word->t.start + pos );
                     if ( node->isEffectiveElement() ) // possibly some <br> or generated text not part of a text node
                         return ldomXPointer(node->getEffectiveNode(), 0);
                     // printf("word %d/%d, len=%d indice=%d (%d > %d + %d - %d)\n", w+1, wc, word->t.len,
@@ -10402,6 +10421,9 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction, bool stric
                             }
                             // Otherwise (not sure if can happen): use the default of word->t.len
                         }
+                    }
+                    if ( firstLetterTextNode ) {
+                        return ldomXPointer( firstLetterTextNode->getEffectiveNode(), word->t.start + pos );
                     }
                     if ( node->isEffectiveElement() ) // possibly some <br> or generated text not part of a text node
                         return ldomXPointer(node->getEffectiveNode(), 0);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6368,6 +6368,7 @@ void ldomNode::ensureFirstLetter(bool initStyle) {
                         // Skip leading non-letter characters (spaces, punctuation, etc.)
                         // until we find the first actual letter
                         bool foundFirstLetter = false;
+                        int foundNonLetterIndex = -1;
                         while ( i < len ) {
                             lUInt16 props = lGetCharProps(text[i]);
                             if ( props & (CH_PROP_UPPER | CH_PROP_LOWER | CH_PROP_DIGIT | CH_PROP_SIGN) ) {
@@ -6375,7 +6376,28 @@ void ldomNode::ensureFirstLetter(bool initStyle) {
                                 foundFirstLetter = true;
                                 break;
                             }
+                            else if ( !(props & CH_PROP_SPACE) ) {
+                                // Found another kind of char that is visible
+                                // if we happen to not get foundFirstLetter in this text node,
+                                // we will have to use it as first letter, even if some letters
+                                // are found in a sibling element (ie. <p>(<em>Letter</em>) as
+                                // we can't wrap across text nodes.
+                                // This is as Firefox and Edge do.
+                                foundNonLetterIndex = i;
+                                // We could either add or not "&& foundNonLetterIndex < 0" to the check
+                                // above to start grabbing below from the first non-space or the last one,
+                                // which would give different results.
+                                // Not adding it does as Firefox.
+                                // Adding it would do more as Edge (except that Edge would stop
+                                // depending on other conditions).
+                                // Let's do simple, as Firefox.
+                            }
                             i++;
+                        }
+                        if ( !foundFirstLetter && foundNonLetterIndex >= 0 ) {
+                            // This first non-letter non-space should act as our first letter.
+                            foundFirstLetter = true;
+                            i = foundNonLetterIndex;
                         }
                         // Now grab any trailing modifiers/punctuation that are part of the first letter
                         if ( foundFirstLetter ) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -10800,58 +10800,48 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                                     rect.right = rect.left + 1;
                                 }
                                 if (extended) { // get width of char at offset
-                                    if (offset == word->t.start && word->t.len == 1) {
-                                        // With CJK chars, the measured width seems
-                                        // less correct than the one measured while
-                                        // making words. So use the calculated word
-                                        // width for one-char-long words instead
-                                        if ( word_is_rtl )
-                                            rect.left = rect.right - word->width;
-                                        else
-                                            rect.right = rect.left + word->width;
+                                    // With one-char-long words, the measured width seems less correct than the one
+                                    // measured while making words (noticed with CJK words). Use it instead.
+                                    int chw = word->t.len == 1 ? word->width : w[ offset - word->t.start ] - chx;
+                                    bool hyphen_added = false;
+                                    if ( offset == word->t.start + word->t.len - 1
+                                            && (word->flags & LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER) ) {
+                                        // if offset is the end of word, and this word has
+                                        // been hyphenated, includes the hyphen width
+                                        chw += font->getHyphenWidth();
+                                        // We then should not account for the right side
+                                        // bearing below
+                                        hyphen_added = true;
+                                    }
+                                    if ( word_is_rtl ) {
+                                        rect.left = rect.right - chw;
+                                        if ( !hyphen_added ) {
+                                            // Also remove our added letter spacing for justification
+                                            // from the left, to have cleaner highlights.
+                                            rect.left += word->added_letter_spacing;
+                                        }
                                     }
                                     else {
-                                        int chw = w[ offset - word->t.start ] - chx;
-                                        bool hyphen_added = false;
-                                        if ( offset == word->t.start + word->t.len - 1
-                                                && (word->flags & LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER) ) {
-                                            // if offset is the end of word, and this word has
-                                            // been hyphenated, includes the hyphen width
-                                            chw += font->getHyphenWidth();
-                                            // We then should not account for the right side
-                                            // bearing below
-                                            hyphen_added = true;
+                                        rect.right = rect.left + chw;
+                                        if ( !hyphen_added ) {
+                                            // Also remove our added letter spacing for justification
+                                            // from the right, to have cleaner highlights.
+                                            rect.right -= word->added_letter_spacing;
                                         }
-                                        if ( word_is_rtl ) {
-                                            rect.left = rect.right - chw;
-                                            if ( !hyphen_added ) {
-                                                // Also remove our added letter spacing for justification
-                                                // from the left, to have cleaner highlights.
-                                                rect.left += word->added_letter_spacing;
-                                            }
-                                        }
-                                        else {
-                                            rect.right = rect.left + chw;
-                                            if ( !hyphen_added ) {
-                                                // Also remove our added letter spacing for justification
-                                                // from the right, to have cleaner highlights.
-                                                rect.right -= word->added_letter_spacing;
-                                            }
-                                        }
-                                        if (adjusted) {
-                                            // Extend left or right if this glyph overflows its
-                                            // origin/advance box (can happen with an italic font,
-                                            // or with a regular font on the right of the letter 'f'
-                                            // or on the left of the letter 'J').
-                                            // Only when negative (overflow) and not when positive
-                                            // (which are more frequent), mostly to keep some good
-                                            // looking rectangles on the sides when highlighting
-                                            // multiple lines.
-                                            rect.left += font->getLeftSideBearing(str[offset], true);
-                                            if ( !hyphen_added )
-                                                rect.right -= font->getRightSideBearing(str[offset], true);
-                                            // Should work wheter rtl or ltr
-                                        }
+                                    }
+                                    if (adjusted) {
+                                        // Extend left or right if this glyph overflows its
+                                        // origin/advance box (can happen with an italic font,
+                                        // or with a regular font on the right of the letter 'f'
+                                        // or on the left of the letter 'J').
+                                        // Only when negative (overflow) and not when positive
+                                        // (which are more frequent), mostly to keep some good
+                                        // looking rectangles on the sides when highlighting
+                                        // multiple lines.
+                                        rect.left += font->getLeftSideBearing(str[offset], true);
+                                        if ( !hyphen_added )
+                                            rect.right -= font->getRightSideBearing(str[offset], true);
+                                        // Should work whether rtl or ltr
                                     }
                                     // Ensure we always return a non-zero width, even for zero-width
                                     // chars or collapsed spaces (to avoid isEmpty() returning true
@@ -10968,44 +10958,37 @@ bool ldomXPointer::getRect(lvRect & rect, bool extended, bool adjusted, int * ct
                         //rect.top = word->y + rc.top + frmline->y + frmline->baseline;
                         rect.top = rc.top + frmline->y;
                         if (extended) { // get width of char at offset
-                            if (offset == word->t.start && word->t.len == 1) {
-                                // With CJK chars, the measured width seems
-                                // less correct than the one measured while
-                                // making words. So use the calculated word
-                                // width for one-char-long words instead
-                                rect.right = rect.left + word->width;
+                            // With one-char-long words, the measured width seems less correct than the one
+                            // measured while making words (noticed with CJK words). Use it instead.
+                            int chw = word->t.len == 1 ? word->width : w[ offset - word->t.start ] - chx;
+                            bool hyphen_added = false;
+                            if ( offset == word->t.start + word->t.len - 1
+                                    && (word->flags & LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER) ) {
+                                // if offset is the end of word, and this word has
+                                // been hyphenated, includes the hyphen width
+                                chw += font->getHyphenWidth();
+                                // We then should not account for the right side
+                                // bearing below
+                                hyphen_added = true;
                             }
-                            else {
-                                int chw = w[ offset - word->t.start ] - chx;
-                                bool hyphen_added = false;
-                                if ( offset == word->t.start + word->t.len - 1
-                                        && (word->flags & LTEXT_WORD_CAN_HYPH_BREAK_LINE_AFTER) ) {
-                                    // if offset is the end of word, and this word has
-                                    // been hyphenated, includes the hyphen width
-                                    chw += font->getHyphenWidth();
-                                    // We then should not account for the right side
-                                    // bearing below
-                                    hyphen_added = true;
-                                }
-                                rect.right = rect.left + chw;
-                                if ( !hyphen_added ) {
-                                    // Also remove our added letter spacing for justification
-                                    // from the right, to have cleaner highlights.
-                                    rect.right -= word->added_letter_spacing;
-                                }
-                                if (adjusted) {
-                                    // Extend left or right if this glyph overflows its
-                                    // origin/advance box (can happen with an italic font,
-                                    // or with a regular font on the right of the letter 'f'
-                                    // or on the left of the letter 'J').
-                                    // Only when negative (overflow) and not when positive
-                                    // (which are more frequent), mostly to keep some good
-                                    // looking rectangles on the sides when highlighting
-                                    // multiple lines.
-                                    rect.left += font->getLeftSideBearing(str[offset], true);
-                                    if ( !hyphen_added )
-                                        rect.right -= font->getRightSideBearing(str[offset], true);
-                                }
+                            rect.right = rect.left + chw;
+                            if ( !hyphen_added ) {
+                                // Also remove our added letter spacing for justification
+                                // from the right, to have cleaner highlights.
+                                rect.right -= word->added_letter_spacing;
+                            }
+                            if (adjusted) {
+                                // Extend left or right if this glyph overflows its
+                                // origin/advance box (can happen with an italic font,
+                                // or with a regular font on the right of the letter 'f'
+                                // or on the left of the letter 'J').
+                                // Only when negative (overflow) and not when positive
+                                // (which are more frequent), mostly to keep some good
+                                // looking rectangles on the sides when highlighting
+                                // multiple lines.
+                                rect.left += font->getLeftSideBearing(str[offset], true);
+                                if ( !hyphen_added )
+                                    rect.right -= font->getRightSideBearing(str[offset], true);
                             }
                             // Ensure we always return a non-zero width, even for zero-width
                             // chars or collapsed spaces (to avoid isEmpty() returning true

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -15239,6 +15239,9 @@ public:
         else if ( STYLE_HAS_CR_HINT(style, TEXT_SELECTION_BLOCK) ) {
             newBlock = true;
         }
+        else if ( elem->getNodeId() == el_br ) {
+            newBlock = true;
+        }
         else if ( rm == erm_inline ) {
             // Don't set newBlock if rendering method is erm_inline,
             // no matter the original CSS display.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -93,7 +93,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.77k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.78k"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0034
 

--- a/crengine/src/renderutil.cpp
+++ b/crengine/src/renderutil.cpp
@@ -1,0 +1,691 @@
+/*
+ * Shared rendering helpers.
+ *
+ * This file currently centralizes the engine's CSS initial-letter support so
+ * layout (lvtextfm.cpp), rendering (lvrend.cpp) and rect / hit-testing
+ * (lvtinydom.cpp) keep using the exact same geometry rules.
+ *
+ * The important model is:
+ *   1. We build a dedicated used font for the ::first-letter pseudo from the
+ *      parent line metrics.
+ *   2. We measure the real glyph ink of that enlarged initial.
+ *   3. When possible, the pseudo's own inner final block is tightened to that
+ *      ink band, then allowed to grow back toward the parent line grid when a
+ *      purely ink-tight band would make ordinary char rects look too rugged.
+ *   4. The outer inline-box still reserves the full sunk shape on the first
+ *      line and for later-line exclusion.
+ *
+ * The trickiest part is baseline handling. Three different baselines matter:
+ *   - the style-adjusted baseline: the font baseline corrected by the used
+ *     line-height; this is the reference used when deriving glyph ink bounds
+ *   - the tightened-band strut baseline: the baseline requested for the
+ *     pseudo's tightened inner one-line box
+ *   - the rendered baseline: the actual baseline returned by
+ *     renderBlockElement() once that inner line has been formatted
+ *
+ * Those last two are often close, but they are not guaranteed to match. Low
+ * glyphs showed that using the requested strut baseline for outer placement is
+ * wrong: the inline-box must align against the rendered baseline, while the
+ * tightened band still needs the strut baseline to stay inside the ink band.
+ */
+
+#include "../include/fb2def.h"
+#include "../include/lvrend.h"
+#include "../include/renderutil.h"
+
+struct InitialLetterInkBounds
+{
+    int min_left;
+    int min_top;
+    int max_right;
+    int max_bottom;
+};
+
+struct InitialLetterInnerTextMetrics
+{
+    bool valid;
+    int line_height;
+    int strut_baseline;
+    LVFontRef font;
+
+    InitialLetterInnerTextMetrics()
+        : valid(false), line_height(0), strut_baseline(0), font()
+    {
+    }
+};
+
+static bool getInitialLetterInkBoundsPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
+        InitialLetterInkBounds & bounds, int computed_em);
+static bool getInitialLetterNaturalBandPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
+        const InitialLetterInkBounds & ink_bounds, int & expand_top, int & natural_height);
+
+// Shared predicate used throughout the engine to answer a very specific
+// question: "does this computed style represent an actually applied
+// initial-letter effect?".
+//
+// We intentionally exclude display:none here so callers do not have to keep
+// repeating that guard before doing extra initial-letter work.
+bool hasAppliedInitialLetter(css_style_rec_t * style) {
+    return style && style->display != css_d_none
+            && style->initial_letter.type == css_val_unspecified
+            && style->initial_letter.value >= 0;
+}
+
+// Applied initial-letter is always carried by a ::first-letter pseudo-element.
+// We use effective-node accessors so the same helper works both on the
+// original pseudo-element and on ::first-line clones that proxy back to it.
+static bool isAppliedInitialLetterPseudoElem(ldomNode * enode, css_style_rec_t * style) {
+    return enode && enode->getEffectiveNodeId() == el_pseudoElem
+            && enode->hasEffectiveAttribute(attr_FirstLetter)
+            && hasAppliedInitialLetter(style);
+}
+
+// Initial-letter rides on top of the existing inline-box pipeline.
+// This helper recognizes the wrapper shape produced by that pipeline:
+// the inlineBox host, whose first child is the ::first-letter pseudo-element.
+//
+// Having a shared recognizer avoids three copies of subtle structural checks,
+// especially once ::first-line clones are involved.
+ldomNode * getInitialLetterInlineBoxPseudoElem(ldomNode * inline_box)
+{
+    if ( !inline_box || inline_box->getChildCount() <= 0 ) {
+        return NULL;
+    }
+    ldomNode * node = inline_box->getChildNode(0);
+    if ( !node || node->getEffectiveNodeId() != el_pseudoElem || !node->hasEffectiveAttribute(attr_FirstLetter) ) {
+        return NULL;
+    }
+    css_style_ref_t style_ref = node->getStyle();
+    if ( style_ref.isNull() || !hasAppliedInitialLetter(style_ref.get()) ) {
+        return NULL;
+    }
+    return node;
+}
+
+// Return the used line-height that initial-letter sizing should be based on.
+//
+// The important subtlety is that we do *not* want ordinary document interline
+// scaling to distort the pseudo-element's own line-height math. The raised/
+// sunk initial is sized from the parent line box, but the pseudo-element's own
+// used line-height should stay anchored to its font metrics and authored CSS.
+//
+// This is why we skip the document-scale adjustment for the initial-letter
+// pseudo itself, while still keeping the usual behavior for ordinary styles.
+// (This helper is used both for the pseudo-element itself and for ordinary
+// parent paragraph line metrics.)
+static int getInitialLetterStyleLineHeightPx(ldomDocument * doc, ldomNode * enode,
+        css_style_rec_t * style, LVFontRef font, int computed_em)
+{
+    bool is_initial_letter = isAppliedInitialLetterPseudoElem(enode, style);
+    int line_h;
+    if ( style->line_height.type == css_val_unspecified &&
+            style->line_height.value == css_generic_normal ) {
+        line_h = font->getHeight();
+    }
+    else {
+        int em = computed_em >= 0 ? computed_em : font->getSize();
+        line_h = lengthToPx(enode, style->line_height, em, em, true);
+    }
+    if ( style->line_height.type != css_val_screen_px &&
+            doc->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE &&
+            !is_initial_letter ) {
+        line_h = (line_h * doc->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
+    }
+    if ( is_initial_letter && line_h < font->getHeight() ) {
+        line_h = font->getHeight();
+    }
+    return line_h;
+}
+
+// Initial-letter geometry is aligned against the line-box baseline, not the raw
+// font baseline. With enlarged initials, using the font baseline directly would
+// make the glyph ink sit too high or too low whenever the used line-height does
+// not match the font height.
+static int getInitialLetterStyleAdjustedBaselinePx(ldomDocument * doc, ldomNode * enode,
+        css_style_rec_t * style, LVFontRef font, int computed_em)
+{
+    int line_height = getInitialLetterStyleLineHeightPx(doc, enode, style, font, computed_em);
+    return font->getBaseline() + (line_height - font->getHeight()) / 2;
+}
+
+// Cap-height is the metric that most closely matches what CSS initial-letter
+// sizing is trying to align visually: the height of uppercase glyph bodies,
+// not total ascender height. Some font backends do not expose it, so we keep
+// the historical 0.7em fallback to stay robust across fonts.
+static int getInitialLetterFontCapHeightPx(LVFontRef font)
+{
+    int cap_height = font->getExtraMetric(font_metric_cap_height);
+    if ( cap_height > 0 )
+        return cap_height;
+    return font->getHeight() * 7 / 10;
+}
+
+// Extract the exact text that ::first-letter owns and apply the same
+// text-transform rendering will later apply.
+//
+// Geometry helpers must operate on the post-transform glyph sequence; otherwise
+// a case conversion could change glyph metrics and we would compute exclusion
+// depth or hit-testing bounds from the wrong characters.
+static bool getInitialLetterText(ldomNode * enode, css_style_rec_t * style, lString32 & text)
+{
+    if ( !isAppliedInitialLetterPseudoElem(enode, style) ) {
+        return false;
+    }
+    int first_letter_end = enode->getEffectiveAttributeValue(attr_FirstLetter).atoi();
+    if ( first_letter_end <= 0 )
+        return false;
+    ldomNode * text_node = enode->getEffectiveFirstLetterTextNode();
+    if ( !text_node )
+        return false;
+    text = text_node->getText();
+    if ( text.length() < first_letter_end )
+        return false;
+    text = text.substr(0, first_letter_end);
+    switch (style->text_transform) {
+        case css_tt_uppercase: text.uppercase(); break;
+        case css_tt_lowercase: text.lowercase(); break;
+        case css_tt_capitalize: text.capitalize(); break;
+        case css_tt_full_width: break;
+        case css_tt_none: break;
+        case css_tt_inherit: break;
+    }
+    return !text.empty();
+}
+
+// Given a target cap-height, iteratively find the font size that actually
+// produces it with the current font lookup pipeline.
+//
+// We cannot just scale once proportionally because the final font metrics are
+// the result of font selection, hinting and backend rounding. The loop keeps
+// re-resolving the font and nudging the size toward the requested cap-height
+// until the remaining difference is visually negligible.
+static int getInitialLetterFontSizePx(ldomNode * enode, css_style_rec_t * style, int target_cap_height_px)
+{
+    int font_size_px = 0;
+    LVFontRef computed_font = enode ? enode->getFont() : LVFontRef();
+    if ( !computed_font.isNull() ) {
+        font_size_px = computed_font->getSize();
+    }
+    if ( font_size_px <= 0 ) {
+        font_size_px = lengthToPx(enode, style->font_size, 0, 0);
+    }
+    if ( font_size_px < 8 )
+        font_size_px = 8;
+    if ( target_cap_height_px < 8 )
+        return 8;
+    int doc_id = enode->getDocument()->getFontContextDocIndex();
+    css_style_rec_t tmp = *style;
+    // Iterate a few times to converge on the requested cap height while keeping the number of getFont()
+    // lookups bounded. 6 rounds has proven plenty to settle (usually in 2 or 3) or get within the +/-1px stop.
+    for ( int i=0; i<6; i++ ) {
+        tmp.font_size.type = css_val_screen_px;
+        tmp.font_size.value = font_size_px;
+        LVFontRef font = getFont(enode, &tmp, doc_id);
+        int font_cap_height = getInitialLetterFontCapHeightPx(font);
+        if ( font_cap_height <= 0 )
+            break;
+        int diff = font_cap_height > target_cap_height_px ? font_cap_height - target_cap_height_px : target_cap_height_px - font_cap_height;
+        if ( diff <= 1 )
+            break;
+        int next_font_size_px = font_size_px * target_cap_height_px / font_cap_height;
+        if ( next_font_size_px == font_size_px ) {
+            if ( font_cap_height < target_cap_height_px && font_size_px < 340 )
+                next_font_size_px++;
+            else if ( font_cap_height > target_cap_height_px && font_size_px > 8 )
+                next_font_size_px--;
+            else
+                break;
+        }
+        if ( next_font_size_px < 8 )
+            next_font_size_px = 8;
+        else if ( next_font_size_px > 340 )
+            next_font_size_px = 340;
+        if ( next_font_size_px == font_size_px )
+            break;
+        font_size_px = next_font_size_px;
+    }
+    return font_size_px;
+}
+
+// Build the used rendering font for the initial-letter pseudo-element.
+//
+// CSS gives us the initial-letter "size" in lines, not a literal font-size.
+// To turn that into an actual font, we:
+//   1. look at the parent line-height and parent cap-height
+//   2. derive the target cap-height for the initial based on the CSS value
+//   3. iteratively search the font-size that reaches that target
+//   4. resolve the final LVFont through the normal engine font lookup
+//
+// Callers may pass the parent style/font when they already have them, which
+// keeps layout/render hot paths from doing redundant lookups.
+static LVFontRef getUsedInitialLetterFont(ldomNode * enode, css_style_rec_t * style,
+        css_style_rec_t * parent_style, LVFontRef parent_font)
+{
+    if ( !isAppliedInitialLetterPseudoElem(enode, style) ) {
+        return LVFontRef();
+    }
+    if ( parent_style == NULL || parent_font.isNull() ) {
+        ldomNode * parent = enode->getParentNode();
+        if ( !parent || parent->isNull() )
+            return LVFontRef();
+        if ( parent_style == NULL ) {
+            css_style_ref_t parent_style_ref = parent->getStyle();
+            if ( parent_style_ref.isNull() )
+                return LVFontRef();
+            parent_style = parent_style_ref.get();
+        }
+        if ( parent_font.isNull() ) {
+            parent_font = parent->getFont();
+            if ( parent_font.isNull() )
+                return LVFontRef();
+        }
+    }
+    int parent_line_height = getInitialLetterStyleLineHeightPx(enode->getDocument(), enode, parent_style, parent_font, -1);
+    if ( parent_line_height <= 0 )
+        return LVFontRef();
+    int initial_letter_size = style->initial_letter.value >> 8;
+    int parent_cap_height = getInitialLetterFontCapHeightPx(parent_font);
+    int target_height = parent_cap_height + ((initial_letter_size - 256) * parent_line_height) / 256;
+    if ( target_height < parent_cap_height )
+        target_height = parent_cap_height;
+    css_style_rec_t tmp = *style;
+    tmp.font_size.type = css_val_screen_px;
+    tmp.font_size.value = getInitialLetterFontSizePx(enode, style, target_height);
+    int doc_id = enode->getDocument()->getFontContextDocIndex();
+    return getFont(enode, &tmp, doc_id);
+}
+
+// The inline-box outer layout still treats the initial as one object, but the
+// pseudo-element's own inner final block can use a tighter one-line box so
+// createXPointer()/getRect() can rely on ordinary per-char text geometry.
+static bool getInitialLetterInnerTextMetrics(ldomNode * enode, InitialLetterInnerTextMetrics & metrics)
+{
+    css_style_ref_t style_ref = enode ? enode->getStyle() : css_style_ref_t();
+    LVFontRef computed_font = enode ? enode->getFont() : LVFontRef();
+    if ( enode == NULL || style_ref.isNull() || computed_font.isNull() ) {
+        return false;
+    }
+    css_style_rec_t * style = style_ref.get();
+    if ( !isAppliedInitialLetterPseudoElem(enode, style) ) {
+        return false;
+    }
+    LVFontRef font = getUsedInitialLetterFont(enode, style, NULL, LVFontRef());
+    if ( font.isNull() ) {
+        return false;
+    }
+    InitialLetterInkBounds ink_bounds;
+    if ( !getInitialLetterInkBoundsPx(enode, style, font, ink_bounds, computed_font->getSize()) ) {
+        return false;
+    }
+    int line_height = ink_bounds.max_bottom - ink_bounds.min_top;
+    if ( line_height <= 0 ) {
+        return false;
+    }
+    int adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(enode->getDocument(), enode, style, font, computed_font->getSize());
+    int strut_baseline = adjusted_baseline - ink_bounds.min_top;
+    // The tightened band must still contain the baseline used to render the
+    // pseudo text. If it would end up fully below that baseline, the glyph may
+    // disappear entirely; if it ends exactly on the baseline, some low glyphs
+    // (like a sunk lowercase 'o') can also get clipped away. Keep the old
+    // metrics in the first case, and just extend the tightened band by 1px in
+    // the second.
+    if ( strut_baseline <= 0 ) {
+        return false;
+    }
+    if ( strut_baseline >= line_height ) {
+        line_height = strut_baseline + 1;
+    }
+    int expand_top = 0;
+    int natural_height = 0;
+    if ( getInitialLetterNaturalBandPx(enode, style, font, ink_bounds, expand_top, natural_height) ) {
+        if ( expand_top > 0 ) {
+            strut_baseline += expand_top;
+            line_height += expand_top;
+        }
+        if ( natural_height > line_height ) {
+            line_height = natural_height;
+        }
+    }
+    if ( strut_baseline >= line_height ) {
+        line_height = strut_baseline + 1;
+    }
+    metrics.line_height = line_height;
+    metrics.strut_baseline = strut_baseline;
+    metrics.font = font;
+    metrics.valid = true;
+    return true;
+}
+
+// Rendering needs one coherent bundle for the pseudo final block and for the
+// actual AddSourceLine() text run. The tightened ink-band metrics are optional,
+// but callers should not have to open-code the fallback chain when they are not
+// available.
+bool getInitialLetterTextLayout(ldomNode * enode, int default_line_height, InitialLetterTextLayout & layout)
+{
+    css_style_ref_t style_ref = enode ? enode->getStyle() : css_style_ref_t();
+    LVFontRef computed_font = enode ? enode->getFont() : LVFontRef();
+    if ( enode == NULL || style_ref.isNull() || computed_font.isNull() ) {
+        return false;
+    }
+    css_style_rec_t * style = style_ref.get();
+    if ( !isAppliedInitialLetterPseudoElem(enode, style) ) {
+        return false;
+    }
+
+    layout = InitialLetterTextLayout();
+    layout.font = computed_font;
+    layout.line_height = default_line_height;
+    layout.first_letter_line_height = default_line_height;
+    int fh = computed_font->getHeight();
+    int fb = computed_font->getBaseline();
+    int f_half_leading = (default_line_height - fh) / 2;
+    layout.strut_baseline = fb + f_half_leading;
+
+    LVFontRef used_font = getUsedInitialLetterFont(enode, style, NULL, LVFontRef());
+    if ( !used_font.isNull() ) {
+        layout.font = used_font;
+        int used_line_height = getInitialLetterStyleLineHeightPx(enode->getDocument(),
+                enode, style, used_font, computed_font->getSize());
+        if ( used_line_height > 0 ) {
+            layout.first_letter_line_height = used_line_height;
+        }
+    }
+
+    InitialLetterInnerTextMetrics inner_metrics;
+    if ( getInitialLetterInnerTextMetrics(enode, inner_metrics) ) {
+        layout.tightened = true;
+        layout.font = inner_metrics.font;
+        layout.line_height = inner_metrics.line_height;
+        layout.strut_baseline = inner_metrics.strut_baseline;
+        layout.first_letter_line_height = inner_metrics.line_height;
+    }
+    return true;
+}
+
+// Measure the union of the actual glyph ink boxes for the rendered initial.
+//
+// We intentionally compute *ink* bounds rather than advance-width bounds:
+// initial-letter exclusion, drawing overflow and selection rectangles should
+// follow what is visibly painted, not the logical pen position alone.
+//
+// The helper first measures cumulative advances for the transformed text, then
+// asks the font backend for each glyph's origin and black-box dimensions, and
+// finally unions those rectangles in line-box coordinates.
+static bool getInitialLetterInkBoundsPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
+        InitialLetterInkBounds & bounds, int computed_em)
+{
+    lString32 text;
+    if ( !getInitialLetterText(enode, style, text) )
+        return false;
+    int adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(enode->getDocument(), enode, style, font, computed_em);
+    int letter_spacing = lengthToPx(enode, style->letter_spacing, computed_em);
+    lUInt16 widths[64];
+    lUInt8 flags[64];
+    int len = text.length();
+    if ( len > 64 ) {
+        len = 64;
+    }
+    // (We measure ink per-codepoint, so this may differ from what will be shaped by Harfbuzz and drawn.
+    // This is probably acceptable as initial-letter is typically one grapheme or a few simple chars.)
+    font->measureText(text.c_str(), len, widths, flags, 0x7FFF, '?', NULL, letter_spacing, false, 0);
+    bounds.min_left = 0;
+    bounds.min_top = 0;
+    bounds.max_right = 0;
+    bounds.max_bottom = 0;
+    bool found = false;
+    for ( int i=0; i<len; i++ ) {
+        LVFont::glyph_info_t glyph;
+        if ( font->getGlyphInfo(text[i], &glyph, '?' ) ) {
+            int pen_x = i > 0 ? widths[i - 1] : 0;
+            int left = pen_x + glyph.originX;
+            int top = adjusted_baseline - glyph.originY;
+            int right = left + glyph.blackBoxX;
+            int bottom = top + glyph.blackBoxY;
+            if ( !found || left < bounds.min_left )
+                bounds.min_left = left;
+            if ( !found || top < bounds.min_top )
+                bounds.min_top = top;
+            if ( right > bounds.max_right )
+                bounds.max_right = right;
+            if ( bottom > bounds.max_bottom )
+                bounds.max_bottom = bottom;
+            found = true;
+        }
+    }
+    return found;
+}
+
+// Expand the pseudo's own one-line band back toward the parent line grid when
+// the visually tightened ink band would otherwise be noticeably smaller than
+// the surrounding natural lines.
+static bool getInitialLetterNaturalBandPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
+        const InitialLetterInkBounds & ink_bounds, int & expand_top, int & natural_height)
+{
+    expand_top = 0;
+    natural_height = 0;
+    ldomNode * parent = enode ? enode->getParentNode() : NULL;
+    if ( !parent || parent->isNull() || !style || font.isNull() ) {
+        return false;
+    }
+    css_style_ref_t parent_style_ref = parent->getStyle();
+    LVFontRef parent_font = parent->getFont();
+    if ( parent_style_ref.isNull() || parent_font.isNull() ) {
+        return false;
+    }
+    css_style_rec_t * parent_style = parent_style_ref.get();
+    int parent_line_height = getInitialLetterStyleLineHeightPx(parent->getDocument(), parent,
+            parent_style, parent_font, -1);
+    if ( parent_line_height <= 0 ) {
+        return false;
+    }
+    int sink = style->initial_letter.value & 0xFF;
+    if ( sink <= 0 ) {
+        sink = 1;
+    }
+    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(parent->getDocument(), parent,
+            parent_style, parent_font, -1);
+    int initial_baseline = font->getBaseline();
+    int initial_letter_size = style->initial_letter.value >> 8;
+    int top_offset;
+    if ( initial_letter_size >= sink * 256 ) {
+        top_offset = parent_adjusted_baseline + (sink - 1) * parent_line_height - initial_baseline;
+    }
+    else {
+        int parent_cap_height = getInitialLetterFontCapHeightPx(parent_font);
+        int initial_cap_height = getInitialLetterFontCapHeightPx(font);
+        top_offset = parent_adjusted_baseline - parent_cap_height
+                    - (initial_baseline - initial_cap_height);
+    }
+    int actual_top = top_offset + ink_bounds.min_top;
+    if ( actual_top > 0 ) {
+        expand_top = actual_top;
+        natural_height = sink * parent_line_height;
+    }
+    else {
+        // Raised initials can already extend above the parent line grid. If we
+        // keep that higher top, the natural bottom has to be measured from that
+        // real top, not from the grid top, otherwise the last sunk line stays
+        // a bit too short.
+        natural_height = sink * parent_line_height - actual_top;
+    }
+    return true;
+}
+
+// Small convenience wrapper for callers that only care about the deepest ink
+// extent. We keep it as a separate helper because some layout paths only need
+// the lower bound to extend exclusion or overflow, and recomputing the full
+// rectangle at each call site would just duplicate boilerplate.
+static int getInitialLetterInkBottomPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font, int computed_em)
+{
+    lString32 text;
+    if ( !getInitialLetterText(enode, style, text) )
+        return -1;
+    int adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(enode->getDocument(), enode, style, font, computed_em);
+    int max_bottom = 0;
+    bool found = false;
+    for ( int i=0; i<text.length(); i++ ) {
+        LVFont::glyph_info_t glyph;
+        if ( font->getGlyphInfo(text[i], &glyph, '?' ) ) {
+            int bottom = adjusted_baseline - glyph.originY + glyph.blackBoxY;
+            if ( bottom > max_bottom )
+                max_bottom = bottom;
+            found = true;
+        }
+    }
+    return found ? max_bottom : -1;
+}
+
+// Inline-box-backed initial-letter layout needs one more derived layer on top
+// of the raw font/ink helpers above: where should the box baseline sit on the
+// first line, and how much depth should later lines exclude below it?
+//
+// This helper converts the CSS size/sink pair into concrete formatter values.
+// It uses the parent paragraph metrics as the reference grid, then adjusts that
+// grid with the actual used font and actual ink extents of the enlarged glyph.
+bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseline,
+        InitialLetterInlineBoxMetrics & metrics)
+{
+    ldomNode * pseudo = getInitialLetterInlineBoxPseudoElem(inline_box);
+    if ( !pseudo ) {
+        return false;
+    }
+    ldomNode * parent = inline_box->getParentNode();
+    if ( !parent || parent->isNull() ) {
+        return false;
+    }
+    css_style_ref_t style_ref = pseudo->getStyle();
+    css_style_ref_t parent_style_ref = parent->getStyle();
+    LVFontRef computed_font = pseudo->getFont();
+    LVFontRef parent_font = parent->getFont();
+    if ( style_ref.isNull() || parent_style_ref.isNull() || computed_font.isNull() || parent_font.isNull() ) {
+        return false;
+    }
+    css_style_rec_t * style = style_ref.get();
+    css_style_rec_t * parent_style = parent_style_ref.get();
+    LVFontRef font = getUsedInitialLetterFont(pseudo, style, parent_style, parent_font);
+    if ( font.isNull() ) {
+        font = computed_font;
+    }
+    int computed_em = computed_font->getSize();
+    int parent_line_height = getInitialLetterStyleLineHeightPx(parent->getDocument(), parent, parent_style, parent_font, -1);
+    if ( parent_line_height <= 0 ) {
+        return false;
+    }
+    int sink = style->initial_letter.value & 0xFF;
+    if ( sink <= 0 ) {
+        sink = 1;
+    }
+    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(parent->getDocument(), parent, parent_style, parent_font, -1);
+    int initial_baseline = font->getBaseline();
+    int initial_letter_size = style->initial_letter.value >> 8;
+    int top_offset;
+    if ( initial_letter_size >= sink * 256 ) {
+        top_offset = parent_adjusted_baseline + (sink - 1) * parent_line_height - initial_baseline;
+    }
+    else {
+        int parent_cap_height = getInitialLetterFontCapHeightPx(parent_font);
+        int initial_cap_height = getInitialLetterFontCapHeightPx(font);
+        top_offset = parent_adjusted_baseline - parent_cap_height
+                    - (initial_baseline - initial_cap_height);
+    }
+    metrics.exclusion_height = sink * parent_line_height;
+    InitialLetterInkBounds ink_bounds;
+    bool have_ink_bounds = getInitialLetterInkBoundsPx(pseudo, style, font, ink_bounds, computed_em);
+    if ( have_ink_bounds ) {
+        InitialLetterInnerTextMetrics inner_metrics;
+        if ( getInitialLetterInnerTextMetrics(pseudo, inner_metrics) ) {
+            int adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(pseudo->getDocument(), pseudo, style, font, computed_em);
+            // renderBlockElement() returns the actual baseline used by the
+            // pseudo final block after it has formatted its single tightened
+            // line. The outer inline-box must align against that rendered
+            // baseline, not directly against the tightened band baseline: low
+            // glyphs showed that the formatter can keep the rendered baseline a
+            // little below the requested strut baseline when the font metrics are
+            // taller than the tightened band.
+            metrics.placement_baseline = parent_adjusted_baseline - top_offset
+                    + rendered_baseline - adjusted_baseline;
+        }
+        else {
+            // The inline-box keeps its own baseline, but must visually sit on the
+            // parent paragraph grid defined by initial-letter size and sink.
+            metrics.placement_baseline = rendered_baseline + parent_adjusted_baseline - top_offset - initial_baseline;
+        }
+        int actual_top = top_offset + ink_bounds.min_top;
+        if ( actual_top < 0 ) {
+            metrics.top_overflow = -actual_top;
+        }
+    }
+    else {
+        metrics.placement_baseline = rendered_baseline + parent_adjusted_baseline - top_offset - initial_baseline;
+    }
+    int visual_bottom = getInitialLetterInkBottomPx(pseudo, style, font, computed_em);
+    if ( visual_bottom <= 0 ) {
+        visual_bottom = getInitialLetterStyleLineHeightPx(pseudo->getDocument(), pseudo, style, font, computed_em);
+    }
+    int actual_bottom = top_offset + visual_bottom;
+    if ( actual_bottom > metrics.exclusion_height ) {
+        metrics.exclusion_height = actual_bottom;
+    }
+    metrics.valid = true;
+    return true;
+}
+
+// Hit-testing wants the visual footprint of the enlarged initial-letter, not
+// the full inline-box line-height. Keep the horizontal footprint reserved by
+// layout, but vertically stay on the actual painted ink rather than the
+// pseudo's smoothed internal line box.
+bool getInitialLetterInlineBoxInkRect(ldomNode * inline_box, lvRect & rect)
+{
+    ldomNode * pseudo = getInitialLetterInlineBoxPseudoElem(inline_box);
+    if ( !pseudo ) {
+        return false;
+    }
+    ldomNode * parent = inline_box->getParentNode();
+    if ( !parent || parent->isNull() ) {
+        return false;
+    }
+    css_style_ref_t style_ref = pseudo->getStyle();
+    css_style_ref_t parent_style_ref = parent->getStyle();
+    LVFontRef computed_font = pseudo->getFont();
+    LVFontRef parent_font = parent->getFont();
+    if ( style_ref.isNull() || parent_style_ref.isNull() || computed_font.isNull() || parent_font.isNull() ) {
+        return false;
+    }
+    LVFontRef font = getUsedInitialLetterFont(pseudo, style_ref.get(), parent_style_ref.get(), parent_font);
+    if ( font.isNull() ) {
+        font = computed_font;
+    }
+    int computed_em = computed_font->getSize();
+    InitialLetterInkBounds ink_bounds;
+    if ( !getInitialLetterInkBoundsPx(pseudo, style_ref.get(), font, ink_bounds, computed_em) ) {
+        return false;
+    }
+    lvRect box_rect;
+    inline_box->getAbsRect(box_rect);
+    // Keep at least the inline-box footprint reserved by layout, but extend it
+    // when actual ink hangs outside it.
+    rect.left = box_rect.left;
+    int ink_left = box_rect.left + ink_bounds.min_left;
+    if ( ink_left < rect.left ) {
+        rect.left = ink_left;
+    }
+    rect.right = box_rect.right;
+    int ink_right = box_rect.left + ink_bounds.max_right;
+    if ( ink_right > rect.right ) {
+        rect.right = ink_right;
+    }
+    int expand_top = 0;
+    int natural_height = 0;
+    if ( getInitialLetterNaturalBandPx(pseudo, style_ref.get(), font, ink_bounds, expand_top, natural_height) ) {
+        rect.top = box_rect.top + expand_top;
+        rect.bottom = rect.top + (ink_bounds.max_bottom - ink_bounds.min_top);
+    }
+    else {
+        rect.top = box_rect.top + ink_bounds.min_top;
+        rect.bottom = box_rect.top + ink_bounds.max_bottom;
+    }
+    if ( rect.height() == 0 && rect.width() > 0 ) {
+        rect.bottom++;
+    }
+    return true;
+}


### PR DESCRIPTION
#### ldomXRange::getRangeText(): newline on `<br/>`

So notes in highlights do reflect BR.

#### `createXPointer(pt)`/`getRect()`: use formatter `src->t.text`

No need to fetch again the text from the node and text_transform it: it is already right here available as `src-t.text`.
This also fixes the behaviour of these 2 methods on a `pseudoElem[FirstLetter]` by actually getting its real text to work with (previously, it was odd, but neglected as not really bothering on rare first-letter).

#### `getRect()`: unify one-char-long word width handling

We had a dedicated branch to handle one-char-long words, to use the more accurate `word->width` instead of the measured char widths. But we missed doing what is done in the other branch: handling any hyphen, and adding side bearings when `adjusted=true`.
Switch to a single branch and handle one-char-long words inline.

#### CSS `::first-letter:` use non-letter char if no letter in first text node

Noticed/discussed at https://github.com/koreader/crengine/issues/646#issuecomment-4322285401.

#### CSS `::first-line`: properly handle inline-block

Previously, we were not cloning inline-block and floats, they were rendered with they style as if on the second line even if on the first line.
We need to pass them as clones to `AddSourceObject()` for the first-line segment, and make `RenderBlockElementEnhanced()` aware of them by using *Effective* methods to resolve their real source when appropriate.
lvtextfm may then get 2 inlineBox, but will use and position only one of them (whether on the first line or not). If the `cloneNode` one is the one being positionned, it will flag the original node's fmt with `BOX_IS_DISCARDED`.
`getRect()` has been made aware of this fact and will jump to its `cloneNode` when meeting a original with this flag.
(we style float to stay consistents, Edge does not, not sure if it is per-specs.)

#### `createXPointer(pt)`: return source text node on `pseudoElem[FirstLetter]`

If `pt` is inside a rendered `::first-letter`, return a xpointer to the original source text node.
(`getRect()` is able to find it again in its `pseudoElem[FirstLetter]`.)

#### `getSegmentRects()`: compare .bottom additionally to .top

With the coming up support for initial-letter, whose rect can extend below the current line height (and that we want as an individual segment), update all .top comparisons to also compare .bottom.

#### lvfntman: add `getCapHeight()`

Also deduplicate `x-height` code.

#### CSS `initial-letter`: add CSS parsing and style slot

Also add missing `page_break_before/after/inside` and `letter_spacing` to style comparison operator.

#### CSS `initial-letter`: render `::first-letter` via inline-box

When a `pseudoElem[FirstLetter]` is created and it is styled with `initial-letter`, make it `display: inline-block` so it's all rendered by the inlineBox pipeline, with some added tweaks:
- lvrend: size its used font and `line-height` appropriately, when feeding it to lvtextfm.
- lvtextfm: handle sunk-line exclusion (like done for floats, but with a specific datastructure).  It also keeps a reference to the font used for drawing (as the style font should still be the original computed font, for sizing related lengths in em unit Also update lvtextfm structs to allow for a signed baseline as we may now get negative baselines.
- lvtinydom.cpp: `clearRendBlockCache()` on closedocument before clearing fonts to avoid a crash.
- All the complex maths for sizing that inlineBox (including its ink-bound line height for text selection) and positionning it properly along the first line's baseline has been done by Github Copilot GPT5-4, and is externalized in a new added module: `renderutil.h/.cpp` (there's some in lvtextfm.cpp).

`createXPointer()`, `getRect()` and `getSegmentRects()` work naturally on this inlineBox after the non-initial-letter related fixes done in the few previous commits.

----
Made with/by Github Copilot over 330 prompts... https://github.com/koreader/crengine/issues/646#issuecomment-4423048512
It was initially promising, met a lot of issues, solved by ad-hoc hacks everywhere, I spend a lot of time simplifying/isolating each hacks to make them proper independant features and bug fixes, which made most of the commits but the 2 last ones.
I'm satisfied with the limited intrusion of this support in lvrend/lvtinydom and lvtexfm (which alas needs quite a bit).
All the maths and original copilot thinking is in renderutil.cpp: I have not really reviewed it, the comments are copilot's, it's hard to get into (because I didn't need to), and the maths for positionning and highlighting rects might still be a bit off with some fonts.... but I'm out of AI credit and can't harrass it more (and I'm losing interest).

(Re-reading the changes here, I still see a few "copilot made" comments that I loathe because they are ad-hoc on the fix we made, and unclear/off-topic in the end... but well... At least, I'll be able to recognize them in the future.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/666)
<!-- Reviewable:end -->
