### PR TITLE
fix: correct content property string length

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -1749,12 +1749,12 @@ void update_style_content_property( css_style_rec_t * style, ldomNode * node ) {
     while ( i < parsed_content_len ) {
         lChar32 ctype = parsed_content[i];
         if ( ctype == 's' ) { // literal string: copy as-is
-            lChar32 len = parsed_content[i] - 1; // (remove added +1)
+            lChar32 len = parsed_content[i+1] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }
         else if ( ctype == 'a' ) { // attribute value: copy as-is
-            lChar32 len = parsed_content[i] - 1; // (remove added +1)
+            lChar32 len = parsed_content[i+1] - 1; // (remove added +1)
             res.append(parsed_content, i, len+2);
             i += len+2;
         }


### PR DESCRIPTION
In `update_style_content_property()`, the length field for `'s'` (literal string) and `'a'` (attribute) content types is read from `parsed_content[i]` instead of `parsed_content[i+1]`. This reads the type character itself as the length, causing a massive over-read and corrupted output.

The parsed content format is:

```
$ <type> <len> <data...> <type> <len> <data...> ...
```

- Position `i` holds the type character (`'s'` = 115, `'a'` = 97)
- Position `i+1` holds the actual length byte

In `get_applied_content_property()` (line 1800), the format is parsed correctly using `i++` to advance through type and length separately. But `update_style_content_property()` reads both from `i`:

```cpp
lChar32 ctype = parsed_content[i];     // type: 's' or 'a'
lChar32 len = parsed_content[i] - 1;   // BUG: reads type again, not length
```

The sibling function `get_applied_content_property()` does it correctly:

```cpp
lChar32 ctype = parsed_content[i++];    // type
lChar32 len = parsed_content[i++] - 1;  // length at next position
```

 Impact: 

The bug affects any CSS `content:` value that contains:

1. **Literal strings** — `content: "Chapter "` or `content: "Text"`
2. **Attribute values** — `content: attr(data-title)` or `content: attr(alt)`
3. **Combined** — `content: "[" attr(n) "]"` (string + attribute + string)

When the type character is `'s'` (char code 115), `len` = 114. The function then tries to copy 116 characters from position `i` and advance `i` by 116, far beyond the actual data. This causes:

- **Over-read** past the end of `parsed_content`, reading garbage or out-of-bounds memory
- **Corrupted `res` string** containing unintended characters from adjacent memory
- **Incorrect `i` advancement**, skipping or misinterpreting subsequent content tokens
- **Potential crash** if over-read hits unmapped memory

fix:
```diff
  if ( ctype == 's' ) { // literal string: copy as-is
-     lChar32 len = parsed_content[i] - 1;
+     lChar32 len = parsed_content[i+1] - 1;
      res.append(parsed_content, i, len+2);
      i += len+2;
  }
  else if ( ctype == 'a' ) { // attribute value: copy as-is
-     lChar32 len = parsed_content[i] - 1;
+     lChar32 len = parsed_content[i+1] - 1;
      res.append(parsed_content, i, len+2);
      i += len+2;
  }
```

note: it post-processes `content:` values that contain quotes (`open-quote`, `close-quote`) by replacing them with computed quote characters. Any EPUB with CSS like:

```css
q::before { content: open-quote; }
q::after { content: close-quote; }
```

...will trigger this code path, and the bug affects any `'s'` or `'a'` tokens that appear in the same `content:` declaration alongside quotes

I don't think this has ever happened (although it's true that CSS has this property, I haven't come across any EPUB files that use it), but we should still consider it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/693)
<!-- Reviewable:end -->
