### PR TITLE
Background image fixes

### DIFF
--- a/crengine/include/cssdef.h
+++ b/crengine/include/cssdef.h
@@ -290,18 +290,6 @@ enum css_background_repeat_value_t {
     css_background_no_repeat,
     css_background_r_inherit
 };
-enum css_background_position_value_t {
-    css_background_left_top = 0,
-    css_background_left_center,
-    css_background_left_bottom,
-    css_background_right_top,
-    css_background_right_center,
-    css_background_right_bottom,
-    css_background_center_top,
-    css_background_center_center,
-    css_background_center_bottom = 8,
-    css_background_p_inherit = 9
-};
 
 enum css_border_collapse_value_t {
     css_border_c_inherit,

--- a/crengine/include/lvdrawbuf.h
+++ b/crengine/include/lvdrawbuf.h
@@ -115,6 +115,7 @@ public:
     virtual void setDitherImages( bool dither ) = 0;
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor
     virtual void setSmoothScalingImages( bool smooth ) = 0;
+    virtual bool getSmoothScalingImages() const = 0;
     /// invert image
     virtual void Invert() = 0;
     /// get buffer width, pixels
@@ -280,6 +281,7 @@ public:
     virtual void setDitherImages( bool dither ) { _ditherImages = dither; }
     /// set to true to switch to a more costly smooth scaler instead of nearest neighbor
     virtual void setSmoothScalingImages( bool smooth ) { _smoothImages = smooth; }
+    virtual bool getSmoothScalingImages() const { return _smoothImages; }
     /// returns current background color
     virtual lUInt32 GetBackgroundColor() const { return _backgroundColor; }
     /// sets current background color

--- a/crengine/include/lvimg.h
+++ b/crengine/include/lvimg.h
@@ -110,7 +110,9 @@ enum ImageTransform {
 
 
 /// creates image which stretches source image by filling center with pixels at splitX, splitY
-LVImageSourceRef LVCreateStretchFilledTransform( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform=IMG_TRANSFORM_SPLIT, ImageTransform vTransform=IMG_TRANSFORM_SPLIT, int splitX=-1, int splitY=-1 );
+/// (smooth only applies to a genuine two-axis IMG_TRANSFORM_STRETCH; it's ignored for
+/// split/tile transforms)
+LVImageSourceRef LVCreateStretchFilledTransform( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform=IMG_TRANSFORM_SPLIT, ImageTransform vTransform=IMG_TRANSFORM_SPLIT, int splitX=-1, int splitY=-1, bool smooth=false );
 /// creates image which fills area with tiled copy
 LVImageSourceRef LVCreateTileTransform( LVImageSourceRef src, int newWidth, int newHeight, int offsetX, int offsetY );
 /// creates XPM image

--- a/crengine/include/lvstyles.h
+++ b/crengine/include/lvstyles.h
@@ -80,7 +80,8 @@ enum css_style_rec_important_bit {
     imp_bit_border_color_left,
     imp_bit_background_image,
     imp_bit_background_repeat,
-    imp_bit_background_position,
+    imp_bit_background_position_x,
+    imp_bit_background_position_y,
     imp_bit_background_size_h,
     imp_bit_background_size_v,
     imp_bit_border_collapse,
@@ -100,7 +101,7 @@ enum css_style_rec_important_bit {
     imp_bit_content,
     imp_bit_cr_hint
 };
-#define NB_IMP_BITS 73 // The number of lines in the enum above: KEEP IT UPDATED.
+#define NB_IMP_BITS 74 // The number of lines in the enum above: KEEP IT UPDATED.
 
 #define NB_IMP_SLOTS    ((NB_IMP_BITS-1)>>5)+1
 // In lvstyles.cpp, we have hardcoded important[0] ... importance[2]
@@ -176,7 +177,7 @@ struct css_style_rec_tag {
     css_length_t border_color[4]; ///< border-top-color, -right-, -bottom-, -left-
     lString8 background_image;
     css_background_repeat_value_t background_repeat;
-    css_background_position_value_t background_position;
+    css_length_t background_position[2]; ///< horizontal, vertical
     css_length_t background_size[2];//first width and second height
     css_border_collapse_value_t border_collapse;
     css_length_t border_spacing[2];//first horizontal and the second vertical spacing
@@ -242,7 +243,6 @@ struct css_style_rec_tag {
     , border_style_right(css_border_none)
     , border_style_left(css_border_none)
     , background_repeat(css_background_repeat)
-    , background_position(css_background_left_top)
     , border_collapse(css_border_c_inherit)
     , orphans(css_orphans_widows_inherit)
     , widows(css_orphans_widows_inherit)
@@ -287,6 +287,9 @@ struct css_style_rec_tag {
         // background-size defaults to "auto auto"
         background_size[0] = css_length_t(css_val_unspecified, css_generic_auto);
         background_size[1] = css_length_t(css_val_unspecified, css_generic_auto);
+        // background-position defaults to "0% 0%" (ie. "left top")
+        background_position[0] = css_length_t(css_val_percent, 0);
+        background_position[1] = css_length_t(css_val_percent, 0);
     }
     void AddRef() { refCount++; }
     int Release() { return --refCount; }

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2435,8 +2435,15 @@ protected:
 	int _split_y;
 	LVArray<lUInt32> _line;
 	LVImageDecoderCallback * _callback;
+	// True when a smooth (interpolated) scale was requested *and* applies here: a
+	// genuine two-axis stretch of a fixed-resolution raster that actually changes
+	// size. We buffer the whole decoded source into _decoded, and OnEndDecode()
+	// runs it through the same smooth scaler used for normal <img> elements
+	// (CRe::qSmoothScaleImage), instead of nearest-neighbor remapping line by line.
+	bool _smoothscale;
+	lUInt8 * __restrict _decoded;
 public:
-    LVStretchImgSource( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform, ImageTransform vTransform, int splitX, int splitY )
+    LVStretchImgSource( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform, ImageTransform vTransform, int splitX, int splitY, bool smooth = false )
 		: _src( src )
 		, _src_dx( src->GetWidth() )
 		, _src_dy( src->GetHeight() )
@@ -2446,6 +2453,9 @@ public:
         , _vTransform(vTransform)
 		, _split_x( splitX )
 		, _split_y( splitY )
+		, _smoothscale( smooth && hTransform == IMG_TRANSFORM_STRETCH && vTransform == IMG_TRANSFORM_STRETCH
+		                && (_src_dx != newWidth || _src_dy != newHeight) )
+		, _decoded(0)
 	{
         if ( _hTransform == IMG_TRANSFORM_TILE )
             if ( _split_x>=_src_dx )
@@ -2457,6 +2467,8 @@ public:
 			_split_x = _src_dx / 2;
 		if ( _split_y<0 || _split_y>=_src_dy )
 			_split_y = _src_dy / 2;
+        if ( _smoothscale )
+            _decoded = new lUInt8[ _src_dy * (_src_dx * 4) ];
 	}
     virtual void OnStartDecode( LVImageSource * )
 	{
@@ -2464,9 +2476,19 @@ public:
         _callback->OnStartDecode(this);
 	}
     virtual bool OnLineDecoded( LVImageSource * obj, int y, lUInt32 * __restrict data );
-    virtual void OnEndDecode( LVImageSource *, bool res)
+    virtual void OnEndDecode( LVImageSource * obj, bool res)
 	{
 		_line.clear();
+        if ( _smoothscale && !res ) {
+            lUInt8 * __restrict sdata = CRe::qSmoothScaleImage(_decoded, _src_dx, _src_dy, false, _dst_dx, _dst_dy);
+            if ( sdata ) {
+                for ( int y=0; y<_dst_dy; y++ )
+                    _callback->OnLineDecoded( obj, y, (lUInt32 *)(sdata + y * (_dst_dx * 4)) );
+                free(sdata);
+            }
+            // else: smooth scaling failed, draw nothing for this image (same as the
+            // normal <img> smooth scaler's failure behavior in LVImageScaledDrawCallback)
+        }
         _callback->OnEndDecode(this, res);
     }
 	virtual ldomDocument * GetSourceDocument() { return _src.isNull() ? NULL : _src->GetSourceDocument(); }
@@ -2482,11 +2504,20 @@ public:
 	}
     virtual ~LVStretchImgSource()
 	{
+        if ( _decoded )
+            delete[] _decoded;
 	}
 };
 
 bool LVStretchImgSource::OnLineDecoded( LVImageSource * obj, int y, lUInt32 * __restrict data )
 {
+    if ( _smoothscale ) {
+        // Defer everything to OnEndDecode()'s smooth-scaling pass: just stash
+        // this source line at native resolution.
+        memcpy(_decoded + (y * (_src_dx * 4)), data, (_src_dx * 4));
+        return true;
+    }
+
     bool res = false;
 
     switch ( _hTransform ) {
@@ -2573,11 +2604,11 @@ bool LVStretchImgSource::OnLineDecoded( LVImageSource * obj, int y, lUInt32 * __
 }
 
 /// creates image which stretches source image by filling center with pixels at splitX, splitY
-LVImageSourceRef LVCreateStretchFilledTransform( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform, ImageTransform vTransform, int splitX, int splitY )
+LVImageSourceRef LVCreateStretchFilledTransform( LVImageSourceRef src, int newWidth, int newHeight, ImageTransform hTransform, ImageTransform vTransform, int splitX, int splitY, bool smooth )
 {
 	if ( src.isNull() )
 		return LVImageSourceRef();
-    return LVImageSourceRef( new LVStretchImgSource( src, newWidth, newHeight, hTransform, vTransform, splitX, splitY ) );
+    return LVImageSourceRef( new LVStretchImgSource( src, newWidth, newHeight, hTransform, vTransform, splitX, splitY, smooth ) );
 }
 
 /// creates image which fills area with tiled copy

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2258,14 +2258,19 @@ lUInt8 * LVSvgImageSource::Render(int &width, int &height, lUInt32 fillcolor, bo
 }
 
 bool LVSvgImageSource::Decode( LVImageDecoderCallback * callback ) {
+    // If the callback can render itself at an exact target size (see
+    // LVStretchImgSource::GetTargetSize()), that's the size we want to
+    // rasterize at directly, instead of the SVG's own intrinsic size.
+    int target_w = 0, target_h = 0;
+    bool have_target_size = false;
     if ( callback ) { // We're going to draw
         // We can't just use doc->renderToBitmap(final_width, final_height) below
         // as lunasvg would just scale it to the final size. We need to tell it
         // this final size early, so it can ensure preserveAspectRatio in it.
-        int w, h;
-        if ( callback->GetTargetSize(w, h) ) {
-            lunasvg_xcontext.target_width = w;
-            lunasvg_xcontext.target_height = h;
+        if ( callback->GetTargetSize(target_w, target_h) ) {
+            have_target_size = true;
+            lunasvg_xcontext.target_width = target_w;
+            lunasvg_xcontext.target_height = target_h;
             // When drawing with Decode(callback), we're coming from NodeImageProxy()
             // which has created us with assume_valid=false, and the next LoadSVGDocument()
             // will be the first load, which will use these target_width/height.
@@ -2284,15 +2289,25 @@ bool LVSvgImageSource::Decode( LVImageDecoderCallback * callback ) {
     if ( ! callback ) // If no callback provided, only size is wanted
         return true;
 
-    lunasvg::Bitmap bitmap = lunasvg_doc->renderToBitmap(_width, _height, 0x00000000);
+    // Render at the requested target size when we have one (this is what
+    // actually rasterizes the vector content at that size -- setting
+    // target_width/height above only feeds preserveAspectRatio resolution
+    // for nested content), falling back to the SVG's own intrinsic size.
+    int render_w = have_target_size ? target_w : _width;
+    int render_h = have_target_size ? target_h : _height;
+    lunasvg::Bitmap bitmap = lunasvg_doc->renderToBitmap(render_w, render_h, 0x00000000);
     if ( ! bitmap.valid() )
         return false;
+    // Use the bitmap's actual size (lunasvg may adjust it, eg. clamping to
+    // preserve aspect ratio) rather than assuming it matches what we asked for.
+    render_w = bitmap.width();
+    render_h = bitmap.height();
 
     callback->OnStartDecode(this);
     lUInt32 * __restrict src = (lUInt32 *)bitmap.data();
-    lUInt32 * __restrict row = new lUInt32 [ _width ];
-    for (int y=0; y<_height; y++) {
-        size_t px_count = _width;
+    lUInt32 * __restrict row = new lUInt32 [ render_w ];
+    for (int y=0; y<render_h; y++) {
+        size_t px_count = render_w;
         lUInt32 * __restrict dst = row;
         while (px_count--) {
             // LunaSVG outputs BGRA with premultiplied alpha, crengine wants BGRa (inverted alpha)
@@ -2425,6 +2440,23 @@ LVImageSourceRef LVCreateStreamCopyImageSource( LVStreamRef stream )
 
 class LVStretchImgSource : public LVImageSource, public LVImageDecoderCallback
 {
+private:
+    // True when scaling from (srcW,srcH) to (dstW,dstH) preserves aspect ratio
+    // (within a small rounding tolerance), as opposed to a deliberately
+    // distorting stretch (eg. CSS background-size with independent width/height
+    // lengths). Only a ratio-preserving stretch is safe for the
+    // _srcIsScalableStretch fast path below: it asks a scalable source (SVG) to
+    // render itself directly via a target-size hint, but (at least with the
+    // vendored lunasvg) that hint always resolves like intrinsic/replaced-element
+    // sizing -- ie. aspect-preserving and letterboxed -- unlike a raw pixel
+    // remap, so it can't reproduce a genuine non-uniform distortion.
+    static bool isUniformScale(int srcW, int srcH, int dstW, int dstH) {
+        if (srcW <= 0 || srcH <= 0)
+            return false;
+        int expected_dstH = (int)(((lInt64)dstW * srcH) / srcW);
+        int diff = dstH - expected_dstH;
+        return (diff >= -2 && diff <= 2);
+    }
 protected:
 	LVImageSourceRef _src;
 	int _src_dx;
@@ -2437,11 +2469,22 @@ protected:
 	int _split_y;
 	LVArray<lUInt32> _line;
 	LVImageDecoderCallback * _callback;
+	// True when _src can render itself directly at our exact target size (eg. an
+	// SVG source) and we're doing a plain fill-the-whole-area stretch on both axes
+	// (not a 9-patch split or a tile, which need a fixed-size source to split/repeat).
+	// In that case there's no native-resolution raster to pixel-remap or smooth-scale
+	// at all: we tell _src our target size via GetTargetSize() below, and
+	// OnLineDecoded() just passes its (already correctly-sized) lines straight
+	// through instead of remapping them.
+	bool _srcIsScalableStretch;
 	// True when a smooth (interpolated) scale was requested *and* applies here: a
 	// genuine two-axis stretch of a fixed-resolution raster that actually changes
 	// size. We buffer the whole decoded source into _decoded, and OnEndDecode()
 	// runs it through the same smooth scaler used for normal <img> elements
 	// (CRe::qSmoothScaleImage), instead of nearest-neighbor remapping line by line.
+	// (Not used when _srcIsScalableStretch, as that path is strictly better: the
+	// source renders natively at the exact target size instead of being decoded
+	// at native resolution and then rescaled.)
 	bool _smoothscale;
 	lUInt8 * __restrict _decoded;
 public:
@@ -2455,7 +2498,9 @@ public:
         , _vTransform(vTransform)
 		, _split_x( splitX )
 		, _split_y( splitY )
-		, _smoothscale( smooth && hTransform == IMG_TRANSFORM_STRETCH && vTransform == IMG_TRANSFORM_STRETCH
+		, _srcIsScalableStretch( src->IsScalable() && hTransform == IMG_TRANSFORM_STRETCH && vTransform == IMG_TRANSFORM_STRETCH
+		                         && isUniformScale(_src_dx, _src_dy, newWidth, newHeight) )
+		, _smoothscale( !_srcIsScalableStretch && smooth && hTransform == IMG_TRANSFORM_STRETCH && vTransform == IMG_TRANSFORM_STRETCH
 		                && (_src_dx != newWidth || _src_dy != newHeight) )
 		, _decoded(0)
 	{
@@ -2493,6 +2538,18 @@ public:
         }
         _callback->OnEndDecode(this, res);
     }
+    // LVImageDecoderCallback: called by _src->Decode(this) below to ask us (as
+    // its callback) what size it should render itself at. Only meaningful when
+    // _srcIsScalableStretch, in which case it's our own fixed target size --
+    // see the member comment above.
+    virtual bool GetTargetSize(int & width, int & height) const {
+        if ( !_srcIsScalableStretch ) {
+            return false;
+        }
+        width = _dst_dx;
+        height = _dst_dy;
+        return true;
+    }
 	virtual ldomDocument * GetSourceDocument() { return _src.isNull() ? NULL : _src->GetSourceDocument(); }
 	virtual ldomNode * GetSourceNode() { return _src.isNull() ? NULL : _src->GetSourceNode(); }
 	virtual LVStream * GetSourceStream() { return NULL; }
@@ -2513,6 +2570,13 @@ public:
 
 bool LVStretchImgSource::OnLineDecoded( LVImageSource * obj, int y, lUInt32 * __restrict data )
 {
+    if ( _srcIsScalableStretch ) {
+        // _src was told (via our GetTargetSize() above) to render itself directly
+        // at _dst_dx x _dst_dy, so this line is already exactly what we want:
+        // no pixel remapping needed, just forward it as-is.
+        return _callback->OnLineDecoded( obj, y, data );
+    }
+
     if ( _smoothscale ) {
         // Defer everything to OnEndDecode()'s smooth-scaling pass: just stash
         // this source line at native resolution.

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2098,8 +2098,10 @@ static LVImageSourceRef lunasvgGetImageSource(lunasvg::external_context_t * xcon
             if ( data.startsWith(lString32("data:image/svg+xml")) ) {
                 int pos = data.pos(U',');
                 if ( pos > 0 ) {
-                    // The attribute value has already been url-decoded at parsing time
-                    lString8 plaindata = UnicodeToUtf8(refName.substr(pos+1));
+                    // The payload may or may not be percent-encoded (eg. a CSS
+                    // background-image - DecodeHTMLUrlString() is a no-op when
+                    // there is nothing to decode.
+                    lString8 plaindata = UnicodeToUtf8(DecodeHTMLUrlString(refName.substr(pos+1)));
                     ref = LVCreateStringStream(plaindata);
                 }
             }

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10287,8 +10287,12 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
             // Resize the decoded image to img_w x img_h if that doesn't match its
             // native pixel size, whether because of background-size, of gRenderDPI
             // scaling, or both (img_w/img_h above already account for either).
+            // Honor the same "Image Scaling" (smooth vs nearest-neighbor) setting
+            // used for normal <img> elements, so background-image scaling looks
+            // consistent with the rest of the page.
             if ( img_w != native_img_w || img_h != native_img_h ) {
-                img = LVCreateStretchFilledTransform(img, img_w, img_h, IMG_TRANSFORM_STRETCH, IMG_TRANSFORM_STRETCH, 0, 0);
+                img = LVCreateStretchFilledTransform(img, img_w, img_h, IMG_TRANSFORM_STRETCH, IMG_TRANSFORM_STRETCH, 0, 0,
+                                                      drawbuf.getSmoothScalingImages());
             }
 
             // We can use some crengine facilities for background repetition and position,

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10201,15 +10201,28 @@ void DrawBorder(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int 
 }
 void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int doc_x,int doc_y, int width, int height, bool clip_to_target=true)
 {
-    // (The provided width and height gives the area we have to draw the background image on)
+    // The caller passes us the node's border box (fmt.getWidth()/getHeight()), for
+    // background-color's default background-clip: border-box. But background-position/-size
+    // resolve against the padding box (the default background-origin), so inset by the
+    // border width below -- see https://www.w3.org/TR/css-backgrounds-3/#the-background-origin
     css_style_ref_t style=enode->getStyle();
     if (!style->background_image.empty()) {
+        int leftBorderwidth = measureBorder(enode, 3);
+        int topBorderwidth = measureBorder(enode, 0);
+        int rightBorderwidth = measureBorder(enode, 1);
+        int bottomBorderwidth = measureBorder(enode, 2);
+        if (leftBorderwidth || topBorderwidth || rightBorderwidth || bottomBorderwidth) {
+            x0 += leftBorderwidth;
+            y0 += topBorderwidth;
+            width -= leftBorderwidth + rightBorderwidth;
+            height -= topBorderwidth + bottomBorderwidth;
+        }
         lString32 filepath = lString32(style->background_image.c_str());
         LVImageSourceRef img = enode->getParentNode()->getDocument()->getObjectImageSource(filepath);
         if (img.isNull()) { // filepath may be url-encoded
             img = enode->getParentNode()->getDocument()->getObjectImageSource(DecodeHTMLUrlString(filepath));
         }
-        if (!img.isNull()) {
+        if (!img.isNull() && width > 0 && height > 0) {
             // Raw, undecoded-transform pixel size of the image file
             int native_img_w = img->GetWidth();
             int native_img_h = img->GetHeight();
@@ -10226,9 +10239,10 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
                  bg_h.type != css_val_unspecified || bg_h.value != css_generic_auto ) {
                 int new_w = 0;
                 int new_h = 0;
-                RenderRectAccessor fmt( enode );
-                int container_w = fmt.getWidth();
-                int container_h = fmt.getHeight();
+                // Use the (already border-inset) padding box as the basis for percentage
+                // sizes and for cover/contain scaling.
+                int container_w = width;
+                int container_h = height;
                 bool check_lengths = true;
                 if ( bg_w.type == css_val_unspecified && bg_h.type == css_val_unspecified ) {
                     if ( bg_w.value == css_generic_contain && bg_h.value == css_generic_contain ) {

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -10210,9 +10210,13 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
             img = enode->getParentNode()->getDocument()->getObjectImageSource(DecodeHTMLUrlString(filepath));
         }
         if (!img.isNull()) {
-            // Native image size
-            int img_w =img->GetWidth();
-            int img_h =img->GetHeight();
+            // Raw, undecoded-transform pixel size of the image file
+            int native_img_w = img->GetWidth();
+            int native_img_h = img->GetHeight();
+            // Native image size, scaled according to gRenderDPI like getStyledImageSize()
+            // does for <img> elements.
+            int img_w = scaleForRenderDPI(native_img_w);
+            int img_h = scaleForRenderDPI(native_img_h);
 
             // See if background-size specified and we need to adjust image native size
             // (if both auto, use image native size)
@@ -10277,11 +10281,14 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
                     // width or height computed to 0: nothing to draw
                     return;
                 }
-                if ( new_w != img_w || new_h != img_h ) {
-                    img = LVCreateStretchFilledTransform(img, new_w, new_h, IMG_TRANSFORM_STRETCH, IMG_TRANSFORM_STRETCH, 0, 0);
-                    img_w = new_w;
-                    img_h = new_h;
-                }
+                img_w = new_w;
+                img_h = new_h;
+            }
+            // Resize the decoded image to img_w x img_h if that doesn't match its
+            // native pixel size, whether because of background-size, of gRenderDPI
+            // scaling, or both (img_w/img_h above already account for either).
+            if ( img_w != native_img_w || img_h != native_img_h ) {
+                img = LVCreateStretchFilledTransform(img, img_w, img_h, IMG_TRANSFORM_STRETCH, IMG_TRANSFORM_STRETCH, 0, 0);
             }
 
             // We can use some crengine facilities for background repetition and position,

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -4865,7 +4865,8 @@ void copystyle( css_style_ref_t source, css_style_ref_t dest )
     dest->border_color[3]=source->border_color[3];
     dest->background_image=source->background_image;
     dest->background_repeat=source->background_repeat;
-    dest->background_position=source->background_position;
+    dest->background_position[0]=source->background_position[0];
+    dest->background_position[1]=source->background_position[1];
     dest->background_size[0]=source->background_size[0];
     dest->background_size[1]=source->background_size[1];
     dest->border_collapse=source->border_collapse;
@@ -10348,45 +10349,22 @@ void DrawBackgroundImage(ldomNode *enode,LVDrawBuf & drawbuf,int x0,int y0,int d
                     break;
             }
             // Compute the position where to draw top left of image, as if
-            // it was a single image when no-repeat
-            int draw_x = 0;
-            int draw_y = 0;
-            switch (style->background_position) {
-                case css_background_left_top:
-                case css_background_left_center:
-                case css_background_left_bottom:
-                    break;
-                case css_background_center_top:
-                case css_background_center_center:
-                case css_background_center_bottom:
-                    draw_x = (width - img_w)/2;
-                    break;
-                case css_background_right_top:
-                case css_background_right_center:
-                case css_background_right_bottom:
-                    draw_x = width - img_w;
-                    break;
-                default:
-                    break;
-            }
-            switch (style->background_position) {
-                case css_background_left_top:
-                case css_background_center_top:
-                case css_background_right_top:
-                    break;
-                case css_background_left_center:
-                case css_background_center_center:
-                case css_background_right_center:
-                    draw_y = (height - img_h)/2;
-                    break;
-                case css_background_left_bottom:
-                case css_background_center_bottom:
-                case css_background_right_bottom:
-                    draw_y = height - img_h;
-                    break;
-                default:
-                    break;
-            }
+            // it was a single image when no-repeat.
+            // Per spec, a <percentage> position is relative to the difference
+            // between the container and (possibly background-size resized)
+            // image sizes, while a <length> is a plain absolute offset.
+            css_length_t bg_pos_x = style->background_position[0];
+            css_length_t bg_pos_y = style->background_position[1];
+            int draw_x;
+            if ( bg_pos_x.type == css_val_percent )
+                draw_x = (width - img_w) * bg_pos_x.value / (100 * 256);
+            else
+                draw_x = lengthToPx(enode, bg_pos_x, width);
+            int draw_y;
+            if ( bg_pos_y.type == css_val_percent )
+                draw_y = (height - img_h) * bg_pos_y.value / (100 * 256);
+            else
+                draw_y = lengthToPx(enode, bg_pos_y, height);
             // If tiling, we need to adjust the transform x/y (the offset
             // in img, so, a value between 0 and img_w/h) to the point
             // inside image that should be at top left of target area
@@ -11753,7 +11731,6 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     UPDATE_STYLE_FIELD( page_break_after, css_pb_inherit );
     UPDATE_STYLE_FIELD( page_break_inside, css_pb_inherit );
     UPDATE_STYLE_FIELD( background_repeat, css_background_r_inherit );
-    UPDATE_STYLE_FIELD( background_position, css_background_p_inherit );
     UPDATE_STYLE_FIELD( float_, css_f_inherit );
     UPDATE_STYLE_FIELD( clear, css_c_inherit );
     UPDATE_STYLE_FIELD( box_sizing, css_bs_inherit );
@@ -12038,6 +12015,9 @@ void setNodeStyle( ldomNode * enode, css_style_ref_t parent_style, LVFontRef par
     // background_size[2] [WH]: computed value: "as specified, but with relative lengths converted into absolute lengths"
     inheritLength( pstyle->background_size[0], parent_style->background_size[0], parent_font_size );
     inheritLength( pstyle->background_size[1], parent_style->background_size[1], parent_font_size );
+    // background_position[2] [XY]: computed value: "as specified, but with relative lengths converted into absolute lengths"
+    inheritLength( pstyle->background_position[0], parent_style->background_position[0], parent_font_size );
+    inheritLength( pstyle->background_position[1], parent_style->background_position[1], parent_font_size );
 
     // border_width[4] [TRBL]: computed value: "the absolute length or 0 if border-style is none or hidden"
     if ( pstyle->border_width[0].type == css_val_inherited ) {

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -3281,33 +3281,136 @@ static const char * css_bg_repeat_names[]={
         "no-repeat",
         NULL
 };
-//background position names
-static const char * css_bg_position_names[]={
-        "left top", // 0
-        "left center",
-        "left bottom",
-        "right top",
-        "right center",
-        "right bottom",
-        "center top",
-        "center center",
-        "center bottom", // 8
-        "top left", // 9
-        "center left",
-        "bottom left",
-        "top right",
-        "center right",
-        "bottom right",
-        "top center",
-        "center center",
-        "bottom center", // 17
-        "center", // 18
-        "left",
-        "right",
-        "top",
-        "bottom", // 22
-        NULL
+// background-position: https://developer.mozilla.org/en-US/docs/Web/CSS/background-position
+// Each of the (up to 2) components can be a keyword (left/right/top/bottom/center)
+// or a <percentage>/<length>. Below are helpers to parse that mix, used by both
+// the standalone background-position property and the background shorthand.
+enum {
+    bg_pos_none = -1,
+    bg_pos_left = 0,
+    bg_pos_right,
+    bg_pos_top,
+    bg_pos_bottom,
+    bg_pos_center,
+    bg_pos_length
 };
+
+// Parses a single <bg-position> component at *decl (a keyword, or a
+// <percentage>/<length> via parse_number_value()). Returns one of the
+// bg_pos_* constants above (length_val is only meaningful for bg_pos_length),
+// or bg_pos_none (and leaves decl untouched, besides skipped spaces) if nothing
+// recognizable is found there.
+static int parse_bg_position_token( const char * & decl, css_length_t & length_val ) {
+    skip_spaces(decl);
+    if ( substr_icompare( "left", decl ) )   return bg_pos_left;
+    if ( substr_icompare( "right", decl ) )  return bg_pos_right;
+    if ( substr_icompare( "top", decl ) )    return bg_pos_top;
+    if ( substr_icompare( "bottom", decl ) ) return bg_pos_bottom;
+    if ( substr_icompare( "center", decl ) ) return bg_pos_center;
+    // accept percent and (positive or negative) length units
+    if ( parse_number_value( decl, length_val, true, true, false, false, false, false, false, false, false, false ) )
+        return bg_pos_length;
+    return bg_pos_none;
+}
+
+// Resolves a parsed component (keyword or length) to its css_length_t value.
+static css_length_t bg_position_component_value( int kw, const css_length_t & length_val ) {
+    switch (kw) {
+        case bg_pos_left:
+        case bg_pos_top:
+            return css_length_t(css_val_percent, 0);
+        case bg_pos_right:
+        case bg_pos_bottom:
+            return css_length_t(css_val_percent, 100 << 8);
+        case bg_pos_center:
+            return css_length_t(css_val_percent, 50 << 8);
+        default: // bg_pos_length
+            return length_val;
+    }
+}
+
+static inline bool bg_pos_is_h_keyword( int kw ) { return kw==bg_pos_left || kw==bg_pos_right || kw==bg_pos_center; }
+static inline bool bg_pos_is_v_keyword( int kw ) { return kw==bg_pos_top  || kw==bg_pos_bottom || kw==bg_pos_center; }
+
+// Parses a full <bg-position> value (1 or 2 components, keywords and/or
+// <percentage>/<length>) from *decl into pos[0] (horizontal) and pos[1]
+// (vertical). Returns false, without touching decl or pos, if the value
+// at *decl isn't a valid 1- or 2-value <bg-position>.
+// Note: this does not implement the CSS3 4-value edge-offset syntax
+// (eg. "right 10px bottom 20px").
+static bool parse_bg_position_value( const char * & decl, css_length_t pos[2] ) {
+    const char * decl_save = decl;
+    css_length_t val[2];
+    int kw[2] = { bg_pos_none, bg_pos_none };
+    int count = 0;
+    for ( ; count < 2; count++ ) {
+        int k = parse_bg_position_token(decl, val[count]);
+        if ( k == bg_pos_none )
+            break;
+        kw[count] = k;
+    }
+    if ( count == 0 ) {
+        decl = decl_save;
+        return false;
+    }
+    if ( count == 1 ) {
+        // A lone "top"/"bottom" sets the vertical component (horizontal
+        // defaults to center); anything else (including a lone "left"/"right",
+        // or a lone percentage/length) sets the horizontal component
+        // (vertical defaults to center).
+        if ( kw[0] == bg_pos_top || kw[0] == bg_pos_bottom ) {
+            pos[0] = css_length_t(css_val_percent, 50 << 8);
+            pos[1] = bg_position_component_value(kw[0], val[0]);
+        }
+        else {
+            pos[0] = bg_position_component_value(kw[0], val[0]);
+            pos[1] = css_length_t(css_val_percent, 50 << 8);
+        }
+        return true;
+    }
+    // Two components: per the <bg-position> grammar (ignoring the 4-value
+    // edge-offset form, out of scope here), a pair is valid in one of two
+    // ways:
+    //  - strict (horizontal, vertical) order: the 1st component is
+    //    left/center/right/<percentage-or-length>, and the 2nd is
+    //    top/center/bottom/<percentage-or-length> (this is what accepts a
+    //    bare number, eg. "left 25%", "75% top", "right 10px");
+    //  - a reordered keyword-only pair (no bare numbers): one of
+    //    {left,center,right} and one of {top,center,bottom}, in either
+    //    order (eg. "top right" meaning the same as "right top").
+    // Anything else -- an axis clash like "top bottom"/"left right", or a
+    // bare number paired with a mismatched keyword like "top 10px"/
+    // "10px left" -- is invalid.
+    bool valid;
+    if ( kw[0] != bg_pos_top && kw[0] != bg_pos_bottom && kw[1] != bg_pos_left && kw[1] != bg_pos_right ) {
+        pos[0] = bg_position_component_value(kw[0], val[0]);
+        pos[1] = bg_position_component_value(kw[1], val[1]);
+        valid = true;
+    }
+    else if ( kw[0] != bg_pos_length && kw[1] != bg_pos_length &&
+              bg_pos_is_h_keyword(kw[1]) && bg_pos_is_v_keyword(kw[0]) ) {
+        pos[0] = bg_position_component_value(kw[1], val[1]);
+        pos[1] = bg_position_component_value(kw[0], val[0]);
+        valid = true;
+    }
+    else {
+        valid = false;
+    }
+    if ( valid ) {
+        // A 3rd bg-position-like token right after a valid pair means this
+        // is (or was meant to be) the CSS3 4-value edge-offset form (eg.
+        // "right 10px bottom 20px", or even just "right 10px top"), which
+        // isn't supported (see note above). Reject the whole value rather
+        // than silently keeping only its first two components, which would
+        // resolve to an incorrect position.
+        const char * after = decl;
+        css_length_t dummy;
+        if ( parse_bg_position_token(after, dummy) == bg_pos_none )
+            return true;
+    }
+    decl = decl_save;
+    return false;
+}
 
 //border-collpase names
 static const char * css_bc_names[]={
@@ -4900,17 +5003,16 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                 n = parse_name( decl, css_bg_repeat_names, -1 );
                 break;
             case cssd_background_position:
-                IF_g_SET_n_AND_break(false, css_background_p_inherit, css_background_left_top);
-                n = parse_name( decl, css_bg_position_names, -1 );
-                // Only values between 0 and 8 will be checked by the background drawing code
-                if ( n>8 ) {
-                    if ( n<18 ) n=n-9;       // "top left" = "left top"
-                    else if ( n==18 ) n=7;   // "center" = "center center"
-                    else if ( n==19 ) n=1;   // "left" = "left center"
-                    else if ( n==20 ) n=4;   // "right" = "right center"
-                    else if ( n==21 ) n=6;   // "top" = "center top"
-                    else if ( n==22 ) n=8;   // "bottom" = "center bottom"
-                    else n=0;                // should not happen, but be "left top"
+                {
+                    IF_g_PUSH_LENGTH_AND_break(2, false, css_val_percent, 0);
+                    css_length_t pos[2];
+                    if ( parse_bg_position_value( decl, pos ) ) {
+                        buf<<(lUInt32) (prop_code | importance | parse_important(decl));
+                        for (int i = 0; i < 2; i++) {
+                            buf<<(lUInt32) pos[i].type;
+                            buf<<(lUInt32) pos[i].value;
+                        }
+                    }
                 }
                 break;
             case cssd_background:
@@ -4929,7 +5031,18 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         buf<<(lUInt32) (cssd_background_repeat | importance | parsed_important);
                         buf<<(lUInt32) (g == css_g_inherit ? css_background_r_inherit : css_background_repeat);
                         buf<<(lUInt32) (cssd_background_position | importance | parsed_important);
-                        buf<<(lUInt32) (g == css_g_inherit ? css_background_p_inherit : css_background_left_top);
+                        if ( g == css_g_inherit ) {
+                            buf<<(lUInt32) css_val_inherited;
+                            buf<<(lUInt32) 0;
+                            buf<<(lUInt32) css_val_inherited;
+                            buf<<(lUInt32) 0;
+                        }
+                        else {
+                            buf<<(lUInt32) css_val_percent;
+                            buf<<(lUInt32) 0;
+                            buf<<(lUInt32) css_val_percent;
+                            buf<<(lUInt32) 0;
+                        }
                         buf<<(lUInt32) (cssd_background_color | importance | parsed_important);
                         if ( g == css_g_inherit ) {
                             buf<<(lUInt32) css_val_inherited;
@@ -4986,19 +5099,8 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         if( repeat != -1 ) {
                             skip_spaces(decl);
                         }
-                        int position = parse_name( decl, css_bg_position_names, -1 );
-                        if ( position != -1 ) {
-                            // Only values between 0 and 8 will be checked by the background drawing code
-                            if ( position>8 ) {
-                                if ( position<18 ) position -= 9;    // "top left" = "left top"
-                                else if ( position==18 ) position=7; // "center" = "center center"
-                                else if ( position==19 ) position=1; // "left" = "left center"
-                                else if ( position==20 ) position=4; // "right" = "right center"
-                                else if ( position==21 ) position=6; // "top" = "center top"
-                                else if ( position==22 ) position=8; // "bottom" = "center bottom"
-                                else position = 0; // should not happen, but be "left top"
-                            }
-                        }
+                        css_length_t position[2];
+                        bool has_position = parse_bg_position_value( decl, position );
                         if( repeat == -1 ) { // Try parsing repeat after position
                             skip_spaces(decl);
                             repeat = parse_name( decl, css_bg_repeat_names, -1 );
@@ -5012,9 +5114,12 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                             buf<<(lUInt32) (cssd_background_repeat | importance | parsed_important);
                             buf<<(lUInt32) repeat;
                         }
-                        if (position != -1) {
+                        if (has_position) {
                             buf<<(lUInt32) (cssd_background_position | importance | parsed_important);
-                            buf<<(lUInt32) position;
+                            for (int i = 0; i < 2; i++) {
+                                buf<<(lUInt32) position[i].type;
+                                buf<<(lUInt32) position[i].value;
+                            }
                         }
                     }
                     else { // no url, only color
@@ -5835,7 +5940,8 @@ void LVCssDeclaration::apply( css_style_rec_t * style, const ldomNode * node ) c
             style->Apply( (css_background_repeat_value_t) *p++, &style->background_repeat, imp_bit_background_repeat, is_important );
             break;
         case cssd_background_position:
-            style->Apply( (css_background_position_value_t) *p++, &style->background_position, imp_bit_background_position, is_important );
+            style->Apply( read_length(p), &style->background_position[0], imp_bit_background_position_x, is_important );
+            style->Apply( read_length(p), &style->background_position[1], imp_bit_background_position_y, is_important );
             break;
         case cssd_background_size:
             style->Apply( read_length(p), &style->background_size[0], imp_bit_background_size_h, is_important );

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -106,7 +106,8 @@ lUInt32 calcHash(css_style_rec_t & rec)
     v = v * 31 + (lUInt32)rec.border_color[2].pack();
     v = v * 31 + (lUInt32)rec.border_color[3].pack();
     v = v * 31 + (lUInt32)rec.background_repeat;
-    v = v * 31 + (lUInt32)rec.background_position;
+    v = v * 31 + (lUInt32)rec.background_position[0].pack();
+    v = v * 31 + (lUInt32)rec.background_position[1].pack();
     v = v * 31 + (lUInt32)rec.background_size[0].pack();
     v = v * 31 + (lUInt32)rec.background_size[1].pack();
     v = v * 31 + (lUInt32)rec.font_family;
@@ -196,7 +197,8 @@ bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)
            r1.border_color[3]==r2.border_color[3]&&
            r1.background_image==r2.background_image&&
            r1.background_repeat==r2.background_repeat&&
-           r1.background_position==r2.background_position&&
+           r1.background_position[0]==r2.background_position[0]&&
+           r1.background_position[1]==r2.background_position[1]&&
            r1.background_size[0]==r2.background_size[0]&&
            r1.background_size[1]==r2.background_size[1]&&
            r1.border_collapse==r2.border_collapse&&
@@ -403,7 +405,8 @@ bool css_style_rec_t::serialize( SerialBuf & buf )
     ST_PUT_LEN4(border_color);
     buf<<background_image;
     ST_PUT_ENUM(background_repeat);
-    ST_PUT_ENUM(background_position);
+    ST_PUT_LEN(background_position[0]);
+    ST_PUT_LEN(background_position[1]);
     ST_PUT_LEN(background_size[0]);
     ST_PUT_LEN(background_size[1]);
     ST_PUT_ENUM(border_collapse);
@@ -480,7 +483,8 @@ bool css_style_rec_t::deserialize( SerialBuf & buf )
     ST_GET_LEN4(border_color);
     buf>>background_image;
     ST_GET_ENUM(css_background_repeat_value_t ,background_repeat);
-    ST_GET_ENUM(css_background_position_value_t ,background_position);
+    ST_GET_LEN(background_position[0]);
+    ST_GET_LEN(background_position[1]);
     ST_GET_LEN(background_size[0]);
     ST_GET_LEN(background_size[1]);
     ST_GET_ENUM(css_border_collapse_value_t ,border_collapse);

--- a/crengine/src/lvstyles.cpp
+++ b/crengine/src/lvstyles.cpp
@@ -47,87 +47,89 @@ lUInt32 calcHash(font_ref_t & f)
 
 lUInt32 calcHash(css_style_rec_t & rec)
 {
-    if ( !rec.hash )
-        rec.hash = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((
-         + (lUInt32)rec.important[0]) * 31
-         + (lUInt32)rec.important[1]) * 31
-         + (lUInt32)rec.important[2]) * 31
-         + (lUInt32)rec.importance[0]) * 31
-         + (lUInt32)rec.importance[1]) * 31
-         + (lUInt32)rec.importance[2]) * 31
-         + (lUInt32)rec.display) * 31
-         + (lUInt32)rec.white_space) * 31
-         + (lUInt32)rec.text_align) * 31
-         + (lUInt32)rec.text_align_last) * 31
-         + (lUInt32)rec.text_decoration) * 31
-         + (lUInt32)rec.text_transform) * 31
-         + (lUInt32)rec.hyphenate) * 31
-         + (lUInt32)rec.list_style_type) * 31
-         + (lUInt32)rec.list_style_position) * 31
-         + (lUInt32)rec.letter_spacing.pack()) * 31
-         + (lUInt32)rec.initial_letter.pack()) * 31
-         + (lUInt32)(rec.page_break_before | (rec.page_break_after<<4) | (rec.page_break_inside<<8))) * 31
-         + (lUInt32)rec.vertical_align.pack()) * 31
-         + (lUInt32)rec.font_size.type) * 31
-         + (lUInt32)rec.font_size.value) * 31
-         + (lUInt32)rec.font_style) * 31
-         + (lUInt32)rec.font_weight) * 31
-         + (lUInt32)rec.font_features.pack()) * 31
-         + (lUInt32)rec.font_optical_sizing) * 31
-         + (lUInt32)rec.line_height.pack()) * 31
-         + (lUInt32)rec.color.pack()) * 31
-         + (lUInt32)rec.background_color.pack()) * 31
-         + (lUInt32)rec.width.pack()) * 31
-         + (lUInt32)rec.height.pack()) * 31
-         + (lUInt32)rec.min_width.pack()) * 31
-         + (lUInt32)rec.min_height.pack()) * 31
-         + (lUInt32)rec.max_width.pack()) * 31
-         + (lUInt32)rec.max_height.pack()) * 31
-         + (lUInt32)rec.text_indent.pack()) * 31
-         + (lUInt32)rec.margin[0].pack()) * 31
-         + (lUInt32)rec.margin[1].pack()) * 31
-         + (lUInt32)rec.margin[2].pack()) * 31
-         + (lUInt32)rec.margin[3].pack()) * 31
-         + (lUInt32)rec.padding[0].pack()) * 31
-         + (lUInt32)rec.padding[1].pack()) * 31
-         + (lUInt32)rec.padding[2].pack()) * 31
-         + (lUInt32)rec.padding[3].pack()) * 31
-         + (lUInt32)rec.border_style_top) * 31
-         + (lUInt32)rec.border_style_right) * 31
-         + (lUInt32)rec.border_style_bottom) * 31
-         + (lUInt32)rec.border_style_left) * 31
-         + (lUInt32)rec.border_width[0].pack()) * 31
-         + (lUInt32)rec.border_width[1].pack()) * 31
-         + (lUInt32)rec.border_width[2].pack()) * 31
-         + (lUInt32)rec.border_width[3].pack()) * 31
-         + (lUInt32)rec.border_color[0].pack()) * 31
-         + (lUInt32)rec.border_color[1].pack()) * 31
-         + (lUInt32)rec.border_color[2].pack()) * 31
-         + (lUInt32)rec.border_color[3].pack()) * 31
-         + (lUInt32)rec.background_repeat)*31
-         + (lUInt32)rec.background_position)*31
-         + (lUInt32)rec.background_size[0].pack())*31
-         + (lUInt32)rec.background_size[1].pack())*31
-         + (lUInt32)rec.font_family) * 31
-         + (lUInt32)rec.border_collapse)*31
-         + (lUInt32)rec.border_spacing[0].pack())*31
-         + (lUInt32)rec.border_spacing[1].pack())*31
-         + (lUInt32)rec.orphans) * 31
-         + (lUInt32)rec.widows) * 31
-         + (lUInt32)rec.float_) * 31
-         + (lUInt32)rec.clear) * 31
-         + (lUInt32)rec.direction) * 31
-         + (lUInt32)rec.visibility) * 31
-         + (lUInt32)rec.line_break) * 31
-         + (lUInt32)rec.word_break) * 31
-         + (lUInt32)rec.box_sizing) * 31
-         + (lUInt32)rec.caption_side) * 31
-         + (lUInt32)rec.ruby_position) * 31
-         + (lUInt32)rec.cr_hint.pack()) * 31
-         + (lUInt32)rec.font_name.getHash()
-         + (lUInt32)rec.background_image.getHash()
-         + (lUInt32)rec.content.getHash());
-    return rec.hash;
+    if ( rec.hash )
+        return rec.hash;
+    lUInt32 v = 31;
+    v = v * 31 + (lUInt32)rec.important[0];
+    v = v * 31 + (lUInt32)rec.important[1];
+    v = v * 31 + (lUInt32)rec.important[2];
+    v = v * 31 + (lUInt32)rec.importance[0];
+    v = v * 31 + (lUInt32)rec.importance[1];
+    v = v * 31 + (lUInt32)rec.importance[2];
+    v = v * 31 + (lUInt32)rec.display;
+    v = v * 31 + (lUInt32)rec.white_space;
+    v = v * 31 + (lUInt32)rec.text_align;
+    v = v * 31 + (lUInt32)rec.text_align_last;
+    v = v * 31 + (lUInt32)rec.text_decoration;
+    v = v * 31 + (lUInt32)rec.text_transform;
+    v = v * 31 + (lUInt32)rec.hyphenate;
+    v = v * 31 + (lUInt32)rec.list_style_type;
+    v = v * 31 + (lUInt32)rec.list_style_position;
+    v = v * 31 + (lUInt32)rec.letter_spacing.pack();
+    v = v * 31 + (lUInt32)rec.initial_letter.pack();
+    v = v * 31 + (lUInt32)(rec.page_break_before | (rec.page_break_after<<4) | (rec.page_break_inside<<8));
+    v = v * 31 + (lUInt32)rec.vertical_align.pack();
+    v = v * 31 + (lUInt32)rec.font_size.type;
+    v = v * 31 + (lUInt32)rec.font_size.value;
+    v = v * 31 + (lUInt32)rec.font_style;
+    v = v * 31 + (lUInt32)rec.font_weight;
+    v = v * 31 + (lUInt32)rec.font_features.pack();
+    v = v * 31 + (lUInt32)rec.font_optical_sizing;
+    v = v * 31 + (lUInt32)rec.line_height.pack();
+    v = v * 31 + (lUInt32)rec.color.pack();
+    v = v * 31 + (lUInt32)rec.background_color.pack();
+    v = v * 31 + (lUInt32)rec.width.pack();
+    v = v * 31 + (lUInt32)rec.height.pack();
+    v = v * 31 + (lUInt32)rec.min_width.pack();
+    v = v * 31 + (lUInt32)rec.min_height.pack();
+    v = v * 31 + (lUInt32)rec.max_width.pack();
+    v = v * 31 + (lUInt32)rec.max_height.pack();
+    v = v * 31 + (lUInt32)rec.text_indent.pack();
+    v = v * 31 + (lUInt32)rec.margin[0].pack();
+    v = v * 31 + (lUInt32)rec.margin[1].pack();
+    v = v * 31 + (lUInt32)rec.margin[2].pack();
+    v = v * 31 + (lUInt32)rec.margin[3].pack();
+    v = v * 31 + (lUInt32)rec.padding[0].pack();
+    v = v * 31 + (lUInt32)rec.padding[1].pack();
+    v = v * 31 + (lUInt32)rec.padding[2].pack();
+    v = v * 31 + (lUInt32)rec.padding[3].pack();
+    v = v * 31 + (lUInt32)rec.border_style_top;
+    v = v * 31 + (lUInt32)rec.border_style_right;
+    v = v * 31 + (lUInt32)rec.border_style_bottom;
+    v = v * 31 + (lUInt32)rec.border_style_left;
+    v = v * 31 + (lUInt32)rec.border_width[0].pack();
+    v = v * 31 + (lUInt32)rec.border_width[1].pack();
+    v = v * 31 + (lUInt32)rec.border_width[2].pack();
+    v = v * 31 + (lUInt32)rec.border_width[3].pack();
+    v = v * 31 + (lUInt32)rec.border_color[0].pack();
+    v = v * 31 + (lUInt32)rec.border_color[1].pack();
+    v = v * 31 + (lUInt32)rec.border_color[2].pack();
+    v = v * 31 + (lUInt32)rec.border_color[3].pack();
+    v = v * 31 + (lUInt32)rec.background_repeat;
+    v = v * 31 + (lUInt32)rec.background_position;
+    v = v * 31 + (lUInt32)rec.background_size[0].pack();
+    v = v * 31 + (lUInt32)rec.background_size[1].pack();
+    v = v * 31 + (lUInt32)rec.font_family;
+    v = v * 31 + (lUInt32)rec.border_collapse;
+    v = v * 31 + (lUInt32)rec.border_spacing[0].pack();
+    v = v * 31 + (lUInt32)rec.border_spacing[1].pack();
+    v = v * 31 + (lUInt32)rec.orphans;
+    v = v * 31 + (lUInt32)rec.widows;
+    v = v * 31 + (lUInt32)rec.float_;
+    v = v * 31 + (lUInt32)rec.clear;
+    v = v * 31 + (lUInt32)rec.direction;
+    v = v * 31 + (lUInt32)rec.visibility;
+    v = v * 31 + (lUInt32)rec.line_break;
+    v = v * 31 + (lUInt32)rec.word_break;
+    v = v * 31 + (lUInt32)rec.box_sizing;
+    v = v * 31 + (lUInt32)rec.caption_side;
+    v = v * 31 + (lUInt32)rec.ruby_position;
+    v = v * 31 + (lUInt32)rec.cr_hint.pack();
+    v = v * 31 + (lUInt32)rec.font_name.getHash();
+    v = v * 31 + (lUInt32)rec.background_image.getHash();
+    v = v * 31 + (lUInt32)rec.content.getHash();
+    rec.hash = v;
+    return v;
 }
 
 bool operator == (const css_style_rec_t & r1, const css_style_rec_t & r2)

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -22176,8 +22176,10 @@ LVStreamRef ldomDocument::getObjectImageStream( lString32 refName )
         if ( data.startsWith(lString32("data:image/svg+xml")) ) {
             int pos = data.pos(U',');
             if ( pos > 0 ) {
-                // The attribute value has already been url-decoded at parsing time
-                lString8 plaindata = UnicodeToUtf8(refName.substr(pos+1));
+                // The payload may or may not be percent-encoded (eg. a CSS
+                // background-image - DecodeHTMLUrlString() is a no-op when
+                // there is nothing to decode.
+                lString8 plaindata = UnicodeToUtf8(DecodeHTMLUrlString(refName.substr(pos+1)));
                 ref = LVCreateStringStream(plaindata);
                 return ref;
             }

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -9460,6 +9460,9 @@ void ldomDocumentWriter::OnTagClose( const lChar32 *, const lChar32 * tagname, b
     // handle. So, here below, we check that both id and curNodeId match the
     // element id we check for.
 
+    if ( id == el_style && curNodeId == el_style )
+        _inHeadStyle = false;
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks.
     // They will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriterFilter::OnTagClose)
@@ -9571,7 +9574,6 @@ void ldomDocumentWriter::OnText( const lChar32 * text, int len, lUInt32 flags )
     // Accumulate <HEAD><STYLE> content
     if (_inHeadStyle) {
         _headStyleText << lString32(text, len);
-        _inHeadStyle = false;
         return;
     }
 
@@ -17516,6 +17518,9 @@ void ldomDocumentWriterFilter::OnTagClose( const lChar32 * /*nsname*/, const lCh
         }
     }
 
+    if ( id == el_style && curNodeId == el_style )
+        _inHeadStyle = false;
+
     // Parse <link rel="stylesheet">, put the css file link in _stylesheetLinks,
     // they will be added to <body><stylesheet> when we meet <BODY>
     // (duplicated in ldomDocumentWriter::OnTagClose)
@@ -17603,7 +17608,6 @@ void ldomDocumentWriterFilter::OnText( const lChar32 * text, int len, lUInt32 fl
     // Accumulate <HEAD><STYLE> content
     if (_inHeadStyle) {
         _headStyleText << lString32(text, len);
-        _inHeadStyle = false;
         return;
     }
 

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -103,7 +103,7 @@ extern const int gDOMVersionCurrent = DOM_VERSION_CURRENT;
 // increment to force complete reload/reparsing of old file
 #define CACHE_FILE_FORMAT_VERSION "3.05.82k"
 /// increment following value to force re-formatting of old book after load
-#define FORMATTING_VERSION_ID 0x0035
+#define FORMATTING_VERSION_ID 0x0036
 
 #ifndef DOC_DATA_COMPRESSION_LEVEL
 /// data compression level (0=no compression, 1=fast compressions, 3=normal compression)

--- a/crengine/src/mathml.cpp
+++ b/crengine/src/mathml.cpp
@@ -1540,7 +1540,8 @@ void setMathMLElementNodeStyle( ldomNode * node, css_style_rec_t * style ) {
             int symbol_w, symbol_h;
             int fgcolor = parentNode->getStyle()->color.value;
             style->background_image = getRadicalSymbolSVGImageString( font->getSize(), thickness_px, fgcolor, symbol_w, symbol_h);
-            style->background_position = css_background_right_bottom;
+            style->background_position[0] = css_length_t(css_val_percent, 100 << 8);
+            style->background_position[1] = css_length_t(css_val_percent, 100 << 8);
             style->background_repeat = css_background_no_repeat;
             style->min_width.type = css_val_screen_px;
             style->min_width.value = symbol_w;

--- a/tests/background-image-test.html
+++ b/tests/background-image-test.html
@@ -1,0 +1,993 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>background-image test suite</title>
+<style>
+/* background-position section */
+#background-position-test .grid {
+    margin-top: 0.5em;
+}
+#background-position-test .case {
+    display: inline-block;
+    vertical-align: top;
+    width: 230px;
+    margin: 0 14px 22px 0;
+}
+#background-position-test .label {
+    font-size: 0.85em;
+    margin-bottom: 3px;
+}
+#background-position-test .label code { display: block; }
+#background-position-test .note {
+    font-size: 0.78em;
+    color: #555;
+    margin-bottom: 3px;
+}
+#background-position-test .box {
+    /* inline-block (not the default block) so the box's own pixel width is
+       always honored: under koreader's "Book" rendering profile, a plain
+       block element's CSS width is only kept if it's a relative unit
+       (%, em, ...) unless absolute units are separately allowed, but an
+       inline-block's width is always computed from its own style, same as
+       a float, regardless of those flags. */
+    display: inline-block;
+    width: 200px;
+    /* padding-top (not height) so the box gets a real rendered height even
+       under koreader's "Book" rendering profile, which doesn't force CSS
+       height onto plain empty blocks (only <hr>/images/floats always get
+       their style height honored there); padding is always added to a
+       block's height regardless of that flag, and backgrounds paint across
+       the padding box by default, so this renders identically to a 110px
+       height in both "Book" and "Web" modes. */
+    padding-top: 110px;
+    border: 1px solid #333;
+    background-color: #eef1f5;
+    /* Target marker, reused by every test case; only background-position
+       differs between cases. */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='10' fill='none' stroke='%23cc2222' stroke-width='3'/%3E%3Ccircle cx='12' cy='12' r='2' fill='%23cc2222'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 24px 24px;
+}
+#background-position-test .box.noimg {
+    background-image: none;
+}
+
+/* MathML radical position section */
+#mathml-radical-position-test {
+    font-family: serif;
+}
+#mathml-radical-position-test .case { margin: 1em 0; }
+#mathml-radical-position-test .label {
+    font-size: 0.85em;
+    color: #555;
+    margin-bottom: 4px;
+    max-width: 55em;
+}
+/* Outline the formula's bounding box so the radical symbol's alignment
+   against its own cell is easier to judge. */
+#mathml-radical-position-test math { border: 1px dashed #4a90d9; padding: 2px; }
+
+/* background-image scaling section */
+#background-image-scaling-test .case { margin: 1.2em 0; }
+#background-image-scaling-test .label {
+    font-size: 0.85em;
+    margin-bottom: 3px;
+}
+#background-image-scaling-test .note {
+    font-size: 0.78em;
+    color: #555;
+    margin-bottom: 8px;
+    max-width: 55em;
+}
+#background-image-scaling-test .demo-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+#background-image-scaling-test .tile-label {
+    font-size: 0.78em;
+    color: #555;
+    text-align: center;
+    margin-top: 4px;
+}
+#background-image-scaling-test .tile-wrap { text-align: center; }
+#background-image-scaling-test img.tile {
+    /* inline-block (not block) so the ancestor .tile-wrap's text-align:
+       center actually centers it, same as it does the .tile-label text
+       below it -- matters when the img (native/DPI-scaled size) is
+       narrower than its label, keeping the img/background-image pair
+       visually aligned. */
+    display: inline-block;
+    border: 1px solid #333;
+}
+#background-image-scaling-test .bgbox {
+    /* inline-block so this box's own pixel width/padding-driven height are
+       always honored under koreader's "Book" rendering profile (see the
+       comment on #background-position-test .box for why). */
+    display: inline-block;
+    border: 1px solid #333;
+    background-color: #f5f5f5;
+    /* 6x4 grid of 10px checkerboard cells (60x40 native size), with a red
+       marker in the top-left cell and a green marker in the bottom-right
+       cell so cropping/orientation is visible under background-size: cover. */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+}
+
+/* SVG and raster image scaling comparison section */
+#svg-raster-scaling-test .case { margin: 1.2em 0; }
+#svg-raster-scaling-test .label {
+    font-size: 0.85em;
+    margin-bottom: 3px;
+}
+#svg-raster-scaling-test .note {
+    font-size: 0.78em;
+    color: #555;
+    margin-bottom: 8px;
+    max-width: 55em;
+}
+#svg-raster-scaling-test .demo-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+#svg-raster-scaling-test .tile-label {
+    font-size: 0.78em;
+    color: #555;
+    text-align: center;
+    margin-top: 4px;
+}
+#svg-raster-scaling-test .tile-wrap { text-align: center; }
+#svg-raster-scaling-test img.tile {
+    /* inline-block (not block) so the ancestor .tile-wrap's text-align:
+       center actually centers it, same as it does the .tile-label text
+       below it -- matters when the img (native/DPI-scaled size) is
+       narrower than its label, keeping the img/background-image pair
+       visually aligned. */
+    display: inline-block;
+    border: 1px solid #333;
+}
+#svg-raster-scaling-test .bgbox {
+    /* inline-block so this box's own pixel width/padding-driven height are
+       always honored under koreader's "Book" rendering profile (see the
+       comment on #background-position-test .box for why). */
+    display: inline-block;
+    border: 1px solid #333;
+    background-color: #f5f5f5;
+    background-repeat: no-repeat;
+}
+
+/* background-repeat section */
+#background-repeat-test .case { margin: 1.2em 0; }
+#background-repeat-test .label {
+    font-size: 0.85em;
+    margin-bottom: 3px;
+}
+#background-repeat-test .note {
+    font-size: 0.78em;
+    color: #555;
+    margin-bottom: 8px;
+    max-width: 55em;
+}
+#background-repeat-test .repeat-box {
+    /* inline-block so this box's own pixel width/padding-driven height are
+       always honored under koreader's "Book" rendering profile (see the
+       comment on #background-position-test .box for why). */
+    display: inline-block;
+    border: 1px solid #333;
+    background-color: #f5f5f5;
+    /* 20x20 tile split into two diagonal triangles with a border, so that
+       correctly-abutting tiles form a continuous zigzag with no gaps or
+       overlaps, and any phase shift from background-position is obvious. */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpolygon points='0,0 20,0 0,20' fill='%233b82f6'/%3E%3Cpolygon points='20,0 20,20 0,20' fill='%23fb923c'/%3E%3Crect x='0' y='0' width='20' height='20' fill='none' stroke='%23333' stroke-width='1'/%3E%3C/svg%3E");
+    background-size: 20px 20px;
+}
+
+body {
+    font-family: sans-serif;
+    margin: 1em;
+}
+h1 { font-size: 1.6em; }
+h2 {
+    font-size: 1.3em;
+    margin-top: 2em;
+    border-bottom: 2px solid #666;
+}
+h3 {
+    font-size: 1.1em;
+    margin-top: 1.6em;
+    border-bottom: 1px solid #999;
+}
+p.intro { max-width: 60em; }
+code { background-color: #eee; }
+
+/* This style block must stay above 8192 characters (lvxml.cpp's
+   TEXT_SPLIT_SIZE): the HTML tokenizer splits larger text nodes across
+   multiple OnText() calls, and ldomDocumentWriter(Filter)::OnText() used to
+   only keep the first chunk of style content, silently dropping the rest
+   -- which broke exactly the rule (this one) that happened to straddle the
+   split point. Keep this rule (or an equivalently large one) last so any
+   regression truncates a real rule instead of a comment or blank space.
+   Fixed in lvtinydom.cpp by moving the accumulation cutoff from OnText()
+   (per chunk) to OnTagClose() (once, on /style). */
+</style>
+</head>
+<body>
+
+<h1>background-image test suite</h1>
+<p class="intro">
+Combines a <code>background-image</code> scaling test suite covering
+<code>background-size</code> scaling, an SVG/raster scaling
+comparison suite, a
+<code>background-repeat</code> tiling test suite, <code>background-position</code>
+test cases, and the MathML radical symbol position regression tests.
+</p>
+
+<section id="background-image-scaling-test">
+<h2>background-image scaling test suite</h2>
+<p class="intro">
+Exercises the DPI-scaling fix in <code>DrawBackgroundImage()</code>
+(<code>lvrend.cpp</code>): the image's native pixel size is now passed
+through <code>scaleForRenderDPI()</code> before being used as the "no
+<code>background-size</code>" size or as the basis for <code>auto</code>/
+<code>cover</code>/<code>contain</code> sizing &#8212; the same scaling
+<code>getStyledImageSize()</code> already applies to plain <code>&lt;img&gt;</code>
+elements.
+</p>
+
+<h3>1. Reference &lt;img&gt; vs. default background-size (no size specified)</h3>
+<div class="case">
+  <div class="label">left: plain <code>&lt;img&gt;</code>, no width/height
+    set &#8212; sized however crengine scales images for the current
+    <code>gRenderDPI</code>. right: a bordered box, deliberately larger
+    than the image (120&#215;80px) with <code>background-repeat: no-repeat</code>
+    and no <code>background-size</code> declared.</div>
+  <div class="note">expected: the checkerboard drawn in the right-hand box
+    (top-left corner, unrepeated) is <em>exactly the same pixel size</em>
+    as the reference <code>&lt;img&gt;</code> on the left.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E"/>
+      <div class="tile-label">&lt;img&gt;, no size set</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 120px; padding-top: 80px;"></div>
+      <div class="tile-label">background-image, no background-size,<br/>in a 120&#215;80px box</div>
+    </div>
+  </div>
+</div>
+
+<h3>2. Explicit background-size on both axes (independent, may distort)</h3>
+<div class="case">
+  <div class="label"><code>background-size: 120px 40px;</code> in a
+    120&#215;40px box</div>
+  <div class="note">expected:
+    the image stretches to exactly 120&#215;40px, so the checkerboard cells become 20px wide &#215; 10px
+    tall (visibly non-square)</div>
+  <div class="bgbox" style="width: 120px; padding-top: 40px; background-size: 120px 40px;"></div>
+</div>
+
+<h3>3. background-size with one axis auto (aspect ratio preserved)</h3>
+<div class="case">
+  <div class="label"><code>background-size: 90px auto;</code> in a
+    90&#215;60px box</div>
+  <div class="note">expected: width iand height are scaled 1.5&#215; (60px &#8594; 90px)
+     &#8212; the checkerboard cells stay square (15&#215;15px),
+    just larger.</div>
+  <div class="bgbox" style="width: 90px; padding-top: 60px; background-size: 90px auto;"></div>
+</div>
+
+<h3>4. background-size: cover</h3>
+<div class="case">
+  <div class="label"><code>background-size: cover;</code> in a
+    150&#215;40px box (much wider than the image's 3:2 aspect ratio)</div>
+  <div class="note">expected: the image is scaled up (uniformly, no
+    distortion &#8212; cells stay square) until it fully covers the box,
+    then cropped</div>
+  <div class="bgbox" style="width: 150px; padding-top: 40px; background-size: cover;"></div>
+</div>
+
+<h3>5. background-size: contain</h3>
+<div class="case">
+  <div class="label"><code>background-size: contain;</code> in a
+    150&#215;120px box (5:4, clearly wider-relative-to-its-height than the
+    image's 3:2 native ratio</div>
+  <div class="note">expected: the image is scaled up uniformly (no
+    distortion &#8212; cells stay square) &#8212; full width, with no
+    cropping, so both the red and green corner markers remain visible;
+the image
+    sits flush in the top-left corner of the box, leaving a 20px-tall pink
+    strip of bare background-color along the bottom</div>
+  <div class="bgbox" style="width: 150px; padding-top: 120px; background-size: contain; background-color: #f472b6;"></div>
+</div>
+
+</section>
+
+<section id="svg-raster-scaling-test">
+<h2>SVG and raster image scaling comparison</h2>
+<p class="intro">
+Compares a plain <code>&lt;img&gt;</code> against the same source used as a
+<code>background-image</code>, side by side, using two small images: a
+16&#215;16 vector SVG icon (a filled circle with a border &#8212; curved edges
+show up scaling/anti-aliasing differences much more clearly than a straight
+diagonal line does) and a 16&#215;16 low-resolution raster PNG checkerboard
+(a 4&#215;4 grid of 4px cells alternating black/white, with a red marker
+cell top-left and a green marker cell bottom-right &#8212; 4px cells.
+</p>
+
+<h3>1. Small SVG icon &#8212; default size (&lt;img&gt; vs background-image)</h3>
+<div class="case">
+  <div class="label">left: plain <code>&lt;img&gt;</code>, no width/height
+    set. right: the same SVG as background-image, no <code>background-size</code>
+    declared, in a 40&#215;40px box.</div>
+  <div class="note">expected: since both paths run the native 16&#215;16 SVG
+    size through the same DPI scaling, the two renderings should be
+    pixel-identical in size, and the diagonal edge should look equally sharp
+    in both.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E"/>
+      <div class="tile-label">&lt;img&gt;, no size set</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 40px; padding-top: 40px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E&quot;);"></div>
+      <div class="tile-label">background-image, no background-size,<br/>in a 40&#215;40px box</div>
+    </div>
+  </div>
+</div>
+
+<h3>2. Small SVG icon &#8212; explicit dimensions (&lt;img&gt; vs background-image)</h3>
+<div class="case">
+  <div class="label">left: <code>&lt;img&gt;</code> with <code>width="64"
+    height="64"</code> (4&#215; the SVG's native 16&#215;16). right: the same
+    SVG as background-image with <code>background-size: 64px 64px</code>, in
+    a 64&#215;64px box.</div>
+  <div class="note">expected: the two should render at exactly the same
+    64&#215;64px size and, since the source is vector, the diagonal edge
+    should still be smooth/anti-aliased rather than pixelated at this larger
+    size, with no visible difference between the two.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" width="64" height="64" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E"/>
+      <div class="tile-label">&lt;img&gt;, 64&#215;64</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 64px; padding-top: 64px; background-size: 64px 64px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E&quot;);"></div>
+      <div class="tile-label">background-image, background-size: 64px 64px</div>
+    </div>
+  </div>
+</div>
+
+<h3>3. Low-resolution raster image &#8212; default size (&lt;img&gt; vs background-image)</h3>
+<div class="case">
+  <div class="label">left: plain <code>&lt;img&gt;</code>, no width/height
+    set, using a 16&#215;16px raster PNG checkerboard (4px cells). right: the
+    same PNG as background-image, no <code>background-size</code> declared,
+    in a 40&#215;40px box.</div>
+  <div class="note">this raster image is only 16&#215;16 native pixels, so
+    unlike the SVG cases above, any scaling applied by
+    <code>scaleForRenderDPI()</code>.
+    Compare the <code>&lt;img&gt;</code> and background-image renderings to
+    check whether they apply the same treatment.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAR0lEQVR42mO8o6b2nwEJKN+8icxlYGRkROH//4+inIGJgUIw8AYw/kfzFCE/o8sPhzBgYGD4T4qfh2E6YCHVz+JLvIdbGAAAqW4cGiqn47YAAAAASUVORK5CYII="/>
+      <div class="tile-label">&lt;img&gt;, no size set</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 40px; padding-top: 40px; background-image: url(&quot;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAR0lEQVR42mO8o6b2nwEJKN+8icxlYGRkROH//4+inIGJgUIw8AYw/kfzFCE/o8sPhzBgYGD4T4qfh2E6YCHVz+JLvIdbGAAAqW4cGiqn47YAAAAASUVORK5CYII=&quot;);"></div>
+      <div class="tile-label">background-image, no background-size,<br/>in a 40&#215;40px box</div>
+    </div>
+  </div>
+</div>
+
+<h3>4. Low-resolution raster image &#8212; explicit upscaled dimensions (&lt;img&gt; vs background-image)</h3>
+<div class="case">
+  <div class="label">left: <code>&lt;img&gt;</code> with <code>width="96"
+    height="96"</code> (6&#215; the PNG's native 16&#215;16). right: the same
+    PNG as background-image with <code>background-size: 96px 96px</code>, in
+    a 96&#215;96px box.</div>
+  <div class="note">at 6&#215; magnification, pixelation (if the scaler is
+    nearest-neighbor) or blurring (if it's smoothed/interpolated) will be
+    unmistakable. Compare the two renderings for both the presence of pixelation
+    and whether <code>&lt;img&gt;</code> and background-image apply it
+    consistently.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" width="96" height="96" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAR0lEQVR42mO8o6b2nwEJKN+8icxlYGRkROH//4+inIGJgUIw8AYw/kfzFCE/o8sPhzBgYGD4T4qfh2E6YCHVz+JLvIdbGAAAqW4cGiqn47YAAAAASUVORK5CYII="/>
+      <div class="tile-label">&lt;img&gt;, 96&#215;96</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 96px; padding-top: 96px; background-size: 96px 96px; background-image: url(&quot;data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAR0lEQVR42mO8o6b2nwEJKN+8icxlYGRkROH//4+inIGJgUIw8AYw/kfzFCE/o8sPhzBgYGD4T4qfh2E6YCHVz+JLvIdbGAAAqW4cGiqn47YAAAAASUVORK5CYII=&quot;);"></div>
+      <div class="tile-label">background-image, background-size: 96px 96px</div>
+    </div>
+  </div>
+</div>
+
+<h3>5. SVG data URI encoding &#8212; percent-encoded vs base64 (&lt;img&gt; vs background-image)</h3>
+<div class="case">
+  <div class="label">the exact same 16&#215;16 SVG icon markup (from cases 1
+    and 2 above), encoded two different ways as a data URI &#8212;
+    percent-encoded (<code>data:image/svg+xml,%3Csvg...</code>) and
+    base64-encoded (<code>data:image/svg+xml;base64,...</code>) &#8212; each
+    rendered both as an <code>&lt;img&gt;</code> and as a
+    <code>background-image</code>.</div>
+  <div class="note">expected: all four tiles are pixel-identical.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <img class="tile" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E"/>
+      <div class="tile-label">&lt;img&gt;, percent-encoded</div>
+    </div>
+    <div class="tile-wrap">
+      <img class="tile" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxNicgaGVpZ2h0PScxNicgdmlld0JveD0nMCAwIDE2IDE2Jz48Y2lyY2xlIGN4PSc4JyBjeT0nOCcgcj0nNycgZmlsbD0nIzNiODJmNicgc3Ryb2tlPScjMDAwJyBzdHJva2Utd2lkdGg9JzEnLz48L3N2Zz4="/>
+      <div class="tile-label">&lt;img&gt;, base64-encoded</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 16px; padding-top: 16px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%233b82f6' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E&quot;);"></div>
+      <div class="tile-label">background-image, percent-encoded</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 16px; padding-top: 16px; background-image: url(&quot;data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxNicgaGVpZ2h0PScxNicgdmlld0JveD0nMCAwIDE2IDE2Jz48Y2lyY2xlIGN4PSc4JyBjeT0nOCcgcj0nNycgZmlsbD0nIzNiODJmNicgc3Ryb2tlPScjMDAwJyBzdHJva2Utd2lkdGg9JzEnLz48L3N2Zz4=&quot;);"></div>
+      <div class="tile-label">background-image, base64-encoded</div>
+    </div>
+  </div>
+</div>
+
+</section>
+
+<section id="background-repeat-test">
+<h2>background-repeat test suite</h2>
+<p class="intro">
+Exercises the tiling logic in <code>DrawBackgroundImage()</code>
+(<code>lvrend.cpp</code>), which supports the four keywords crengine parses
+for <code>background-repeat</code>: <code>repeat</code> (the initial value),
+<code>repeat-x</code>, <code>repeat-y</code>, and <code>no-repeat</code>.
+</p>
+
+<h3>1. background-repeat: repeat</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: repeat;</code> in a
+    205&#215;103px box (deliberately not a multiple of the 20px tile, to
+    show edge clipping)</div>
+  <div class="note">expected: the tile fills the box in both directions
+    from the top-left corner, with the diagonal zigzag continuing
+    unbroken across tile boundaries; the rightmost column and bottom row
+    of tiles are partially clipped by the box edges (10&#215;20px / 20&#215;3px
+    /  10&#215;3px remainders) rather than leaving a gap or squeezing in an
+    extra part-tile</div>
+  <div class="repeat-box" style="width: 205px; padding-top: 103px; background-repeat: repeat;"></div>
+</div>
+
+<h3>2. Default (property not set)</h3>
+<div class="case">
+  <div class="label">no <code>background-repeat</code> declared, same
+    205&#215;103px box</div>
+  <div class="note">expected: identical to case 1 &#8212; <code>repeat</code>
+    is the initial value</div>
+  <div class="repeat-box" style="width: 205px; padding-top: 103px;"></div>
+</div>
+
+<h3>3. background-repeat: repeat-x</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: repeat-x;</code> in a
+    205&#215;60px box</div>
+  <div class="note">expected: a single row of tiles across the full
+    width along the top edge (default <code>background-position: 0% 0%</code>),
+    clipped on the right; no tiling downward &#8212; the rest of the box
+    below the row shows only the plain background-color</div>
+  <div class="repeat-box" style="width: 205px; padding-top: 60px; background-repeat: repeat-x;"></div>
+</div>
+
+<h3>4. background-repeat: repeat-y</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: repeat-y;</code> in a
+    60px&#215;103px box</div>
+  <div class="note">expected: a single column of tiles down the full
+    height along the left edge, clipped on the bottom; no tiling
+    rightward &#8212; the rest of the box to the right of the column shows
+    only the plain background-color</div>
+  <div class="repeat-box" style="width: 60px; padding-top: 103px; background-repeat: repeat-y;"></div>
+</div>
+
+<h3>5. background-repeat: no-repeat</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: no-repeat;</code> in a
+    60&#215;60px box</div>
+  <div class="note">expected: a single tile in the top-left corner only;
+    the rest of the box shows only the plain background-color</div>
+  <div class="repeat-box" style="width: 60px; padding-top: 60px; background-repeat: no-repeat;"></div>
+</div>
+
+<h3>6. background-repeat: repeat with an offset background-position</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: repeat; background-position: 10px 10px;</code>
+    in the same 205&#215;103px box as case 1</div>
+  <div class="note">expected: tiling is phase-shifted so that a full
+    tile's top-left corner sits exactly at (10px, 10px)</div>
+  <div class="repeat-box" style="width: 205px; padding-top: 103px; background-repeat: repeat; background-position: 10px 10px;"></div>
+</div>
+
+<h3>7. Case-insensitivity</h3>
+<div class="case">
+  <div class="label"><code>background-repeat: Repeat-X;</code> in a
+    205&#215;60px box</div>
+  <div class="note">expected: same as <code>repeat-x</code> (case 3):
+    keywords are ASCII case-insensitive</div>
+  <div class="repeat-box" style="width: 205px; padding-top: 60px; background-repeat: Repeat-X;"></div>
+</div>
+
+</section>
+
+<section id="background-position-test">
+<h2>background-position test suite</h2>
+<p class="intro">
+Every box below is 200&#215;110px with a light fill and a 1px border, and
+carries the same 24&#215;24px target-marker image (a small red crosshair).
+</p>
+
+<h3>1. Default (property not set)</h3>
+<div class="grid">
+  <div class="case">
+    <div class="label">no <code>background-position</code> declared</div>
+    <div class="note">expected: initial value <code>0% 0%</code> (top left)</div>
+    <div class="box" style=""></div>
+  </div>
+</div>
+
+<h3>2. One value &#8212; keywords</h3>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: left;</code></div>
+    <div class="note">expected: left edge, vertically centered</div>
+    <div class="box" style="background-position: left;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right;</code></div>
+    <div class="note">expected: right edge, vertically centered</div>
+    <div class="box" style="background-position: right;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: top;</code></div>
+    <div class="note">expected: top edge, horizontally centered</div>
+    <div class="box" style="background-position: top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: bottom;</code></div>
+    <div class="note">expected: bottom edge, horizontally centered</div>
+    <div class="box" style="background-position: bottom;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: center;</code></div>
+    <div class="note">expected: centered on both axes</div>
+    <div class="box" style="background-position: center;"></div>
+  </div>
+</div>
+
+<h3>3. One value &#8212; percentages and lengths</h3>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: 0%;</code></div>
+    <div class="note">expected: same as <code>left</code></div>
+    <div class="box" style="background-position: 0%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 25%;</code></div>
+    <div class="note">expected: 25% across, vertically centered</div>
+    <div class="box" style="background-position: 25%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 50%;</code></div>
+    <div class="note">expected: same as <code>center</code></div>
+    <div class="box" style="background-position: 50%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 75%;</code></div>
+    <div class="note">expected: 75% across, vertically centered</div>
+    <div class="box" style="background-position: 75%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 100%;</code></div>
+    <div class="note">expected: same as <code>right</code></div>
+    <div class="box" style="background-position: 100%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: -10%;</code></div>
+    <div class="note">negative percentage (valid: percentages aren't
+      clamped) &#8212; expected: the computed position sits slightly left of
+      the box's left edge, but backgrounds are clipped to the padding box, so
+      only a thin sliver of the marker is visible at the left edge (the rest
+      is clipped off), vertically centered</div>
+    <div class="box" style="background-position: -10%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 120%;</code></div>
+    <div class="note">percentage over 100% (valid) &#8212; expected: the
+      marker is not visible</div>
+    <div class="box" style="background-position: 120%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 20px;</code></div>
+    <div class="note">expected: 20px from left, vertically centered</div>
+    <div class="box" style="background-position: 20px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: -20px;</code></div>
+    <div class="note">expected: the computed position sits 20px to the left
+      of the box, but backgrounds are clipped to the padding box, so only a
+      4px-wide sliver of the marker (its right edge) is visible at the left
+      border &#8212; the rest is clipped off, vertically centered</div>
+    <div class="box" style="background-position: -20px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 2em;</code></div>
+    <div class="note">expected: 2em from left (font-relative unit), vertically
+      centered</div>
+    <div class="box" style="background-position: 2em;"></div>
+  </div>
+</div>
+
+<h3>4. Two values &#8212; keyword pairs</h3>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: left top;</code></div>
+    <div class="note">expected: top-left corner</div>
+    <div class="box" style="background-position: left top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right top;</code></div>
+    <div class="note">expected: top-right corner</div>
+    <div class="box" style="background-position: right top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: left bottom;</code></div>
+    <div class="note">expected: bottom-left corner</div>
+    <div class="box" style="background-position: left bottom;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right bottom;</code></div>
+    <div class="note">expected: bottom-right corner</div>
+    <div class="box" style="background-position: right bottom;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: center center;</code></div>
+    <div class="note">expected: centered on both axes</div>
+    <div class="box" style="background-position: center center;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: center top;</code></div>
+    <div class="note">expected: top edge, horizontally centered</div>
+    <div class="box" style="background-position: center top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: left center;</code></div>
+    <div class="note">expected: left edge, vertically centered</div>
+    <div class="box" style="background-position: left center;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: top right;</code></div>
+    <div class="note">reversed keyword order (still no attached offsets) &#8212;
+      expected: same as <code>right top</code> (top-right corner)</div>
+    <div class="box" style="background-position: top right;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: bottom left;</code></div>
+    <div class="note">reversed keyword order &#8212; expected: same as
+      <code>left bottom</code> (bottom-left corner)</div>
+    <div class="box" style="background-position: bottom left;"></div>
+  </div>
+</div>
+
+<h3>5. Two values &#8212; percentages and lengths</h3>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: 25% 75%;</code></div>
+    <div class="note">expected: 25% across, 75% down</div>
+    <div class="box" style="background-position: 25% 75%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 75% 25%;</code></div>
+    <div class="note">expected: 75% across, 25% down</div>
+    <div class="box" style="background-position: 75% 25%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 0% 100%;</code></div>
+    <div class="note">expected: same as <code>left bottom</code></div>
+    <div class="box" style="background-position: 0% 100%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 100% 0%;</code></div>
+    <div class="note">expected: same as <code>right top</code></div>
+    <div class="box" style="background-position: 100% 0%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 20px 30px;</code></div>
+    <div class="note">expected: 20px from left, 30px from top</div>
+    <div class="box" style="background-position: 20px 30px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: -10px -10px;</code></div>
+    <div class="note">expected: the computed position sits 10px above and
+      10px left of the box, but backgrounds are clipped to the padding box,
+      so only a 14&#215;14px corner of the marker is visible at the
+      top-left &#8212; the rest is clipped off</div>
+    <div class="box" style="background-position: -10px -10px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 20px 50%;</code></div>
+    <div class="note">mixed length/percent &#8212; expected: 20px from left,
+      vertically centered</div>
+    <div class="box" style="background-position: 20px 50%;"></div>
+  </div>
+</div>
+
+<h3>6. Two values &#8212; keyword combined with percentage/length</h3>
+<p class="intro">
+These are the strict-order, no-attached-offset combinations: a
+horizontal-slot token (<code>left</code>/<code>center</code>/<code>right</code>/
+&lt;percentage or length&gt;) followed by a vertical-slot token
+(<code>top</code>/<code>center</code>/<code>bottom</code>/&lt;percentage or
+length&gt;). Note the quirky cases at the end: a lone edge keyword followed
+by a bare number does <em>not</em> mean "offset from that edge" here &#8212;
+that meaning only applies to the attached-offset form (out of scope for this
+suite), so the number is taken as a position on the other axis instead.
+</p>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: left 25%;</code></div>
+    <div class="note">expected: left edge, 25% down</div>
+    <div class="box" style="background-position: left 25%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 75% top;</code></div>
+    <div class="note">expected: 75% across, top edge</div>
+    <div class="box" style="background-position: 75% top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: center 30px;</code></div>
+    <div class="note">expected: horizontally centered, 30px from top</div>
+    <div class="box" style="background-position: center 30px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right 10px;</code></div>
+    <div class="note"><strong>quirk:</strong> only one keyword and it's in
+      the horizontal slot, so <code>10px</code> is the vertical value &#8212;
+      expected: right edge, 10px from top (<em>not</em> "10px in from the
+      right edge")</div>
+    <div class="box" style="background-position: right 10px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 10px bottom;</code></div>
+    <div class="note">expected: 10px from left, bottom edge</div>
+    <div class="box" style="background-position: 10px bottom;"></div>
+  </div>
+</div>
+
+<h3>7. Case-insensitivity</h3>
+<p class="intro">
+CSS keywords are ASCII case-insensitive, so mixed/upper-case spellings of
+the same keywords must resolve identically to their lower-case forms.
+</p>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: LEFT;</code></div>
+    <div class="note">expected: same as <code>left</code> (left edge,
+      vertically centered)</div>
+    <div class="box" style="background-position: LEFT;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: Center;</code></div>
+    <div class="note">expected: same as <code>center</code> (centered on
+      both axes)</div>
+    <div class="box" style="background-position: Center;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: Right Bottom;</code></div>
+    <div class="note">expected: same as <code>right bottom</code>
+      (bottom-right corner)</div>
+    <div class="box" style="background-position: Right Bottom;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: TOP RIGHT;</code></div>
+    <div class="note">expected: same as <code>top right</code> / <code>right
+      top</code> (top-right corner)</div>
+    <div class="box" style="background-position: TOP RIGHT;"></div>
+  </div>
+</div>
+
+<h3>8. Invalid values (property should be ignored)</h3>
+<p class="intro">
+Per the <a href="https://drafts.csswg.org/css-backgrounds/#the-background-position">CSS
+Backgrounds spec grammar</a> for <code>&lt;bg-position&gt;</code>, none of
+these have a legal 1- or 2-value interpretation, so the whole declaration
+should be dropped and the property should fall back to its initial value
+(<code>0% 0%</code>, top left) &#8212; same as section 1.
+</p>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: top bottom;</code></div>
+    <div class="note">invalid: both tokens can only fill the vertical slot,
+      leaving the required horizontal component unfilled &#8212; expected:
+      falls back to top left</div>
+    <div class="box" style="background-position: top bottom;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: left right;</code></div>
+    <div class="note">invalid: both tokens can only fill the horizontal slot
+      &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: left right;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: top 10px;</code></div>
+    <div class="note">invalid: <code>10px</code> can only attach as an
+      offset to a preceding <code>left</code>/<code>right</code>/
+      <code>top</code>/<code>bottom</code> keyword within its own axis, so
+      "<code>top 10px</code>" is entirely a vertical-side component, leaving
+      the required horizontal component unfilled &#8212; expected: falls
+      back to top left</div>
+    <div class="box" style="background-position: top 10px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: 10px left;</code></div>
+    <div class="note">invalid: a bare &lt;length-percentage&gt; must be the
+      first component when paired with a keyword, and can never stand alone
+      unattached to a keyword &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: 10px left;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: middle;</code></div>
+    <div class="note">invalid: <code>middle</code> is not a
+      <code>background-position</code> keyword (that's <code>center</code>)
+      &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: middle;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: banana;</code></div>
+    <div class="note">invalid: unrecognized token &#8212; expected: falls
+      back to top left</div>
+    <div class="box" style="background-position: banana;"></div>
+  </div>
+</div>
+
+<h3>9. Three- and four-value edge-offset form (not implemented, rejected)</h3>
+<p class="intro">
+CSS also defines a 3-/4-value "edge-offset" form of <code>&lt;bg-position&gt;</code>
+(eg. <code>right 10px bottom 20px</code>).
+crengine does not parse this form: any 3rd/4th token following an otherwise
+valid 2-value pair is rejected outright, falling back to the initial value
+(<code>0% 0%</code>, top left).
+</p>
+<div class="grid">
+  <div class="case">
+    <div class="label"><code>background-position: right 10px bottom 20px;</code></div>
+    <div class="note">4-value form &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: right 10px bottom 20px;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right 20% bottom 10%;</code></div>
+    <div class="note">4-value form with percentage offsets &#8212; expected:
+      falls back to top left (<em>not</em> equivalent to
+      <code>background-position: 80% 90%;</code>)</div>
+    <div class="box" style="background-position: right 20% bottom 10%;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right 10px top;</code></div>
+    <div class="note">3-value form &#8212; expected: falls back to top left
+      (<em>not</em> the quirky 2-value <code>right 10px</code> reading from
+      section 6, with <code>top</code> ignored)</div>
+    <div class="box" style="background-position: right 10px top;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right 10px left;</code></div>
+    <div class="note">invalid even under the edge-offset grammar (both
+      components forced horizontal) &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: right 10px left;"></div>
+  </div>
+  <div class="case">
+    <div class="label"><code>background-position: right 10px bottom 20px 30px;</code></div>
+    <div class="note">a 5th token can't be part of any valid
+      <code>background-position</code> &#8212; expected: falls back to top left</div>
+    <div class="box" style="background-position: right 10px bottom 20px 30px;"></div>
+  </div>
+</div>
+</section>
+
+<section id="mathml-radical-position-test">
+<h2>MathML radical symbol position test</h2>
+<p class="intro">
+Exercises the code path in <code>mathml.cpp</code>'s
+<code>setMathMLElementNodeStyle()</code> that draws the radical (&radic;)
+symbol as a synthesized SVG <code>background-image</code> on the
+<code>msqrt</code>/<code>mroot</code> root-symbol cell, anchored with
+<code>background-position: 100% 100%</code> (bottom-right of the cell). This
+was previously set via the fixed keyword-pair enum
+<code>css_background_right_bottom</code>; now that
+<code>background-position</code> is stored as two arbitrary
+<code>css_length_t</code> values instead of a closed set of keyword pairs,
+it is set directly as two 100% <code>css_length_t</code> percentages. The
+dashed blue border around each formula outlines the <code>&lt;math&gt;</code>
+element's box, making it easier to see whether the symbol is flush with the
+bottom of its cell as expected.
+</p>
+
+<h3>1. Plain msqrt &#8212; short radicand</h3>
+<div class="case">
+  <div class="label">expected: the hook of the radical sign sits right at
+    the baseline of "x", with the diagonal stroke rising to meet the
+    horizontal bar above the radicand &#8212; no gap or misalignment at the
+    bottom</div>
+  <math><msqrt><mi>x</mi></msqrt></math>
+</div>
+
+<h3>2. msqrt with a tall radicand (fraction)</h3>
+<div class="case">
+  <div class="label">the fraction makes the root symbol's cell noticeably
+    taller than the symbol's own natural size &#8212; this is the key
+    regression case for background-position: since the symbol image is
+    anchored bottom-right, its hook must still meet the bottom of the cell
+    (and the radicand's baseline) even though the cell has grown taller;
+    anchored top-left instead, the symbol would float near the top of the
+    cell with a visible gap underneath</div>
+  <math><msqrt><mfrac><mi>a</mi><mi>b</mi></mfrac></msqrt></math>
+</div>
+
+<h3>3. mroot &#8212; cube root with an index</h3>
+<div class="case">
+  <div class="label">expected: small "3" index sits above-left of the root
+    symbol; the symbol's hook still meets the radicand's baseline at the
+    bottom</div>
+  <math><mroot><mi>x</mi><mn>3</mn></mroot></math>
+</div>
+
+<h3>4. mroot with a tall radicand</h3>
+<div class="case">
+  <div class="label">combines the index-cell layout from case 3 with the
+    tall-radicand case from case 2 &#8212; the symbol must still hug the
+    bottom-right of its (now taller) cell</div>
+  <math><mroot><mfrac><mi>a</mi><mi>b</mi></mfrac><mn>3</mn></mroot></math>
+</div>
+
+<h3>5. Nested msqrt</h3>
+<div class="case">
+  <div class="label">a root inside a root &#8212; both radical symbols must
+    independently anchor to the bottom of their own cell</div>
+  <math><msqrt><msqrt><mi>x</mi></msqrt></msqrt></math>
+</div>
+
+<h3>6. Font-size scaling</h3>
+<div class="case">
+  <div class="label"><code>font-size: 2.5em</code> on the
+    <code>&lt;math&gt;</code> element &#8212; the radical symbol is
+    regenerated at the larger size (<code>getRadicalSymbolSVGImageString</code>
+    is called with the resolved font size), so it must still be aligned to
+    the bottom-right of its (now larger) cell, not just scaled up from a
+    stale position</div>
+  <math style="font-size: 2.5em;"><msqrt><mi>x</mi></msqrt></math>
+</div>
+
+<h3>7. displaystyle attribute</h3>
+<div class="case">
+  <div class="label"><code>displaystyle="true"</code> &#8212; this makes the
+    cell use the display-style vertical gap metric instead of the compact
+    one, changing the cell's height; the symbol must still anchor correctly
+    regardless of which gap metric was used</div>
+  <math displaystyle="true"><msqrt><mfrac><mi>a</mi><mi>b</mi></mfrac></msqrt></math>
+</div>
+
+<h3>Expected behaviour</h3>
+<p class="intro">
+In every case above, the diagonal check-mark stroke of the radical symbol
+should visually connect: its lower hook touches the baseline/bottom of the
+radicand content, and its upper tip touches the left end of the horizontal
+bar drawn over the radicand (the cell's top/left border). If the symbol
+image were left- or top-aligned within its cell instead of anchored
+bottom-right, you would see it detached from the bar and radicand, floating
+with a visible gap underneath &#8212; most obviously in cases 2, 4, and 7,
+where the cell is noticeably taller than the symbol itself.
+</p>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
This is (mostly) a series of fixes for background-image. The commits in order are:

1. Adds an html file to test `background-image` functionality and the subsequent changes (`tests/background-image-test.html`).
2. **lvrend: Scale background-image to screen dpi** Images in `<img>` are already scaled from their native resolution to the screen DPI when the CSS does not provide explicit dimensions; this applies the same behaviour to `background-image`.
3. **lvimg/lvrend: Smooth scale background-image** Images in `<img>` already use smooth scaling when "Image Scaling" is set to "best"; this applies similar behaviour to `background-image`.
4. **lvimg/lvtinydom: background-image % decode url** `<img>` already applies percent-decoding to URLs - required for path names with special characters and also for data URLs containing SVGs etc.  This applies the same handling to `background-image`.
5. **lvrend: Fix background-image size and position** According to the CSS spec the position of a `background-image` should be aligned to the "padding box" - the inside of the border. The size of the image was being calculated inconsistently and the position was aligned to to the "border box" - the outside of the border - resulting in visible
gaps between the image and the border in some situations.
6. **lvimg: background-image render svg at scaled size** When an SVG image needs to be scaled - either because of the screen DPI setting or because the CSS sets explicit dimensions - render the SVG at the scaled size rather than its native size to avoid pixelation (match how `<img>` already renders SVGs).
7. **css/lvrend: background-position numeric values** This is more of an enhancement than a bug fix - Support percentage and length values in `background-position` (as well as the currently supported keywords top, center, etc) as per the CSS1 spec (note this only adds support for CSS1 2 value positions - not the more complex 4 value positions added later).
8. **lvtinydom: fix <style> content truncation** This fix is unrelated to `background-image` but instead is a fix to CSS parsing to parse`<style>` blocks greater than 8k - a limitation discovered when the test html file grew large enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/728)
<!-- Reviewable:end -->
