### PR TITLE
hyphman: avoid using cri18n

### DIFF
--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -41,15 +41,7 @@
 #include "../include/textlang.h"
 
 
-#ifdef ANDROID
-
 #define _32(x) lString32(x)
-
-#else
-
-#include "../include/cri18n.h"
-
-#endif
 
 int HyphMan::_LeftHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;
 int HyphMan::_RightHyphenMin = HYPH_DEFAULT_HYPHEN_MIN;


### PR DESCRIPTION
No point in pulling the whole module (hyphman is the only user) for some minor internal use (not surfaced to the user).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/698)
<!-- Reviewable:end -->
