### PR TITLE
cmake: add setting for custom memory manager use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ endfunction()
 # Boolean options.
 option(DISABLE_CLOEXEC "force disable closexec support" OFF)
 option(DISABLE_LFS     "force disable LFS support"      OFF)
+option(OWN_MEM_MAN     "use custom memory manager"      ON)
 
 # Feature options.
 set(AUTO AUTO CACHE STRING "override value of all 'auto' features")
@@ -236,6 +237,12 @@ if(NOT DISABLE_LFS)
     set(CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1)
     check_type_size(off64_t OFF64_T)
     set(CMAKE_REQUIRED_DEFINITIONS)
+endif()
+
+if(OWN_MEM_MAN)
+    set(USE_OWN_MEM_MAN 1)
+else()
+    set(USE_OWN_MEM_MAN 0)
 endif()
 
 configure_file(crengine/include/crsetup.h.cmake crsetup.h @ONLY)

--- a/crengine/include/crsetup.h.cmake
+++ b/crengine/include/crsetup.h.cmake
@@ -53,7 +53,7 @@
 
 /// System.
 #define CR_USE_THREADS                       0
-#define LDOM_USE_OWN_MEM_MAN                 1
+#define LDOM_USE_OWN_MEM_MAN                 @USE_OWN_MEM_MAN@
 
 /// Text.
 #define USE_LIMITED_FONT_SIZES_SET           0


### PR DESCRIPTION
Useful for running under ASAN / valgrind.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/715)
<!-- Reviewable:end -->
