### PR TITLE
fix(css): improve background shorthand parsing

### DIFF
--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -5054,82 +5054,221 @@ bool LVCssDeclaration::parse( const char * &decl, bool higher_importance, lxmlDo
                         }
                         break;
                     }
-                    // Limited parsing of this possibly complex property
-                    // We only support a single layer in these orders:
-                    //   - color
-                    //   - url(...) repeat position
-                    //   - color url(...) repeat position
-                    //   - color url(...) position repeat
-                    // (with repeat and position possibly absent or re-ordered)
+                    // Robust, token-skipping parsing of the `background`
+                    // shorthand (a single layer). Supported components:
+                    //   <bg-image>        : url(...) or none
+                    //   <repeat-style>    : repeat | repeat-x | repeat-y | no-repeat
+                    //   <bg-position> [ / <bg-size> ]
+                    //   <'background-color'>
+                    // Unknown tokens (eg. background-attachment/origin/clip
+                    // keywords such as scroll/fixed/border-box, or typos) are
+                    // now skipped instead of aborting the parse, so they can no
+                    // longer "stick" the cursor and silently drop the valid
+                    // tokens that follow (eg. `url(x) scroll no-repeat` used to
+                    // lose everything after `scroll`). `none` as the image, or a
+                    // color-only shorthand, resets the image to none (initial),
+                    // so `background: none` / `background: red` no longer leave a
+                    // previously-set image in place.
+
+                    // <'background-color'> is accepted anywhere in the (single)
+                    // layer, per CSS: it belongs to the <final-bg-layer>, and a
+                    // single-layer shorthand is by definition its own final layer.
+                    // So `background: red`, `background: red url(x)` and
+                    // `background: url(x) red` are all valid and set both the image
+                    // and the color. Two colors in one layer is invalid CSS, so it
+                    // makes the whole shorthand invalid (dropped). This matches W3C
+                    // for the single-layer case (multi-layer comma syntax, where a
+                    // color must be in the last layer, is out of scope here).
                     css_length_t color;
                     bool has_color = parse_color_value(decl, color);
                     skip_spaces(decl);
-                    const char *tmp = decl;
-                    int len = 0;
-                    while (*tmp && *tmp!=';' && *tmp!=stop_char && *tmp!='!') {
-                        if ( *tmp == '(' && *(tmp-3) == 'u' && *(tmp-2) == 'r' && *(tmp-1) == 'l') {
-                            // Accepts everything until ')' after 'url(', including ';'
-                            // needed when parsing: url("data:image/png;base64,abcd...")
-                            tmp++; len++;
-                            while ( *tmp && *tmp!=')' ) {
+
+                    lString8 image_str;         // resolved url path (when an image is given)
+                    bool has_image = false;     // a <bg-image> component was seen
+                    bool image_is_none = false; // <bg-image> was the keyword "none"
+                    int repeat = -1;
+                    css_length_t position[2];
+                    bool has_position = false;
+                    css_length_t size[2];
+                    bool has_size = false;
+
+                    while (*decl && *decl != ';' && *decl != stop_char && *decl != '!' && *decl != ',') {
+                        skip_spaces(decl);
+                        if (!*decl || *decl == ';' || *decl == stop_char || *decl == '!' || *decl == ',')
+                            break;
+
+                        // <'background-color'>: accepted anywhere in the layer
+                        // (see comment above). A second color makes the whole
+                        // shorthand invalid per CSS, so drop the declaration.
+                        css_length_t c;
+                        if (parse_color_value(decl, c)) {
+                            if (has_color)
+                                return false; // invalid: more than one <background-color>
+                            has_color = true;
+                            color = c;
+                            skip_spaces(decl);
+                            continue;
+                        }
+
+                        // <bg-image>: url(...)  (keyword is case-insensitive, like
+                        // the other keywords matched via substr_icompare in this file)
+                        // Only one <bg-image> is allowed per layer. A second url()
+                        // makes the whole shorthand invalid per CSS, so we drop the
+                        // entire declaration instead of applying a partial value.
+                        if (toLower(*decl)=='u' && toLower(*(decl+1))=='r' && toLower(*(decl+2))=='l' && *(decl+3)=='(') {
+                            if (has_image)
+                                return false; // invalid: more than one <bg-image> in a layer
+                            const char *tmp = decl;
+                            int len = 0;
+                            while (*tmp && *tmp != ')') {
                                 tmp++; len++;
                             }
+                            len++; // include the ')'
+                            image_str.append(decl, len);
+                            decl += len;
+                            resolve_url_path(image_str, codeBase);
+                            has_image = true;
+                            image_is_none = false;
+                            continue;
                         }
-                        else {
-                            tmp++; len++;
+                        // <bg-image>: none
+                        if (substr_icompare("none", decl)) {
+                            if (has_image)
+                                return false; // invalid: more than one <bg-image> in a layer
+                            has_image = true;
+                            image_is_none = true;
+                            continue;
                         }
-                    }
-                    lString8 str;
-                    str.append(decl,len);
-                    if ( Utf8ToUnicode(str).lowercase().startsWith("url(") ) {
-                        tmp = str.c_str();
-                        len = 0;
-                        while (*tmp && *tmp!=')') {
-                            tmp++; len++;
+                        // <repeat-style>
+                        int r = parse_name(decl, css_bg_repeat_names, -1);
+                        if (r != -1) {
+                            repeat = r;
+                            continue;
                         }
-                        len = len + 1;
-                        str.clear();
-                        str.append(decl, len);
-                        decl += len;
-                        resolve_url_path(str, codeBase);
-                        len = str.length();
-                        // Try parsing following repeat and position
-                        skip_spaces(decl);
-                        int repeat = parse_name( decl, css_bg_repeat_names, -1 );
-                        if( repeat != -1 ) {
+                        // <bg-position> [ / <bg-size> ]
+                        css_length_t pos[2];
+                        bool did_position = parse_bg_position_value(decl, pos);
+                        if (did_position) {
+                            has_position = true;
+                            position[0] = pos[0];
+                            position[1] = pos[1];
                             skip_spaces(decl);
                         }
-                        css_length_t position[2];
-                        bool has_position = parse_bg_position_value( decl, position );
-                        if( repeat == -1 ) { // Try parsing repeat after position
+                        // Optional '/ <bg-size>' (whether or not a position
+                        // preceded it, eg. "url(x) / 120px 40px")
+                        if (*decl == '/') {
+                            decl++;
                             skip_spaces(decl);
-                            repeat = parse_name( decl, css_bg_repeat_names, -1 );
-                        }
-                        parsed_important = parse_important(decl);
-                        buf<<(lUInt32) (cssd_background_image | importance | parsed_important);
-                        buf<<(lUInt32) len;
-                        for (int i = 0; i < len; i++)
-                            buf<<(lUInt32) str[i];
-                        if(repeat != -1) {
-                            buf<<(lUInt32) (cssd_background_repeat | importance | parsed_important);
-                            buf<<(lUInt32) repeat;
-                        }
-                        if (has_position) {
-                            buf<<(lUInt32) (cssd_background_position | importance | parsed_important);
-                            for (int i = 0; i < 2; i++) {
-                                buf<<(lUInt32) position[i].type;
-                                buf<<(lUInt32) position[i].value;
+                            int i;
+                            for (i = 0; i < 2; i++) {
+                                // accept percent, auto and contain/cover
+                                if (!parse_number_value(decl, size[i], true, false, true, false, false, false, true))
+                                    break;
                             }
+                            if (i) {
+                                if (i == 1) { // Only 1 value parsed
+                                    if (size[0].type == css_val_unspecified) { // "auto", "contain" or "cover"
+                                        size[1].type = css_val_unspecified;
+                                        size[1].value = size[0].value;
+                                    }
+                                    else { // first value is a length: second value should be "auto"
+                                        size[1].type = css_val_unspecified;
+                                        size[1].value = css_generic_auto;
+                                    }
+                                }
+                                has_size = true;
+                            }
+                            continue;
+                        }
+                        if (did_position)
+                            continue;
+                        // Unknown token: skip it (and any balanced parentheses,
+                        // eg. an unsupported gradient(...) value) so it cannot
+                        // prevent the parsing of the tokens that follow
+                        while (*decl && *decl != ' ' && *decl != '\t' && *decl != ';' &&
+                               *decl != stop_char && *decl != '!' && *decl != ',') {
+                            // Skip a quoted string as a single unit.
+                            if (*decl == '\'' || *decl == '"') {
+                                char quote = *decl++;
+                                while (*decl && *decl != quote) {
+                                    if (*decl == '\\' && *(decl+1)) // skip escaped char
+                                        decl++;
+                                    decl++;
+                                }
+                                if (*decl == quote)
+                                    decl++; // consume the closing quote
+                                continue;
+                            }
+                            if (*decl == '(') {
+                                int depth = 0;
+                                do {
+                                    // Inside the parenthesised group, also skip
+                                    // quoted strings so their parens don't affect depth.
+                                    if (*decl == '\'' || *decl == '"') {
+                                        char quote = *decl++;
+                                        while (*decl && *decl != quote) {
+                                            if (*decl == '\\' && *(decl+1)) decl++;
+                                            decl++;
+                                        }
+                                        if (*decl == quote) decl++;
+                                        continue;
+                                    }
+                                    if (*decl == '(') depth++;
+                                    else if (*decl == ')') depth--;
+                                    decl++;
+                                } while (*decl && depth > 0);
+                                continue;
+                            }
+                            decl++;
                         }
                     }
-                    else { // no url, only color
-                        decl += len; // skip any unsupported stuff until !
-                        parsed_important = parse_important(decl);
+
+                    parsed_important = parse_important(decl);
+
+                    // <bg-image>: emit the url, or reset to none when "none" was
+                    // given, or when the shorthand was color-only (background-
+                    // image's initial value is "none")
+                    if (has_image && !image_is_none) {
+                        int ilen = image_str.length();
+                        buf<<(lUInt32) (cssd_background_image | importance | parsed_important);
+                        buf<<(lUInt32) ilen;
+                        for (int i = 0; i < ilen; i++)
+                            buf<<(lUInt32) image_str[i];
                     }
-                    if ( has_color ) {
+                    else if (image_is_none || (has_color && !has_image)) {
+                        buf<<(lUInt32) (cssd_background_image | importance | parsed_important);
+                        buf<<(lUInt32) 0; // empty string -> no image
+                    }
+                    if (repeat != -1) {
+                        buf<<(lUInt32) (cssd_background_repeat | importance | parsed_important);
+                        buf<<(lUInt32) repeat;
+                    }
+                    if (has_position) {
+                        buf<<(lUInt32) (cssd_background_position | importance | parsed_important);
+                        for (int i = 0; i < 2; i++) {
+                            buf<<(lUInt32) position[i].type;
+                            buf<<(lUInt32) position[i].value;
+                        }
+                    }
+                    if (has_size) {
+                        buf<<(lUInt32) (cssd_background_size | importance | parsed_important);
+                        for (int i = 0; i < 2; i++) {
+                            buf<<(lUInt32) size[i].type;
+                            buf<<(lUInt32) size[i].value;
+                        }
+                    }
+                    // <'background-color'>: emit the parsed color, or reset to
+                    // transparent when "none" was the image (background: none
+                    // resets color to its initial value)
+                    if (has_color) {
                         buf<<(lUInt32) (cssd_background_color | importance | parsed_important);
                         buf<<(lUInt32) color.type;
                         buf<<(lUInt32) color.value;
+                    }
+                    else if (image_is_none) {
+                        buf<<(lUInt32) (cssd_background_color | importance | parsed_important);
+                        buf<<(lUInt32) css_val_color;
+                        buf<<(lUInt32) CSS_COLOR_TRANSPARENT;
                     }
                 }
                 break;

--- a/tests/background-image-test.html
+++ b/tests/background-image-test.html
@@ -186,6 +186,47 @@
     background-size: 20px 20px;
 }
 
+/* background shorthand section */
+#background-shorthand-test .case { margin: 1.2em 0; }
+#background-shorthand-test .label {
+    font-size: 0.85em;
+    margin-bottom: 3px;
+}
+#background-shorthand-test .note {
+    font-size: 0.78em;
+    color: #555;
+    margin-bottom: 8px;
+    max-width: 55em;
+}
+#background-shorthand-test .demo-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+#background-shorthand-test .tile-label {
+    font-size: 0.78em;
+    color: #555;
+    text-align: center;
+    margin-top: 4px;
+}
+#background-shorthand-test .tile-wrap { text-align: center; }
+#background-shorthand-test .bgbox {
+    /* inline-block so this box's own pixel width/padding-driven height are
+       always honored under koreader's "Book" rendering profile (see the
+       comment on #background-position-test .box for why). */
+    display: inline-block;
+    border: 1px solid #333;
+    background-color: #f5f5f5;
+}
+#background-shorthand-test .withbg {
+    /* A base rule carrying an image + repeat, used by case 6 below to show
+        that the `background: none` shorthand resets a previously-set image. */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: 24px 24px;
+}
+
 body {
     font-family: sans-serif;
     margin: 1em;
@@ -987,6 +1028,135 @@ bottom-right, you would see it detached from the bar and radicand, floating
 with a visible gap underneath &#8212; most obviously in cases 2, 4, and 7,
 where the cell is noticeably taller than the symbol itself.
 </p>
+</section>
+
+<section id="background-shorthand-test">
+<h2>background shorthand (with background-size) test suite</h2>
+<p class="intro">
+Exercises the <code>background</code> shorthand parser in
+<code>lvstsheet.cpp</code>, specifically the optional
+<code>background-size</code> that follows the position and is separated from
+it by <code>/</code> (eg. <code>center / cover</code>, or just
+<code>/ cover</code> with the default position). Each case pairs the shorthand
+form (left) against the equivalent expanded longhand (right) and expects them
+to render identically.
+</p>
+
+<h3>1. Shorthand with position and size: <code>center / cover</code></h3>
+<div class="case">
+  <div class="label"><code>background: url(...) no-repeat center / cover;</code>
+    vs. the equivalent longhand</div>
+  <div class="note">expected: both render the image centered and scaled with
+    <code>cover</code>, pixel-identical.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;) no-repeat center / cover;"></div>
+      <div class="tile-label">shorthand: center / cover</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;); background-repeat: no-repeat; background-position: center; background-size: cover;"></div>
+      <div class="tile-label">longhand equivalent</div>
+    </div>
+  </div>
+</div>
+
+<h3>2. Shorthand with size only: <code>/ 120px 40px</code> (default position)</h3>
+<div class="case">
+  <div class="label"><code>background: url(...) / 120px 40px;</code>
+    vs. the equivalent longhand</div>
+  <div class="note">expected: the image stretches to exactly 120&#215;40px
+    (non-square cells), pixel-identical between the two.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 120px; padding-top: 40px; background: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;) no-repeat top / 120px 40px;"></div>
+      <div class="tile-label">shorthand: / 120px 40px</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 120px; padding-top: 40px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;); background-repeat: no-repeat; background-size: 120px 40px;"></div>
+      <div class="tile-label">longhand equivalent</div>
+    </div>
+  </div>
+</div>
+
+<h3>3. Shorthand with color and <code>contain</code>: <code>#f472b6 url(...) center / contain</code></h3>
+<div class="case">
+  <div class="label"><code>background: #f472b6 url(...) no-repeat center / contain;</code>
+    vs. the equivalent longhand</div>
+  <div class="note">expected: pink background with the image centered and
+    scaled with <code>contain</code> (full width, no cropping), pixel-identical
+    between the two.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 120px; background: #f472b6 url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;) no-repeat center / contain;"></div>
+      <div class="tile-label">shorthand: color url(...) center / contain</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 120px; background-color: #f472b6; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;); background-repeat: no-repeat; background-position: center; background-size: contain;"></div>
+      <div class="tile-label">longhand equivalent</div>
+    </div>
+  </div>
+</div>
+
+<h3>4. Repeat after size: <code>center / cover no-repeat</code></h3>
+<div class="case">
+  <div class="label"><code>background: url(...) center / cover no-repeat;</code>
+    vs. the equivalent longhand</div>
+  <div class="note">expected: image centered, scaled with <code>cover</code>,
+    not repeated, pixel-identical between the two.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;) center / cover no-repeat;"></div>
+      <div class="tile-label">shorthand: center / cover no-repeat</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='0' width='60' height='40' fill='none' stroke='%23000' stroke-width='2'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;); background-repeat: no-repeat; background-position: center; background-size: cover;"></div>
+      <div class="tile-label">longhand equivalent</div>
+    </div>
+  </div>
+</div>
+
+<h3>5. Unknown token skipped: <code>url(...) scroll no-repeat center / cover</code></h3>
+<div class="case">
+  <div class="label"><code>background: url(...) scroll no-repeat center / cover;</code>
+    vs. the equivalent longhand. <code>scroll</code> is a
+    <code>background-attachment</code> keyword that crengine does not support;
+    the shorthand parser must skip it instead of aborting, so the valid
+    tokens after it still parse.</div>
+  <div class="note">expected: identical to case 1 (centered, scaled with
+    <code>cover</code>) &#8212; the stray <code>scroll</code> is ignored.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;) scroll no-repeat center / cover;"></div>
+      <div class="tile-label">shorthand with stray `scroll`</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox" style="width: 150px; padding-top: 40px; background-image: url(&quot;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='60' height='40' viewBox='0 0 60 40'%3E%3Crect x='0' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='0' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='0' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='10' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='10' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='0' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='10' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='20' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='30' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='40' y='20' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='50' y='20' width='10' height='10' fill='%23fde047'/%3E%3Crect x='0' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='10' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='20' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='30' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Crect x='40' y='30' width='10' height='10' fill='%23fde047'/%3E%3Crect x='50' y='30' width='10' height='10' fill='%233b82f6'/%3E%3Ccircle cx='5' cy='5' r='3' fill='%23dc2626'/%3E%3Ccircle cx='55' cy='35' r='3' fill='%2316a34a'/%3E%3C/svg%3E&quot;); background-repeat: no-repeat; background-position: center; background-size: cover;"></div>
+      <div class="tile-label">longhand equivalent</div>
+    </div>
+  </div>
+</div>
+
+<h3>6. <code>background: none</code> resets a previously-set image</h3>
+<div class="case">
+  <div class="label">left: a box with a base <code>.withbg</code> rule setting a
+    background-image, overridden inline by <code>background: none;</code>.
+    right: the same box without the override (image visible).</div>
+  <div class="note">expected: left shows <em>no image and a transparent
+    background</em> (the inline <code>background: none</code> shorthand resets
+    both <code>background-image</code> to none and <code>background-color</code>
+    to its initial transparent value), right keeps the image.</div>
+  <div class="demo-row">
+    <div class="tile-wrap">
+      <div class="bgbox withbg" style="background: none;"></div>
+      <div class="tile-label">withbg + `background: none`</div>
+    </div>
+    <div class="tile-wrap">
+      <div class="bgbox withbg"></div>
+      <div class="tile-label">withbg alone</div>
+    </div>
+  </div>
+</div>
+
 </section>
 
 </body>


### PR DESCRIPTION
I'm having the following issue with the background shorthand parser:

1. **Unknown tokens abort the whole parse.** The old parser scanned the
   declaration until it found a `url(`, then tried to read a repeat keyword and
   a position. Any unsupported keyword (e.g. `background-attachment`'s
   `scroll`/`fixed`, `background-origin`/`clip`'s `border-box`, or a typo) would
   "stick" the cursor and silently drop every valid token that followed. For
   example `background: url(x) scroll no-repeat` lost both `scroll` *and*
   `no-repeat`, rendering nothing.

2. **`background: none` / color-only shorthand did nothing.** The old code
   only emitted a `background-image` when it saw `url(...)`; otherwise it
   skipped to the next `!`. So `background: none` was a complete no-op, leaving
   a previously-set image in place. `background: red` likewise kept the old
   image.

3. **`background-size` inside the shorthand was unsupported.** There was no way
   to write `background: url(x) center / cover` or `url(x) / 120px 40px`; only
   the separate `background-size` property worked.

## Changes

Rewrite the `background` (single-layer) branch as a token-skipping loop. Each
iteration tries, in order: `url(...)`, `none`, a repeat keyword, a
`<bg-position>`, an optional `/ <bg-size>`, and otherwise skips the unknown
token (including any balanced `gradient(...)`-style parentheses) so it cannot
block the tokens that follow.

- `<bg-size>` is parsed with the exact same `parse_number_value(...)` call and
  single-value expansion already used by the standalone `background-size`
  property, so `center / cover`, `/ 120px 40px`, and `color url(...) center /
  contain` produce byte-identical results to the equivalent longhand.
- `<bg-image>` is reset to none (empty string) when the image is `none`, or
  when the shorthand is color-only (`background: red`). `background: none` also
  resets `<background-color>` to its initial `transparent`.

```cpp
while (*decl && *decl != ';' && *decl != stop_char && *decl != '!' && *decl != ',') {
    skip_spaces(decl);
    if (url(...)     ) { resolve; has_image=true;  continue; }
    if (none         ) { has_image=true; image_is_none=true; continue; }
    if (repeat name  ) { repeat=r; continue; }
    if (bg-position  ) { has_position=true; continue; }
    if (*decl == '/')   { parse <bg-size>; has_size=true; continue; }
    // unknown token: skip it (and balanced parens) so it can't block later tokens
}
// emit background_image (or reset to none), repeat, position, size, color
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/735)
<!-- Reviewable:end -->
