### PR TITLE
css: include fontFaceDecl in stylesheet hash

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -303,9 +303,6 @@ private:
     //   reusing the same file;
     // - the document's live stylesheet (_ua_stylesheet) needs them so that
     //   getHash() changes when a style tweak's @font-face rule changes
-    //   (e.g. a different src: local() target), which is otherwise
-    //   invisible to the render-context hash used to decide whether a
-    //   reformat is needed.
     // Any other LVStyleSheet (author stylesheet merge destinations, nested
     // at-rule scratch sheets, etc) is never used as a cache key or fed into
     // getHash(), so nothing would ever read decls recorded into it; leaving

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -307,8 +307,9 @@ private:
     //   invisible to the render-context hash used to decide whether a
     //   reformat is needed.
     // Any other LVStyleSheet (author stylesheet merge destinations, nested
-    // at-rule scratch sheets, etc) never gets cached or hashed for this
-    // purpose, so isn't worth recording into.
+    // at-rule scratch sheets, etc) is never used as a cache key or fed into
+    // getHash(), so nothing would ever read decls recorded into it; leaving
+    // tracking off avoids accumulating decls nobody consumes.
     bool _trackFontFaceDecls = false;
 
 public:

--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -295,12 +295,20 @@ private:
     void set(LVPtrVector<LVCssSelector> & v );
 
     LVArray<LVFontFaceDecl> _fontFaceDecls;
-    // Off by default: only the per-file LVStyleSheet objects that
-    // LVImportStylesheetParser builds for StyleSheetCache need to remember
-    // their @font-face decls (to replay registrations on a cache hit for a
-    // later DocFragment reusing the same file). The document's live
-    // stylesheet, and any other LVStyleSheet, never gets cached and so
-    // never has its decls read back -- don't bother recording them there.
+    // Off by default. Two distinct consumers opt a given LVStyleSheet
+    // instance in:
+    // - the per-file LVStyleSheet objects that LVImportStylesheetParser
+    //   builds for StyleSheetCache need to remember their @font-face decls
+    //   to replay registrations on a cache hit for a later DocFragment
+    //   reusing the same file;
+    // - the document's live stylesheet (_ua_stylesheet) needs them so that
+    //   getHash() changes when a style tweak's @font-face rule changes
+    //   (e.g. a different src: local() target), which is otherwise
+    //   invisible to the render-context hash used to decide whether a
+    //   reformat is needed.
+    // Any other LVStyleSheet (author stylesheet merge destinations, nested
+    // at-rule scratch sheets, etc) never gets cached or hashed for this
+    // purpose, so isn't worth recording into.
     bool _trackFontFaceDecls = false;
 
 public:
@@ -345,6 +353,7 @@ public:
         _selector_count_stack.clear();
         _selectors.clear();
         _stack.clear();
+        _fontFaceDecls.clear();
     }
     /// set document to retrieve ID values from
     void setDocument( lxmlDocBase * doc ) { _doc = doc; }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -7684,6 +7684,8 @@ void LVStyleSheet::set(LVPtrVector<LVCssSelector> & v  )
 LVStyleSheet::LVStyleSheet( LVStyleSheet & sheet )
 :   _doc( sheet._doc )
 ,   _nested( sheet._nested )
+,   _fontFaceDecls( sheet._fontFaceDecls )
+,   _trackFontFaceDecls( sheet._trackFontFaceDecls )
 {
     set( sheet._selectors );
     _selector_count = sheet._selector_count;
@@ -7857,6 +7859,20 @@ lUInt32 LVStyleSheet::getHash() const
     for ( int i=0; i<_selectors.length(); i++ ) {
         if ( _selectors[i] )
             hash = hash * 31 + _selectors[i]->getHash() + i*15324;
+    }
+    // Only non-empty when this instance opted into tracking (see
+    // _trackFontFaceDecls): folds @font-face state (notably src: local()
+    // targets, which don't otherwise appear in any selector/declaration)
+    // into the hash, so callers relying on getHash() to detect a
+    // rendering-relevant change (eg. checkRenderContext()) see one.
+    for ( int i=0; i<_fontFaceDecls.length(); i++ ) {
+        const LVFontFaceDecl & d = _fontFaceDecls[i];
+        lUInt32 declHash = d.url.getHash();
+        declHash = declHash * 31 + d.face.getHash();
+        declHash = declHash * 31 + (lUInt32)d.weight;
+        declHash = declHash * 31 + (lUInt32)d.italic;
+        declHash = declHash * 31 + (lUInt32)d.isLocal;
+        hash = hash * 31 + declHash + i*7919;
     }
     return hash;
 }

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -7863,8 +7863,7 @@ lUInt32 LVStyleSheet::getHash() const
     // Only non-empty when this instance opted into tracking (see
     // _trackFontFaceDecls): folds @font-face state (notably src: local()
     // targets, which don't otherwise appear in any selector/declaration)
-    // into the hash, so callers relying on getHash() to detect a
-    // rendering-relevant change (eg. checkRenderContext()) see one.
+    // into the hash.
     for ( int i=0; i<_fontFaceDecls.length(); i++ ) {
         const LVFontFaceDecl & d = _fontFaceDecls[i];
         lUInt32 declHash = d.url.getHash();

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3811,6 +3811,11 @@ lxmlDocBase::lxmlDocBase( int /*dataBufSize*/ )
 {
     // create and add one data buffer
     _ua_stylesheet.setDocument( this );
+    // Style tweaks are reparsed into this live stylesheet at runtime, and a
+    // tweak's @font-face rule (eg. a changed src: local() target) must be
+    // able to invalidate the render-context hash -- see getHash() and
+    // _trackFontFaceDecls in lvstsheet.h.
+    _ua_stylesheet.enableFontFaceDeclTracking();
     _stylesheet.setDocument( this );
 }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -3811,10 +3811,7 @@ lxmlDocBase::lxmlDocBase( int /*dataBufSize*/ )
 {
     // create and add one data buffer
     _ua_stylesheet.setDocument( this );
-    // Style tweaks are reparsed into this live stylesheet at runtime, and a
-    // tweak's @font-face rule (eg. a changed src: local() target) must be
-    // able to invalidate the render-context hash -- see getHash() and
-    // _trackFontFaceDecls in lvstsheet.h.
+    // Style tweaks may contain @font-face rule, be sure we notice any change
     _ua_stylesheet.enableFontFaceDeclTracking();
     _stylesheet.setDocument( this );
 }


### PR DESCRIPTION
The stylesheet hash should include `LVFontFaceDecl`'s so a re-render is triggered when `@font-face` declarations change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/722)
<!-- Reviewable:end -->
