### PR TITLE
fix a bunch of clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks: >
   clang-analyzer-unix.MallocSizeof,
   clang-analyzer-unix.MismatchedDeallocator,
   clang-analyzer-unix.StdCLibraryFunctions,
+  -clang-diagnostic-vla-cxx-extension,
   misc-redundant-expression,
   misc-static-assert,
   readability-duplicate-include,

--- a/crengine/include/hyphman.h
+++ b/crengine/include/hyphman.h
@@ -51,7 +51,7 @@ public:
         , _right_hyphen_min(rightHyphenMin)
         { }
     lString32 getId() { return _id; }
-    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 ) = 0;
+    virtual bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 ) = 0;
     virtual ~HyphMethod() { }
     virtual lUInt32 getCount() { return 0; }
     virtual lUInt32 getSize() { return 0; }
@@ -162,7 +162,7 @@ public:
     HyphMan();
     ~HyphMan();
 
-    static bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 );
+    static bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 );
     /* Obsolete:
     inline static bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize=1 )
     {
@@ -202,7 +202,7 @@ public:
 
     static inline lUInt32 getHash() { return _hash_value; };
 
-    static bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    static bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     static lString32 getHyphenation(const char *word);
 };
 

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -865,7 +865,7 @@ public:
     void getNextFloatMinYs( int & left, int & right );
     void setNextFloatMinYs( int left, int right );
     void getInvolvedFloatIds( int & float_count, lUInt32 * float_ids );
-    void setInvolvedFloatIds( int float_count, lUInt32 * float_ids );
+    void setInvolvedFloatIds( int float_count, const lUInt32 * float_ids );
 
     void push();
     void clear();

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1155,8 +1155,8 @@ public:
     const lString32 & getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 id ) const;
     const lString32 & getFirstInnerAttributeValue( lUInt16 id ) const { return getFirstInnerAttributeValue( LXML_NS_ANY, id ); }
     /// returns all attribute values by attribute name id, looking at all children
-    const void getAllInnerAttributeValues( lUInt16 nsid, lUInt16 id, lString32Collection & values ) const;
-    const void getAllInnerAttributeValues( lUInt16 id, lString32Collection & values ) const {
+    void getAllInnerAttributeValues( lUInt16 nsid, lUInt16 id, lString32Collection & values ) const;
+    void getAllInnerAttributeValues( lUInt16 id, lString32Collection & values ) const {
         return getAllInnerAttributeValues( LXML_NS_ANY, id, values );
     }
 

--- a/crengine/src/hist.cpp
+++ b/crengine/src/hist.cpp
@@ -661,7 +661,7 @@ static lString32 decodeText(lString8 text) {
     return Utf8ToUnicode(buf);
 }
 
-static int findBytes(lChar8 * buf, int start, int end, const lChar8 * pattern) {
+static int findBytes(const lChar8 * buf, int start, int end, const lChar8 * pattern) {
     int len = lStr_len(pattern);
     for (int i = start; i <= end - len; i++) {
         int j = 0;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1480,7 +1480,7 @@ lString32 UserHyphDict::getHyphenation(const char *word)
         flags[i] = 0;
     }
 
-    TextLangMan::getTextLangCfg()->getHyphMethod()->hyphenate(word_str.c_str(), len, widths, flags, 0, 0xFFFF, 1);
+    TextLangMan::getTextLangCfg()->getHyphMethod()->hyphenate(word_str.c_str(), len, widths, flags, 0, 0xFFFF, 1); // cppcheck-suppress uninitvar
 
     lString32 hyphenation;
     size_t i;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -70,7 +70,7 @@ class TexHyph : public HyphMethod
 public:
     int largest_overflowed_word;
     bool match( const lChar32 * str, char * mask );
-    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    virtual bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     void addPattern( TexPattern * pattern );
     void checkForModifiers( lString32 str );
     TexHyph( lString32 id=HYPH_DICT_ID_DICTIONARY, int leftHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN, int rightHyphenMin=HYPHMETHOD_DEFAULT_HYPHEN_MIN );
@@ -86,7 +86,7 @@ class AlgoHyph : public HyphMethod
 {
 public:
     AlgoHyph(): HyphMethod(HYPH_DICT_ID_ALGORITHM) {};
-    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    virtual bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     virtual ~AlgoHyph();
 };
 
@@ -94,7 +94,7 @@ class SoftHyphensHyph : public HyphMethod
 {
 public:
     SoftHyphensHyph(): HyphMethod(HYPH_DICT_ID_SOFTHYPHENS) {};
-    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
+    virtual bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize );
     virtual ~SoftHyphensHyph();
 };
 
@@ -102,7 +102,7 @@ class NoHyph : public HyphMethod
 {
 public:
     NoHyph(): HyphMethod(HYPH_DICT_ID_NONE) {};
-    virtual bool hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+    virtual bool hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
     {
         CR_UNUSED6(str, len, widths, flags, hyphCharWidth, maxWidth);
         return false;
@@ -237,7 +237,7 @@ bool HyphMan::isEnabled() {
     */
 }
 
-bool HyphMan::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool HyphMan::hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     return TextLangMan::getMainLangHyphMethod()->hyphenate( str, len, widths, flags, hyphCharWidth, maxWidth, flagSize );
     /* Obsolete:
@@ -453,7 +453,7 @@ HyphMan::~HyphMan()
 // and AlgoHyph::hyphenate(): if soft hyphens are found in the
 // provided word, trust and use them; don't do the regular patterns
 // and algorithm matching.
-static bool softhyphens_hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+static bool softhyphens_hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     bool soft_hyphens_found = false;
     for ( int i = 0; i<len; i++ ) {
@@ -473,7 +473,7 @@ static bool softhyphens_hyphenate( const lChar32 * str, int len, lUInt16 * width
     return soft_hyphens_found;
 }
 
-bool SoftHyphensHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool SoftHyphensHyph::hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( UserHyphDict::hasWords() ) {
         if ( UserHyphDict::hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize) )
@@ -931,7 +931,7 @@ bool TexHyph::match( const lChar32 * str, char * mask )
 //    return true;
 //}
 
-bool TexHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool TexHyph::hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( UserHyphDict::hasWords() ) {
         if ( UserHyphDict::hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize) )
@@ -1070,7 +1070,7 @@ bool TexHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 
     return res;
 }
 
-bool AlgoHyph::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool AlgoHyph::hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( UserHyphDict::hasWords() ) {
         if ( UserHyphDict::hyphenate(str, len, widths, flags, hyphCharWidth, maxWidth, flagSize) )
@@ -1492,7 +1492,7 @@ lString32 UserHyphDict::getHyphenation(const char *word)
     return hyphenation;
 }
 
-bool UserHyphDict::hyphenate( const lChar32 * str, int len, lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
+bool UserHyphDict::hyphenate( const lChar32 * str, int len, const lUInt16 * widths, lUInt8 * flags, lUInt16 hyphCharWidth, lUInt16 maxWidth, size_t flagSize )
 {
     if ( !UserHyphDict::hasWords() ) {
         return false;

--- a/crengine/src/hyphman.cpp
+++ b/crengine/src/hyphman.cpp
@@ -1472,8 +1472,8 @@ lString32 UserHyphDict::getHyphenation(const char *word)
 
     lString32 word_str(orig_word_str.c_str() + start, end - start);
     size_t len = word_str.length();
-    lUInt16 widths[len+2]; // NOLINT(clang-diagnostic-vla-cxx-extension)
-    lUInt8 flags[len+2]; // NOLINT(clang-diagnostic-vla-cxx-extension)
+    lUInt16 widths[len+2];
+    lUInt8 flags[len+2];
 
     for ( size_t i = 0; i < len; ++i ) {
         widths[i] = 0;

--- a/crengine/src/lvfnt.cpp
+++ b/crengine/src/lvfnt.cpp
@@ -190,7 +190,7 @@ lUInt16 lvfontMeasureText( const lvfont_handle pfont,
             break;
         if (flags[hwEnd-1]&LCHAR_ALLOW_WRAP_AFTER)
             break;
-        if (ch=='.' || ch==',' || ch=='!' || ch=='?' || ch=='?')
+        if (ch=='.' || ch==',' || ch=='!' || ch=='?')
             break;
 
     }

--- a/crengine/src/lvfntman.cpp
+++ b/crengine/src/lvfntman.cpp
@@ -1743,7 +1743,7 @@ public:
         _BulletListItemFont = fontMan->GetFont(
             getSize(),
             400,  // regular weight   // bullets stays the regular weight and non-italic, even
-            0,    // no italic        // when their UL and LI are bold and/or italic
+            false,// no italic        // when their UL and LI are bold and/or italic
             getFontFamily(),
             preferred_bullet_fonts,   // We can provide a list, fontMan->GetFont() will split t and look for each
             0,    // no feature needed
@@ -5784,7 +5784,7 @@ public:
             }
             else {
                 ch = getHyphChar();
-                isHyphen = 0;
+                isHyphen = false;
             }
 
             LVFontGlyphCacheItem * item = getGlyph(ch, def_char);

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -1048,7 +1048,7 @@ public:
     LVGifImageSource();
     virtual ~LVGifImageSource();
     void Clear();
-    const int GetColorTableColorCount() {
+    int GetColorTableColorCount() {
         if (m_flg_gtc)
             return m_global_color_table_color_count;
         else
@@ -1091,7 +1091,7 @@ public:
     LVGifFrame(LVGifImageSource * pImage);
     ~LVGifFrame();
     void Clear();
-    const int GetColorTableColorCount() {
+    int GetColorTableColorCount() {
         if (m_flg_ltc)
             return m_local_color_table_color_count;
         else

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10153,7 +10153,7 @@ void DrawBodyBackground( LVDrawBuf & drawbuf, bool draw_bg_color, bool draw_bg_i
     // or starts inside this page/screen: we may have inter body margins, or
     // some initial top margin above the first body.
     // We need to check there is really none to be able to draw on the whole buffer.
-    bool no_visible_previous_body = doc_y <= 0; // This body started before page top
+    const bool no_visible_previous_body = doc_y <= 0; // This body started before page top
     if ( !no_visible_previous_body ) {
         // Find previous body if any, to see if would have some part in this page
         // We expect either sibling BODY (FB2) or sibling DocFragement>BODY (EPUB)
@@ -10175,22 +10175,17 @@ void DrawBodyBackground( LVDrawBuf & drawbuf, bool draw_bg_color, bool draw_bg_i
                 }
             }
         }
-        if ( !prevBody ) {
-            no_visible_previous_body = true;
-        }
-        else {
+        if ( prevBody ) {
             // Make out the doc_y this prev body would have
             lvRect prevrect;
             prevBody->getAbsRect(prevrect);
             lvRect thisrect;
             enode->getAbsRect(thisrect);
             int prev_bottom_doc_y = doc_y - thisrect.top + prevrect.bottom;
-            if ( prev_bottom_doc_y <= 0 ) { // previous body ends before this page
-                no_visible_previous_body = true;
-            }
-            else {
-                // There may be unused space between this prev body bottom and
-                // this body top, caused by collapsed body top/bottom margins.
+            if ( prev_bottom_doc_y > 0 ) {
+                // Previous body does not end before this page: there may be unused
+                // space between this prev body bottom and this body top, caused by
+                // collapsed body top/bottom margins.
                 // Make the boundary between backgrounds at the middle of this (round up)
                 bg_top = y0 + doc_y - (thisrect.top - prevrect.bottom)/2;
             }
@@ -10198,7 +10193,7 @@ void DrawBodyBackground( LVDrawBuf & drawbuf, bool draw_bg_color, bool draw_bg_i
     }
     // Same checks as above, but for a next body below this one
     RenderRectAccessor fmt( enode );
-    bool no_visible_next_body = doc_y + fmt.getHeight() >= dy; // this body ends after page bottom
+    const bool no_visible_next_body = doc_y + fmt.getHeight() >= dy; // this body ends after page bottom
     if ( !no_visible_next_body ) {
         // Find next body
         ldomNode * nextBody = NULL;
@@ -10219,21 +10214,16 @@ void DrawBodyBackground( LVDrawBuf & drawbuf, bool draw_bg_color, bool draw_bg_i
                 }
             }
         }
-        if ( !nextBody ) {
-            no_visible_next_body = true;
-        }
-        else {
+        if ( nextBody ) {
             lvRect nextrect;
             nextBody->getAbsRect(nextrect);
             lvRect thisrect;
             enode->getAbsRect(thisrect);
             int next_top_doc_y = doc_y - thisrect.top + nextrect.top;
-            if ( next_top_doc_y >= dy ) { // next body starts after this page
-                no_visible_next_body = true;
-            }
-            else {
-                // There may be unused space between this next body top and
-                // this body bottom, caused by collapsed body top/bottom margins
+            if ( next_top_doc_y < dy ) {
+                // Next body starts on this page: There may be unused space
+                // between this next body top and this body bottom, caused by
+                // collapsed body top/bottom margins.
                 // Make the boundary between backgrounds at the middle of this (round down)
                 bg_bottom = y0 + doc_y + fmt.getHeight() + (nextrect.top - thisrect.bottom + 1)/2;
             }

--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -15,6 +15,7 @@
 
 #include "../include/lvstring.h"
 #include <assert.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -5293,12 +5294,16 @@ public:
         "DEBUG",
         "TRACE",
         };
+        if (!f) {
+            fprintf(stderr, "fopen(%s): %s\n", fname, strerror(errno));
+            f = stderr;
+        }
         fwrite( utf8sign, 3, 1, f);
         info( "Started logging. Level=%s", log_level_names[getLogLevel()] );
     }
 
     virtual ~CRFileLogger() {
-        if ( f && autoClose ) {
+        if ( f && autoClose && f != stderr ) {
             info( "Stopped logging" );
             fclose( f );
         }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -7059,7 +7059,7 @@ bool parse_attr_value( const char * &str, char * buf, bool &parse_trailing_i, ch
             parse_trailing_i = false;
             if (end_pos == 0) // Empty value, or some leading space: this is invalid
                 return false;
-            if (str[pos] && str[pos]==' ' && str[pos+1] && (str[pos+1]=='i' || str[pos+1]=='I')) {
+            if (str[pos]==' ' && str[pos+1] && (str[pos+1]=='i' || str[pos+1]=='I')) {
                 parse_trailing_i = true;
                 pos+=2;
             }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -2292,7 +2292,7 @@ void RenderRectAccessor::getInvolvedFloatIds( int & float_count, lUInt32 * float
     if (float_count > 3) float_ids[3] = _extra4;
     if (float_count > 4) float_ids[4] = _extra5;
 }
-void RenderRectAccessor::setInvolvedFloatIds( int float_count, lUInt32 * float_ids )
+void RenderRectAccessor::setInvolvedFloatIds( int float_count, const lUInt32 * float_ids )
 {
     if ( _dirty ) {
         _dirty = false;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -1764,7 +1764,6 @@ LVStreamRef ldomBlobCache::getBlob( lString32 name )
     return LVStreamRef();
 }
 
-#if BUILD_LITE!=1
 //#define DEBUG_RENDER_RECT_ACCESS
 #ifdef DEBUG_RENDER_RECT_ACCESS
   static signed char render_rect_flags[200000]={0};
@@ -2309,8 +2308,6 @@ void RenderRectAccessor::setInvolvedFloatIds( int float_count, const lUInt32 * f
     if (float_count > 4) _extra5 = float_ids[4];
     _modified = true;
 }
-
-#endif
 
 
 class ldomPersistentText;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19903,7 +19903,7 @@ const lString32 & ldomNode::getFirstInnerAttributeValue( lUInt16 nsid, lUInt16 i
 }
 
 /// returns all attribute values by attribute name id, looking at all children
-const void ldomNode::getAllInnerAttributeValues( lUInt16 nsid, lUInt16 id, lString32Collection & values ) const
+void ldomNode::getAllInnerAttributeValues( lUInt16 nsid, lUInt16 id, lString32Collection & values ) const
 {
     ASSERT_NODE_NOT_NULL;
     values.clear();

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -1709,7 +1709,7 @@ public:
         }
         str.trimDoubleSpaces(false, false, true);
         lChar32 singleChar = getSingleLineChar( str );
-        if ( singleChar!=0 && singleChar>='A' )
+        if ( singleChar>='A' )
             singleChar = 0;
         bool isHeader = singleChar!=0;
         if ( formatFlags & tftDoubleEmptyLineBeforeHeaders ) {

--- a/crengine/src/lvxml.cpp
+++ b/crengine/src/lvxml.cpp
@@ -5928,7 +5928,6 @@ end_of_node:
 
             m_txt_buf.erase(0, last_split_txtlen);
             tlen = m_txt_buf.length();
-            last_split_txtlen = 0;
 
             //=====================================================
             if (flgBreak) {

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -721,7 +721,7 @@ public:
         if ( !hdr.read(stream) )
             return false;
         if ( hdr.recordCount==0 )
-            return 0;
+            return false;
 
         if ( hdr.checkType("TEXt") && hdr.checkCreator("REAd") )
             _format = PALMDOC;

--- a/crengine/src/props.cpp
+++ b/crengine/src/props.cpp
@@ -475,7 +475,7 @@ bool CRPropAccessor::getBool( const char * propName, bool &result ) const
 
 bool CRPropAccessor::getBoolDef( const char * propName, bool defValue ) const
 {
-    bool v = 0;
+    bool v = false;
     if ( !getBool( propName, v ) )
         return defValue;
     else

--- a/thirdparty/antiword/antiword.h
+++ b/thirdparty/antiword/antiword.h
@@ -724,6 +724,7 @@ extern void	*xcalloc(size_t, size_t);
 extern void 	*xrealloc(void *, size_t);
 extern char	*xstrdup(const char *);
 extern void 	*xfree(void *);
+#define xfree(P) (xfree(P), NULL)
 /* xml.c */
 extern void	vCreateBookIntro(diagram_type *, int);
 extern void	vPrologueXML(diagram_type *, const options_type *);

--- a/thirdparty/antiword/debug.h
+++ b/thirdparty/antiword/debug.h
@@ -64,44 +64,44 @@
 
 #else
 
-#define DBG_MSG(t)		/* EMPTY */
-#define DBG_STRN(t,m)		/* EMPTY */
-#define DBG_CHR(m)		/* EMPTY */
-#define DBG_DEC(m)		/* EMPTY */
-#define DBG_HEX(m)		/* EMPTY */
-#define DBG_FLT(m)		/* EMPTY */
+#define DBG_MSG(t)		(void)(t)
+#define DBG_STRN(t,m)		((void)(t),(void)(m))
+#define DBG_CHR(m)		(void)(m)
+#define DBG_DEC(m)		(void)(m)
+#define DBG_HEX(m)		(void)(m)
+#define DBG_FLT(m)		(void)(m)
 
 #define DBG_FIXME()		/* EMPTY */
-#define DBG_PRINT_BLOCK(b,m)	/* EMPTY */
-#define DBG_UNICODE(t)		/* EMPTY */
-#define DBG_UNICODE_N(t,m)	/* EMPTY */
+#define DBG_PRINT_BLOCK(b,m)	((void)(b),(void)(m))
+#define DBG_UNICODE(t)		(void)(t)
+#define DBG_UNICODE_N(t,m)	((void)(t),(void)(m))
 
-#define DBG_MSG_C(c,t)		/* EMPTY */
-#define DBG_STRN_C(c,t,m)	/* EMPTY */
-#define DBG_CHR_C(c,m)		/* EMPTY */
-#define DBG_DEC_C(c,m)		/* EMPTY */
-#define DBG_HEX_C(c,m)		/* EMPTY */
-#define DBG_FLT_C(c,m)		/* EMPTY */
+#define DBG_MSG_C(c,t)		(void)((c) && (t))
+#define DBG_STRN_C(c,t,m)	(void)((c) && ((t),(m)))
+#define DBG_CHR_C(c,m)		(void)((c) && (m))
+#define DBG_DEC_C(c,m)		(void)((c) && (m))
+#define DBG_HEX_C(c,m)		(void)((c) && (m))
+#define DBG_FLT_C(c,m)		(void)((c) && (m))
 
 #endif /* DEBUG */
 
-#define NO_DBG_MSG(t)		/* EMPTY */
-#define NO_DBG_STRN(t,m)	/* EMPTY */
-#define NO_DBG_CHR(m)		/* EMPTY */
-#define NO_DBG_DEC(m)		/* EMPTY */
-#define NO_DBG_HEX(m)		/* EMPTY */
-#define NO_DBG_FLT(m)		/* EMPTY */
+#define NO_DBG_MSG(t)		(void)(t)
+#define NO_DBG_STRN(t,m)	((void)(t),(void)(m))
+#define NO_DBG_CHR(m)		(void)(m)
+#define NO_DBG_DEC(m)		(void)(m)
+#define NO_DBG_HEX(m)		(void)(m)
+#define NO_DBG_FLT(m)		(void)(m)
 
-#define NO_DBG_PRINT_BLOCK(b,m)	/* EMPTY */
-#define NO_DBG_UNICODE(t)	/* EMPTY */
-#define NO_DBG_UNICODE_N(t,m)	/* EMPTY */
+#define NO_DBG_PRINT_BLOCK(b,m)	((void)(b),(void)(m))
+#define NO_DBG_UNICODE(t)	(void)(t)
+#define NO_DBG_UNICODE_N(t,m)	((void)(t),(void)(m))
 
-#define NO_DBG_MSG_C(c,t)	/* EMPTY */
-#define NO_DBG_STRN_C(c,t,m)	/* EMPTY */
-#define NO_DBG_CHR_C(c,m)	/* EMPTY */
-#define NO_DBG_DEC_C(c,m)	/* EMPTY */
-#define NO_DBG_HEX_C(c,m)	/* EMPTY */
-#define NO_DBG_FLT_C(c,m)	/* EMPTY */
+#define NO_DBG_MSG_C(c,t)	(void)((c) && (t))
+#define NO_DBG_STRN_C(c,t,m)	(void)((c) && ((t),(m)))
+#define NO_DBG_CHR_C(c,m)	(void)((c) && (m))
+#define NO_DBG_DEC_C(c,m)	(void)((c) && (m))
+#define NO_DBG_HEX_C(c,m)	(void)((c) && (m))
+#define NO_DBG_FLT_C(c,m)	(void)((c) && (m))
 
 #if defined(TRACE)
 

--- a/thirdparty/antiword/out2window.c
+++ b/thirdparty/antiword/out2window.c
@@ -484,7 +484,6 @@ tComputeStringLengthMax(const char *szString, size_t tColumnWidthMax)
 	}
 
 	tLen = 0;
-	tWidth = 0;
 	for (;;) {
 		tLenPrev = tLen;
 		tLen += tGetCharacterLength(szString + tLen);

--- a/thirdparty/antiword/prop6.c
+++ b/thirdparty/antiword/prop6.c
@@ -1050,7 +1050,7 @@ vGet6ChrInfo(FILE *pFile, ULONG ulStartBlock,
 	fail(aulBBD == NULL);
 
 	ulBeginCharInfo = ulGetLong(0xb8, aucHeader); /* fcPlcfbteChpx */
-	NO_DBG_HEX(lBeginCharInfo);
+	NO_DBG_HEX(ulBeginCharInfo);
 	tCharInfoLen = (size_t)ulGetLong(0xbc, aucHeader); /* lcbPlcfbteChpx */
 	NO_DBG_DEC(tCharInfoLen);
 	if (tCharInfoLen < 4) {

--- a/thirdparty/antiword/prop8.c
+++ b/thirdparty/antiword/prop8.c
@@ -120,9 +120,9 @@ vGet8DopInfo(FILE *pFile, const pps_type *pTable,
 	fail(aulBBD == NULL || aulSBD == NULL);
 
 	ulBeginDocpInfo = ulGetLong(0x192, aucHeader); /* fcDop */
-	NO_DBG_HEX(ulBeginSectInfo);
+	NO_DBG_HEX(ulBeginDocpInfo);
 	tDocpInfoLen = (size_t)ulGetLong(0x196, aucHeader); /* lcbDop */
-	NO_DBG_DEC(tSectInfoLen);
+	NO_DBG_DEC(tDocpInfoLen);
 	if (tDocpInfoLen < 28) {
 		DBG_MSG("No Document information");
 		return;
@@ -518,6 +518,9 @@ eGet8RowInfo(int iFodo,
 	if (bFound2416_0 || bFound244b_0) {
 		return found_not_a_cell;
 	}
+	// Silence clang-tidy warnings (clang-analyzer-deadcode.DeadStores).
+	(void)bFound244c_0;
+	(void)bFound244c_1;
 	return found_nothing;
 } /* end of eGet8RowInfo */
 

--- a/thirdparty/antiword/propmod.c
+++ b/thirdparty/antiword/propmod.c
@@ -64,7 +64,7 @@ vAdd2PropModList(const UCHAR *aucPropMod)
 
 	tLen = 2 + (size_t)usGetWord(0, aucPropMod);
 	NO_DBG_HEX(tLen);
-	NO_DBG_PRINT_BLOCK(pucPropMod, tLen);
+	NO_DBG_PRINT_BLOCK(aucPropMod, tLen);
 	ppAnchor[tNextFree] = xmalloc(tLen);
 	memcpy(ppAnchor[tNextFree], aucPropMod, tLen);
 	tNextFree++;

--- a/thirdparty/antiword/stylesheet.c
+++ b/thirdparty/antiword/stylesheet.c
@@ -565,7 +565,7 @@ vGet6Stylesheet(FILE *pFile, ULONG ulStartBlock,
 						aucBuffer + tOffset + tPos + 2,
 						(int)tUpxLen, pFont);
 				NO_DBG_DEC(pFont->usFontSize);
-				NO_DBG_DEC(pFont->ucFontcolor);
+				NO_DBG_DEC(pFont->ucFontColor);
 				NO_DBG_HEX(pFont->usFontStyle);
 			}
 		}
@@ -768,7 +768,7 @@ vGet8Stylesheet(FILE *pFile, const pps_info_type *pPPS,
 						aucBuffer + tOffset + tPos + 2,
 						(int)tUpxLen, pFont);
 				NO_DBG_DEC(pFont->usFontSize);
-				NO_DBG_DEC(pFont->ucFontcolor);
+				NO_DBG_DEC(pFont->ucFontColor);
 				NO_DBG_HEX(pFont->usFontStyle);
 			}
 		}

--- a/thirdparty/antiword/word2text.c
+++ b/thirdparty/antiword/word2text.c
@@ -555,7 +555,7 @@ ulGetChar(FILE *pFile, list_id_enum eListID)
 		}
 		if (!bEndRowFast) {
 			bEndRowFast = eRowInfo == found_end_of_row;
-			NO_DBG_HEX_C(bEndRowFast, pRowInfo->ulFileOffsetEnd);
+			NO_DBG_HEX_C(pRowInfo, pRowInfo->ulFileOffsetEnd);
 		}
 
 		if (!bStartStyle) {
@@ -651,7 +651,7 @@ bWordDecryptor(FILE *pFile, long lFilesize, diagram_type *pDiag)
 	ULONG	ulChar;
 	long	lBeforeIndentation, lAfterIndentation;
 	long	lLeftIndentation, lLeftIndentation1, lRightIndentation;
-	long	lWidthCurr, lWidthMax, lDefaultTabWidth, lHalfSpaceWidth, lTmp;
+	long	lWidthCurr, lWidthMax, lDefaultTabWidth, lTmp;
 	list_id_enum 	eListID;
 	image_info_enum	eRes;
 	UINT	uiFootnoteNumber, uiEndnoteNumber, uiTmp;
@@ -1133,9 +1133,11 @@ bWordDecryptor(FILE *pFile, long lFilesize, diagram_type *pDiag)
 				vStoreCharacter(TAB, pOutput);
 				break;
 			}
-			lHalfSpaceWidth = (lComputeSpaceWidth(
+#if 0
+			long lHalfSpaceWidth = (lComputeSpaceWidth(
 					pOutput->tFontRef,
 					pOutput->usFontSize) + 1) / 2;
+#endif
 			lTmp = lTotalStringWidth(pAnchor);
 			lTmp += lDrawUnits2MilliPoints(pDiag->lXleft);
 			lTmp /= lDefaultTabWidth;
@@ -1273,7 +1275,6 @@ pHdrFtrDecryptor(FILE *pFile, ULONG ulCharPosStart, ULONG ulCharPosNext)
 	long	lWidthCurr, lWidthMax;
 	long	lRightIndentation;
 	USHORT	usChar;
-	UCHAR	ucAlignment;
 	BOOL	bSkip;
 
 	fail(iWordVersion < 0);
@@ -1286,7 +1287,6 @@ pHdrFtrDecryptor(FILE *pFile, ULONG ulCharPosStart, ULONG ulCharPosNext)
 	}
 
 	lRightIndentation = 0;
-	ucAlignment = ALIGNMENT_LEFT;
 	bSkip = FALSE;
 	lWidthMax = lGetWidthMax(tOptions.iParagraphBreak);
 	pAnchor = pStartNewOutput(NULL, NULL);

--- a/thirdparty/antiword/xmalloc.c
+++ b/thirdparty/antiword/xmalloc.c
@@ -124,6 +124,7 @@ xstrdup(const char *szArg)
  * returns NULL;
  * This makes p=xfree(p) possible, free memory and overwrite the pointer to it.
  */
+#undef xfree
 void *
 xfree(void *pvArg)
 {

--- a/thirdparty/chmlib/src/lzx.c
+++ b/thirdparty/chmlib/src/lzx.c
@@ -345,7 +345,7 @@ int LZXreset(struct LZXstate *pState)
  * Returns 0 for OK or 1 for error
  */
 
-static int make_decode_table(ULONG nsyms, ULONG nbits, UBYTE *length, UWORD *table) {
+static int make_decode_table(ULONG nsyms, ULONG nbits, const UBYTE *length, UWORD *table) {
     register UWORD sym;
     register ULONG leaf;
     register UBYTE bit_num = 1;


### PR DESCRIPTION
```diff
--- before
+++ after
@@ -1,20 +1,15 @@
-      1 [clang-analyzer-core.NonNullParamChecker]
       1 [clang-analyzer-core.NullDereference]
       1 [clang-analyzer-core.uninitialized.Branch]
       1 [clang-analyzer-cplusplus.NewDeleteLeaks]
       1 [clang-analyzer-unix.Malloc]
       1 [clang-diagnostic-implicit-const-int-float-conversion]
-      1 [clang-diagnostic-vla-cxx-extension]
-      1 [readability-redundant-preprocessor]
       2 [clang-analyzer-core.DivideZero]
       2 [clang-analyzer-optin.performance.Padding]
       3 [clang-analyzer-core.NullPointerArithm]
       3 [clang-analyzer-core.uninitialized.UndefReturn]
       3 [clang-analyzer-optin.core.EnumCastOutOfRange]
-      3 [misc-redundant-expression]
       4 [clang-analyzer-core.UndefinedBinaryOperatorResult]
-      5 [readability-non-const-parameter]
       6 [clang-analyzer-core.uninitialized.Assign]
+      8 [clang-analyzer-deadcode.DeadStores]
      19 [clang-analyzer-security.ArrayBound]
      26 [clang-analyzer-cplusplus.NewDelete]
-    207 [clang-analyzer-deadcode.DeadStores]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/721)
<!-- Reviewable:end -->
