### PR TITLE
Fix floats/inline-block on first line. Add lunasvgGetImageSizeHelper()

### DIFF
--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2068,11 +2068,8 @@ static void lunasvgTextToPathsHelper(lunasvg::external_context_t * xcontext, con
         0, 0, -1, 0, -1, -1, &collector);
 }
 
-static bool lunasvgDrawImageHelper(lunasvg::external_context_t * xcontext, const char * url, const unsigned char * bitmap, int width, int height, double & original_aspect_ratio)
+static LVImageSourceRef lunasvgGetImageSource(lunasvg::external_context_t * xcontext, const char * url)
 {
-    if ( !bitmap || width <= 0 || height <= 0 )
-        return false;
-
     LVImageSourceRef img;
     ldomDocument * doc = ((LVNodeImageSource *)xcontext->external_object)->GetSourceDocument();
     if ( doc ) {
@@ -2110,7 +2107,27 @@ static bool lunasvgDrawImageHelper(lunasvg::external_context_t * xcontext, const
                 img = LVCreateStreamImageSource( ref );
         }
     }
-    if ( img.isNull() )
+    return img;
+}
+
+static bool lunasvgGetImageSizeHelper(lunasvg::external_context_t * xcontext, const char * url, int & width, int & height)
+{
+    LVImageSourceRef img = lunasvgGetImageSource(xcontext, url);
+    if ( img.isNull() || img->GetWidth() <= 0 || img->GetHeight() <= 0 )
+        return false;
+
+    width = img->GetWidth();
+    height = img->GetHeight();
+    return true;
+}
+
+static bool lunasvgDrawImageHelper(lunasvg::external_context_t * xcontext, const char * url, const unsigned char * bitmap, int width, int height, double & original_aspect_ratio)
+{
+    if ( !bitmap || width <= 0 || height <= 0 )
+        return false;
+
+    LVImageSourceRef img = lunasvgGetImageSource(xcontext, url);
+    if ( img.isNull() || img->GetWidth() <= 0 || img->GetHeight() <= 0 )
         return false;
 
     original_aspect_ratio = (double)img->GetWidth() / (double)img->GetHeight();
@@ -2167,6 +2184,7 @@ LVSvgImageSource::LVSvgImageSource( ldomNode * node, LVStreamRef stream )
     lunasvg_xcontext.external_object = this;
     lunasvg_xcontext.text_to_paths_helper = &lunasvgTextToPathsHelper;
     lunasvg_xcontext.draw_image_helper = &lunasvgDrawImageHelper;
+    lunasvg_xcontext.get_image_size_helper = &lunasvgGetImageSizeHelper;
 }
 LVSvgImageSource::~LVSvgImageSource() {}
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -6652,6 +6652,33 @@ static void copyRendMethodFromSources(ldomNode * node) {
         if ( source ) {
             if ( source->isElement() ) {
                 node->setRendMethod( source->getRendMethod() );
+                lUInt16 source_node_id = source->getNodeId();
+                if ( source_node_id == el_floatBox || source_node_id == el_inlineBox ) {
+                    // On these elements, initNodeRendMethod() has reported on them
+                    // a few specific styles from their child. But it skips cloneNodes,
+                    // and these styles are required for rendering floats and inlineboxes
+                    // part of the first line sequence. Let's do the same here.
+                    css_style_ref_t source_style = source->getStyle();
+                    css_style_ref_t node_style = node->getStyle();
+                    css_style_ref_t style( new css_style_rec_t );
+                    copystyle(node_style, style);
+                    bool style_changed = false;
+                    if ( node_style->display != source_style->display ) {
+                        style->display = source_style->display;
+                        style_changed = true;
+                    }
+                    if ( source_node_id == el_floatBox && node_style->float_ != source_style->float_ ) {
+                        style->float_ = source_style->float_;
+                        style_changed = true;
+                    }
+                    if ( source_node_id == el_inlineBox && !(node_style->vertical_align == source_style->vertical_align) ) {
+                        style->vertical_align = source_style->vertical_align;
+                        style_changed = true;
+                    }
+                    if ( style_changed ) {
+                        node->setStyle(style);
+                    }
+                }
             }
             else {
                 // Not really needed, but safer, and let's have ~i (inline)


### PR DESCRIPTION
#### CSS ::first-line: fix floats/inline-block on first line

If present on the first line, embedded floats with float:right were rendered on the left, and vertical-align not ensured in inline-block boxes.

#### lvimg: add lunasvgGetImageSizeHelper()

So LunaSVG, calling crengine to render aother image embedded in a SVG, can get the image size and properly ensure preserveAspectRatio.
See https://github.com/koreader/koreader/issues/15842#issuecomment-5303178606.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/725)
<!-- Reviewable:end -->
