### PR TITLE
chmlib: fix android compilation warning

### DIFF
--- a/thirdparty/chmlib/src/chm_lib.c
+++ b/thirdparty/chmlib/src/chm_lib.c
@@ -62,9 +62,7 @@
 #include <stdio.h>
 #endif
 
-#if __sun || __sgi
 #include <strings.h>
-#endif
 
 #ifdef WIN32
 #include <windows.h>


### PR DESCRIPTION
```
thirdparty/chmlib/src/chm_lib.c:1538:27: warning: implicit declaration of function 'ffs' is invalid in C99 [-Wimplicit-function-declaration]
        int window_size = ffs(h->window_size) - 1;
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/701)
<!-- Reviewable:end -->
