### PR TITLE
fix: correct charToHex buffer access

### DIFF
--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -196,8 +196,8 @@ lChar32 LVTextFileBase::ReadRtfChar( int, const lChar32 * conv_table )
     if ( ch=='\\' && ch2!='\'' ) {
     } else if (ch=='\\' ) {
         m_buf_pos++;
-        int digit1 = charToHex( m_buf[0] );
-        int digit2 = charToHex( m_buf[1] );
+        int digit1 = charToHex( m_buf[m_buf_pos] );
+        int digit2 = charToHex( m_buf[m_buf_pos+1] );
         m_buf_pos+=2;
         if ( digit1>=0 && digit2>=0 ) {
             ch = ( (lChar8)((digit1 << 4) | digit2) );


### PR DESCRIPTION

In `ReadRtfChar()`, the RTF hex escape `\'xx` (e.g. `\'e9` for é) reads digits from `m_buf[0]` and `m_buf[1]` — always the start of the buffer — instead of the current read position `m_buf[m_buf_pos]`.

After skipping the `\` in `\'xx`, `m_buf_pos` is advanced once, but the hex digit positions are hardcoded to absolute indices:

```cpp
m_buf_pos++;
int digit1 = charToHex( m_buf[0] );   // BUG: always reads from buffer start
int digit2 = charToHex( m_buf[1] );   // BUG: always reads from buffer start
m_buf_pos+=2;
```

The correct positions are `m_buf_pos` and `m_buf_pos+1` after the increment

All non-ASCII characters encoded with `\'xx` in RTF files are corrupted. This affects accented Latin characters (é, ü, ñ, ö....)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/696)
<!-- Reviewable:end -->
