### PR TITLE
chore(crengine): handle null bytes in append

### DIFF
--- a/crengine/src/lvstring.cpp
+++ b/crengine/src/lvstring.cpp
@@ -884,9 +884,10 @@ lString32 & lString32::append(const lChar32 * str)
 
 lString32 & lString32::append(const lChar32 * str, size_type count)
 {
-    reserve(pchunk->len + count);
-    _lStr_ncpy(pchunk->buf32 + pchunk->len, str, count);
-    pchunk->len += count;
+    size_type len = _lStr_nlen(str, count);
+    reserve(pchunk->len + len);
+    _lStr_ncpy(pchunk->buf32 + pchunk->len, str, len);
+    pchunk->len += len;
     return *this;
 }
 
@@ -901,9 +902,10 @@ lString32 & lString32::append(const lChar8 * str)
 
 lString32 & lString32::append(const lChar8 * str, size_type count)
 {
-    reserve(pchunk->len + count);
-    _lStr_ncpy(pchunk->buf32+pchunk->len, str, count);
-    pchunk->len += count;
+    size_type len = _lStr_nlen(str, count);
+    reserve(pchunk->len + len);
+    _lStr_ncpy(pchunk->buf32+pchunk->len, str, len);
+    pchunk->len += len;
     return *this;
 }
 


### PR DESCRIPTION
- Compute actual string length with _lStr_nlen
- Prevent over-reserving and copying extra chars

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/738)
<!-- Reviewable:end -->
