### PR TITLE
CSS: fix attribute matching with id/name/href, add more length units, fix "rem", add "urem" and "urlh"

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -249,11 +249,18 @@ enum css_value_type_t {
     css_val_em,   // relative to font size of the current element
     css_val_ex,   // 1ex =~ 0.5em in many fonts (https://developer.mozilla.org/en-US/docs/Web/CSS/length)
     css_val_ch,   // 1ch assumed to be 0.5em for widths when impractical to determine (same url)
-    css_val_rem,  // 'root em', relative to font-size of the root element (typically <html>)
+    css_val_rem,  // 'root em', relative to font-size of the document root element (typically <html>)
+    css_val_urem, // relative to the engine/user root font size (document default font)
     css_val_vw,   // 1 percent of the screen width
     css_val_vh,   // 1 percent of the screen height
     css_val_vmin, // maximum of 1 percent of the screen height or width
     css_val_vmax, // minimum of 1 percent of the screen height or width
+    css_val_q,    // quarter-millimeter, 40q = 1cm
+    css_val_rex,  // root ex, approximated like ex from the document root element font size
+    css_val_rch,  // root ch, approximated like ch from the document root element font size
+    css_val_lh,   // relative to the computed line-height of the current element
+    css_val_rlh,  // relative to the computed line-height of the root element
+    css_val_urlh, // relative to the engine/user root line-height (document default font + interline)
     css_val_percent,
     css_val_screen_px, // screen px, for already scaled values
     css_val_color

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2578,6 +2578,72 @@ lUInt32 styleToTextFmtFlags( bool is_block, const css_style_ref_t & style, lUInt
     return flg;
 }
 
+// Returns the used line-height in screen px for a node style.
+// All related values (%, em, ex, unitless) apply their factor to font->getSize().
+// Only "normal" uses font->getHeight(). Absolute units and rem-like units are
+// handled by lengthToPx().
+static int getLineHeightPx(ldomNode * node, css_style_rec_t * style, LVFontRef font)
+{
+    ldomDocument * doc = node->getDocument();
+    if ( style->line_height.type == css_val_screen_px ) {
+        // (If in screen_px, interline_scale_factor has already been
+        // applied in  setNodeStyle() when inherited.)
+        return style->line_height.value;
+    }
+    int line_h;
+    if ( style->line_height.type == css_val_unspecified && style->line_height.value == css_generic_normal ) {
+        line_h = font->getHeight();
+    }
+    else if ( style->line_height.type == css_val_lh || style->line_height.type == css_val_rlh
+            || style->line_height.type == css_val_urlh ) {
+        // setNodeStyle() resolves line-height: lh/rlh to screen_px, so seeing them
+        // here mostly means we are being asked too early: fall back to the font height.
+        line_h = font->getHeight();
+    }
+    else {
+        // In all other cases (%, em, unitless/unspecified), we can just
+        // scale 'em', and use the computed value for absolute sized
+        // values and 'rem' (related to root element font size).
+        int em = font->getSize();
+        line_h = lengthToPx(node, style->line_height, em, em, true);
+        if ( line_h < 0 )
+            line_h = font->getHeight();
+    }
+    // Scale line_h according to document's _interlineScaleFactor
+    int interline_scale_factor = doc->getInterlineScaleFactor();
+    if ( interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE )
+        line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+    return line_h;
+}
+
+static int getUserRootLineHeightPx(ldomDocument * doc)
+{
+    // Our private u* root units stay anchored to the document default font,
+    // ie. the user/UI root baseline rather than the publisher's <html> style.
+    int line_h = doc->getDefaultFont()->getHeight();
+    int interline_scale_factor = doc->getInterlineScaleFactor();
+    if ( interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE )
+        line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
+    return line_h;
+}
+
+static ldomNode * getRootUnitNode(ldomNode * node)
+{
+    // The CSS root can be the real <html>/<FictionBook>, or a DocFragment in
+    // EPUB/CHM where <html> has been rewritten to that fragment wrapper. Walk up
+    // from the current node so rem/rlh stay local to the current fragment.
+    for ( ldomNode * n = node; n; n = n->getParentNode() ) {
+        lUInt16 node_id = n->getNodeId();
+        if ( node_id == el_DocFragment || node_id == el_html || node_id == el_FictionBook )
+            return n;
+    }
+    ldomDocument * doc = node->getDocument();
+    ldomNode * root = doc->getRootNode();
+    if ( root && root->getChildCount() > 0 )
+        root = root->getChildNode(0);
+    return root;
+}
+
 // Convert CSS value (type + number value) to screen px
 int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, bool unspecified_as_em )
 {
@@ -2633,8 +2699,45 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
         break;
     }
 
-    case css_val_rem: // value = rem*256 (font size of the root element)
+    case css_val_urem: // value = urem*256 (engine/user root font size)
         px = (node->getDocument()->getDefaultFont()->getSize() * val.value) >> 8;
+        break;
+    case css_val_rem: // value = rem*256 (font size of the document root element)
+        {
+            ldomNode * root = getRootUnitNode(node);
+            // When the actual root element font is not available yet (typically
+            // while we are computing it), rem falls back to the initial document default.
+            int root_font_size = root && !root->getFont().isNull()
+                    ? root->getFont()->getSize()
+                    : node->getDocument()->getDefaultFont()->getSize();
+            px = (root_font_size * val.value) >> 8;
+        }
+        break;
+    case css_val_rex:
+    case css_val_rch: // Same approximation as ex/ch, but from the document root element font size.
+        {
+            ldomNode * root = getRootUnitNode(node);
+            int root_font_size = root && !root->getFont().isNull()
+                    ? root->getFont()->getSize()
+                    : node->getDocument()->getDefaultFont()->getSize();
+            px = (root_font_size * val.value) >> 9;
+        }
+        break;
+
+    case css_val_urlh: // engine/user root line height
+        px = (getUserRootLineHeightPx(node->getDocument()) * val.value) >> 8;
+        break;
+    case css_val_lh:
+        px = (getLineHeightPx(node, node->getStyle().get(), node->getFont()) * val.value) >> 8;
+        break;
+    case css_val_rlh:
+        {
+            ldomNode * root = getRootUnitNode(node);
+            int root_line_h = root && !root->getStyle().isNull() && !root->getFont().isNull()
+                    ? getLineHeightPx(root, root->getStyle().get(), root->getFont())
+                    : getUserRootLineHeightPx(node->getDocument());
+            px = (root_line_h * val.value) >> 8;
+        }
         break;
 
     /* absolute value, less often used - value = unit*256 */
@@ -2658,6 +2761,10 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
     case css_val_pc: // 12 pt     6pc = 96px
         if (gRenderDPI)
             px = 96 * value / 6 >> 8;
+        break;
+    case css_val_q: // 40q = 1cm = 96/2.54px
+        if (gRenderDPI)
+            px = (int)(96 * value / 101.6) >> 8;
         break;
     case css_val_vw: {
         int page_width = node->getDocument()->getPageWidth();
@@ -2696,7 +2803,10 @@ int lengthToPx( ldomNode * node, css_length_t val, int base_px, int base_em, boo
 bool is_length_relative_unit(css_length_t val)
 {
     return (val.type == css_val_percent || val.type == css_val_em ||
-            val.type == css_val_ex || val.type == css_val_ch || val.type == css_val_rem ||
+            val.type == css_val_ex || val.type == css_val_ch ||
+            val.type == css_val_rem || val.type == css_val_urem ||
+            val.type == css_val_rex || val.type == css_val_rch ||
+            val.type == css_val_lh || val.type == css_val_rlh || val.type == css_val_urlh ||
             val.type == css_val_vw || val.type == css_val_vh ||
             val.type == css_val_vmin || val.type == css_val_vmax);
 }
@@ -3155,17 +3265,7 @@ lString32 renderListItemMarker( ldomNode * enode, int & marker_width, int * fina
         // kind of background, if inside it has already been drawn)
         lUInt32 bgcl = LTEXT_COLOR_TRANSPARENT;
         if (line_h < 0) { // -1, not specified by caller: find it out from the node
-            if ( style->line_height.type == css_val_unspecified &&
-                        style->line_height.value == css_generic_normal ) {
-                line_h = font->getHeight(); // line-height: normal
-            }
-            else {
-                int em = font->getSize();
-                line_h = lengthToPx(enode, style->line_height, em, em, true);
-            }
-            // Scale line_h according to document's _interlineScaleFactor
-            if (style->line_height.type != css_val_screen_px && doc->getInterlineScaleFactor() != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                line_h = (line_h * doc->getInterlineScaleFactor()) >> INTERLINE_SCALE_FACTOR_SHIFT;
+            line_h = getLineHeightPx(enode, style.get(), font);
             if ( STYLE_HAS_CR_HINT(style, STRUT_CONFINED) )
                 flags |= LTEXT_STRUT_CONFINED;
             if ( final_line_h ) {
@@ -7642,24 +7742,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         if ( is_empty_line_elem && style_height.type == css_val_unspecified ) {
             // No height specified: default to line-height, just like
             // if it were rendered final.
-            int line_h;
-            if ( style->line_height.type == css_val_unspecified &&
-                        style->line_height.value == css_generic_normal ) {
-                line_h = enode->getFont()->getHeight(); // line-height: normal
-            }
-            else {
-                // In all other cases (%, em, unitless/unspecified), we can just
-                // scale 'em', and use the computed value for absolute sized
-                // values and 'rem' (related to root element font size).
-                line_h = lengthToPx(enode, style->line_height, em, em, true);
-            }
-            // Scale line_h according to document's _interlineScaleFactor, but
-            // not if it was already in screen_px, which means it has already
-            // been scaled (in setNodeStyle() when inherited).
-            int interline_scale_factor = enode->getDocument()->getInterlineScaleFactor();
-            if (style->line_height.type != css_val_screen_px && interline_scale_factor != INTERLINE_SCALE_FACTOR_NO_SCALE)
-                line_h = (line_h * interline_scale_factor) >> INTERLINE_SCALE_FACTOR_SHIFT;
-            style_height.value = line_h;
+            style_height.value = getLineHeightPx(enode, style.get(), enode->getFont());
             style_height.type = css_val_screen_px;
         }
         // We don't have a container height to apply heights in %, so ignore them
@@ -11443,7 +11526,31 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
         pstyle->font_size.type = parent_style->font_size.type;
         pstyle->font_size.value = parent_style->font_size.value * pstyle->font_size.value / 100 / 256;
         break;
+    case css_val_lh:
+        // In font-size, lh resolves against the parent's computed line-height.
+        pstyle->font_size.value = getLineHeightPx(enode, parent_style.get(), parent_font) * pstyle->font_size.value / 256;
+        pstyle->font_size.type = css_val_screen_px;
+        break;
+    case css_val_rlh:
+        {
+            // Publisher-facing root line-height, from the actual document root element.
+            ldomNode * root = getRootUnitNode(enode);
+            int root_line_h = root && !root->getStyle().isNull() && !root->getFont().isNull()
+                    ? getLineHeightPx(root, root->getStyle().get(), root->getFont())
+                    : getUserRootLineHeightPx(doc);
+            pstyle->font_size.value = root_line_h * pstyle->font_size.value / 256;
+            pstyle->font_size.type = css_val_screen_px;
+        }
+        break;
+    case css_val_urlh:
+        // Private engine/user root line-height, from the document default font.
+        pstyle->font_size.value = getUserRootLineHeightPx(doc) * pstyle->font_size.value / 256;
+        pstyle->font_size.type = css_val_screen_px;
+        break;
     case css_val_rem:
+    case css_val_urem:
+    case css_val_rex:
+    case css_val_rch:
     case css_val_vw:
     case css_val_vh:
     case css_val_vmin:
@@ -11455,6 +11562,7 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     case css_val_mm:
     case css_val_pt:
     case css_val_pc:
+    case css_val_q:
         // absolute size, nothing to do
         break;
     case css_val_unspecified:
@@ -11502,6 +11610,25 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
                 pstyle->line_height = parent_style->line_height; // inherit as-is
                 break;
         }
+    }
+    else if (pstyle->line_height.type == css_val_lh) {
+        // In line-height, lh resolves against the parent's computed line-height.
+        pstyle->line_height.value = getLineHeightPx(enode, parent_style.get(), parent_font) * pstyle->line_height.value / 256;
+        pstyle->line_height.type = css_val_screen_px;
+    }
+    else if (pstyle->line_height.type == css_val_rlh) {
+        ldomNode * root = getRootUnitNode(enode);
+        int root_line_h = root && !root->getStyle().isNull() && !root->getFont().isNull()
+                ? getLineHeightPx(root, root->getStyle().get(), root->getFont())
+                : getUserRootLineHeightPx(doc);
+        // Publisher-facing root line-height, from the actual document root element.
+        pstyle->line_height.value = root_line_h * pstyle->line_height.value / 256;
+        pstyle->line_height.type = css_val_screen_px;
+    }
+    else if (pstyle->line_height.type == css_val_urlh) {
+        // Private engine/user root line-height, from the document default font.
+        pstyle->line_height.value = getUserRootLineHeightPx(doc) * pstyle->line_height.value / 256;
+        pstyle->line_height.type = css_val_screen_px;
     }
 
     // vertical_align: computed value: "for percentage and length values, the absolute length, otherwise the keyword as specified"

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -782,6 +782,8 @@ bool parse_number_value( const char * & str, css_length_t & value,
         value.type = css_val_ch;
     else if ( substr_icompare( "rem", str ) )
         value.type = css_val_rem;
+    else if ( substr_icompare( "urem", str ) )
+        value.type = css_val_urem;
     else if ( substr_icompare( "px", str ) )
         value.type = css_val_px;
     else if ( substr_icompare( "in", str ) )
@@ -808,6 +810,18 @@ bool parse_number_value( const char * & str, css_length_t & value,
         value.type = css_val_vmin;
     else if ( substr_icompare( "vmax", str ) )
         value.type = css_val_vmax;
+    else if ( substr_icompare( "q", str ) )
+        value.type = css_val_q;
+    else if ( substr_icompare( "rex", str ) )
+        value.type = css_val_rex;
+    else if ( substr_icompare( "rch", str ) )
+        value.type = css_val_rch;
+    else if ( substr_icompare( "lh", str ) )
+        value.type = css_val_lh;
+    else if ( substr_icompare( "rlh", str ) )
+        value.type = css_val_rlh;
+    else if ( substr_icompare( "urlh", str ) )
+        value.type = css_val_urlh;
     else if ( css_is_alpha(*str) ) { // some other unit we don't support
         str = orig_pos; // revert our possible str++
         return false;

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5966,6 +5966,56 @@ bool LVCssSelectorRule::quickClassCheck(const lUInt32 *classHashes, size_t size)
     return false;
 }
 
+static bool getOriginalFragmentAttributeValue(const ldomNode *node, lUInt16 attrid, lString32 &original_value) {
+    // EPUB/CHM documents are merged into a single DOM, and ldomDocumentFragmentWriter
+    // rewrites some attributes with a "_doc_fragment_N_ " prefix so they stay unique.
+    // CSS selectors should still be able to target the original source value, so we
+    // recover it here when the stored DOM value clearly comes from that rewrite.
+    if (attrid == attr_id || attrid == attr_name) {
+        lString32 value = node->getAttributeValue(attrid);
+        if (!value.startsWith(U"_doc_fragment_"))
+            return false;
+        int sep = value.pos(lString32(" "));
+        if (sep <= 0 || sep + 1 >= value.length())
+            return false;
+        if (value[sep - 1] != U'_')
+            return false;
+        original_value = value.substr(sep + 1, value.length() - sep - 1);
+        return true;
+    }
+    if (attrid == attr_href || attrid == attr_src || attrid == attr_data) {
+        lString32 value = node->getAttributeValue(attrid);
+        if (!value.startsWith(U"#_doc_fragment_"))
+            return false;
+        int sep = value.pos(lString32(" "));
+        if (sep <= 1 || sep + 1 > value.length())
+            return false;
+        if (value[sep - 1] != U'_')
+            return false;
+        lString32 doc_fragment_id;
+        const ldomNode *parent = node;
+        while (parent) {
+            if (parent->getNodeId() == el_DocFragment) {
+                doc_fragment_id = parent->getAttributeValue(attr_id);
+                break;
+            }
+            parent = parent->getParentNode();
+        }
+        if (doc_fragment_id.empty())
+            return false;
+        // Cross-fragment links lose their original path when imported into the
+        // single DOM, so only recover the original "#id" for same-fragment refs.
+        lString32 same_fragment_prefix = lString32(U"#") + doc_fragment_id + U"_ ";
+        if (!value.startsWith(same_fragment_prefix))
+            return false;
+        original_value = lString32(U"#");
+        if (sep + 1 < value.length())
+            original_value << value.substr(sep + 1, value.length() - sep - 1);
+        return true;
+    }
+    return false;
+}
+
 bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
 {
     if (!node || node->isNull() || node->isRoot())
@@ -6098,7 +6148,16 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             lString32 val = node->getAttributeValue(_attrid);
             if (_type == cssrt_attreq_i)
                 val.lowercase();
-            return val == _value;
+            if (val == _value)
+                return true;
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
+                return false;
+            if (_type == cssrt_attreq_i)
+                original_val.lowercase();
+            return original_val == _value;
         }
         break;
     case cssrt_attrhas:       // E[foo~="value"]
@@ -6118,6 +6177,20 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             int pos;
             while ((pos = val.pos(_value, start)) >= 0) {
                 if ((pos == 0 || val[pos - 1] == ' ') && (pos + value_len == val_len || val[pos + value_len] == ' '))
+                    return true;
+                start = pos + 1;
+            }
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
+                return false;
+            if (_type == cssrt_attrhas_i)
+                original_val.lowercase();
+            val_len = original_val.length();
+            start = 0;
+            while ((pos = original_val.pos(_value, start)) >= 0) {
+                if ((pos == 0 || original_val[pos - 1] == ' ') && (pos + value_len == val_len || original_val[pos + value_len] == ' '))
                     return true;
                 start = pos + 1;
             }
@@ -6141,12 +6214,27 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             if (_type == cssrt_attrstarts_i)
                 val.lowercase();
             if (value_len == val_len) {
-                return val == _value;
+                if (val == _value)
+                    return true;
             }
-            if (val[value_len] != '-')
+            else if (val[value_len] == '-' && val.substr(0, value_len) == _value) {
+                return true;
+            }
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
                 return false;
-            val = val.substr(0, value_len);
-            return val == _value;
+            val_len = original_val.length();
+            if (value_len > val_len)
+                return false;
+            if (_type == cssrt_attrstarts_i)
+                original_val.lowercase();
+            if (value_len == val_len)
+                return original_val == _value;
+            if (original_val[value_len] != '-')
+                return false;
+            return original_val.substr(0, value_len) == _value;
         }
         break;
     case cssrt_attrstarts:    // E[foo^="value"]
@@ -6164,7 +6252,20 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             val = val.substr(0, value_len);
             if (_type == cssrt_attrstarts_i)
                 val.lowercase();
-            return val == _value;
+            if (val == _value)
+                return true;
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
+                return false;
+            val_len = original_val.length();
+            if (value_len > val_len)
+                return false;
+            original_val = original_val.substr(0, value_len);
+            if (_type == cssrt_attrstarts_i)
+                original_val.lowercase();
+            return original_val == _value;
         }
         break;
     case cssrt_attrends:    // E[foo$="value"]
@@ -6182,7 +6283,20 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             val = val.substr(val_len-value_len, value_len);
             if (_type == cssrt_attrends_i)
                 val.lowercase();
-            return val == _value;
+            if (val == _value)
+                return true;
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
+                return false;
+            val_len = original_val.length();
+            if (value_len > val_len)
+                return false;
+            original_val = original_val.substr(val_len-value_len, value_len);
+            if (_type == cssrt_attrends_i)
+                original_val.lowercase();
+            return original_val == _value;
         }
         break;
     case cssrt_attrcontains:    // E[foo*="value"]
@@ -6197,7 +6311,18 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
                 return false;
             if (_type == cssrt_attrcontains_i)
                 val.lowercase();
-            return val.pos(_value, 0) >= 0;
+            if (val.pos(_value, 0) >= 0)
+                return true;
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed it with "_doc_fragment_N_ " to keep merged-DOM attributes unique.
+            lString32 original_val;
+            if ( !getOriginalFragmentAttributeValue(node, _attrid, original_val) )
+                return false;
+            if (_value.length()>original_val.length())
+                return false;
+            if (_type == cssrt_attrcontains_i)
+                original_val.lowercase();
+            return original_val.pos(_value, 0) >= 0;
         }
         break;
     case cssrt_id:            // E#id
@@ -6205,23 +6330,12 @@ bool LVCssSelectorRule::check( const ldomNode * & node, bool allow_cache ) const
             const lString32 &val = node->getAttributeValue(attr_id);
             if ( val.empty() )
                 return false;
-            // With EPUBs and CHMs, using ldomDocumentFragmentWriter,
-            // we get the codeBasePrefix (+ a space) prepended to the
-            // original id, ie: id="_doc_fragment_7_ origId"
-            if ( !val.endsWith(_value) )
-                return false;
-            int prefix_len = val.length() - _value.length();
-            if ( prefix_len == 0 )
-                return true; // exact match (non EPUB/CHM)
-            if ( val[prefix_len - 1] != U' ' )
-                return false; // not a space, can't be a match
-            // Ensure this prefix looks enough like a codeBasePrefix so
-            // that we can consider it a match
-            if ( prefix_len >= 2 && val[prefix_len - 2] != U'_' )
-                return false; // not the trailing '_' of a "_doc_fragment_7_"
-            if ( val.startsWith(U"_doc_fragment_") )
+            if ( val == _value )
                 return true;
-            return false;
+            // Retry with the pre-rewrite source value, as DocFragment import may have
+            // prefixed id= with "_doc_fragment_N_ " to keep merged-DOM ids unique.
+            lString32 original_val;
+            return getOriginalFragmentAttributeValue(node, attr_id, original_val) && original_val == _value;
         }
         break;
     case cssrt_class:         // E.class

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -95,7 +95,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.80k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0034
+#define FORMATTING_VERSION_ID 0x0035
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)


### PR DESCRIPTION
#### CSS: fix attribute matching with id/name/href

We prepend these with `_doc_fragment_N_`, so also check the attribute value with that prefix removed.
Should allow closing https://github.com/koreader/koreader/issues/15481.

#### CSS: add more length units, fix "rem", add "urem" and "urlh"

- Add `q/rex/rch/lh/rlh`
  Closes https://github.com/koreader/crengine/issues/670.
- Fix `rem` to use the font-size set on `<html>`, and not the user-set font size
- Add unofficial `urem` to get back that behaviour (useful for style tweaks), and `urlh` for the user set line-height.
See   See https://github.com/koreader/koreader/issues/7515#issuecomment-4643644992.
Should allow closing https://github.com/koreader/koreader/issues/15339

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/710)
<!-- Reviewable:end -->
