### PR TITLE
Kerning improvement: add precise fractional glyph positioning

### DIFF
--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -7,6 +7,7 @@
 #define PROP_FONT_ANTIALIASING       "font.antialiasing.mode"
 #define PROP_FONT_HINTING            "font.hinting.mode"
 #define PROP_FONT_KERNING            "font.kerning.mode"
+#define PROP_FONT_FRACTIONAL_POSITIONING "font.fractional.positioning"
 #define PROP_FONT_COLOR              "font.color.default"
 #define PROP_FONT_FACE               "font.face.default"
 #define PROP_FONT_BASE_WEIGHT        "font.face.base.weight"        // replaces PROP_FONT_WEIGHT_EMBOLDEN ("font.face.weight.embolden")

--- a/crengine/include/lvdocviewprops.h
+++ b/crengine/include/lvdocviewprops.h
@@ -7,7 +7,6 @@
 #define PROP_FONT_ANTIALIASING       "font.antialiasing.mode"
 #define PROP_FONT_HINTING            "font.hinting.mode"
 #define PROP_FONT_KERNING            "font.kerning.mode"
-#define PROP_FONT_FRACTIONAL_POSITIONING "font.fractional.positioning"
 #define PROP_FONT_COLOR              "font.color.default"
 #define PROP_FONT_FACE               "font.face.default"
 #define PROP_FONT_BASE_WEIGHT        "font.face.base.weight"        // replaces PROP_FONT_WEIGHT_EMBOLDEN ("font.face.weight.embolden")

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -768,8 +768,8 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
-    /// set fractional glyph positioning phase count
-    virtual void SetFractionalGlyphPositioning( int /*mode*/ ) { }
+    /// set fractional glyph positioning granularity (1, 2, 4, 8, 16, 32 or 64 phases per pixel)
+    virtual void SetFractionalGlyphPositioning( int /*granularity*/ ) { }
 
     /// get monospace size scale percent
     virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -217,13 +217,8 @@ enum kerning_mode_t {
     KERNING_MODE_DISABLED,
     KERNING_MODE_FREETYPE,
     KERNING_MODE_HARFBUZZ_LIGHT,
-    KERNING_MODE_HARFBUZZ,
-    KERNING_MODE_HARFBUZZ_FULL
+    KERNING_MODE_HARFBUZZ
 };
-
-inline bool isHarfBuzzShapingMode(kerning_mode_t mode) {
-    return mode == KERNING_MODE_HARFBUZZ || mode == KERNING_MODE_HARFBUZZ_FULL;
-}
 
 
 // Hint flags for measuring and drawing (some used only with full Harfbuzz)

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -217,8 +217,17 @@ enum kerning_mode_t {
     KERNING_MODE_DISABLED,
     KERNING_MODE_FREETYPE,
     KERNING_MODE_HARFBUZZ_LIGHT,
-    KERNING_MODE_HARFBUZZ
+    KERNING_MODE_HARFBUZZ,
+    KERNING_MODE_HARFBUZZ_FULL
 };
+
+inline bool isHarfBuzzShapingMode(kerning_mode_t mode) {
+    return mode == KERNING_MODE_HARFBUZZ || mode == KERNING_MODE_HARFBUZZ_FULL;
+}
+
+inline int getFractionalGlyphPositioningGranularity(kerning_mode_t mode) {
+    return mode == KERNING_MODE_HARFBUZZ_FULL ? 4 : 1;
+}
 
 
 // Hint flags for measuring and drawing (some used only with full Harfbuzz)
@@ -768,8 +777,6 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
-    /// set fractional glyph positioning granularity (1, 2, 4, 8, 16, 32 or 64 phases per pixel)
-    virtual void SetFractionalGlyphPositioning( int /*granularity*/ ) { }
 
     /// get monospace size scale percent
     virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -225,10 +225,6 @@ inline bool isHarfBuzzShapingMode(kerning_mode_t mode) {
     return mode == KERNING_MODE_HARFBUZZ || mode == KERNING_MODE_HARFBUZZ_FULL;
 }
 
-inline int getFractionalGlyphPositioningGranularity(kerning_mode_t mode) {
-    return mode == KERNING_MODE_HARFBUZZ_FULL ? 4 : 1;
-}
-
 
 // Hint flags for measuring and drawing (some used only with full Harfbuzz)
 // These 4 translate (after mask & shift) from LTEXT_WORD_* equivalents
@@ -777,6 +773,8 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
+    /// set fractional glyph positioning granularity (1, 2, 4, 8, 16, 32 or 64 phases per pixel)
+    virtual void SetFractionalGlyphPositioning( int /*granularity*/ ) { }
 
     /// get monospace size scale percent
     virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -768,6 +768,8 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
+    /// set fractional glyph positioning phase count
+    virtual void SetFractionalGlyphPositioning( int /*mode*/ ) { }
 
     /// get monospace size scale percent
     virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -768,6 +768,8 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
+    /// get fractional glyph positioning granularity
+    virtual int GetFractionalGlyphPositioning() { return 1; }
     /// set fractional glyph positioning granularity (1, 2, 4, 8, 16, 32 or 64 phases per pixel)
     virtual void SetFractionalGlyphPositioning( int /*granularity*/ ) { }
 

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -234,7 +234,6 @@ enum kerning_mode_t {
 #define LFNT_HINT_TRANSFORM_STRETCH      0x0100 /// Glyph(s) are to be stretched so their bounding box fits the provided w/h
 #define LFNT_HINT_CJK_ALTERED_WIDTH      0x0200 /// CJK full width glyph is to be shifted to look correct in a non-nominal width
 #define LFNT_HINT_CJK_SCALED_WIDTH       0x0400 /// CJK full width glyph has been scaled by cjk_width_scale_percent
-
 // These 4 translate from LTEXT_TD_* equivalents (see lvtextfm.h). Keep them in sync.
 #define LFNT_DRAW_UNDERLINE              0x1000 /// underlined text
 #define LFNT_DRAW_OVERLINE               0x2000 /// overlined text
@@ -768,10 +767,10 @@ public:
     virtual kerning_mode_t GetKerningMode() { return _kerningMode; }
     /// get kerning mode: true==ON, false=OFF
     virtual void SetKerningMode( kerning_mode_t mode ) { _kerningMode = mode; gc(); clearGlyphCache(); }
-    /// get fractional glyph positioning granularity
-    virtual int GetFractionalGlyphPositioning() { return 1; }
-    /// set fractional glyph positioning granularity (1, 2, 4, 8, 16, 32 or 64 phases per pixel)
-    virtual void SetFractionalGlyphPositioning( int /*granularity*/ ) { }
+    /// get fractional glyph positioning strength (0: off, 1..3: increasing precision)
+    virtual int GetFractionalGlyphPositioning() { return 0; }
+    /// set fractional glyph positioning strength (0: off, 1..3: increasing precision)
+    virtual void SetFractionalGlyphPositioning( int /*strength*/ ) { }
 
     /// get monospace size scale percent
     virtual int GetMonospaceSizeScale() { return _monospaceSizeScale; }

--- a/crengine/include/lvfntman.h
+++ b/crengine/include/lvfntman.h
@@ -234,6 +234,7 @@ enum kerning_mode_t {
 #define LFNT_HINT_TRANSFORM_STRETCH      0x0100 /// Glyph(s) are to be stretched so their bounding box fits the provided w/h
 #define LFNT_HINT_CJK_ALTERED_WIDTH      0x0200 /// CJK full width glyph is to be shifted to look correct in a non-nominal width
 #define LFNT_HINT_CJK_SCALED_WIDTH       0x0400 /// CJK full width glyph has been scaled by cjk_width_scale_percent
+
 // These 4 translate from LTEXT_TD_* equivalents (see lvtextfm.h). Keep them in sync.
 #define LFNT_DRAW_UNDERLINE              0x1000 /// underlined text
 #define LFNT_DRAW_OVERLINE               0x2000 /// overlined text

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6681,8 +6681,8 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #endif
 	static int int_option_hinting[] = { 0, 1, 2 };
 	props->limitValueList(PROP_FONT_HINTING, int_option_hinting, 3);
-	static int int_option_kerning[] = { 0, 1, 2, 3, 4 };
-	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 5);
+	static int int_option_kerning[] = { 0, 1, 2, 3 };
+	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 4);
     static int int_options_1_2[] = { 2, 1 };
 	props->limitValueList(PROP_LANDSCAPE_PAGES, int_options_1_2, 2);
 	props->limitValueList(PROP_PAGES_TWO_VISIBLE_AS_ONE_PAGE_NUMBER, bool_options_def_false, 2);
@@ -6891,13 +6891,13 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         //     REQUEST_RENDER("propsApply - kerning")
         } else if (name == PROP_FONT_KERNING) {
             int mode = props->getIntDef(PROP_FONT_KERNING, (int)KERNING_MODE_DISABLED);
-            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=(int)KERNING_MODE_HARFBUZZ_FULL) {
+            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=(int)KERNING_MODE_HARFBUZZ) {
                 //CRLog::debug("Setting kerning mode to %d", mode);
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 REQUEST_RENDER("propsApply - font kerning")
             }
         } else if (name == PROP_FONT_FRACTIONAL_POSITIONING) {
-            int granularity = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 4);
+            int granularity = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 1);
             fontMan->SetFractionalGlyphPositioning(granularity);
             REQUEST_RENDER("propsApply - font fractional positioning")
         } else if (name == PROP_FONT_BASE_WEIGHT) {

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6896,6 +6896,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 REQUEST_RENDER("propsApply - font kerning")
             }
+        } else if (name == PROP_FONT_FRACTIONAL_POSITIONING) {
+            int granularity = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 4);
+            fontMan->SetFractionalGlyphPositioning(granularity);
+            REQUEST_RENDER("propsApply - font fractional positioning")
         } else if (name == PROP_FONT_BASE_WEIGHT) {
             // replaces PROP_FONT_WEIGHT_EMBOLDEN
             int v = props->getIntDef(PROP_FONT_BASE_WEIGHT, 400);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6681,8 +6681,8 @@ void LVDocView::propsUpdateDefaults(CRPropRef props) {
 #endif
 	static int int_option_hinting[] = { 0, 1, 2 };
 	props->limitValueList(PROP_FONT_HINTING, int_option_hinting, 3);
-	static int int_option_kerning[] = { 0, 1, 2, 3 };
-	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 4);
+	static int int_option_kerning[] = { 0, 1, 2, 3, 4 };
+	props->limitValueList(PROP_FONT_KERNING, int_option_kerning, 5);
     static int int_options_1_2[] = { 2, 1 };
 	props->limitValueList(PROP_LANDSCAPE_PAGES, int_options_1_2, 2);
 	props->limitValueList(PROP_PAGES_TWO_VISIBLE_AS_ONE_PAGE_NUMBER, bool_options_def_false, 2);
@@ -6891,15 +6891,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
         //     REQUEST_RENDER("propsApply - kerning")
         } else if (name == PROP_FONT_KERNING) {
             int mode = props->getIntDef(PROP_FONT_KERNING, (int)KERNING_MODE_DISABLED);
-            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=3) {
+            if ((int)fontMan->GetKerningMode() != mode && mode>=0 && mode<=(int)KERNING_MODE_HARFBUZZ_FULL) {
                 //CRLog::debug("Setting kerning mode to %d", mode);
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 REQUEST_RENDER("propsApply - font kerning")
             }
-        } else if (name == PROP_FONT_FRACTIONAL_POSITIONING) {
-            int mode = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 0);
-            fontMan->SetFractionalGlyphPositioning(mode);
-            REQUEST_RENDER("propsApply - font fractional positioning")
         } else if (name == PROP_FONT_BASE_WEIGHT) {
             // replaces PROP_FONT_WEIGHT_EMBOLDEN
             int v = props->getIntDef(PROP_FONT_BASE_WEIGHT, 400);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6896,6 +6896,10 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 fontMan->SetKerningMode((kerning_mode_t)mode);
                 REQUEST_RENDER("propsApply - font kerning")
             }
+        } else if (name == PROP_FONT_FRACTIONAL_POSITIONING) {
+            int mode = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 0);
+            fontMan->SetFractionalGlyphPositioning(mode);
+            REQUEST_RENDER("propsApply - font fractional positioning")
         } else if (name == PROP_FONT_BASE_WEIGHT) {
             // replaces PROP_FONT_WEIGHT_EMBOLDEN
             int v = props->getIntDef(PROP_FONT_BASE_WEIGHT, 400);

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -6897,9 +6897,11 @@ CRPropRef LVDocView::propsApply(CRPropRef props) {
                 REQUEST_RENDER("propsApply - font kerning")
             }
         } else if (name == PROP_FONT_FRACTIONAL_POSITIONING) {
-            int granularity = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 1);
-            fontMan->SetFractionalGlyphPositioning(granularity);
-            REQUEST_RENDER("propsApply - font fractional positioning")
+            int strength = props->getIntDef(PROP_FONT_FRACTIONAL_POSITIONING, 0);
+            if (fontMan->GetFractionalGlyphPositioning() != strength) {
+                fontMan->SetFractionalGlyphPositioning(strength);
+                REQUEST_RENDER("propsApply - font fractional positioning")
+            }
         } else if (name == PROP_FONT_BASE_WEIGHT) {
             // replaces PROP_FONT_WEIGHT_EMBOLDEN
             int v = props->getIntDef(PROP_FONT_BASE_WEIGHT, 400);

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -260,7 +260,21 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
-static int fractionalGlyphPositioningMode = 0;
+static int fractionalGlyphPositioningGranularity = 1;
+
+static int normalizeFractionalGlyphPositioningGranularity(int granularity) {
+    switch (granularity) {
+    case 2:
+    case 4:
+    case 8:
+    case 16:
+    case 32:
+    case 64:
+        return granularity;
+    default:
+        return 1;
+    }
+}
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -3059,13 +3073,16 @@ public:
             int t_notdef_start = -1;
             int t_notdef_end = -1;
             bool max_width_reached = false; // set when reached while measuring with the fallback font
-            bool use_fractional_positioning = fractionalGlyphPositioningMode == 4;
+            bool use_fractional_positioning = fractionalGlyphPositioningGranularity > 1;
             lInt32 cur_width_64 = 0;
             for (int t = 0; t < len; t++) {
                 #ifdef DEBUG_MEASURE_TEXT
                     printf("MTHB t%d (=%x) ", t, text[t]);
                 #endif
                 // Grab all glyphs that do not belong to a cluster greater that our char position
+                // With fractional positioning, a cluster can have a non-zero 26.6 advance
+                // while still rounding to the same integer pixel width as the previous one.
+                // So we can't use cur_width == prev_width to detect zero-advance clusters.
                 bool cluster_has_advance = false;
                 while ( hg < glyph_count ) {
                     hcl = glyph_info[hg].cluster;
@@ -3648,20 +3665,28 @@ public:
         return item;
     }
 
-    LVFontGlyphCacheItem * getGlyphByIndexSubpixel(lUInt32 index, int phase_64) {
-        if (_drawMonochrome || phase_64 <= 0)
+    LVFontGlyphCacheItem * getGlyphByIndexSubpixel(lUInt32 index, int phase_step, int phase_count) {
+        if (_drawMonochrome || phase_step <= 0 || phase_count <= 1)
             return getGlyphByIndex(index);
 
-        // Cache one shifted bitmap for each non-zero quarter-pixel phase.
-        // Phase 0 uses the normal glyph cache entry; phases 1..3 are stored
-        // in the upper bits of the cache key to avoid changing the cache type.
-        int phase_step = phase_64 / 16;
-        if (phase_step <= 0)
-            return getGlyphByIndex(index);
-        if (phase_step > 3)
-            phase_step = 3;
-
-        lUInt32 cache_index = ((lUInt32)phase_step << 28) | (index & 0x0FFFFFFF);
+        // This is the same loading/rendering path as getGlyphByIndex(), but with
+        // the outline shifted horizontally before rendering. The phase count is
+        // the requested number of addressable positions inside one pixel:
+        //   1  phase : 0/64 only, normal glyph cache entry
+        //   4  phases: 0/64, 16/64, 32/64, 48/64
+        //   64 phases: every 1/64 pixel position
+        //
+        // Phase 0 uses the normal glyph cache entry. Non-zero phases are stored
+        // in the high 6 bits of the existing 32-bit glyph cache key, leaving the
+        // lower 26 bits for the glyph index. This keeps the cache type unchanged
+        // and supports up to 64 phases, but assumes practical glyph indices stay
+        // below 2^26. Current fonts are far below this, but it is still an
+        // implementation assumption rather than a format guarantee.
+        if (phase_step >= phase_count)
+            phase_step = phase_count - 1;
+        static const int SUBPIXEL_PHASE_SHIFT = 26;
+        static const lUInt32 SUBPIXEL_GLYPH_INDEX_MASK = (1u << SUBPIXEL_PHASE_SHIFT) - 1;
+        lUInt32 cache_index = ((lUInt32)phase_step << SUBPIXEL_PHASE_SHIFT) | (index & SUBPIXEL_GLYPH_INDEX_MASK);
         LVFontGlyphCacheItem *item = _glyph_cache2.getByIndex(cache_index);
         if (!item) {
             int rend_flags = FT_LOAD_TARGET_LIGHT;
@@ -3698,7 +3723,7 @@ public:
                 FT_GlyphSlot_Oblique(_slot);
             }
 
-            FT_Outline_Translate(&_slot->outline, phase_step * 16, 0);
+            FT_Outline_Translate(&_slot->outline, phase_step * (64 / phase_count), 0);
             FT_Render_Glyph(_slot, FT_RENDER_MODE_LIGHT);
 
             if (_synth_weight > 0 && is_embolden) {
@@ -4358,7 +4383,8 @@ public:
             int fb_t_start = 0;
             int fb_t_end = len;
             int hg = 0;  // index in glyph_info/glyph_pos
-            bool use_fractional_positioning = fractionalGlyphPositioningMode == 4;
+            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
+            bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 x_64 = x * 64;
             while (hg < glyph_count) { // hg is the start of a new cluster at this point
                 bool draw_with_fallback = false;
@@ -4488,6 +4514,9 @@ public:
                     #endif
                     // Draw glyphs of this same cluster
                     int prev_x = x;
+                    // With fractional positioning, a cluster can advance in 26.6 units
+                    // without changing the rounded integer x. Track the original
+                    // HarfBuzz advance to decide whether letter spacing should apply.
                     bool cluster_has_advance = false;
                     for (i = hg; i < hg2; i++) {
                         if ( svg_collector ) {
@@ -4582,6 +4611,13 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
+                                // Keep the original integer path for CJK width tweaks.
+                                // These paths adjust x and w using final pixel widths so that
+                                // punctuation anchoring, scaling and underlines stay aligned.
+                                // They are the CJK width-changing flags set by lvtextfm.cpp
+                                // before DrawTextString(), from LTEXT_WORD_IS_FLEXIBLE_WIDTH_CJK
+                                // and cjk_width_scale_percent. LFNT_HINT_TRANSFORM_STRETCH is
+                                // another width-changing draw flag, handled by transform_stretch above.
                                 if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
                                     drawGlyphItem(buf,
                                               x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
@@ -4594,12 +4630,13 @@ public:
                                     lInt32 draw_x_64 = x_64 + glyph_pos[i].x_offset;
                                     int draw_x = FONT_METRIC_FLOOR_TO_PX(draw_x_64);
                                     int phase_64 = FONT_METRIC_FRAC_64(draw_x_64);
-                                    int phase_step = (phase_64 + 8) / 16;
-                                    if (phase_step >= 4) {
+                                    int phase_unit = 64 / fractional_positioning_granularity;
+                                    int phase_step = (phase_64 + phase_unit / 2) / phase_unit;
+                                    if (phase_step >= fractional_positioning_granularity) {
                                         phase_step = 0;
                                         draw_x += 1;
                                     }
-                                    LVFontGlyphCacheItem *draw_item = getGlyphByIndexSubpixel(glyph_info[i].codepoint, phase_step * 16);
+                                    LVFontGlyphCacheItem *draw_item = getGlyphByIndexSubpixel(glyph_info[i].codepoint, phase_step, fractional_positioning_granularity);
                                     if (!draw_item)
                                         draw_item = item;
                                     drawGlyphItem(buf,
@@ -6579,13 +6616,13 @@ public:
         });
     }
 
-    virtual void SetFractionalGlyphPositioning(int mode) {
-        mode = mode == 4 ? 4 : 0;
-        if (fractionalGlyphPositioningMode == mode)
+    virtual void SetFractionalGlyphPositioning(int granularity) {
+        granularity = normalizeFractionalGlyphPositioningGranularity(granularity);
+        if (fractionalGlyphPositioningGranularity == granularity)
             return;
         FONT_MAN_GUARD
-        fractionalGlyphPositioningMode = mode;
-        CRLog::debug("Fractional glyph positioning mode is changed: %d", mode);
+        fractionalGlyphPositioningGranularity = granularity;
+        CRLog::debug("Fractional glyph positioning granularity is %d", granularity);
         gc();
         clearGlyphCache();
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -260,28 +260,7 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
-// Tunable by PROP_FONT_FRACTIONAL_POSITIONING, but only used by
-// KERNING_MODE_HARFBUZZ_FULL. Other kerning modes force effective granularity 1.
-static int fractionalGlyphPositioningGranularity = 4;
-
-static int normalizeFractionalGlyphPositioningGranularity(int granularity) {
-    switch (granularity) {
-    case 1:
-    case 2:
-    case 4:
-    case 8:
-    case 16:
-    case 32:
-    case 64:
-        return granularity;
-    default:
-        return 4;
-    }
-}
-
-static int getFractionalGlyphPositioningGranularity(kerning_mode_t mode) {
-    return mode == KERNING_MODE_HARFBUZZ_FULL ? fractionalGlyphPositioningGranularity : 1;
-}
+static int fractionalGlyphPositioningGranularity = 1;
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -1706,7 +1685,7 @@ public:
     virtual LVFontRef getDecimalListItemFont() {
         if ( !_DecimalListItemFont.isNull() )
             return _DecimalListItemFont;
-        if ( isHarfBuzzShapingMode(_kerningMode) && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
+        if ( _kerningMode == KERNING_MODE_HARFBUZZ && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
             // We can request the same font with OpenType feature "tabular nums", for fixed width
             // digits and better alignment of decimal list items (no need to do it if this feature
             // has already been enabled for this font). If the font does not support the feature,
@@ -1901,7 +1880,7 @@ public:
     }
     void setupHBFeatures() {
         _hb_features.clear();
-        if ( isHarfBuzzShapingMode(_kerningMode) ) {
+        if ( _kerningMode == KERNING_MODE_HARFBUZZ ) {
             // We reserve 2 for those we're adding now, +2 for possibly added CSS font features
             // (otherwise, LVArray would expand from 2 to 11 on the next addition - it will
             // then expand from 4 to 14 on the 3rd added CSS font feature).
@@ -2644,7 +2623,7 @@ public:
         svg_collector->_advance_y = svg_collector->_advance_y * scale;
 
         #if USE_HARFBUZZ==1
-            if (isHarfBuzzShapingMode(_kerningMode) && code_is_glyph_index ) {
+            if (_kerningMode == KERNING_MODE_HARFBUZZ && code_is_glyph_index ) {
                 // With kerning mode harfbuzz, we get called with the fallback font and the glyph
                 // index in that font. No need to check if it is present or iterate fallback fonts.
                 // We can use hb_font_draw_glyph() which will make a smoother shape than
@@ -2903,7 +2882,7 @@ public:
         // measure character widths
 
     #if USE_HARFBUZZ==1
-        if (isHarfBuzzShapingMode(_kerningMode)) {
+        if (_kerningMode == KERNING_MODE_HARFBUZZ) {
 
             /** from harfbuzz/src/hb-buffer.h
              * hb_glyph_info_t:
@@ -3080,7 +3059,7 @@ public:
             int t_notdef_start = -1;
             int t_notdef_end = -1;
             bool max_width_reached = false; // set when reached while measuring with the fallback font
-            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity(_kerningMode);
+            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
             bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 cur_width_64 = 0;
             for (int t = 0; t < len; t++) {
@@ -3290,7 +3269,7 @@ public:
                     printf("%d:%d ", t, widths[t] - (t>0?widths[t-1]:0));
                 printf("\n");
             #endif
-        } // isHarfBuzzShapingMode(_kerningMode)
+        } // _kerningMode == KERNING_MODE_HARFBUZZ
 
         else if (_kerningMode == KERNING_MODE_HARFBUZZ_LIGHT) {
             struct LVCharTriplet triplet;
@@ -4237,7 +4216,7 @@ public:
     virtual bool kerningEnabled() {
         #if (ALLOW_KERNING==1)
             #if USE_HARFBUZZ==1
-                return isHarfBuzzShapingMode(_kerningMode)
+                return _kerningMode == KERNING_MODE_HARFBUZZ
                     || (_kerningMode == KERNING_MODE_FREETYPE && FT_HAS_KERNING( _face ));
             #else
                 return _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
@@ -4283,7 +4262,7 @@ public:
         int x0 = x;
 
     #if USE_HARFBUZZ==1
-        if (isHarfBuzzShapingMode(_kerningMode)) {
+        if (_kerningMode == KERNING_MODE_HARFBUZZ) {
             // See measureText() for more comments on how to work with Harfbuzz,
             // as we do and must work the same way here.
             int glyph_count;
@@ -4391,7 +4370,7 @@ public:
             int fb_t_start = 0;
             int fb_t_end = len;
             int hg = 0;  // index in glyph_info/glyph_pos
-            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity(_kerningMode);
+            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
             bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 x_64 = x * 64;
             while (hg < glyph_count) { // hg is the start of a new cluster at this point
@@ -4708,7 +4687,7 @@ public:
                 }
             }
 
-        } // isHarfBuzzShapingMode(_kerningMode)
+        } // _kerningMode == KERNING_MODE_HARFBUZZ
         else if (_kerningMode == KERNING_MODE_HARFBUZZ_LIGHT) {
             struct LVCharTriplet triplet;
             struct LVCharPosInfo posInfo;
@@ -6633,7 +6612,19 @@ public:
     }
 
     virtual void SetFractionalGlyphPositioning(int granularity) {
-        granularity = normalizeFractionalGlyphPositioningGranularity(granularity);
+        switch (granularity) {
+        case 1:
+        case 2:
+        case 4:
+        case 8:
+        case 16:
+        case 32:
+        case 64:
+            break;
+        default:
+            granularity = 1;
+            break;
+        }
         if (fractionalGlyphPositioningGranularity == granularity)
             return;
         FONT_MAN_GUARD

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -224,6 +224,17 @@ static void destroy_SVGGlyphsCollector_svg_funcs() {
 // Uncomment to use the former >>6 (trunc) with no rounding (instead of previous one)
 // #define FONT_METRIC_TO_PX(x)    ((x) >> 6)
 
+static inline int FONT_METRIC_FLOOR_TO_PX(lInt32 x)
+{
+    return x >= 0 ? (x >> 6) : -(((-x) + 63) >> 6);
+}
+
+static inline int FONT_METRIC_FRAC_64(lInt32 x)
+{
+    int floor_px = FONT_METRIC_FLOOR_TO_PX(x);
+    return x - floor_px * 64;
+}
+
 #if COLOR_BACKBUFFER==0
 //#define USE_BITMAP_FONT
 #endif
@@ -249,6 +260,7 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
+static int fractionalGlyphPositioningMode = 0;
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -3047,15 +3059,19 @@ public:
             int t_notdef_start = -1;
             int t_notdef_end = -1;
             bool max_width_reached = false; // set when reached while measuring with the fallback font
+            bool use_fractional_positioning = fractionalGlyphPositioningMode == 4;
+            lInt32 cur_width_64 = 0;
             for (int t = 0; t < len; t++) {
                 #ifdef DEBUG_MEASURE_TEXT
                     printf("MTHB t%d (=%x) ", t, text[t]);
                 #endif
                 // Grab all glyphs that do not belong to a cluster greater that our char position
+                bool cluster_has_advance = false;
                 while ( hg < glyph_count ) {
                     hcl = glyph_info[hg].cluster;
                     if (hcl <= t) {
                         int advance = 0;
+                        lInt32 advance_64 = 0;
                         if ( glyph_info[hg].codepoint != 0 ) { // Codepoint found in this font
                             #ifdef DEBUG_MEASURE_TEXT
                                 printf("(found cp=%x) ", glyph_info[hg].codepoint);
@@ -3100,6 +3116,7 @@ public:
                                     // And fix our current width
                                     cur_width = widths[lastFitChar-1];
                                     prev_width = cur_width;
+                                    cur_width_64 = cur_width * 64;
                                     #ifdef DEBUG_MEASURE_TEXT
                                         printf("MTHB ### measured past failures > W= %d\n[...]", cur_width);
                                     #endif
@@ -3118,24 +3135,35 @@ public:
                                 // And go on with the found glyph now that we fixed what was before
                             }
                             // Glyph found in this font
-                            if ( glyph_pos[hg].x_advance )
-                                advance = FONT_METRIC_TO_PX(glyph_pos[hg].x_advance + _synth_weight_strength);
+                            if ( glyph_pos[hg].x_advance ) {
+                                advance_64 = glyph_pos[hg].x_advance + _synth_weight_strength;
+                                advance = FONT_METRIC_TO_PX(advance_64);
+                            }
                         }
                         else {
                             #ifdef DEBUG_MEASURE_TEXT
                                 printf("(glyph not found) ");
                             #endif
                             // Keep the advance of .notdef/tofu in case there is no fallback font to correct them
-                            if ( glyph_pos[hg].x_advance )
-                                advance = FONT_METRIC_TO_PX(glyph_pos[hg].x_advance + _synth_weight_strength);
+                            if ( glyph_pos[hg].x_advance ) {
+                                advance_64 = glyph_pos[hg].x_advance + _synth_weight_strength;
+                                advance = FONT_METRIC_TO_PX(advance_64);
+                            }
                             if ( t_notdef_start < 0 ) {
                                 t_notdef_start = t;
                             }
                         }
+                        if ( use_fractional_positioning ) {
+                            cluster_has_advance = cluster_has_advance || advance_64 != 0;
+                            cur_width_64 += advance_64;
+                            cur_width = FONT_METRIC_TO_PX(cur_width_64);
+                        }
+                        else {
+                            cur_width += advance;
+                        }
                         #ifdef DEBUG_MEASURE_TEXT
-                            printf("c%d+%d ", hcl, advance);
+                            printf("c%d+%d ", hcl, use_fractional_positioning ? cur_width - prev_width : advance);
                         #endif
-                        cur_width += advance;
                         cur_cluster = hcl;
                         hg++;
                         continue; // keep grabbing glyphs
@@ -3157,13 +3185,19 @@ public:
                     // We're either a single char cluster, or the start
                     // of a multi chars cluster.
                     flags[t] = GET_CHAR_FLAGS(text[t]);
-                    if (cur_width == prev_width) {
+                    if ( use_fractional_positioning ? !cluster_has_advance : cur_width == prev_width ) {
                         // But if there is no advance (this happens with soft-hyphens),
                         // flag it and don't add any letter spacing.
                         flags[t] |= LCHAR_IS_CLUSTER_TAIL;
                     }
                     else {
-                        cur_width += letter_spacing; // only between clusters/graphemes
+                        if ( use_fractional_positioning ) {
+                            cur_width_64 += letter_spacing * 64; // only between clusters/graphemes
+                            cur_width = FONT_METRIC_TO_PX(cur_width_64);
+                        }
+                        else {
+                            cur_width += letter_spacing; // only between clusters/graphemes
+                        }
                     }
                     // It seems each soft-hyphen is in its own cluster, of length 1 and width 0,
                     // so HarfBuzz must already deal correctly with soft-hyphens.
@@ -3208,6 +3242,7 @@ public:
                     }
                     // And add all that to our current width
                     cur_width = widths[lastFitChar-1];
+                    cur_width_64 = cur_width * 64;
                     #ifdef DEBUG_MEASURE_TEXT
                         printf("MTHB ### measured past failures at EOT > W= %d\n[...]", cur_width);
                     #endif
@@ -3607,6 +3642,77 @@ public:
             }
 
             item = newItem(&_glyph_cache2, index, _slot);
+            if (item)
+                _glyph_cache2.put(item);
+        }
+        return item;
+    }
+
+    LVFontGlyphCacheItem * getGlyphByIndexSubpixel(lUInt32 index, int phase_64) {
+        if (_drawMonochrome || phase_64 <= 0)
+            return getGlyphByIndex(index);
+
+        // Cache one shifted bitmap for each non-zero quarter-pixel phase.
+        // Phase 0 uses the normal glyph cache entry; phases 1..3 are stored
+        // in the upper bits of the cache key to avoid changing the cache type.
+        int phase_step = phase_64 / 16;
+        if (phase_step <= 0)
+            return getGlyphByIndex(index);
+        if (phase_step > 3)
+            phase_step = 3;
+
+        lUInt32 cache_index = ((lUInt32)phase_step << 28) | (index & 0x0FFFFFFF);
+        LVFontGlyphCacheItem *item = _glyph_cache2.getByIndex(cache_index);
+        if (!item) {
+            int rend_flags = FT_LOAD_TARGET_LIGHT;
+            if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
+                rend_flags |= FT_LOAD_NO_AUTOHINT;
+            }
+            else if (_hintingMode == HINTING_MODE_AUTOHINT) {
+                rend_flags |= FT_LOAD_FORCE_AUTOHINT;
+            }
+            else if (_hintingMode == HINTING_MODE_DISABLED) {
+                rend_flags |= FT_LOAD_NO_AUTOHINT | FT_LOAD_NO_HINTING;
+            }
+            if ( FT_HAS_COLOR(_face) && _hintingMode != HINTING_MODE_DISABLED )
+                rend_flags |= FT_LOAD_COLOR;
+
+            updateTransform();
+            int error = FT_Load_Glyph( _face, index, rend_flags );
+            if ( error == FT_Err_Execution_Too_Long && _hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR ) {
+                rend_flags |= FT_LOAD_NO_HINTING;
+                error = FT_Load_Glyph( _face, index, rend_flags );
+            }
+            if ( error )
+                return NULL;
+            if ( _slot->format != FT_GLYPH_FORMAT_OUTLINE )
+                return getGlyphByIndex(index);
+
+            bool is_embolden = false;
+            if (_synth_weight > 0) {
+                FT_Outline_Embolden(&_slot->outline, _synth_weight_strength);
+                FT_Outline_Translate(&_slot->outline, 0, -_synth_weight_half_strength);
+                is_embolden = true;
+            }
+            if (_italic==2) {
+                FT_GlyphSlot_Oblique(_slot);
+            }
+
+            FT_Outline_Translate(&_slot->outline, phase_step * 16, 0);
+            FT_Render_Glyph(_slot, FT_RENDER_MODE_LIGHT);
+
+            if (_synth_weight > 0 && is_embolden) {
+                if ( _slot->format == FT_GLYPH_FORMAT_OUTLINE ) {
+                    if ( _slot->metrics.horiAdvance > 0 ) {
+                        _slot->metrics.horiAdvance = (_slot->linearHoriAdvance >> 10) + _synth_weight_strength;
+                    }
+                    else {
+                        _slot->metrics.horiBearingX -= _synth_weight_strength;
+                    }
+                }
+            }
+
+            item = newItem(&_glyph_cache2, cache_index, _slot);
             if (item)
                 _glyph_cache2.put(item);
         }
@@ -4252,6 +4358,8 @@ public:
             int fb_t_start = 0;
             int fb_t_end = len;
             int hg = 0;  // index in glyph_info/glyph_pos
+            bool use_fractional_positioning = fractionalGlyphPositioningMode == 4;
+            lInt32 x_64 = x * 64;
             while (hg < glyph_count) { // hg is the start of a new cluster at this point
                 bool draw_with_fallback = false;
                 int hcl = glyph_info[hg].cluster;
@@ -4369,6 +4477,7 @@ public:
                        def_char, palette, fb_addHyphen, lang_cfg, fb_flags, letter_spacing,
                        width, text_decoration_back_gap, target_w, target_h, svg_collector );
                     x += fb_advance;
+                    x_64 = x * 64;
                     #ifdef DEBUG_DRAW_TEXT
                         printf("DTHB ### drawn past notdef > X+= %d\n[...]", fb_advance);
                     #endif
@@ -4379,6 +4488,7 @@ public:
                     #endif
                     // Draw glyphs of this same cluster
                     int prev_x = x;
+                    bool cluster_has_advance = false;
                     for (i = hg; i < hg2; i++) {
                         if ( svg_collector ) {
                             bool can_adjust_from_previous = (i == hg) && !isHBScriptCursive(hb_buffer_get_script(_hb_buffer));
@@ -4397,14 +4507,20 @@ public:
                                 int w = target_w / glyph_count;
                                 DrawStretchedGlyph(buf, glyph_info[i].codepoint, x, y, w, target_h, palette);
                                 x += w;
+                                x_64 = x * 64;
+                                cluster_has_advance = true;
                             }
                             else {
                                 // Regular drawing of glyph at the baseline
                                 int w;
+                                lInt32 w_64 = 0;
                                 if ( glyph_pos[i].x_advance )
-                                    w = FONT_METRIC_TO_PX(glyph_pos[i].x_advance + _synth_weight_strength);
+                                    w_64 = glyph_pos[i].x_advance + _synth_weight_strength;
+                                if ( glyph_pos[i].x_advance )
+                                    w = FONT_METRIC_TO_PX(w_64);
                                 else
                                     w = 0;
+                                cluster_has_advance = cluster_has_advance || w_64 != 0;
                                 #ifdef DEBUG_DRAW_TEXT
                                     printf("%x(x=%d+%d,w=%d) ", glyph_info[i].codepoint, x,
                                             item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), w);
@@ -4466,11 +4582,33 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
-                                drawGlyphItem(buf,
-                                          x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
-                                          y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
-                                          item, palette);
-                                x += w;
+                                if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
+                                    drawGlyphItem(buf,
+                                              x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
+                                              y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
+                                              item, palette);
+                                    x += w;
+                                    x_64 = x * 64;
+                                }
+                                else {
+                                    lInt32 draw_x_64 = x_64 + glyph_pos[i].x_offset;
+                                    int draw_x = FONT_METRIC_FLOOR_TO_PX(draw_x_64);
+                                    int phase_64 = FONT_METRIC_FRAC_64(draw_x_64);
+                                    int phase_step = (phase_64 + 8) / 16;
+                                    if (phase_step >= 4) {
+                                        phase_step = 0;
+                                        draw_x += 1;
+                                    }
+                                    LVFontGlyphCacheItem *draw_item = getGlyphByIndexSubpixel(glyph_info[i].codepoint, phase_step * 16);
+                                    if (!draw_item)
+                                        draw_item = item;
+                                    drawGlyphItem(buf,
+                                              draw_x + draw_item->origin_x,
+                                              y + _baseline - draw_item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
+                                              draw_item, palette);
+                                    x_64 += w_64;
+                                    x = FONT_METRIC_TO_PX(x_64);
+                                }
                             }
                         }
                         #ifdef DEBUG_DRAW_TEXT
@@ -4479,11 +4617,18 @@ public:
                         #endif
                     }
                     // Whole cluster drawn: add letter spacing
-                    if ( x > prev_x ) {
+                    if ( use_fractional_positioning ? cluster_has_advance : x > prev_x ) {
                         // But only if this cluster has some advance
                         // (e.g. a soft-hyphen makes its own cluster, that
                         // draws a space glyph, but with no advance)
-                        x += letter_spacing;
+                        if ( use_fractional_positioning ) {
+                            x_64 += letter_spacing * 64;
+                            x = FONT_METRIC_TO_PX(x_64);
+                        }
+                        else {
+                            x += letter_spacing;
+                            x_64 = x * 64;
+                        }
                     }
                 }
                 hg = hg2;
@@ -6432,6 +6577,17 @@ public:
         _instance_cache.forEachFont([mode](LVFontRef& f) {
             f->setKerningMode(mode);
         });
+    }
+
+    virtual void SetFractionalGlyphPositioning(int mode) {
+        mode = mode == 4 ? 4 : 0;
+        if (fractionalGlyphPositioningMode == mode)
+            return;
+        FONT_MAN_GUARD
+        fractionalGlyphPositioningMode = mode;
+        CRLog::debug("Fractional glyph positioning mode is changed: %d", mode);
+        gc();
+        clearGlyphCache();
     }
 
     /// set monospace size scale percent

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -260,6 +260,28 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
+// Tunable by PROP_FONT_FRACTIONAL_POSITIONING, but only used by
+// KERNING_MODE_HARFBUZZ_FULL. Other kerning modes force effective granularity 1.
+static int fractionalGlyphPositioningGranularity = 4;
+
+static int normalizeFractionalGlyphPositioningGranularity(int granularity) {
+    switch (granularity) {
+    case 1:
+    case 2:
+    case 4:
+    case 8:
+    case 16:
+    case 32:
+    case 64:
+        return granularity;
+    default:
+        return 4;
+    }
+}
+
+static int getFractionalGlyphPositioningGranularity(kerning_mode_t mode) {
+    return mode == KERNING_MODE_HARFBUZZ_FULL ? fractionalGlyphPositioningGranularity : 1;
+}
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -6609,6 +6631,17 @@ public:
         _instance_cache.forEachFont([mode](LVFontRef& f) {
             f->setKerningMode(mode);
         });
+    }
+
+    virtual void SetFractionalGlyphPositioning(int granularity) {
+        granularity = normalizeFractionalGlyphPositioningGranularity(granularity);
+        if (fractionalGlyphPositioningGranularity == granularity)
+            return;
+        FONT_MAN_GUARD
+        fractionalGlyphPositioningGranularity = granularity;
+        CRLog::debug("Fractional glyph positioning granularity is %d", granularity);
+        gc();
+        clearGlyphCache();
     }
 
     /// set monospace size scale percent

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -4633,8 +4633,7 @@ public:
                                 // The normal fractional path would ignore that adjusted w and
                                 // advance from the original HarfBuzz w_64 instead, which can put
                                 // glyph placement, advance and decoration extents out of sync with
-                                // the adjusted CJK cell. LFNT_HINT_TRANSFORM_STRETCH is another
-                                // width-changing draw flag, handled by transform_stretch above.
+                                // the adjusted CJK cell.
                                 if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
                                     drawGlyphItem(buf,
                                               x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -260,21 +260,6 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
-static int fractionalGlyphPositioningGranularity = 1;
-
-static int normalizeFractionalGlyphPositioningGranularity(int granularity) {
-    switch (granularity) {
-    case 2:
-    case 4:
-    case 8:
-    case 16:
-    case 32:
-    case 64:
-        return granularity;
-    default:
-        return 1;
-    }
-}
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -1699,7 +1684,7 @@ public:
     virtual LVFontRef getDecimalListItemFont() {
         if ( !_DecimalListItemFont.isNull() )
             return _DecimalListItemFont;
-        if ( _kerningMode == KERNING_MODE_HARFBUZZ && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
+        if ( isHarfBuzzShapingMode(_kerningMode) && !(getFeatures() & LFNT_OT_FEATURES_P_TNUM) ) {
             // We can request the same font with OpenType feature "tabular nums", for fixed width
             // digits and better alignment of decimal list items (no need to do it if this feature
             // has already been enabled for this font). If the font does not support the feature,
@@ -1894,7 +1879,7 @@ public:
     }
     void setupHBFeatures() {
         _hb_features.clear();
-        if ( _kerningMode == KERNING_MODE_HARFBUZZ ) {
+        if ( isHarfBuzzShapingMode(_kerningMode) ) {
             // We reserve 2 for those we're adding now, +2 for possibly added CSS font features
             // (otherwise, LVArray would expand from 2 to 11 on the next addition - it will
             // then expand from 4 to 14 on the 3rd added CSS font feature).
@@ -2637,7 +2622,7 @@ public:
         svg_collector->_advance_y = svg_collector->_advance_y * scale;
 
         #if USE_HARFBUZZ==1
-            if (_kerningMode == KERNING_MODE_HARFBUZZ && code_is_glyph_index ) {
+            if (isHarfBuzzShapingMode(_kerningMode) && code_is_glyph_index ) {
                 // With kerning mode harfbuzz, we get called with the fallback font and the glyph
                 // index in that font. No need to check if it is present or iterate fallback fonts.
                 // We can use hb_font_draw_glyph() which will make a smoother shape than
@@ -2896,7 +2881,7 @@ public:
         // measure character widths
 
     #if USE_HARFBUZZ==1
-        if (_kerningMode == KERNING_MODE_HARFBUZZ) {
+        if (isHarfBuzzShapingMode(_kerningMode)) {
 
             /** from harfbuzz/src/hb-buffer.h
              * hb_glyph_info_t:
@@ -3073,7 +3058,8 @@ public:
             int t_notdef_start = -1;
             int t_notdef_end = -1;
             bool max_width_reached = false; // set when reached while measuring with the fallback font
-            bool use_fractional_positioning = fractionalGlyphPositioningGranularity > 1;
+            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity(_kerningMode);
+            bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 cur_width_64 = 0;
             for (int t = 0; t < len; t++) {
                 #ifdef DEBUG_MEASURE_TEXT
@@ -3282,7 +3268,7 @@ public:
                     printf("%d:%d ", t, widths[t] - (t>0?widths[t-1]:0));
                 printf("\n");
             #endif
-        } // _kerningMode == KERNING_MODE_HARFBUZZ
+        } // isHarfBuzzShapingMode(_kerningMode)
 
         else if (_kerningMode == KERNING_MODE_HARFBUZZ_LIGHT) {
             struct LVCharTriplet triplet;
@@ -4229,7 +4215,7 @@ public:
     virtual bool kerningEnabled() {
         #if (ALLOW_KERNING==1)
             #if USE_HARFBUZZ==1
-                return _kerningMode == KERNING_MODE_HARFBUZZ
+                return isHarfBuzzShapingMode(_kerningMode)
                     || (_kerningMode == KERNING_MODE_FREETYPE && FT_HAS_KERNING( _face ));
             #else
                 return _kerningMode != KERNING_MODE_DISABLED && FT_HAS_KERNING( _face );
@@ -4275,7 +4261,7 @@ public:
         int x0 = x;
 
     #if USE_HARFBUZZ==1
-        if (_kerningMode == KERNING_MODE_HARFBUZZ) {
+        if (isHarfBuzzShapingMode(_kerningMode)) {
             // See measureText() for more comments on how to work with Harfbuzz,
             // as we do and must work the same way here.
             int glyph_count;
@@ -4383,7 +4369,7 @@ public:
             int fb_t_start = 0;
             int fb_t_end = len;
             int hg = 0;  // index in glyph_info/glyph_pos
-            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
+            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity(_kerningMode);
             bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 x_64 = x * 64;
             while (hg < glyph_count) { // hg is the start of a new cluster at this point
@@ -4701,7 +4687,7 @@ public:
                 }
             }
 
-        } // _kerningMode == KERNING_MODE_HARFBUZZ
+        } // isHarfBuzzShapingMode(_kerningMode)
         else if (_kerningMode == KERNING_MODE_HARFBUZZ_LIGHT) {
             struct LVCharTriplet triplet;
             struct LVCharPosInfo posInfo;
@@ -6623,17 +6609,6 @@ public:
         _instance_cache.forEachFont([mode](LVFontRef& f) {
             f->setKerningMode(mode);
         });
-    }
-
-    virtual void SetFractionalGlyphPositioning(int granularity) {
-        granularity = normalizeFractionalGlyphPositioningGranularity(granularity);
-        if (fractionalGlyphPositioningGranularity == granularity)
-            return;
-        FONT_MAN_GUARD
-        fractionalGlyphPositioningGranularity = granularity;
-        CRLog::debug("Fractional glyph positioning granularity is %d", granularity);
-        gc();
-        clearGlyphCache();
     }
 
     /// set monospace size scale percent

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -4611,13 +4611,22 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
-                                // Keep the original integer path for CJK width tweaks.
-                                // These paths adjust x and w using final pixel widths so that
-                                // punctuation anchoring, scaling and underlines stay aligned.
-                                // They are the CJK width-changing flags set by lvtextfm.cpp
-                                // before DrawTextString(), from LTEXT_WORD_IS_FLEXIBLE_WIDTH_CJK
-                                // and cjk_width_scale_percent. LFNT_HINT_TRANSFORM_STRETCH is
-                                // another width-changing draw flag, handled by transform_stretch above.
+                                // lvtextfm.cpp sets these flags when it has already width-adjusted
+                                // a CJK glyph cell: LTEXT_WORD_IS_FLEXIBLE_WIDTH_CJK may compress
+                                // punctuation for line fitting, and cjk_width_scale_percent may
+                                // enlarge CJK cells. At this point, the glyph is expected to fit
+                                // at a specific position inside that adjusted integer-pixel cell.
+                                //
+                                // For normal glyphs, x/w are just the integer-pixel form of the
+                                // HarfBuzz position/advance. With these flags, the CJK code above
+                                // rewrites x/w to mean the manually adjusted final cell geometry:
+                                // x is where this adjusted glyph should be drawn, and w is the
+                                // remaining width needed to land on the adjusted cell boundary.
+                                // The normal fractional path would ignore that adjusted w and
+                                // advance from the original HarfBuzz w_64 instead, which can put
+                                // glyph placement, advance and decoration extents out of sync with
+                                // the adjusted CJK cell. LFNT_HINT_TRANSFORM_STRETCH is another
+                                // width-changing draw flag, handled by transform_stretch above.
                                 if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
                                     drawGlyphItem(buf,
                                               x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -4598,21 +4598,8 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
-                                // lvtextfm.cpp sets these flags when it has already width-adjusted
-                                // a CJK glyph cell: LTEXT_WORD_IS_FLEXIBLE_WIDTH_CJK may compress
-                                // punctuation for line fitting, and cjk_width_scale_percent may
-                                // enlarge CJK cells. At this point, the glyph is expected to fit
-                                // at a specific position inside that adjusted integer-pixel cell.
-                                //
-                                // For normal glyphs, x/w are just the integer-pixel form of the
-                                // HarfBuzz position/advance. With these flags, the CJK code above
-                                // rewrites x/w to mean the manually adjusted final cell geometry:
-                                // x is where this adjusted glyph should be drawn, and w is the
-                                // remaining width needed to land on the adjusted cell boundary.
-                                // The normal fractional path would ignore that adjusted w and
-                                // advance from the original HarfBuzz w_64 instead, which can put
-                                // glyph placement, advance and decoration extents out of sync with
-                                // the adjusted CJK cell.
+                                // With these CJK flags, x/w have already been computed/adjusted,
+                                // so use them as-is, without fractional positioning.
                                 if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
                                     drawGlyphItem(buf,
                                               x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -273,7 +273,7 @@ LVFontManager * fontMan = NULL;
 
 static double gammaLevel = 1.0;
 static int gammaIndex = GAMMA_NO_CORRECTION_INDEX;
-static int fractionalGlyphPositioningGranularity = 1;
+static int fractionalGlyphPositioningStrength = 0;
 
 /// returns first found face from passed list, or return face for font found by family only
 lString8 LVFontManager::findFontFace(lString8 commaSeparatedFaceList, css_font_family_t fallbackByFamily) {
@@ -1573,6 +1573,22 @@ protected:
     LVHashTable<struct LVCharTriplet, struct LVCharPosInfo> _width_cache2;
 #endif
 public:
+    int getFractionalGlyphPositioningGranularity() const {
+        if (!fractionalGlyphPositioningStrength)
+            return 1;
+        // Strength 1, 2 and 3 bound the positioning error to 1/96, 1/192
+        // and 1/384 em respectively. Cap at eight phases to limit cache use.
+        // At 48 px/em, strengths 1/2/3 use 1/2/4 phases. Each higher
+        // strength doubles the px/em thresholds: strength 3 uses 8 phases
+        // below 48 px/em, 4 below 96, 2 below 192, and 1 above.
+        int x_ppem = _face->size->metrics.x_ppem;
+        int error_denominator = 96 << (fractionalGlyphPositioningStrength - 1);
+        int phase_count = 1;
+        while (phase_count < 8 && 2 * phase_count * x_ppem < error_denominator)
+            phase_count *= 2;
+        return phase_count;
+    }
+
 
     virtual void clearFontRefs( const LVFont *ptr ) {
         if ( _fallbackFont.get() == ptr ) {
@@ -3072,7 +3088,7 @@ public:
             int t_notdef_start = -1;
             int t_notdef_end = -1;
             bool max_width_reached = false; // set when reached while measuring with the fallback font
-            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
+            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity();
             bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 cur_width_64 = 0;
             for (int t = 0; t < len; t++) {
@@ -3080,9 +3096,6 @@ public:
                     printf("MTHB t%d (=%x) ", t, text[t]);
                 #endif
                 // Grab all glyphs that do not belong to a cluster greater that our char position
-                // With fractional positioning, a cluster can have a non-zero 26.6 advance
-                // while still rounding to the same integer pixel width as the previous one.
-                // So we can't use cur_width == prev_width to detect zero-advance clusters.
                 bool cluster_has_advance = false;
                 while ( hg < glyph_count ) {
                     hcl = glyph_info[hg].cluster;
@@ -3171,15 +3184,21 @@ public:
                             }
                         }
                         if ( use_fractional_positioning ) {
-                            cluster_has_advance = cluster_has_advance || advance_64 != 0;
                             cur_width_64 += advance_64;
+                            #ifdef DEBUG_MEASURE_TEXT
+                                advance = FONT_METRIC_TO_PX(cur_width_64) - cur_width;
+                            #endif
                             cur_width = FONT_METRIC_TO_PX(cur_width_64);
+                            cluster_has_advance = cluster_has_advance || advance_64 != 0;
+                            // (With fractional positioning, a cluster can have a non-zero 26.6 advance
+                            // while still rounding to the same integer pixel width as the previous one.)
                         }
                         else {
                             cur_width += advance;
+                            cluster_has_advance = cur_width != prev_width;
                         }
                         #ifdef DEBUG_MEASURE_TEXT
-                            printf("c%d+%d ", hcl, use_fractional_positioning ? cur_width - prev_width : advance);
+                            printf("c%d+%d ", hcl, advance);
                         #endif
                         cur_cluster = hcl;
                         hg++;
@@ -3202,18 +3221,18 @@ public:
                     // We're either a single char cluster, or the start
                     // of a multi chars cluster.
                     flags[t] = GET_CHAR_FLAGS(text[t]);
-                    if ( use_fractional_positioning ? !cluster_has_advance : cur_width == prev_width ) {
+                    if ( !cluster_has_advance ) {
                         // But if there is no advance (this happens with soft-hyphens),
                         // flag it and don't add any letter spacing.
                         flags[t] |= LCHAR_IS_CLUSTER_TAIL;
                     }
-                    else {
+                    else { // Only add letter-spacing between clusters/graphemes.
                         if ( use_fractional_positioning ) {
-                            cur_width_64 += letter_spacing * 64; // only between clusters/graphemes
+                            cur_width_64 += letter_spacing * 64;
                             cur_width = FONT_METRIC_TO_PX(cur_width_64);
                         }
                         else {
-                            cur_width += letter_spacing; // only between clusters/graphemes
+                            cur_width += letter_spacing;
                         }
                     }
                     // It seems each soft-hyphen is in its own cluster, of length 1 and width 0,
@@ -3666,7 +3685,12 @@ public:
     }
 
     LVFontGlyphCacheItem * getGlyphByIndexSubpixel(lUInt32 index, int phase_step, int phase_count) {
-        if (_drawMonochrome || phase_step <= 0 || phase_count <= 1)
+        if (phase_count <= 1 || _drawMonochrome )
+            return NULL;
+        // Phase zero has no outline translation, so reuse the normal bitmap.
+        if (phase_step == 0)
+            return getGlyphByIndex(index);
+        if (phase_step < 0)
             return NULL;
 
         // This is the same loading/rendering path as getGlyphByIndex(), but with
@@ -3678,23 +3702,19 @@ public:
         //
         // Subpixel phase 0 uses the normal glyph cache entry. Non-zero phases are stored
         // in the high 6 bits of the existing 32-bit glyph cache key, leaving the
-        // lower 26 bits for the glyph index. This keeps the cache type unchanged
-        // and supports up to 64 phases, but assumes practical glyph indices stay
-        // below 2^26. Current fonts are far below this, but it is still an
-        // implementation assumption rather than a format guarantee.
+        // lower 26 bits for the glyph index.
+        // (This shared cache key scheme can cause subpixel entries for indices < 2^26
+        // to collide with normal entries for indices >= 2^26: current fonts are far
+        // below that, so we accept this constraint.)
         if (phase_step >= phase_count)
             phase_step = phase_count - 1;
         static const int SUBPIXEL_PHASE_SHIFT = 26;
-        static const lUInt32 SUBPIXEL_GLYPH_INDEX_MASK = (1u << SUBPIXEL_PHASE_SHIFT) - 1;
-        if (index & ~SUBPIXEL_GLYPH_INDEX_MASK) {
-            // For an index  >= 2^26 (very rare), skip the packed phase-key cache and return
-            // the ordinary glyph cache entry keyed by the unmodified index, to avoid collisions
-            // with non-phase-zero entries.
-            return getGlyphByIndex(index);
-        }
-        lUInt32 cache_index = ((lUInt32)phase_step << SUBPIXEL_PHASE_SHIFT) | index;
+        lUInt32 cache_index = ((lUInt32)phase_step << SUBPIXEL_PHASE_SHIFT)
+                            | (index & ((1u << SUBPIXEL_PHASE_SHIFT) - 1));
         LVFontGlyphCacheItem *item = _glyph_cache2.getByIndex(cache_index);
         if (!item) {
+            // Unlike getGlyphByIndex(), we cannot request FT_LOAD_RENDER here:
+            // we must translate the loaded outline for this subpixel phase first.
             int rend_flags = FT_LOAD_TARGET_LIGHT;
             if (_hintingMode == HINTING_MODE_BYTECODE_INTERPRETOR) {
                 rend_flags |= FT_LOAD_NO_AUTOHINT;
@@ -3719,6 +3739,8 @@ public:
             if (_slot->format != FT_GLYPH_FORMAT_OUTLINE)
                 return NULL;
 
+            // Apply synthetic transformations before the phase translation, then
+            // render the final outline explicitly.
             bool is_embolden = false;
             if (_synth_weight > 0) {
                 FT_Outline_Embolden(&_slot->outline, _synth_weight_strength);
@@ -3728,7 +3750,6 @@ public:
             if (_italic==2) {
                 FT_GlyphSlot_Oblique(_slot);
             }
-
             FT_Outline_Translate(&_slot->outline, phase_step * (64 / phase_count), 0);
             FT_Render_Glyph(_slot, FT_RENDER_MODE_LIGHT);
 
@@ -4389,7 +4410,7 @@ public:
             int fb_t_start = 0;
             int fb_t_end = len;
             int hg = 0;  // index in glyph_info/glyph_pos
-            int fractional_positioning_granularity = fractionalGlyphPositioningGranularity;
+            int fractional_positioning_granularity = getFractionalGlyphPositioningGranularity();
             bool use_fractional_positioning = fractional_positioning_granularity > 1;
             lInt32 x_64 = x * 64;
             while (hg < glyph_count) { // hg is the start of a new cluster at this point
@@ -4520,9 +4541,6 @@ public:
                     #endif
                     // Draw glyphs of this same cluster
                     int prev_x = x;
-                    // With fractional positioning, a cluster can advance in 26.6 units
-                    // without changing the rounded integer x. Track the original
-                    // unrounded advance to decide whether letter spacing should apply.
                     bool cluster_has_advance = false;
                     for (i = hg; i < hg2; i++) {
                         if ( svg_collector ) {
@@ -4534,32 +4552,60 @@ public:
                             svg_collector->addGlyph();
                             continue;
                         }
-                        LVFontGlyphCacheItem *item = getGlyphByIndex(glyph_info[i].codepoint);
-                        if (item) {
-                            if ( transform_stretch ) {
+                        LVFontGlyphCacheItem *item = NULL;
+                        if ( transform_stretch ) {
+                            item = getGlyphByIndex(glyph_info[i].codepoint);
+                            if (item) {
                                 // Stretched drawing of glyph to the x/y/w/h provided (used with MathML)
                                 // Split the targeted width to each glyph in case we have more than one
                                 int w = target_w / glyph_count;
                                 DrawStretchedGlyph(buf, glyph_info[i].codepoint, x, y, w, target_h, palette);
                                 x += w;
                                 x_64 = x * 64;
-                                cluster_has_advance = true;
+                                cluster_has_advance = x > prev_x;
                             }
-                            else {
-                                // Regular drawing of glyph at the baseline
-                                int w;
-                                lInt32 w_64 = 0;
-                                if ( glyph_pos[i].x_advance )
-                                    w_64 = glyph_pos[i].x_advance + _synth_weight_strength;
-                                if ( glyph_pos[i].x_advance )
-                                    w = FONT_METRIC_TO_PX(w_64);
-                                else
-                                    w = 0;
-                                cluster_has_advance = cluster_has_advance || w_64 != 0;
-                                #ifdef DEBUG_DRAW_TEXT
-                                    printf("%x(x=%d+%d,w=%d) ", glyph_info[i].codepoint, x,
-                                            item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), w);
-                                #endif
+                            #ifdef DEBUG_DRAW_TEXT
+                            else
+                                printf("SKIPPED %x", glyph_info[i].codepoint);
+                            #endif
+                            continue;
+                        }
+                        // Regular drawing of glyph at the baseline
+                        int draw_x = x;
+                        bool use_subpixel_glyph = use_fractional_positioning
+                                    && !(flags & (LFNT_HINT_CJK_ALTERED_WIDTH | LFNT_HINT_CJK_SCALED_WIDTH));
+                        if (use_subpixel_glyph) {
+                            int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(x_64 + glyph_pos[i].x_offset,
+                                                            fractional_positioning_granularity, draw_x);
+                            item = getGlyphByIndexSubpixel(glyph_info[i].codepoint,
+                                                            phase_step, fractional_positioning_granularity);
+                        }
+                        if (!item) {
+                            // Bitmap/color/monochrome glyphs cannot represent a phase,
+                            // so use the normal cache entry and rounded placement.
+                            item = getGlyphByIndex(glyph_info[i].codepoint);
+                            use_subpixel_glyph = false;
+                            draw_x = x;
+                        }
+                        if (!item) {
+                            #ifdef DEBUG_DRAW_TEXT
+                                printf("SKIPPED %x", glyph_info[i].codepoint);
+                            #endif
+                            continue;
+                        }
+                        int w = 0;
+                        lInt32 w_64 = 0;
+                        if ( glyph_pos[i].x_advance ) {
+                            w_64 = glyph_pos[i].x_advance + _synth_weight_strength;
+                            w = FONT_METRIC_TO_PX(w_64);
+                        }
+                        #ifdef DEBUG_DRAW_TEXT
+                            printf("%x(x=%d+%d,w=%d) ", glyph_info[i].codepoint, x,
+                                item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset), w);
+                        #endif
+                        if ( flags & (LFNT_HINT_CJK_ALTERED_WIDTH | LFNT_HINT_CJK_SCALED_WIDTH) ) {
+                                // With these CJK flags, we will compute/adjust x/w and we'll use
+                                // them as-is. use_subpixel_glyph has already been set to false above.
                                 if ( flags & LFNT_HINT_CJK_ALTERED_WIDTH ) {
                                     int orig_width = width;
                                     if ( flags & LFNT_HINT_CJK_SCALED_WIDTH ) {
@@ -4617,44 +4663,30 @@ public:
                                     // gives x=x0+width, which is necessary to correctly draw any underline
                                     w = x0 + width - x;
                                 }
-                                // With these CJK flags, x/w have already been computed/adjusted,
-                                // so use them as-is, without fractional positioning.
-                                if ( (flags & LFNT_HINT_CJK_ALTERED_WIDTH) || (flags & LFNT_HINT_CJK_SCALED_WIDTH) || !use_fractional_positioning ) {
-                                    drawGlyphItem(buf,
-                                              x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
-                                              y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
-                                              item, palette);
-                                    x += w;
-                                    x_64 = x * 64;
-                                }
-                                else {
-                                    int draw_x;
-                                    int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(
-                                        x_64 + glyph_pos[i].x_offset,
-                                        fractional_positioning_granularity, draw_x);
-                                    LVFontGlyphCacheItem *draw_item = getGlyphByIndexSubpixel(glyph_info[i].codepoint, phase_step, fractional_positioning_granularity);
-                                    if (!draw_item) {
-                                        draw_item = item;
-                                        // A normal bitmap cannot represent this subpixel phase.
-                                        // Keep the former rounded integer placement.
-                                        draw_x = x;
-                                    }
-                                    drawGlyphItem(buf,
-                                              draw_x + draw_item->origin_x,
-                                              y + _baseline - draw_item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
-                                              draw_item, palette);
-                                    x_64 += w_64;
-                                    x = FONT_METRIC_TO_PX(x_64);
-                                }
-                            }
+                                draw_x = x;
                         }
-                        #ifdef DEBUG_DRAW_TEXT
-                        else
-                            printf("SKIPPED %x", glyph_info[i].codepoint);
-                        #endif
+                        if (!use_subpixel_glyph) {
+                            drawGlyphItem(buf,
+                                      draw_x + item->origin_x + FONT_METRIC_TO_PX(glyph_pos[i].x_offset),
+                                      y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
+                                      item, palette);
+                            x += w;
+                            x_64 = x * 64;
+                            cluster_has_advance = x > prev_x;
+                        }
+                        else {
+                            // (x_offset was already accounted for when computing phase_step)
+                            drawGlyphItem(buf,
+                                      draw_x + item->origin_x,
+                                      y + _baseline - item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
+                                      item, palette);
+                            x_64 += w_64;
+                            x = FONT_METRIC_TO_PX(x_64);
+                            cluster_has_advance = cluster_has_advance || w_64 != 0;
+                        }
                     }
                     // Whole cluster drawn: add letter spacing
-                    if ( use_fractional_positioning ? cluster_has_advance : x > prev_x ) {
+                    if ( cluster_has_advance ) {
                         // But only if this cluster has some advance
                         // (e.g. a soft-hyphen makes its own cluster, that
                         // draws a space glyph, but with no advance)
@@ -4682,27 +4714,27 @@ public:
 
             if (addHyphen) {
                 ch = getHyphChar();
-                LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
+                int draw_x = x;
+                LVFontGlyphCacheItem *item = NULL;
+                if (use_fractional_positioning) {
+                    FT_UInt hyphen_index = getCharIndex(ch, 0);
+                    if (hyphen_index) {
+                        int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(x_64,
+                                                fractional_positioning_granularity, draw_x);
+                        item = getGlyphByIndexSubpixel(hyphen_index,
+                                                phase_step, fractional_positioning_granularity);
+                    }
+                }
+                if (!item) {
+                    // Phase zero and hyphens from a fallback font use the normal cache entry.
+                    item = getGlyph(ch, def_char);
+                    draw_x = x;
+                }
                 if (item) {
                     w = item->advance;
-                    int draw_x = x;
-                    LVFontGlyphCacheItem *draw_item = item;
-                    if (use_fractional_positioning) {
-                        FT_UInt hyphen_index = getCharIndex(ch, 0);
-                        if (hyphen_index) {
-                            int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(
-                                x_64, fractional_positioning_granularity, draw_x);
-                            LVFontGlyphCacheItem *subpixel_item = getGlyphByIndexSubpixel(
-                                hyphen_index, phase_step, fractional_positioning_granularity);
-                            if (subpixel_item)
-                                draw_item = subpixel_item;
-                            else
-                                draw_x = x;
-                        }
-                    }
-                    drawGlyphItem(buf, draw_x + draw_item->origin_x,
-                                   y + _baseline - draw_item->origin_y,
-                                   draw_item, palette);
+                    drawGlyphItem(buf, draw_x + item->origin_x,
+                                   y + _baseline - item->origin_y,
+                                   item, palette);
                     x  += w; // + letter_spacing; (let's not add any letter-spacing after hyphen)
                 }
             }
@@ -6632,28 +6664,17 @@ public:
     }
 
     virtual int GetFractionalGlyphPositioning() {
-        return fractionalGlyphPositioningGranularity;
+        return fractionalGlyphPositioningStrength;
     }
 
-    virtual void SetFractionalGlyphPositioning(int granularity) {
-        switch (granularity) {
-        case 1:
-        case 2:
-        case 4:
-        case 8:
-        case 16:
-        case 32:
-        case 64:
-            break;
-        default:
-            granularity = 1;
-            break;
-        }
-        if (fractionalGlyphPositioningGranularity == granularity)
+    virtual void SetFractionalGlyphPositioning(int strength) {
+        if (strength < 0 || strength > 3)
+            strength = 0;
+        if (fractionalGlyphPositioningStrength == strength)
             return;
         FONT_MAN_GUARD
-        fractionalGlyphPositioningGranularity = granularity;
-        CRLog::debug("Fractional glyph positioning granularity is %d", granularity);
+        fractionalGlyphPositioningStrength = strength;
+        CRLog::debug("Fractional glyph positioning strength is %d", strength);
         gc();
         clearGlyphCache();
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -235,6 +235,19 @@ static inline int FONT_METRIC_FRAC_64(lInt32 x)
     return x - floor_px * 64;
 }
 
+static inline int FONT_METRIC_SUBPIXEL_PHASE_STEP(lInt32 x, int phase_count, int &draw_x)
+{
+    draw_x = FONT_METRIC_FLOOR_TO_PX(x);
+    int phase_64 = FONT_METRIC_FRAC_64(x);
+    int phase_unit = 64 / phase_count;
+    int phase_step = (phase_64 + phase_unit / 2) / phase_unit;
+    if (phase_step >= phase_count) {
+        phase_step = 0;
+        draw_x += 1;
+    }
+    return phase_step;
+}
+
 #if COLOR_BACKBUFFER==0
 //#define USE_BITMAP_FONT
 #endif
@@ -3654,7 +3667,7 @@ public:
 
     LVFontGlyphCacheItem * getGlyphByIndexSubpixel(lUInt32 index, int phase_step, int phase_count) {
         if (_drawMonochrome || phase_step <= 0 || phase_count <= 1)
-            return getGlyphByIndex(index);
+            return NULL;
 
         // This is the same loading/rendering path as getGlyphByIndex(), but with
         // the outline shifted horizontally before rendering. The phase count is
@@ -3663,7 +3676,7 @@ public:
         //   4  phases: 0/64, 16/64, 32/64, 48/64
         //   64 phases: every 1/64 pixel position
         //
-        // Phase 0 uses the normal glyph cache entry. Non-zero phases are stored
+        // Subpixel phase 0 uses the normal glyph cache entry. Non-zero phases are stored
         // in the high 6 bits of the existing 32-bit glyph cache key, leaving the
         // lower 26 bits for the glyph index. This keeps the cache type unchanged
         // and supports up to 64 phases, but assumes practical glyph indices stay
@@ -3673,7 +3686,13 @@ public:
             phase_step = phase_count - 1;
         static const int SUBPIXEL_PHASE_SHIFT = 26;
         static const lUInt32 SUBPIXEL_GLYPH_INDEX_MASK = (1u << SUBPIXEL_PHASE_SHIFT) - 1;
-        lUInt32 cache_index = ((lUInt32)phase_step << SUBPIXEL_PHASE_SHIFT) | (index & SUBPIXEL_GLYPH_INDEX_MASK);
+        if (index & ~SUBPIXEL_GLYPH_INDEX_MASK) {
+            // For an index  >= 2^26 (very rare), skip the packed phase-key cache and return
+            // the ordinary glyph cache entry keyed by the unmodified index, to avoid collisions
+            // with non-phase-zero entries.
+            return getGlyphByIndex(index);
+        }
+        lUInt32 cache_index = ((lUInt32)phase_step << SUBPIXEL_PHASE_SHIFT) | index;
         LVFontGlyphCacheItem *item = _glyph_cache2.getByIndex(cache_index);
         if (!item) {
             int rend_flags = FT_LOAD_TARGET_LIGHT;
@@ -3697,8 +3716,8 @@ public:
             }
             if ( error )
                 return NULL;
-            if ( _slot->format != FT_GLYPH_FORMAT_OUTLINE )
-                return getGlyphByIndex(index);
+            if (_slot->format != FT_GLYPH_FORMAT_OUTLINE)
+                return NULL;
 
             bool is_embolden = false;
             if (_synth_weight > 0) {
@@ -4503,7 +4522,7 @@ public:
                     int prev_x = x;
                     // With fractional positioning, a cluster can advance in 26.6 units
                     // without changing the rounded integer x. Track the original
-                    // HarfBuzz advance to decide whether letter spacing should apply.
+                    // unrounded advance to decide whether letter spacing should apply.
                     bool cluster_has_advance = false;
                     for (i = hg; i < hg2; i++) {
                         if ( svg_collector ) {
@@ -4609,18 +4628,17 @@ public:
                                     x_64 = x * 64;
                                 }
                                 else {
-                                    lInt32 draw_x_64 = x_64 + glyph_pos[i].x_offset;
-                                    int draw_x = FONT_METRIC_FLOOR_TO_PX(draw_x_64);
-                                    int phase_64 = FONT_METRIC_FRAC_64(draw_x_64);
-                                    int phase_unit = 64 / fractional_positioning_granularity;
-                                    int phase_step = (phase_64 + phase_unit / 2) / phase_unit;
-                                    if (phase_step >= fractional_positioning_granularity) {
-                                        phase_step = 0;
-                                        draw_x += 1;
-                                    }
+                                    int draw_x;
+                                    int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(
+                                        x_64 + glyph_pos[i].x_offset,
+                                        fractional_positioning_granularity, draw_x);
                                     LVFontGlyphCacheItem *draw_item = getGlyphByIndexSubpixel(glyph_info[i].codepoint, phase_step, fractional_positioning_granularity);
-                                    if (!draw_item)
+                                    if (!draw_item) {
                                         draw_item = item;
+                                        // A normal bitmap cannot represent this subpixel phase.
+                                        // Keep the former rounded integer placement.
+                                        draw_x = x;
+                                    }
                                     drawGlyphItem(buf,
                                               draw_x + draw_item->origin_x,
                                               y + _baseline - draw_item->origin_y - FONT_METRIC_TO_PX(glyph_pos[i].y_offset),
@@ -4667,9 +4685,24 @@ public:
                 LVFontGlyphCacheItem *item = getGlyph(ch, def_char);
                 if (item) {
                     w = item->advance;
-                    drawGlyphItem(buf, x + item->origin_x,
-                               y + _baseline - item->origin_y,
-                               item, palette);
+                    int draw_x = x;
+                    LVFontGlyphCacheItem *draw_item = item;
+                    if (use_fractional_positioning) {
+                        FT_UInt hyphen_index = getCharIndex(ch, 0);
+                        if (hyphen_index) {
+                            int phase_step = FONT_METRIC_SUBPIXEL_PHASE_STEP(
+                                x_64, fractional_positioning_granularity, draw_x);
+                            LVFontGlyphCacheItem *subpixel_item = getGlyphByIndexSubpixel(
+                                hyphen_index, phase_step, fractional_positioning_granularity);
+                            if (subpixel_item)
+                                draw_item = subpixel_item;
+                            else
+                                draw_x = x;
+                        }
+                    }
+                    drawGlyphItem(buf, draw_x + draw_item->origin_x,
+                                   y + _baseline - draw_item->origin_y,
+                                   draw_item, palette);
                     x  += w; // + letter_spacing; (let's not add any letter-spacing after hyphen)
                 }
             }
@@ -6596,6 +6629,10 @@ public:
         _instance_cache.forEachFont([mode](LVFontRef& f) {
             f->setKerningMode(mode);
         });
+    }
+
+    virtual int GetFractionalGlyphPositioning() {
+        return fractionalGlyphPositioningGranularity;
     }
 
     virtual void SetFractionalGlyphPositioning(int granularity) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2020,7 +2020,7 @@ public:
             FriBidiLevel newBidiLevel;
         #endif
         #if (USE_HARFBUZZ==1)
-            bool usingHarfbuzz = isHarfBuzzShapingMode(m_kerning_mode);
+            bool usingHarfbuzz = m_kerning_mode == KERNING_MODE_HARFBUZZ;
             // Unicode script change (note: hb_script_t is uint32_t)
             lUInt32 prevScript = HB_SCRIPT_COMMON;
             hb_unicode_funcs_t* _hb_unicode_funcs = hb_unicode_funcs_get_default();
@@ -4186,7 +4186,7 @@ public:
                         // If not using Harfbuzz, procede to mirror parens & al (don't
                         // do that if Harfbuzz is used, as it does that by itself, and
                         // would mirror back our mirrored chars!)
-                        if ( !isHarfBuzzShapingMode(m_kerning_mode) ) {
+                        if ( m_kerning_mode != KERNING_MODE_HARFBUZZ ) {
                             lChar32 * str = (lChar32*)(srcline->t.text + word->t.start);
                             FriBidiChar mirror;
                             for (int i=0; i < word->t.len; i++) {

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -2020,7 +2020,7 @@ public:
             FriBidiLevel newBidiLevel;
         #endif
         #if (USE_HARFBUZZ==1)
-            bool usingHarfbuzz = m_kerning_mode == KERNING_MODE_HARFBUZZ;
+            bool usingHarfbuzz = isHarfBuzzShapingMode(m_kerning_mode);
             // Unicode script change (note: hb_script_t is uint32_t)
             lUInt32 prevScript = HB_SCRIPT_COMMON;
             hb_unicode_funcs_t* _hb_unicode_funcs = hb_unicode_funcs_get_default();
@@ -4186,7 +4186,7 @@ public:
                         // If not using Harfbuzz, procede to mirror parens & al (don't
                         // do that if Harfbuzz is used, as it does that by itself, and
                         // would mirror back our mirrored chars!)
-                        if ( m_kerning_mode != KERNING_MODE_HARFBUZZ ) {
+                        if ( !isHarfBuzzShapingMode(m_kerning_mode) ) {
                             lChar32 * str = (lChar32*)(srcline->t.text + word->t.start);
                             FriBidiChar mirror;
                             for (int i=0; i < word->t.len; i++) {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -398,6 +398,9 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     // if ( fontMan->getKerning() )
     //     hash += 127365;
     hash = hash * 31 + (int)fontMan->GetKerningMode();
+    // Measurements only change when toggling fractional positionning (1 means not enabled),
+    // not when only the granularity changes.
+    hash = hash * 31 + (fontMan->GetFractionalGlyphPositioning() != 1);
     hash = hash * 31 + fontMan->GetMonospaceSizeScale();
     hash = hash * 31 + (int)fontMan->GetFallbackFontSizesAdjusted();
     hash = hash * 31 + fontMan->GetFontListHash(documentId);
@@ -428,8 +431,9 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
         hash = hash * 31 + UserHyphDict::getHash();
     }
     /*
-    printf("  %d %d %d %d %d %d %d %d %d %d %d\n",
+    printf("  %d %d %d %d %d %d %d %d %d %d %d %d\n",
         (int)fontMan->GetKerningMode(),
+        fontMan->GetFractionalGlyphPositioning(),
         fontMan->GetMonospaceSizeScale(),
         (int)fontMan->GetFallbackFontSizesAdjusted(),
         fontMan->GetFontListHash(documentId),

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -398,9 +398,9 @@ lUInt32 calcGlobalSettingsHash(int documentId, bool already_rendered)
     // if ( fontMan->getKerning() )
     //     hash += 127365;
     hash = hash * 31 + (int)fontMan->GetKerningMode();
-    // Measurements only change when toggling fractional positionning (1 means not enabled),
-    // not when only the granularity changes.
-    hash = hash * 31 + (fontMan->GetFractionalGlyphPositioning() != 1);
+    // All enabled strengths preserve fractional layout; only enabling or
+    // disabling it changes measurements.
+    hash = hash * 31 + (fontMan->GetFractionalGlyphPositioning() != 0);
     hash = hash * 31 + fontMan->GetMonospaceSizeScale();
     hash = hash * 31 + (int)fontMan->GetFallbackFontSizesAdjusted();
     hash = hash * 31 + fontMan->GetFontListHash(documentId);


### PR DESCRIPTION
Disclaimer: code generated by coding agent, read and cleaned by me. However, I'm not a cpp-dev.

This PR adds an 16-phase horizontal fractional positioning mode for HarfBuzz-shaped text. This new path preserves advances in 26.6 fixed-point during measurement and draws glyphs from phase-specific cache entries (only when fractional positioning is explicitly enabled). Code keeps the default rendering path unchanged. 

This fixes some visual kerning defects that are present in koreader. 

Comparing 'best' kerning option to new proposed 'precise':

<img width="404" height="618" alt="Screenshot 2026-06-25 at 21 37 58" src="https://github.com/user-attachments/assets/3f92e602-7230-4d98-951f-701257390a61" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/685)
<!-- Reviewable:end -->