### PR TITLE
Expose importing a document from a passed LvContainerRef

### DIFF
--- a/crengine/include/epubfmt.h
+++ b/crengine/include/epubfmt.h
@@ -5,7 +5,11 @@
 #include "../include/lvtinydom.h"
 
 bool DetectEpubFormat( LVStreamRef stream );
+bool DetectEpubFormat( LVContainerRef arc );
 bool ImportEpubDocument( LVStreamRef stream, ldomDocument * doc, LVDocViewCallback * progressCallback,
+    CacheLoadingCallback * formatCallback, bool metadataOnly = false,
+    const elem_def_t * node_scheme=NULL, const attr_def_t * attr_scheme=NULL, const ns_def_t * ns_scheme=NULL);
+bool ImportEpubDocument( LVContainerRef arc, ldomDocument * doc, LVDocViewCallback * progressCallback,
     CacheLoadingCallback * formatCallback, bool metadataOnly = false,
     const elem_def_t * node_scheme=NULL, const attr_def_t * attr_scheme=NULL, const ns_def_t * ns_scheme=NULL);
 lString32 EpubGetRootFilePath( LVContainerRef m_arc );

--- a/crengine/include/lvdocview.h
+++ b/crengine/include/lvdocview.h
@@ -955,6 +955,8 @@ public:
     bool LoadDocument( const lChar32 * fname, bool metadataOnly = false );
     /// load document from stream
     bool LoadDocument( LVStreamRef stream, bool metadataOnly = false );
+    /// load EPUB document from container
+    bool LoadEpubDocument( LVContainerRef container, const lChar32 * fname, bool metadataOnly = false );
 
     /// save last file position
     void savePosition();

--- a/crengine/src/epubfmt.cpp
+++ b/crengine/src/epubfmt.cpp
@@ -75,9 +75,8 @@ public:
 //    }
 //}
 
-bool DetectEpubFormat( LVStreamRef stream )
+bool DetectEpubFormat( LVContainerRef m_arc )
 {
-    LVContainerRef m_arc = LVOpenArchieve( stream );
     if ( m_arc.isNull() )
         return false; // not a ZIP archive
 
@@ -106,6 +105,12 @@ bool DetectEpubFormat( LVStreamRef stream )
     if ( mimeType != U"application/epub+zip" )
         return false;
     return true;
+}
+
+bool DetectEpubFormat( LVStreamRef stream )
+{
+    LVContainerRef m_arc = LVOpenArchieve( stream );
+    return DetectEpubFormat( m_arc );
 }
 
 void ReadEpubNcxToc( ldomDocument * doc, ldomNode * mapRoot, LVTocItem * baseToc, ldomDocumentFragmentWriter & appender ) {
@@ -1293,11 +1298,10 @@ public:
     }
 };
 
-bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCallback * progressCallback,
+bool ImportEpubDocument( LVContainerRef arc, ldomDocument * m_doc, LVDocViewCallback * progressCallback,
             CacheLoadingCallback * formatCallback, bool metadataOnly,
             const elem_def_t * node_scheme, const attr_def_t * attr_scheme, const ns_def_t * ns_scheme )
 {
-    LVContainerRef arc = LVOpenArchieve( stream );
     if ( arc.isNull() )
         return false; // not a ZIP archive
 
@@ -2222,4 +2226,13 @@ bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCall
 
     return true;
 
+}
+
+bool ImportEpubDocument( LVStreamRef stream, ldomDocument * m_doc, LVDocViewCallback * progressCallback,
+            CacheLoadingCallback * formatCallback, bool metadataOnly,
+            const elem_def_t * node_scheme, const attr_def_t * attr_scheme, const ns_def_t * ns_scheme )
+{
+    LVContainerRef arc = LVOpenArchieve( stream );
+    return ImportEpubDocument( arc, m_doc, progressCallback, formatCallback, metadataOnly,
+            node_scheme, attr_scheme, ns_scheme );
 }

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -4406,6 +4406,82 @@ void LVDocView::createDefaultDocument(lString32 title, lString32 message) {
     REQUEST_RENDER("resize")
 }
 
+/// load EPUB document from container
+bool LVDocView::LoadEpubDocument(LVContainerRef container, const lChar32 * fname, bool metadataOnly) {
+	if (container.isNull())
+		return false;
+
+	Clear();
+
+	lString32 filename32(fname ? fname : U"");
+	m_filename = filename32;
+	m_doc_props->setString(DOC_PROP_FILE_NAME, filename32);
+
+	m_swapDone = false;
+
+	setRenderProps(0, 0); // to allow apply styles and rend method while loading
+
+	if (m_callback) {
+		m_callback->OnLoadFileStart(filename32);
+	}
+	LVLock lock(getMutex());
+
+	clearImageCache();
+	lvsize_t containerSize = 0;
+	if (container->GetSize(&containerSize) == LVERR_OK) {
+		m_filesize = containerSize;
+		m_doc_props->setString(DOC_PROP_FILE_SIZE, lString32::itoa((int)containerSize));
+	}
+	m_stream.Clear();
+
+#if (USE_ZLIB==1)
+	if ( DetectEpubFormat( container ) ) {
+		CRLog::info("EPUB format detected");
+		createEmptyDocument();
+		m_doc->setProps( m_doc_props );
+		setRenderProps( 0, 0 ); // to allow apply styles and rend method while loading
+		setDocFormat( doc_format_epub );
+		if ( m_callback )
+			m_callback->OnLoadFileFormatDetected(doc_format_epub);
+		updateDocStyleSheet();
+		// See epubfmt.cpp's ExtractCoverFilenameFromCoverPageFragment()
+		// for why we need to pass fb2_elem_table and such.
+		bool res = ImportEpubDocument( container, m_doc, m_callback, this, metadataOnly, fb2_elem_table, fb2_attr_table, fb2_ns_table );
+		if ( !res ) {
+			setDocFormat( doc_format_none );
+			createDefaultDocument( cs32("ERROR: Error reading EPUB format"), cs32("Cannot open document") );
+			if ( m_callback ) {
+				m_callback->OnLoadFileError( cs32("Error reading EPUB document") );
+			}
+			return false;
+		} else {
+			m_container = m_doc->getContainer();
+			m_doc_props = m_doc->getProps();
+			setRenderProps( 0, 0 );
+			REQUEST_RENDER("loadDocument")
+			if ( m_callback ) {
+				m_callback->OnLoadFileEnd( );
+				//m_doc->compact();
+				m_doc->dumpStatistics();
+			}
+			m_arc = m_doc->getContainer();
+
+#ifdef SAVE_COPY_OF_LOADED_DOCUMENT //def _DEBUG
+			LVStreamRef ostream = LVOpenFileStream( "test_save_source.xml", LVOM_WRITE );
+			m_doc->saveToStream( ostream, "utf-16" );
+#endif
+
+			return true;
+		}
+	}
+#endif
+
+	if ( m_callback ) {
+		m_callback->OnLoadFileError( cs32("Error reading EPUB document") );
+	}
+	return false;
+}
+
 /// load document from stream
 bool LVDocView::LoadDocument(LVStreamRef stream, bool metadataOnly) {
 


### PR DESCRIPTION
Add api for importing epub document directly from an LVContainer. 
Related to https://github.com/koreader/koreader/issues/15649

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/708)
<!-- Reviewable:end -->
