### PR TITLE
fix(crengine): decode UTF-8 in lString32::assign

### DIFF
--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -656,23 +656,10 @@ lString32 & lString32::assign(const lChar8 * str)
     }
     else
     {
-        size_type len = _lStr_len(str);
-        if (pchunk->nref==1)
-        {
-            if (pchunk->size < len)
-            {
-                // resize is necessary
-                pchunk->buf32 = (lChar32*) ::realloc( pchunk->buf32, sizeof(lChar32)*(len+1) );
-                pchunk->size = len;
-            }
-        }
-        else
-        {
-            release();
-            alloc(len);
-        }
-        _lStr_cpy( pchunk->buf32, str );
-        pchunk->len = len;
+        // lChar8 is UTF-8: decode it into Unicode, like the lString32(const
+        // lChar8*) constructor does. A plain byte copy would turn multi-byte
+        // UTF-8 sequences into a mojibake of one code point per byte.
+        *this = Utf8ToUnicode(str);
     }
     return *this;
 }


### PR DESCRIPTION
When assigning an `lChar8` (UTF-8) string to an `lString32` via
`lString32::assign(const lChar8*)`, the result is **mojibake** for any
non-ASCII character (Vietnamese, Cyrillic, CJK, accented Latin, ...).
The old `assign` performed a plain byte copy:

```cpp
size_type len = _lStr_len(str);          // length in bytes
if (pchunk->nref==1) { ... } else { release(); alloc(len); }
_lStr_cpy( pchunk->buf32, str );         // each byte -> one code point
pchunk->len = len;                       // counted in bytes
```

For multi-byte UTF-8, every byte is placed into its own code point, breaking
the string (e.g. `"é"`, bytes `0xC3 0xA9`, becomes two code points `U+00C3`,
`U+00A9` instead of `U+00E9`).

Key point: the constructor `lString32(const lChar8*)` already decodes UTF-8
(`*this = Utf8ToUnicode(str)`, lvstring.cpp:572), so `assign` behaved
**differently** from the constructor — an inconsistency. Any caller passing a
multi-byte UTF-8 string to `assign` got a broken result

## Impact
- **Correct for ASCII input** (byte == code point) → byte-identical result to
  the old code.
- **Fixes mojibake** for multi-byte UTF-8 → returns the correct number of
  Unicode characters.
- **No semantic change** for valid input; very low regression risk (only the
  allocation path differs: temp + `operator=` instead of in-place overwrite of
  the old `pchunk`).
- `lChar8` is UTF-8 throughout crengine, so the API contract always expects
  UTF-8 decoding -> no caller should rely on `assign` doing a byte copy.

lI noticed there was a function `assign(const lChar8*, count)`, but it doesn't seem to be called anywhere, so I didn't modify it. As for the other versions of the `assign` function for example, `assign(const lString32&)` they've already been decoded, so there's no need to change them

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/737)
<!-- Reviewable:end -->
