### PR TITLE
lvfntman: exclude document-embedded fonts from `getFaceList()`

### DIFF
--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6746,7 +6746,7 @@ public:
                 if (face.documentId != -1)
                     continue;
                 // typeface holds the original-case display name;
-                // getName() is the lowercase lookup key and must not be used for display.
+                // getName() is the lowercase lookup key, not used for display.
                 lString32 name = Utf8ToUnicode(face.typeface);
                 list.add(name);
                 break;

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -6730,18 +6730,27 @@ public:
         _instance_cache.gc();
     }
 
-    /// returns available typefaces
+    /// returns available typefaces (global fonts only - excludes document-embedded fonts)
     virtual void getFaceList( lString32Collection & list )
     {
         FONT_MAN_GUARD
         list.clear();
         for (int i = 0; i < _registry.familyCount(); i++) {
             const LVFontFamily* f = _registry.familyAt(i);
-            // faceAt(0).typeface holds the original-case display name;
-            // getName() is the lowercase lookup key and must not be used for display.
+            // A family can hold a mix of global and document-scoped faces when
+            // a document font shares its typeface name with a global one, so
+            // find the first global face rather than assuming faceAt(0) is global.
             assert(f->faceCount() > 0); // registerFace() always adds a face; removeFonts() prunes empties
-            lString32 name = Utf8ToUnicode(f->faceAt(0).typeface);
-            list.add(name);
+            for (int j = 0; j < f->faceCount(); j++) {
+                const LVFontFace& face = f->faceAt(j);
+                if (face.documentId != -1)
+                    continue;
+                // typeface holds the original-case display name;
+                // getName() is the lowercase lookup key and must not be used for display.
+                lString32 name = Utf8ToUnicode(face.typeface);
+                list.add(name);
+                break;
+            }
         }
         list.sort();
     }


### PR DESCRIPTION
## Summary

"Generate font test document" (Font settings) started listing embedded fonts from the currently open document, which weren't included in KOReader 2026.03.

This is a regression from the font manager refactor (72cf7cc2, "Refactor Font Manager; Add variable fonts"). The old `LVFontCache::getFaceList()` explicitly skipped faces with `documentId != -1`. Its replacement, the registry-based `LVFreeTypeFontManager::getFaceList()`, dropped that filter — it walked every family in `_registry` and took the first face's name regardless of `documentId`, so document-embedded fonts registered via `RegisterDocumentFont()` leaked into `cre.getFontFaces()` (used by KOReader's `ReaderFont:buildFontsTestDocument()`).

Fix: restore the `documentId != -1` filter in `getFaceList()`, now applied per-face rather than per-family, since a family in the new registry can mix a global face and a document-scoped face sharing the same typeface name (which couldn't happen in the old flat list).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/686)
<!-- Reviewable:end -->
