### PR TITLE
lvdocview: fix source page numbers with a page-list not in reading order

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -2510,6 +2510,7 @@ public:
 class LVPageMap
 {
     friend class ldomDocument;
+    friend class LVDocView;
 private:
     ldomDocument *  _doc;
     int             _valid_for_visible_page_numbers;
@@ -2523,6 +2524,9 @@ private:
         item->_index = _children.length();
         _children.add(item);
     }
+    /// order items by their resolved document Y position (see lvtinydom.cpp).
+    /// Only for LVDocView::updatePageMapInfo(), which has resolved _doc_y beforehand.
+    void sortByDocY();
 public:
     /// serialize to byte array (pointer will be incremented by number of bytes written)
     bool serialize( SerialBuf & buf );

--- a/crengine/src/lvdocview.cpp
+++ b/crengine/src/lvdocview.cpp
@@ -958,35 +958,54 @@ LVPageMap * LVDocView::getPageMap() {
 
 /// update page info for LVPageMapItems
 void LVDocView::updatePageMapInfo(LVPageMap * pagemap) {
-    // Ensure page and doc_y never go backward
-    int prev_page = 0;
+    // A page list is not required to be in reading order: a conversion may move
+    // front matter to the end of the spine while the page list keeps referencing
+    // it at its original place. So, don't assume list order is reading order:
+    // resolve each item's true position, and only then order and normalize.
+    int nb = pagemap->getChildCount();
+    // 1) Resolve each item's document Y and page from its XPointer, with no clamping.
+    //    Note whether these positions happen to be in ascending order, so we can
+    //    skip the sorting below in the usual case of a page list in reading order.
+    bool needs_sort = false;
     int prev_doc_y = 0;
-    for (int i = 0; i < pagemap->getChildCount(); i++) {
+    for (int i = 0; i < nb; i++) {
         LVPageMapItem * item = pagemap->getChild(i);
-        if (!item->getXPointer().isNull()) {
-            int doc_y = item->getDocY(true); // refresh
-            int page = -1;
-            if (doc_y >= 0) {
-                page = m_pages.FindNearestPage(doc_y, 0);
-                if (page < 0 || page >= getPageCount(true))
-                    page = -1;
-                else
-                    page = getExternalPageNumber(page);
-            }
-            item->_page = page;
-            if ( item->_page < prev_page )
-                item->_page = prev_page;
-            else
-                prev_page = item->_page;
-            if ( item->_doc_y < prev_doc_y )
-                item->_doc_y = prev_doc_y;
-            else
-                prev_doc_y = item->_doc_y;
-        }
-        else {
-            item->_page = prev_page;
+        int doc_y = -1;
+        if (!item->getXPointer().isNull())
+            doc_y = item->getDocY(true); // refresh
+        if (doc_y < 0) {
+            // Position not resolvable (ie. XPointer to a node not found): keep this
+            // item next to its predecessor in the list, and have it get its page
+            // number in 3) below.
             item->_doc_y = prev_doc_y;
+            item->_page = -1;
+            continue;
         }
+        int page = m_pages.FindNearestPage(doc_y, 0);
+        if (page < 0 || page >= getPageCount(true))
+            page = -1;
+        else
+            page = getExternalPageNumber(page);
+        item->_doc_y = doc_y;
+        item->_page = page;
+        if (doc_y < prev_doc_y)
+            needs_sort = true;
+        prev_doc_y = doc_y;
+    }
+    // 2) Order items by their resolved position, so consumers can expect the page
+    //    map to be in reading order (and can binary search it by position).
+    if (needs_sort)
+        pagemap->sortByDocY();
+    // 3) Ensure page numbers never go backward: items with no page number get the one
+    //    of their (now, in reading order) predecessor. Positions being ordered, the
+    //    page numbers computed above can't go backward otherwise.
+    int prev_page = 0;
+    for (int i = 0; i < nb; i++) {
+        LVPageMapItem * item = pagemap->getChild(i);
+        if (item->_page < 0)
+            item->_page = prev_page;
+        else
+            prev_page = item->_page;
     }
     pagemap->setPageValidForVisiblePageNumbers( getVisiblePageNumberCount() );
 }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -22705,6 +22705,11 @@ void LVPageMap::sortByDocY()
         }
         _children[j+1] = item;
     }
+    // Keep _index in sync with the new order, so it still is the index of the item
+    // in this page map (as set by addPage()), and still a valid tie-break above if
+    // we are called again.
+    for ( int i=0; i<nb; i++ )
+        _children[i]->_index = i;
 }
 
 /// serialize to byte array (pointer will be incremented by number of bytes written)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -22677,6 +22677,36 @@ bool LVPageMapItem::deserialize( ldomDocument * doc, SerialBuf & buf )
     return !buf.error();
 
 }
+
+/// order items by their resolved document Y position
+void LVPageMap::sortByDocY()
+{
+    // _doc_y must have been resolved by LVDocView::updatePageMapInfo() before we're called.
+    // Items sharing the same position are tie-broken on their _index, so they keep their
+    // relative order (a page list may reference the same location twice, and unresolved
+    // items are given the position of their predecessor).
+    // We use an insertion sort: page lists are small (a few hundred items at most), and
+    // they are usually already ordered or nearly so - which this handles in O(n) passes,
+    // while needing no additional dependency (LVPtrVector::sort() uses qsort(), which
+    // is not stable, and we don't want to pull in <algorithm> for std::stable_sort()).
+    int nb = _children.length();
+    for ( int i=1; i<nb; i++ ) {
+        LVPageMapItem * item = _children[i];
+        int j = i - 1;
+        while ( j >= 0 ) {
+            LVPageMapItem * prev = _children[j];
+            bool prev_is_after = prev->_doc_y != item->_doc_y ? prev->_doc_y > item->_doc_y
+                                                              : prev->_index > item->_index;
+            if ( !prev_is_after )
+                break;
+            _children[j+1] = prev; // shift it right (don't use LVPtrVector::set(),
+                                   // which would delete the item it overwrites)
+            j--;
+        }
+        _children[j+1] = item;
+    }
+}
+
 /// serialize to byte array (pointer will be incremented by number of bytes written)
 bool LVPageMap::serialize( SerialBuf & buf )
 {


### PR DESCRIPTION
Fixes #688.

### Problem

The page map is built in page list order, and `LVDocView::updatePageMapInfo()` made `_page`/`_doc_y` non-decreasing *in that list order*. But a page list is not required to be in reading order: conversions commonly move front matter (a copyright page) to the end of the spine while the page list keeps referencing it among the front matter, which is what the [DAISY page-list guidance](https://kb.daisy.org/publishing/docs/navigation/pagelist.html) asks for, and epubcheck dropped its reading order requirement in w3c/epubcheck@d0f12a9.

With such a page list, one out-of-order entry raises the clamping values to a near-the-end position, and every entry after it is clamped up to that. With the two sample EPUBs from #688 (identical spine `title(i) ch1(1) ch2(2) ch3(3) copyright(ii)`, one with the page list in print order `i, ii, 1, 2, 3`):

| rendered page | 0 | 1 | 2 | 3 | 4 |
| --- | --- | --- | --- | --- | --- |
| before | i | i | i | i | ii |
| after | i | 1 | 2 | 3 | ii |

So the source page number freezes on the last label before the out-of-order entry, and the page numbers in the margin all pile up at that one position.

### Fix

`updatePageMapInfo()` now resolves each item's position with no clamping, orders the items by that resolved position, and only then ensures page numbers don't go backward. Three commits:

1. `lvtinydom: add LVPageMap::sortByDocY()` — private helper (`LVDocView` made a friend, as it already is of `LVPageMapItem`): insertion sort on `_doc_y`, tie-broken on `_index`.
2. `lvdocview: updatePageMapInfo(): order page map by resolved position` — the fix itself.
3. `lvtinydom: LVPageMap::sortByDocY(): keep _index in sync` — the extra pass you asked for, kept separate so it is easy to review or drop.

### Notes for review

- The implementation is @tachibana-shin's, from [crenginex@5dd88b3](https://github.com/tachibana-shin/crenginex/commit/5dd88b3463df99a3832d62dfc84bda3b8886f03c) + its `std::sort` → insertion sort follow-up, used with their permission and credited via `Co-authored-by:`. Two changes to it: the `_index` pass above, and the handling of unresolvable entries below.
- Sorting is skipped when the resolved positions are already ascending, so nothing changes for a page list in reading order, nor for synthetic page maps (`buildSyntheticPageMap()` walks the document in order).
- Items whose XPointer doesn't resolve are given their list predecessor's position in pass 1, so they stay next to it and inherit its page number, as before. (Leaving them at `_doc_y = -1` and filling them in after the sort would instead move them all to the start of the page map.)
- The page map ends up in reading order, which is what consumers already expect: `cre.cpp` binary searches it by `doc_y` to find the current or a visible page label ("We expect items to be ordered by doc_y"), and reads the first and last items as the first and last page labels. The "go to page" list follows reading order too, so jumping to a page lands where the label is.
- The page map is serialized in `_children` order, so a book already in cache keeps its old page map until its next re-render (any setting change triggering one, since `render()` calls `invalidatePageInfo()`). I did not bump `CACHE_FILE_FORMAT_VERSION` for this — your call if you'd rather have it fixed on first reopen.

### Testing

- Both translation units compile with no new diagnostics.
- The two functions were also copied verbatim into a standalone harness with stubs, checking: the sample EPUB above (labels advance `i 1 2 3 ii`), a reading-order page list left untouched with no sort, stability and `_index` renumbering on entries sharing a position, unresolvable entries, an entry past the last rendered page, empty/single-item page maps, idempotency on a second run, and 2000 randomized page maps (ordered, stable, `_index` = 0..n-1, positions preserved).
- Not yet exercised in KOReader itself — I'd need to build koreader-base against this branch; happy to do that if you want it before merging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/711)
<!-- Reviewable:end -->
