### PR TITLE
pdbfmt: implement MOBI links with an ID map

### DIFF
--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -92,6 +92,8 @@
 // 20260812: XPointers serialized by toStringV2() now always emit an
 // explicit [1] for the first sibling element of its kind. This avoids
 // costly forward sibling scans.
+// Also allows MOBI documents to inject a standalone <a> marker inside text
+// for resolving 'filepos' links (which may split a text node).
 
 #include "crsetup.h"
 

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -50,9 +50,11 @@ static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
 }
 
 // Does the start tag spanning [tagStart, tagEnd) already declare an "id" or
-// "filepos-id" attribute? If so, return its value (so a link can point at it
-// instead of us injecting a duplicate id). Returns an empty string if none.
-static lString32 tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd) {
+// "filepos-id" attribute? If so, set *idValue to its value and return true (so
+// a link can point at it instead of us injecting a duplicate id). Returns false
+// if the tag has no such attribute. An empty id="" still returns true (the tag
+// has an id, so we must not inject a second one).
+static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString32 & idValue) {
     for (int i = tagStart; i < tagEnd; i++) {
         // An attribute name is preceded by whitespace (or the tag name).
         bool atBoundary = (i == tagStart) ||
@@ -99,11 +101,12 @@ static lString32 tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd) {
             p++;
         }
         if (p > valStart)
-            return lString32((const lChar8 *)(data + valStart), p - valStart);
-        // Attribute present but empty value: still counts as "has an id".
-        return lString32(U"");
+            idValue = lString32((const lChar8 *)(data + valStart), p - valStart);
+        else
+            idValue.clear(); // empty id=""
+        return true;
     }
-    return lString32();
+    return false;
 }
 
 // Scan raw HTML bytes for filepos="NNNN" occurrences, record the numeric values.
@@ -225,8 +228,8 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
                 // (If the offset is in text, we hit a '<' first and nextGT
                 // stays -1, so we insert a standalone marker instead.)
                 if (nextGT > insertPos) {
-                    lString32 existingId = tagGetIdAttr(data, prevLT, nextGT);
-                    if (!existingId.empty()) {
+                    lString32 existingId;
+                    if (tagGetIdAttr(data, prevLT, nextGT, existingId)) {
                         // The tag already has an id: point the link at it.
                         resolver.targetIds.set(filepos, existingId);
                     } else {
@@ -255,8 +258,8 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
                     if (data[k] == '<') break;
                 }
                 if (nextGT > j) {
-                    lString32 existingId = tagGetIdAttr(data, j, nextGT);
-                    if (!existingId.empty()) {
+                    lString32 existingId;
+                    if (tagGetIdAttr(data, j, nextGT, existingId)) {
                         // The tag already has an id: point the link at it.
                         resolver.targetIds.set(filepos, existingId);
                     } else {
@@ -270,9 +273,14 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
             insertPos = outPos;
         if (injectIntoTag) {
             // Copy up to (but not including) the closing '>', then emit the
-            // attribute, then the '>'.
-            rewritten->Write(data + outPos, tagEndPos - outPos, NULL);
+            // attribute, then the '>'. For a self-closing tag (<div/>), the
+            // attribute must go before the '/'.
+            bool selfClosing = (tagEndPos > outPos && data[tagEndPos - 1] == '/');
+            int copyEnd = selfClosing ? tagEndPos - 1 : tagEndPos;
+            rewritten->Write(data + outPos, copyEnd - outPos, NULL);
             writeFileposIdAttr(rewritten, filepos);
+            if (selfClosing)
+                rewritten->Write("/", 1, NULL);
             outPos = tagEndPos;
         } else if (domVersion >= 20260812) {
             // Only inject a standalone <a> marker (which may split a text node

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -305,18 +305,34 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
 // - filepos="NNNN" -> href="#fileposNNNN" (link to a byte-offset target)
 class MobiHtmlWriterFilter : public ldomDocumentWriterFilter {
     MobiFileposResolver & _resolver;
+    bool _curTagHasId; // whether the current tag already got an id attribute
 public:
     MobiHtmlWriterFilter(ldomDocument * document, MobiFileposResolver & resolver)
         : ldomDocumentWriterFilter(document, false, HTML_AUTOCLOSE_TABLE)
-        , _resolver(resolver) {}
+        , _resolver(resolver)
+        , _curTagHasId(false) {}
+
+    virtual ldomNode * OnTagOpen(const lChar32 * nsname, const lChar32 * tagname) {
+        _curTagHasId = false;
+        return ldomDocumentWriterFilter::OnTagOpen(nsname, tagname);
+    }
 
     virtual void OnAttribute(const lChar32 * nsname, const lChar32 * attrname,
                              const lChar32 * attrvalue) {
         if (attrname && !lStr_cmp(attrname, U"filepos-id")) {
-            // Target marker: rewrite to a regular id attribute so it is
-            // registered in the id->node map (and serialized to cache).
-            ldomDocumentWriterFilter::OnAttribute(nsname, U"id", attrvalue);
+            // MOBI target marker: rewrite to a regular id attribute so it is
+            // registered in the id->node map (and serialized to cache). But
+            // skip it if the tag already has a plain id, to avoid a duplicate.
+            if (!_curTagHasId) {
+                ldomDocumentWriterFilter::OnAttribute(nsname, U"id", attrvalue);
+                _curTagHasId = true;
+            }
             return;
+        }
+        if (attrname && !lStr_cmp(attrname, U"id")) {
+            // The tag has a plain id: remember it, so a following filepos-id
+            // won't be rewritten into a second id attribute.
+            _curTagHasId = true;
         }
         if (attrname && !lStr_cmp(attrname, U"filepos")) {
             // Link to a byte offset: rewrite to href="#fileposNNNN", or to the

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -44,16 +44,22 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
         if (!matchFileposBytes(data, dataSize, i)) { i++; continue; }
         int pos = i + 7;
         // Skip whitespace before '='
-        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '\t')) pos++;
+        while (pos < dataSize &&
+                    (data[pos] == ' ' || data[pos] == '\t')) {
+            pos++;
+        }
         if (pos >= dataSize || data[pos] != '=') { i++; continue; }
         pos++; // skip '='
         // Skip whitespace and an optional opening quote
-        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '"' || data[pos] == '\''))
+        while (pos < dataSize &&
+                    (data[pos] == ' ' || data[pos] == '"' || data[pos] == '\'')) {
             pos++;
+        }
         // Parse the integer value
         lUInt64 val = 0;
         int numStart = pos;
-        while (pos < dataSize && data[pos] >= '0' && data[pos] <= '9') {
+        while (pos < dataSize &&
+                    data[pos] >= '0' && data[pos] <= '9') {
             val = val * 10 + (data[pos] - '0');
             pos++;
         }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -174,7 +174,7 @@ static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
             // Find the nearest '>' after pos (stopping at any '<').
             for (int j = pos; j < dataSize; j++) {
                 if (data[j] == '>') {
-                    if (j > pos) { tagStart = prevLT; tagEnd = j; return true; }
+                    if (j >= pos) { tagStart = prevLT; tagEnd = j; return true; }
                     break;
                 }
                 if (data[j] == '<') break;
@@ -183,6 +183,10 @@ static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
     }
     // Is pos immediately followed (after whitespace) by a start tag?
     int j = pos;
+    // If we landed on '>' (end of a closing or start tag), advance past it so
+    // we can look for the following start tag.
+    if (j < dataSize && data[j] == '>')
+        j++;
     while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
                 data[j] == '\r' || data[j] == '\n')) {
         j++;

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -7,12 +7,15 @@
 //#define DUMP_PDB_CONTENTS
 
 // --- MOBI filepos fragment support ---
-// MOBI uses byte offsets for internal links: <a filepos="NNNN"> points to the
-// byte offset NNNN in the uncompressed HTML, and <... filepos-id="XXX"> marks a
-// target. We resolve these by (1) injecting <a id="fileposNNNN"></a> markers at
-// each referenced byte offset (the same approach calibre uses), and (2) rewriting
-// filepos/filepos-id attributes into href/id so the existing id->node map handles
-// fragment resolution (and is serialized to cache).
+// MOBI uses two independent mechanisms for internal links:
+// - <a filepos="NNNN"> points to byte offset NNNN in the uncompressed HTML.
+//   Nothing in the source marks that offset; we must add an anchor there.
+// - filepos-id="XXX" on an element marks it as a target (used by the NCX/TOC).
+// We resolve both by rewriting them into plain href/id attributes, so the
+// existing id->node map handles fragment resolution (and survives cache
+// serialization). For each referenced byte offset, we inject an anchor: either
+// a filepos-id attribute on the tag containing the offset, or (if the offset
+// lands in text/whitespace) a standalone <a id="fileposNNNN"></a> element.
 
 static const char * MOBI_FILEPOS_ID_PREFIX = "filepos";
 

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -114,22 +114,19 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
         if (!matchFileposBytes(data, dataSize, i)) { i++; continue; }
         int pos = i + 7;
         // Skip whitespace before '='
-        while (pos < dataSize &&
-                    (data[pos] == ' ' || data[pos] == '\t')) {
+        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '\t')) {
             pos++;
         }
         if (pos >= dataSize || data[pos] != '=') { i++; continue; }
         pos++; // skip '='
         // Skip whitespace and an optional opening quote
-        while (pos < dataSize &&
-                    (data[pos] == ' ' || data[pos] == '"' || data[pos] == '\'')) {
+        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '"' || data[pos] == '\'')) {
             pos++;
         }
         // Parse the integer value
         lUInt64 val = 0;
         int numStart = pos;
-        while (pos < dataSize &&
-                    data[pos] >= '0' && data[pos] <= '9') {
+        while (pos < dataSize && data[pos] >= '0' && data[pos] <= '9') {
             val = val * 10 + (data[pos] - '0');
             pos++;
         }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -155,6 +155,15 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
     out->Write(buf, len, NULL);
 }
 
+// Does the start tag spanning [tagStart, tagEnd] (with data[tagEnd] == '>')
+// close itself, i.e. end with '/>' possibly preceded by whitespace?
+static bool isSelfClosingTag(const lUInt8 * data, int tagStart, int tagEnd) {
+    int i = tagEnd - 1;
+    while (i > tagStart && (data[i] == ' ' || data[i] == '\t'))
+        i--;
+    return i > tagStart && data[i] == '/';
+}
+
 // Locate a start tag we can attach a synthetic id to, given a byte offset pos.
 // If pos is inside a start tag, return that tag's [<, >) span. Otherwise, if
 // pos is immediately followed (after whitespace) by a start tag, return that
@@ -174,30 +183,45 @@ static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
             // Find the nearest '>' after pos (stopping at any '<').
             for (int j = pos; j < dataSize; j++) {
                 if (data[j] == '>') {
-                    if (j >= pos) { tagStart = prevLT; tagEnd = j; return true; }
+                    // Skip self-closing void tags (e.g. <mbp:pagebreak/>): an
+                    // id on them is useless and they get autoBoxed, so fall
+                    // through to the following-tag scan instead.
+                    if (!isSelfClosingTag(data, prevLT, j)) {
+                        tagStart = prevLT; tagEnd = j; return true;
+                    }
+                    pos = j + 1; // skip past this self-closing tag
                     break;
                 }
                 if (data[j] == '<') break;
             }
         }
     }
-    // Is pos immediately followed (after whitespace) by a start tag?
+    // Is pos followed (after whitespace) by a start tag? Skip self-closing
+    // void tags (e.g. <mbp:pagebreak/>) and keep looking for a real element.
     int j = pos;
     // If we landed on '>' (end of a closing or start tag), advance past it so
     // we can look for the following start tag.
     if (j < dataSize && data[j] == '>')
         j++;
-    while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
-                data[j] == '\r' || data[j] == '\n')) {
-        j++;
-    }
-    if (j < dataSize && data[j] == '<' && j + 1 < dataSize &&
-                data[j + 1] != '/') {
-        // Find the '>' closing this start tag.
-        for (int k = j + 1; k < dataSize; k++) {
-            if (data[k] == '>') { tagStart = j; tagEnd = k; return true; }
-            if (data[k] == '<') break;
+    while (true) {
+        while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
+                    data[j] == '\r' || data[j] == '\n')) {
+            j++;
         }
+        if (!(j < dataSize && data[j] == '<' && j + 1 < dataSize &&
+                    data[j + 1] != '/'))
+            break;
+        // Find the '>' closing this start tag.
+        int k = j + 1;
+        while (k < dataSize && data[k] != '>' && data[k] != '<')
+            k++;
+        if (k >= dataSize || data[k] != '>')
+            break; // malformed
+        if (!isSelfClosingTag(data, j, k)) {
+            tagStart = j; tagEnd = k; return true;
+        }
+        // Self-closing void tag: skip past it and continue.
+        j = k + 1;
     }
     return false;
 }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -6,6 +6,177 @@
 // uncomment following line to save PDB content streams to /tmp
 //#define DUMP_PDB_CONTENTS
 
+// --- MOBI filepos fragment support ---
+// MOBI uses byte offsets for internal links: <a filepos="NNNN"> points to the
+// byte offset NNNN in the uncompressed HTML, and <... filepos-id="XXX"> marks a
+// target. We resolve these by (1) injecting <a id="fileposNNNN"></a> markers at
+// each referenced byte offset (the same approach calibre uses), and (2) rewriting
+// filepos/filepos-id attributes into href/id so the existing id->node map handles
+// fragment resolution (and is serialized to cache).
+
+static const char * MOBI_FILEPOS_ID_PREFIX = "filepos";
+
+static int compareUInt32(const void * left, const void * right) {
+    lUInt32 a = *(const lUInt32 *)left, b = *(const lUInt32 *)right;
+    return (a < b) ? -1 : (a > b) ? 1 : 0;
+}
+
+// Quick case-insensitive check: does data[pos..pos+6] match "filepos"?
+static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
+    if (pos + 7 > dataSize) return false;
+    for (int i = 0; i < 7; i++) {
+        lUInt8 ch = data[pos + i];
+        lUInt8 expected = (lUInt8)"filepos"[i];
+        if (ch != expected && (ch < 'A' || ch > 'Z' || ch != (expected - 32)))
+            return false;
+    }
+    return true;
+}
+
+// Scan raw HTML bytes for filepos="NNNN" occurrences, record the numeric values.
+static void collectMobiFileposData(const lUInt8 * data, int dataSize,
+        LVArray<lUInt32> & fileposRefs) {
+    LVHashTable<lUInt32, lUInt8> seenRefs(256);
+    for (int i = 0; i < dataSize - 8; ) {
+        if (!matchFileposBytes(data, dataSize, i)) { i++; continue; }
+        int pos = i + 7;
+        // Skip whitespace before '='
+        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '\t')) pos++;
+        if (pos >= dataSize || data[pos] != '=') { i++; continue; }
+        pos++; // skip '='
+        // Skip whitespace and an optional opening quote
+        while (pos < dataSize && (data[pos] == ' ' || data[pos] == '"' || data[pos] == '\''))
+            pos++;
+        // Parse the integer value
+        lUInt64 val = 0;
+        int numStart = pos;
+        while (pos < dataSize && data[pos] >= '0' && data[pos] <= '9') {
+            val = val * 10 + (data[pos] - '0');
+            pos++;
+        }
+        if (pos > numStart && val > 0 && val <= (lUInt64)dataSize) {
+            lUInt32 filepos = (lUInt32)val;
+            lUInt8 marker = 0;
+            if (!seenRefs.get(filepos, marker)) {
+                seenRefs.set(filepos, 1);
+                fileposRefs.add(filepos);
+            }
+        }
+        i = pos; // resume after the value
+    }
+}
+
+static void appendBytes(LVArray<lUInt8> & out, const lUInt8 * data, int len) {
+    if (len > 0) out.add(data, len);
+}
+
+static void appendMobiMarker(LVArray<lUInt8> & out, lUInt32 filepos) {
+    lString8 marker("<a id=\"");
+    marker.append(MOBI_FILEPOS_ID_PREFIX);
+    marker.appendDecimal((lInt64)filepos);
+    marker.append("\"></a>");
+    appendBytes(out, (const lUInt8 *)marker.c_str(), marker.length());
+}
+
+// Pre-process the raw HTML stream: find all filepos=NNNN references and inject
+// <a id="fileposNNNN"></a> markers at those byte offsets, so the existing
+// id->node map can resolve them (and they survive cache serialization).
+static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
+    LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
+    if (buffered.isNull())
+        return LVStreamRef();
+    stream->SetPos(0);
+    LVPumpStream(buffered, stream);
+    buffered->SetPos(0);
+    LVByteArrayRef rawData = buffered->GetData();
+    if (rawData.isNull() || rawData->empty()) {
+        stream->SetPos(0);
+        return LVStreamRef();
+    }
+    const lUInt8 * data = rawData->get();
+    int dataSize = rawData->length();
+
+    LVArray<lUInt32> fileposRefs;
+    collectMobiFileposData(data, dataSize, fileposRefs);
+    if (fileposRefs.empty()) {
+        stream->SetPos(0);
+        return LVStreamRef();
+    }
+
+    // Sort for sequential insertion
+    qsort(fileposRefs.get(), fileposRefs.length(), sizeof(lUInt32), compareUInt32);
+
+    // Build the rewritten byte array with markers inserted at filepos offsets.
+    // If the offset falls inside a tag (<...>), move past the closing '>'.
+    LVArray<lUInt8> rewritten;
+    rewritten.reserve(dataSize + fileposRefs.length() * 64);
+    int outPos = 0;
+    for (int i = 0; i < fileposRefs.length(); i++) {
+        lUInt32 filepos = fileposRefs[i];
+        int insertPos = (int)filepos;
+        // Check if filepos is inside a tag by scanning backward for '<' and forward for '>'
+        if (insertPos > 0 && insertPos < dataSize) {
+            // Find the nearest '<' before insertPos that is not closed by '>'
+            int prevLT = -1;
+            for (int j = insertPos - 1; j >= 0; j--) {
+                if (data[j] == '<') { prevLT = j; break; }
+                if (data[j] == '>') break; // not inside a tag
+            }
+            if (prevLT >= 0) {
+                // Find the nearest '>' after insertPos
+                int nextGT = -1;
+                for (int j = insertPos; j < dataSize; j++) {
+                    if (data[j] == '>') { nextGT = j; break; }
+                    if (data[j] == '<') break;
+                }
+                if (nextGT > insertPos)
+                    insertPos = nextGT + 1;
+            }
+        }
+        if (insertPos < outPos)
+            insertPos = outPos;
+        appendBytes(rewritten, data + outPos, insertPos - outPos);
+        appendMobiMarker(rewritten, filepos);
+        outPos = insertPos;
+    }
+    appendBytes(rewritten, data + outPos, dataSize - outPos);
+    stream->SetPos(0);
+    return LVCreateMemoryStream(rewritten.ptr(), rewritten.length(), true, LVOM_READ);
+}
+
+// Custom callback filter that rewrites MOBI-specific attributes during HTML parsing:
+// - filepos-id="XXX" -> id="XXX" (target marker, registered in the id->node map)
+// - filepos="NNNN" -> href="#fileposNNNN" (link to a byte-offset target)
+class MobiHtmlWriterFilter : public ldomDocumentWriterFilter {
+public:
+    MobiHtmlWriterFilter(ldomDocument * document)
+        : ldomDocumentWriterFilter(document, false, HTML_AUTOCLOSE_TABLE) {}
+
+    virtual void OnAttribute(const lChar32 * nsname, const lChar32 * attrname,
+                             const lChar32 * attrvalue) {
+        if (attrname && !lStr_cmp(attrname, U"filepos-id")) {
+            // Target marker: rewrite to a regular id attribute so it is
+            // registered in the id->node map (and serialized to cache).
+            ldomDocumentWriterFilter::OnAttribute(nsname, U"id", attrvalue);
+            return;
+        }
+        if (attrname && !lStr_cmp(attrname, U"filepos")) {
+            // Link to a byte offset: rewrite to href="#fileposNNNN".
+            lInt64 filepos = 0;
+            if (lString32(attrvalue).atoi(filepos) && filepos >= 0 && filepos <= 0xFFFFFFFFLL) {
+                lString32 href(U"#");
+                href.append(MOBI_FILEPOS_ID_PREFIX);
+                href.appendDecimal(filepos);
+                ldomDocumentWriterFilter::OnAttribute(nsname, U"href", href.c_str());
+                return;
+            }
+        }
+        ldomDocumentWriterFilter::OnAttribute(nsname, attrname, attrvalue);
+    }
+};
+
+// --- end MOBI filepos fragment support ---
+
 struct PDBHdr
 {
     lUInt8    name[32];
@@ -1310,16 +1481,24 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
     case doc_format_html:
         // HTML
         {
+            LVStreamRef parserStream = stream;
+            bool isMobiHtml = pdb->getFormat() == PDBFile::MOBI;
 
-            ldomDocumentWriterFilter writerFilter(doc, false,
-                    HTML_AUTOCLOSE_TABLE);
-            LVHTMLParser parser(stream, &writerFilter);
+            if (isMobiHtml) {
+                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream);
+                if (!rewrittenStream.isNull())
+                    parserStream = rewrittenStream;
+            }
+
+            MobiHtmlWriterFilter mobiWriterFilter(doc);
+            LVHTMLParser parser(parserStream, &mobiWriterFilter);
             parser.setProgressCallback(progressCallback);
             if ( !parser.CheckFormat() ) {
                 return false;
             } else {
-                if (pdb->getFormat()==PDBFile::MOBI && isCorrectUtf8Text(stream))
+                if (isMobiHtml && isCorrectUtf8Text(parserStream))
                     parser.SetCharset(U"utf-8");
+                parserStream->SetPos(0);
                 if (!parser.Parse()) {
                     return false;
                 }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -169,8 +169,7 @@ static bool isSelfClosingTag(const lUInt8 * data, int tagStart, int tagEnd) {
 // pos is immediately followed (after whitespace) by a start tag, return that
 // tag's span. Returns false (leaving tagStart/tagEnd untouched) if neither
 // applies, i.e. the offset lands in text/whitespace with no following start tag.
-static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
-        int & tagStart, int & tagEnd) {
+static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos, int & tagStart, int & tagEnd) {
     // Is pos inside a start tag? Find the nearest '<' before pos that is not
     // already closed by a '>'.
     if (pos > 0 && pos < dataSize) {
@@ -204,12 +203,10 @@ static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
     if (j < dataSize && data[j] == '>')
         j++;
     while (true) {
-        while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
-                    data[j] == '\r' || data[j] == '\n')) {
+        while (j < dataSize && (data[j] == ' ' || data[j] == '\t' || data[j] == '\r' || data[j] == '\n')) {
             j++;
         }
-        if (!(j < dataSize && data[j] == '<' && j + 1 < dataSize &&
-                    data[j + 1] != '/'))
+        if (!(j < dataSize && data[j] == '<' && j + 1 < dataSize && data[j + 1] != '/'))
             break;
         // Find the '>' closing this start tag.
         int k = j + 1;

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -112,7 +112,6 @@ static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString3
 // Scan raw HTML bytes for filepos="NNNN" occurrences, record the numeric values.
 static void collectMobiFileposData(const lUInt8 * data, int dataSize,
         LVArray<lUInt32> & fileposRefs) {
-    LVHashTable<lUInt32, lUInt8> seenRefs(256);
     for (int i = 0; i < dataSize - 8; ) {
         if (!matchFileposBytes(data, dataSize, i)) { i++; continue; }
         int pos = i + 7;
@@ -134,12 +133,7 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
             pos++;
         }
         if (pos > numStart && val > 0 && val <= (lUInt64)dataSize) {
-            lUInt32 filepos = (lUInt32)val;
-            lUInt8 marker = 0;
-            if (!seenRefs.get(filepos, marker)) {
-                seenRefs.set(filepos, 1);
-                fileposRefs.add(filepos);
-            }
+            fileposRefs.add((lUInt32)val);
         }
         i = pos; // resume after the value
     }
@@ -188,6 +182,15 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
 
     // Sort for sequential insertion
     qsort(fileposRefs.get(), fileposRefs.length(), sizeof(lUInt32), compareUInt32);
+
+    // Dedup in-place
+    int n = 1;
+    for (int i = 1; i < fileposRefs.length(); i++) {
+        if (fileposRefs[i] != fileposRefs[n-1])
+            fileposRefs[n++] = fileposRefs[i];
+    }
+    if (n < fileposRefs.length())
+        fileposRefs.erase(n, fileposRefs.length() - n);
 
     // Build the rewritten byte array with markers inserted at filepos offsets.
     LVStreamRef rewritten = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -175,7 +175,7 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
 // whereas attaching the id to the following element keeps the target on the
 // correct page. Only when the offset lands mid-text do we insert a standalone
 // <a id="fileposNNNN"></a> marker (the same approach calibre uses).
-static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver) {
+static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver, lUInt32 domVersion) {
     LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
     if (buffered.isNull())
         return LVStreamRef();
@@ -282,9 +282,15 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
             rewritten->Write(data + outPos, tagEndPos - outPos, NULL);
             writeFileposIdAttr(rewritten, filepos);
             outPos = tagEndPos;
-        } else {
+        } else if (domVersion >= 20260812) {
+            // Only inject a standalone <a> marker (which may split a text node
+            // and break highlights) when a recent DOM version is requested.
             rewritten->Write(data + outPos, insertPos - outPos, NULL);
             writeFileposMarker(rewritten, filepos);
+            outPos = insertPos;
+        } else {
+            // Older DOM: skip the marker entirely to avoid splitting text nodes.
+            rewritten->Write(data + outPos, insertPos - outPos, NULL);
             outPos = insertPos;
         }
     }
@@ -1646,7 +1652,7 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
             MobiFileposResolver mobiResolver;
 
             if (isMobiHtml) {
-                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver);
+                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver, doc->getDOMVersionRequested());
                 if (!rewrittenStream.isNull())
                     parserStream = rewrittenStream;
             }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -141,16 +141,16 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
 
 // Emit an id="fileposNNNN" attribute into the stream, to be placed inside a start tag.
 static void writeFileposIdAttr(LVStreamRef & out, lUInt32 filepos) {
-    lString8 attr;
-    attr << " id=\"" << MOBI_FILEPOS_ID_PREFIX << fmt::decimal(filepos) << "\"";
-    *out << attr;
+    char buf[64];
+    int len = snprintf(buf, sizeof(buf), " id=\"%s%u\"", MOBI_FILEPOS_ID_PREFIX, (unsigned)filepos);
+    out->Write(buf, len, NULL);
 }
 
 // Emit a standalone <a id="fileposNNNN"></a> marker.
 static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
-    lString8 marker;
-    marker << "<a id=\"" << MOBI_FILEPOS_ID_PREFIX << fmt::decimal(filepos) << "\"></a>";
-    *out << marker;
+    char buf[64];
+    int len = snprintf(buf, sizeof(buf), "<a id=\"%s%u\"></a>", MOBI_FILEPOS_ID_PREFIX, (unsigned)filepos);
+    out->Write(buf, len, NULL);
 }
 
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -49,11 +49,11 @@ static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
     return matchAscii(data, pos, "filepos", 7);
 }
 
-// Does the start tag spanning [tagStart, tagEnd) already declare an "id" or
-// "filepos-id" attribute? If so, set *idValue to its value and return true (so
-// a link can point at it instead of us injecting a duplicate id). Returns false
-// if the tag has no such attribute. An empty id="" still returns true (the tag
-// has an id, so we must not inject a second one).
+// Does the start tag spanning [tagStart, tagEnd) already declare a non-empty
+// "id" or "filepos-id" attribute? If so, set *idValue to its value and return
+// true (so a link can point at it instead of us injecting a duplicate id).
+// Returns false if the tag has no such attribute, or if it is empty (id=""),
+// in which case the caller injects our own id="fileposNNNN" to override it.
 static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString32 & idValue) {
     for (int i = tagStart; i < tagEnd; i++) {
         // An attribute name is preceded by whitespace (or the tag name).
@@ -103,7 +103,7 @@ static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString3
         if (p > valStart)
             idValue = lString32((const lChar8 *)(data + valStart), p - valStart);
         else
-            idValue.clear(); // empty id=""
+            return false; // empty id="": let the caller inject its own id
         return true;
     }
     return false;

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -1673,7 +1673,11 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
             }
 
             MobiHtmlWriterFilter mobiWriterFilter(doc, mobiResolver);
-            LVHTMLParser parser(parserStream, &mobiWriterFilter);
+            ldomDocumentWriterFilter plainWriterFilter(doc, false, HTML_AUTOCLOSE_TABLE);
+            ldomDocumentWriterFilter * writerFilter = isMobiHtml
+                ? static_cast<ldomDocumentWriterFilter *>(&mobiWriterFilter)
+                : &plainWriterFilter;
+            LVHTMLParser parser(parserStream, writerFilter);
             parser.setProgressCallback(progressCallback);
             if ( !parser.CheckFormat() ) {
                 return false;

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -280,7 +280,7 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
             rewritten->Write(data + outPos, copyEnd - outPos, NULL);
             writeFileposIdAttr(rewritten, filepos);
             if (selfClosing)
-                rewritten->Write("/", 1, NULL);
+                *rewritten << "/";
             outPos = tagEndPos;
         } else if (allowInjectStandaloneId) {
             // Only inject a standalone <a> marker (which may split a text node

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -330,8 +330,11 @@ public:
             return;
         }
         if (attrname && !lStr_cmp(attrname, U"id")) {
-            // The tag has a plain id: remember it, so a following filepos-id
-            // won't be rewritten into a second id attribute.
+            // If a filepos-id already claimed this tag's id slot, drop this
+            // plain id so the DOM's surviving id matches what tagGetIdAttr()
+            // picks first (avoids a duplicate id attribute).
+            if (_curTagHasId)
+                return;
             _curTagHasId = true;
         }
         if (attrname && !lStr_cmp(attrname, U"filepos")) {

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -170,7 +170,7 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
 // element keeps the target on the correct page. Only when the offset lands
 // mid-text do we insert a standalone <a id="fileposNNNN"></a> marker (the same
 // approach calibre uses).
-static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver, lUInt32 domVersion) {
+static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver, bool allowInjectStandaloneId) {
     LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
     if (buffered.isNull())
         return LVStreamRef();
@@ -282,7 +282,7 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
             if (selfClosing)
                 rewritten->Write("/", 1, NULL);
             outPos = tagEndPos;
-        } else if (domVersion >= 20260812) {
+        } else if (allowInjectStandaloneId) {
             // Only inject a standalone <a> marker (which may split a text node
             // and break highlights) when a recent DOM version is requested.
             rewritten->Write(data + outPos, insertPos - outPos, NULL);
@@ -1669,9 +1669,11 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
             LVStreamRef parserStream = stream;
             bool isMobiHtml = pdb->getFormat() == PDBFile::MOBI;
             MobiFileposResolver mobiResolver;
+            // Injecting a standalone <a> marker into text could split a text nodes and break highlights.
+            bool allowInjectStandaloneId = doc->getDOMVersionRequested() >= 20260812;
 
             if (isMobiHtml) {
-                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver, doc->getDOMVersionRequested());
+                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver, allowInjectStandaloneId);
                 if (!rewrittenStream.isNull())
                     parserStream = rewrittenStream;
             }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -145,22 +145,18 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
     }
 }
 
-// Emit an id="fileposNNNN" attribute into the stream, to be placed inside a start tag. 
+// Emit an id="fileposNNNN" attribute into the stream, to be placed inside a start tag.
 static void writeFileposIdAttr(LVStreamRef & out, lUInt32 filepos) {
-    lString8 attr(" id=\"");
-    attr.append(MOBI_FILEPOS_ID_PREFIX);
-    attr.appendDecimal((lInt64)filepos);
-    attr.append("\"");
-    out->Write(attr.c_str(), attr.length(), NULL);
+    lString8 attr;
+    attr << " id=\"" << MOBI_FILEPOS_ID_PREFIX << fmt::decimal(filepos) << "\"";
+    *out << attr;
 }
 
 // Emit a standalone <a id="fileposNNNN"></a> marker.
 static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
-    lString8 marker("<a id=\"");
-    marker.append(MOBI_FILEPOS_ID_PREFIX);
-    marker.appendDecimal((lInt64)filepos);
-    marker.append("\"></a>");
-    out->Write(marker.c_str(), marker.length(), NULL);
+    lString8 marker;
+    marker << "<a id=\"" << MOBI_FILEPOS_ID_PREFIX << fmt::decimal(filepos) << "\"></a>";
+    *out << marker;
 }
 
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -145,10 +145,9 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
     }
 }
 
-// Emit a filepos-id="fileposNNNN" attribute (rewritten to id= by the writer
-// filter) into the stream, to be placed inside a start tag.
+// Emit an id="fileposNNNN" attribute into the stream, to be placed inside a start tag. 
 static void writeFileposIdAttr(LVStreamRef & out, lUInt32 filepos) {
-    lString8 attr(" filepos-id=\"");
+    lString8 attr(" id=\"");
     attr.append(MOBI_FILEPOS_ID_PREFIX);
     attr.appendDecimal((lInt64)filepos);
     attr.append("\"");
@@ -167,14 +166,14 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject
 // anchors at those byte offsets, so the existing id->node map can resolve them
 // (and they survive cache serialization).
-// Where the offset falls inside a start tag, we add a filepos-id="fileposNNNN"
-// attribute to that tag (which the writer filter will rewrite to id=), avoiding
-// splitting any text node. Otherwise, if the offset is immediately followed
-// (after whitespace) by a start tag, we attach the id to that tag too: an empty
-// inline <a> anchor right after a page break would resolve to the previous page,
-// whereas attaching the id to the following element keeps the target on the
-// correct page. Only when the offset lands mid-text do we insert a standalone
-// <a id="fileposNNNN"></a> marker (the same approach calibre uses).
+// Where the offset falls inside a start tag, we add an id="fileposNNNN"
+// attribute to that tag, avoiding splitting any text node. Otherwise, if the
+// offset is immediately followed (after whitespace) by a start tag, we attach
+// the id to that tag too: an empty inline <a> anchor right after a page break
+// would resolve to the previous page, whereas attaching the id to the following
+// element keeps the target on the correct page. Only when the offset lands
+// mid-text do we insert a standalone <a id="fileposNNNN"></a> marker (the same
+// approach calibre uses).
 static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver, lUInt32 domVersion) {
     LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
     if (buffered.isNull())
@@ -210,9 +209,9 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
     for (int i = 0; i < fileposRefs.length(); i++) {
         lUInt32 filepos = fileposRefs[i];
         int insertPos = (int)filepos;
-        // If the offset falls inside a tag (<...>), add a filepos-id attribute
-        // to that tag rather than inserting a separate <a> element (which would
-        // split a text node and break highlights).
+        // If the offset falls inside a tag (<...>), add an id attribute to that
+        // tag rather than inserting a separate <a> element (which would split a
+        // text node and break highlights).
         bool injectIntoTag = false;
         int tagEndPos = insertPos;
         if (insertPos > 0 && insertPos < dataSize) {

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -113,6 +113,8 @@ static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString3
 static void collectMobiFileposData(const lUInt8 * data, int dataSize,
         LVArray<lUInt32> & fileposRefs) {
     for (int i = 0; i < dataSize - 8; ) {
+        lUInt8 ch = data[i];
+        if (ch != 'f' && ch != 'F') { i++; continue; }
         if (!matchFileposBytes(data, dataSize, i)) { i++; continue; }
         int pos = i + 7;
         // Skip whitespace before '='

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -75,21 +75,13 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
     }
 }
 
-static void appendBytes(LVArray<lUInt8> & out, const lUInt8 * data, int len) {
-    if (len > 0) out.add(data, len);
-}
-
-static void appendMobiMarker(LVArray<lUInt8> & out, lUInt32 filepos) {
-    lString8 marker("<a id=\"");
-    marker.append(MOBI_FILEPOS_ID_PREFIX);
-    marker.appendDecimal((lInt64)filepos);
-    marker.append("\"></a>");
-    appendBytes(out, (const lUInt8 *)marker.c_str(), marker.length());
-}
-
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject
-// <a id="fileposNNNN"></a> markers at those byte offsets, so the existing
-// id->node map can resolve them (and they survive cache serialization).
+// anchors at those byte offsets, so the existing id->node map can resolve them
+// (and they survive cache serialization).
+// Where the offset falls inside a start tag, we add a filepos-id="fileposNNNN"
+// attribute to that tag (which the writer filter will rewrite to id=), avoiding
+// splitting any text node. Otherwise, we insert a standalone <a id="fileposNNNN">
+// </a> marker (the same approach calibre uses).
 static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
     LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
     if (buffered.isNull())
@@ -116,14 +108,20 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
     qsort(fileposRefs.get(), fileposRefs.length(), sizeof(lUInt32), compareUInt32);
 
     // Build the rewritten byte array with markers inserted at filepos offsets.
-    // If the offset falls inside a tag (<...>), move past the closing '>'.
-    LVArray<lUInt8> rewritten;
-    rewritten.reserve(dataSize + fileposRefs.length() * 64);
+    LVStreamRef rewritten = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
+    if (rewritten.isNull()) {
+        stream->SetPos(0);
+        return LVStreamRef();
+    }
     int outPos = 0;
     for (int i = 0; i < fileposRefs.length(); i++) {
         lUInt32 filepos = fileposRefs[i];
         int insertPos = (int)filepos;
-        // Check if filepos is inside a tag by scanning backward for '<' and forward for '>'
+        // If the offset falls inside a tag (<...>), add a filepos-id attribute
+        // to that tag rather than inserting a separate <a> element (which would
+        // split a text node and break highlights).
+        bool injectIntoTag = false;
+        int tagEndPos = insertPos;
         if (insertPos > 0 && insertPos < dataSize) {
             // Find the nearest '<' before insertPos that is not closed by '>'
             int prevLT = -1;
@@ -131,26 +129,48 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
                 if (data[j] == '<') { prevLT = j; break; }
                 if (data[j] == '>') break; // not inside a tag
             }
-            if (prevLT >= 0) {
-                // Find the nearest '>' after insertPos
+            if (prevLT >= 0 && data[prevLT + 1] != '/') {
+                // Find the nearest '>' after insertPos (stopping at any '<')
                 int nextGT = -1;
                 for (int j = insertPos; j < dataSize; j++) {
                     if (data[j] == '>') { nextGT = j; break; }
                     if (data[j] == '<') break;
                 }
-                if (nextGT > insertPos)
-                    insertPos = nextGT + 1;
+                // We're inside a start tag if a '>' follows before any '<'.
+                // (If the offset is in text, we hit a '<' first and nextGT
+                // stays -1, so we insert a standalone marker instead.)
+                if (nextGT > insertPos) {
+                    injectIntoTag = true;
+                    tagEndPos = nextGT; // '>' position (attribute goes before it)
+                }
             }
         }
         if (insertPos < outPos)
             insertPos = outPos;
-        appendBytes(rewritten, data + outPos, insertPos - outPos);
-        appendMobiMarker(rewritten, filepos);
-        outPos = insertPos;
+        if (injectIntoTag) {
+            // Copy up to (but not including) the closing '>', then emit the
+            // attribute, then the '>'.
+            rewritten->Write(data + outPos, tagEndPos - outPos, NULL);
+            lString8 attr(" filepos-id=\"");
+            attr.append(MOBI_FILEPOS_ID_PREFIX);
+            attr.appendDecimal((lInt64)filepos);
+            attr.append("\"");
+            rewritten->Write(attr.c_str(), attr.length(), NULL);
+            outPos = tagEndPos;
+        } else {
+            rewritten->Write(data + outPos, insertPos - outPos, NULL);
+            lString8 marker("<a id=\"");
+            marker.append(MOBI_FILEPOS_ID_PREFIX);
+            marker.appendDecimal((lInt64)filepos);
+            marker.append("\"></a>");
+            rewritten->Write(marker.c_str(), marker.length(), NULL);
+            outPos = insertPos;
+        }
     }
-    appendBytes(rewritten, data + outPos, dataSize - outPos);
+    rewritten->Write(data + outPos, dataSize - outPos, NULL);
+    rewritten->SetPos(0);
     stream->SetPos(0);
-    return LVCreateMemoryStream(rewritten.ptr(), rewritten.length(), true, LVOM_READ);
+    return rewritten;
 }
 
 // Custom callback filter that rewrites MOBI-specific attributes during HTML parsing:

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -57,9 +57,7 @@ static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
 static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString32 & idValue) {
     for (int i = tagStart; i < tagEnd; i++) {
         // An attribute name is preceded by whitespace (or the tag name).
-        bool atBoundary = (i == tagStart) ||
-            data[i-1] == ' ' || data[i-1] == '\t' ||
-            data[i-1] == '\r' || data[i-1] == '\n';
+        bool atBoundary = (i == tagStart) || data[i-1] == ' ' || data[i-1] == '\t' || data[i-1] == '\r' || data[i-1] == '\n';
         if (!atBoundary)
             continue;
         int remaining = tagEnd - i;
@@ -75,29 +73,23 @@ static bool tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd, lString3
         if (nameLen == 0)
             continue;
         int afterName = i + nameLen;
-        if (afterName < tagEnd && data[afterName] != ' ' &&
-                    data[afterName] != '\t' && data[afterName] != '=' &&
-                    data[afterName] != '>')
+        if (afterName < tagEnd && data[afterName] != ' ' && data[afterName] != '\t' && data[afterName] != '=' && data[afterName] != '>')
             continue; // e.g. "idle", "width": not the id attribute
         // Skip whitespace and an optional '=' and quote to reach the value
         int p = afterName;
-        while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' ||
-                    data[p] == '\r' || data[p] == '\n')) {
+        while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' || data[p] == '\r' || data[p] == '\n')) {
             p++;
         }
         if (p < tagEnd && data[p] == '=') {
             p++;
-            while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' ||
-                        data[p] == '\r' || data[p] == '\n')) {
+            while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' || data[p] == '\r' || data[p] == '\n')) {
                 p++;
             }
             if (p < tagEnd && (data[p] == '"' || data[p] == '\''))
                 p++;
         }
         int valStart = p;
-        while (p < tagEnd && data[p] != '"' && data[p] != '\'' &&
-                    data[p] != ' ' && data[p] != '\t' &&
-                    data[p] != '\r' && data[p] != '\n' && data[p] != '>') {
+        while (p < tagEnd && data[p] != '"' && data[p] != '\'' && data[p] != ' ' && data[p] != '\t' && data[p] != '\r' && data[p] != '\n' && data[p] != '>') {
             p++;
         }
         if (p > valStart)

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -1689,31 +1689,41 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
         {
             LVStreamRef parserStream = stream;
             bool isMobiHtml = pdb->getFormat() == PDBFile::MOBI;
-            MobiFileposResolver mobiResolver;
-            // Injecting a standalone <a> marker into text could split a text nodes and break highlights.
+
+            // Injecting a standalone <a> marker into text could split a text node
+            // and break highlights; only do it on recent DOM versions.
             bool allowInjectStandaloneId = doc->getDOMVersionRequested() >= 20260812;
 
             if (isMobiHtml) {
+                MobiFileposResolver mobiResolver;
                 LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver, allowInjectStandaloneId);
                 if (!rewrittenStream.isNull())
                     parserStream = rewrittenStream;
-            }
 
-            MobiHtmlWriterFilter mobiWriterFilter(doc, mobiResolver);
-            ldomDocumentWriterFilter plainWriterFilter(doc, false, HTML_AUTOCLOSE_TABLE);
-            ldomDocumentWriterFilter * writerFilter = isMobiHtml
-                ? static_cast<ldomDocumentWriterFilter *>(&mobiWriterFilter)
-                : &plainWriterFilter;
-            LVHTMLParser parser(parserStream, writerFilter);
-            parser.setProgressCallback(progressCallback);
-            if ( !parser.CheckFormat() ) {
-                return false;
-            } else {
-                if (isMobiHtml && isCorrectUtf8Text(parserStream))
-                    parser.SetCharset(U"utf-8");
-                parserStream->SetPos(0);
-                if (!parser.Parse()) {
+                MobiHtmlWriterFilter mobiWriterFilter(doc, mobiResolver);
+                LVHTMLParser parser(parserStream, &mobiWriterFilter);
+                parser.setProgressCallback(progressCallback);
+                if ( !parser.CheckFormat() ) {
                     return false;
+                } else {
+                    if (isCorrectUtf8Text(parserStream))
+                        parser.SetCharset(U"utf-8");
+                    parserStream->SetPos(0);
+                    if (!parser.Parse()) {
+                        return false;
+                    }
+                }
+            } else {
+                ldomDocumentWriterFilter plainWriterFilter(doc, false, HTML_AUTOCLOSE_TABLE);
+                LVHTMLParser parser(parserStream, &plainWriterFilter);
+                parser.setProgressCallback(progressCallback);
+                if ( !parser.CheckFormat() ) {
+                    return false;
+                } else {
+                    parserStream->SetPos(0);
+                    if (!parser.Parse()) {
+                        return false;
+                    }
                 }
             }
         }

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -171,15 +171,10 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
 // mid-text do we insert a standalone <a id="fileposNNNN"></a> marker (the same
 // approach calibre uses).
 static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver, bool allowInjectStandaloneId) {
-    LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
-    if (buffered.isNull())
-        return LVStreamRef();
     stream->SetPos(0);
-    LVPumpStream(buffered, stream);
-    buffered->SetPos(0);
-    LVByteArrayRef rawData = buffered->GetData();
+    LVByteArrayRef rawData = stream->GetData();
+    stream->SetPos(0);
     if (rawData.isNull() || rawData->empty()) {
-        stream->SetPos(0);
         return LVStreamRef();
     }
     const lUInt8 * data = rawData->get();
@@ -188,7 +183,6 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
     LVArray<lUInt32> fileposRefs;
     collectMobiFileposData(data, dataSize, fileposRefs);
     if (fileposRefs.empty()) {
-        stream->SetPos(0);
         return LVStreamRef();
     }
 

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -19,21 +19,91 @@
 
 static const char * MOBI_FILEPOS_ID_PREFIX = "filepos";
 
+// Maps a filepos byte offset to the id a link should target. Only populated
+// when the target element already has its own id, so we point the link at that
+// id instead of injecting a synthetic one (which would duplicate it).
+struct MobiFileposResolver {
+    LVHashTable<lUInt32, lString32> targetIds;
+    MobiFileposResolver() : targetIds(256) {}
+};
+
 static int compareUInt32(const void * left, const void * right) {
     lUInt32 a = *(const lUInt32 *)left, b = *(const lUInt32 *)right;
     return (a < b) ? -1 : (a > b) ? 1 : 0;
 }
 
-// Quick case-insensitive check: does data[pos..pos+6] match "filepos"?
-static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
-    if (pos + 7 > dataSize) return false;
-    for (int i = 0; i < 7; i++) {
+// Case-insensitive match of a fixed-length ASCII string at data[pos].
+static bool matchAscii(const lUInt8 * data, int pos, const char * str, int len) {
+    for (int i = 0; i < len; i++) {
         lUInt8 ch = data[pos + i];
-        lUInt8 expected = (lUInt8)"filepos"[i];
+        lUInt8 expected = (lUInt8)str[i];
         if (ch != expected && (ch < 'A' || ch > 'Z' || ch != (expected - 32)))
             return false;
     }
     return true;
+}
+
+// Quick case-insensitive check: does data[pos..pos+6] match "filepos"?
+static bool matchFileposBytes(const lUInt8 * data, int dataSize, int pos) {
+    if (pos + 7 > dataSize) return false;
+    return matchAscii(data, pos, "filepos", 7);
+}
+
+// Does the start tag spanning [tagStart, tagEnd) already declare an "id" or
+// "filepos-id" attribute? If so, return its value (so a link can point at it
+// instead of us injecting a duplicate id). Returns an empty string if none.
+static lString32 tagGetIdAttr(const lUInt8 * data, int tagStart, int tagEnd) {
+    for (int i = tagStart; i < tagEnd; i++) {
+        // An attribute name is preceded by whitespace (or the tag name).
+        bool atBoundary = (i == tagStart) ||
+            data[i-1] == ' ' || data[i-1] == '\t' ||
+            data[i-1] == '\r' || data[i-1] == '\n';
+        if (!atBoundary)
+            continue;
+        int remaining = tagEnd - i;
+        int nameLen = 0;
+        // "filepos-id" (9 chars)
+        if (remaining >= 9 && matchAscii(data, i, "filepos-id", 9)) {
+            nameLen = 9;
+        }
+        // "id" (2 chars)
+        else if (remaining >= 2 && matchAscii(data, i, "id", 2)) {
+            nameLen = 2;
+        }
+        if (nameLen == 0)
+            continue;
+        int afterName = i + nameLen;
+        if (afterName < tagEnd && data[afterName] != ' ' &&
+                    data[afterName] != '\t' && data[afterName] != '=' &&
+                    data[afterName] != '>')
+            continue; // e.g. "idle", "width": not the id attribute
+        // Skip whitespace and an optional '=' and quote to reach the value
+        int p = afterName;
+        while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' ||
+                    data[p] == '\r' || data[p] == '\n')) {
+            p++;
+        }
+        if (p < tagEnd && data[p] == '=') {
+            p++;
+            while (p < tagEnd && (data[p] == ' ' || data[p] == '\t' ||
+                        data[p] == '\r' || data[p] == '\n')) {
+                p++;
+            }
+            if (p < tagEnd && (data[p] == '"' || data[p] == '\''))
+                p++;
+        }
+        int valStart = p;
+        while (p < tagEnd && data[p] != '"' && data[p] != '\'' &&
+                    data[p] != ' ' && data[p] != '\t' &&
+                    data[p] != '\r' && data[p] != '\n' && data[p] != '>') {
+            p++;
+        }
+        if (p > valStart)
+            return lString32((const lChar8 *)(data + valStart), p - valStart);
+        // Attribute present but empty value: still counts as "has an id".
+        return lString32(U"");
+    }
+    return lString32();
 }
 
 // Scan raw HTML bytes for filepos="NNNN" occurrences, record the numeric values.
@@ -75,14 +145,37 @@ static void collectMobiFileposData(const lUInt8 * data, int dataSize,
     }
 }
 
+// Emit a filepos-id="fileposNNNN" attribute (rewritten to id= by the writer
+// filter) into the stream, to be placed inside a start tag.
+static void writeFileposIdAttr(LVStreamRef & out, lUInt32 filepos) {
+    lString8 attr(" filepos-id=\"");
+    attr.append(MOBI_FILEPOS_ID_PREFIX);
+    attr.appendDecimal((lInt64)filepos);
+    attr.append("\"");
+    out->Write(attr.c_str(), attr.length(), NULL);
+}
+
+// Emit a standalone <a id="fileposNNNN"></a> marker.
+static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
+    lString8 marker("<a id=\"");
+    marker.append(MOBI_FILEPOS_ID_PREFIX);
+    marker.appendDecimal((lInt64)filepos);
+    marker.append("\"></a>");
+    out->Write(marker.c_str(), marker.length(), NULL);
+}
+
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject
 // anchors at those byte offsets, so the existing id->node map can resolve them
 // (and they survive cache serialization).
 // Where the offset falls inside a start tag, we add a filepos-id="fileposNNNN"
 // attribute to that tag (which the writer filter will rewrite to id=), avoiding
-// splitting any text node. Otherwise, we insert a standalone <a id="fileposNNNN">
-// </a> marker (the same approach calibre uses).
-static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
+// splitting any text node. Otherwise, if the offset is immediately followed
+// (after whitespace) by a start tag, we attach the id to that tag too: an empty
+// inline <a> anchor right after a page break would resolve to the previous page,
+// whereas attaching the id to the following element keeps the target on the
+// correct page. Only when the offset lands mid-text do we insert a standalone
+// <a id="fileposNNNN"></a> marker (the same approach calibre uses).
+static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResolver & resolver) {
     LVStreamRef buffered = LVCreateMemoryStream(NULL, 0, false, LVOM_READWRITE);
     if (buffered.isNull())
         return LVStreamRef();
@@ -140,8 +233,44 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
                 // (If the offset is in text, we hit a '<' first and nextGT
                 // stays -1, so we insert a standalone marker instead.)
                 if (nextGT > insertPos) {
-                    injectIntoTag = true;
-                    tagEndPos = nextGT; // '>' position (attribute goes before it)
+                    lString32 existingId = tagGetIdAttr(data, prevLT, nextGT);
+                    if (!existingId.empty()) {
+                        // The tag already has an id: point the link at it.
+                        resolver.targetIds.set(filepos, existingId);
+                    } else {
+                        injectIntoTag = true;
+                        tagEndPos = nextGT; // '>' position (attribute goes before it)
+                    }
+                }
+            }
+        }
+        if (!injectIntoTag) {
+            // The offset is not inside a tag. If it is immediately followed
+            // (after whitespace) by a start tag, attach the id to that tag
+            // instead of emitting an empty <a> marker: an empty inline anchor
+            // right after a page break resolves to the previous page.
+            int j = insertPos;
+            while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
+                        data[j] == '\r' || data[j] == '\n')) {
+                j++;
+            }
+            if (j < dataSize && data[j] == '<' && j + 1 < dataSize &&
+                        data[j + 1] != '/') {
+                // Find the '>' closing this start tag
+                int nextGT = -1;
+                for (int k = j + 1; k < dataSize; k++) {
+                    if (data[k] == '>') { nextGT = k; break; }
+                    if (data[k] == '<') break;
+                }
+                if (nextGT > j) {
+                    lString32 existingId = tagGetIdAttr(data, j, nextGT);
+                    if (!existingId.empty()) {
+                        // The tag already has an id: point the link at it.
+                        resolver.targetIds.set(filepos, existingId);
+                    } else {
+                        injectIntoTag = true;
+                        tagEndPos = nextGT;
+                    }
                 }
             }
         }
@@ -151,19 +280,11 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
             // Copy up to (but not including) the closing '>', then emit the
             // attribute, then the '>'.
             rewritten->Write(data + outPos, tagEndPos - outPos, NULL);
-            lString8 attr(" filepos-id=\"");
-            attr.append(MOBI_FILEPOS_ID_PREFIX);
-            attr.appendDecimal((lInt64)filepos);
-            attr.append("\"");
-            rewritten->Write(attr.c_str(), attr.length(), NULL);
+            writeFileposIdAttr(rewritten, filepos);
             outPos = tagEndPos;
         } else {
             rewritten->Write(data + outPos, insertPos - outPos, NULL);
-            lString8 marker("<a id=\"");
-            marker.append(MOBI_FILEPOS_ID_PREFIX);
-            marker.appendDecimal((lInt64)filepos);
-            marker.append("\"></a>");
-            rewritten->Write(marker.c_str(), marker.length(), NULL);
+            writeFileposMarker(rewritten, filepos);
             outPos = insertPos;
         }
     }
@@ -177,9 +298,11 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream) {
 // - filepos-id="XXX" -> id="XXX" (target marker, registered in the id->node map)
 // - filepos="NNNN" -> href="#fileposNNNN" (link to a byte-offset target)
 class MobiHtmlWriterFilter : public ldomDocumentWriterFilter {
+    MobiFileposResolver & _resolver;
 public:
-    MobiHtmlWriterFilter(ldomDocument * document)
-        : ldomDocumentWriterFilter(document, false, HTML_AUTOCLOSE_TABLE) {}
+    MobiHtmlWriterFilter(ldomDocument * document, MobiFileposResolver & resolver)
+        : ldomDocumentWriterFilter(document, false, HTML_AUTOCLOSE_TABLE)
+        , _resolver(resolver) {}
 
     virtual void OnAttribute(const lChar32 * nsname, const lChar32 * attrname,
                              const lChar32 * attrvalue) {
@@ -190,9 +313,17 @@ public:
             return;
         }
         if (attrname && !lStr_cmp(attrname, U"filepos")) {
-            // Link to a byte offset: rewrite to href="#fileposNNNN".
+            // Link to a byte offset: rewrite to href="#fileposNNNN", or to the
+            // target element's existing id if it already had one.
             lInt64 filepos = 0;
             if (lString32(attrvalue).atoi(filepos) && filepos >= 0 && filepos <= 0xFFFFFFFFLL) {
+                lString32 targetId;
+                if (_resolver.targetIds.get((lUInt32)filepos, targetId)) {
+                    lString32 href(U"#");
+                    href.append(targetId);
+                    ldomDocumentWriterFilter::OnAttribute(nsname, U"href", href.c_str());
+                    return;
+                }
                 lString32 href(U"#");
                 href.append(MOBI_FILEPOS_ID_PREFIX);
                 href.appendDecimal(filepos);
@@ -1512,14 +1643,15 @@ bool ImportPDBDocument( LVStreamRef & stream, ldomDocument * doc, LVDocViewCallb
         {
             LVStreamRef parserStream = stream;
             bool isMobiHtml = pdb->getFormat() == PDBFile::MOBI;
+            MobiFileposResolver mobiResolver;
 
             if (isMobiHtml) {
-                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream);
+                LVStreamRef rewrittenStream = preprocessMobiHtmlStream(stream, mobiResolver);
                 if (!rewrittenStream.isNull())
                     parserStream = rewrittenStream;
             }
 
-            MobiHtmlWriterFilter mobiWriterFilter(doc);
+            MobiHtmlWriterFilter mobiWriterFilter(doc, mobiResolver);
             LVHTMLParser parser(parserStream, &mobiWriterFilter);
             parser.setProgressCallback(progressCallback);
             if ( !parser.CheckFormat() ) {

--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -155,6 +155,49 @@ static void writeFileposMarker(LVStreamRef & out, lUInt32 filepos) {
     out->Write(buf, len, NULL);
 }
 
+// Locate a start tag we can attach a synthetic id to, given a byte offset pos.
+// If pos is inside a start tag, return that tag's [<, >) span. Otherwise, if
+// pos is immediately followed (after whitespace) by a start tag, return that
+// tag's span. Returns false (leaving tagStart/tagEnd untouched) if neither
+// applies, i.e. the offset lands in text/whitespace with no following start tag.
+static bool findStartTagAt(const lUInt8 * data, int dataSize, int pos,
+        int & tagStart, int & tagEnd) {
+    // Is pos inside a start tag? Find the nearest '<' before pos that is not
+    // already closed by a '>'.
+    if (pos > 0 && pos < dataSize) {
+        int prevLT = -1;
+        for (int j = pos - 1; j >= 0; j--) {
+            if (data[j] == '<') { prevLT = j; break; }
+            if (data[j] == '>') break; // not inside a tag
+        }
+        if (prevLT >= 0 && data[prevLT + 1] != '/') {
+            // Find the nearest '>' after pos (stopping at any '<').
+            for (int j = pos; j < dataSize; j++) {
+                if (data[j] == '>') {
+                    if (j > pos) { tagStart = prevLT; tagEnd = j; return true; }
+                    break;
+                }
+                if (data[j] == '<') break;
+            }
+        }
+    }
+    // Is pos immediately followed (after whitespace) by a start tag?
+    int j = pos;
+    while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
+                data[j] == '\r' || data[j] == '\n')) {
+        j++;
+    }
+    if (j < dataSize && data[j] == '<' && j + 1 < dataSize &&
+                data[j + 1] != '/') {
+        // Find the '>' closing this start tag.
+        for (int k = j + 1; k < dataSize; k++) {
+            if (data[k] == '>') { tagStart = j; tagEnd = k; return true; }
+            if (data[k] == '<') break;
+        }
+    }
+    return false;
+}
+
 // Pre-process the raw HTML stream: find all filepos=NNNN references and inject
 // anchors at those byte offsets, so the existing id->node map can resolve them
 // (and they survive cache serialization).
@@ -209,63 +252,14 @@ static LVStreamRef preprocessMobiHtmlStream(LVStreamRef stream, MobiFileposResol
         // text node and break highlights).
         bool injectIntoTag = false;
         int tagEndPos = insertPos;
-        if (insertPos > 0 && insertPos < dataSize) {
-            // Find the nearest '<' before insertPos that is not closed by '>'
-            int prevLT = -1;
-            for (int j = insertPos - 1; j >= 0; j--) {
-                if (data[j] == '<') { prevLT = j; break; }
-                if (data[j] == '>') break; // not inside a tag
-            }
-            if (prevLT >= 0 && data[prevLT + 1] != '/') {
-                // Find the nearest '>' after insertPos (stopping at any '<')
-                int nextGT = -1;
-                for (int j = insertPos; j < dataSize; j++) {
-                    if (data[j] == '>') { nextGT = j; break; }
-                    if (data[j] == '<') break;
-                }
-                // We're inside a start tag if a '>' follows before any '<'.
-                // (If the offset is in text, we hit a '<' first and nextGT
-                // stays -1, so we insert a standalone marker instead.)
-                if (nextGT > insertPos) {
-                    lString32 existingId;
-                    if (tagGetIdAttr(data, prevLT, nextGT, existingId)) {
-                        // The tag already has an id: point the link at it.
-                        resolver.targetIds.set(filepos, existingId);
-                    } else {
-                        injectIntoTag = true;
-                        tagEndPos = nextGT; // '>' position (attribute goes before it)
-                    }
-                }
-            }
-        }
-        if (!injectIntoTag) {
-            // The offset is not inside a tag. If it is immediately followed
-            // (after whitespace) by a start tag, attach the id to that tag
-            // instead of emitting an empty <a> marker: an empty inline anchor
-            // right after a page break resolves to the previous page.
-            int j = insertPos;
-            while (j < dataSize && (data[j] == ' ' || data[j] == '\t' ||
-                        data[j] == '\r' || data[j] == '\n')) {
-                j++;
-            }
-            if (j < dataSize && data[j] == '<' && j + 1 < dataSize &&
-                        data[j + 1] != '/') {
-                // Find the '>' closing this start tag
-                int nextGT = -1;
-                for (int k = j + 1; k < dataSize; k++) {
-                    if (data[k] == '>') { nextGT = k; break; }
-                    if (data[k] == '<') break;
-                }
-                if (nextGT > j) {
-                    lString32 existingId;
-                    if (tagGetIdAttr(data, j, nextGT, existingId)) {
-                        // The tag already has an id: point the link at it.
-                        resolver.targetIds.set(filepos, existingId);
-                    } else {
-                        injectIntoTag = true;
-                        tagEndPos = nextGT;
-                    }
-                }
+        int tagStart;
+        if (findStartTagAt(data, dataSize, insertPos, tagStart, tagEndPos)) {
+            lString32 existingId;
+            if (tagGetIdAttr(data, tagStart, tagEndPos, existingId)) {
+                // The tag already has an id: point the link at it.
+                resolver.targetIds.set(filepos, existingId);
+            } else {
+                injectIntoTag = true;
             }
         }
         if (insertPos < outPos)


### PR DESCRIPTION
MOBI uses byte offsets for internal links: <a filepos="NNNN"> points to byte offset NNNN, and filepos-id="XXX" marks a target.

Rewrite filepos-id/filepos attributes to plain id/href and inject <a id="fileposNNNN"></a> markers at the referenced offsets (as calibre does), so the existing id->node map resolves fragments and survives cache serialization.

---

This is an improved version of the patch in <https://github.com/koreader/koreader/issues/11621#issuecomment-4328024820>, but it's fundamentally the same principle.

It remains a bit hackish, but that was more or less endorsed by @poire-z in <https://github.com/koreader/koreader/pull/15877#discussion_r3791720408>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/726)
<!-- Reviewable:end -->
