### PR TITLE
crengine: add -cr-hint: invert-colors for night mode reading

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -444,6 +444,7 @@ enum css_generic_value_t {
 // One can use this hint on IMG to avoid any such resize, trusting the publisher's CSS to do
 // the right things to avoid any overflow.
 #define CSS_CR_HINT_NO_CAP_IMAGE_SIZE       0x00000020 // -cr-hint: no-cap-image-size
+#define CSS_CR_HINT_INVERT_COLORS           0x00000040 // -cr-hint: invert-colors
 
 // A node with these should be considered as TOC item of level N when building alternate TOC
 #define CSS_CR_HINT_TOC_LEVEL1              0x00000100 // -cr-hint: toc-level1

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -119,6 +119,15 @@ enum css_style_rec_important_bit {
 // so they get the same consistent style they would get after a re-rendering.
 #define STYLE_REC_FLAG_INHERITABLE_APPLIED  0x02
 
+// Tracks color values already pre-inverted by -cr-hint: invert-colors, so
+// descendants inheriting them don't invert them a second time.
+#define STYLE_REC_INVERTED_COLOR                    0x01
+#define STYLE_REC_INVERTED_BACKGROUND_COLOR         0x02
+#define STYLE_REC_INVERTED_BORDER_TOP_COLOR         0x04
+#define STYLE_REC_INVERTED_BORDER_RIGHT_COLOR       0x08
+#define STYLE_REC_INVERTED_BORDER_BOTTOM_COLOR      0x10
+#define STYLE_REC_INVERTED_BORDER_LEFT_COLOR        0x20
+
 /**
     \brief Element style record.
 
@@ -189,6 +198,7 @@ struct css_style_rec_tag {
     css_ruby_position_t    ruby_position;
     lString32              content;
     css_length_t           cr_hint;
+    lUInt8                 cr_hint_inverted_colors;
     // The following should only be used when applying stylesheets while in lvend.cpp setNodeStyle(),
     // and cleaned up there, before the style is cached and shared. They are not serialized.
     lInt8                flags; // bitmap of STYLE_REC_FLAG_*
@@ -251,6 +261,7 @@ struct css_style_rec_tag {
     , caption_side(css_cs_inherit)
     , ruby_position(css_rp_inherit)
     , cr_hint(css_val_inherited, 0)
+    , cr_hint_inverted_colors(0)
     , flags(0)
     , pseudo_elem_before_style(NULL)
     , pseudo_elem_after_style(NULL)

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -62,6 +62,17 @@ int scaleForRenderDPI( int value ) {
     return value;
 }
 
+inline lUInt8 styleRecInvertedBorderColorFlag(int border_id)
+{
+    switch (border_id) {
+        case 0: return STYLE_REC_INVERTED_BORDER_TOP_COLOR;
+        case 1: return STYLE_REC_INVERTED_BORDER_RIGHT_COLOR;
+        case 2: return STYLE_REC_INVERTED_BORDER_BOTTOM_COLOR;
+        case 3: return STYLE_REC_INVERTED_BORDER_LEFT_COLOR;
+        default: return 0;
+    }
+}
+
 // Uncomment for debugging enhanced block rendering
 // #define DEBUG_BLOCK_RENDERING
 
@@ -297,6 +308,9 @@ void collapse_border(css_style_ref_t & target_style, int & current_target_size,
             }
             target_style->border_width[border_id] = neighbour_style->border_width[border_id];
             target_style->border_color[border_id] = neighbour_style->border_color[border_id];
+            lUInt8 inverted_color_flag = styleRecInvertedBorderColorFlag(border_id);
+            target_style->cr_hint_inverted_colors &= ~inverted_color_flag;
+            target_style->cr_hint_inverted_colors |= neighbour_style->cr_hint_inverted_colors & inverted_color_flag;
             current_target_size = neighbour_size;
         }
     }
@@ -2470,6 +2484,30 @@ inline lUInt32 getForegroundColor(const css_style_ref_t style)
             return LTEXT_COLOR_IS_RESERVED(style->color.value) ? LTEXT_COLOR_RESERVED_REPLACE : style->color.value;
         }
         return LTEXT_COLOR_CURRENT; // should not happen
+}
+
+inline lUInt32 invertNonGrayscaleColor(lUInt32 color)
+{
+    lUInt32 r = (color >> 16) & 0xFF;
+    lUInt32 g = (color >> 8) & 0xFF;
+    lUInt32 b = color & 0xFF;
+    if ( r != g || r != b ) // non-grayscale only
+        color ^= 0x00FFFFFF;
+    return color;
+}
+
+inline void invertStyleColorIfNeeded(css_length_t & color, lUInt8 & inverted_color_flags,
+                                     lUInt8 inverted_color_flag, bool skip_fully_transparent)
+{
+    if ( color.type != css_val_color || (inverted_color_flags & inverted_color_flag) )
+        return;
+    if ( skip_fully_transparent && IS_COLOR_FULLY_TRANSPARENT(color.value) )
+        return;
+    lUInt32 inverted_color = invertNonGrayscaleColor(color.value);
+    if ( inverted_color != (lUInt32)color.value ) {
+        color.value = inverted_color;
+        inverted_color_flags |= inverted_color_flag;
+    }
 }
 
 lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt32 oldflags, int direction )
@@ -4739,6 +4777,7 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->content = source->content ;
     dest->cr_hint.type = source->cr_hint.type ;
     dest->cr_hint.value = source->cr_hint.value ;
+    dest->cr_hint_inverted_colors = source->cr_hint_inverted_colors ;
 }
 
 // Only used by renderBlockElementLegacy()
@@ -11575,21 +11614,23 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // That is, 'color' will always be a css_val_color.
     // For the other 'background_color' and 'border_color[]', the only value possible
     // with css_val_unspecified is css_generic_currentcolor.
-
     // color
     // Inherited by default. Must always be a css_val_color: so 'inherit' or 'currentcolor'
     // is resolved to the parent's color (which will be our root node's color if no other
     // parent node got its color set).
     if ( pstyle->color.type == css_val_inherited || pstyle->color.type == css_val_unspecified ) {
         pstyle->color = parent_style->color;
+        pstyle->cr_hint_inverted_colors |= parent_style->cr_hint_inverted_colors & STYLE_REC_INVERTED_COLOR;
     }
 
     // border-color
     // Not inherited by default, defaults to "currentcolor", which should be kept as-is
     // so it can be inherited as-is ("currentcolor" should be resolved at use-time).
     for ( int i=0; i < 4; i++ ) {
-        if ( pstyle->border_color[i].type == css_val_inherited )
+        if ( pstyle->border_color[i].type == css_val_inherited ) {
             pstyle->border_color[i] = parent_style->border_color[i];
+            pstyle->cr_hint_inverted_colors |= parent_style->cr_hint_inverted_colors & styleRecInvertedBorderColorFlag(i);
+        }
     }
 
     // background-color
@@ -11598,6 +11639,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // simply draw its children over the already filled rect.
     if ( pstyle->background_color.type == css_val_inherited ) {
         pstyle->background_color = parent_style->background_color;
+        pstyle->cr_hint_inverted_colors |= parent_style->cr_hint_inverted_colors & STYLE_REC_INVERTED_BACKGROUND_COLOR;
     }
     else if (    pstyle->display >= css_d_table_row_group
               && pstyle->display <= css_d_table_cell
@@ -11613,6 +11655,12 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         //   background-color should handle it - but as a TR don't draw it,
         //   it will be propagated to the TD/TH under.
         // - (but not for TABLE, which draws itself its background.)
+        bool fcolor_inverted = pstyle->background_color.type == css_val_color ? // "currentcolor" if not
+                                (pstyle->cr_hint_inverted_colors & STYLE_REC_INVERTED_BACKGROUND_COLOR) :
+                                (pstyle->cr_hint_inverted_colors & STYLE_REC_INVERTED_COLOR);
+        bool parent_background_color_inverted = parent_style->background_color.type == css_val_color ? // "currentcolor" if not
+                                        (parent_style->cr_hint_inverted_colors & STYLE_REC_INVERTED_BACKGROUND_COLOR) :
+                                        (parent_style->cr_hint_inverted_colors & STYLE_REC_INVERTED_COLOR);
         lUInt32 fcolor = pstyle->background_color.type == css_val_color ? // "currentcolor" if not
                                     pstyle->background_color.value : pstyle->color.value;
         lUInt32 pcolor = parent_style->background_color.type == css_val_color ? // "currentcolor" if not
@@ -11623,6 +11671,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         if ( IS_COLOR_FULLY_TRANSPARENT(fcolor) ) {
             // Fully transparent: just use parent bgcolor.
             pstyle->background_color = parent_style->background_color;
+            pstyle->cr_hint_inverted_colors |= parent_style->cr_hint_inverted_colors & STYLE_REC_INVERTED_BACKGROUND_COLOR;
         }
         else if ( IS_COLOR_FULLY_OPAQUE(fcolor) ) {
             // Fully opaque: no blending needed, just let it be.
@@ -11631,30 +11680,31 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
             // Parent fully transparent: just let this node color be.
         }
         else {
+            // If this element is hinted, invert only this element's own semi-transparent
+            // background contribution before blending. Inverting the final blended color
+            // would also invert the propagated parent contribution, which may have its own
+            // inversion state.
+            if ( STYLE_HAS_CR_HINT(pstyle, INVERT_COLORS) && !fcolor_inverted )
+                fcolor = invertNonGrayscaleColor(fcolor);
             pstyle->background_color.value = combineColors(fcolor, pcolor);
             pstyle->background_color.type = css_val_color; // in case it was unspecified/currentcolor
+            if ( STYLE_HAS_CR_HINT(pstyle, INVERT_COLORS) || fcolor_inverted || parent_background_color_inverted )
+                pstyle->cr_hint_inverted_colors |= STYLE_REC_INVERTED_BACKGROUND_COLOR;
         }
     }
 
     // -cr-hint: invert-colors: pre-invert non-grayscale colors so KOReader night mode's
-    // global framebuffer inversion cancels it out and preserves the intended hue.
+    // global framebuffer inversion cancels it out and preserves the intended hue. Track
+    // which computed values were already pre-inverted so a later matching descendant that
+    // inherits them through any number of non-matching ancestors doesn't invert them again.
     if ( STYLE_HAS_CR_HINT(pstyle, INVERT_COLORS) ) {
-        if ( pstyle->color.type == css_val_color ) {
-            lUInt32 cl = pstyle->color.value;
-            lUInt32 r = (cl >> 16) & 0xFF;
-            lUInt32 g = (cl >> 8) & 0xFF;
-            lUInt32 b = cl & 0xFF;
-            if ( r != g || r != b ) // non-grayscale only
-                pstyle->color.value = cl ^ 0x00FFFFFF;
-        }
-        if ( pstyle->background_color.type == css_val_color
-             && !IS_COLOR_FULLY_TRANSPARENT(pstyle->background_color.value) ) {
-            lUInt32 cl = pstyle->background_color.value;
-            lUInt32 r = (cl >> 16) & 0xFF;
-            lUInt32 g = (cl >> 8) & 0xFF;
-            lUInt32 b = cl & 0xFF;
-            if ( r != g || r != b ) // non-grayscale only
-                pstyle->background_color.value = cl ^ 0x00FFFFFF;
+        invertStyleColorIfNeeded(pstyle->color, pstyle->cr_hint_inverted_colors,
+                                 STYLE_REC_INVERTED_COLOR, false);
+        invertStyleColorIfNeeded(pstyle->background_color, pstyle->cr_hint_inverted_colors,
+                                 STYLE_REC_INVERTED_BACKGROUND_COLOR, true);
+        for ( int i=0; i < 4; i++ ) {
+            invertStyleColorIfNeeded(pstyle->border_color[i], pstyle->cr_hint_inverted_colors,
+                                     styleRecInvertedBorderColorFlag(i), true);
         }
     }
 

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -11636,6 +11636,28 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         }
     }
 
+    // -cr-hint: invert-colors: pre-invert non-grayscale colors so KOReader night mode's
+    // global framebuffer inversion cancels it out and preserves the intended hue.
+    if ( STYLE_HAS_CR_HINT(pstyle, INVERT_COLORS) ) {
+        if ( pstyle->color.type == css_val_color ) {
+            lUInt32 cl = pstyle->color.value;
+            lUInt32 r = (cl >> 16) & 0xFF;
+            lUInt32 g = (cl >> 8) & 0xFF;
+            lUInt32 b = cl & 0xFF;
+            if ( r != g || r != b ) // non-grayscale only
+                pstyle->color.value = cl ^ 0x00FFFFFF;
+        }
+        if ( pstyle->background_color.type == css_val_color
+             && !IS_COLOR_FULLY_TRANSPARENT(pstyle->background_color.value) ) {
+            lUInt32 cl = pstyle->background_color.value;
+            lUInt32 r = (cl >> 16) & 0xFF;
+            lUInt32 g = (cl >> 8) & 0xFF;
+            lUInt32 b = cl & 0xFF;
+            if ( r != g || r != b ) // non-grayscale only
+                pstyle->background_color.value = cl ^ 0x00FFFFFF;
+        }
+    }
+
     // background-image
     // We have put "\x01" when meeting "background-image: inherit"
     if ( pstyle->background_image.length() == 1 && pstyle->background_image[0] == '\x01' )

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3582,6 +3582,7 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         else if ( substr_icompare("footnote", decl) )               hints |= CSS_CR_HINT_FOOTNOTE;
                         else if ( substr_icompare("footnote-ignore", decl) )        hints |= CSS_CR_HINT_FOOTNOTE_IGNORE;
                         else if ( substr_icompare("no-cap-image-size", decl) )      hints |= CSS_CR_HINT_NO_CAP_IMAGE_SIZE;
+                        else if ( substr_icompare("invert-colors", decl) )          hints |= CSS_CR_HINT_INVERT_COLORS;
                         else if ( substr_icompare("no-presentational", decl) ) {
                             // "-cr-hint: no-presentational" can be explicitely set on a node so any presentational-hint
                             // later selector is not matching, to avoid (some) presentational hints. For this to be

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -44,7 +44,7 @@ lUInt32 calcHash(font_ref_t & f)
 lUInt32 calcHash(css_style_rec_t & rec)
 {
     if ( !rec.hash )
-        rec.hash = (((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
+        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
          + (lUInt32)rec.important[0]) * 31
          + (lUInt32)rec.important[1]) * 31
          + (lUInt32)rec.important[2]) * 31
@@ -119,6 +119,7 @@ lUInt32 calcHash(css_style_rec_t & rec)
          + (lUInt32)rec.caption_side) * 31
          + (lUInt32)rec.ruby_position) * 31
          + (lUInt32)rec.cr_hint.pack()) * 31
+         + (lUInt32)rec.cr_hint_inverted_colors) * 31
          + (lUInt32)rec.font_name.getHash()
          + (lUInt32)rec.background_image.getHash()
          + (lUInt32)rec.content.getHash());
@@ -206,7 +207,8 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.caption_side == r2.caption_side&&
            r1.ruby_position == r2.ruby_position&&
            r1.content == r2.content&&
-           r1.cr_hint==r2.cr_hint;
+           r1.cr_hint==r2.cr_hint&&
+           r1.cr_hint_inverted_colors==r2.cr_hint_inverted_colors;
 }
 
 
@@ -411,6 +413,7 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_ENUM(ruby_position);
     buf << content;
     ST_PUT_LEN(cr_hint);
+    buf << cr_hint_inverted_colors;
     lUInt32 hash = calcHash(*this);
     buf << hash;
     return !buf.error();
@@ -487,6 +490,7 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_ENUM(css_ruby_position_t, ruby_position);
     buf>>content;
     ST_GET_LEN(cr_hint);
+    buf >> cr_hint_inverted_colors;
     lUInt32 hash = 0;
     buf >> hash;
     // printf("imp: %llx oldhash: %lx ", important, hash);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -93,7 +93,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 
 /// change in case of incompatible changes in swap/cache file format to avoid using incompatible swap file
 // increment to force complete reload/reparsing of old file
-#define CACHE_FILE_FORMAT_VERSION "3.05.78k"
+#define CACHE_FILE_FORMAT_VERSION "3.05.78l"
 /// increment following value to force re-formatting of old book after load
 #define FORMATTING_VERSION_ID 0x0034
 


### PR DESCRIPTION
Closes #675

This PR adds a new `-cr-hint: invert-colors` that inverts an element's computed `color` and `background-color` values at style-apply time. This lets users preserve deliberately colored elements when reading in KOReader's night mode, which globally inverts the framebuffer.

The implementation plan is posted as a comment below.

**Note:** This work was prepared with assistance from a dreb harness AI agent running under explicit human supervision.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/676)
<!-- Reviewable:end -->
