### PR TITLE
lvarray: fix `LVArray::set`

### DIFF
--- a/crengine/include/lvarray.h
+++ b/crengine/include/lvarray.h
@@ -102,7 +102,7 @@ public:
     /// sets item by index (extends vector if necessary)
     void set( int index, T item )
     {
-        reserve( index );
+        reserve( index + 1 );
         _array[index] = item;
     }
     /// returns size of buffer


### PR DESCRIPTION
To set an item at index n (zero-based), we need to ensure size is at least n+1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/704)
<!-- Reviewable:end -->
