### PR TITLE
chore(lvtinydom) : correct leftSpace calculation for tabs

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -20114,7 +20114,7 @@ lString8 ldomNode::getText8( lChar8 blockDelimiter, int maxSize ) const
                 if (i >= getChildCount() - 1)
                     break;
                 if ( blockDelimiter && child->isElement() ) {
-                    if ( child->getStyle()->display == css_d_block )
+                    if ( !child->getStyle().isNull() && child->getStyle()->display == css_d_block )
                         txt << blockDelimiter;
                 }
             }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -17600,9 +17600,9 @@ void ldomDocumentWriterFilter::OnText( const lChar32 * text, int len, lUInt32 fl
             bool isHr = false;
             if ( autoPara ) {
                 while ( (*text==' ' || *text=='\t' || *text==160) && len > 0 ) {
+                    leftSpace += (*text == '\t') ? 8 : 1;
                     text++;
                     len--;
-                    leftSpace += (*text == '\t') ? 8 : 1;
                 }
                 paraTag = leftSpace > 8 ? U"h2" : U"p";
                 lChar32 ch = 0;


### PR DESCRIPTION
Change  1: In `OnText()` with `TXTFLG_PRE` flag, leading whitespace is counted to decide whether to wrap the line in `<h2>` (leftSpace > 8) or `<p>`. The tab check was placed after `text++`, so it checked the **next** character instead of the **current** one

```cpp
// OLD: advance first, check wrong char
text++;
len--;
leftSpace += (*text == '\t') ? 8 : 1;  // checks next char

// NEW: check current char before advance
leftSpace += (*text == '\t') ? 8 : 1;  // checks current char
text++;
len--;
```

This causes tabs to be counted as 1 instead of 8, leading to wrong `<h2>` vs `<p>` decisions for plain text files with tab indentation.

Change 2: `getText8()` accesses `child->getStyle()->display` without checking if `getStyle()` returns null. Element nodes without a style cause null pointer dereference.

```diff
- if ( child->getStyle()->display == css_d_block )
+ if ( !child->getStyle().isNull() && child->getStyle()->display == css_d_block )
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/695)
<!-- Reviewable:end -->
