### PR TITLE
lvref: fix `LVRefVec::set`

### DIFF
--- a/crengine/include/lvref.h
+++ b/crengine/include/lvref.h
@@ -572,7 +572,7 @@ public:
     /// sets item by index (extends vector if necessary)
     void set( int index, LVRef<T> item )
     {
-        reserve( index );
+        reserve( index + 1 );
         _array[index] = item;
     }
     /// returns size of buffer


### PR DESCRIPTION
To set an item at index n (zero-based), we need to ensure size is at least n+1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/707)
<!-- Reviewable:end -->
