### PR TITLE
pdbfmt: guard against empty buffer in MOBI extra-data stripping

### DIFF
--- a/crengine/src/pdbfmt.cpp
+++ b/crengine/src/pdbfmt.cpp
@@ -529,6 +529,8 @@ private:
         for (int flag = 0x8000; flag; flag >>= 1) {
             if (!(_mobiExtraDataFlags & flag))
                 continue;
+            if (buf.length() == 0)
+                return; // nothing to strip from an empty record
             lInt32 n = buf[buf.length()-1];
             if (flag == 1) {
                 n &= 3;


### PR DESCRIPTION
The only valid clang-tidy concern that came up in <https://github.com/koreader/crengine/pull/726>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/727)
<!-- Reviewable:end -->
