### PR TITLE
lvfntmap: Synthesized small caps improvements

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -5142,8 +5142,9 @@ public:
     virtual int DrawTextString(LVDrawBuf* buf, int x, int y,
                                 const lChar32* text, int len, lChar32 def_char,
                                 lUInt32* palette, bool addHyphen, TextLangCfg* lc,
-                                lUInt32 flags, int ls, int width, int tbg,
-                                int tw, int th, SVGGlyphsCollector* svg) {
+                                lUInt32 flags, int letter_spacing, int width,
+                                int text_decoration_back_gap,
+                                int target_w, int target_h, SVGGlyphsCollector* svg) {
         int x0 = x;
         // Shift small-font glyphs down so their baseline aligns with the normal font's.
         int y_small = y + (_font->getBaseline() - _smallFont->getBaseline());
@@ -5161,34 +5162,45 @@ public:
                 x += f->DrawTextString(buf, x, f == _smallFont ? y_small : y,
                                        run.mapped + i, runLen, def_char,
                                        palette, runHasHyphen, lc, noDecFlags,
-                                       ls, -1, 0, -1, -1, svg);
+                                       letter_spacing, -1, 0, -1, -1, svg);
                 i = j;
             }
         }
-        if (flags & LFNT_DRAW_DECORATION_MASK) {
-            // Match LVFreeTypeFace::DrawTextString's formulas exactly (using the main
-            // font's real underline metrics, not a generic size-based approximation),
-            // so decorated small-caps text lines up with plain text on the same line.
-            // This is a deliberate duplicate (not shared via a helper) of the
-            // LFNT_DRAW_UNDERLINE/OVERLINE/LINE_THROUGH block in
-            // LVFreeTypeFace::DrawTextString() above (lvfntman.cpp:4759-4786):
-            // keep the two in sync if those formulas ever change.
+        // This is a deliberate duplicate (not shared via a helper) of the
+        // LFNT_DRAW_UNDERLINE/OVERLINE/LINE_THROUGH block in
+        // LVFreeTypeFace::DrawTextString() above (lvfntman.cpp:4759-4786):
+        // keep the two in sync if those formulas ever change.
+        int advance = x - x0;
+        if ( flags & LFNT_DRAW_DECORATION_MASK ) {
+            // text decoration: underline, etc.
+            // Don't overflow the provided width (which may be lower than our
+            // pen x if last glyph was a space not accounted in word width)
+            if ( width >= 0 && x > x0 + width)
+                x = x0 + width;
+            // And start the decoration before x0 if it is continued
+            // from previous word
+            x0 -= text_decoration_back_gap;
             int thickness = getUnderlineThickness();
             lUInt32 cl = buf->GetTextColor();
-            if (flags & LFNT_DRAW_UNDERLINE) {
+            if ( flags & LFNT_DRAW_UNDERLINE ) {
                 int liney = y + getBaseline() + getUnderlineOffset();
-                buf->FillRect(x0, liney, x, liney+thickness, cl);
+                buf->FillRect( x0, liney, x, liney+thickness, cl );
             }
-            if (flags & LFNT_DRAW_OVERLINE) {
+            if ( flags & LFNT_DRAW_OVERLINE ) {
+                // For now, we use the underline thickness as the offset from top, so
+                // to not be too high (should probably be computed from other metrics)
                 int liney = y + thickness;
-                buf->FillRect(x0, liney, x, liney+thickness, cl);
+                buf->FillRect( x0, liney, x, liney+thickness, cl );
+                // If we want to use this flag while developping for visually marking the start of words, use this instead:
+                // buf->FillRect( x0-getBaseline()/4, y, x0+getBaseline()/4, y+1, cl );
             }
-            if (flags & LFNT_DRAW_LINE_THROUGH) {
+            if ( flags & LFNT_DRAW_LINE_THROUGH ) {
+                // int liney = y + getBaseline() - getSize()/4 - h/2;
                 int liney = y + getBaseline() - getSize()*2/7;
-                buf->FillRect(x0, liney, x, liney+thickness, cl);
+                buf->FillRect( x0, liney, x, liney+thickness, cl );
             }
         }
-        return x - x0;
+        return advance;
     }
     virtual ~LVFontSmallCapsTransform() {}
 };

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -7303,7 +7303,11 @@ public:
                 smallVars.set(LVFONT_TAG_WDTH, computed_variations.wdth);
             if (computed_variations.opsz_set)
                 smallVars.set(LVFONT_TAG_OPSZ, computed_variations.opsz * 0.75f);
-            LVFontRef smallRef = GetFont(small_size, weight, italic,
+            // Downscaled glyphs lose apparent stroke thickness, so request a bit
+            // of extra weight on the small font to compensate.
+            int small_weight = weight + 100;
+            if (small_weight > 1000) small_weight = 1000;
+            LVFontRef smallRef = GetFont(small_size, small_weight, italic,
                                          face.css_family, face.typeface,
                                          features & ~(LFNT_OT_FEATURES_P_SMCP | LFNT_OT_FEATURES_P_C2SC),
                                          face.documentId, false, smallVars.empty() ? NULL : &smallVars);

--- a/tests/FONT_MANAGER_TEST_PLAN.md
+++ b/tests/FONT_MANAGER_TEST_PLAN.md
@@ -254,6 +254,9 @@ These were bugs found during the refactor; verify they do not regress.
 | 16.16 | French accented lowercase in small-caps (&#xE9;, &#xE8;, &#xE7;, &#xE0;, &#xF4;, &#xEA;, &#xEB;, &#xEF;) | Each accented lowercase letter maps to its accented uppercase form (e.g. &#xE9;&#x2192;&#xC9;) before shrinking — not to the unaccented capital, and not left as lowercase |
 | 16.17 | French accented uppercase (&#xC9;) in all-small-caps | The accented capital is also shrunk to the small size, same as plain ASCII capitals |
 | 16.18 | C-cedilla (&#xE7;/&#xC7;) and oe-ligature (&#x153;/&#x152;) in small-caps | Both map and shrink correctly; no missing-glyph boxes |
+| 16.19 | Underlined justified text (narrow column, no small-caps) | Underline runs continuously through every inter-word justification gap, with no breaks, on a same-run word sequence |
+| 16.20 | Underlined justified text + synthesised small-caps | Underline still runs continuously through the expanded inter-word gaps; the gap before each word must not be left undecorated (regression check for `LVFontSmallCapsTransform::DrawTextString` ignoring the `text_decoration_back_gap` parameter) |
+| 16.21 | Enable "Word Expansion" in reader settings; view an underlined small-caps line (e.g. 16.10's comparison line) on a short/last line of a justified paragraph | Underline runs continuously through the extra inter-glyph spacing added within the word, including across a lowercase&#x2192;uppercase (small-font&#x2192;main-font) run boundary, not just between separate words |
 
 ---
 

--- a/tests/make_test_epub.py
+++ b/tests/make_test_epub.py
@@ -202,6 +202,11 @@ p    { margin: 0.2em 0; }
 .sc-underline { font-variant-caps: small-caps; text-decoration: underline; }
 .sc-overline  { font-variant-caps: small-caps; text-decoration: overline; }
 .sc-strike    { font-variant-caps: small-caps; text-decoration: line-through; }
+
+/* Justification: large side margins (rather than 'width', which book/page
+   rendering mode does not constrain the same way web rendering mode does)
+   narrow the available line box to force visible word-expansion gaps */
+.justify-narrow { text-align: justify; margin-left: 35%; margin-right: 35%; }
 """
 
 # Each chapter is plain XHTML
@@ -744,6 +749,16 @@ line-height centre, not at the shrunk glyphs' centre</p>
 <p class="sample serif sc-bold underline">The Quick Brown Fox Jumps Over The Lazy Dog.</p>
 <p class="label">Underlined + italic small-caps</p>
 <p class="sample serif sc-italic underline">The Quick Brown Fox Jumps Over The Lazy Dog.</p>
+
+<h2>Small caps + text-decoration + justification (serif)</h2>
+<p class="label">Underlined, justified, no small-caps, for comparison &#x2014;
+narrow column forces visible word-expansion gaps; the underline must run
+continuously through every inter-word gap with no breaks</p>
+<p class="sample serif underline justify-narrow">The quick brown fox jumps over the lazy dog. A short justified paragraph to force word expansion gaps.</p>
+<p class="label">Underlined, justified, small-caps &#x2014; the underline must
+still run continuously through the expanded inter-word gaps, not stop and
+restart at each word</p>
+<p class="sample serif sc underline justify-narrow">The quick brown fox jumps over the lazy dog. A short justified paragraph to force word expansion gaps.</p>
 
 <h2>Expected behaviour</h2>
 <p>With <strong>native small-caps</strong> (font has the 'smcp' OpenType feature):


### PR DESCRIPTION
Two modifications to `LVFontSmallCapsTransform` to improve the appearance of synthesized small caps:

1) Add extra weight to synthesized letters 
   - Small caps are synthesized by reducing the size of normal capitals to 75%, which tends to make the letters appear slightly lighter.
   - This change adds extra weight to the synthesized small capitals so their weight better matches normal capitals.
   - An extra weight of 100 has turned out to give good results through trial and error.

2) Extend decorations (underline etc) to cover word expansion gap with justified text 
   - This avoids visible gaps in the decoration between words when using synthetic small caps with justified text.
   - Extended test epub with a narrow, justified run of small caps text to make the scenario more visible.
   - I have not observed any similar issue with word expansion and Claude confirms that is handled correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/684)
<!-- Reviewable:end -->
