### PR TITLE
lvimg: fix `LVUnpackedImgSource` destructor

### DIFF
--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2869,7 +2869,7 @@ public:
             free( _grayImage );
         if ( _colorImage )
             free( _colorImage );
-        if ( _colorImage )
+        if ( _colorImage16 )
             free( _colorImage16 );
     }
 };


### PR DESCRIPTION
Unused, so no impact, apart from getting rid of a static linting warning (my preference would be to need that code, and the crgui / crskin stuff too).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/689)
<!-- Reviewable:end -->
