### PR TITLE
Fix SVG sizing. Various optimizations when large collection of children

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -968,6 +968,7 @@ private:
     void autoboxChildren( int startIndex, int endIndex, bool handleFloating=false );
     void removeChildren( int startIndex, int endIndex );
     bool cleanIfOnlyEmptyTextInline( bool handleFloating=false );
+    bool removeStandaloneWhitespaceTextChildrenInMixedContent( bool handleFloating=false );
     /// returns true if element has inline content (non empty text, images, <BR>)
     bool hasNonEmptyInlineContent( bool ignoreFloats=false );
 
@@ -1293,6 +1294,8 @@ public:
 
     /// for display:list-item node, get marker
     bool getNodeListMarker( int & counterValue, lString32 & marker, int & markerWidth );
+    /// returns true if text node contains only plain whitespace
+    bool isWhitespaceText() const;
     /// is node a floating floatBox
     bool isFloatingBox() const;
     /// is node an inlineBox that has not been re-inlined by having

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1865,9 +1865,9 @@ protected:
     void initIndex();
 public:
     /// returns bottom level index
-    int getIndex() { return _indexes[_level-1]; }
+    int getIndex() const { return _indexes[_level-1]; }
     /// returns node level
-    int getLevel() { return _level; }
+    int getLevel() const { return _level; }
     /// default constructor
     ldomXPointerEx()
 	    : ldomXPointer()
@@ -1923,6 +1923,8 @@ public:
     {
         return _data->getDocument()==v._data->getDocument() && _data->getNode()==v._data->getNode() && _data->getOffset()==v._data->getOffset();
     }
+    /// returns true when this node path is a prefix of the provided xpointer path
+    bool isPathPrefixOf( const ldomXPointerEx & v ) const;
     /// searches path for element with specific id, returns level at which element is founs, 0 if not found
     int findElementInPath( lUInt16 id );
     /// compare two pointers, returns -1, 0, +1

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -3271,7 +3271,7 @@ lString32 extractDocSeriesAndNumber( ldomDocument * doc, lString32 & seriesNumbe
 lString32 extractDocKeywords( ldomDocument * doc );
 lString32 extractDocDescription( ldomDocument * doc );
 
-bool IsEmptySpace( const lChar32 * text, int len );
+
 
 /// parse XML document from stream, returns NULL if failed
 ldomDocument * LVParseXMLStream( LVStreamRef stream,

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5463,8 +5463,7 @@ int renderBlockElementLegacy( LVRendPageContext & context, ldomNode * enode, int
                         if ( child->isText() ) {
                             // We may occasionally let empty text nodes among block elements,
                             // just skip them
-                            lString32 s = child->getText();
-                            if ( IsEmptySpace(s.c_str(), s.length() ) )
+                            if ( child->isWhitespaceText() )
                                 continue;
                             crFatalError(144, "Attempting to render non-empty Text node");
                         }
@@ -8731,8 +8730,7 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                     if ( child->isText() ) {
                         // We may occasionally let empty text nodes among block elements,
                         // just skip them
-                        lString32 s = child->getText();
-                        if ( IsEmptySpace(s.c_str(), s.length() ) )
+                        if ( child->isWhitespaceText() )
                             continue;
                         crFatalError(144, "Attempting to render non-empty Text node");
                     }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2947,9 +2947,10 @@ bool getStyledImageSize( ldomNode * enode, int & img_width, int & img_height, in
         //     https://wiki.mozilla.org/SVG:Sizing
         //     https://docs.google.com/presentation/d/1POUiroOBbLmXYlQKf0pIR8zVkHWH9jRVN-w8A4aNsIk/
         //     https://oreillymedia.github.io/Using_SVG/guide/units.html
-        //   ie. <svg width="100%" height="100%" viewBox="0 0 509 800" preserveAspectRatio="xMidYMid meet">
-        //   SVG wrappers for cover images use width="100%" and height="100%"
-        //   So, assume the % to be relative to the container width and the page height
+        //   We still resolve a % width against the known container width, as that gives
+        //   sensible results for the common wrappers like:
+        //     <svg width="100%" height="100%" viewBox="0 0 509 800" ...>
+        //   But for height we only resolve % when we have a definite container height.
         lString32 at_width = enode->getAttributeValue(attr_width);
         if ( !at_width.empty() ) {
             lString8 s8 = UnicodeToUtf8(at_width);
@@ -2968,8 +2969,20 @@ bool getStyledImageSize( ldomNode * enode, int & img_width, int & img_height, in
             css_length_t svg_h;
             if ( parse_number_value(s, svg_h) ) {
                 if ( svg_h.type == css_val_percent ) {
-                    int ref_height = enode->getDocument()->getPageHeight() - enode->getSurroundingAddedHeight(true);
-                    height = lengthToPx(enode, svg_h, ref_height);
+                    if ( container_height >= 0 ) {
+                        height = lengthToPx(enode, svg_h, container_height);
+                    }
+                    // We used to have:
+                    //  int ref_height = enode->getDocument()->getPageHeight() - enode->getSurroundingAddedHeight(true);
+                    //  height = lengthToPx(enode, svg_h, ref_height);
+                    // to treat height="100%" as "page height", but this makes
+                    // inline or inline-block SVG wrappers spuriously page-tall.
+                    // But it seems we can just leave it unset: the generic used-value
+                    // sizing code below will derive the missing height from the
+                    // resolved width and the SVG intrinsic aspect ratio.
+                    // Then, when formatted by lvtextfm.cpp, it may be scaled down
+                    // further so the final rendered height, plus surrounding
+                    // margins/borders/padding, does not overflow the page height.
                 }
                 else if ( is_length_relative_unit(svg_h) ) {
                     height = lengthToPx(enode, svg_h, 0);

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5995,6 +5995,19 @@ bool IsEmptySpace( const lChar32 * text, int len )
    return true;
 }
 
+bool ldomNode::isWhitespaceText() const
+{
+    if ( !isText() )
+        return false;
+    const lString8 s8(getText8());
+    const lChar8 * text = s8.c_str();
+    int len = s8.length();
+    for ( int i=0; i<len; i++ )
+        if ( text[i]!=' ' && text[i]!='\r' && text[i]!='\n' && text[i]!='\t' )
+            return false;
+    return true;
+}
+
 
 /////////////////////////////////////////////////////////////////
 /// lxmlElementWriter
@@ -7868,8 +7881,22 @@ void ldomNode::initNodeRendMethod()
                 // a cache file is used, and we'll end up being erm_final anyway).
                 // But let's keep it, in case it handles some edge cases.
             } else {
+                bool skipAutoboxLoop = false;
+                // Most mixed-content HTML nodes only have block children plus
+                // formatting whitespace text nodes. Drop these ignorable text
+                // runs in one compaction pass before the older autobox loop,
+                // so we don't pay for thousands of middle-of-array removals.
+                if ( removeStandaloneWhitespaceTextChildrenInMixedContent(handleFloating) ) {
+                    detectChildTypes( this, hasBlockItems, hasInline, hasInternalTableItems, hasFloating, handleFloating );
+                    if ( !hasInline ) {
+                        // If only block-ish children remain after that cleanup,
+                        // we can avoid the autobox pass entirely.
+                        setRendMethod( erm_block );
+                        skipAutoboxLoop = true;
+                    }
+                }
                 // cleanup or autobox
-                int i=getChildCount()-1;
+                int i = skipAutoboxLoop ? -1 : getChildCount()-1;
                 for ( ; i>=0; i-- ) {
                     ldomNode * node = getChildNode(i);
 
@@ -21475,6 +21502,81 @@ void ldomNode::addChild( lInt32 childNodeIndex )
         modify(); // convert to mutable element
     tinyElement * me = NPELEM;
     me->_children.add( childNodeIndex );
+}
+
+bool ldomNode::removeStandaloneWhitespaceTextChildrenInMixedContent( bool handleFloating )
+{
+#if BUILD_LITE!=1
+    ASSERT_NODE_NOT_NULL;
+    if ( !isElement() )
+        return false;
+    // In mixed block/inline content, most inline runs are often just whitespace
+    // separators between block siblings (typical HTML pretty-printing). The
+    // legacy autoboxChildren() path would later remove them one by one from the
+    // middle of a potentially huge _children array, which is quadratic. Compact
+    // them in one pass here, now that styles and rendMethods tell us whether
+    // such whitespace is really ignorable in this context.
+    tinyElement * me = isPersistent() ? NULL : NPELEM;
+    int childCount = getChildCount();
+    if ( childCount == 0 )
+        return false;
+    LVArray<lInt32> keptChildren;
+    bool compacting = false;
+    for ( int i=0; i<childCount; ) {
+        ldomNode * node = getChildNode(i);
+        if ( node->isWhitespaceText() ) {
+            int j = i;
+            while ( j+1 < childCount && getChildNode(j+1)->isWhitespaceText() )
+                j++;
+            ldomNode * prev = i > 0 ? getChildNode(i-1) : NULL;
+            ldomNode * next = j+1 < childCount ? getChildNode(j+1) : NULL;
+            bool prevInlineish = prev && ( isInlineNode(prev) || (handleFloating && isFloatingNode(prev)) );
+            bool nextInlineish = next && ( isInlineNode(next) || (handleFloating && isFloatingNode(next)) );
+            // Keep whitespace only when it sits between inline-ish siblings.
+            // Leading/trailing whitespace around such runs, and whitespace
+            // between block siblings, would be trimmed or removed later by
+            // autoboxChildren(); doing it in one pass avoids many costly
+            // middle-of-array removals on huge child collections.
+            bool keepRun = prevInlineish && nextInlineish && ( isInlineNode(prev) || isInlineNode(next) );
+            if ( keepRun ) {
+                if ( compacting ) {
+                    for ( int k=i; k<=j; k++ )
+                        keptChildren.add( me->_children[k] );
+                }
+            }
+            else {
+                if ( !compacting ) {
+                    // Keep the common no-removal path cheap: delay both modify()
+                    // and temporary array allocation until we have found the
+                    // first whitespace run that should really be dropped.
+                    if ( !me ) {
+                        modify();
+                        me = NPELEM;
+                    }
+                    compacting = true;
+                    keptChildren.reserve(childCount);
+                    for ( int k=0; k<i; k++ )
+                        keptChildren.add( me->_children[k] );
+                }
+                for ( int k=i; k<=j; k++ )
+                    getChildNode(k)->destroy();
+            }
+            i = j + 1;
+            continue;
+        }
+        if ( compacting )
+            keptChildren.add( me->_children[i] );
+        i++;
+    }
+    if ( compacting ) {
+        me->_children = keptChildren;
+        return true;
+    }
+    return false;
+#else
+    CR_UNUSED(handleFloating);
+    return false;
+#endif
 }
 
 /// move range of children startChildIndex to endChildIndex inclusively to specified element

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -5987,7 +5987,7 @@ bool lxmlDocBase::deserializeMaps( SerialBuf & buf )
 }
 #endif
 
-bool IsEmptySpace( const lChar32 * text, int len )
+static bool IsEmptySpace( const lChar32 * text, int len )
 {
    for (int i=0; i<len; i++)
       if ( text[i]!=' ' && text[i]!='\r' && text[i]!='\n' && text[i]!='\t')
@@ -6792,14 +6792,12 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
     // (Note: did not check how floats inside <PRE> are supposed to work)
     if ( !pre ) {
         while ( firstNonEmpty<=endIndex && getChildNode(firstNonEmpty)->isText() ) {
-            lString32 s = getChildNode(firstNonEmpty)->getText();
-            if ( !IsEmptySpace(s.c_str(), s.length() ) )
+            if ( !getChildNode(firstNonEmpty)->isWhitespaceText() )
                 break;
             firstNonEmpty++;
         }
         while ( lastNonEmpty>=endIndex && getChildNode(lastNonEmpty)->isText() ) {
-            lString32 s = getChildNode(lastNonEmpty)->getText();
-            if ( !IsEmptySpace(s.c_str(), s.length() ) )
+            if ( !getChildNode(lastNonEmpty)->isWhitespaceText() )
                 break;
             lastNonEmpty--;
         }
@@ -6810,8 +6808,7 @@ void ldomNode::autoboxChildren( int startIndex, int endIndex, bool handleFloatin
                 hasInline = true;
                 if ( !hasNonEmptyInline ) {
                     if (node->isText()) {
-                        lString32 s = node->getText();
-                        if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
+                        if ( !node->isWhitespaceText() ) {
                             hasNonEmptyInline = true;
                         }
                     }
@@ -6942,8 +6939,7 @@ bool ldomNode::cleanIfOnlyEmptyTextInline( bool handleFloating )
     for ( ; i>=0; i-- ) {
         ldomNode * node = getChildNode(i);
         if ( node->isText() ) {
-            lString32 s = node->getText();
-            if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
+            if ( !node->isWhitespaceText() ) {
                 return false;
             }
         }
@@ -6981,8 +6977,7 @@ bool ldomNode::hasNonEmptyInlineContent( bool ignoreFloats )
     // padding top/bottom (and height if check ENSURE_STYLE_HEIGHT)
     // if these will introduce some content.
     if ( isText() ) {
-        lString32 s = getText();
-        return !IsEmptySpace(s.c_str(), s.length() );
+        return !isWhitespaceText();
     }
     if (getNodeId() == el_br) {
         return true;
@@ -7055,14 +7050,12 @@ ldomNode * ldomNode::boxWrapChildren( int startIndex, int endIndex, lUInt16 elem
     int lastNonEmpty = endIndex;
     if (!pre) {
         while ( firstNonEmpty<=endIndex && getChildNode(firstNonEmpty)->isText() ) {
-            lString32 s = getChildNode(firstNonEmpty)->getText();
-            if ( !IsEmptySpace(s.c_str(), s.length() ) )
+            if ( !getChildNode(firstNonEmpty)->isWhitespaceText() )
                 break;
             firstNonEmpty++;
         }
         while ( lastNonEmpty>=endIndex && getChildNode(lastNonEmpty)->isText() ) {
-            lString32 s = getChildNode(lastNonEmpty)->getText();
-            if ( !IsEmptySpace(s.c_str(), s.length() ) )
+            if ( !getChildNode(lastNonEmpty)->isWhitespaceText() )
                 break;
             lastNonEmpty--;
         }
@@ -7129,8 +7122,7 @@ int initTableRendMethods( ldomNode * enode, int state )
             if ( child->getNodeId() == el_autoBoxing && child->getChildCount() == 1 && child->getChildNode(0)->isText()) {
                 // A text node wrapped in an <autoBoxing> because it was surrounded
                 // by non-inline elements (the other table subelements)
-                lString32 s = child->getChildNode(0)->getText();
-                if ( IsEmptySpace(s.c_str(), s.length()) ) {
+                if ( child->getChildNode(0)->isWhitespaceText() ) {
                     is_whitespace = true;
                 }
             }
@@ -7141,8 +7133,7 @@ int initTableRendMethods( ldomNode * enode, int state )
             // by the XML parsers, but we may see some when completing
             // incomplete tables or when white-space:pre, or in case of
             // style changes (inline > table) after a book has been loaded.
-            lString32 s = child->getText();
-            if ( IsEmptySpace(s.c_str(), s.length()) ) {
+            if ( child->isWhitespaceText() ) {
                 is_whitespace = true;
             }
         }
@@ -7642,8 +7633,7 @@ void ldomNode::initNodeRendMethod()
                     // are all empty text.
                     for ( int i=0; i < getChildCount(); i++ ) {
                         if ( getChildNode(i)->isText() ) {
-                            lString32 s = getChildNode(i)->getText();
-                            if ( !IsEmptySpace(s.c_str(), s.length() ) ) {
+                            if ( !getChildNode(i)->isWhitespaceText() ) {
                                 has_non_empty_text_nodes = true;
                                 break;
                             }
@@ -7687,14 +7677,12 @@ void ldomNode::initNodeRendMethod()
                             // Remove any preceeding or following empty text nodes (there can't
                             // be consecutive text nodes) so we don't get spurious empty lines.
                             if ( i < getChildCount()-1 && getChildNode(i+1)->isText() ) {
-                                lString32 s = getChildNode(i+1)->getText();
-                                if ( IsEmptySpace(s.c_str(), s.length() ) ) {
+                                if ( getChildNode(i+1)->isWhitespaceText() ) {
                                     removeChildren(i+1, i+1);
                                 }
                             }
                             if ( i > 0 && getChildNode(i-1)->isText() ) {
-                                lString32 s = getChildNode(i-1)->getText();
-                                if ( IsEmptySpace(s.c_str(), s.length() ) ) {
+                                if ( getChildNode(i-1)->isWhitespaceText() ) {
                                     removeChildren(i-1, i-1);
                                     i--; // update our position
                                 }
@@ -7961,8 +7949,7 @@ void ldomNode::initNodeRendMethod()
                             int run_in_idx = inBetweenTextNode ? i-2 : i-1;
                             int block_idx = i;
                             if ( inBetweenTextNode ) {
-                                lString32 text = inBetweenTextNode->getText();
-                                if ( IsEmptySpace(text.c_str(), text.length() ) ) {
+                                if ( inBetweenTextNode->isWhitespaceText() ) {
                                     removeChildren(i-1, i-1);
                                     block_idx = i-1;
                                 }
@@ -8051,8 +8038,7 @@ void ldomNode::initNodeRendMethod()
                 int cm = child->getRendMethod();
                 int is_whitespace = false;
                 if ( child->getNodeId() == el_autoBoxing && child->getChildCount() == 1 && child->getChildNode(0)->isText() ) {
-                    lString32 s = child->getChildNode(0)->getText();
-                    if ( IsEmptySpace(s.c_str(), s.length()) )
+                    if ( child->getChildNode(0)->isWhitespaceText() )
                         is_whitespace = true;
                 }
                 if ( cd == css_d_table_cell ) {
@@ -8143,8 +8129,7 @@ void ldomNode::initNodeRendMethod()
             int cm = child->getRendMethod();
             int is_whitespace = false;
             if ( child->getNodeId() == el_autoBoxing && child->getChildCount() == 1 && child->getChildNode(0)->isText() ) {
-                lString32 s = child->getChildNode(0)->getText();
-                if ( IsEmptySpace(s.c_str(), s.length()) )
+                if ( child->getChildNode(0)->isWhitespaceText() )
                     is_whitespace = true;
             }
             bool is_misparented = false;
@@ -8384,8 +8369,7 @@ void ldomNode::initNodeRendMethod()
                         elemId = child->getNodeId();
                     }
                     else {
-                        lString32 s = child->getText();
-                        elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
+                        elemId = child->isWhitespaceText() ? -2 : -1;
                         // When meeting an empty space (elemId==-2), we'll delay wrapping
                         // decision to when we process the next node.
                         // We'll also not start a wrap with it.
@@ -8473,8 +8457,7 @@ void ldomNode::initNodeRendMethod()
                             elemId = child->getNodeId();
                         }
                         else {
-                            lString32 s = child->getText();
-                            elemId = IsEmptySpace(s.c_str(), s.length()) ? -2 : -1;
+                            elemId = child->isWhitespaceText() ? -2 : -1;
                             // When meeting an empty space (elemId==-2), we'll delay wrapping
                             // decision to when we process the next node.
                             // We'll also not start a wrap with it.

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -4359,7 +4359,8 @@ static void writeSVGNode( LVStream * stream, ldomNode * node, bool forward_node_
 static void addAtImportCssFiles(ldomDocument * document, lString32 cssFile, lString32Collection & cssFiles); // defined just below writeNodeEx()
 
 static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection & cssFiles, LVStream * extra_stream, int wflags=0,
-    ldomXPointerEx startXP=ldomXPointerEx(), ldomXPointerEx endXP=ldomXPointerEx(), int indentBaseLevel=-1)
+    ldomXPointerEx startXP=ldomXPointerEx(), ldomXPointerEx endXP=ldomXPointerEx(), int indentBaseLevel=-1,
+    ldomXPointerEx * currentXP=NULL, const ldomXPointerEx * startNodeXP=NULL, const ldomXPointerEx * endNodeXP=NULL)
 {
     bool isStartNode = false;
     bool isEndNode = false;
@@ -4367,48 +4368,46 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
     bool isBeforeEnd = false;
     bool containsStart = false;
     bool containsEnd = false;
+    // We used to recompute ldomXPointerEx(node, 0) at each recursive
+    // step, but that can be expensive on huge flat DOMs because it has
+    // to rebuild the node path from parent/sibling indexes. It is
+    // cheaper to compute the initial xpointer once, then update it
+    // while descending/ascending recursion. These locals back the
+    // optional XPointer parameters during that recursion.
+    ldomXPointerEx currentXPBacking;
+    ldomXPointerEx startNodeXPBacking;
+    ldomXPointerEx endNodeXPBacking;
 
     if ( !startXP.isNull() && !endXP.isNull() ) {
-        ldomXPointerEx currentEXP = ldomXPointerEx(node, 0);
-        // Use start (offset=0) of text node for comparisons, but keep original XPointers
-        ldomXPointerEx startEXP = ldomXPointerEx( startXP );
-        startEXP.setOffset(0);
-        ldomXPointerEx endEXP = ldomXPointerEx( endXP );
-        endEXP.setOffset(0);
-        if (currentEXP == startEXP)
-            isStartNode = true;
-        if (currentEXP == endEXP)
-            isEndNode = true;
-        if ( currentEXP.compare( startEXP ) >= 0 ) {
-            isAfterStart = true;
+        if ( !currentXP ) {
+            // Initial call: compute these once
+            currentXPBacking = ldomXPointerEx(node, 0);
+            currentXP = &currentXPBacking;
+            // Use start/end with offset=0 for node comparisons, but keep the
+            // original XPointers for text slicing below.
+            startNodeXPBacking = ldomXPointerEx( startXP );
+            startNodeXPBacking.setOffset(0);
+            startNodeXP = &startNodeXPBacking;
+            endNodeXPBacking = ldomXPointerEx( endXP );
+            endNodeXPBacking.setOffset(0);
+            endNodeXP = &endNodeXPBacking;
         }
-        if ( currentEXP.compare( endEXP ) <= 0 ) {
-            isBeforeEnd = true;
-        }
-        ldomNode *tmp;
-        tmp = startXP.getNode();
-        while (tmp) {
-            if (tmp == node) {
-                containsStart = true;
-                break;
-            }
-            tmp = tmp->getParentNode();
-        }
-        tmp = endXP.getNode();
-        while (tmp) {
-            if (tmp == node) {
-                containsEnd = true;
-                break;
-            }
-            tmp = tmp->getParentNode();
-        }
+        int cmpStart = currentXP->compare( *startNodeXP );
+        int cmpEnd = currentXP->compare( *endNodeXP );
+        isStartNode = cmpStart == 0;
+        isEndNode = cmpEnd == 0;
+        isAfterStart = cmpStart >= 0;
+        isBeforeEnd = cmpEnd <= 0;
+        containsStart = currentXP->isPathPrefixOf( *startNodeXP );
+        containsEnd = currentXP->isPathPrefixOf( *endNodeXP );
     }
     else {
+        // Whole subtree: no comparison and no XPointer maintenance needed
         containsStart = true;
         containsEnd = true;
         isAfterStart = true;
         isBeforeEnd = true;
-        // but not isStartNode nor isEndNode, as these use startXP and endXP
+        // but not isStartNode nor isEndNode: no actual start/end boundary node
     }
 
     bool isInitialNode = false;
@@ -4806,7 +4805,11 @@ static void writeNodeEx( LVStream * stream, ldomNode * node, lString32Collection
                 *stream << "\n";
             if ( ! isStylesheetTag ) {
                 for ( int i=0; i<(int)node->getChildCount(); i++ ) {
-                    writeNodeEx( stream, node->getChildNode(i), cssFiles, extra_stream, wflags, startXP, endXP, indentBaseLevel );
+                    bool moved = currentXP ? currentXP->child(i) : false;
+                    writeNodeEx( stream, node->getChildNode(i), cssFiles, extra_stream, wflags, startXP, endXP, indentBaseLevel,
+                        currentXP, startNodeXP, endNodeXP );
+                    if ( moved )
+                        currentXP->parent();
                 }
             }
             else {
@@ -12001,6 +12004,17 @@ void ldomXPointerEx::initIndex()
     for ( int i=0; i<_level; i++ ) {
         _indexes[ i ] = m[ _level - i - 1 ];
     }
+}
+
+bool ldomXPointerEx::isPathPrefixOf( const ldomXPointerEx & v ) const
+{
+    if ( _level > v._level )
+        return false;
+    for ( int i=0; i<_level; i++ ) {
+        if ( _indexes[i] != v._indexes[i] )
+            return false;
+    }
+    return true;
 }
 
 /// move to sibling #

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19,7 +19,7 @@
 // Users of this library can request the old behaviour by setting
 // gDOMVersionRequested to an older version to request the old (possibly
 // buggy) behaviour.
-#define DOM_VERSION_CURRENT 20240114
+#define DOM_VERSION_CURRENT 20260812
 
 // Also defined in include/lvtinydom.h
 #define DOM_VERSION_WITH_NORMALIZED_XPOINTERS 20200223
@@ -88,6 +88,10 @@
 // EPUB <spine>, and not only those with media-type="application/xhtml+xml".
 // This means we can insert <DocFragment> in the DOM that wouldn't be here
 // before, and risk DocFragment[index] in xpointers to get the index shifted.
+//
+// 20260812: XPointers serialized by toStringV2() now always emit an
+// explicit [1] for the first sibling element of its kind. This avoids
+// costly forward sibling scans.
 
 #include "crsetup.h"
 
@@ -11604,10 +11608,15 @@ lString32 ldomXPointer::toStringV2()
             lString32 name = p->getNodeName();
             if ( !parent )
                 return "/" + name + path;
+            // The following "cosmetic" xpointer string tweak could be costly
+            // in some cases. Do it only when an older dom_version is requested
+            // (= previously opened books, as frontend may rely on raw string
+            // equality with saved annotations).
+            bool explicitFirstIndex = getDocument()->getDOMVersionRequested() >= 20260812;
             int count = 0;
             ldomNodeIdPredicate predicat(p->getNodeId());
             int index = getElementIndex(parent, p, predicat, count);
-            if ( count == 1 ) {
+            if ( !explicitFirstIndex && count == 1 ) {
                 // We're first, but see if we have following siblings with the
                 // same element name, so we can have "div[1]" instead of "div"
                 // when parent has more than one of it (as toStringV1 does).
@@ -11619,7 +11628,7 @@ lString32 ldomXPointer::toStringV2()
                     }
                 }
             }
-            if ( count>1 )
+            if ( explicitFirstIndex || count>1 )
                 path = cs32("/") + name + "[" + fmt::decimal(index) + "]" + path;
             else
                 path = cs32("/") + name + path;
@@ -11627,9 +11636,10 @@ lString32 ldomXPointer::toStringV2()
             // text
             if ( !parent )
                 return cs32("/text()") + path;
+            bool explicitFirstIndex = getDocument()->getDOMVersionRequested() >= 20260812;
             int count = 0;
             int index = getElementIndex(parent, p, isTextNode, count);
-            if ( count == 1 ) {
+            if ( !explicitFirstIndex && count == 1 ) {
                 // We're first, but see if we have following text siblings,
                 // so we can have "text()[1]" instead of "text()" when
                 // parent has more than one text node (as toStringV1 does).
@@ -11641,7 +11651,7 @@ lString32 ldomXPointer::toStringV2()
                     }
                 }
             }
-            if ( count>1 )
+            if ( explicitFirstIndex || count>1 )
                 path = cs32("/text()") + "[" + fmt::decimal(index) + "]" + path;
             else
                 path = "/text()" + path;


### PR DESCRIPTION
#### lvrend: getStyledImageSize(): fix SVG sizing

Removed the special handling of SVG wrapper that was computing a height in % relative to the page height. It seems it all works just fine when computing only the width.
This fixes spuriously page-tall inline SVG wrappers.
See https://github.com/koreader/koreader/issues/15842#issuecomment-5239103745
Should allow closing https://github.com/koreader/koreader/issues/15842

#### lvtinydom: toStringV2(): drop forward sibling scans

For a first DIV child, if was checking if it had any other DIV sibling, to output `/div[1]` if yes but only `/div` if not. The forward sibling scan, needed to establish that, can be quite costly in some cases, so no longer do it.
Bump DOM version as frontend may rely on raw string equality of xpointers with past saved annotations.
See https://github.com/koreader/koreader/issues/15848#issuecomment-5241249814.
Should allow closing https://github.com/koreader/koreader/issues/15848.

#### lvtinydom: writeNodeEx(): avoid expensive ldomXPointerEx()

Build, manipulate and pass ldomXPointerEx instead of recreating a new one from the node, which can be expensive when tree traversal involves nodes having a large collections of children.

#### lvtinydom: initNodeRendMethod() optimize specific case

Most mixed-content HTML nodes only have block children plus formatting whitespace text nodes. Drop these ignorable text runs in one compaction pass before the classic autobox loop, so we don't pay for thousands of middle-of-array removals.
(This reduces the loading time of a book having a `<body>` with 100,000 `<p>...</p>\n` children by 90%.)

These 2 commits fix other slowness, with View HTML and first book opening, noticed while investigating https://github.com/koreader/koreader/issues/15848.

#### lvtinydom/lvrend: use isWhitespaceText()

Replace usages of IsEmptySpace() (which was needlessly converting to Unicode) with the recently added node->isWhitespaceText().
As suggested by @benoit-pierre below.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/723)
<!-- Reviewable:end -->
