### PR TITLE
lvimg/lvtinydom: fix font-face fonts not applying to SVG text

### DIFF
--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1101,11 +1101,6 @@ public:
     int getChildIndex( lUInt32 dataIndex ) const;
     /// returns true if node is document's root
     bool isRoot() const;
-    /// walks up from this node to the nearest DocFragment ancestor and returns
-    /// its sibling index (its position among the root's children), or -1 if
-    /// no DocFragment ancestor is found (non-EPUB documents, or nodes above
-    /// the DocFragment level)
-    int getDocFragmentIdx() const;
     /// returns true if node is text
     inline bool isText() const { return _handle._dataIndex && !(_handle._dataIndex&1); }
     /// returns true if node is element
@@ -1316,6 +1311,12 @@ public:
 
     /// is node an image
     bool isImage() const;
+
+    /// walks up from this node to the nearest DocFragment ancestor and returns
+    /// its sibling index (its position among the root's children), or -1 if
+    /// no DocFragment ancestor is found (non-EPUB documents, or nodes above
+    /// the DocFragment level)
+    int getDocFragmentIdx() const;
 
     /// return real (as in the original HTML) parent/siblings by skipping any internal
     /// boxing element up or down (returns NULL when no more sibling)

--- a/crengine/include/lvtinydom.h
+++ b/crengine/include/lvtinydom.h
@@ -1101,6 +1101,11 @@ public:
     int getChildIndex( lUInt32 dataIndex ) const;
     /// returns true if node is document's root
     bool isRoot() const;
+    /// walks up from this node to the nearest DocFragment ancestor and returns
+    /// its sibling index (its position among the root's children), or -1 if
+    /// no DocFragment ancestor is found (non-EPUB documents, or nodes above
+    /// the DocFragment level)
+    int getDocFragmentIdx() const;
     /// returns true if node is text
     inline bool isText() const { return _handle._dataIndex && !(_handle._dataIndex&1); }
     /// returns true if node is element

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2036,10 +2036,7 @@ static void lunasvgTextToPathsHelper(lunasvg::external_context_t * xcontext, con
         font_family << node->getFont()->getTypeFace().c_str();
     }
 
-    // @font-face fonts are scoped to the DocFragment (spine item) that declared
-    // them (see ldomNode::getDocFragmentIdx()). Without this, GetFont() defaults
-    // to docFragmentIdx=-1, which fails allowedForDocFragment() for any embedded
-    // font and silently falls back to a non-matching font.
+    // Find the containing docFragmentIdx so @font-face declarations are scoped correctly.
     int docFragmentIdx = (docId != -1 && node) ? node->getDocFragmentIdx() : -1;
 
     // We may get very small or very large font size from SVG, so work with a normal font

--- a/crengine/src/lvimg.cpp
+++ b/crengine/src/lvimg.cpp
@@ -2036,6 +2036,12 @@ static void lunasvgTextToPathsHelper(lunasvg::external_context_t * xcontext, con
         font_family << node->getFont()->getTypeFace().c_str();
     }
 
+    // @font-face fonts are scoped to the DocFragment (spine item) that declared
+    // them (see ldomNode::getDocFragmentIdx()). Without this, GetFont() defaults
+    // to docFragmentIdx=-1, which fails allowedForDocFragment() for any embedded
+    // font and silently falls back to a non-matching font.
+    int docFragmentIdx = (docId != -1 && node) ? node->getDocFragmentIdx() : -1;
+
     // We may get very small or very large font size from SVG, so work with a normal font
     // size that crengine will accept, and scale the coordinates we'll get.
     int font_size = 64;
@@ -2043,7 +2049,7 @@ static void lunasvgTextToPathsHelper(lunasvg::external_context_t * xcontext, con
     LunaSVGGlyphsCollector collector(scale, callback);
 
     LVFontRef font = fontMan->GetFont(font_size, font_spec->weight, font_spec->italic, css_ff_sans_serif,
-                                        font_family, font_spec->features, docId, true);
+                                        font_family, font_spec->features, docId, true, NULL, docFragmentIdx);
 
     TextLangCfg * lang_cfg = NULL;
     if ( font_spec->lang )

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2397,27 +2397,14 @@ int LVRendGetBaseFontWeight()
     return rend_font_base_weight;
 }
 
-/// Walk up the DOM tree from `node` to find the nearest DocFragment ancestor
-/// and return its sibling index (its position among the root's children).
-/// Returns -1 if no DocFragment ancestor is found (non-EPUB documents, or
-/// nodes that are themselves above the DocFragment level).
-/// This is only a fallback for callers that don't already know the DocFragment
-/// they're working in: bulk passes over the whole tree (the recursive style
-/// pass, cache reload) already cross DocFragment boundaries explicitly as
-/// they go, and should pass that index into getFont()/initNodeFont() instead
-/// of paying for this walk on every node.
-static int getNodeDocFragmentIdx(ldomNode * node)
-{
-    for (ldomNode * n = node; n && !n->isNull() && !n->isRoot(); n = n->getParentNode()) {
-        if (n->getNodeId() == el_DocFragment)
-            return (int)n->getNodeIndex();
-    }
-    return -1;
-}
-
 /// docFragmentIdx: pass the node's DocFragment sibling index if the caller already
 /// knows it (eg. from a traversal that tracks it), or leave at the default to
-/// have it looked up by walking up from node.
+/// have it looked up by walking up from node (see ldomNode::getDocFragmentIdx()).
+/// This walk-up is only meant as a fallback for callers that don't already know
+/// the DocFragment they're working in: bulk passes over the whole tree (the
+/// recursive style pass, cache reload) already cross DocFragment boundaries
+/// explicitly as they go, and should pass that index into getFont()/initNodeFont()
+/// instead of paying for this walk on every node.
 LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId, int docFragmentIdx)
 {
     int sz;
@@ -2460,7 +2447,7 @@ LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId, int 
     if (style->font_optical_sizing != css_fos_none && gRenderDPI >= 100)
         variations.set(LVFONT_TAG_OPSZ, sz * 72.0f / (float)gRenderDPI);
     if (docFragmentIdx == DOC_FRAGMENT_IDX_UNKNOWN)
-        docFragmentIdx = (documentId != -1) ? getNodeDocFragmentIdx(node) : -1;
+        docFragmentIdx = (documentId != -1) ? node->getDocFragmentIdx() : -1;
     LVFontRef fnt = fontMan->GetFont(
         sz,
         fw,

--- a/crengine/src/lvrend.cpp
+++ b/crengine/src/lvrend.cpp
@@ -2400,11 +2400,8 @@ int LVRendGetBaseFontWeight()
 /// docFragmentIdx: pass the node's DocFragment sibling index if the caller already
 /// knows it (eg. from a traversal that tracks it), or leave at the default to
 /// have it looked up by walking up from node (see ldomNode::getDocFragmentIdx()).
-/// This walk-up is only meant as a fallback for callers that don't already know
-/// the DocFragment they're working in: bulk passes over the whole tree (the
-/// recursive style pass, cache reload) already cross DocFragment boundaries
-/// explicitly as they go, and should pass that index into getFont()/initNodeFont()
-/// instead of paying for this walk on every node.
+/// This walk-up is meant as a fallback for callers that don't already know
+/// the DocFragment they're working in.
 LVFontRef getFont(ldomNode * node, css_style_rec_t * style, int documentId, int docFragmentIdx)
 {
     int sz;

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -21453,6 +21453,17 @@ bool ldomNode::getNodeListMarker( int & counterValue, lString32 & marker, int & 
 #endif
 }
 
+/// walks up from this node to the nearest DocFragment ancestor and returns
+/// its sibling index, or -1 if none is found
+int ldomNode::getDocFragmentIdx() const
+{
+    ASSERT_NODE_NOT_NULL;
+    for ( const ldomNode * n = this; n && !n->isNull() && !n->isRoot(); n = n->getParentNode() ) {
+        if ( n->getNodeId() == el_DocFragment )
+            return n->getNodeIndex();
+    }
+    return -1;
+}
 
 /// returns first child node
 ldomNode * ldomNode::getFirstChild() const
@@ -21900,18 +21911,6 @@ public:
 
     }
 };
-
-/// walks up from this node to the nearest DocFragment ancestor and returns
-/// its sibling index, or -1 if none is found
-int ldomNode::getDocFragmentIdx() const
-{
-    ASSERT_NODE_NOT_NULL;
-    for ( const ldomNode * n = this; n && !n->isNull() && !n->isRoot(); n = n->getParentNode() ) {
-        if ( n->getNodeId() == el_DocFragment )
-            return n->getNodeIndex();
-    }
-    return -1;
-}
 
 bool ldomNode::isImage() const
 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19555,6 +19555,18 @@ bool ldomNode::isRoot() const
     return false;
 }
 
+/// walks up from this node to the nearest DocFragment ancestor and returns
+/// its sibling index, or -1 if none is found
+int ldomNode::getDocFragmentIdx() const
+{
+    ASSERT_NODE_NOT_NULL;
+    for ( const ldomNode * n = this; n && !n->isNull() && !n->isRoot(); n = n->getParentNode() ) {
+        if ( n->getNodeId() == el_DocFragment )
+            return n->getNodeIndex();
+    }
+    return -1;
+}
+
 /// call to invalidate cache if persistent node content is modified
 void ldomNode::modified()
 {

--- a/crengine/src/lvtinydom.cpp
+++ b/crengine/src/lvtinydom.cpp
@@ -19555,18 +19555,6 @@ bool ldomNode::isRoot() const
     return false;
 }
 
-/// walks up from this node to the nearest DocFragment ancestor and returns
-/// its sibling index, or -1 if none is found
-int ldomNode::getDocFragmentIdx() const
-{
-    ASSERT_NODE_NOT_NULL;
-    for ( const ldomNode * n = this; n && !n->isNull() && !n->isRoot(); n = n->getParentNode() ) {
-        if ( n->getNodeId() == el_DocFragment )
-            return n->getNodeIndex();
-    }
-    return -1;
-}
-
 /// call to invalidate cache if persistent node content is modified
 void ldomNode::modified()
 {
@@ -21912,6 +21900,18 @@ public:
 
     }
 };
+
+/// walks up from this node to the nearest DocFragment ancestor and returns
+/// its sibling index, or -1 if none is found
+int ldomNode::getDocFragmentIdx() const
+{
+    ASSERT_NODE_NOT_NULL;
+    for ( const ldomNode * n = this; n && !n->isNull() && !n->isRoot(); n = n->getParentNode() ) {
+        if ( n->getNodeId() == el_DocFragment )
+            return n->getNodeIndex();
+    }
+    return -1;
+}
 
 bool ldomNode::isImage() const
 {


### PR DESCRIPTION
f8d5543c scoped `@font-face` fonts to the DocFragment (EPUB spine item) that declares them: `LVFontFace::allowedForDocFragment()` now rejects a face when `docFragmentIdx` is -1 and the face has a non-empty `docFragmentIdxSet`.

`lunasvgTextToPathsHelper()`, used when LunaSVG renders `<text>`/`<tspan>` inside an `<svg>`, called `fontMan->GetFont()` without a `docFragmentIdx`, so it defaulted to -1 and any embedded `@font-face` font was filtered out for SVG text, silently falling back to a non-matching font.

Promote the DocFragment walk-up that already backed `getFont()`'s `DOC_FRAGMENT_IDX_UNKNOWN` handling in `lvrend.cpp` from a static file-local helper into `ldomNode::getDocFragmentIdx()`, so it can be shared with `lvimg.cpp`, and use it in `lunasvgTextToPathsHelper()` to pass the correct `docFragmentIdx` through to `GetFont()`.

Fixes https://github.com/koreader/koreader/issues/15935 (font-family part; the SVG positioning regression reported in the same issue is separate and not addressed here).


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/733)
<!-- Reviewable:end -->
