### PR TITLE
lvstsheet: speed up CSS application via class-bucketed selectors

### DIFF
--- a/crengine/include/lvstsheet.h
+++ b/crengine/include/lvstsheet.h
@@ -175,6 +175,9 @@ public:
     bool isFullChecking() const { return _type == cssrt_ancessor || _type == cssrt_predsibling; }
     lUInt32 getHash() const;
     lUInt32 getWeight() const;
+    LVCssSelectorRuleType getType() const { return _type; }
+    /// Class hash for class rules, 0 otherwise.
+    lUInt32 getClassValueHash() const { return (_type==cssrt_class) ? _valueHash : 0; }
 };
 
 /** \brief simple CSS selector
@@ -203,6 +206,7 @@ public:
     ~LVCssSelector() { if (_next) delete _next; } // NOLINT(clang-analyzer-cplusplus.NewDelete)
     bool parse( const char * &str, lxmlDocBase * doc, bool useragent_sheet=false, bool for_functional_pseudo_class=false );
     lUInt16 getElementNameId() const { return _id; }
+    int getPseudoElem() const { return _pseudo_elem; }
     bool check( const ldomNode * node, bool allow_cache=true ) const;
     bool quickClassCheck(const lUInt32 *classHashes, size_t size) const;
     void applyToPseudoElement( const ldomNode * node, css_style_rec_t * style ) const;
@@ -232,6 +236,8 @@ public:
     LVCssSelector * getNext() const { return _next; }
     void setNext(LVCssSelector * next) { _next = next; }
     lUInt32 getHash() const;
+    /// The selector's leading rule (rightmost of the chain), or NULL if none.
+    const LVCssSelectorRule * getFirstRule() const { return _rules.get(); }
     LVCssSelector * getCopy() const {
         // Return a copy (with everything except _next) that can
         // be delete()'d without impacting this LVCssSelector
@@ -278,6 +284,27 @@ private:
 
     LVPtrVector <LVCssSelector> _selectors;
     LVPtrVector <LVPtrVector <LVCssSelector> > _stack;
+
+    // Lazily-built index of _selectors[0] (the chain of selectors whose
+    // leading rule is NOT an element name). Buckets the chain by leading class
+    // so `apply()` only visits selectors a node could match. Buckets are
+    // subsequences of the chain, so cascade order is preserved.
+    struct SEL0Entry {
+        LVCssSelector * sel;
+        lUInt32         chainIndex; // position in the _selectors[0] chain (for ties)
+        SEL0Entry() : sel(NULL), chainIndex(0) { }
+        SEL0Entry(LVCssSelector * s, lUInt32 i) : sel(s), chainIndex(i) { }
+    };
+    // selectors whose leading rule is not a class (universal/type/attr/pseudo/empty)
+    LVArray<SEL0Entry> _sel0NoClass;
+    // classHash -> bucket of selectors whose leading rule is that class
+    // (parallel arrays: _sel0ClassHashes[i] <-> _sel0ClassBuckets[i])
+    LVArray<lUInt32> _sel0ClassHashes;
+    LVArray<LVArray<SEL0Entry> > _sel0ClassBuckets;
+    bool               _sel0IndexReady;
+    void buildSel0Index();
+    static inline bool isClassLeading(const LVCssSelector * s);
+
     LVPtrVector <LVCssSelector> * dup()
     {
         LVPtrVector <LVCssSelector> * res = new LVPtrVector <LVCssSelector>();
@@ -352,11 +379,15 @@ public:
         _selectors.clear();
         _stack.clear();
         _fontFaceDecls.clear();
+        _sel0IndexReady = false;
+        _sel0NoClass.clear();
+        _sel0ClassHashes.clear();
+        _sel0ClassBuckets.clear();
     }
     /// set document to retrieve ID values from
     void setDocument( lxmlDocBase * doc ) { _doc = doc; }
     /// constructor
-    LVStyleSheet( lxmlDocBase * doc=NULL, bool nested=false ) : _doc(doc) , _nested(nested) , _selector_count(0) { }
+    LVStyleSheet( lxmlDocBase * doc=NULL, bool nested=false ) : _doc(doc) , _nested(nested) , _selector_count(0) , _sel0IndexReady(false) { }
     /// copy constructor
     LVStyleSheet( LVStyleSheet & sheet );
     /// parse stylesheet, compile and add found rules to sheet

--- a/crengine/src/lvstsheet.cpp
+++ b/crengine/src/lvstsheet.cpp
@@ -7775,6 +7775,7 @@ LVCssSelector::LVCssSelector( LVCssSelector & v )
 void LVStyleSheet::set(LVPtrVector<LVCssSelector> & v  )
 {
     _selectors.clear();
+    _sel0IndexReady = false;
     if ( !v.size() )
         return;
     _selectors.reserve( v.size() );
@@ -7812,11 +7813,53 @@ static void for_each_split(const lChar32 *begin, F functor) {
         functor(begin, end);
 }
 
+bool LVStyleSheet::isClassLeading(const LVCssSelector * s)
+{
+    // True when the leading rule is a class rule and the selector isn't a
+    // pseudo-element. Otherwise quickClassCheck() passes unconditionally.
+    if ( s->getPseudoElem() > 0 )
+        return false;
+    const LVCssSelectorRule * r = s->getFirstRule();
+    return r && r->getType() == cssrt_class;
+}
+
+void LVStyleSheet::buildSel0Index()
+{
+    // Build the fast lookup buckets for the _selectors[0] chain.
+    LVCssSelector * s = _selectors[0];
+    _sel0NoClass.clear();
+    _sel0ClassHashes.clear();
+    _sel0ClassBuckets.clear();
+    lUInt32 idx = 0;
+    for ( ; s; s = s->getNext(), idx++ ) {
+        if ( !isClassLeading(s) ) {
+            _sel0NoClass.add( SEL0Entry(s, idx) );
+            continue;
+        }
+        lUInt32 classHash = s->getFirstRule()->getClassValueHash();
+        // linear scan; buckets are few and this runs rarely
+        int bi = -1;
+        for ( int i=0; i<_sel0ClassHashes.length(); i++ ) {
+            if ( _sel0ClassHashes[i] == classHash ) {
+                bi = i;
+                break;
+            }
+        }
+        if ( bi < 0 ) {
+            bi = _sel0ClassHashes.length();
+            _sel0ClassHashes.add( classHash );
+            _sel0ClassBuckets.add( LVArray<SEL0Entry>() );
+        }
+        _sel0ClassBuckets[bi].add( SEL0Entry(s, idx) );
+    }
+    _sel0IndexReady = true;
+}
+
 void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
 {
     if (!_selectors.length())
         return; // no rules!
-        
+
     lUInt16 id = node->getNodeId();
     if ( id == el_body && node->getParentNode()->isRoot() ) {
         // Don't apply anything to the <body> container of <DocFragment>
@@ -7884,8 +7927,14 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
     // first checked agains all <p>).
     // To see which selectors apply to a <p>, we must iterate thru both chains,
     // checking and applying them in the order of specificity/parsed position.
-    LVCssSelector * selector_0 = _selectors[0];
+    //
+    // We merge only the _selectors[0] buckets a node can match (see
+    // buildSel0Index) with the _selectors[id] chain, in specificity order.
     LVCssSelector * selector_id = id>0 && id<_selectors.length() ? _selectors[id] : NULL;
+
+    if ( !_sel0IndexReady ) {
+        const_cast<LVStyleSheet*>(this)->buildSel0Index();
+    }
 
     LVArray<lUInt32> class_hash_array;
     const lString32 &v = node->getEffectiveAttributeValue(attr_class);
@@ -7893,35 +7942,88 @@ void LVStyleSheet::apply( const ldomNode * node, css_style_rec_t * style ) const
         class_hash_array.add(lString32::getHash(begin, end));
     });
 
-    for (;;)
-    {
-        if (selector_0!=NULL)
-        {
-            if (selector_id==NULL || selector_0->getSpecificity() < selector_id->getSpecificity() )
-            {
-                // step by sel_0
-                if (selector_0->quickClassCheck(class_hash_array.ptr(), class_hash_array.length()))
-                    selector_0->apply( node, style );
-                selector_0 = selector_0->getNext();
-            }
-            else
-            {
-                // step by sel_id
-                if (selector_id->quickClassCheck(class_hash_array.ptr(), class_hash_array.length()))
-                    selector_id->apply( node, style );
-                selector_id = selector_id->getNext();
+    // Cursors: one per selectable _selectors[0] bucket plus one for the
+    // _selectors[id] chain. A bucket cursor reads bucket[pos]; the id cursor
+    // walks its linked chain.
+    struct Cursor {
+        const LVArray<SEL0Entry> * bucket; // NULL for the selector_id chain
+        int                         pos;
+        LVCssSelector             * sel;
+        lUInt32                     chainIndex;
+        lUInt32                     specificity;
+        bool                        isSelId;
+    };
+
+    LVArray<Cursor> cursors;
+    cursors.reserve( class_hash_array.length() + 2 );
+
+    auto addBucketCursor = [&]( const LVArray<SEL0Entry> * b ) {
+        if (!b || b->length()==0) return;
+        Cursor c;
+        c.bucket = b; c.pos = 0; c.isSelId = false;
+        c.sel = (*b)[0].sel; c.chainIndex = (*b)[0].chainIndex; c.specificity = c.sel->getSpecificity();
+        cursors.add(c);
+    };
+
+    addBucketCursor( &_sel0NoClass );
+    const LVArray<SEL0Entry> * classBucketsPtr = _sel0ClassBuckets.ptr();
+    if ( classBucketsPtr ) {
+        for ( int ci=0; ci<class_hash_array.length(); ci++ ) {
+            lUInt32 h = class_hash_array[ci];
+            for ( int bi=0; bi<_sel0ClassHashes.length(); bi++ ) {
+                if ( _sel0ClassHashes[bi] == h ) {
+                    addBucketCursor( &classBucketsPtr[bi] );
+                    break;
+                }
             }
         }
-        else if (selector_id!=NULL)
-        {
-            // step by sel_id
-            if (selector_id->quickClassCheck(class_hash_array.ptr(), class_hash_array.length()))
-                selector_id->apply( node, style );
-            selector_id = selector_id->getNext();
+    }
+    if ( selector_id ) {
+        Cursor c;
+        c.bucket = NULL; c.pos = 0; c.isSelId = true;
+        c.sel = selector_id; c.chainIndex = 0; c.specificity = selector_id->getSpecificity();
+        cursors.add(c);
+    }
+
+    // pick the cursor with the lowest specificity (ties: selector_id chain
+    // wins, then lower chainIndex), apply it, and advance it.
+    for (;;) {
+        int best = -1;
+        for ( int i=0; i<cursors.length(); i++ ) {
+            if ( cursors[i].sel == NULL ) continue;
+            if ( best < 0 ) {
+                best = i;
+                continue;
+            }
+            const Cursor & a = cursors[best];
+            const Cursor & b = cursors[i];
+            bool better = false;
+            if ( b.specificity < a.specificity ) {
+                better = true;
+            } else if ( b.specificity == a.specificity ) {
+                if ( b.isSelId && !a.isSelId ) better = true;
+                else if ( b.isSelId == a.isSelId && b.chainIndex < a.chainIndex ) better = true;
+            }
+            if ( better ) best = i;
         }
-        else
-        {
-            break; // end of chains
+        if ( best < 0 ) break;
+
+        Cursor & cur = cursors[best];
+        if ( cur.sel->quickClassCheck(class_hash_array.ptr(), class_hash_array.length()) )
+            cur.sel->apply( node, style );
+
+        // advance
+        if ( cur.bucket ) {
+            cur.pos++;
+            if ( cur.pos < cur.bucket->length() ) {
+                const SEL0Entry & e = (*cur.bucket)[cur.pos];
+                cur.sel = e.sel; cur.chainIndex = e.chainIndex; cur.specificity = e.sel->getSpecificity();
+            } else {
+                cur.sel = NULL;
+            }
+        } else {
+            cur.sel = cur.sel->getNext();
+            if ( cur.sel ) { cur.chainIndex = 0; cur.specificity = cur.sel->getSpecificity(); }
         }
     }
 }
@@ -8093,6 +8195,7 @@ bool LVStyleSheet::parseAndAdvance( const char * &str, bool useragent_sheet, lSt
                 next = p->getNext();
                 insert_into_selectors(p, _selectors);
             }
+            _sel0IndexReady = false;
         }
     }
     return _selectors.length() > 0;
@@ -8176,6 +8279,7 @@ bool LVStyleSheet::gatherNodeMatchingRulesets(ldomNode * node, const char * str,
 }
 
 void LVStyleSheet::merge(const LVStyleSheet &other) {
+    _sel0IndexReady = false;
     int length = other._selectors.length();
     if (length > _selectors.length())
         _selectors.set(length - 1, nullptr);

--- a/tests/class-bucket-test.html
+++ b/tests/class-bucket-test.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Class-bucketed selector test suite</title>
+<style>
+body {
+    font-family: sans-serif;
+    margin: 1em;
+}
+h1 { font-size: 1.6em; }
+h2 {
+    font-size: 1.3em;
+    margin-top: 2em;
+    border-bottom: 2px solid #666;
+}
+h3 { font-size: 1.1em; margin: 1.2em 0 0.4em; }
+section { margin-bottom: 2em; }
+.case { margin: 1em 0; padding: 0.6em; border: 1px solid #ccc; background: #fafafa; }
+.label { font-size: 0.85em; margin-bottom: 4px; }
+.label code, .note code { background-color: #eee; }
+.note { font-size: 0.78em; color: #555; margin-bottom: 6px; max-width: 60em; }
+.result { margin: 4px 0; padding: 4px 8px; }
+
+/* Section 1: classes named after their border color. Look-alike classes
+   (redd, blue2, greenish) live in other buckets and must not leak in. */
+#s1 .green { border: 2px solid green; }
+#s1 .red   { border: 2px solid red; }
+#s1 .blue  { border: 2px solid blue; }
+
+/* Section 2: equal-specificity rules in different buckets; later wins. */
+#s2 .pink   { color: pink; }
+#s2 .violet { color: violet; }
+
+/* Section 3: higher specificity must beat bucket merge order. */
+#s3 .shallow { border: 2px solid red; }
+#s3 .deep    { border: 2px solid green; }
+
+/* Section 4: .class::before / .class::after. A node has one ::before box,
+   so a later matching ::before (equal specificity) overrides content. */
+#s4 .note::before { content: "[NOTE] "; color: #0055cc; font-weight: bold; }
+#s4 .note::after  { content: " [end]"; color: #0055cc; }
+#s4 .warn::before { content: "!! "; color: #cc0000; font-weight: bold; }
+
+/* Section 5: non-class leading rules still apply. */
+#s5 *              { font-family: inherit; }
+#s5 span.attr-yes  { border: 2px solid green; }
+#s5 span.attr-no   { border: 2px solid red; }
+#s5 [data-mark]    { background: #ccffcc; }
+#s5 .link a        { color: blue; }
+#s5 .probe :first-child { font-style: italic; }
+
+/* Section 6: multiple classes hit several buckets at once. */
+#s6 .multi-a { border: 2px solid green; }
+#s6 .multi-b { margin-left: 1.5em; }
+#s6 .only    { color: red; }
+
+/* Section 7: class-leading rules with more selectors to their left. */
+#s7 .quote { border-left: 4px solid #888; padding-left: 6px; }
+#s7 div .quote { border-left: 4px solid #cc8800; }
+</style>
+</head>
+<body>
+
+<h1>Class-bucketed selector test suite</h1>
+<p class="note" style="max-width:60em">
+Tests <code>LVStyleSheet::buildSel0Index()</code> / <code>apply()</code> in
+<code>lvstsheet.cpp</code>. These bucket the <code>_selectors[0]</code> chain
+by leading class so a node only visits buckets it can match. The cascade
+(specificity, source order, pseudo-elements) must behave exactly as before.
+</p>
+
+<section id="s1">
+<h2>1. Class buckets stay separate</h2>
+<div class="case">
+  <div class="label">each class matches its own color; look-alikes must not.</div>
+  <div class="note">expected: <code>green</code> is green-bordered,
+    <code>red</code> red, <code>blue</code> blue; <code>redd</code>,
+    <code>blue2</code>, <code>greenish</code> get no border.</div>
+  <div class="result green">green</div>
+  <div class="result red">red</div>
+  <div class="result blue">blue</div>
+  <div class="result redd">redd (no border)</div>
+  <div class="result blue2">blue2 (no border)</div>
+  <div class="result greenish">greenish (no border)</div>
+</div>
+</section>
+
+<section id="s2">
+<h2>2. Source order wins across buckets</h2>
+<div class="case">
+  <div class="label"><code>.pink</code> and <code>.violet</code> have equal
+    specificity but live in different buckets.</div>
+  <div class="note">expected: <strong>violet</strong> text (later source rule
+    wins) regardless of class order.</div>
+  <div class="result pink violet">pink violet</div>
+  <div class="result violet pink">violet pink (still violet)</div>
+</div>
+</section>
+
+<section id="s3">
+<h2>3. Specificity beats bucket order</h2>
+<div class="case">
+  <div class="label"><code>#s3 .shallow</code> (0,2,0) is defined before
+    <code>.deep</code> (0,1,0); both match.</div>
+  <div class="note">expected: <strong>green</strong> border.</div>
+  <div class="result deep shallow">deep shallow</div>
+</div>
+</section>
+
+<section id="s4">
+<h2>4. Class + pseudo-element selectors</h2>
+<div class="case">
+  <div class="label">regression: a class-leading <code>::before</code>/
+    <code>::after</code> must still apply (it must not be bucketed by class,
+    since pseudo-element nodes carry no class).</div>
+  <div class="note">expected: <code>note</code> shows &quot;[NOTE] ... [end]&quot;;
+    <code>warn</code> shows &quot;!!&quot;; <code>note warn</code> shows
+    &quot;!! ... [end]&quot; (the later <code>.warn::before</code> overrides
+    <code>content</code>, as there is one <code>::before</code> box).</div>
+  <div class="result note">this is a note</div>
+  <div class="result note warn">this is a note and a warning</div>
+  <div class="result warn">this is a warning</div>
+</div>
+</section>
+
+<section id="s5">
+<h2>5. Non-class leading rules still apply</h2>
+<div class="probe">
+  <p>first child of .probe &#8212; must be italic
+    (<code>#s5 .probe :first-child</code>).</p>
+  <p>second child of .probe &#8212; must NOT be italic.</p>
+</div>
+<div class="case">
+  <div class="label">attribute, element-name, and universal leading rules
+    always apply.</div>
+  <div class="note">expected: <strong>attr-yes</strong> span is green,
+    <strong>attr-no</strong> span is red; <code>data-mark</code> line has a
+    light green background; the link in <code>.link</code> is blue.</div>
+  <div class="result"><span class="attr-yes">attr-yes span</span></div>
+  <div class="result"><span class="attr-no">attr-no span</span></div>
+  <div class="result" data-mark="x">carries data-mark</div>
+  <div class="result">no class, no attribute</div>
+  <div class="result link"><a href="#">a link inside .link</a></div>
+</div>
+</section>
+
+<section id="s6">
+<h2>6. Multiple classes and the no-class case</h2>
+<div class="case">
+  <div class="label"><code>multi-a multi-b</code> reach both buckets;
+    <code>.only</code> must not leak to class-less nodes.</div>
+  <div class="note">expected: the first box is green and indented; the no-class
+    box stays plain; <code>only</code> is red.</div>
+  <div class="result multi-a multi-b">multi-a multi-b</div>
+  <div class="result">no class (stays plain)</div>
+  <div class="result only">only (red)</div>
+</div>
+</section>
+
+<section id="s7">
+<h2>7. Class-leading combinators</h2>
+<p class="note" style="max-width:60em">regression: a class-leading rule with
+  more selectors to its left (<code>#s7 .quote</code>,
+  <code>#s7 div .quote</code>) lands in the <code>quote</code> bucket and must
+  cascade correctly. The first quote sits directly inside
+  <code>&lt;section id=&quot;s7&quot;&gt;</code> (no <code>div</code> ancestor),
+  so only <code>#s7 .quote</code> applies (gray). The second is wrapped in a
+  <code>&lt;div&gt;</code>, so <code>#s7 div .quote</code> also applies
+  (orange).</p>
+<div class="quote">bare quote (no div ancestor &#8212; gray)</div>
+<div><div class="quote">deeper quote (inside a div &#8212; orange)</div></div>
+</section>
+
+</body>
+</html>


### PR DESCRIPTION
With the slow Japanese EPUB in koreader/koreader#15995, `LVStyleSheet::apply()` walks the entire `_selectors[0] selector` chain for every element, ~2,860 rules per element (Perf: `LVCssSelectorRule::quickClassCheck` at ~1.31B calls).

Quoting OpenCode's Big Pickle:
> This buckets _selectors[0] by the selector's leading class (buildSel0Index()) so each element only visits the buckets it can match, k-way merged with the _selectors[id] chain in (specificity, selector_id, chainIndex) order. Class-leading selectors that must still be checked unconditionally (pseudo-elements, non-class or compound leading rules) are excluded from bucketing via isClassLeading().
> 
> Measured on a cold open (cleared cr3cache) of the issue-15995 book:
> - loading: 0.732s → 0.156s
> - first render: 1.432s → 0.756s (~2.16s → ~0.91s total)
> 
> Benchmarking (headless, dummy SDL driver):
> 
> 1. Clear the crengine render cache for a true cold open: `rm -rf koreader-emulator-x86_64-linux-gnu-debug/koreader/cache/cr3cache`
> 2. Run the emulator without a window via the dummy SDL video driver: `SDL_VIDEODRIVER=dummy ./kodev run "test/issues/15995 slow Japanese book/死亡遊戯で飯を食う。２【電子特典付き】.epub"`
> 3. Read the INFO markers from the log:
> INFO CreDocument: loading document...
> INFO CreDocument: loading done. (Xs)
> INFO CreDocument: rendering document...
> INFO CreDocument: rendering done. (Xs)

Perhaps mainly as a curiosity; it's likely better if @spfenwick tells Claude to come up with an altogether more elegant refactoring of the entire affair. :laughing:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/crengine/739)
<!-- Reviewable:end -->
