### PR TITLE
fix(lvtextfm): correct memory deallocation

### DIFF
--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -5912,7 +5912,7 @@ static void freeFrmLines( formatted_text_fragment_t * m_pbuffer )
         while ( (pair = it.next()) ) {
             delete pair->value;
         }
-        free( m_pbuffer->inlineboxes_links );
+        delete m_pbuffer->inlineboxes_links;
     }
     m_pbuffer->inlineboxes_links = NULL;
 }


### PR DESCRIPTION
`m_pbuffer->inlineboxes_links` is allocated with `new` (line 2386) but freed with `free()` in `freeFrmLines()` (line 5915). The destructor is never called, leaking internal allocations (buckets, entries)
`free()` only releases the raw memory without calling the destructor, so all internal `LVHashTable` entries and their values are leaked

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/694)
<!-- Reviewable:end -->
