### PR TITLE
lvfntman: fix fonts in UI not displayed with own font

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5998,6 +5998,7 @@ class LVFontSelector {
         return computed;
     }
 
+public:
     /// family must be non-null; callers check registry.findFamily()/familyAt() first.
     LVFontMatch matchFamily(const LVFontFamily* family,
                              int weight, bool italic,
@@ -6040,17 +6041,6 @@ class LVFontSelector {
         m.face                = face;
         m.computed_variations = computeVariations(*face, requested, weight, italic);
         return m;
-    }
-
-public:
-    /// Matches a face within a known family, without the typeface-list parsing,
-    /// preferred-family, and generic-family fallback steps of select(). Used
-    /// when the caller already has the exact family (e.g. looking up the file
-    /// backing a name from getFaceList()) and a fallback to an unrelated family
-    /// would be wrong.
-    LVFontMatch matchExact(const LVFontFamily* family, int weight, bool italic) const
-    {
-        return matchFamily(family, weight, italic, LVFontVariations());
     }
 
     LVFontMatch select(int weight, bool italic,
@@ -6786,7 +6776,7 @@ public:
         if (!fam)
             return false;
         int weight = bold ? 700 : 400;
-        LVFontMatch m = _font_selector.matchExact(fam, weight, italic);
+        LVFontMatch m = _font_selector.matchFamily(fam, weight, italic, LVFontVariations());
         if (!m.valid())
             return false;
         filename     = m.face->file_path;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6043,6 +6043,16 @@ class LVFontSelector {
     }
 
 public:
+    /// Matches a face within a known family, without the typeface-list parsing,
+    /// preferred-family, and generic-family fallback steps of select(). Used
+    /// when the caller already has the exact family (e.g. looking up the file
+    /// backing a name from getFaceList()) and a fallback to an unrelated family
+    /// would be wrong.
+    LVFontMatch matchExact(const LVFontFamily* family, int weight, bool italic) const
+    {
+        return matchFamily(family, weight, italic, LVFontVariations());
+    }
+
     LVFontMatch select(int weight, bool italic,
                         css_font_family_t family,
                         const lString8& typeface,
@@ -6767,6 +6777,24 @@ public:
             }
         }
         list.sort();
+    }
+
+    virtual bool getFontFileNameAndFaceIndex( lString32 name, bool bold, bool italic, lString8 & filename, int & index, int & family_type, bool & has_ot_math, bool & has_emojis )
+    {
+        FONT_MAN_GUARD
+        const LVFontFamily* fam = _registry.findFamily(UnicodeToUtf8(name));
+        if (!fam)
+            return false;
+        int weight = bold ? 700 : 400;
+        LVFontMatch m = _font_selector.matchExact(fam, weight, italic);
+        if (!m.valid())
+            return false;
+        filename     = m.face->file_path;
+        index        = m.face->face_index;
+        family_type  = (int)m.face->css_family;
+        has_ot_math  = m.face->has_ot_math;
+        has_emojis   = m.face->has_emojis;
+        return true;
     }
 
     /// makes sure registered fonts have a proper entry at weight 400 and 700 when possible,


### PR DESCRIPTION
## Summary

`getFontFileNameAndFaceIndex()` — used by the "Display font names with their own font" setting to look up the file/face backing a font name — was dropped during the font manager refactor. The old implementation lived on the legacy `LVFontCache`/`_registered_list` class, which the refactor replaced with `LVFontRegistry`/`LVFontSelector`. The override was moved into an `#if 0` block alongside other removed legacy methods, but no equivalent was written for the new registry, so calls fell through to the base class stub which always returns `false`. As a result, the font name list always rendered in the default font.

## Fix

- `crengine/src/lvfntman.cpp`: Made the `matchFamily()` method of `LVFontSelector` public.
- Re-implemented `LVFreeTypeFontManager::getFontFileNameAndFaceIndex()`: resolves the family by exact name via `_registry.findFamily()`, then uses `_font_selector.matchExact()` to pick the best face for the requested weight/italic, returning its file path, face index, family, and math/emoji flags.

## Test plan

- [x] Built KOReader with the change
- [x] Enabled Font > Font settings > "Display font names with their own font" on an EPUB and confirmed font names render in their own font
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/683)
<!-- Reviewable:end -->
