### PR TITLE
lvfntman: bugfix duplicate LVFontFace id

### DIFF
--- a/FONTMANAGER_REFACTOR.md
+++ b/FONTMANAGER_REFACTOR.md
@@ -532,6 +532,20 @@ This ordering is enforced explicitly in the destructor body.
 
 ## Future Work
 
+**Regression: duplicate-face detection ignored the requested family name.** *(Fixed)*
+`LVFontFace::id()` originally computed face identity from `(file_path,
+face_index, documentId)` only, so registering the *same font file* under a
+*second* `@font-face` family name, in the same document, was silently
+dropped as a duplicate by `tryRegisterFace()`. This was a regression relative
+to pre-refactor behaviour: the old `LVFontDef::operator==()` included
+`_typeface == def._typeface` in its equality check (confirmed at
+`72cf7cc2^`), so two registrations of the same file under different requested
+family names were correctly treated as distinct.
+
+Fixed by folding `typeface` into `id()`'s hash, mirroring the old `_typeface`
+equality check. Covered by Chapter 10 of `tests/font-manager-test.epub`
+(see `tests/FONT_MANAGER_TEST_PLAN.md` sec 17).
+
 **OpenType features.**
 Replace `int features` (32-bit bitmap) with an open-ended `LVFontFeatureSet`
 (vector of `hb_feature_t`). Removes the 32-feature limit, supports numeric
@@ -608,19 +622,14 @@ The FontConfig path registers all non-monospace fonts as `css_ff_sans_serif`.
 FontConfig can distinguish serif from sans-serif but the code does not use it.
 Step 3 of `select()` would benefit automatically if classification were added.
 
-**Synthesised small caps.** *(Done)*
-`LVFontFace` gained `has_small_caps`, detected in `inspectFTFace()` via
-HarfBuzz's `hb_ot_layout_language_find_feature()` lookup for the `smcp` GSUB
-feature. In `loadAndCache()`, when `LFNT_OT_FEATURES_P_SMCP` or
-`LFNT_OT_FEATURES_P_C2SC` is requested and the face has no native small-caps
-coverage, the loaded instance is wrapped in a new `LVFontSmallCapsTransform`
-(analogous to `LVFontBoldTransform`) that routes lowercase characters to their
-uppercase glyphs in a second font instance loaded at ~75% of the requested
-size, and shifts that smaller font's baseline to align with the main font's.
-The smaller instance is fetched via a recursive `GetFont()` call carrying
-through the `wdth`/`ital`/`slnt` axis values from `computed_variations` (wght
-is conveyed via the existing `weight` parameter), with `opsz` scaled by the
-same 0.75 ratio as the size so optical sizing tracks the smaller glyphs.
+**Synthesised small caps.**
+Add `bool requested_small_caps` to `LVFontInstanceKey` (include in `operator==`
+and `hash()`). In `loadAndCache()`, detect the mismatch (requested small caps,
+face has no native small-caps coverage) and wrap the loaded instance in a new
+`LVFontSmallCapsTransform` — analogous to `LVFontBoldTransform` — that scales
+lowercase glyphs to approximately 0.8 of cap height and shifts them to sit on
+the baseline. `GetFont()` would receive a `requested_small_caps` flag from the
+CSS `font-variant: small-caps` property.
 
 **CSS improvements: non-standard weights, font-width/font-stretch, oblique with custom angles.**
 - *Non-standard weights:* the selection and synthesis infrastructure already

--- a/FONTMANAGER_REFACTOR.md
+++ b/FONTMANAGER_REFACTOR.md
@@ -622,14 +622,19 @@ The FontConfig path registers all non-monospace fonts as `css_ff_sans_serif`.
 FontConfig can distinguish serif from sans-serif but the code does not use it.
 Step 3 of `select()` would benefit automatically if classification were added.
 
-**Synthesised small caps.**
-Add `bool requested_small_caps` to `LVFontInstanceKey` (include in `operator==`
-and `hash()`). In `loadAndCache()`, detect the mismatch (requested small caps,
-face has no native small-caps coverage) and wrap the loaded instance in a new
-`LVFontSmallCapsTransform` — analogous to `LVFontBoldTransform` — that scales
-lowercase glyphs to approximately 0.8 of cap height and shifts them to sit on
-the baseline. `GetFont()` would receive a `requested_small_caps` flag from the
-CSS `font-variant: small-caps` property.
+**Synthesised small caps.** *(Done)*
+`LVFontFace` gained `has_small_caps`, detected in `inspectFTFace()` via
+HarfBuzz's `hb_ot_layout_language_find_feature()` lookup for the `smcp` GSUB
+feature. In `loadAndCache()`, when `LFNT_OT_FEATURES_P_SMCP` or
+`LFNT_OT_FEATURES_P_C2SC` is requested and the face has no native small-caps
+coverage, the loaded instance is wrapped in a new `LVFontSmallCapsTransform`
+(analogous to `LVFontBoldTransform`) that routes lowercase characters to their
+uppercase glyphs in a second font instance loaded at ~75% of the requested
+size, and shifts that smaller font's baseline to align with the main font's.
+The smaller instance is fetched via a recursive `GetFont()` call carrying
+through the `wdth`/`ital`/`slnt` axis values from `computed_variations` (wght
+is conveyed via the existing `weight` parameter), with `opsz` scaled by the
+same 0.75 ratio as the size so optical sizing tracks the smaller glyphs.
 
 **CSS improvements: non-standard weights, font-width/font-stretch, oblique with custom angles.**
 - *Non-standard weights:* the selection and synthesis infrastructure already

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5717,11 +5717,14 @@ struct LVFontFace {
     /// and use _wght_min/_wght_max as the axis range instead.
     int getStaticWeight() const { return hasWeightAxis() ? 0 : (int)_wght_min; }
 
-    /// Stable identity hash: (file, face_index, documentId).
+    /// Stable identity hash: (file, face_index, documentId, typeface).
+    /// typeface is included so that registering the same font file under a
+    /// second @font-face family name is not mistaken for a duplicate.
     lUInt32 id() const {
         lUInt32 h = file_path.getHash();
         h = h * 31 + (lUInt32)face_index;
         h = h * 31 + (lUInt32)(documentId == -1 ? 0 : documentId);
+        h = h * 31 + typeface.getHash();
         return h;
     }
 };

--- a/tests/FONT_MANAGER_TEST_PLAN.md
+++ b/tests/FONT_MANAGER_TEST_PLAN.md
@@ -257,6 +257,20 @@ These were bugs found during the refactor; verify they do not regress.
 
 ---
 
+## 17. Duplicate face registration (Chapter 10)
+
+**Goal:** Verify that registering the same embedded font file under two
+different `@font-face` family names succeeds for both, rather than the
+second being silently dropped as a duplicate.
+
+| # | Action | Expected |
+|---|--------|----------|
+| 17.1 | View Chapter 10, line A (`font-family: "EmbeddedDupA"`) | Renders in the embedded monospace font |
+| 17.2 | View Chapter 10, line B (`font-family: "EmbeddedDupB"`) | Renders in the embedded monospace font — identical to line A |
+| 17.3 | Lines A and B are visually identical | If line B instead renders in the serif reading font, the duplicate-face-detection regression (`LVFontFace::id()` ignoring `typeface`) has returned |
+
+---
+
 ## Test environment notes
 
 - Test with both a **static font family** (e.g. Noto Serif — separate Regular/Bold/Italic/BoldItalic files) and a **variable font** (e.g. Literata — single file with wght and opsz axes).

--- a/tests/make_test_epub.py
+++ b/tests/make_test_epub.py
@@ -11,6 +11,15 @@ import zipfile
 
 MIMETYPE = b"application/epub+zip"
 
+# Real font binary used to test embedding the same file under two distinct
+# @font-face family names (see CH10 below). Reused from KOReader's bundled
+# fonts rather than vendoring a duplicate copy -- this script is expected to
+# run from within a full koreader checkout (crengine is nested under
+# base/thirdparty/kpvcrlib here).
+FONT_SRC_PATH = os.path.join(os.path.dirname(__file__),
+                              "..", "..", "..", "..", "..",
+                              "resources", "fonts", "droid", "DroidSansMono.ttf")
+
 CONTAINER_XML = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0" xmlns="urn:oasis:schemas:container">
@@ -43,6 +52,8 @@ CONTENT_OPF = """\
     <item id="ch07"    href="ch07.html"    media-type="application/xhtml+xml"/>
     <item id="ch08"    href="ch08.html"    media-type="application/xhtml+xml"/>
     <item id="ch09"    href="ch09.html"    media-type="application/xhtml+xml"/>
+    <item id="ch10"    href="ch10.html"    media-type="application/xhtml+xml"/>
+    <item id="font-mono" href="fonts/mono.ttf" media-type="font/ttf"/>
     <item id="padding" href="padding.bin"  media-type="application/octet-stream"/>
   </manifest>
   <spine toc="ncx">
@@ -55,6 +66,7 @@ CONTENT_OPF = """\
     <itemref idref="ch07"/>
     <itemref idref="ch08"/>
     <itemref idref="ch09"/>
+    <itemref idref="ch10"/>
   </spine>
 </package>
 """
@@ -102,6 +114,10 @@ TOC_NCX = """\
     <navPoint id="ch09" playOrder="9">
       <navLabel><text>9. Small Caps</text></navLabel>
       <content src="ch09.html"/>
+    </navPoint>
+    <navPoint id="ch10" playOrder="10">
+      <navLabel><text>10. Duplicate Face Registration</text></navLabel>
+      <content src="ch10.html"/>
     </navPoint>
   </navMap>
 </ncx>
@@ -715,6 +731,51 @@ whole string.</p>
 </html>
 """
 
+CH10 = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+  "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head><title>Duplicate Face Registration</title>
+<link rel="stylesheet" type="text/css" href="style.css"/>
+<style type="text/css">
+@font-face {
+  font-family: "EmbeddedDupA";
+  src: url("fonts/mono.ttf");
+}
+@font-face {
+  font-family: "EmbeddedDupB";
+  src: url("fonts/mono.ttf");
+}
+.dup-a { font-family: "EmbeddedDupA", serif; }
+.dup-b { font-family: "EmbeddedDupB", serif; }
+</style>
+</head>
+<body>
+<h1>Chapter 10 &#x2014; Duplicate Face Registration</h1>
+<p>Regresion check: the same embedded font file (<code>fonts/mono.ttf</code>)
+is declared by two separate <code>@font-face</code> rules under two different
+family names, "EmbeddedDupA" and "EmbeddedDupB". Both rules reference the
+exact same file, so the font manager must register the file twice -- once per
+family name -- rather than treating the second registration as a duplicate of
+the first.</p>
+
+<h2>Test</h2>
+<p class="label">Line A: font-family: "EmbeddedDupA"</p>
+<p class="sample dup-a">The quick brown fox jumps over the lazy dog. 0123456789</p>
+<p class="label">Line B: font-family: "EmbeddedDupB"</p>
+<p class="sample dup-b">The quick brown fox jumps over the lazy dog. 0123456789</p>
+
+<h2>Expected behaviour</h2>
+<p>Both lines must render in the embedded monospace font and look identical
+to each other. If the second @font-face registration was silently dropped as
+a duplicate (the regression this chapter targets), line B falls back to the
+serif reading font instead and looks visibly different from line A --
+specifically, it will not be monospaced.</p>
+</body>
+</html>
+"""
+
 # ---------------------------------------------------------------------------
 # Padding
 # ---------------------------------------------------------------------------
@@ -730,6 +791,16 @@ PADDING = bytes((i * 2654435761) & 0xFF for i in range(PADDING_SIZE))
 # ---------------------------------------------------------------------------
 
 def build_epub(path):
+    font_src_path = os.path.normpath(FONT_SRC_PATH)
+    if not os.path.isfile(font_src_path):
+        raise SystemExit(
+            f"Font file not found: {font_src_path}\n"
+            "Chapter 10 (duplicate face registration) embeds a real font "
+            "file and needs to be run from within a full koreader checkout "
+            "(crengine nested under base/thirdparty/kpvcrlib).")
+    with open(font_src_path, "rb") as f:
+        font_data = f.read()
+
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         # mimetype must be first and uncompressed
@@ -748,6 +819,8 @@ def build_epub(path):
         zf.writestr("OEBPS/ch07.html",        CH07)
         zf.writestr("OEBPS/ch08.html",        CH08)
         zf.writestr("OEBPS/ch09.html",        CH09)
+        zf.writestr("OEBPS/ch10.html",        CH10)
+        zf.writestr("OEBPS/fonts/mono.ttf",   font_data)
         zf.writestr(zipfile.ZipInfo("OEBPS/padding.bin"), PADDING,
                     compress_type=zipfile.ZIP_STORED)
     with open(path, "wb") as f:


### PR DESCRIPTION
## `lvfntman`: fix duplicate-face detection ignoring requested family name

### Problem

`LVFontFace::id()`, introduced by the font manager refactor, computed face identity from `(file_path, face_index, documentId)` only. `tryRegisterFace()` rejects any face whose `id()` collides with an already-registered one as a duplicate — so registering the *same embedded font file* under a *second* `@font-face` family name in the same document was silently dropped. `RegisterDocumentFont()` returned `false` for the second name, and the second family was never created.

This is a regression versus pre-refactor behaviour: the old `LVFontDef::operator==()` (used by `findDuplicate()`) included `_typeface` in its equality check, so two registrations of the same file under different requested family names were correctly treated as distinct. `id()` dropped `typeface` from identity entirely.

Reusing one font file under multiple `@font-face` family names is a real-world pattern (e.g. an EPUB declaring a fallback alias name for an already-embedded file).

### Fix

Fold `typeface` into `LVFontFace::id()`'s hash, mirroring the old `_typeface` equality check. Verified that widening identity here is safe for both callers of `hasFaceId()` (`tryRegisterFace()` and `getInstantiatedDocumentFontList()`) — in both cases the wider identity is the more correct one.

### Test plan

Added Chapter 10 to `tests/font-manager-test.epub` (generated by `tests/make_test_epub.py`): embeds one font file via two separate `@font-face` rules under different family names and renders a line under each. Before the fix, the second line falls back to the serif reading font; after the fix both lines render identically in the embedded monospace font. See `tests/FONT_MANAGER_TEST_PLAN.md` sec 17 for manual verification steps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/682)
<!-- Reviewable:end -->
