### PR TITLE
crengine: preserve element background/text colors in night mode

### DIFF
--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -108,6 +108,36 @@ public:
     /// set to true to invert images only (so they get inverted back to normal by nightmode)
     virtual void setInvertImages( bool invert ) = 0;
     virtual bool getInvertImages() const = 0;
+    /// set to true to invert background colors only (so they get inverted back to normal by nightmode)
+    virtual void setInvertBackgroundColors( bool invert ) = 0;
+    virtual bool getInvertBackgroundColors() const = 0;
+    /// set to true to invert text colors only (so they get inverted back to normal by nightmode)
+    virtual void setInvertTextColors( bool invert ) = 0;
+    virtual bool getInvertTextColors() const = 0;
+    lUInt32 applyNightModeToBackgroundColor( lUInt32 cl ) const {
+        if ( !getInvertBackgroundColors() )
+            return cl;
+        if ( (cl & 0xFF000000) == 0xFF000000 )
+            return cl;
+        lUInt32 r = (cl >> 16) & 0xFF;
+        lUInt32 g = (cl >> 8) & 0xFF;
+        lUInt32 b = cl & 0xFF;
+        if ( r == g && r == b )
+            return cl;
+        return (cl & 0xFF000000) | ((255-r) << 16) | ((255-g) << 8) | (255-b);
+    }
+    lUInt32 applyNightModeToTextColor( lUInt32 cl ) const {
+        if ( !getInvertTextColors() )
+            return cl;
+        if ( (cl & 0xFF000000) == 0xFF000000 )
+            return cl;
+        lUInt32 r = (cl >> 16) & 0xFF;
+        lUInt32 g = (cl >> 8) & 0xFF;
+        lUInt32 b = cl & 0xFF;
+        if ( r == g && r == b )
+            return cl;
+        return (cl & 0xFF000000) | ((255-r) << 16) | ((255-g) << 8) | (255-b);
+    }
     /// set to true to enforce dithering (only relevant for 8bpp Gray drawBuf)
     virtual void setDitherImages( bool dither ) = 0;
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor
@@ -259,6 +289,8 @@ protected:
     lUInt32 _textColor;
     bool _hidePartialGlyphs;
     bool _invertImages;
+    bool _invertBackgroundColors;
+    bool _invertTextColors;
     bool _ditherImages;
     bool _smoothImages;
     int _drawnImagesCount;
@@ -269,6 +301,12 @@ public:
     /// set to true to invert images only (so they get inverted back to normal by nightmode)
     virtual void setInvertImages( bool invert ) { _invertImages = invert; }
     virtual bool getInvertImages() const { return _invertImages; }
+    /// set to true to invert background colors only (so they get inverted back to normal by nightmode)
+    virtual void setInvertBackgroundColors( bool invert ) { _invertBackgroundColors = invert; }
+    virtual bool getInvertBackgroundColors() const { return _invertBackgroundColors; }
+    /// set to true to invert text colors only (so they get inverted back to normal by nightmode)
+    virtual void setInvertTextColors( bool invert ) { _invertTextColors = invert; }
+    virtual bool getInvertTextColors() const { return _invertTextColors; }
     /// set to true to enforce dithering (only relevant for 8bpp Gray drawBuf)
     virtual void setDitherImages( bool dither ) { _ditherImages = dither; }
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor
@@ -316,7 +354,8 @@ public:
     int getDrawnImagesSurface() const { return _drawnImagesSurface; }
 
     LVBaseDrawBuf() : _dx(0), _dy(0), _rowsize(0), _data(NULL), _drawExtraInfo(NULL), _hidePartialGlyphs(true),
-                        _invertImages(false), _ditherImages(false), _smoothImages(false),
+                        _invertImages(false), _invertBackgroundColors(false), _invertTextColors(false),
+                        _ditherImages(false), _smoothImages(false),
                         _drawnImagesCount(0), _drawnImagesSurface(0) { }
     virtual ~LVBaseDrawBuf() { }
 };

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10249,7 +10249,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 // 2-steps drawing), we may need to drawbuf.SetBackgroundColor()
                 // for the text to be correctly drawn over this background color.
                 oldColor = drawbuf.GetBackgroundColor();
-                drawbuf.SetBackgroundColor( bg_color );
+                drawbuf.SetBackgroundColor( enode->getNodeId() == el_body ? bg_color : drawbuf.applyNightModeToBackgroundColor( bg_color ) );
                 restoreBackgroundColor = true;
             }
             bool draw_bg_image = draw_background && !style->background_image.empty();
@@ -10269,7 +10269,7 @@ void DrawDocument( LVDrawBuf & drawbuf, ldomNode * enode, int x0, int y0, int dx
                 else {
                     // Regular element: draw bgcolor or image inside its border box
                     if ( draw_bg_color )
-                        drawbuf.FillRect( x0 + doc_x, y0 + doc_y, x0 + doc_x+fmt.getWidth(), y0+doc_y+fmt.getHeight(), bg_color );
+                        drawbuf.FillRect( x0 + doc_x, y0 + doc_y, x0 + doc_x+fmt.getWidth(), y0+doc_y+fmt.getHeight(), drawbuf.applyNightModeToBackgroundColor( bg_color ) );
                     if ( draw_bg_image )
                         DrawBackgroundImage(enode, drawbuf, x0, y0, doc_x, doc_y, fmt.getWidth(), fmt.getHeight());
                         // (Commented identical calls below as they seem redundant with what was just done here)

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -6303,7 +6303,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                             if ( lastWordStart!=-1 && lastWordColor!=bgcl ) {
                                 // Draw the background of a different color for previous words
                                 if ( ((lastWordColor>>24) & 0xFF) != 0xFF ) // Not reserved, not alpha=100% (not transparent)
-                                    buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, lastWordColor );
+                                    buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, buf->applyNightModeToBackgroundColor( lastWordColor ) );
                                 lastWordStart = -1;
                             }
                             // Draw the background for this pad up to its padding+border, but not its margin
@@ -6313,7 +6313,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                             lastWordEnd = x + frmline->x + word->x + word->o.height; // padding+border-right
                             lastWordColor = bgcl;
                             if ( ((lastWordColor>>24) & 0xFF) != 0xFF ) // Not reserved, not alpha=100% (not transparent)
-                                buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, lastWordColor );
+                                buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, buf->applyNightModeToBackgroundColor( lastWordColor ) );
                             lastWordStart = -1;
                             lastWordEnd = -1;
                             lastWordColor = LTEXT_COLOR_CURRENT;
@@ -6323,7 +6323,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                                 // Draw the background of a different color for previous words
                                 if ( lastWordStart!=-1 )
                                     if ( ((lastWordColor>>24) & 0xFF) != 0xFF ) // Not reserved, not alpha=100% (not transparent)
-                                        buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, lastWordColor );
+                                        buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, buf->applyNightModeToBackgroundColor( lastWordColor ) );
                                 // Next drawing will include this pad's padding+border-left
                                 lastWordColor=bgcl;
                                 lastWordStart = x + frmline->x + word->x + word->width - word->o.height;
@@ -6341,7 +6341,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                     if ( lastWordColor!=bgcl || lastWordStart==-1 ) {
                         if ( lastWordStart!=-1 )
                             if ( ((lastWordColor>>24) & 0xFF) != 0xFF ) // Not reserved, not alpha=100% (not transparent)
-                                buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, lastWordColor );
+                                buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, buf->applyNightModeToBackgroundColor( lastWordColor ) );
                         lastWordColor=bgcl;
                         lastWordStart = x+frmline->x+word->x;
                     }
@@ -6350,7 +6350,7 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
             }
             if ( lastWordStart!=-1 ) {
                 if ( ((lastWordColor>>24) & 0xFF) != 0xFF )
-                    buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, lastWordColor );
+                    buf->FillRect( lastWordStart, y + frmline->y, lastWordEnd, y + frmline->y + frmline->height, buf->applyNightModeToBackgroundColor( lastWordColor ) );
             }
 
             // Draw borders if we noticed there could be some
@@ -6624,10 +6624,10 @@ void LFormattedText::Draw( LVDrawBuf * buf, int x, int y, ldomMarkedRangeList * 
                         // Otherwise, LTEXT_COLOR_CURRENT: keep current buffer color
                     }
                     else {
-                        buf->SetTextColor( cl );
+                        buf->SetTextColor( buf->applyNightModeToTextColor( cl ) );
                     }
                     if ( !LTEXT_COLOR_IS_RESERVED(bgcl) )
-                        buf->SetBackgroundColor( bgcl );
+                        buf->SetBackgroundColor( buf->applyNightModeToBackgroundColor( bgcl ) );
                     // Add drawing flags: text decoration (underline...)
                     lUInt32 drawFlags = srcline->flags & LTEXT_TD_MASK;
                     // and chars direction, and if word begins or ends paragraph (for Harfbuzz)


### PR DESCRIPTION
Part of koreader/koreader#15544.

This PR adds crengine-side support for preserving element `background-color` and `color` values in KOReader night mode.

KOReader night mode globally inverts the framebuffer after rendering. crengine already pre-inverts colored image pixels via `_invertImages` so images keep their original colors. This change extends the same approach to CSS colors:

- Adds `setInvertBackgroundColors()` / `getInvertBackgroundColors()` and `setInvertTextColors()` / `getInvertTextColors()` to `LVDrawBuf`/`LVBaseDrawBuf`.
- Adds helpers `applyNightModeToBackgroundColor()` and `applyNightModeToTextColor()` that invert non-grayscale colors while leaving grayscale and transparent/special colors untouched.
- Applies the helpers to block backgrounds (`lvrend.cpp`), inline backgrounds (`lvtextfm.cpp`), and inline text colors (`lvtextfm.cpp`).
- Leaves `<body>`/page backgrounds untouched so they still invert normally (white → black).

Sibling PRs:
- koreader/koreader-base: TBD — Lua↔C bridge.
- koreader/koreader: TBD — frontend toggles.

**Note:** This work was prepared with assistance from a dreb harness AI agent running under explicit human supervision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/674)
<!-- Reviewable:end -->
