### PR TITLE
fix(lvrend): correct right padding calculation

### DIFF
--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -1328,7 +1328,7 @@ public:
                 table_paddings_width = 0;
                 if ( !border_collapse ) { // padding were not applied when border-collapse
                     table_paddings_width += lengthToPx(elem, table_style->padding[0], table_width);
-                    table_paddings_width += lengthToPx(elem, table_style->padding[0], table_width);
+                    table_paddings_width += lengthToPx(elem, table_style->padding[1], table_width);
                 }
                 assignable_width = table_width - table_outer_borders_width - table_paddings_width - table_borderspacings_width;
                 restw = assignable_width - min_needed_width;


### PR DESCRIPTION
When re-applying minimum width on tables with CSS `min-width`, the table padding width calculation uses `padding[0]` (left padding) on both lines, completely ignoring `padding[1]` (right padding). This causes incorrect `assignable_width` and `restw` values, leading to misaligned table columns.

```cpp
table_paddings_width += lengthToPx(elem, table_style->padding[0], table_width);
table_paddings_width += lengthToPx(elem, table_style->padding[0], table_width);  // ← BUG: padding[0] again
```

The `padding` array order is defined in `lvstyles.h:158`:

```cpp
css_length_t padding[4]; ///< padding-left, -right, -top, -bottom
```

So `padding[0]` = left, `padding[1]` = right. The second line should use `padding[1]`.

`lvrend.cpp` is the core CSS layout engine for KOReader. This bug affects any table with a CSS `min-width` larger than its content width, where left and right padding differ. The result is doubled left padding and zero right padding in the width calculation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/692)
<!-- Reviewable:end -->
