### PR TITLE
CSS initial-letter: carry exclusion across following blocks

### DIFF
--- a/crengine/include/lvrend.h
+++ b/crengine/include/lvrend.h
@@ -45,6 +45,7 @@
 #define RENDER_RECT_FLAG_BOX_IS_POSITIONNED                 0x0400 // for inlineBox (when X/Y set in its erm_final)
 #define RENDER_RECT_FLAG_DO_MATH_TRANSFORM                  0x0800 // do math glyph stretching
 #define RENDER_RECT_FLAG_BOX_IS_DISCARDED                   0x1000 // source inlineBox hidden in favor of a ::first-line clone owner
+#define RENDER_RECT_FLAG_NO_CLEAR_OWN_INITIAL_LETTER        0x2000
 #define RENDER_RECT_FLAG_TEMP_USED_AS_CSS_CHECK_CACHE       0x8000 // has been cleared and is used as a CSS checks cache
 
 #define RENDER_RECT_SET_FLAG(r, f)     ( r.setFlags( r.getFlags() | RENDER_RECT_FLAG_##f ) )
@@ -84,6 +85,7 @@ public:
     // Forwarded from BLOCK_RENDERING_DO_NOT_CLEAR_OWN_FLOATS
     // (or not when table cell erm_final)
     bool no_clear_own_floats;
+    bool no_clear_own_initial_letter;
     bool use_floatIds;
     // Footprints, used when they are more than 5 floats involved,
     // or ALLOW_EXACT_FLOATS_FOOTPRINTS not enabled.
@@ -93,14 +95,29 @@ public:
     int right_h;
     int left_min_y;
     int right_min_y;
-    // FloatIds, used when less than 5 floats involved
-    // and ALLOW_EXACT_FLOATS_FOOTPRINTS enabled
+    // FloatIds, used when there are at most 5 exact saved nodes involved
+    // and ALLOW_EXACT_FLOATS_FOOTPRINTS enabled. These are usually floatBox
+    // nodes, but one slot may be used by an initial-letter inlineBox so
+    // we can rebuild its carried exclusion without extra cached fields.
     int nb_floatIds;
     lUInt32 floatIds[5];
     // Floats to transfer to final block for it to
     // start with these 5 "fake" embedded floats
     int floats_cnt;
     int floats[5][6]; // max 5 floats, with (x,y,w,h,is_right,inward_margin) each
+    // Initial letter exclusion area (from a previous formatting) but still active,
+    // transferred to a new final block formatting so it can wrap around.
+    bool initial_letter_active;
+    lUInt32 initial_letter_id;
+    int  initial_letter_end_y;
+    int  initial_letter_x;
+    int  initial_letter_width;
+    bool initial_letter_is_right;
+    // New initial letter received from a final block formatting when it has
+    // met one, possibly still ongoing and to carry onto next formattings.
+    lUInt32 formatted_initial_letter_id;
+    bool formatted_initial_letter_carry_on;
+    int  formatted_initial_letter_carry_end_y;
 
     int getFinalMinY() { return used_min_y; };
     int getFinalMaxY() { return used_max_y; };
@@ -109,13 +126,20 @@ public:
     void generateEmbeddedFloatsFromFootprints( int final_width );
     void generateEmbeddedFloatsFromFloatIds( ldomNode * node, int final_width );
     void forwardOverflowingFloat( int x, int y, int w, int h, bool r, ldomNode * node );
+    void forwardFoundInitialLetter(lUInt32 node_id, bool carry_on, int end_y);
     int getTopShiftX(int final_width, bool get_right_shift=false);
 
-    BlockFloatFootprint( FlowState * fl=NULL, int dleft=0, int dtop=0, bool noclearownfloats=false ) :
+    BlockFloatFootprint( FlowState * fl=NULL, int dleft=0, int dtop=0,
+                         bool noclearownfloats=false, bool noclearowninitialletter=false ) :
         flow(fl), d_left(dleft), d_top(dtop), used_min_y(0), used_max_y(0),
-        no_clear_own_floats(noclearownfloats), use_floatIds(false),
+        no_clear_own_floats(noclearownfloats),
+        no_clear_own_initial_letter(noclearowninitialletter), use_floatIds(false),
         left_w(0), left_h(0), right_w(0), right_h(0), left_min_y(0), right_min_y(0),
-        nb_floatIds(0), floats_cnt(0)
+        nb_floatIds(0), floats_cnt(0),
+        initial_letter_active(false), initial_letter_id(0), initial_letter_end_y(0),
+        initial_letter_x(0), initial_letter_width(0), initial_letter_is_right(false),
+        formatted_initial_letter_id(0),
+        formatted_initial_letter_carry_on(false), formatted_initial_letter_carry_end_y(0)
         { }
 };
 

--- a/crengine/include/renderutil.h
+++ b/crengine/include/renderutil.h
@@ -4,6 +4,19 @@
 // Keep this header narrow: only expose helpers that need to be shared across
 // those translation units. At the moment, that public surface is entirely
 // about CSS initial-letter support.
+//
+// Initial-letter support ends up needing a few different geometries:
+// - the inlineBox host rect: the ordinary layout/container box
+// - the ink rect: the actual painted visual footprint, used for hit-testing
+//   and final-block overflow adjustment
+// - the exclusion geometry: the wrap/carry obstacle used for later lines and
+//   later blocks
+// - the selection/highlight rects: these are *not* provided here, and still
+//   come from the normal formatted-text/xpointer rect code in lvtinydom.cpp
+//
+// This header therefore covers only the initial-letter-specific shared
+// geometry helpers; ordinary text selection geometry remains on the regular
+// ldomXPointer::getRect() path.
 
 #ifndef __RENDERUTIL_H_INCLUDED__
 #define __RENDERUTIL_H_INCLUDED__
@@ -16,14 +29,16 @@ struct InitialLetterInlineBoxMetrics
 {
     // placement_baseline is the inline-box baseline to use on the first line.
     // exclusion_height is how far the sunk shape must exclude following lines,
-    // and top_overflow is the real ink that sticks above the first line top.
+    // top_overflow is the real ink that sticks above the first line top, and
+    // ink_bottom is the real painted bottom relative to the inline-box top.
     bool valid;
     int placement_baseline;
     int exclusion_height;
     int top_overflow;
+    int ink_bottom;
 
     InitialLetterInlineBoxMetrics()
-        : valid(false), placement_baseline(0), exclusion_height(0), top_overflow(0)
+        : valid(false), placement_baseline(0), exclusion_height(0), top_overflow(0), ink_bottom(0)
     {
     }
 };
@@ -56,6 +71,11 @@ bool hasAppliedInitialLetter(css_style_rec_t * style);
 // and returns the pseudo-element when present.
 ldomNode * getInitialLetterInlineBoxPseudoElem(ldomNode * inline_box);
 
+// Resolve an initial-letter inlineBox from its cached tiny-node id. The carry
+// path keeps this id as its stable source of truth and rebuilds geometry from
+// the current RenderRectAccessor when needed.
+ldomNode * getInitialLetterInlineBoxById(ldomDocument * doc, lUInt32 node_id);
+
 // Build the rendering bundle for an applied initial-letter pseudo-element.
 // This gives renderFinalBlock() one always-usable place to fetch the enlarged
 // font, the pseudo block strut/band metrics, and the line-height for the
@@ -71,9 +91,27 @@ bool getInitialLetterTextLayout(ldomNode * enode, int default_line_height,
 bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseline,
         InitialLetterInlineBoxMetrics & metrics);
 
+// Return how much painted ink extends outside the host inline-box on each side.
+// The vertical exclusion math differs between formatter and renderer, but this
+// horizontal widening is shared by line measurement and carried exclusion.
+bool getInitialLetterInlineBoxHorizontalInkOverflow(ldomNode * inline_box,
+        int & left_overflow, int & right_overflow);
+
 // Return the ink-tight rectangle for an inline-box-backed initial-letter.
 // This keeps the horizontal footprint reserved by layout, but trims the
 // vertical bounds to the actual glyph ink for hit-testing/highlight purposes.
 bool getInitialLetterInlineBoxInkRect(ldomNode * inline_box, lvRect & rect);
+
+// Rebuild the carried later-line exclusion directly from an initial-letter
+// inlineBox render cache entry. This is used when reformatting later blocks:
+// we keep the inlineBox node id in the saved float-id list and derive the same
+// exclusion geometry from its cached absolute rect and baseline.
+bool getInitialLetterInlineBoxExclusion(ldomNode * inline_box, int & abs_x, int & width,
+        int & abs_end_y, bool & is_right);
+
+// Convenience wrapper around getInitialLetterInlineBoxExclusion() when the
+// caller only has the cached inlineBox id.
+bool getInitialLetterInlineBoxExclusionById(ldomDocument * doc, lUInt32 node_id,
+        int & abs_x, int & width, int & abs_end_y, bool & is_right);
 
 #endif // __RENDERUTIL_H_INCLUDED__

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -5877,6 +5877,9 @@ private:
     int  last_split_after_flag; // in case we need to adjust upcoming line's flag vs previous line's
     bool in_non_linear_sequence;
     bool in_combining_non_linear_sequence;
+    bool initial_letter_active;
+    lUInt32 initial_letter_id; // inlineBox id (x/width/side are rebuilt from it when needed)
+    int  initial_letter_end_y; // flow-relative end y, kept only for quick "already past current y?" checks
 
     // vm_* : state of our handling of collapsable vertical margins
     bool vm_has_some;              // true when some vertical margin added, reset to false when pushed
@@ -5914,6 +5917,9 @@ public:
         last_split_after_flag(RN_SPLIT_AUTO),
         in_non_linear_sequence(false),
         in_combining_non_linear_sequence(false),
+        initial_letter_active(false),
+        initial_letter_id(0),
+        initial_letter_end_y(0),
         vm_has_some(false),
         vm_disabled(false),
         vm_target_avoid_pb_inside(false),
@@ -6099,6 +6105,41 @@ public:
         return baseline_y;
     }
 
+    bool hasCarriedInitialLetter() {
+        return initial_letter_active;
+    }
+    void resetCarriedInitialLetterExclusion() {
+        initial_letter_active = false;
+        initial_letter_id = 0;
+        initial_letter_end_y = 0;
+    }
+    void setCarriedInitialLetterExclusion( lUInt32 node_id, int end_y ) {
+        if ( node_id == 0 || end_y <= c_y ) {
+            resetCarriedInitialLetterExclusion();
+            return;
+        }
+        initial_letter_active = true;
+        initial_letter_id = node_id;
+        initial_letter_end_y = end_y;
+    }
+    bool advancePastCarriedInitialLetter() {
+        if ( !initial_letter_active ) {
+            return false;
+        }
+        int cleared_y = initial_letter_end_y;
+        int dy = cleared_y - c_y;
+        if ( dy > 0 ) {
+            addSpaceToContext(c_y, cleared_y, 1, false, false, false);
+            moveDown( dy );
+            seen_content_since_page_split = true;
+        }
+        resetCarriedInitialLetterExclusion();
+        return dy > 0;
+    }
+
+    bool hasActiveFloatFootprint() {
+        return _floats.length() > 0 || initial_letter_active;
+    }
     bool hasActiveFloats() {
         return _floats.length() > 0;
     }
@@ -6836,6 +6877,11 @@ public:
                     // no page split over them
                 }
             }
+            if ( initial_letter_active && initial_letter_end_y > new_c_y ) {
+                // A carried initial-letter tail cannot escape the block
+                // formatting context either.
+                new_c_y = initial_letter_end_y;
+            }
             // addSpaceToContext() will take care of avoiding page split
             // where some (non-cleared) floats are still running.
             addSpaceToContext(last_c_y, new_c_y, 1, false, false, false);
@@ -6908,6 +6954,9 @@ public:
                 _floats.remove(i);
                 delete flt;
             }
+        }
+        if ( initial_letter_active && initial_letter_end_y <= c_y ) {
+            resetCarriedInitialLetterExclusion();
         }
         return had_floats_running;
     }
@@ -7141,10 +7190,11 @@ public:
     BlockFloatFootprint getFloatFootprint(ldomNode * node, int d_left, int d_right, int d_top ) {
         // Returns the footprint of current floats over a final block
         // to be laid out at current c_y (+d_top).
-        // This footprint will be a set of floats to represent outer
-        // floats possibly having some impact over the final block
-        // about to be formatted.
-        // These floats can be either:
+        // This footprint is mainly a set of floats that represents outer
+        // floats possibly having some impact over the final block about to be
+        // formatted. It may also carry one active initial-letter exclusion.
+        //
+        // The float part can be either:
         // - real floats rectangles, when they are no more than 5
         //   and ALLOW_EXACT_FLOATS_FOOTPRINTS is enabled
         // - or "fake" floats ("footprints") embodying all floats
@@ -7153,7 +7203,15 @@ public:
         //   intersecting with this final block, but whose y sets
         //   the minimal y for the possible upcoming embedded floats.
         //
-        // Why at most "5" real floats?
+        // When a carried initial-letter is present, we keep it separate from
+        // these fake float footprints when we can spare an exact saved id slot:
+        // a later formatting can then rebuild its own dedicated exclusion
+        // geometry from that initial-letter inlineBox rect. It must stay a
+        // distinct obstacle, not a normal float rect: ordinary float clear
+        // semantics should not apply to it, and later real floats should not
+        // stack against a previous initial-letter as if it were an actual float.
+        //
+        // Why at most "5" exact saved ids?
         // Because I initially went with the "fake" floats solution,
         // because otherwise, storing references (per final block) to
         // a variable number of other floatBox nodes would need another
@@ -7167,16 +7225,23 @@ public:
         // the real floatBoxes node (which I can if they are no more
         // than 5), so we can fetch their real positions and dimensions
         // each time a final block is to be (re-)formatted, to allow
-        // for a nicer layout of text around these (at most 5) floats.
+        // for a nicer layout of text around these floats. One of these
+        // slots may also be used by a carried initial-letter inlineBox.
 
         // We need erm_final at level 1 (body, floatBox or inlineBox child)
         // to clear their own floats, to get them accounted in the document,
         // float, or inlineBox height, so they are fully contained in it and
         // don't overflow. (Level 0 can't be erm_final).
         bool no_clear_own_floats = (level > 1) && BLOCK_RENDERING(rend_flags, DO_NOT_CLEAR_OWN_FLOATS);
-        BlockFloatFootprint footprint = BlockFloatFootprint( this, d_left, d_top, no_clear_own_floats);
-        if (_floats.length() == 0) // zero footprint if no float
+        // We will handle cross-block initial-letter carry, the formatter
+        // will give us back the exclusion and doesn't need to grow its
+        // height to its ink bottom
+        bool no_clear_own_initial_letter = true;
+        BlockFloatFootprint footprint = BlockFloatFootprint( this, d_left, d_top,
+                                            no_clear_own_floats, no_clear_own_initial_letter );
+        if ( !hasActiveFloatFootprint() ) // no float, no initial letter
             return footprint;
+        bool allow_exact = BLOCK_RENDERING(rend_flags, ALLOW_EXACT_FLOATS_FOOTPRINTS);
         int top_y = c_y + d_top;
         int left_x = x_min + d_left;
         int right_x = x_max - d_right;
@@ -7198,7 +7263,7 @@ public:
         // printf("left_x = x_min %d + d_left %d = %d  top_y=%d\n", x_min, d_left, left_x, top_y);
         for (int i=0; i<_floats.length(); i++) {
             BlockFloat * flt = _floats[i];
-            if ( BLOCK_RENDERING(rend_flags, ALLOW_EXACT_FLOATS_FOOTPRINTS) ) {
+            if ( allow_exact ) {
                 // Ignore floats already passed by and possibly not yet removed
                 if (flt->bottom > top_y) {
                     if (floats_involved < 5) { // at most 5 slots
@@ -7260,12 +7325,54 @@ public:
                 }
             }
         }
-        if ( floats_involved > 0 && floats_involved <= 5) {
+        if ( initial_letter_active && initial_letter_end_y > top_y ) {
+            // FlowState keeps only the inlineBox id: we must rebuild
+            // the formatter obstacle x/width/side from the current
+            // cached inlineBox geometry.
+            int abs_x;
+            int width;
+            int abs_end_y;
+            bool is_right;
+            if ( getInitialLetterInlineBoxExclusionById( node->getDocument(),
+                            initial_letter_id, abs_x, width, abs_end_y, is_right ) ) {
+                int exclusion_x = abs_x - left_x;
+                int exclusion_right = exclusion_x + width;
+                if ( exclusion_x < 0 )
+                    exclusion_x = 0;
+                if ( exclusion_right > final_width )
+                    exclusion_right = final_width;
+                if ( exclusion_right > exclusion_x ) {
+                    footprint.initial_letter_active = true;
+                    footprint.initial_letter_id = initial_letter_id;
+                    footprint.initial_letter_x = exclusion_x;
+                    footprint.initial_letter_width = exclusion_right - exclusion_x;
+                    footprint.initial_letter_is_right = is_right;
+                    // The carried exclusion end_y is already stored in the same
+                    // y-space as c_y, so just rebase it to this final block text top.
+                    footprint.initial_letter_end_y = initial_letter_end_y - top_y;
+                }
+            }
+        }
+        bool save_initial_letter_as_exact_id = footprint.initial_letter_active;
+        int exact_ids_involved = floats_involved + (save_initial_letter_as_exact_id ? 1 : 0);
+        bool use_exact_ids = allow_exact && exact_ids_involved > 0 && exact_ids_involved <= 5;
+        if ( !use_exact_ids && save_initial_letter_as_exact_id && _floats.length() == 0 ) {
+            // Even when exact float footprints are disabled, we can still use one
+            // saved id to preserve a carried initial-letter if no real floats are
+            // currently active: there is then no float footprint information to lose.
+            use_exact_ids = true;
+        }
+        if ( use_exact_ids ) {
             // We can use floatIds
             footprint.use_floatIds = true;
             footprint.nb_floatIds = floats_involved;
-            // No need to call generateEmbeddedFloatsFromFloatIds() as we
-            // already computed them above.
+            if ( save_initial_letter_as_exact_id ) {
+                footprint.floatIds[footprint.nb_floatIds] = footprint.initial_letter_id;
+                footprint.nb_floatIds++;
+            }
+            // No need to call generateEmbeddedFloatsFromFloatIds() as we already
+            // computed the float rectangles above. If an initial-letter inlineBox id
+            // is present, restore() will rebuild its carried exclusion from it.
             /* Uncomment for checking reproducible results (here and below)
                footprint.generateEmbeddedFloatsFromFloatIds( node, final_width );
             */
@@ -7295,13 +7402,41 @@ public:
                 footprint.left_min_y = 0;
             if (footprint.right_min_y < 0 )
                 footprint.right_min_y = 0;
-            // Generate the float to transfer
+            if ( footprint.initial_letter_active ) {
+                // Rare fallback when we cannot spare one saved exact-id slot for
+                // the initial-letter inlineBox: clear below it by turning the
+                // top footprint into a full-width exclusion.
+                int clear_y = footprint.initial_letter_end_y;
+                if ( footprint.left_h < clear_y )
+                    footprint.left_h = clear_y;
+                if ( footprint.right_h > footprint.left_h )
+                    footprint.left_h = footprint.right_h;
+                footprint.left_w = final_width;
+                footprint.right_w = final_width;
+                footprint.right_h = footprint.left_h;
+                if ( footprint.left_min_y < clear_y )
+                    footprint.left_min_y = clear_y;
+                if ( footprint.right_min_y < clear_y )
+                    footprint.right_min_y = clear_y;
+                footprint.initial_letter_active = false;
+                footprint.initial_letter_id = 0;
+            }
+            // Generate the floats to transfer
             footprint.generateEmbeddedFloatsFromFootprints( final_width );
         }
         return footprint;
     }
 
 }; // Done with FlowState
+
+void BlockFloatFootprint::forwardFoundInitialLetter(lUInt32 node_id, bool carry_on, int end_y)
+{
+    formatted_initial_letter_id = node_id;
+    if ( carry_on && node_id != 0 && end_y > 0 ) {
+        formatted_initial_letter_carry_on = true;
+        formatted_initial_letter_carry_end_y = end_y;
+    }
+}
 
 // Register overflowing embedded floats into the main flow
 void BlockFloatFootprint::forwardOverflowingFloat( int x, int y, int w, int h, bool r, ldomNode * node )
@@ -7325,13 +7460,66 @@ void BlockFloatFootprint::generateEmbeddedFloatsFromFloatIds( ldomNode * node,  
     // RenderRectAccessor of the current node, and all the floats
     // that were associated to the node because of their involvement
     // in text layout.
+    // Most saved ids are floatBox nodes; one slot may also contain
+    // a carried initial-letter inlineBox so we can rebuild its
+    // dedicated exclusion geometry.
     lvRect rc;
     node->getAbsRect( rc, true ); // get formatted text abs coordinates
     int node_x = rc.left;
     int node_y = rc.top;
+    initial_letter_active = false;
+    initial_letter_id = 0;
+    initial_letter_end_y = 0;
+    initial_letter_x = 0;
+    initial_letter_width = 0;
+    initial_letter_is_right = false;
     floats_cnt = 0;
     for (int i=0; i<nb_floatIds; i++) {
         ldomNode * fbox = node->getDocument()->getTinyNode(floatIds[i]); // get node from its dataIndex
+        if ( !fbox ) {
+            crFatalError(145, "Missing saved float footprint node");
+        }
+        if ( fbox->getEffectiveNodeId() == el_inlineBox ) {
+            int abs_x;
+            int width;
+            int abs_end_y;
+            bool is_right;
+            if ( !getInitialLetterInlineBoxPseudoElem(fbox) ) {
+                crFatalError(146, "Saved float footprint inlineBox is not an initial-letter");
+            }
+            if ( !getInitialLetterInlineBoxExclusion(fbox, abs_x, width, abs_end_y, is_right) ) {
+                crFatalError(147, "Failed to rebuild saved initial-letter exclusion");
+            }
+            int x0 = abs_x - node_x;
+            int x1 = x0 + width;
+            if ( x0 < 0 )
+                x0 = 0;
+            else if ( x0 > final_width )
+                x0 = final_width;
+            if ( x1 < 0 )
+                x1 = 0;
+            else if ( x1 > final_width )
+                x1 = final_width;
+            int end_y = abs_end_y - node_y;
+            if ( end_y <= 0 ) {
+                crFatalError(148, "Saved initial-letter exclusion has invalid end_y");
+            }
+            if ( x1 <= x0 ) {
+                // This carried exclusion does not overlap the current final
+                // block width, so it has no effect on this block layout.
+                continue;
+            }
+            initial_letter_active = true;
+            initial_letter_id = floatIds[i];
+            initial_letter_end_y = end_y;
+            initial_letter_x = x0;
+            initial_letter_width = x1 - x0;
+            initial_letter_is_right = is_right;
+            continue;
+        }
+        if ( fbox->getEffectiveNodeId() != el_floatBox ) {
+            crFatalError(149, "Saved float footprint node has unexpected type");
+        }
         // The floatBox rect values should be exactly the same as what was
         // used in the flow's _floats when rendering. We can check if this
         // is not the case (so a bug) by uncommenting a few things below.
@@ -7463,6 +7651,12 @@ void BlockFloatFootprint::store(ldomNode * node)
     else {
         RENDER_RECT_UNSET_FLAG(fmt, NO_CLEAR_OWN_FLOATS);
     }
+    if ( no_clear_own_initial_letter ) {
+        RENDER_RECT_SET_FLAG(fmt, NO_CLEAR_OWN_INITIAL_LETTER);
+    }
+    else {
+        RENDER_RECT_UNSET_FLAG(fmt, NO_CLEAR_OWN_INITIAL_LETTER);
+    }
     fmt.push();
 }
 
@@ -7478,8 +7672,18 @@ void BlockFloatFootprint::restore(ldomNode * node, int final_width)
         fmt.getTopRectsExcluded( left_w, left_h, right_w, right_h );
         fmt.getNextFloatMinYs( left_min_y, right_min_y );
         generateEmbeddedFloatsFromFootprints( final_width );
+        // No exact carried initial-letter was saved on this path. If there had
+        // been one earlier, getFloatFootprint() already degraded it into a
+        // full-width clear footprint before storing these generic top rects.
+        initial_letter_active = false;
+        initial_letter_id = 0;
+        initial_letter_end_y = 0;
+        initial_letter_x = 0;
+        initial_letter_width = 0;
+        initial_letter_is_right = false;
     }
     no_clear_own_floats = RENDER_RECT_HAS_FLAG(fmt, NO_CLEAR_OWN_FLOATS);
+    no_clear_own_initial_letter = RENDER_RECT_HAS_FLAG(fmt, NO_CLEAR_OWN_INITIAL_LETTER);
 }
 
 int BlockFloatFootprint::getTopShiftX(int final_width, bool get_right_shift)
@@ -8441,6 +8645,15 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
         break_before = RN_SPLIT_ALWAYS;
     }
 
+    // If we have a carried initial-letter still active, and we meet a block
+    // with HasFirstLetter (which may or may not be an initial-letter), clear
+    // that initial-letter (per-specs if initial-letter, otherwise not, but
+    // simpler to not check if it is (which is expensive) and do it in all
+    // cases, probably for the best).
+    bool cleared_carried_initial_letter = flow->hasCarriedInitialLetter() && enode->hasAttribute(attr_HasFirstLetter)
+                                        ? flow->advancePastCarriedInitialLetter()
+                                        : false;
+
     if ( no_margin_collapse ) {
         // Push any earlier margin so it does not get collapsed with this one
         flow->pushVerticalMargin();
@@ -9022,8 +9235,11 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 // margin now (and not delay it to the first addContentLine()).
                 // This can mess with proper margins collapsing if we were to
                 // output no content (we don't know that yet).
-                // So, do it only if we have floats.
-                if ( flow->hasActiveFloats() )
+                // So, do it only if we have an active float footprint, or if we
+                // just cleared a carried initial-letter because this block starts
+                // with its own one: in both cases renderFinalBlock() must see the
+                // final post-margin absolute y before it stores its geometry.
+                if ( flow->hasActiveFloatFootprint() || cleared_carried_initial_letter )
                     flow->pushVerticalMargin();
 
                 int inner_width = width - padding_left - padding_right;
@@ -9135,6 +9351,48 @@ void renderBlockElementEnhanced( FlowState * flow, ldomNode * enode, int x, int 
                 int final_h = enode->renderFinalBlock( txform, &fmt, inner_width, &float_footprint );
                 int final_min_y = float_footprint.getFinalMinY();
                 int final_max_y = float_footprint.getFinalMaxY();
+
+                if ( float_footprint.formatted_initial_letter_id ) {
+                    ldomNode * initial_letter_inline_box = getInitialLetterInlineBoxById(enode->getDocument(),
+                                                                    float_footprint.formatted_initial_letter_id);
+                    if ( initial_letter_inline_box ) {
+                        // Initial-letter ink can extend beyond the formatter's own line box height,
+                        // so grow the final block overflow if that happens. As we can only get that
+                        // ink rect in abs coordinates, we must get our final rect abs coordinates
+                        // too (at this time, its x/y are set - they may be shifted later, but so
+                        // would the inlineBox: their difference will stay the same).
+                        lvRect final_abs_rect;
+                        enode->getAbsRect(final_abs_rect, true);
+                        lvRect initial_letter_abs_rect;
+                        if ( !getInitialLetterInlineBoxInkRect(initial_letter_inline_box, initial_letter_abs_rect) ) {
+                            // Fallback to the host inlineBox rect when precise ink geometry cannot be rebuilt;
+                            // it is less exact but still provides a safe conservative overflow bound.
+                            initial_letter_inline_box->getAbsRect(initial_letter_abs_rect);
+                        }
+                        int initial_letter_top = initial_letter_abs_rect.top - final_abs_rect.top;
+                        int initial_letter_bottom = initial_letter_abs_rect.bottom - final_abs_rect.top;
+                        if ( initial_letter_top < final_min_y ) {
+                            final_min_y = initial_letter_top;
+                        }
+                        if ( initial_letter_bottom > final_max_y ) {
+                            final_max_y = initial_letter_bottom;
+                        }
+                        // If formatting reported that our initial letter inline box overflows
+                        // its own rect, its exclusion must be carried onto following blocks.
+                        // (The above is about top and bottom ink overflows, used for drawing it,
+                        // this one is about the exclusion area affecting next rendering.)
+                        if ( float_footprint.formatted_initial_letter_carry_on ) {
+                            // Forward that local exclusion end_y into the current FlowState y-space.
+                            int final_text_top_in_flow = flow->getCurrentAbsoluteY() + padding_top;
+                            // Matches getFloatFootprint()'s top_y: convert between FlowState y-space
+                            // and the final block-local y-space used in BlockFloatFootprint.
+                            flow->setCarriedInitialLetterExclusion(float_footprint.formatted_initial_letter_id,
+                                    final_text_top_in_flow + float_footprint.formatted_initial_letter_carry_end_y );
+                        }
+                    }
+                }
+                // (If a previous carried exclusion has been passed over after this block height,
+                // it will be reset by any flow->addContent*() done below.)
 
                 flow->getPageContext()->updateRenderProgress(1);
                 #ifdef DEBUG_DUMP_ENABLED

--- a/crengine/src/lvtextfm.cpp
+++ b/crengine/src/lvtextfm.cpp
@@ -432,6 +432,7 @@ public:
     bool m_has_float_to_position;
     bool m_has_ongoing_float;
     bool m_no_clear_own_floats;
+    bool m_no_clear_own_initial_letter;
     kerning_mode_t m_kerning_mode;
     bool m_allow_strut_confining;
     bool m_has_multiple_scripts;
@@ -456,9 +457,13 @@ public:
     bool m_has_cjk; // true when some CJK met
     int  m_cjk_prev_line_added_space_div; // Used with CJK justified lines, to
     int  m_cjk_prev_line_added_space_mod; // apply same spacing on last line.
+    lUInt32 m_formatted_initial_letter_id;
+    int  m_formatted_initial_letter_ink_end_y;
     struct {
         bool active;
+        bool is_carried;
         bool is_right;
+        lUInt32 node_id;
         int x;
         int width;
         int start_y;
@@ -498,11 +503,16 @@ public:
         m_has_float_to_position = false;
         m_has_ongoing_float = false;
         m_no_clear_own_floats = false;
+        m_no_clear_own_initial_letter = false;
         m_has_multiple_scripts = false;
         m_usable_left_overflow = 0;
         m_usable_right_overflow = 0;
         m_hanging_punctuation = false;
+        m_formatted_initial_letter_id = 0;
+        m_formatted_initial_letter_ink_end_y = 0;
         m_initial_letter_exclusion.active = false;
+        m_initial_letter_exclusion.is_carried = false;
+        m_initial_letter_exclusion.node_id = 0;
         m_initial_letter_exclusion.is_right = false;
         m_initial_letter_exclusion.x = 0;
         m_initial_letter_exclusion.width = 0;
@@ -537,7 +547,6 @@ public:
         RenderRectAccessor fmt( node );
         InitialLetterInlineBoxMetrics metrics;
         if ( !getInitialLetterInlineBoxMetrics(node, fmt.getBaseline(), metrics) ) {
-            m_initial_letter_exclusion.active = false;
             return;
         }
         int exclusion_start = frmline->y + frmline->height;
@@ -545,31 +554,22 @@ public:
         // same vertical shift must extend the later-line exclusion footprint.
         int exclusion_end = frmline->y + metrics.top_overflow + metrics.exclusion_height;
         if ( exclusion_end <= exclusion_start ) {
-            m_initial_letter_exclusion.active = false;
             return;
         }
         int exclusion_x = fmt.getX();
         int exclusion_right = exclusion_x + fmt.getWidth();
         // This mirrors the width widening done when the inline-box is first measured.
-        lvRect ink_rect;
-        if ( getInitialLetterInlineBoxInkRect(node, ink_rect) ) {
-            lvRect box_rect;
-            node->getAbsRect(box_rect);
+        int left_overflow = 0;
+        int right_overflow = 0;
+        if ( getInitialLetterInlineBoxHorizontalInkOverflow(node, left_overflow, right_overflow) ) {
             if ( m_para_dir_is_rtl ) {
-                int left_overflow = box_rect.left - ink_rect.left;
-                if ( left_overflow > 0 ) {
-                    exclusion_x -= left_overflow;
-                }
+                exclusion_x -= left_overflow;
             }
             else {
-                int right_overflow = ink_rect.right - box_rect.right;
-                if ( right_overflow > 0 ) {
-                    exclusion_right += right_overflow;
-                }
+                exclusion_right += right_overflow;
             }
         }
         if ( exclusion_right <= 0 || exclusion_x >= m_pbuffer->width ) {
-            m_initial_letter_exclusion.active = false;
             return;
         }
         if ( exclusion_x < 0 ) {
@@ -578,12 +578,23 @@ public:
         if ( exclusion_right > m_pbuffer->width ) {
             exclusion_right = m_pbuffer->width;
         }
+        // We only report back (if/via float_footprint, to renderBlockElementEnhanced())
+        // the initial letter we found if it has generated an exclusion area.
+        lUInt32 node_id = node->getDataIndex();
+        m_formatted_initial_letter_id = node_id;
         m_initial_letter_exclusion.active = true;
+        m_initial_letter_exclusion.is_carried = false;
+        m_initial_letter_exclusion.node_id = node_id;
         m_initial_letter_exclusion.is_right = m_para_dir_is_rtl;
         m_initial_letter_exclusion.x = exclusion_x;
         m_initial_letter_exclusion.width = exclusion_right - exclusion_x;
         m_initial_letter_exclusion.start_y = exclusion_start;
         m_initial_letter_exclusion.end_y = exclusion_end;
+        int inline_box_top = frmline->y + frmline->baseline - word->o.baseline + word->y;
+        int ink_end = inline_box_top + metrics.ink_bottom;
+        if ( ink_end > m_formatted_initial_letter_ink_end_y ) {
+            m_formatted_initial_letter_ink_end_y = ink_end;
+        }
     }
 
     // Embedded floats positioning helpers.
@@ -896,6 +907,10 @@ public:
         // inner floats (we don't fill the height of outer floats (float_footprint)
         // as they can still apply over our siblings.)
         fillAndMoveToY( getFloatsMaxBottomY() );
+    }
+    void finalizeInitialLetterInk() {
+        // Similar for a still ongoing initial-letter
+        fillAndMoveToY( m_formatted_initial_letter_ink_end_y );
     }
     void fillAndMoveToY(int target_y) {
         // Adds blank lines to fill the vertical space from current m_y to target_y.
@@ -2411,21 +2426,14 @@ public:
                             // of the running text (ie. italic 'f').
                             // (activateInitialLetterInlineBoxExclusion() will do the same for
                             // the exclusion area).
-                            lvRect ink_rect;
-                            if ( getInitialLetterInlineBoxInkRect(node, ink_rect) ) {
-                                lvRect box_rect;
-                                node->getAbsRect(box_rect);
+                            int left_overflow = 0;
+                            int right_overflow = 0;
+                            if ( getInitialLetterInlineBoxHorizontalInkOverflow(node, left_overflow, right_overflow) ) {
                                 if ( m_para_dir_is_rtl ) {
-                                    int left_overflow = box_rect.left - ink_rect.left;
-                                    if ( left_overflow > 0 ) {
-                                        width += left_overflow;
-                                    }
+                                    width += left_overflow;
                                 }
                                 else {
-                                    int right_overflow = ink_rect.right - box_rect.right;
-                                    if ( right_overflow > 0 ) {
-                                        width += right_overflow;
-                                    }
+                                    width += right_overflow;
                                 }
                             }
                             // It feels we can let a space following the initial letter
@@ -3648,8 +3656,13 @@ public:
             // still spans this line
             frmline->flags |= LTEXT_LINE_SPLIT_AVOID_BEFORE;
         }
-        if ( m_initial_letter_exclusion.active && m_y < m_initial_letter_exclusion.end_y && !first ) {
-            // Avoid page split alongside a sinking initial letter
+        if ( m_initial_letter_exclusion.active && m_y < m_initial_letter_exclusion.end_y
+                                               && m_y >= m_initial_letter_exclusion.start_y ) {
+            // Avoid page split on every line actually affected by the exclusion.
+            // (Using the exclusion start_y rather than the naive:
+            //   (!first || m_initial_letter_exclusion.is_carried)
+            // keeps this working in these two cases and also when splitParagraphs() starts
+            // a new sub-paragraph after a <br/> and our initial letter still spans.)
             frmline->flags |= LTEXT_LINE_SPLIT_AVOID_BEFORE;
         }
         if ( lineIsBidi ) {
@@ -5667,18 +5680,6 @@ public:
             #endif
         }
 
-        // If we have an initial-letter still ongoing, extend that paragraph height
-        // so it contains it fully so it does not overlap on the following paragraph.
-        if ( isLastPara && m_initial_letter_exclusion.active && m_y < m_initial_letter_exclusion.end_y
-                && m_pbuffer->frmlinecount > 0 ) {
-            formatted_line_t * last_line = m_pbuffer->frmlines[m_pbuffer->frmlinecount - 1];
-            int extra_height = m_initial_letter_exclusion.end_y - m_y;
-            if ( last_line && extra_height > 0 ) {
-                last_line->height += extra_height;
-                m_y += extra_height;
-                m_pbuffer->height = m_y;
-            }
-        }
     }
 
     void processEmbeddedBlock( int idx )
@@ -5824,6 +5825,14 @@ public:
             // Clear our own floats so they are fully contained in this final block.
             finalizeFloats();
         }
+        if ( !m_no_clear_own_initial_letter ) {
+            // Likewise, contain our own initial-letter ink
+            // (When m_no_clear_own_initial_letter unset, we are rendering a table cell
+            // or a standalone float/inlinebox: we clear only down to the bottom ink,
+            // and not down to the exclusion area which is usually aligned to a paragraph
+            // line box, so possibly taller, which would leave some blank space.)
+            finalizeInitialLetterInk();
+        }
         if ( clear_after_last_flag ) {
             floatClearText( clear_after_last_flag );
         }
@@ -5965,6 +5974,7 @@ lUInt32 LFormattedText::Format(lUInt16 width, lUInt16 page_height, int para_dire
 
     if (float_footprint) {
         formatter.m_no_clear_own_floats = float_footprint->no_clear_own_floats;
+        formatter.m_no_clear_own_initial_letter = float_footprint->no_clear_own_initial_letter;
 
         // BlockFloatFootprint provides a set of floats to represent
         // outer floats possibly having some footprint over the final
@@ -5983,9 +5993,31 @@ lUInt32 LFormattedText::Format(lUInt16 width, lUInt16 page_height, int para_dire
             flt->is_right = (bool)(float_footprint->floats[i][4]);
             flt->inward_margin = float_footprint->floats[i][5];
         }
+        // It can also provide the exclusion area from a previous initial letter
+        // not fully consumed by its own final block.
+        if ( float_footprint->initial_letter_active ) {
+            formatter.m_initial_letter_exclusion.active = true;
+            formatter.m_initial_letter_exclusion.is_carried = true;
+            formatter.m_initial_letter_exclusion.node_id = float_footprint->initial_letter_id;
+            formatter.m_initial_letter_exclusion.is_right = float_footprint->initial_letter_is_right;
+            formatter.m_initial_letter_exclusion.x = float_footprint->initial_letter_x;
+            formatter.m_initial_letter_exclusion.width = float_footprint->initial_letter_width;
+            formatter.m_initial_letter_exclusion.start_y = 0;
+            formatter.m_initial_letter_exclusion.end_y = float_footprint->initial_letter_end_y;
+        }
     }
 
     lUInt32 h = formatter.format();
+
+    if ( float_footprint && formatter.m_formatted_initial_letter_id && float_footprint->no_clear_own_initial_letter ) {
+        // By the time formatting ends, m_formatted_initial_letter_id survives
+        // only if the formatter also installed the matching local exclusion.
+        bool carry_new_initial_letter = formatter.m_initial_letter_exclusion.active
+                                     && formatter.m_initial_letter_exclusion.end_y > (int)h;
+        float_footprint->forwardFoundInitialLetter(formatter.m_formatted_initial_letter_id,
+                                        carry_new_initial_letter,
+                                        formatter.m_initial_letter_exclusion.end_y);
+    }
 
     if ( float_footprint && float_footprint->no_clear_own_floats ) {
         // If we did not finalize/clear our embedded floats, forward

--- a/crengine/src/renderutil.cpp
+++ b/crengine/src/renderutil.cpp
@@ -82,6 +82,30 @@ static bool isAppliedInitialLetterPseudoElem(ldomNode * enode, css_style_rec_t *
             && hasAppliedInitialLetter(style);
 }
 
+// The actual ::first-letter pseudo can live below nested inline elements
+// (<i>, <span>, ...) and even below ::first-line cloneNodes. When we need the
+// paragraph-level grid or direction that own the initial-letter effect, walk
+// up the unboxed/effective ancestor chain until we reach the block that was
+// flagged with attr_HasFirstLetter.
+static ldomNode * getInitialLetterOwnerBlock(ldomNode * enode)
+{
+    if ( !enode ) {
+        return NULL;
+    }
+    ldomNode * node = enode->getEffectiveNode();
+    if ( !node ) {
+        return NULL;
+    }
+    ldomNode * ancestor = node->getUnboxedParent();
+    while ( ancestor ) {
+        if ( ancestor->hasAttribute(attr_HasFirstLetter) ) {
+            return ancestor;
+        }
+        ancestor = ancestor->getUnboxedParent();
+    }
+    return NULL;
+}
+
 // Initial-letter rides on top of the existing inline-box pipeline.
 // This helper recognizes the wrapper shape produced by that pipeline:
 // the inlineBox host, whose first child is the ::first-letter pseudo-element.
@@ -90,7 +114,11 @@ static bool isAppliedInitialLetterPseudoElem(ldomNode * enode, css_style_rec_t *
 // especially once ::first-line clones are involved.
 ldomNode * getInitialLetterInlineBoxPseudoElem(ldomNode * inline_box)
 {
-    if ( !inline_box || inline_box->getChildCount() <= 0 ) {
+    if ( !inline_box ) {
+        return NULL;
+    }
+    inline_box = inline_box->getEffectiveNode();
+    if ( !inline_box || inline_box->getEffectiveNodeId() != el_inlineBox || inline_box->getChildCount() <= 0 ) {
         return NULL;
     }
     ldomNode * node = inline_box->getChildNode(0);
@@ -102,6 +130,21 @@ ldomNode * getInitialLetterInlineBoxPseudoElem(ldomNode * inline_box)
         return NULL;
     }
     return node;
+}
+
+ldomNode * getInitialLetterInlineBoxById(ldomDocument * doc, lUInt32 node_id)
+{
+    if ( !doc || node_id == 0 ) {
+        return NULL;
+    }
+    ldomNode * inline_box = doc->getTinyNode(node_id);
+    if ( !inline_box || inline_box->getEffectiveNodeId() != el_inlineBox ) {
+        return NULL;
+    }
+    if ( !getInitialLetterInlineBoxPseudoElem(inline_box) ) {
+        return NULL;
+    }
+    return inline_box;
 }
 
 // Return the used line-height that initial-letter sizing should be based on.
@@ -460,23 +503,27 @@ static bool getInitialLetterInkBoundsPx(ldomNode * enode, css_style_rec_t * styl
 // Expand the pseudo's own one-line band back toward the parent line grid when
 // the visually tightened ink band would otherwise be noticeably smaller than
 // the surrounding natural lines.
-static bool getInitialLetterNaturalBandPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
-        const InitialLetterInkBounds & ink_bounds, int & expand_top, int & natural_height)
+//
+// Keep this owner-block-based top placement shared: newer initial-letter paths
+// (nested inline content, ::first-line clones, carried exclusion rebuild) all
+// need to agree on where the paragraph grid says the initial starts.
+static bool getInitialLetterTopOffsetPx(ldomNode * enode, css_style_rec_t * style,
+        LVFontRef font, int & top_offset, int & parent_line_height)
 {
-    expand_top = 0;
-    natural_height = 0;
-    ldomNode * parent = enode ? enode->getParentNode() : NULL;
-    if ( !parent || parent->isNull() || !style || font.isNull() ) {
+    top_offset = 0;
+    parent_line_height = 0;
+    ldomNode * owner = getInitialLetterOwnerBlock(enode);
+    if ( !owner || owner->isNull() || !style || font.isNull() ) {
         return false;
     }
-    css_style_ref_t parent_style_ref = parent->getStyle();
-    LVFontRef parent_font = parent->getFont();
-    if ( parent_style_ref.isNull() || parent_font.isNull() ) {
+    css_style_ref_t owner_style_ref = owner->getStyle();
+    LVFontRef owner_font = owner->getFont();
+    if ( owner_style_ref.isNull() || owner_font.isNull() ) {
         return false;
     }
-    css_style_rec_t * parent_style = parent_style_ref.get();
-    int parent_line_height = getInitialLetterStyleLineHeightPx(parent->getDocument(), parent,
-            parent_style, parent_font, -1);
+    css_style_rec_t * owner_style = owner_style_ref.get();
+    parent_line_height = getInitialLetterStyleLineHeightPx(owner->getDocument(), owner,
+            owner_style, owner_font, -1);
     if ( parent_line_height <= 0 ) {
         return false;
     }
@@ -484,19 +531,35 @@ static bool getInitialLetterNaturalBandPx(ldomNode * enode, css_style_rec_t * st
     if ( sink <= 0 ) {
         sink = 1;
     }
-    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(parent->getDocument(), parent,
-            parent_style, parent_font, -1);
+    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(owner->getDocument(), owner,
+            owner_style, owner_font, -1);
     int initial_baseline = font->getBaseline();
     int initial_letter_size = style->initial_letter.value >> 8;
-    int top_offset;
     if ( initial_letter_size >= sink * 256 ) {
         top_offset = parent_adjusted_baseline + (sink - 1) * parent_line_height - initial_baseline;
     }
     else {
-        int parent_cap_height = getInitialLetterFontCapHeightPx(parent_font);
+        int parent_cap_height = getInitialLetterFontCapHeightPx(owner_font);
         int initial_cap_height = getInitialLetterFontCapHeightPx(font);
         top_offset = parent_adjusted_baseline - parent_cap_height
                     - (initial_baseline - initial_cap_height);
+    }
+    return true;
+}
+
+static bool getInitialLetterNaturalBandPx(ldomNode * enode, css_style_rec_t * style, LVFontRef font,
+        const InitialLetterInkBounds & ink_bounds, int & expand_top, int & natural_height)
+{
+    expand_top = 0;
+    natural_height = 0;
+    int top_offset = 0;
+    int parent_line_height = 0;
+    if ( !getInitialLetterTopOffsetPx(enode, style, font, top_offset, parent_line_height) ) {
+        return false;
+    }
+    int sink = style->initial_letter.value & 0xFF;
+    if ( sink <= 0 ) {
+        sink = 1;
     }
     int actual_top = top_offset + ink_bounds.min_top;
     if ( actual_top > 0 ) {
@@ -537,6 +600,30 @@ static int getInitialLetterInkBottomPx(ldomNode * enode, css_style_rec_t * style
     return found ? max_bottom : -1;
 }
 
+// Initial-letter exclusion/overflow is primarily driven by glyph ink. Keep
+// underline support conservative: when underline is present, just extend the
+// lower bound to include the rule that DrawTextString() will paint below the
+// baseline. This is enough to avoid most clashes with following wrapped lines
+// or a later carried-initial clear, without trying to model decoration joins.
+//
+// We intentionally do not try the same for top decorations such as overline:
+// avoiding overlap with previous paragraphs would require real layout
+// clearance above the block, not just a larger overflow rect, and that feels
+// too invasive for such a rare case.
+static int getInitialLetterDecorationBottomPx(ldomNode * enode, css_style_rec_t * style,
+        LVFontRef font, int computed_em)
+{
+    if ( !isAppliedInitialLetterPseudoElem(enode, style) ) {
+        return -1;
+    }
+    if ( style->text_decoration != css_td_underline && style->text_decoration != css_td_blink ) {
+        return -1;
+    }
+    int adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(enode->getDocument(), enode, style, font, computed_em);
+    int underline_bottom = adjusted_baseline + font->getUnderlineOffset() + font->getUnderlineThickness();
+    return underline_bottom > adjusted_baseline ? underline_bottom : -1;
+}
+
 // Inline-box-backed initial-letter layout needs one more derived layer on top
 // of the raw font/ink helpers above: where should the box baseline sit on the
 // first line, and how much depth should later lines exclude below it?
@@ -551,25 +638,36 @@ bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseli
     if ( !pseudo ) {
         return false;
     }
-    ldomNode * parent = inline_box->getParentNode();
-    if ( !parent || parent->isNull() ) {
+    ldomNode * styled_parent = pseudo->getEffectiveParentNode();
+    ldomNode * owner = getInitialLetterOwnerBlock(pseudo);
+    if ( !styled_parent || styled_parent->isNull() || !owner || owner->isNull() ) {
         return false;
     }
+    // These two ancestors serve different roles when the first letter starts in
+    // nested inline content (eg. <p><i>T</i>est): the styled parent provides
+    // inherited font/style context for sizing the glyph, while the owner block
+    // provides the paragraph line grid that size/sink and later-line exclusion
+    // are measured against. With ::first-line clones, *Effective* access keeps
+    // both lookups anchored to the original source subtree.
     css_style_ref_t style_ref = pseudo->getStyle();
-    css_style_ref_t parent_style_ref = parent->getStyle();
+    css_style_ref_t styled_parent_style_ref = styled_parent->getStyle();
+    css_style_ref_t owner_style_ref = owner->getStyle();
     LVFontRef computed_font = pseudo->getFont();
-    LVFontRef parent_font = parent->getFont();
-    if ( style_ref.isNull() || parent_style_ref.isNull() || computed_font.isNull() || parent_font.isNull() ) {
+    LVFontRef styled_parent_font = styled_parent->getFont();
+    LVFontRef owner_font = owner->getFont();
+    if ( style_ref.isNull() || styled_parent_style_ref.isNull() || owner_style_ref.isNull()
+            || computed_font.isNull() || styled_parent_font.isNull() || owner_font.isNull() ) {
         return false;
     }
     css_style_rec_t * style = style_ref.get();
-    css_style_rec_t * parent_style = parent_style_ref.get();
-    LVFontRef font = getUsedInitialLetterFont(pseudo, style, parent_style, parent_font);
+    css_style_rec_t * styled_parent_style = styled_parent_style_ref.get();
+    css_style_rec_t * owner_style = owner_style_ref.get();
+    LVFontRef font = getUsedInitialLetterFont(pseudo, style, styled_parent_style, styled_parent_font);
     if ( font.isNull() ) {
         font = computed_font;
     }
     int computed_em = computed_font->getSize();
-    int parent_line_height = getInitialLetterStyleLineHeightPx(parent->getDocument(), parent, parent_style, parent_font, -1);
+    int parent_line_height = getInitialLetterStyleLineHeightPx(owner->getDocument(), owner, owner_style, owner_font, -1);
     if ( parent_line_height <= 0 ) {
         return false;
     }
@@ -577,7 +675,7 @@ bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseli
     if ( sink <= 0 ) {
         sink = 1;
     }
-    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(parent->getDocument(), parent, parent_style, parent_font, -1);
+    int parent_adjusted_baseline = getInitialLetterStyleAdjustedBaselinePx(owner->getDocument(), owner, owner_style, owner_font, -1);
     int initial_baseline = font->getBaseline();
     int initial_letter_size = style->initial_letter.value >> 8;
     int top_offset;
@@ -585,7 +683,7 @@ bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseli
         top_offset = parent_adjusted_baseline + (sink - 1) * parent_line_height - initial_baseline;
     }
     else {
-        int parent_cap_height = getInitialLetterFontCapHeightPx(parent_font);
+        int parent_cap_height = getInitialLetterFontCapHeightPx(owner_font);
         int initial_cap_height = getInitialLetterFontCapHeightPx(font);
         top_offset = parent_adjusted_baseline - parent_cap_height
                     - (initial_baseline - initial_cap_height);
@@ -621,15 +719,141 @@ bool getInitialLetterInlineBoxMetrics(ldomNode * inline_box, int rendered_baseli
         metrics.placement_baseline = rendered_baseline + parent_adjusted_baseline - top_offset - initial_baseline;
     }
     int visual_bottom = getInitialLetterInkBottomPx(pseudo, style, font, computed_em);
+    int decoration_bottom = getInitialLetterDecorationBottomPx(pseudo, style, font, computed_em);
+    if ( decoration_bottom > visual_bottom ) {
+        visual_bottom = decoration_bottom;
+    }
     if ( visual_bottom <= 0 ) {
         visual_bottom = getInitialLetterStyleLineHeightPx(pseudo->getDocument(), pseudo, style, font, computed_em);
     }
     int actual_bottom = top_offset + visual_bottom;
+    metrics.ink_bottom = actual_bottom;
     if ( actual_bottom > metrics.exclusion_height ) {
         metrics.exclusion_height = actual_bottom;
     }
     metrics.valid = true;
     return true;
+}
+
+bool getInitialLetterInlineBoxHorizontalInkOverflow(ldomNode * inline_box,
+        int & left_overflow, int & right_overflow)
+{
+    left_overflow = 0;
+    right_overflow = 0;
+    lvRect ink_rect;
+    if ( !getInitialLetterInlineBoxInkRect(inline_box, ink_rect) ) {
+        return false;
+    }
+    lvRect box_rect;
+    inline_box->getAbsRect(box_rect);
+    left_overflow = box_rect.left - ink_rect.left;
+    if ( left_overflow < 0 ) {
+        left_overflow = 0;
+    }
+    right_overflow = ink_rect.right - box_rect.right;
+    if ( right_overflow < 0 ) {
+        right_overflow = 0;
+    }
+    return true;
+}
+
+bool getInitialLetterInlineBoxExclusion(ldomNode * inline_box, int & abs_x, int & width,
+        int & abs_end_y, bool & is_right)
+{
+    abs_x = 0;
+    width = 0;
+    abs_end_y = 0;
+    is_right = false;
+    if ( !inline_box ) {
+        return false;
+    }
+    RenderRectAccessor fmt(inline_box);
+    InitialLetterInlineBoxMetrics metrics;
+    if ( !getInitialLetterInlineBoxMetrics(inline_box, fmt.getBaseline(), metrics) ) {
+        return false;
+    }
+    ldomNode * owner = getInitialLetterOwnerBlock(inline_box);
+    if ( !owner || owner->isNull() ) {
+        return false;
+    }
+    css_style_ref_t owner_style_ref = owner->getStyle();
+    LVFontRef owner_font = owner->getFont();
+    if ( owner_style_ref.isNull() || owner_font.isNull() ) {
+        return false;
+    }
+    lvRect box_rect;
+    inline_box->getAbsRect(box_rect);
+    int exclusion_x = box_rect.left;
+    int exclusion_right = box_rect.right;
+    RenderRectAccessor parent_fmt(owner);
+    int direction = RENDER_RECT_GET_DIRECTION(parent_fmt);
+    if ( direction == REND_DIRECTION_UNSET ) {
+        lvRect parent_rect;
+        owner->getAbsRect(parent_rect, true);
+        is_right = box_rect.left + box_rect.right > parent_rect.left + parent_rect.right;
+    }
+    else {
+        is_right = direction == REND_DIRECTION_RTL;
+    }
+    int left_overflow = 0;
+    int right_overflow = 0;
+    if ( getInitialLetterInlineBoxHorizontalInkOverflow(inline_box, left_overflow, right_overflow) ) {
+        if ( is_right ) {
+            if ( left_overflow > 0 ) {
+                exclusion_x -= left_overflow;
+            }
+        }
+        else {
+            if ( right_overflow > 0 ) {
+                exclusion_right += right_overflow;
+            }
+        }
+    }
+    width = exclusion_right - exclusion_x;
+    if ( width <= 0 ) {
+        return false;
+    }
+    abs_x = exclusion_x;
+    int strut_baseline = getInitialLetterStyleAdjustedBaselinePx(owner->getDocument(),
+            owner, owner_style_ref.get(), owner_font, -1);
+    ldomNode * final_node = inline_box;
+    while ( final_node ) {
+        if ( final_node->getRendMethod() == erm_final ) {
+            break;
+        }
+        final_node = final_node->getParentNode();
+    }
+    if ( final_node ) {
+        LFormattedTextRef formatted;
+        CVRendBlockCache & cache = final_node->getDocument()->getRendBlockCache();
+        if ( cache.get(final_node, formatted) && !formatted.isNull() ) {
+            strut_baseline = formatted->GetBuffer()->strut_baseline;
+        }
+    }
+    // box_rect.top is the absolute top of the inlineBox host. From there, move
+    // down to the owner block's strut baseline, then to the initial-letter
+    // placement baseline, then by the exclusion depth used by later wrapped
+    // lines. Using the owner block here keeps carried exclusion aligned with
+    // the paragraph even when the initial itself sits in a nested inline span.
+    // Note that any first-line lift caused by metrics.top_overflow is already
+    // reflected in box_rect.top via the inlineBox y stored by lvtextfm.cpp, so
+    // we must not add top_overflow a second time here.
+    abs_end_y = box_rect.top - strut_baseline + metrics.placement_baseline + metrics.exclusion_height;
+    return abs_end_y > box_rect.top;
+}
+
+bool getInitialLetterInlineBoxExclusionById(ldomDocument * doc, lUInt32 node_id,
+        int & abs_x, int & width, int & abs_end_y, bool & is_right)
+{
+    ldomNode * inline_box = getInitialLetterInlineBoxById(doc, node_id);
+    if ( !inline_box ) {
+        abs_x = 0;
+        width = 0;
+        abs_end_y = 0;
+        is_right = false;
+        return false;
+    }
+    return getInitialLetterInlineBoxExclusion(inline_box, abs_x, width, abs_end_y, is_right);
 }
 
 // Hit-testing wants the visual footprint of the enlarged initial-letter, not
@@ -642,7 +866,7 @@ bool getInitialLetterInlineBoxInkRect(ldomNode * inline_box, lvRect & rect)
     if ( !pseudo ) {
         return false;
     }
-    ldomNode * parent = inline_box->getParentNode();
+    ldomNode * parent = inline_box->getEffectiveParentNode();
     if ( !parent || parent->isNull() ) {
         return false;
     }
@@ -685,6 +909,16 @@ bool getInitialLetterInlineBoxInkRect(ldomNode * inline_box, lvRect & rect)
     else {
         rect.top = box_rect.top + ink_bounds.min_top;
         rect.bottom = box_rect.top + ink_bounds.max_bottom;
+    }
+    // Keep top overflow ink-only. Extending it for overline would not solve
+    // the actual inter-paragraph overlap issue, which would need block-level
+    // top clearance semantics.
+    int decoration_bottom = getInitialLetterDecorationBottomPx(pseudo, style_ref.get(), font, computed_em);
+    if ( decoration_bottom > 0 ) {
+        int decoration_abs_bottom = box_rect.top + decoration_bottom;
+        if ( decoration_abs_bottom > rect.bottom ) {
+            rect.bottom = decoration_abs_bottom;
+        }
     }
     if ( rect.height() == 0 && rect.width() > 0 ) {
         rect.bottom++;


### PR DESCRIPTION
Implement per-spec initial-letter exclusion carry across following blocks.
When a sunk initial-letter extends beyond its own paragraph, keep its exclusion active for subsequent blocks so their inline content wraps around it until the exclusion ends. If a following block starts with its own initial-letter, clear the previous carried exclusion before formatting it.
Also update renderutil initial-letter helpers so they correctly resolve and measure the applied initial-letter in cases involving nested inline content and ::first-line clones. Use the owning block for paragraph-grid/exclusion geometry while keeping the styled parent for inherited font sizing, and conservatively include underline bottom decoration in the exclusion depth and ink overflow.

Should allow closing https://github.com/koreader/koreader/issues/15817.
Also noticed and discussed at https://github.com/koreader/crengine/issues/646#issuecomment-4504032271.

(Painfully made by driving copilot - after we had something working, it took 20+ hours to clean all the kludge and get to something as clean/straightforward with localized changes as what ends up in this PR...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/724)
<!-- Reviewable:end -->
