### PR TITLE
fix(refcache): initialize size and table in ctor

### DIFF
--- a/crengine/include/lvrefcache.h
+++ b/crengine/include/lvrefcache.h
@@ -325,7 +325,9 @@ public:
 
     /// from index array
     LVIndexedRefCache( LVArray<ref_t> &list )
-    : index(NULL)
+    : size(0)
+    , table(NULL)
+    , index(NULL)
     , indexsize(0)
     , nextindex(0)
     , freeindex(0)


### PR DESCRIPTION
`LVIndexedRefCache` constructor calls `setIndex()` → `clear()` before `size` and `table` are initialized, causing undefined behavior (dereferencing garbage pointers, iterating garbage loop count).

Members are initialized in declaration order (line 132-140):

```cpp
private:
    int size;                    // 1st
    LVRefCacheRec ** table;      // 2nd
    LVRefCacheIndexRec * index;  // 3rd
    int indexsize;
    int nextindex;
    int freeindex;
    int numitems;
```

But the initializer list only covers `index` onward:

```cpp
LVIndexedRefCache( LVArray<ref_t> &list )
: index(NULL)        // ← size and table skipped
, indexsize(0)
, nextindex(0)
, freeindex(0)
, numitems(0)
{
    setIndex(list);  // → clear() → uses uninitialized size and table
}
```

`clear()` immediately iterates `size` times and dereferences `table[i]` — both are garbage values.

Add `size(0)` and `table(NULL)` to the initializer list in declaration order:

```cpp
: size(0)
, table(NULL)
, index(NULL)
, indexsize(0)
, nextindex(0)
, freeindex(0)
, numitems(0)
```

`LVIndexedRefCache` is used as `_styles` and `_fonts` members of `ldomDocument` (`lvtinydom.h:540-541`), which is the core document model . maybe? This section is quite complicated, so I'm not sure if this code is actually running in practice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/690)
<!-- Reviewable:end -->
