### PR TITLE
fix(hyphman): fix CR-LF check in user dictionary

### DIFF
--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1372,7 +1372,7 @@ lUInt8 UserHyphDict::init(lString32 filename, bool reload)
             printf("CRE WARNING: UserHyphDict dictionary word too long: '%s'\n", word);
 
         for ( i = 0; i<HYPHENATION_LENGTH-1; ++i ) { // -1 because of tailling NULL
-            if ( buf[i] == '\r' &&  i+1<filesize && buf[i+1] == '\n' ) {
+            if ( buf[pos] == '\r' &&  pos+1<filesize && buf[pos+1] == '\n' ) {
                 pos += 2;
                 break;
             }

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1255,6 +1255,8 @@ lUInt8 UserHyphDict::addEntry(const char *word, const char* hyphenation)
 
     // generate mask
     masks[words_in_memory] = (char*) malloc((word_len+1) * sizeof(char)); // +1 for termination
+    if (masks[words_in_memory] == NULL)
+        return USER_HYPH_DICT_MALFORMED;
 
     size_t hyphenation_pos = 1;
     size_t i = hyphenation_pos;
@@ -1316,6 +1318,8 @@ lUInt8 UserHyphDict::init(lString32 filename, bool reload)
 
     // buffer to hold user hyphenation file
     char *buf = (char*) malloc(filesize * sizeof(char));
+    if (buf == NULL)
+        return USER_HYPH_DICT_ERROR_NOT_SORTED;
 
     lvsize_t count = 0;
     instream->Read(buf, filesize, &count);


### PR DESCRIPTION
Change 1: `UserHyphDict::init()` reads a user hyphenation file into `buf[]` and parses entries line by line. The mask-reading loop checks for `\r\n` line endings using `buf[i]` instead of `buf[pos]`, so it always reads from the start of the file rather than the current parse position. This causes the mask to absorb stray `\r`/`\n` bytes, corrupting the dictionary.

`pos` tracks the current read position in `buf[]`. After reading the word (up to `;`), `pos` is past the semicolon. The mask loop then resets `i` to 0 but uses `buf[i]` for the CR-LF check:

```cpp
// pos = 4 after reading "abc;" from "abc;1010\r\ndef;0101\r\n"
for ( i = 0; i<HYPHENATION_LENGTH-1; ++i ) {
    if ( buf[i] == '\r' &&  i+1<filesize && buf[i+1] == '\n' ) {  // ← BUG: always buf[0], buf[1]...
        pos += 2;
        break;
    }
    mask[i] = buf[pos++];  // ← correct: reads from pos
}
```

`buf[0]` = `'a'`, not `'\r'`. The `\r\n` is never detected, so `mask` absorbs both `\r` and `\n` as data. Every subsequent entry shifts by 1-2 bytes, corrupting the entire dictionary.

Changes 2:

The mask buffer allocation has no NULL check. The function returns `lUInt8` but uses a bare `return;` on failure:

```cpp
lUInt8 UserHyphDict::addEntry(const char *word, const char* hyphenation)
{
    // ...
    masks[words_in_memory] = (char*) malloc((word_len+1) * sizeof(char));
    // ← no NULL check: dereferences NULL pointer on OOM
```

Bare `return;` in a non-void function is undefined behavior.

The file read buffer allocation has no NULL check, and `buf` is used immediately after:

```cpp
char *buf = (char*) malloc(filesize * sizeof(char));
// ← no NULL check
lvsize_t count = 0;
instream->Read(buf, filesize, &count);  // dereferences NULL
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/691)
<!-- Reviewable:end -->
